### PR TITLE
[objects] generalize `ObjectState` to capture native and Move ob…

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -4,7 +4,9 @@
 #![deny(warnings)]
 
 use fastpay::{network, transport};
-use fastpay_core::{authority::*, base_types::*, committee::*, messages::*, serialize::*};
+use fastpay_core::{
+    authority::*, base_types::*, committee::*, messages::*, object::Object, serialize::*,
+};
 
 use bytes::Bytes;
 use futures::stream::StreamExt;
@@ -125,12 +127,8 @@ impl ClientServerBenchmark {
             let object_id: ObjectID = address_to_object_id_hack(keypair.0);
             let i = AuthorityState::get_shard(self.num_shards, &object_id) as usize;
             assert!(states[i].in_shard(&object_id));
-            let client = ObjectState {
-                id: object_id,
-                contents: Vec::new(),
-                owner: keypair.0,
-                next_sequence_number: SequenceNumber::from(0),
-            };
+            let mut client = Object::with_id_for_testing(object_id);
+            client.transfer(keypair.0);
             states[i].insert_object(client);
             account_keys.push(keypair);
         }

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -164,6 +164,9 @@ impl AccountsConfig {
                     }
                 }
             }
+            OrderKind::Publish(_) | OrderKind::Call(_) => {
+                unimplemented!("update_for_received_transfer of Call or Publish")
+            }
         }
     }
 

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -4,7 +4,7 @@
 #![deny(warnings)]
 
 use fastpay::{config::*, network, transport};
-use fastpay_core::{authority::*, base_types::*, committee::Committee};
+use fastpay_core::{authority::*, base_types::*, committee::Committee, object::Object};
 
 use futures::future::join_all;
 use log::*;
@@ -47,12 +47,8 @@ fn make_shard_server(
             continue;
         }
 
-        let client = ObjectState {
-            id,
-            contents: Vec::new(),
-            owner: *address,
-            next_sequence_number: SequenceNumber::from(0),
-        };
+        let mut client = Object::with_id_for_testing(id);
+        client.transfer(*address);
         state.insert_object(client);
     }
 

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -19,6 +19,9 @@ ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde-name = "0.1.2"
 structopt = "0.3.21"
 
+move-binary-format = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
+move-core-types = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
+
 [dev-dependencies]
 similar-asserts = { version = "1.1.0" }
 serde-reflection = "0.3.2"

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -217,6 +217,7 @@ where
 
 /// Used for communicate_transfers
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 enum CommunicateAction {
     SendOrder(Order),
     SynchronizeNextSequenceNumber(SequenceNumber),
@@ -650,6 +651,9 @@ where
                         entry.insert(certificate);
                     }
                     Ok(())
+                }
+                OrderKind::Publish(_) | OrderKind::Call(_) => {
+                    unimplemented!("receiving (?) Move call or publish")
                 }
             }
         })

--- a/fastpay_core/src/error.rs
+++ b/fastpay_core/src/error.rs
@@ -23,6 +23,8 @@ macro_rules! fp_ensure {
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Fail, Hash)]
 /// Custom error type for FastPay.
+
+#[allow(clippy::large_enum_variant)]
 pub enum FastPayError {
     // Signature verification
     #[fail(display = "Signature is not valid: {}", error)]

--- a/fastpay_core/src/lib.rs
+++ b/fastpay_core/src/lib.rs
@@ -18,4 +18,5 @@ pub mod committee;
 pub mod downloader;
 pub mod fastpay_smart_contract;
 pub mod messages;
+pub mod object;
 pub mod serialize;

--- a/fastpay_core/src/object.rs
+++ b/fastpay_core/src/object.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+
+use move_binary_format::CompiledModule;
+use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
+
+use crate::base_types::{FastPayAddress, ObjectID, ObjectRef, SequenceNumber};
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct MoveObject {
+    pub type_: StructTag,
+    pub contents: Vec<u8>,
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum Data {
+    /// An object whose governing logic lives in a published Move module
+    Move(MoveObject),
+    /// A published Move module
+    Module(CompiledModule),
+    // ... FastX "native" types go here
+}
+
+impl Data {
+    pub fn is_read_only(&self) -> bool {
+        use Data::*;
+        match self {
+            Move(_) => false,
+            Module(_) => true,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub struct Object {
+    /// The meat of the object
+    pub data: Data,
+    /// The authenticator that unlocks this object (eg. public key, or other)
+    pub owner: FastPayAddress,
+    pub next_sequence_number: SequenceNumber,
+}
+
+impl Object {
+    pub fn to_object_reference(&self) -> ObjectRef {
+        (self.id(), self.next_sequence_number)
+    }
+
+    pub fn id(&self) -> ObjectID {
+        use Data::*;
+
+        match &self.data {
+            Move(v) => AccountAddress::try_from(&v.contents[0..16]).unwrap(), //unimplemented!("parse ID from bytes"), // TODO: parse from v
+            Module(m) => *m.self_id().address(),
+        }
+    }
+
+    /// Change the owner of `self` to `new_owner`
+    // TODO: we do not want to support unconditional transfers of all objects. eliminate
+    pub fn transfer(&mut self, new_owner: FastPayAddress) {
+        // TODO: probably want to enforce imutability in type system instead of with dynamic checks
+        assert!(
+            !self.data.is_read_only(),
+            "Cannot transfer an immutable object"
+        );
+        self.owner = new_owner;
+    }
+
+    // TODO: this should be test-only, but it's still used in bench and server
+    pub fn with_id_for_testing(id: ObjectID) -> Self {
+        use crate::base_types::PublicKeyBytes;
+        use move_core_types::identifier::Identifier;
+
+        let owner = PublicKeyBytes([0; 32]);
+        let module = Identifier::new("Test").unwrap();
+        let name = Identifier::new("Struct").unwrap();
+        let type_params = Vec::new();
+        let data = Data::Move(MoveObject {
+            type_: StructTag {
+                address: AccountAddress::new([0u8; AccountAddress::LENGTH]),
+                module,
+                name,
+                type_params,
+            },
+            contents: id.to_vec(),
+        });
+        let next_sequence_number = SequenceNumber::new();
+        Self {
+            owner,
+            data,
+            next_sequence_number,
+        }
+    }
+}

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -4,8 +4,9 @@
 
 use super::*;
 use crate::{
-    authority::{Authority, AuthorityState, ObjectState},
+    authority::{Authority, AuthorityState},
     base_types::Amount,
+    object::Object,
 };
 use futures::lock::Mutex;
 use std::{
@@ -121,12 +122,8 @@ fn fund_account<I: IntoIterator<Item = i128>>(
     for (_, client) in clients.iter_mut() {
         let addr = address;
         let object_id: ObjectID = address_to_object_id_hack(address);
-        let mut object = ObjectState::new_with_balance(
-            Vec::new(),
-            /* no receive log to justify the balances */ Vec::new(),
-        );
-        object.id = object_id;
-        object.owner = addr;
+        let mut object = Object::with_id_for_testing(object_id);
+        object.transfer(addr);
 
         client
             .0


### PR DESCRIPTION
…jects

- Move `ObjectState` to its own file and rename it to `Object`
- An `Object` can be one of three things (for now): a gas token, a Move value, or a Move module
- An object knows its ID, owner, type, and mutability status
- Introduce WIP new message types (Publish and Call) that will create/consumed Move values and modules. For now, handling these messages is unimplemented.