### PR TITLE
[messages] add enum for Order to simplify adding new order types

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -148,21 +148,21 @@ impl ClientServerBenchmark {
                 user_data: UserData::default(),
             };
             next_recipient = *pubx;
-            let order = TransferOrder::new(transfer.clone(), secx);
-            let shard = AuthorityState::get_shard(self.num_shards, &order.transfer.object_id);
+            let order = Order::new_transfer(transfer.clone(), secx);
+            let shard = AuthorityState::get_shard(self.num_shards, order.object_id());
 
             // Serialize order
-            let bufx = serialize_transfer_order(&order);
+            let bufx = serialize_order(&order);
             assert!(!bufx.is_empty());
 
             // Make certificate
-            let mut certificate = CertifiedTransferOrder {
-                value: order,
+            let mut certificate = CertifiedOrder {
+                order,
                 signatures: Vec::new(),
             };
             for i in 0..committee.quorum_threshold() {
                 let (pubx, secx) = keys.get(i).unwrap();
-                let sig = Signature::new(&certificate.value.transfer, secx);
+                let sig = Signature::new(&certificate.order.kind, secx);
                 certificate.signatures.push((*pubx, sig));
             }
 

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -50,7 +50,7 @@ pub enum FastPayError {
         display = "Cannot initiate transfer while a transfer order is still pending confirmation: {:?}",
         pending_confirmation
     )]
-    PreviousTransferMustBeConfirmedFirst { pending_confirmation: TransferOrder },
+    PreviousTransferMustBeConfirmedFirst { pending_confirmation: Order },
     #[fail(display = "Transfer order was processed but no signature was produced by authority")]
     ErrorWhileProcessingTransferOrder,
     #[fail(

--- a/fastpay_core/src/fastpay_smart_contract.rs
+++ b/fastpay_core/src/fastpay_smart_contract.rs
@@ -69,19 +69,18 @@ impl FastPaySmartContract for FastPaySmartContractState {
         &mut self,
         transaction: RedeemTransaction,
     ) -> Result<(), failure::Error> {
-        transaction.transfer_certificate.check(&self.committee)?;
-        let order = transaction.transfer_certificate.value;
-        let transfer = &order.transfer;
+        transaction.certificate.check(&self.committee)?;
+        let order = transaction.certificate.order;
 
         let account = self
             .accounts
-            .entry(transfer.sender)
+            .entry(*order.sender())
             .or_insert_with(AccountOnchainState::new);
         ensure!(
-            account.last_redeemed < Some(transfer.sequence_number),
+            account.last_redeemed < Some(order.sequence_number()),
             "Transfer certificates to Primary must have increasing sequence numbers.",
         );
-        account.last_redeemed = Some(transfer.sequence_number);
+        account.last_redeemed = Some(order.sequence_number());
 
         Ok(())
     }

