### PR TITLE
[verifier] Add module builder for easier testing

### DIFF
--- a/fastx_programmability/verifier/tests/module_builder/mod.rs
+++ b/fastx_programmability/verifier/tests/module_builder/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod module_builder;

--- a/fastx_programmability/verifier/tests/module_builder/module_builder.rs
+++ b/fastx_programmability/verifier/tests/module_builder/module_builder.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// SPDX-License-Identifier: Apache-2.0
+
+use fastx_types::FASTX_FRAMEWORK_ADDRESS;
+use move_binary_format::file_format::*;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+
+pub struct ModuleBuilder {
+    module: CompiledModule,
+}
+
+impl ModuleBuilder {
+    pub fn new(address: AccountAddress, name: &str) -> Self {
+        Self {
+            module: CompiledModule {
+                version: move_binary_format::file_format_common::VERSION_MAX,
+                module_handles: vec![ModuleHandle {
+                    address: AddressIdentifierIndex(0),
+                    name: IdentifierIndex(0),
+                }],
+                self_module_handle_idx: ModuleHandleIndex(0),
+                identifiers: vec![Identifier::new(name).unwrap()],
+                address_identifiers: vec![address],
+                struct_handles: vec![],
+                struct_defs: vec![],
+                function_handles: vec![],
+                function_defs: vec![],
+                signatures: vec![
+                    Signature(vec![]), // void
+                ],
+                constant_pool: vec![],
+                field_handles: vec![],
+                friend_decls: vec![],
+                struct_def_instantiations: vec![],
+                function_instantiations: vec![],
+                field_instantiations: vec![],
+            },
+        }
+    }
+
+    pub fn default() -> Self {
+        Self::new(FASTX_FRAMEWORK_ADDRESS, "ID")
+    }
+
+    pub fn get_module(&self) -> &CompiledModule {
+        &self.module
+    }
+
+    pub fn get_self_index(&self) -> ModuleHandleIndex {
+        self.module.self_module_handle_idx
+    }
+
+    pub fn add_function(
+        &mut self,
+        module_idx: ModuleHandleIndex,
+        name: &str,
+        parameters: Vec<SignatureToken>,
+        ret: Vec<SignatureToken>,
+    ) -> (FunctionHandleIndex, FunctionDefinitionIndex) {
+        let new_handle = FunctionHandle {
+            module: module_idx,
+            name: self.add_identifier(name),
+            parameters: self.add_signature(parameters),
+            return_: self.add_signature(ret),
+            type_parameters: vec![],
+        };
+        let handle_idx = FunctionHandleIndex(self.module.function_handles.len() as u16);
+        self.module.function_handles.push(new_handle);
+        let new_def = FunctionDefinition {
+            function: handle_idx,
+            visibility: Visibility::Public,
+            acquires_global_resources: vec![],
+            code: Some(CodeUnit {
+                locals: SignatureIndex(0),
+                code: vec![Bytecode::Ret],
+            }),
+        };
+        self.module.function_defs.push(new_def);
+        (
+            handle_idx,
+            FunctionDefinitionIndex((self.module.function_defs.len() - 1) as u16),
+        )
+    }
+
+    pub fn add_struct(
+        &mut self,
+        module_index: ModuleHandleIndex,
+        name: &str,
+        abilities: AbilitySet,
+        fields: Vec<FieldDefinition>,
+    ) -> (StructHandleIndex, StructDefinitionIndex) {
+        let new_handle = StructHandle {
+            module: module_index,
+            name: self.add_identifier(name),
+            abilities,
+            type_parameters: vec![],
+        };
+        let handle_idx = StructHandleIndex(self.module.struct_handles.len() as u16);
+        self.module.struct_handles.push(new_handle);
+        let new_def = StructDefinition {
+            struct_handle: handle_idx,
+            field_information: StructFieldInformation::Declared(fields),
+        };
+        self.module.struct_defs.push(new_def);
+        (
+            handle_idx,
+            StructDefinitionIndex((self.module.struct_defs.len() - 1) as u16),
+        )
+    }
+
+    pub fn add_module(&mut self, address: AccountAddress, name: &str) -> ModuleHandleIndex {
+        let handle = ModuleHandle {
+            address: self.add_address(address),
+            name: self.add_identifier(name),
+        };
+        self.module.module_handles.push(handle);
+        ModuleHandleIndex((self.module.module_handles.len() - 1) as u16)
+    }
+
+    pub fn create_field(&mut self, name: &str, ty: SignatureToken) -> FieldDefinition {
+        let id = self.add_identifier(name);
+        FieldDefinition {
+            name: id,
+            signature: TypeSignature(ty),
+        }
+    }
+
+    pub fn set_bytecode(&mut self, func_def: FunctionDefinitionIndex, bytecode: Vec<Bytecode>) {
+        let code = &mut self.module.function_defs[func_def.0 as usize]
+            .code
+            .as_mut()
+            .unwrap()
+            .code;
+        *code = bytecode;
+    }
+
+    fn add_identifier(&mut self, id: &str) -> IdentifierIndex {
+        self.module.identifiers.push(Identifier::new(id).unwrap());
+        IdentifierIndex((self.module.identifiers.len() - 1) as u16)
+    }
+
+    fn add_signature(&mut self, sig: Vec<SignatureToken>) -> SignatureIndex {
+        self.module.signatures.push(Signature(sig));
+        SignatureIndex((self.module.signatures.len() - 1) as u16)
+    }
+
+    fn add_address(&mut self, address: AccountAddress) -> AddressIdentifierIndex {
+        self.module.address_identifiers.push(address);
+        AddressIdentifierIndex((self.module.address_identifiers.len() - 1) as u16)
+    }
+}

