### PR TITLE
[genesis] add logic for extracting genesis modules for FastX framework

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.115", features = ["derive"] }
 tokio = { version = "0.2.22", features = ["full"] }
 
 fastx-adapter = { path = "../fastx_programmability/adapter" }
+fastx-framework = { path = "../fastx_programmability/framework" }
 fastx-types = { path = "../fastx_types" }
 
 move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }

--- a/fastpay_core/src/genesis.rs
+++ b/fastpay_core/src/genesis.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use fastx_adapter::adapter;
+use fastx_framework::{self};
+use fastx_types::{
+    base_types::{PublicKeyBytes, SequenceNumber, TransactionDigest, TxContext},
+    object::Object,
+    FASTX_FRAMEWORK_ADDRESS,
+};
+
+/// Create and return objects wrapping the genesis modules for fastX
+pub fn create_genesis_module_objects() -> Result<Vec<Object>> {
+    let mut tx_context = TxContext::new(TransactionDigest::genesis());
+    let mut modules = fastx_framework::get_framework_modules()?;
+    adapter::generate_module_ids(&mut modules, &mut tx_context)?;
+    let module_objects = modules
+        .into_iter()
+        .map(|m| {
+            Object::new_module(
+                m,
+                PublicKeyBytes::from_move_address_hack(&FASTX_FRAMEWORK_ADDRESS),
+                SequenceNumber::new(),
+            )
+        })
+        .collect();
+    Ok(module_objects)
+}

--- a/fastpay_core/src/lib.rs
+++ b/fastpay_core/src/lib.rs
@@ -12,3 +12,4 @@ pub mod authority;
 pub mod client;
 pub mod downloader;
 pub mod fastpay_smart_contract;
+pub mod genesis;

--- a/fastx_programmability/adapter/Cargo.toml
+++ b/fastx_programmability/adapter/Cargo.toml
@@ -14,6 +14,7 @@ structopt = "0.3.21"
 
 move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-bytecode-utils = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-cli = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-vm-runtime = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }

--- a/fastx_programmability/adapter/src/bytecode_rewriter.rs
+++ b/fastx_programmability/adapter/src/bytecode_rewriter.rs
@@ -3,14 +3,13 @@
 
 use anyhow::{bail, Result};
 use move_binary_format::{
-    access::ModuleAccess,
-    file_format::{AddressIdentifierIndex, IdentifierIndex, ModuleHandle, ModuleHandleIndex},
+    file_format::{AddressIdentifierIndex, IdentifierIndex},
     CompiledModule,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
 };
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 #[cfg(test)]
 #[path = "unit_tests/bytecode_rewriter_tests.rs"]
@@ -73,97 +72,33 @@ impl ModuleHandleRewriter {
         })
     }
 
-    /// Return the index of the `ModuleHandle` with ID `module_id` in `m`'s module handle table,
-    /// if there is one
-    fn get_module_handle(module_id: &ModuleId, m: &CompiledModule) -> Option<ModuleHandleIndex> {
-        m.module_handles
-            .iter()
-            .position(|h| &m.module_id_for_handle(h) == module_id)
-            .map(|idx| ModuleHandleIndex(idx as u16))
-    }
-
-    /// Return the index of the `ModuleHandle` with ID `module_id` in `m`'s module handle table
-    /// If there is no module handle for `module_id` in `m`'s module handle table, add it
-    fn get_or_create_module_handle(
-        module_id: &ModuleId,
-        m: &mut CompiledModule,
-    ) -> ModuleHandleIndex {
-        Self::get_module_handle(module_id, m).unwrap_or_else(|| {
-            let address = Self::get_or_create_address(module_id.address(), m);
-            let name = Self::get_or_create_identifier(module_id.name(), m);
-            let handle = ModuleHandle { address, name };
-            let next_handle_idx = ModuleHandleIndex(m.module_handles.len() as u16);
-            m.module_handles.push(handle);
-            debug_assert!(
-                &m.module_id_for_handle(m.module_handle_at(next_handle_idx)) == module_id
-            );
-            next_handle_idx
-        })
-    }
-
     /// Apply the module ID substitution in `self.sub_map` to `m`.
     /// Returns an error if the domain of `sub_map` contains a `ModuleID` without a corresponding handle in `m`
