### PR TITLE
[diem dep] bump diem version to 346301f33b3489bb4e486ae6c0aa5e030223b492

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -17,6 +17,6 @@ fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-framework = { path = "../fastx_programmability/framework" }
 fastx-types = { path = "../fastx_types" }
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
 

--- a/fastx_programmability/adapter/Cargo.toml
+++ b/fastx_programmability/adapter/Cargo.toml
@@ -12,12 +12,12 @@ anyhow = "1.0.38"
 bcs = "0.1.2"
 structopt = "0.3.21"
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-bytecode-utils = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-cli = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-vm-runtime = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-bytecode-utils = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-cli = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-vm-runtime = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
 
 fastx-framework = { path = "../framework" }
 fastx-verifier = { path = "../verifier" }

--- a/fastx_programmability/framework/Cargo.toml
+++ b/fastx_programmability/framework/Cargo.toml
@@ -14,10 +14,10 @@ smallvec = "1.6.1"
 fastx-types = { path = "../../fastx_types" }
 fastx-verifier = { path = "../verifier" }
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-package = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-stdlib = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-vm-runtime = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-vm-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-package = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-stdlib = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-vm-runtime = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-vm-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
 
 fastx-types = { path = "../../fastx_types" }

--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -22,5 +22,5 @@ sha3 = "0.9.1"
 structopt = "0.3.21"
 thiserror = "1.0"
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
-move-core-types = { git = "https://github.com/diem/diem", rev="5572eae5e35407f10316b473f95cb155a5e8d40b" }
+move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }


### PR DESCRIPTION
This will allow us to use the new VM API introduced in https://github.com/diem/diem/pull/10073 in the fastX adapter.