--- a/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
+++ b/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
@@ -1,222 +1,162 @@
-use fastx_types::FASTX_FRAMEWORK_ADDRESS;
+// Copyright (c) Facebook, Inc. and its affiliates.
+// SPDX-License-Identifier: Apache-2.0
+
+mod module_builder;
+
 use fastx_verifier::struct_with_key_verifier::verify_module;
-
+pub use module_builder::module_builder::ModuleBuilder;
 use move_binary_format::file_format::*;
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::account_address::AccountAddress;
 
-fn make_module() -> CompiledModule {
-    CompiledModule {
-        version: move_binary_format::file_format_common::VERSION_MAX,
-        module_handles: vec![
-            // ID module from fastx framework.
-            ModuleHandle {
-                address: AddressIdentifierIndex(0),
-                name: IdentifierIndex(0),
-            },
-            // Test module with same name ("ID") but at different address.
-            ModuleHandle {
-                address: AddressIdentifierIndex(1),
-                name: IdentifierIndex(0),
-            },
-        ],
-        self_module_handle_idx: ModuleHandleIndex(1),
-        identifiers: vec![
-            Identifier::new("ID").unwrap(), // ID Module name as well as struct name
-            Identifier::new("foo").unwrap(), // Test struct name
-            Identifier::new("id").unwrap(), // id field
-        ],
-        address_identifiers: vec![
-            FASTX_FRAMEWORK_ADDRESS,                            // ID Module address
-            AccountAddress::new([1u8; AccountAddress::LENGTH]), // A random address
-        ],
-        struct_handles: vec![
-            // The FASTX_FRAMEWORK_ADDRESS::ID::ID struct
-            StructHandle {
-                module: ModuleHandleIndex(0),
-                name: IdentifierIndex(0),
-                abilities: AbilitySet::EMPTY | Ability::Store | Ability::Drop,
-                type_parameters: vec![],
-            },
-            // A random ID::ID struct from a different address
-            StructHandle {
-                module: ModuleHandleIndex(1),
-                name: IdentifierIndex(0),
-                abilities: AbilitySet::EMPTY | Ability::Store | Ability::Drop,
-                type_parameters: vec![],
-            },
-        ],
-        struct_defs: vec![],
-        function_handles: vec![],
-        function_defs: vec![],
-        signatures: vec![
-            Signature(vec![]),                       // void
-            Signature(vec![SignatureToken::Signer]), // Signer
-        ],
-        constant_pool: vec![],
-        field_handles: vec![],
-        friend_decls: vec![],
-        struct_def_instantiations: vec![],
-        function_instantiations: vec![],
-        field_instantiations: vec![],
-    }
+const ID_STRUCT: StructHandleIndex = StructHandleIndex(0);
+
+fn make_module_with_id_struct() -> ModuleBuilder {
+    let mut module = ModuleBuilder::default();
+    module.add_struct(
+        module.get_self_index(),
+        "ID",
+        AbilitySet::EMPTY | Ability::Store | Ability::Drop,
+        vec![],
+    );
+    module
 }
 
 #[test]
 fn key_struct_with_drop() {
-    let mut module = make_module();
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(1),
-        name: IdentifierIndex(1),
-        abilities: AbilitySet::EMPTY | Ability::Key | Ability::Drop,
-        type_parameters: vec![],
-    });
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex(2),
-            signature: TypeSignature(SignatureToken::U64),
-        }]),
-    });
-    assert!(verify_module(&module)
+    let mut module = make_module_with_id_struct();
+    let id_field = module.create_field("id", SignatureToken::Struct(ID_STRUCT));
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key | Ability::Drop,
+        vec![id_field],
+    );
+    assert!(verify_module(module.get_module())
         .unwrap_err()
         .to_string()
-        .contains("Struct foo cannot have both key and drop abilities"));
+        .contains("Struct S cannot have both key and drop abilities"));
 }
 
 #[test]
 fn non_key_struct_without_fields() {
-    let mut module = make_module();
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(1),
-        name: IdentifierIndex(1),
-        abilities: AbilitySet::EMPTY | Ability::Drop,
-        type_parameters: vec![],
-    });
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![]),
-    });
-    assert!(verify_module(&module).is_ok());
+    let mut module = make_module_with_id_struct();
+    module.add_struct(module.get_self_index(), "S", AbilitySet::EMPTY, vec![]);
+    assert!(verify_module(module.get_module()).is_ok());
 }
 
 #[test]
 fn key_struct_without_fields() {
-    let mut module = make_module();
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(1),
-        name: IdentifierIndex(1),
-        abilities: AbilitySet::EMPTY | Ability::Key,
-        type_parameters: vec![],
-    });
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![]),
-    });
-    assert!(verify_module(&module)
+    let mut module = make_module_with_id_struct();
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![],
+    );
+    assert!(verify_module(module.get_module())
         .unwrap_err()
         .to_string()
-        .contains("First field of struct foo must be 'id', no field found"));
+        .contains("First field of struct S must be 'id', no field found"));
 }
 
 #[test]
 fn key_struct_first_field_not_id() {
-    let mut module = make_module();
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(1),
-        name: IdentifierIndex(1),
-        abilities: AbilitySet::EMPTY | Ability::Key,
-        type_parameters: vec![],
-    });
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex(1),
-            signature: TypeSignature(SignatureToken::U64),
-        }]),
-    });
-    assert!(verify_module(&module)
+    let mut module = make_module_with_id_struct();
+    let foo_field = module.create_field("foo", SignatureToken::Struct(ID_STRUCT));
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![foo_field],
+    );
+    assert!(verify_module(module.get_module())
         .unwrap_err()
         .to_string()
-        .contains("First field of struct foo must be 'id', foo found"));
+        .contains("First field of struct S must be 'id', foo found"));
+}
 
