### PR TITLE
[NFC] object_id must already exist in accounts

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -142,7 +142,7 @@ impl Authority for AuthorityState {
         let mut sender_object = self
             .accounts
             .get_mut(&transfer.object_id)
-            .unwrap();
+            .expect("The existence of object_id is already checked.");
 
         let mut sender_sequence_number = sender_object.next_sequence_number;
 


### PR DESCRIPTION
In the previous lines it was already verified that the object ID must exist in the accounts. No need to use or_insert_with().