### PR TITLE
fix: avoid making SequenceNumber's newType pub

### DIFF
--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -555,8 +555,8 @@ where
         self.next_sequence_number = new_next_sequence_number;
         // Sanity check
         assert_eq!(
-            self.sent_certificates.len() as u64,
-            self.next_sequence_number.0
+            self.sent_certificates.len(),
+            usize::from(self.next_sequence_number)
         );
         Ok(())
     }

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -24,7 +24,7 @@ pub struct Balance(i128);
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
 )]
-pub struct SequenceNumber(pub u64);
+pub struct SequenceNumber(u64);
 
 pub type ShardId = u32;
 pub type VersionNumber = SequenceNumber;


### PR DESCRIPTION
#43 introduced a change making the `SequenceNumber` NewType public, and I happened to have the fix at hand.