### PR TITLE
[verifier] Add global storage access verifier for move

### DIFF
--- a/fastx_programmability/verifier/src/global_storage_access_verifier.rs
+++ b/fastx_programmability/verifier/src/global_storage_access_verifier.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::verification_failure;
+use fastx_types::error::FastPayResult;
+use move_binary_format::{
+    binary_views::BinaryIndexedView,
+    file_format::{Bytecode, CompiledModule},
+};
+
+pub fn verify_module(module: &CompiledModule) -> FastPayResult {
+    verify_global_storage_access(module)
+}
+
+/// Global storage in fastx is handled by fastx instead of within Move.
+/// Hence we want to forbid any global storage access in Move.
+fn verify_global_storage_access(module: &CompiledModule) -> FastPayResult {
+    let view = BinaryIndexedView::Module(module);
+    for func_def in &module.function_defs {
+        if func_def.code.is_none() {
+            continue;
+        }
+        let code = &func_def.code.as_ref().unwrap().code;
+        let mut invalid_bytecode = vec![];
+        for bytecode in code {
+            match bytecode {
+                Bytecode::MoveFrom(_)
+                | Bytecode::MoveFromGeneric(_)
+                | Bytecode::MoveTo(_)
+                | Bytecode::MoveToGeneric(_)
+                | Bytecode::ImmBorrowGlobal(_)
+                | Bytecode::MutBorrowGlobal(_)
+                | Bytecode::ImmBorrowGlobalGeneric(_)
+                | Bytecode::MutBorrowGlobalGeneric(_)
+                | Bytecode::Exists(_)
+                | Bytecode::ExistsGeneric(_) => {
+                    invalid_bytecode.push(bytecode);
+                }
+                Bytecode::Pop
+                | Bytecode::Ret
+                | Bytecode::BrTrue(_)
+                | Bytecode::BrFalse(_)
+                | Bytecode::Branch(_)
+                | Bytecode::LdU8(_)
+                | Bytecode::LdU64(_)
+                | Bytecode::LdU128(_)
+                | Bytecode::CastU8
+                | Bytecode::CastU64
+                | Bytecode::CastU128
+                | Bytecode::LdConst(_)
+                | Bytecode::LdTrue
+                | Bytecode::LdFalse
+                | Bytecode::CopyLoc(_)
+                | Bytecode::MoveLoc(_)
+                | Bytecode::StLoc(_)
+                | Bytecode::Call(_)
+                | Bytecode::CallGeneric(_)
+                | Bytecode::Pack(_)
+                | Bytecode::PackGeneric(_)
+                | Bytecode::Unpack(_)
+                | Bytecode::UnpackGeneric(_)
+                | Bytecode::ReadRef
+                | Bytecode::WriteRef
+                | Bytecode::FreezeRef
+                | Bytecode::MutBorrowLoc(_)
+                | Bytecode::ImmBorrowLoc(_)
+                | Bytecode::MutBorrowField(_)
+                | Bytecode::MutBorrowFieldGeneric(_)
+                | Bytecode::ImmBorrowField(_)
+                | Bytecode::ImmBorrowFieldGeneric(_)
+                | Bytecode::Add
+                | Bytecode::Sub
+                | Bytecode::Mul
+                | Bytecode::Mod
+                | Bytecode::Div
+                | Bytecode::BitOr
+                | Bytecode::BitAnd
+                | Bytecode::Xor
+                | Bytecode::Shl
+                | Bytecode::Shr
+                | Bytecode::Or
+                | Bytecode::And
+                | Bytecode::Not
+                | Bytecode::Eq
+                | Bytecode::Neq
+                | Bytecode::Lt
+                | Bytecode::Gt
+                | Bytecode::Le
+                | Bytecode::Ge
+                | Bytecode::Abort
+                | Bytecode::Nop
+                | Bytecode::VecPack(_, _)
+                | Bytecode::VecLen(_)
+                | Bytecode::VecImmBorrow(_)
+                | Bytecode::VecMutBorrow(_)
+                | Bytecode::VecPushBack(_)
+                | Bytecode::VecPopBack(_)
+                | Bytecode::VecUnpack(_, _)
+                | Bytecode::VecSwap(_) => {}
+            }
+        }
+        if !invalid_bytecode.is_empty() {
+            return Err(verification_failure(format!(
+                "Access to Move global storage is not allowed. Found in function {}: {:?}",
+                view.identifier_at(view.function_handle_at(func_def.function).name),
+                invalid_bytecode,
+            )));
+        }
+    }
+    Ok(())
+}