-    module.struct_defs.pop();
-    // Make id the second field, and it should still fail verification.
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![
-            FieldDefinition {
-                name: IdentifierIndex(1),
-                signature: TypeSignature(SignatureToken::U64),
-            },
-            FieldDefinition {
-                name: IdentifierIndex(2),
-                signature: TypeSignature(SignatureToken::Struct(StructHandleIndex(0))),
-            },
-        ]),
-    });
-    assert!(verify_module(&module)
+#[test]
+fn key_struct_second_field_id() {
+    let mut module = make_module_with_id_struct();
+    let foo_field = module.create_field("foo", SignatureToken::Struct(ID_STRUCT));
+    let id_field = module.create_field("id", SignatureToken::Struct(ID_STRUCT));
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![foo_field, id_field],
+    );
+    assert!(verify_module(module.get_module())
         .unwrap_err()
         .to_string()
-        .contains("First field of struct foo must be 'id', foo found"));
+        .contains("First field of struct S must be 'id', foo found"));
 }
 
 #[test]
 fn key_struct_id_field_incorrect_type() {
-    let mut module = make_module();
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(0),
-        name: IdentifierIndex(1),
-        abilities: AbilitySet::EMPTY | Ability::Key,
-        type_parameters: vec![],
-    });
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex(2),
-            signature: TypeSignature(SignatureToken::U64),
-        }]),
-    });
-    assert!(verify_module(&module)
+    let mut module = make_module_with_id_struct();
+    let id_field = module.create_field("id", SignatureToken::U64);
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![id_field],
+    );
+    assert!(verify_module(module.get_module())
         .unwrap_err()
         .to_string()
-        .contains("First field of struct foo must be of ID type, U64 type found"));
+        .contains("First field of struct S must be of ID type, U64 type found"));
+}
 