-    pub fn sub_module_ids(&self, m: &mut CompiledModule) -> Result<()> {
-        let mut handle_index_sub_map = BTreeMap::new();
-        let (old_ids_for_friends, friends_to_sub): (HashSet<ModuleId>, Vec<(usize, &ModuleId)>) = m
+    pub fn sub_module_ids(&self, m: &mut CompiledModule) {
+        let handles_to_sub = m
+            .module_handles
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, h)| {
+                let old_id = &m.module_id_for_handle(h);
+                self.sub_map.get(old_id).map(|new_id| (idx, new_id))
+            })
+            .collect::<Vec<(usize, &ModuleId)>>();
+        let friends_to_sub = m
             .friend_decls
             .iter()
             .enumerate()
             .filter_map(|(idx, h)| {
-                let old_id = m.module_id_for_handle(h);
-                self.sub_map
-                    .get(&old_id)
-                    .map(|new_id| (old_id, (idx, new_id)))
+                let old_id = &m.module_id_for_handle(h);
+                self.sub_map.get(old_id).map(|new_id| (idx, new_id))
             })
-            .unzip();
-
-        for (old_id, new_id) in self.sub_map.iter() {
-            let old_handle_index = match Self::get_module_handle(old_id, m) {
-                Some(idx) => idx,
-                None => {
-                    if old_ids_for_friends.contains(old_id) {
-                        // old_id is in the friends table; we will sub for it later
-                        continue;
-                    } else {
-                        // `old_id` is not in the module table, and not a friend that we will sub for later. fail
-                        bail!(
-                            "Module ID {:?} in the sub_map domain not found in module `m`",
-                            old_id
-                        )
-                    }
-                }
-            };
-            let new_handle_index = Self::get_or_create_module_handle(new_id, m);
-            let res = handle_index_sub_map.insert(old_handle_index, new_handle_index);
-            debug_assert!(
-                res.is_none(),
-                "There should be exactly one handle for each input ID"
-            )
-        }
-        // maps are always the same size unless there is a friend-only sub
-        debug_assert!(
-            (old_ids_for_friends.is_empty() && handle_index_sub_map.len() == self.sub_map.len())
-                || handle_index_sub_map.len() <= self.sub_map.len()
-        );
-
-        // handle_index_sub_map is ready. walk through the bytecode, find everywhere a handle index in the
-        // domain of the map is used, and replace it with a handle index in the range of the map
-
-        // substitute self address
-        if let Some(new_handle_index) = handle_index_sub_map.get(&m.self_module_handle_idx) {
-            m.self_module_handle_idx = *new_handle_index
-        };
-        // substitute function handles
-        for h in m.function_handles.iter_mut() {
-            if let Some(new_handle_index) = handle_index_sub_map.get(&h.module) {
-                h.module = *new_handle_index
-            }
-        }
-        // substitute struct handles
-        for h in m.struct_handles.iter_mut() {
-            if let Some(new_handle_index) = handle_index_sub_map.get(&h.module) {
-                h.module = *new_handle_index
-            }
+            .collect::<Vec<(usize, &ModuleId)>>();
+        // substitute module handles
+        for (idx, new_id) in handles_to_sub {
+            let new_addr = Self::get_or_create_address(new_id.address(), m);
+            let new_name = Self::get_or_create_identifier(new_id.name(), m);
+            m.module_handles[idx].address = new_addr;
+            m.module_handles[idx].name = new_name;
         }
         // substitute friends
         for (idx, new_id) in friends_to_sub {
@@ -172,7 +107,37 @@ impl ModuleHandleRewriter {
             m.friend_decls[idx].address = new_addr;
             m.friend_decls[idx].name = new_name;
         }
+        // check that substitution did not create duplicate handles or friends. the Move verifier will
+        // also check this later, but it's easier to understand what's going on if we raise the alarm
+        // here.
+        // TODO: if we wanted to, we could support rewriting the tables to eliminate duplicates,
+        // but this is more involved + will never happen in FastX's usage of the rewriter
+        // (modulo hash collisions in ID generation).
+        #[cfg(debug_assertions)]
+        {
+            Self::check_no_duplicate_handles(m)
+        }
+    }
 
-        Ok(())
+    #[cfg(debug_assertions)]
+    fn check_no_duplicate_handles(m: &CompiledModule) {
+        use std::collections::HashSet;
+
+        let mut module_handles = HashSet::new();
+        let mut friends = HashSet::new();
+
+        // Note: it's also possible that the duplicate existed before rewriting. We don't check this
+        debug_assert!(
+            m.module_handles.iter().all(|h| module_handles.insert(h)),
+            "Bytecode rewriting introduced duplicate module handle"
+        );
+        debug_assert!(
+            m.friend_decls.iter().all(|h| friends.insert(h)),
+            "Bytecode rewriting introduced duplicate friends"
+        );
+    }
+
+    pub fn into_inner(self) -> BTreeMap<ModuleId, ModuleId> {
+        self.sub_map
     }
 }

