### PR TITLE
fix: fix dead code warning in release mode

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -550,6 +550,7 @@ impl<'a> AuthorityTemporaryStore<'a> {
     }
 
     /// An internal check of the invariants (will only fire in debug)
+    #[cfg(debug_assertions)]
     fn check_invariants(&self) {
         // Check uniqueness in the 'written' set
         debug_assert!(


### PR DESCRIPTION
#62 introduced a function that's never called in release mode and fires a warning there, breaking the benchmarks. This makes it not exist in release mode.