### PR TITLE
Add ID leak verifier

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -401,7 +401,7 @@ impl AuthorityState {
         let object = self.object_state(&object_id)?;
         let lock = self
             .get_order_lock(&object.to_object_reference())
-            .or(Ok(&None))?;
+            .or::<FastPayError>(Ok(&None))?;
 
         Ok(AccountInfoResponse {
             object_id: object.id(),

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
 
 fastx-types = { path = "../../fastx_types" }

--- a/fastx_programmability/verifier/src/id_leak_verifier.rs
+++ b/fastx_programmability/verifier/src/id_leak_verifier.rs
@@ -1,0 +1,398 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+//! Objects whose struct type has key ability represent FastNFT objects.
+//! They have unique IDs that should never be reused. This verifier makes
+//! sure that the id field of FastNFT objects never get leaked.
+//! Unpack is the only bytecode that could extract the id field out of
+//! a FastNFT object. From there, we track the flow of the value and make
+//! sure it can never get leaked outside of the function. There are four
+//! ways it can happen:
+//! 1. Returned
+//! 2. Written into a mutable reference
+//! 3. Added to a vector
+//! 4. Passed to a function call
+
+use crate::verification_failure;
+use fastx_types::error::{FastPayError, FastPayResult};
+use move_binary_format::{
+    binary_views::{BinaryIndexedView, FunctionView},
+    file_format::{
+        Bytecode, CodeOffset, CompiledModule, FunctionDefinitionIndex, FunctionHandle, LocalIndex,
+        StructDefinition, StructFieldInformation,
+    },
+};
+use move_bytecode_verifier::absint::{
+    AbstractDomain, AbstractInterpreter, BlockInvariant, BlockPostcondition, JoinResult,
+    TransferFunctions,
+};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AbstractValue {
+    ID,
+    NonID,
+}
+
+impl AbstractValue {
+    pub fn join(&self, value: &AbstractValue) -> AbstractValue {
+        if self == value {
+            *value
+        } else {
+            AbstractValue::ID
+        }
+    }
+}
+
+pub fn verify_module(module: &CompiledModule) -> FastPayResult {
+    verify_id_leak(module)
+}
+
+fn verify_id_leak(module: &CompiledModule) -> FastPayResult {
+    let binary_view = BinaryIndexedView::Module(module);
+    for (index, func_def) in module.function_defs.iter().enumerate() {
+        let code = match func_def.code.as_ref() {
+            Some(code) => code,
+            None => continue,
+        };
+        let handle = binary_view.function_handle_at(func_def.function);
+        let func_view =
+            FunctionView::function(module, FunctionDefinitionIndex(index as u16), code, handle);
+        let initial_state = AbstractState::new(&func_view);
+        let mut verifier = IDLeakAnalysis::new(&binary_view, &func_view);
+        let inv_map = verifier.analyze_function(initial_state, &func_view);
+        // Report all the join failures
+        for (_block_id, BlockInvariant { post, .. }) in inv_map {
+            match post {
+                BlockPostcondition::Error(err) => match err {
+                    FastPayError::ModuleVerificationFailure { error } => {
+                        return Err(FastPayError::ModuleVerificationFailure {
+                            error: format!(
+                                "ID leak detected in function {}: {}",
+                                binary_view.identifier_at(handle.name),
+                                error
+                            ),
+                        });
+                    }
+                    _ => {
+                        panic!("Unexpected error type");
+                    }
+                },
+                // Block might be unprocessed if all predecessors had an error
+                BlockPostcondition::Unprocessed | BlockPostcondition::Success => (),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct AbstractState {
+    locals: BTreeMap<LocalIndex, AbstractValue>,
+}
+
+impl AbstractState {
+    /// create a new abstract state
+    pub fn new(function_view: &FunctionView) -> Self {
+        let mut state = AbstractState {
+            locals: BTreeMap::new(),
+        };
+
+        for param_idx in 0..function_view.parameters().len() {
+            state
+                .locals
+                .insert(param_idx as LocalIndex, AbstractValue::NonID);
+        }
+
+        state
+    }
+}
+
+impl AbstractDomain for AbstractState {
+    /// attempts to join state to self and returns the result
+    fn join(&mut self, state: &AbstractState) -> JoinResult {
+        let mut changed = false;
+        for (local, value) in &state.locals {
+            let old_value = *self.locals.get(local).unwrap_or(&AbstractValue::NonID);
+            changed |= *value != old_value;
+            self.locals.insert(*local, value.join(&old_value));
+        }
+        if changed {
+            JoinResult::Changed
+        } else {
+            JoinResult::Unchanged
+        }
+    }
+}
+
+struct IDLeakAnalysis<'a> {
+    binary_view: &'a BinaryIndexedView<'a>,
+    function_view: &'a FunctionView<'a>,
+    stack: Vec<AbstractValue>,
+}
+
+impl<'a> IDLeakAnalysis<'a> {
+    fn new(binary_view: &'a BinaryIndexedView<'a>, function_view: &'a FunctionView<'a>) -> Self {
+        Self {
+            binary_view,
+            function_view,
+            stack: vec![],
+        }
+    }
+}
+
+impl<'a> TransferFunctions for IDLeakAnalysis<'a> {
+    type State = AbstractState;
+    type AnalysisError = FastPayError;
+
+    fn execute(
+        &mut self,
+        state: &mut Self::State,
+        bytecode: &Bytecode,
+        index: CodeOffset,
+        _: CodeOffset,
+    ) -> Result<(), Self::AnalysisError> {
+        execute_inner(self, state, bytecode, index)?;
+        Ok(())
+    }
+}
+
+impl<'a> AbstractInterpreter for IDLeakAnalysis<'a> {}
+
+fn call(verifier: &mut IDLeakAnalysis, function_handle: &FunctionHandle) -> FastPayResult {
+    let parameters = verifier
+        .binary_view
+        .signature_at(function_handle.parameters);
+    for _ in 0..parameters.len() {
+        if verifier.stack.pop().unwrap() == AbstractValue::ID {
+            return Err(verification_failure(
+                "ID leaked through function call.".to_string(),
+            ));
+        }
+    }
+
+    let return_ = verifier.binary_view.signature_at(function_handle.return_);
+    for _ in 0..return_.0.len() {
+        verifier.stack.push(AbstractValue::NonID);
+    }
+    Ok(())
+}
+
+fn num_fields(struct_def: &StructDefinition) -> usize {
+    match &struct_def.field_information {
+        StructFieldInformation::Native => 0,
+        StructFieldInformation::Declared(fields) => fields.len(),
+    }
+}
+
+fn pack(verifier: &mut IDLeakAnalysis, struct_def: &StructDefinition) {
+    let mut has_id = false;
+    for _ in 0..num_fields(struct_def) {
+        has_id |= verifier.stack.pop().unwrap() == AbstractValue::ID;
+    }
+    verifier.stack.push(if has_id {
+        AbstractValue::ID
+    } else {
+        AbstractValue::NonID
+    });
+}
+
+fn unpack(verifier: &mut IDLeakAnalysis, struct_def: &StructDefinition) {
+    // When unpacking, fields of the struct will be pushed to the stack in order.
+    // An object whose struct type has key ability must have the first field as "id",
+    // representing the ID field of the object. It's the focus of our tracking.
+    // The struct_with_key_verifier verifies that the first field must be the id field.
+    verifier.stack.pop().unwrap();
+    let handle = verifier
+        .binary_view
+        .struct_handle_at(struct_def.struct_handle);
+    verifier.stack.push(if handle.abilities.has_key() {
+        AbstractValue::ID
+    } else {
+        AbstractValue::NonID
+    });
+    for _ in 1..num_fields(struct_def) {
+        verifier.stack.push(AbstractValue::NonID);
+    }
+}
+
+fn execute_inner(
+    verifier: &mut IDLeakAnalysis,
+    state: &mut AbstractState,
+    bytecode: &Bytecode,
+    _: CodeOffset,
+) -> FastPayResult {
+    // TODO: Better dianostics with location
+    match bytecode {
+        Bytecode::Pop => {
+            verifier.stack.pop().unwrap();
+        }
+        Bytecode::CopyLoc(local) => {
+            let value = state.locals.get(local).unwrap();
+            verifier.stack.push(*value);
+        }
+        Bytecode::MoveLoc(local) => {
+            let value = state.locals.remove(local).unwrap();
+            verifier.stack.push(value);
+        }
+        Bytecode::StLoc(local) => {
+            let value = verifier.stack.pop().unwrap();
+            state.locals.insert(*local, value);
+        }
+
+        // Reference won't be ID.
+        Bytecode::FreezeRef
+        // ID doesn't have copy ability, hence ReadRef won't produce an ID.
+        | Bytecode::ReadRef
+        // Following are unary operators that don't apply to ID.
+        | Bytecode::CastU8
+        | Bytecode::CastU64
+        | Bytecode::CastU128
+        | Bytecode::Not
+        | Bytecode::VecLen(_)
+        | Bytecode::VecPopBack(_) => {
+            verifier.stack.pop().unwrap();
+            verifier.stack.push(AbstractValue::NonID);
+        }
+
+        // These bytecodes don't operate on any value.
+        Bytecode::Branch(_)
+        | Bytecode::Nop => {}
+
+        // These binary operators cannot produce ID as result.
+        Bytecode::Eq
+        | Bytecode::Neq
+        | Bytecode::Add
+        | Bytecode::Sub
+        | Bytecode::Mul
+        | Bytecode::Mod
+        | Bytecode::Div
+        | Bytecode::BitOr
+        | Bytecode::BitAnd
+        | Bytecode::Xor
+        | Bytecode::Shl
+        | Bytecode::Shr
+        | Bytecode::Or
+        | Bytecode::And
+        | Bytecode::Lt
+        | Bytecode::Gt
+        | Bytecode::Le
+        | Bytecode::Ge
+        | Bytecode::VecImmBorrow(_)
+        | Bytecode::VecMutBorrow(_) => {
+            verifier.stack.pop().unwrap();
+            verifier.stack.pop().unwrap();
+            verifier.stack.push(AbstractValue::NonID);
+        }
+        Bytecode::WriteRef => {
+            // Top of stack is the reference, and the second element is the value.
+            verifier.stack.pop().unwrap();
+            if verifier.stack.pop().unwrap() == AbstractValue::ID {
+                return Err(verification_failure("ID is leaked to a reference.".to_string()));
+            }
+        }
+
+        // These bytecodes produce references, and hence cannot be ID.
+        Bytecode::MutBorrowLoc(_)
+        | Bytecode::ImmBorrowLoc(_)
+        | Bytecode::MutBorrowField(_)
+        | Bytecode::MutBorrowFieldGeneric(_)
+        | Bytecode::ImmBorrowField(_)
+        | Bytecode::ImmBorrowFieldGeneric(_) => {
+            verifier.stack.push(AbstractValue::NonID);
+        }
+
+        // These bytecodes are not allowed, and will be
+        // flagged as error in a different verifier.
+        Bytecode::MoveFrom(_)
+                | Bytecode::MoveFromGeneric(_)
+                | Bytecode::MoveTo(_)
+                | Bytecode::MoveToGeneric(_)
+                | Bytecode::ImmBorrowGlobal(_)
+                | Bytecode::MutBorrowGlobal(_)
+                | Bytecode::ImmBorrowGlobalGeneric(_)
+                | Bytecode::MutBorrowGlobalGeneric(_)
+                | Bytecode::Exists(_)
+                | Bytecode::ExistsGeneric(_) => {
+            panic!("Should have been checked by global_storage_access_verifier.");
+        }
+
+        Bytecode::Call(idx) => {
+            let function_handle = verifier.binary_view.function_handle_at(*idx);
+            call(verifier, function_handle)?;
+        }
+        Bytecode::CallGeneric(idx) => {
+            let func_inst = verifier.binary_view.function_instantiation_at(*idx);
+            let function_handle = verifier.binary_view.function_handle_at(func_inst.handle);
+            call(verifier, function_handle)?;
+        }
+
+        Bytecode::Ret => {
+            for _ in 0..verifier.function_view.return_().len() {
+                if verifier.stack.pop().unwrap() == AbstractValue::ID {
+                    return Err(verification_failure("ID leaked through function return.".to_string()));
+                }
+            }
+        }
+
+        Bytecode::BrTrue(_) | Bytecode::BrFalse(_) | Bytecode::Abort => {
+            verifier.stack.pop().unwrap();
+        }
+
+        // These bytecodes produce constants, and hence cannot be ID.
+        Bytecode::LdTrue | Bytecode::LdFalse | Bytecode::LdU8(_) | Bytecode::LdU64(_) | Bytecode::LdU128(_) | Bytecode::LdConst(_) => {
+            verifier.stack.push(AbstractValue::NonID);
+        }
+
+        Bytecode::Pack(idx) => {
+            let struct_def = verifier.binary_view.struct_def_at(*idx)?;
+            pack(verifier, struct_def);
+        }
+        Bytecode::PackGeneric(idx) => {
+            let struct_inst = verifier.binary_view.struct_instantiation_at(*idx)?;
+            let struct_def = verifier.binary_view.struct_def_at(struct_inst.def)?;
+            pack(verifier, struct_def);
+        }
+        Bytecode::Unpack(idx) => {
+            let struct_def = verifier.binary_view.struct_def_at(*idx)?;
+            unpack(verifier, struct_def);
+        }
+        Bytecode::UnpackGeneric(idx) => {
+            let struct_inst = verifier.binary_view.struct_instantiation_at(*idx)?;
+            let struct_def = verifier.binary_view.struct_def_at(struct_inst.def)?;
+            unpack(verifier, struct_def);
+        }
+
+        Bytecode::VecPack(_, num) => {
+            for _ in 0..*num {
+                if verifier.stack.pop().unwrap() == AbstractValue::ID {
+                    return Err(verification_failure("ID is leaked into a vector".to_string()));
+                }
+            }
+            verifier.stack.push(AbstractValue::NonID);
+        }
+
+        Bytecode::VecPushBack(_) => {
+            if verifier.stack.pop().unwrap() == AbstractValue::ID {
+                return Err(verification_failure("ID is leaked into a vector".to_string()));
+            }
+            verifier.stack.pop().unwrap();
+        }
+
+        Bytecode::VecUnpack(_, num) => {
+            verifier.stack.pop().unwrap();
+
+            for _ in 0..*num {
+                verifier.stack.push(AbstractValue::NonID);
+            }
+        }
+
+        Bytecode::VecSwap(_) => {
+            verifier.stack.pop().unwrap();
+            verifier.stack.pop().unwrap();
+            verifier.stack.pop().unwrap();
+        }
+    };
+    Ok(())
+}

--- a/fastx_programmability/verifier/src/lib.rs
+++ b/fastx_programmability/verifier/src/lib.rs
@@ -3,8 +3,9 @@
 
 pub mod verifier;
 
-mod global_storage_access_verifier;
-mod struct_with_key_verifier;
+pub mod global_storage_access_verifier;
+pub mod id_leak_verifier;
+pub mod struct_with_key_verifier;
 
 use fastx_types::error::FastPayError;
 

--- a/fastx_programmability/verifier/src/verifier.rs
+++ b/fastx_programmability/verifier/src/verifier.rs
@@ -6,10 +6,11 @@
 use fastx_types::error::FastPayResult;
 use move_binary_format::file_format::CompiledModule;
 
-use crate::{global_storage_access_verifier, struct_with_key_verifier};
+use crate::{global_storage_access_verifier, id_leak_verifier, struct_with_key_verifier};
 
 /// Helper for a "canonical" verification of a module.
 pub fn verify_module(module: &CompiledModule) -> FastPayResult {
     struct_with_key_verifier::verify_module(module)?;
-    global_storage_access_verifier::verify_module(module)
+    global_storage_access_verifier::verify_module(module)?;
+    id_leak_verifier::verify_module(module)
 }

--- a/fastx_programmability/verifier/tests/global_storage_access_verification_tests.rs
+++ b/fastx_programmability/verifier/tests/global_storage_access_verification_tests.rs
@@ -1,4 +1,4 @@
-use fastx_verifier::verifier::verify_module;
+use fastx_verifier::global_storage_access_verifier::verify_module;
 use move_binary_format::file_format::*;
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 

--- a/fastx_programmability/verifier/tests/id_leak_verification_test.rs
+++ b/fastx_programmability/verifier/tests/id_leak_verification_test.rs
@@ -1,0 +1,278 @@
+use fastx_framework::FASTX_FRAMEWORK_ADDRESS;
+use fastx_verifier::id_leak_verifier::verify_module;
+use move_binary_format::file_format::*;
+use move_core_types::identifier::Identifier;
+
+fn make_module() -> CompiledModule {
+    /*
+    We are setting up a module that looks like this:
+    struct Foo has key {
+        id: 0x1::ID::ID
+    }
+    */
+    CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_MAX,
+        module_handles: vec![ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("ID").unwrap(), // ID Module name as well as struct name
+            Identifier::new("S").unwrap(),  // Test struct name
+            Identifier::new("id").unwrap(), // id field
+            Identifier::new("foo").unwrap(), // Test function name
+            Identifier::new("transfer").unwrap(),
+        ],
+        address_identifiers: vec![FASTX_FRAMEWORK_ADDRESS],
+        struct_handles: vec![
+            // The FASTX_FRAMEWORK_ADDRESS::ID::ID struct
+            StructHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(0),
+                abilities: AbilitySet::EMPTY | Ability::Store | Ability::Drop,
+                type_parameters: vec![],
+            },
+            // A struct with key ability
+            StructHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                abilities: AbilitySet::EMPTY | Ability::Key,
+                type_parameters: vec![],
+            },
+        ],
+        struct_defs: vec![StructDefinition {
+            struct_handle: StructHandleIndex(1),
+            field_information: StructFieldInformation::Declared(vec![
+                // id field.
+                FieldDefinition {
+                    name: IdentifierIndex(2),
+                    signature: TypeSignature(SignatureToken::Struct(StructHandleIndex(0))),
+                },
+            ]),
+        }],
+        function_handles: vec![],
+        function_defs: vec![],
+        signatures: vec![
+            Signature(vec![]),                                             // void
+            Signature(vec![SignatureToken::Struct(StructHandleIndex(0))]), // (ID)
+            Signature(vec![SignatureToken::Struct(StructHandleIndex(1))]), // (S)
+        ],
+        constant_pool: vec![],
+        field_handles: vec![],
+        friend_decls: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    }
+}
+
+#[test]
+fn id_leak_through_direct_return() {
+    /*
+    fun foo(f: Foo): 0x1::ID::ID {
+        let Foo { id: id } = f;
+        return id;
+    }
+    */
+    let mut module = make_module();
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(3),
+        parameters: SignatureIndex(2),
+        return_: SignatureIndex(1),
+        type_parameters: vec![],
+    });
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Private,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![
+                Bytecode::MoveLoc(0),
+                Bytecode::Unpack(StructDefinitionIndex(0)),
+                Bytecode::Ret,
+            ],
+        }),
+    });
+    let result = verify_module(&module);
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("ID leak detected in function foo: ID leaked through function return."));
+}
+
+#[test]
+fn id_leak_through_indirect_return() {
+    /*
+    fun foo(f: Foo): Foo {
+        let Foo { id: id } = f;
+        let r = Foo { id: id };
+        return r;
+    }
+    */
+    let mut module = make_module();
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(3),
+        parameters: SignatureIndex(2),
+        return_: SignatureIndex(1),
+        type_parameters: vec![],
+    });
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Private,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![
+                Bytecode::MoveLoc(0),
+                Bytecode::Unpack(StructDefinitionIndex(0)),
+                Bytecode::Pack(StructDefinitionIndex(0)),
+                Bytecode::Ret,
+            ],
+        }),
+    });
+    let result = verify_module(&module);
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("ID leak detected in function foo: ID leaked through function return."));
+}
+
+#[test]
+fn id_leak_through_reference() {
+    /*
+    fun foo(f: Foo, ref: &mut 0x1::ID::ID) {
+        let Foo { id: id } = f;
+        *ref = id;
+    }
+    */
+    let mut module = make_module();
+    module.signatures.push(Signature(vec![
+        SignatureToken::Struct(StructHandleIndex(1)),
+        SignatureToken::MutableReference(Box::new(SignatureToken::Struct(StructHandleIndex(0)))),
+    ]));
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(3),
+        parameters: SignatureIndex(3),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    });
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Private,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![
+                Bytecode::MoveLoc(0),
+                Bytecode::Unpack(StructDefinitionIndex(0)),
+                Bytecode::MoveLoc(1),
+                Bytecode::WriteRef,
+                Bytecode::Ret,
+            ],
+        }),
+    });
+    let result = verify_module(&module);
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("ID leak detected in function foo: ID is leaked to a reference."));
+}
+
+#[test]
+fn id_direct_leak_through_call() {
+    /*
+    fun transfer(id: 0x1::ID::ID);
+
+    fun foo(f: Foo) {
+        let Foo { id: id } = f;
+        transfer(id);
+    }
+    */
+    let mut module = make_module();
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(3),
+        parameters: SignatureIndex(2),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    });
+    // A dummy transfer function.
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(4),
+        parameters: SignatureIndex(1),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    });
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Private,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![
+                Bytecode::MoveLoc(0),
+                Bytecode::Unpack(StructDefinitionIndex(0)),
+                Bytecode::Call(FunctionHandleIndex(1)),
+            ],
+        }),
+    });
+    let result = verify_module(&module);
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("ID leak detected in function foo: ID leaked through function call."));
+}
+
+#[test]
+fn id_indirect_leak_through_call() {
+    /*
+    fun transfer(f: Foo);
+
+    fun foo(f: Foo) {
+        let Foo { id: id } = f;
+        let newf = Foo { id: id };
+        transfer(newf);
+    }
+    */
+    let mut module = make_module();
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(3),
+        parameters: SignatureIndex(2),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    });
+    // A dummy transfer function.
+    module.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(4),
+        parameters: SignatureIndex(2),
+        return_: SignatureIndex(0),
+        type_parameters: vec![],
+    });
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: Visibility::Private,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![
+                Bytecode::MoveLoc(0),
+                Bytecode::Unpack(StructDefinitionIndex(0)),
+                Bytecode::Pack(StructDefinitionIndex(0)),
+                Bytecode::Call(FunctionHandleIndex(1)),
+            ],
+        }),
+    });
+    let result = verify_module(&module);
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("ID leak detected in function foo: ID leaked through function call."));
+}

