### PR TITLE
[programmability] connect authority to adapter

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -13,7 +13,9 @@ rand = "0.7.3"
 serde = { version = "1.0.115", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 
+fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-types = { path = "../fastx_types" }
+
 move-binary-format = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
 move-core-types = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
 

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -555,8 +555,8 @@ where
         self.next_sequence_number = new_next_sequence_number;
         // Sanity check
         assert_eq!(
-            self.sent_certificates.len(),
-            self.next_sequence_number.into()
+            self.sent_certificates.len() as u64,
+            self.next_sequence_number.0
         );
         Ok(())
     }

--- a/fastx_programmability/adapter/Cargo.toml
+++ b/fastx_programmability/adapter/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 anyhow = "1.0.38"
 bcs = "0.1.2"
 structopt = "0.3.21"
-sha3 = "0.9.1"
 
 ## uncomment for debugging with local copy of diem repo
 # move-binary-format = { path = "../../../diem/language/move-binary-format" }
@@ -26,7 +25,6 @@ move-core-types = { git = "https://github.com/diem/diem", rev="661a2d1367a64a020
 move-cli = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
 move-vm-runtime = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
 
-fastpay_core = { path = "../../fastpay_core" }
 fastx-framework = { path = "../framework" }
 fastx-verifier = { path = "../verifier" }
 fastx-types = { path = "../../fastx_types" }

--- a/fastx_programmability/adapter/src/lib.rs
+++ b/fastx_programmability/adapter/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod adapter;
-mod state_view;
+pub mod state_view;
 
 use move_core_types::account_address::AccountAddress;
 

--- a/fastx_programmability/adapter/src/main.rs
+++ b/fastx_programmability/adapter/src/main.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use fastx_adapter::adapter::FastXAdapter;
+
+use fastx_adapter::state_view::FastXStateView;
 use fastx_framework::{natives, FASTX_FRAMEWORK_ADDRESS, MOVE_STDLIB_ADDRESS};
 
 use move_cli::{Command, Move};
@@ -65,18 +66,11 @@ fn main() -> Result<()> {
     use FastXCommand::*;
     match args.cmd {
         MoveCommand(cmd) => move_cli::run_cli(natives, &error_descriptions, &args.move_args, &cmd),
-        Run {
-            module,
-            function,
-            sender,
-            args,
-            type_args,
-            gas_budget,
-        } => {
+        Run { .. } => {
             // TODO: take build_dir and storage_dir as CLI inputs
-            let mut adapter = FastXAdapter::create("build", "storage")?;
-            adapter.execute_local(module, function, sender, args, type_args, gas_budget)?;
-            Ok(())
+            let _state_view = FastXStateView::create("build", "storage")?;
+            //adapter.execute_local(module, function, sender, args, type_args, gas_budget)?;
+            unimplemented!("Fixme: local adapter")
         }
     }
 }

--- a/fastx_programmability/adapter/src/state_view.rs
+++ b/fastx_programmability/adapter/src/state_view.rs
@@ -14,7 +14,7 @@ use move_core_types::{
     resolver::{ModuleResolver, ResourceResolver},
 };
 
-pub(crate) struct FastXStateView {
+pub struct FastXStateView {
     pub inner: OnDiskStateView,
 }
 

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -14,5 +14,4 @@ publish = false
 move-binary-format = { git = "https://github.com/diem/diem", rev="661a2d1367a64a02027e4ed8f4b18f0a37cfaa17" }
 
 fastx-types = { path = "../../fastx_types" }
-
 fastx-framework = { path = "../framework" }

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -24,7 +24,7 @@ pub struct Balance(i128);
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
 )]
-pub struct SequenceNumber(u64);
+pub struct SequenceNumber(pub u64);
 
 pub type ShardId = u32;
 pub type VersionNumber = SequenceNumber;
@@ -37,6 +37,23 @@ pub struct KeyPair(dalek::Keypair);
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKeyBytes(pub [u8; dalek::PUBLIC_KEY_LENGTH]);
+
+impl PublicKeyBytes {
+    /// Truncate a public key so it fits into a Move account address
+    // TODO(https://github.com/MystenLabs/fastnft/issues/44): eliminate once we extend size of `AccountAddress`
+    pub fn to_address_hack(&self) -> AccountAddress {
+        AccountAddress::try_from(&self.0[0..AccountAddress::LENGTH]).unwrap()
+    }
+
+    /// Extend an account address into a public key by adding zeros
+    // TODO(https://github.com/MystenLabs/fastnft/issues/44): eliminate once we extend size of `AccountAddress`.
+    pub fn from_move_address_hack(address: &AccountAddress) -> PublicKeyBytes {
+        let mut fastpay_addr = [0u8; dalek::PUBLIC_KEY_LENGTH];
+        let addr_bytes = address.to_vec();
+        fastpay_addr[..addr_bytes.len()].clone_from_slice(&addr_bytes[..]);
+        PublicKeyBytes(fastpay_addr)
+    }
+}
 
 pub type PrimaryAddress = PublicKeyBytes;
 pub type FastPayAddress = PublicKeyBytes;

--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -113,6 +113,10 @@ pub enum FastPayError {
     OrderLockReset,
     #[error("Could not find the referenced object.")]
     ObjectNotFound,
+    #[error("Object ID did not have the expected type")]
+    BadObjectType { error: String },
+    #[error("Move Execution failed")]
+    MoveExecutionFailure,
 }
 
 pub type FastPayResult<T = ()> = Result<T, FastPayError>;

--- a/fastx_types/src/lib.rs
+++ b/fastx_types/src/lib.rs
@@ -16,3 +16,4 @@ pub mod committee;
 pub mod messages;
 pub mod object;
 pub mod serialize;
+pub mod storage;

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -183,6 +183,31 @@ impl Order {
         Order { kind, signature }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_move_call(
+        sender: FastPayAddress,
+        module: ModuleId, // TODO: Could also be ObjectId?
+        function: Identifier,
+        type_arguments: Vec<TypeTag>,
+        gas_payment: ObjectRef,
+        object_arguments: Vec<ObjectRef>,
+        pure_arguments: Vec<Vec<u8>>,
+        gas_budget: u64,
+        secret: &KeyPair,
+    ) -> Self {
+        let kind = OrderKind::Call(MoveCall {
+            sender,
+            module,
+            function,
+            type_arguments,
+            gas_payment,
+            object_arguments,
+            pure_arguments,
+            gas_budget,
+        });
+        Self::new(kind, secret)
+    }
+
     pub fn new_transfer(transfer: Transfer, secret: &KeyPair) -> Self {
         Self::new(OrderKind::Transfer(transfer), secret)
     }

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -44,6 +44,20 @@ pub struct Object {
 }
 
 impl Object {
+    /// Create a new Move object
+    pub fn new_move(
+        type_: StructTag,
+        contents: Vec<u8>,
+        owner: FastPayAddress,
+        next_sequence_number: SequenceNumber,
+    ) -> Self {
+        Object {
+            data: Data::Move(MoveObject { type_, contents }),
+            owner,
+            next_sequence_number,
+        }
+    }
+
     pub fn to_object_reference(&self) -> ObjectRef {
         (self.id(), self.next_sequence_number)
     }
@@ -68,12 +82,9 @@ impl Object {
         self.owner = new_owner;
     }
 
-    // TODO: this should be test-only, but it's still used in bench and server
-    pub fn with_id_for_testing(id: ObjectID) -> Self {
-        use crate::base_types::PublicKeyBytes;
+    pub fn with_id_owner_for_testing(id: ObjectID, owner: FastPayAddress) -> Self {
         use move_core_types::identifier::Identifier;
 
-        let owner = PublicKeyBytes([0; 32]);
         let module = Identifier::new("Test").unwrap();
         let name = Identifier::new("Struct").unwrap();
         let type_params = Vec::new();
@@ -92,5 +103,13 @@ impl Object {
             data,
             next_sequence_number,
         }
+    }
+
+    // TODO: this should be test-only, but it's still used in bench and server
+    pub fn with_id_for_testing(id: ObjectID) -> Self {
+        use crate::base_types::PublicKeyBytes;
+
+        let owner = PublicKeyBytes([0; 32]);
+        Self::with_id_owner_for_testing(id, owner)
     }
 }

--- a/fastx_types/src/storage.rs
+++ b/fastx_types/src/storage.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{base_types::ObjectID, object::Object};
+
+/// An abstraction of the (possibly distributed) store for objects, and (soon) events and transactions
+pub trait Storage {
+    fn read_object(&self, id: &ObjectID) -> Option<Object>;
+
+    fn write_object(&mut self, object: Object);
+
+    fn delete_object(&mut self, id: &ObjectID);
+}


### PR DESCRIPTION
Lots more to be done here, but this is a start at finally connecting these two key components!

- Add `Storage` trait + implement it for `AuthorityState`
- Implement the `ResourceResolver` and `ModuleResolver` traits for `AuthorityState` so it can be used as a DB by the Move VM
- Generalize adapter to operate over `Storage` trait rather than `FastXStateView`
- Add logic for handling `MoveCall` order type in the authority
- Add e2e test that creates a `MoveCall` order invoking a nonexistent module that fails appropriately

Note: this temporarily breaks the CLI version of the fastX adapter (which is not hooked up to tests anyway). It can be fixed by implementing the `Storage` trait for `FastXStateView` + doing a few other things, but I left it broken for now since this PR is already quite meaty.