### PR TITLE
[programmability] processing logic for module publishing

### DIFF
--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "0.2.22", features = ["full"] }
 ed25519 = { version = "1.0.1"}
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde-name = "0.1.2"
+sha3 = "0.9.1"
 structopt = "0.3.21"
 thiserror = "1.0"
 

--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -103,6 +103,10 @@ pub enum FastPayError {
     ModuleLoadFailure { error: String },
     #[error("Failed to verify the Move module, reason: {error:?}.")]
     ModuleVerificationFailure { error: String },
+    #[error("Failed to verify the Move module, reason: {error:?}.")]
+    ModuleDeserializationFailure { error: String },
+    #[error("Failed to publish the Move module(s), reason: {error:?}.")]
+    ModulePublishFailure { error: String },
 
     // Internal state errors
     #[error("Attempt to re-initialize an order lock.")]

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -58,6 +58,18 @@ impl Object {
         }
     }
 
+    pub fn new_module(
+        m: CompiledModule,
+        owner: FastPayAddress,
+        next_sequence_number: SequenceNumber,
+    ) -> Self {
+        Object {
+            data: Data::Module(m),
+            owner,
+            next_sequence_number,
+        }
+    }
+
     pub fn to_object_reference(&self) -> ObjectRef {
         (self.id(), self.next_sequence_number)
     }


### PR DESCRIPTION
Filling out the logic for processing a module publish message. This will allow us to define a fastX genesis transaction containing an initial set of modules, which we need for testing anything with programmability.

This is a bit rough (see the many inline TODO's/tasks), but an important step toward getting a system w/ programmability working end-to-end!

- Added the `TxContext` type, which knows how to generate globally unique ID's from the digest of the current transaction.
- Add `adapter::publish`, which deserializes/verifies a set of input modules, generates fresh object ID's for them, and returns fastX objects containing each module
- Filled out the authority code path that handles a module publish message, did some refactoring to make sure the modules get persisted as output objects
- Added an end-to-end test demonstrating successful publishing of a module.