### PR TITLE
[fastx benchmarking] Removed unnecessary TX order sending

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -34,16 +34,16 @@ struct ClientServerBenchmark {
     #[structopt(long, default_value = "9555")]
     port: u32,
     /// Size of the FastPay committee
-    #[structopt(long, default_value = "10")]
+    #[structopt(name = "committee-size", long, default_value = "10")]
     committee_size: usize,
     /// Number of shards per FastPay authority
-    #[structopt(long, default_value = "15")]
+    #[structopt(name = "num-shards", long, default_value = "15")]
     num_shards: u32,
     /// Maximum number of requests in flight (0 for blocking client)
     #[structopt(long, default_value = "1000")]
     max_in_flight: usize,
     /// Number of accounts and transactions used in the benchmark
-    #[structopt(long, default_value = "40000")]
+    #[structopt(name = "num-accounts", long, default_value = "40000")]
     num_accounts: usize,
     /// Timeout for sending queries (us)
     #[structopt(long, default_value = "4000000")]
@@ -105,12 +105,12 @@ impl ClientServerBenchmark {
         };
 
         // Pick an authority and create one state per shard.
-        let (public_auth0, secret_auth0) = keys.pop().unwrap();
+        let (public_auth0, secret_auth0) = &keys[0];
         let mut states = Vec::new();
         for i in 0..self.num_shards {
             let state = AuthorityState::new_shard(
                 committee.clone(),
-                public_auth0,
+                *public_auth0,
                 secret_auth0.copy(),
                 i as u32,
                 self.num_shards,


### PR DESCRIPTION
![fastx_flow](https://user-images.githubusercontent.com/93547199/147423677-f4d0546c-1280-4de3-9285-0d00c9f907ba.png)
`Reasoning:`
Current benchmark measures B-C-D and F-G-H and returns the sum.
**In lines 160-164 we already certify the TX (which eliminates steps B-D), so there is no need to send the orders to the authorities.
However in measuring the throughput, should we include this roundtrip just for completeness sake? @gdanezis** 

By removing B-D, throughput is 34% higher => 35000tx/s vs 26000 tx/s

`Solution`
This PR provides the option to measure B-C-D and F-G-H separately, or both via CLI selector.
Will enhance this in future to optionally measure end-to-end (B-H and B-L)