### PR TITLE
Add storage/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Move build directory
 build
+storage/
 
 .DS_Store
 


### PR DESCRIPTION
When running Move, it creates a storage/ directory, ignore it from git.