### PR TITLE
[fastx types] stored module bytes in Object instead of CompiledModule

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -664,11 +664,7 @@ impl<'a> ModuleResolver for AuthorityTemporaryStore<'a> {
             .get(module_id.address())
         {
             Some(o) => match &o.data {
-                Data::Module(c) => {
-                    let mut bytes = Vec::new();
-                    c.serialize(&mut bytes).expect("Invariant violation: serialization of well-formed module should never fail");
-                    Ok(Some(bytes))
-                }
+                Data::Module(c) => Ok(Some(c.clone())),
                 _ => Err(FastPayError::BadObjectType {
                     error: "Expected module object".to_string(),
                 }),

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -190,11 +190,11 @@ fn test_publish_dependent_module_ok() {
     // create a genesis state that contains the gas object and genesis modules
     let mut genesis_module_objects = genesis::create_genesis_module_objects().unwrap();
     let genesis_module = match &genesis_module_objects[0].data {
-        Data::Module(m) => m,
+        Data::Module(m) => CompiledModule::deserialize(m).unwrap(),
         _ => unreachable!(),
     };
     // create a module that depends on a genesis module
-    let dependent_module = make_dependent_module(genesis_module);
+    let dependent_module = make_dependent_module(&genesis_module);
     let dependent_module_bytes = {
         let mut bytes = Vec::new();
         dependent_module.serialize(&mut bytes).unwrap();


### PR DESCRIPTION
This should allow us to derive `Serialize` and `Deserialize` for `Object`.