### PR TITLE
[Move] Update build command in doc and fix a typo in a move file

### DIFF
--- a/fastx_programmability/framework/README.md
+++ b/fastx_programmability/framework/README.md
@@ -17,5 +17,5 @@ For reading/editing Move, your best bet is vscode + this [plugin](https://market
 
 ```
 # Inside the fastx_programmability/framework dir
-move package build
+move package -d build
 ```

--- a/fastx_programmability/framework/examples/EconMod.move
+++ b/fastx_programmability/framework/examples/EconMod.move
@@ -10,7 +10,7 @@ module Examples::EconMod {
     use FastX::ID::ID;
     use FastX::Transfer;
     use FastX::TxContext::{Self, TxContext};
-asd
+
     /// Created by `monster_owner`, a player with a monster that's too strong
     /// for them to slay + transferred to a player who can slay the monster.
     /// The two players split the reward for slaying the monster according to


### PR DESCRIPTION
`move package build` command will look for move files under sources/ and scripts/.
Renaming examples to scripts will allow move build to actually build them.