--- a/fastx_programmability/verifier/src/lib.rs
+++ b/fastx_programmability/verifier/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod verifier;
 
+mod global_storage_access_verifier;
 mod struct_with_key_verifier;
 
 use fastx_types::error::FastPayError;

--- a/fastx_programmability/verifier/src/verifier.rs
+++ b/fastx_programmability/verifier/src/verifier.rs
@@ -6,9 +6,10 @@
 use fastx_types::error::FastPayResult;
 use move_binary_format::file_format::CompiledModule;
 
-use crate::struct_with_key_verifier;
+use crate::{global_storage_access_verifier, struct_with_key_verifier};
 
 /// Helper for a "canonical" verification of a module.
 pub fn verify_module(module: &CompiledModule) -> FastPayResult {
-    struct_with_key_verifier::verify_module(module)
+    struct_with_key_verifier::verify_module(module)?;
+    global_storage_access_verifier::verify_module(module)
 }

--- a/fastx_programmability/verifier/tests/global_storage_access_verification_tests.rs
+++ b/fastx_programmability/verifier/tests/global_storage_access_verification_tests.rs
@@ -1,0 +1,78 @@
+use fastx_verifier::verifier::verify_module;
+use move_binary_format::file_format::*;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+
+fn make_module() -> CompiledModule {
+    CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_MAX,
+        module_handles: vec![ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![Identifier::new("foo").unwrap()],
+        address_identifiers: vec![AccountAddress::new([0u8; AccountAddress::LENGTH])],
+        struct_handles: vec![],
+        struct_defs: vec![],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(0),
+            parameters: SignatureIndex(0),
+            return_: SignatureIndex(0),
+            type_parameters: vec![],
+        }],
+        function_defs: vec![],
+        signatures: vec![
+            Signature(vec![]),                       // void
+            Signature(vec![SignatureToken::Signer]), // Signer
+        ],
+        constant_pool: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    }
+}
+
+#[test]
+fn function_with_global_access_bytecode() {
+    let mut module = make_module();
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Private,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![],
+        }),
+    });
+    assert!(verify_module(&module).is_ok());
+    let code = &mut module.function_defs[0].code.as_mut().unwrap().code;
+    // All the bytecode that could access global storage.
+    code.extend(vec![
+        Bytecode::Exists(StructDefinitionIndex(0)),
+        Bytecode::ImmBorrowGlobal(StructDefinitionIndex(0)),
+        Bytecode::ImmBorrowGlobalGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MoveFrom(StructDefinitionIndex(0)),
+        Bytecode::MoveFromGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MoveTo(StructDefinitionIndex(0)),
+        Bytecode::MoveToGeneric(StructDefInstantiationIndex(0)),
+        Bytecode::MutBorrowGlobal(StructDefinitionIndex(0)),
+        Bytecode::MutBorrowGlobalGeneric(StructDefInstantiationIndex(0)),
+    ]);
+    let invalid_bytecode_str = format!("{:?}", code);
+    // Add a few valid bytecode that doesn't access global storage.
+    code.extend(vec![
+        Bytecode::Add,
+        Bytecode::ImmBorrowField(FieldHandleIndex(0)),
+        Bytecode::Call(FunctionHandleIndex(0)),
+    ]);
+    assert!(verify_module(&module)
+        .unwrap_err()
+        .to_string()
+        .contains(&format!(
+            "Access to Move global storage is not allowed. Found in function foo: {}",
+            invalid_bytecode_str
+        )));
+}


### PR DESCRIPTION
Add a new verifier that forbids any global storage access in Move.
Added unit tests.
close #16 