### PR TITLE
[fastx types] Add gas coin type

### DIFF
--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -3,12 +3,12 @@
 
 use anyhow::Result;
 
-use crate::{
-    bytecode_rewriter::ModuleHandleRewriter,
-    genesis::{TX_CONTEXT_ADDRESS, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
-};
+use crate::bytecode_rewriter::ModuleHandleRewriter;
 use fastx_types::{
-    base_types::{FastPayAddress, ObjectID, ObjectRef, SequenceNumber, TxContext},
+    base_types::{
+        FastPayAddress, ObjectID, ObjectRef, SequenceNumber, TxContext, TX_CONTEXT_ADDRESS,
+        TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
+    },
     error::{FastPayError, FastPayResult},
     object::{Data, MoveObject, Object},
     storage::Storage,

--- a/fastx_programmability/framework/sources/GAS.move
+++ b/fastx_programmability/framework/sources/GAS.move
@@ -1,0 +1,19 @@
+/// Coin<Gas> is the token used to pay for gas in FastX
+module FastX::GAS {
+    use FastX::Coin;
+    use FastX::Transfer;
+    use FastX::TxContext::{Self, TxContext};
+
+    /// Name of the coin
+    struct GAS has drop {}
+
+    /// Register the token to acquire its `TreasuryCap`. Because
+    /// this is a module initializer, it ensures the currency only gets
+    /// registered once.
+    // TODO(https://github.com/MystenLabs/fastnft/issues/90): implement module initializers
+    fun init(ctx: &mut TxContext) {
+        // Get a treasury cap for the coin and give it to the transaction sender
+        let treasury_cap = Coin::create_currency(GAS{}, ctx);
+        Transfer::transfer(treasury_cap, TxContext::get_signer_address(ctx))
+    }
+}

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -6,6 +6,8 @@ use std::convert::{TryFrom, TryInto};
 use ed25519_dalek as dalek;
 use ed25519_dalek::{Digest, Signer, Verifier};
 use move_core_types::account_address::AccountAddress;
+use move_core_types::ident_str;
+use move_core_types::identifier::IdentStr;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use sha3::Sha3_256;
@@ -71,6 +73,14 @@ pub type ObjectRef = (ObjectID, SequenceNumber);
 // have transfer transactions so we index them by the object/seq they mutate.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct TransactionDigest((ObjectID, SequenceNumber));
+
+// TODO: migrate TxContext type + these constants to a separate file
+/// 0xB86E858F2D22236F2D96DF498FF001D0
+pub const TX_CONTEXT_ADDRESS: AccountAddress = AccountAddress::new([
+    0xB8, 0x6E, 0x85, 0x8F, 0x2D, 0x22, 0x23, 0x6F, 0x2D, 0x96, 0xDF, 0x49, 0x8F, 0xF0, 0x01, 0xD0,
+]);
+pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("TxContext");
+pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = TX_CONTEXT_MODULE_NAME;
 
 #[derive(Debug)]
 pub struct TxContext {

--- a/fastx_types/src/coin.rs
+++ b/fastx_types/src/coin.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{
+    account_address::AccountAddress,
+    ident_str,
+    identifier::IdentStr,
+    language_storage::{StructTag, TypeTag},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    base_types::ObjectID,
+    gas_coin::{GAS_ADDRESS, GAS_MODULE_NAME, GAS_STRUCT_NAME},
+    id::ID,
+};
+
+/// 0x7ABB80D444EB9F84F0CF64CC34CF8760
+pub const COIN_ADDRESS: AccountAddress = AccountAddress::new([
+    0x7A, 0xBB, 0x80, 0xD4, 0x44, 0xEB, 0x9F, 0x84, 0xF0, 0xCF, 0x64, 0xCC, 0x34, 0xCF, 0x87, 0x60,
+]);
+pub const COIN_MODULE_NAME: &IdentStr = ident_str!("Coin");
+pub const COIN_STRUCT_NAME: &IdentStr = COIN_MODULE_NAME;
+
+// Rust version of the Move FastX::Coin::Coin type
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Coin {
+    id: ID,
+    value: u64,
+}
+
+impl Coin {
+    pub fn new(id: ID, value: u64) -> Self {
+        Self { id, value }
+    }
+
+    pub fn type_(type_param: StructTag) -> StructTag {
+        StructTag {
+            address: GAS_ADDRESS,
+            name: GAS_STRUCT_NAME.to_owned(),
+            module: GAS_MODULE_NAME.to_owned(),
+            type_params: vec![TypeTag::Struct(type_param)],
+        }
+    }
+
+    pub fn id(&self) -> &ObjectID {
+        self.id.object_id()
+    }
+
+    pub fn value(&self) -> u64 {
+        self.value
+    }
+
+    pub fn to_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+}

--- a/fastx_types/src/gas_coin.rs
+++ b/fastx_types/src/gas_coin.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::StructTag,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{base_types::ObjectID, coin::Coin, id::ID};
+
+/// 0x330D4D3816201553185C08101CF1AB5E
+pub const GAS_ADDRESS: AccountAddress = AccountAddress::new([
+    0x33, 0x0D, 0x4D, 0x38, 0x16, 0x20, 0x15, 0x53, 0x18, 0x5C, 0x08, 0x10, 0x1C, 0xF1, 0xAB, 0x5E,
+]);
+pub const GAS_MODULE_NAME: &IdentStr = ident_str!("GAS");
+pub const GAS_STRUCT_NAME: &IdentStr = GAS_MODULE_NAME;
+
+/// Rust version of the Move FastX::Coin::Coin<FastX::GAS::GAS> type
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GasCoin(Coin);
+
+impl GasCoin {
+    pub fn new(id: ObjectID, value: u64) -> Self {
+        Self(Coin::new(ID::new(id), value))
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0.value()
+    }
+
+    pub fn type_() -> StructTag {
+        Coin::type_(StructTag {
+            address: GAS_ADDRESS,
+            name: GAS_STRUCT_NAME.to_owned(),
+            module: GAS_MODULE_NAME.to_owned(),
+            type_params: Vec::new(),
+        })
+    }
+
+    pub fn id(&self) -> &ObjectID {
+        self.0.id()
+    }
+
+    pub fn to_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+}

--- a/fastx_types/src/id.rs
+++ b/fastx_types/src/id.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::StructTag,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::base_types::ObjectID;
+
+/// 0x26580A83058312EAAD705393D6AE6B23
+pub const ID_ADDRESS: AccountAddress = AccountAddress::new([
+    0x26, 0x58, 0x0A, 0x83, 0x05, 0x83, 0x12, 0xEA, 0xAD, 0x70, 0x53, 0x93, 0xD6, 0xAE, 0x6B, 0x23,
+]);
+pub const ID_MODULE_NAME: &IdentStr = ident_str!("ID");
+pub const ID_STRUCT_NAME: &IdentStr = ID_MODULE_NAME;
+
+/// Rust version of the Move FastX::ID::ID type
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ID {
+    id: IDBytes,
+}
+
+/// Rust version of the Move FastX::ID::IDBytes type
+#[derive(Debug, Serialize, Deserialize)]
+struct IDBytes {
+    bytes: ObjectID,
+}
+
+impl ID {
+    pub fn new(bytes: ObjectID) -> Self {
+        Self {
+            id: IDBytes::new(bytes),
+        }
+    }
+
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: ID_ADDRESS,
+            name: ID_STRUCT_NAME.to_owned(),
+            module: ID_MODULE_NAME.to_owned(),
+            type_params: Vec::new(),
+        }
+    }
+
+    pub fn object_id(&self) -> &ObjectID {
+        &self.id.bytes
+    }
+
+    pub fn to_bcs_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+}
+
+impl IDBytes {
+    pub fn new(bytes: ObjectID) -> Self {
+        Self { bytes }
+    }
+}

--- a/fastx_types/src/lib.rs
+++ b/fastx_types/src/lib.rs
@@ -14,7 +14,10 @@ use move_core_types::account_address::AccountAddress;
 pub mod error;
 
 pub mod base_types;
+pub mod coin;
 pub mod committee;
+pub mod gas_coin;
+pub mod id;
 pub mod messages;
 pub mod object;
 pub mod serialize;

--- a/fastx_types/src/unit_tests/base_types_tests.rs
+++ b/fastx_types/src/unit_tests/base_types_tests.rs
@@ -3,6 +3,8 @@
 
 #![allow(clippy::blacklisted_name)]
 
+use crate::gas_coin::GasCoin;
+
 use super::*;
 
 #[derive(Serialize, Deserialize)]
@@ -35,4 +37,15 @@ fn test_signatures() {
 fn test_max_sequence_number() {
     let max = SequenceNumber::max();
     assert_eq!(max.0 * 2 + 1, std::u64::MAX);
+}
+
+#[test]
+fn test_gas_coin_ser_deser_roundtrip() {
+    let id = ObjectID::random();
+    let coin = GasCoin::new(id, 10);
+    let coin_bytes = coin.to_bcs_bytes();
+
+    let deserialized_coin: GasCoin = bcs::from_bytes(&coin_bytes).unwrap();
+    assert_eq!(deserialized_coin.id(), coin.id());
+    assert_eq!(deserialized_coin.value(), coin.value());
 }


### PR DESCRIPTION
This bridges one useful object type from the Move world to the Rust one. `Transfer` orders now act over objects whose type is "gas coin".
    
- Introduce new `GAS` module in Move + use it to instantiate the generic `Coin` type. The resulting type for a gas token is `Coin::Coin<GAS>`,
- Introduce Rust wrappers for the Move `Coin`, `Coin<GAS>`, and `ID` types
- Use `Coin<GAS>` as the type of all test objects constructed by `Object::with_id_owner_for_testing`. The value of each test coin is 0, but we can change that if desired.
- Restrict `Transfer` orders so they only work on gas coins.