--- a/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
+++ b/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
@@ -1,5 +1,5 @@
 use fastx_framework::FASTX_FRAMEWORK_ADDRESS;
-use fastx_verifier::verifier::verify_module;
+use fastx_verifier::struct_with_key_verifier::verify_module;
 use move_binary_format::file_format::*;
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 

--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -4,6 +4,7 @@
 use thiserror::Error;
 
 use crate::{base_types::*, messages::*};
+use move_binary_format::errors::PartialVMError;
 use serde::{Deserialize, Serialize};
 
 #[macro_export]
@@ -128,3 +129,11 @@ pub enum FastPayError {
 }
 
 pub type FastPayResult<T = ()> = Result<T, FastPayError>;
+
+impl std::convert::From<PartialVMError> for FastPayError {
+    fn from(error: PartialVMError) -> Self {
+        FastPayError::ModuleVerificationFailure {
+            error: error.to_string(),
+        }
+    }
+}


### PR DESCRIPTION
FastNFT object IDs need to be unique and have 1:1 mapping to the object. This verifier checks that the id field of a key object never gets leaked, which could lead to the id being used in a different object.
The leakage of an ID starts when unpack happens on a FastNFT object (object whose struct type has key ability). This verifier uses abstract interpretation to track the flow of this ID, and makes sure:
1. It never gets returned
2. It never gets written into a mutable reference
3. It never gets added to a vector

Note:
We don't prevent packing an ID to an object, because it is safe to do so as long as the object never gets leaked in any of the ways above.
We prevents ID going into a vector because most vector operations operate on references, which makes it impossible to know what happens after the leak.

This commit depends on https://github.com/diem/diem/pull/10071 from Diem repo to make absint module public. We need that to go in first, bump Diem version in FastNFT, before we could land this.