--- a/fastx_programmability/adapter/src/main.rs
+++ b/fastx_programmability/adapter/src/main.rs
@@ -4,7 +4,8 @@
 use anyhow::Result;
 
 use fastx_adapter::state_view::FastXStateView;
-use fastx_framework::{natives, FASTX_FRAMEWORK_ADDRESS, MOVE_STDLIB_ADDRESS};
+use fastx_framework::natives;
+use fastx_types::{FASTX_FRAMEWORK_ADDRESS, MOVE_STDLIB_ADDRESS};
 
 use move_cli::{Command, Move};
 use move_core_types::{

--- a/fastx_programmability/adapter/src/unit_tests/bytecode_rewriter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/bytecode_rewriter_tests.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::file_format::{
-    self, AbilitySet, FunctionHandle, SignatureIndex, StructHandle,
+use move_binary_format::{
+    access::ModuleAccess,
+    file_format::{
+        self, AbilitySet, FunctionHandle, ModuleHandle, ModuleHandleIndex, SignatureIndex,
+        StructHandle,
+    },
 };
 use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 
@@ -41,6 +45,29 @@ fn make_module_handle(id: &ModuleId, m: &mut CompiledModule) -> ModuleHandle {
     }
 }
 
+/// Return the index of the `ModuleHandle` with ID `module_id` in `m`'s module handle table
+/// If there is no module handle for `module_id` in `m`'s module handle table, add it
+fn get_or_create_module_handle(module_id: &ModuleId, m: &mut CompiledModule) -> ModuleHandleIndex {
+    get_module_handle(module_id, m).unwrap_or_else(|| {
+        let address = ModuleHandleRewriter::get_or_create_address(module_id.address(), m);
+        let name = ModuleHandleRewriter::get_or_create_identifier(module_id.name(), m);
+        let handle = ModuleHandle { address, name };
+        let next_handle_idx = ModuleHandleIndex(m.module_handles.len() as u16);
+        m.module_handles.push(handle);
+        debug_assert!(&m.module_id_for_handle(m.module_handle_at(next_handle_idx)) == module_id);
+        next_handle_idx
+    })
+}
+
+/// Return the index of the `ModuleHandle` with ID `module_id` in `m`'s module handle table,
+/// if there is one
+fn get_module_handle(module_id: &ModuleId, m: &CompiledModule) -> Option<ModuleHandleIndex> {
+    m.module_handles
+        .iter()
+        .position(|h| &m.module_id_for_handle(h) == module_id)
+        .map(|idx| ModuleHandleIndex(idx as u16))
+}
+
 #[test]
 fn add_address_and_identifier() {
     // check that adding new addresses and identifier's to the module's table works
@@ -70,19 +97,6 @@ fn add_address_and_identifier() {
     assert!(ModuleHandleRewriter::get_or_create_identifier(name, &mut m) == id_idx);
 }
 
-#[test]
-fn add_module_handle() {
-    let id = make_id(12, ident_str!("Name"));
-
-    let mut m = file_format::empty_module();
-    let old_handles_len = m.module_handles.len();
-    let module_idx = ModuleHandleRewriter::get_or_create_module_handle(&id, &mut m);
-    assert!(m.module_handles.len() == old_handles_len + 1);
-    assert!(m.module_id_for_handle(m.module_handle_at(module_idx)) == id);
-    // after addition, should look up existing handle instead of adding a new one
-    assert!(ModuleHandleRewriter::get_or_create_module_handle(&id, &mut m) == module_idx);
-}
-
 // Check enforcement of the internal "sub map domain and range are disjoint" invariant
 #[test]
 fn test_disjoint_domain_range() {
@@ -102,9 +116,9 @@ fn test_disjoint_domain_range() {
     assert!(ModuleHandleRewriter::new(sub_map).is_err());
 }
 
-// the domain of sub_map must be present in the module we're trying to rewrite
+// it's ok if an element on the domain of sub_map is not present in the module we're trying to rewrite
 #[test]
-fn sub_target_does_not_exist() {
+fn sub_target_does_not_exist_ok() {
     let id1 = make_id(0, ident_str!("Name1"));
     let id2 = make_id(1, ident_str!("Name2"));
 
@@ -115,8 +129,8 @@ fn sub_target_does_not_exist() {
     };
 
     let mut m = file_format::empty_module();
-    // fail's because there's no handle for `id1` in `m`
-    assert!(rewriter.sub_module_ids(&mut m).is_err());
+    // there's no handle for `id1` in `m`, but should work anyway
+    rewriter.sub_module_ids(&mut m)
 }
 
 // the domain of sub_map must be present in the module we're trying to rewrite
@@ -134,13 +148,62 @@ fn sub_friend_only() {
         sub_map.insert(id1.clone(), id2.clone());
         ModuleHandleRewriter::new(sub_map).unwrap()
     };
-    rewriter.sub_module_ids(&mut m).unwrap();
+    rewriter.sub_module_ids(&mut m);
 
     assert!(m.address_identifier_at(m.friend_decls[0].address) == id2.address());
     assert!(m.identifier_at(m.friend_decls[0].name) == id2.name());
 }
 
-// Substitution between two module ID's that already exist in the module table
+// substitution where the new ID does not yet exist in the module table
+#[test]
+fn sub_non_existing() {
+    // id's that exist in the module
+    let old_id1 = make_id(10, ident_str!("Name1"));
+    let old_id2 = make_id(11, ident_str!("Name2"));
+    // an id that does not exist in the module
+    let new_id = make_id(12, ident_str!("Name3"));
+
+    let mut m = file_format::empty_module();
+    // add the old id's to the module
+    let old_idx1 = get_or_create_module_handle(&old_id1, &mut m);
+    let old_idx2 = get_or_create_module_handle(&old_id2, &mut m);
+
+    // add some struct and function handles that use the old id's
+    m.self_module_handle_idx = old_idx2;
+    m.struct_handles.push(make_struct_handle(old_idx2));
+    m.function_handles.push(make_function_handle(old_idx2));
+    m.struct_handles.push(make_struct_handle(old_idx1));
+    m.function_handles.push(make_function_handle(old_idx1));
+    let friend_handle1 = make_module_handle(&old_id2, &mut m);
+    let friend_handle2 = make_module_handle(&old_id1, &mut m);
+    m.friend_decls.push(friend_handle1);
+    m.friend_decls.push(friend_handle2);
+
+    // substitute for new_id, which has not yet been added to the module
+    let old_handles_len = m.module_handles.len();
+    let old_friends_len = m.friend_decls.len();
+    let rewriter = {
+        let mut sub_map = BTreeMap::new();
+        sub_map.insert(old_id1.clone(), new_id.clone());
+        ModuleHandleRewriter::new(sub_map).unwrap()
+    };
+    rewriter.sub_module_ids(&mut m);
+    // module handles and friends tables should not change in size
+    assert!(m.module_handles.len() == old_handles_len);
+    assert!(m.friend_decls.len() == old_friends_len);
+    // substituted handles and friends should have new id's
+    assert!(m.module_id_for_handle(m.module_handle_at(old_idx1)) == new_id);
+    assert!(m.address_identifier_at(m.friend_decls[1].address) == new_id.address());
+    assert!(m.identifier_at(m.friend_decls[1].name) == new_id.name());
+    // unrelated handles and friends should not have changed
+    assert!(m.module_id_for_handle(m.module_handle_at(old_idx2)) == old_id2);
+    assert!(m.address_identifier_at(m.friend_decls[0].address) == old_id2.address());
+    assert!(m.identifier_at(m.friend_decls[0].name) == old_id2.name());
+}
+
+// Substitution between two module ID's that already exist in the module table.
+// This is currently not supported and should cause a panic
+#[should_panic]
 #[test]
 fn sub_existing() {
     let id1 = make_id(10, ident_str!("Name1"));
@@ -148,9 +211,9 @@ fn sub_existing() {
     let id3 = make_id(12, ident_str!("Name3"));
 
     let mut m = file_format::empty_module();
-    let idx1 = ModuleHandleRewriter::get_or_create_module_handle(&id1, &mut m);
-    let idx2 = ModuleHandleRewriter::get_or_create_module_handle(&id2, &mut m);
-    let idx3 = ModuleHandleRewriter::get_or_create_module_handle(&id3, &mut m);
+    let idx1 = get_or_create_module_handle(&id1, &mut m);
+    let _idx2 = get_or_create_module_handle(&id2, &mut m);
+    let idx3 = get_or_create_module_handle(&id3, &mut m);
 
     // set the self ID to idx1
     m.self_module_handle_idx = idx1;
@@ -166,76 +229,10 @@ fn sub_existing() {
     m.friend_decls.push(friend_handle2);
 
     // substitute id1 for id2
-    let old_handles = m.module_handles.clone();
     let rewriter = {
         let mut sub_map = BTreeMap::new();
         sub_map.insert(id1.clone(), id2.clone());
         ModuleHandleRewriter::new(sub_map).unwrap()
     };
-    rewriter.sub_module_ids(&mut m).unwrap();
-    // substitution should not change the module handles table if id2 is already in the module
-    assert!(old_handles == m.module_handles);
-    // substitution should change the contents of the id1 self address, struct handles, friends, and module handles to id2
-    assert!(m.self_module_handle_idx == idx2);
-    assert!(m.struct_handles[0].module == idx2);
-    assert!(m.function_handles[0].module == idx2);
-    assert!(m.address_identifier_at(m.friend_decls[0].address) == id2.address());
-    assert!(m.identifier_at(m.friend_decls[0].name) == id2.name());
-    // but should not change unrelated handles
-    assert!(m.struct_handles[1].module == idx3);
-    assert!(m.function_handles[1].module == idx3);
-    assert!(m.address_identifier_at(m.friend_decls[1].address) == id3.address());
-    assert!(m.identifier_at(m.friend_decls[1].name) == id3.name());
-}
-
-// substitution where the new ID does not yet exist in the module table
-#[test]
-fn sub_non_existing() {
-    // id's that exist in the module
-    let old_id1 = make_id(10, ident_str!("Name1"));
-    let old_id2 = make_id(11, ident_str!("Name2"));
-    // an id that does not exist in the module
-    let new_id = make_id(12, ident_str!("Name3"));
-
-    let mut m = file_format::empty_module();
-    // add the old id's to the module
-    let old_idx1 = ModuleHandleRewriter::get_or_create_module_handle(&old_id1, &mut m);
-    let old_idx2 = ModuleHandleRewriter::get_or_create_module_handle(&old_id2, &mut m);
-
-    // add some struct and function handles that use the old id's
-    m.self_module_handle_idx = old_idx2;
-    m.struct_handles.push(make_struct_handle(old_idx2));
-    m.function_handles.push(make_function_handle(old_idx2));
-    m.struct_handles.push(make_struct_handle(old_idx1));
-    m.function_handles.push(make_function_handle(old_idx1));
-    let friend_handle1 = make_module_handle(&old_id2, &mut m);
-    let friend_handle2 = make_module_handle(&old_id1, &mut m);
-    m.friend_decls.push(friend_handle1);
-    m.friend_decls.push(friend_handle2);
-
-    // substitute for new_id, which has not yet been added to the module
-    let old_handles_len = m.module_handles.len();
-    let rewriter = {
-        let mut sub_map = BTreeMap::new();
-        sub_map.insert(old_id1.clone(), new_id.clone());
-        ModuleHandleRewriter::new(sub_map).unwrap()
-    };
-    rewriter.sub_module_ids(&mut m).unwrap();
-    // module handles table should have grown to accomodate id2
-    assert!(m.module_handles.len() == old_handles_len + 1);
-    // new id should have been added to the end of the table
-    let new_idx = ModuleHandleIndex((m.module_handles.len() - 1) as u16);
-    assert!(m.module_id_for_handle(m.module_handle_at(new_idx)) == new_id);
-
-    // substitution should change the contents of the id1 struct handles, and module handles
-    assert!(m.struct_handles[1].module == new_idx);
-    assert!(m.function_handles[1].module == new_idx);
-    assert!(m.address_identifier_at(m.friend_decls[1].address) == new_id.address());
-    assert!(m.identifier_at(m.friend_decls[1].name) == new_id.name());
-    // but should not change unrelated handles
-    assert!(m.self_module_handle_idx == old_idx2);
-    assert!(m.struct_handles[0].module == old_idx2);
-    assert!(m.function_handles[0].module == old_idx2);
-    assert!(m.address_identifier_at(m.friend_decls[0].address) == old_id2.address());
-    assert!(m.identifier_at(m.friend_decls[0].name) == old_id2.name());
+    rewriter.sub_module_ids(&mut m); // should panic with "rewriting introduced duplicate" here
 }

--- a/fastx_programmability/framework/Cargo.toml
+++ b/fastx_programmability/framework/Cargo.toml
@@ -8,9 +8,14 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+anyhow = "1.0.38"
 smallvec = "1.6.1"
 
+fastx-types = { path = "../../fastx_types" }
+fastx-verifier = { path = "../verifier" }
+
 move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-package = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-stdlib = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }

--- a/fastx_programmability/framework/sources/Authenticator.move
+++ b/fastx_programmability/framework/sources/Authenticator.move
@@ -1,8 +1,6 @@
 module FastX::Authenticator {
     use Std::Signer;
 
-    friend FastX::ID;
-
     /// Authenticator for an end-user (e.g., a public key)
     // TODO: ideally, we would use the Move `address`` type here,
     // but Move forces `address`'s to be 16 bytes
@@ -55,5 +53,7 @@ module FastX::Authenticator {
     }
 
     /// Manufacture an address from these bytes
-    public(friend) native fun bytes_to_address(bytes: vector<u8>): address;
+    // TODO(): bring this back
+    //public(friend) native fun bytes_to_address(bytes: vector<u8>): address;
+    public native fun bytes_to_address(bytes: vector<u8>): address;
 }

--- a/fastx_programmability/framework/sources/ID.move
+++ b/fastx_programmability/framework/sources/ID.move
@@ -2,7 +2,8 @@
 module FastX::ID {
     use FastX::Authenticator;
 
-    friend FastX::TxContext;
+    // TODO(): bring this back
+    //friend FastX::TxContext;
 
     /// Globally unique identifier of an object. This is a privileged type
     /// that can only be derived from a `TxContext`
@@ -17,7 +18,9 @@ module FastX::ID {
     }
 
     /// Create a new ID. Only callable by TxContext
-    public(friend) fun new(bytes: vector<u8>): ID {
+    // TODO (): bring this back
+    //public(friend) fun new(bytes: vector<u8>): ID {
+    public fun new(bytes: vector<u8>): ID {
         ID { id: IDBytes { bytes: Authenticator::bytes_to_address(bytes) } }
     }
 

--- a/fastx_programmability/framework/src/lib.rs
+++ b/fastx_programmability/framework/src/lib.rs
@@ -1,31 +1,62 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::account_address::AccountAddress;
-
-/// 0x1-- account address where Move stdlib modules are stored
-pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::new([
-    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
-]);
-
-/// 0x2-- account address where fastX framework modules are stored
-pub const FASTX_FRAMEWORK_ADDRESS: AccountAddress = AccountAddress::new([
-    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8,
-]);
+use anyhow::Result;
+use fastx_types::MOVE_STDLIB_ADDRESS;
+use fastx_verifier::verifier as fastx_bytecode_verifier;
+use move_binary_format::CompiledModule;
+use move_core_types::{ident_str, language_storage::ModuleId};
+use move_package::{compilation::compiled_package::CompiledPackage, BuildConfig};
+use std::path::PathBuf;
 
 pub mod natives;
 
-#[test]
-fn check_that_move_code_can_be_built() {
-    use move_package::BuildConfig;
-    use std::path::PathBuf;
+/// Return all the modules of the fastX framework and its dependencies in topologically
+/// sorted dependency order (leaves first)
+pub fn get_framework_modules() -> Result<Vec<CompiledModule>> {
+    let include_examples = false;
+    let verify = true;
+    get_framework_modules_(include_examples, verify)
+}
 
+fn get_framework_modules_(include_examples: bool, verify: bool) -> Result<Vec<CompiledModule>> {
+    // TODO: prune unused deps from Move stdlib instead of using an explicit denylist.
+    // The manually curated list are modules that do not pass the FastX verifier
+    let denylist = vec![
+        ModuleId::new(MOVE_STDLIB_ADDRESS, ident_str!("Capability").to_owned()),
+        ModuleId::new(MOVE_STDLIB_ADDRESS, ident_str!("Event").to_owned()),
+        ModuleId::new(MOVE_STDLIB_ADDRESS, ident_str!("GUID").to_owned()),
+    ];
+    let package = build(include_examples)?;
+    let filtered_modules = package
+        .transitive_compiled_modules()
+        .iter_modules_owned()
+        .into_iter()
+        .filter(|m| !denylist.contains(&m.self_id()))
+        .collect();
+    if verify {
+        for m in &filtered_modules {
+            move_bytecode_verifier::verify_module(m).unwrap();
+            fastx_bytecode_verifier::verify_module(m).unwrap();
+            // TODO(https://github.com/MystenLabs/fastnft/issues/69): Run Move linker
+        }
+    }
+    Ok(filtered_modules)
+}
+
+/// Include the Move package's `example` modules if `include_examples` is true, omits them otherwise
+fn build(include_examples: bool) -> Result<CompiledPackage> {
     let framework_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let build_config = BuildConfig {
-        dev_mode: true,
+        dev_mode: include_examples,
         ..Default::default()
     };
-    build_config
-        .compile_package(&framework_dir, &mut Vec::new())
-        .unwrap();
+    build_config.compile_package(&framework_dir, &mut Vec::new())
+}
+
+#[test]
+fn check_that_move_code_can_be_built_and_verified() {
+    let include_examples = true;
+    let verify = true;
+    get_framework_modules_(include_examples, verify).unwrap();
 }

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -13,4 +13,3 @@ move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e3
 move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 
 fastx-types = { path = "../../fastx_types" }
-fastx-framework = { path = "../framework" }

--- a/fastx_programmability/verifier/src/struct_with_key_verifier.rs
+++ b/fastx_programmability/verifier/src/struct_with_key_verifier.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::verification_failure;
-use fastx_framework::FASTX_FRAMEWORK_ADDRESS;
-use fastx_types::{error::FastPayResult, fp_ensure};
+use fastx_types::{error::FastPayResult, fp_ensure, FASTX_FRAMEWORK_ADDRESS};
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,

--- a/fastx_programmability/verifier/tests/id_leak_verification_test.rs
+++ b/fastx_programmability/verifier/tests/id_leak_verification_test.rs
@@ -1,4 +1,4 @@
-use fastx_framework::FASTX_FRAMEWORK_ADDRESS;
+use fastx_types::FASTX_FRAMEWORK_ADDRESS;
 use fastx_verifier::id_leak_verifier::verify_module;
 use move_binary_format::file_format::*;
 use move_core_types::identifier::Identifier;

--- a/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
+++ b/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
@@ -1,5 +1,6 @@
-use fastx_framework::FASTX_FRAMEWORK_ADDRESS;
+use fastx_types::FASTX_FRAMEWORK_ADDRESS;
 use fastx_verifier::struct_with_key_verifier::verify_module;
+
 use move_binary_format::file_format::*;
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -109,6 +109,15 @@ impl TransactionDigest {
     pub fn new(id: ObjectID, seq: SequenceNumber) -> Self {
         Self((id, seq))
     }
+
+    /// Get the mock digest of the genesis transaction
+    /// TODO(https://github.com/MystenLabs/fastnft/issues/65): we can pick anything here    
+    pub fn genesis() -> Self {
+        Self::new(
+            ObjectID::new([0u8; ObjectID::LENGTH]),
+            SequenceNumber::new(),
+        )
+    }
 }
 
 pub fn get_key_pair() -> (FastPayAddress, KeyPair) {

--- a/fastx_types/src/lib.rs
+++ b/fastx_types/src/lib.rs
@@ -8,6 +8,8 @@
 )]
 #![deny(warnings)]
 
+use move_core_types::account_address::AccountAddress;
+
 #[macro_use]
 pub mod error;
 
@@ -17,3 +19,13 @@ pub mod messages;
 pub mod object;
 pub mod serialize;
 pub mod storage;
+
+/// 0x1-- account address where Move stdlib modules are stored
+pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::new([
+    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
+]);
+
+/// 0x2-- account address where fastX framework modules are stored
+pub const FASTX_FRAMEWORK_ADDRESS: AccountAddress = AccountAddress::new([
+    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8,
+]);


### PR DESCRIPTION
- Add code in `framework/lib.rs` to build and verify the FastX framework Move modules + their dependencies in the Move stdlib and hand back a list of `CompiledModule`s. Add test to ensure that this code always works on the current set of framework modules.
- Add genesis.rs, which calls this code and wraps each module in an `Object` with a freshly generated ID
- Add an authority test that creates a genesis state with a module `M` in it, then successfully processes a new `publish` order containing a module that depends on `M`.
- Fix bugs in `publish` flow revealed by attempting to write this test.

A couple of major issues came up during this that will need to be fixed later. The easier, but less high-pri one is: https://github.com/MystenLabs/fastnft/issues/69; it basically stops us from calling the Move linke. The naster, and much more high-pri one (it stops us from creating a genesis with modules that depend on each other) is https://github.com/MystenLabs/fastnft/issues/71.