--- a/fastpay_core/src/serialize.rs
+++ b/fastpay_core/src/serialize.rs
@@ -13,9 +13,9 @@ mod serialize_tests;
 
 #[derive(Serialize, Deserialize)]
 pub enum SerializedMessage {
-    Order(Box<TransferOrder>),
-    Vote(Box<SignedTransferOrder>),
-    Cert(Box<CertifiedTransferOrder>),
+    Order(Box<Order>),
+    Vote(Box<SignedOrder>),
+    Cert(Box<CertifiedOrder>),
     Error(Box<FastPayError>),
     InfoReq(Box<AccountInfoRequest>),
     InfoResp(Box<AccountInfoResponse>),
@@ -26,9 +26,9 @@ pub enum SerializedMessage {
 // so that the variant tags match.
 #[derive(Serialize)]
 enum ShallowSerializedMessage<'a> {
-    Order(&'a TransferOrder),
-    Vote(&'a SignedTransferOrder),
-    Cert(&'a CertifiedTransferOrder),
+    Order(&'a Order),
+    Vote(&'a SignedOrder),
+    Cert(&'a CertifiedOrder),
     Error(&'a FastPayError),
     InfoReq(&'a AccountInfoRequest),
     InfoResp(&'a AccountInfoResponse),
@@ -56,14 +56,11 @@ pub fn serialize_message(msg: &SerializedMessage) -> Vec<u8> {
     serialize(msg)
 }
 
-pub fn serialize_transfer_order(value: &TransferOrder) -> Vec<u8> {
+pub fn serialize_order(value: &Order) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Order(value))
 }
 
-pub fn serialize_transfer_order_into<W>(
-    writer: W,
-    value: &TransferOrder,
-) -> Result<(), failure::Error>
+pub fn serialize_transfer_order_into<W>(writer: W, value: &Order) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {
@@ -74,14 +71,11 @@ pub fn serialize_error(value: &FastPayError) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Error(value))
 }
 
-pub fn serialize_cert(value: &CertifiedTransferOrder) -> Vec<u8> {
+pub fn serialize_cert(value: &CertifiedOrder) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Cert(value))
 }
 
-pub fn serialize_cert_into<W>(
-    writer: W,
-    value: &CertifiedTransferOrder,
-) -> Result<(), failure::Error>
+pub fn serialize_cert_into<W>(writer: W, value: &CertifiedOrder) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {
@@ -96,11 +90,11 @@ pub fn serialize_info_response(value: &AccountInfoResponse) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::InfoResp(value))
 }
 
-pub fn serialize_vote(value: &SignedTransferOrder) -> Vec<u8> {
+pub fn serialize_vote(value: &SignedOrder) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Vote(value))
 }
 
-pub fn serialize_vote_into<W>(writer: W, value: &SignedTransferOrder) -> Result<(), failure::Error>
+pub fn serialize_vote_into<W>(writer: W, value: &SignedOrder) -> Result<(), failure::Error>
 where
     W: std::io::Write,
 {

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -18,12 +18,9 @@ use tokio::runtime::Runtime;
 struct LocalAuthorityClient(Arc<Mutex<AuthorityState>>);
 
 impl AuthorityClient for LocalAuthorityClient {
-    fn handle_transfer_order(
-        &mut self,
-        order: TransferOrder,
-    ) -> AsyncResult<'_, AccountInfoResponse, FastPayError> {
+    fn handle_order(&mut self, order: Order) -> AsyncResult<'_, AccountInfoResponse, FastPayError> {
         let state = self.0.clone();
-        Box::pin(async move { state.lock().await.handle_transfer_order(order) })
+        Box::pin(async move { state.lock().await.handle_order(order) })
     }
 
     fn handle_confirmation_order(

--- a/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
+++ b/fastpay_core/src/unit_tests/fastpay_smart_contract_tests.rs
@@ -57,18 +57,10 @@ fn test_handle_redeem_transaction_ok() {
     assert!(contract_state
         .handle_redeem_transaction(redeem_transaction.clone())
         .is_ok());
-    let sender = redeem_transaction
-        .transfer_certificate
-        .value
-        .transfer
-        .sender;
+    let sender = redeem_transaction.certificate.order.sender();
 
-    let account = contract_state.accounts.get(&sender).unwrap();
-    let sequence_number = redeem_transaction
-        .transfer_certificate
-        .value
-        .transfer
-        .sequence_number;
+    let account = contract_state.accounts.get(sender).unwrap();
+    let sequence_number = redeem_transaction.certificate.order.sequence_number();
     assert_eq!(account.last_redeemed, Some(sequence_number));
 }
 
@@ -149,14 +141,12 @@ fn init_redeem_transaction(
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(primary_transfer, &sender_key);
-    let vote = SignedTransferOrder::new(order.clone(), name, &secret);
+    let order = Order::new_transfer(primary_transfer, &sender_key);
+    let vote = SignedOrder::new(order.clone(), name, &secret);
     let mut builder = SignatureAggregator::try_new(order, &committee).unwrap();
     let certificate = builder
         .append(vote.authority, vote.signature)
         .unwrap()
         .unwrap();
-    RedeemTransaction {
-        transfer_certificate: certificate,
-    }
+    RedeemTransaction { certificate }
 }

--- a/fastpay_core/src/unit_tests/messages_tests.rs
+++ b/fastpay_core/src/unit_tests/messages_tests.rs
@@ -22,19 +22,19 @@ fn test_signed_values() {
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer.clone(), &sec1);
-    let bad_order = TransferOrder::new(transfer, &sec2);
+    let order = Order::new_transfer(transfer.clone(), &sec1);
+    let bad_order = Order::new_transfer(transfer, &sec2);
 
-    let v = SignedTransferOrder::new(order.clone(), a1, &sec1);
+    let v = SignedOrder::new(order.clone(), a1, &sec1);
     assert!(v.check(&committee).is_ok());
 
-    let v = SignedTransferOrder::new(order.clone(), a2, &sec2);
+    let v = SignedOrder::new(order.clone(), a2, &sec2);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(order, a3, &sec3);
+    let v = SignedOrder::new(order, a3, &sec3);
     assert!(v.check(&committee).is_err());
 
-    let v = SignedTransferOrder::new(bad_order, a1, &sec1);
+    let v = SignedOrder::new(bad_order, a1, &sec1);
     assert!(v.check(&committee).is_err());
 }
 
@@ -56,12 +56,12 @@ fn test_certificates() {
         sequence_number: SequenceNumber::new(),
         user_data: UserData::default(),
     };
-    let order = TransferOrder::new(transfer.clone(), &sec1);
-    let bad_order = TransferOrder::new(transfer, &sec2);
+    let order = Order::new_transfer(transfer.clone(), &sec1);
+    let bad_order = Order::new_transfer(transfer, &sec2);
 
-    let v1 = SignedTransferOrder::new(order.clone(), a1, &sec1);
-    let v2 = SignedTransferOrder::new(order.clone(), a2, &sec2);
-    let v3 = SignedTransferOrder::new(order.clone(), a3, &sec3);
+    let v1 = SignedOrder::new(order.clone(), a1, &sec1);
+    let v2 = SignedOrder::new(order.clone(), a2, &sec2);
+    let v3 = SignedOrder::new(order.clone(), a3, &sec3);
 
     let mut builder = SignatureAggregator::try_new(order.clone(), &committee).unwrap();
     assert!(builder


### PR DESCRIPTION
Previously, there were transfer orders (to transfer funds), and confirmation orders (to commit an order that has gathered
signatures from a quorum of authorities. This PR converts the first kind of orders to an enum, which will make it easy to
add new kinds of orders (publish Move module, invoke smart contract function, create objects, ...).

Every order must know its sender, sequence number, and object ID. In time, this will need to be generalized to multiple objects, each with its own sequence number (see https://github.com/MystenLabs/fastnft/issues/8).

In addition, several usages of `Order` assume that there is a single recipient address (see: all the spots outside messages.rs where we need to pattern match on the `OrderKind`). These will also need to be refactored in time--some orders will have multiple recipients, some will have none, and in some cases the recipients may not be known prior to executing the order.