-    module.struct_defs.pop();
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex(2),
-            signature: TypeSignature(SignatureToken::Struct(StructHandleIndex(1))),
-        }]),
-    });
-    assert!(verify_module(&module).unwrap_err().to_string().contains("First field of struct foo must be of type 00000000000000000000000000000002::ID::ID, 01010101010101010101010101010101::ID::ID type found"));
+#[test]
+fn key_struct_id_field_incorrect_struct_address() {
+    let mut module = make_module_with_id_struct();
+    let new_module_idx =
+        module.add_module(AccountAddress::new([1u8; AccountAddress::LENGTH]), "ID");
+    let (fake_id_struct, _) = module.add_struct(
+        new_module_idx,
+        "ID",
+        AbilitySet::EMPTY | Ability::Store | Ability::Drop,
+        vec![],
+    );
+    let id_field = module.create_field("id", SignatureToken::Struct(fake_id_struct));
+    module.add_struct(
+        new_module_idx,
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![id_field],
+    );
+    assert!(verify_module(module.get_module()).unwrap_err().to_string().contains("First field of struct S must be of type 00000000000000000000000000000002::ID::ID, 01010101010101010101010101010101::ID::ID type found"));
+}
 
-    module.struct_defs.pop();
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex(2),
-            signature: TypeSignature(SignatureToken::Struct(StructHandleIndex(2))),
-        }]),
-    });
-    assert!(verify_module(&module).unwrap_err().to_string().contains("First field of struct foo must be of type 00000000000000000000000000000002::ID::ID, 00000000000000000000000000000002::ID::foo type found"));
+#[test]
+fn key_struct_id_field_incorrect_struct_name() {
+    let mut module = make_module_with_id_struct();
+    let (fake_id_struct, _) = module.add_struct(
+        module.get_self_index(),
+        "FOO",
+        AbilitySet::EMPTY | Ability::Store | Ability::Drop,
+        vec![],
+    );
+    let id_field = module.create_field("id", SignatureToken::Struct(fake_id_struct));
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![id_field],
+    );
+    assert!(verify_module(module.get_module()).unwrap_err().to_string().contains("First field of struct S must be of type 00000000000000000000000000000002::ID::ID, 00000000000000000000000000000002::ID::FOO type found"));
 }
 
 #[test]
 fn key_struct_id_field_valid() {
-    let mut module = make_module();
-    module.struct_handles.push(StructHandle {
-        module: ModuleHandleIndex(1),
-        name: IdentifierIndex(2),
-        abilities: AbilitySet::EMPTY | Ability::Key,
-        type_parameters: vec![],
-    });
-    module.struct_defs.push(StructDefinition {
-        struct_handle: StructHandleIndex(2),
-        field_information: StructFieldInformation::Declared(vec![FieldDefinition {
-            name: IdentifierIndex(2),
-            signature: TypeSignature(SignatureToken::Struct(StructHandleIndex(0))),
-        }]),
-    });
-    assert!(verify_module(&module).is_ok());
+    let mut module = make_module_with_id_struct();
+    let id_field = module.create_field("id", SignatureToken::Struct(ID_STRUCT));
+    module.add_struct(
+        module.get_self_index(),
+        "S",
+        AbilitySet::EMPTY | Ability::Key,
+        vec![id_field],
+    );
+    assert!(verify_module(module.get_module()).is_ok());
 }


### PR DESCRIPTION
One thing that has been holding me back from adding more verifier tests is the difficulty of constructing test modules. Trying to remember and get all the handles right was very confusing, and the code wasn't very readable. It will be very difficult to maintain as well.
Before it's too late, add a module builder that helps build modules for testing.
Note that due to a bug in Rust, we have to do `pub use` in every test when importing the common library.