### PR TITLE
Fix a release build break

### DIFF
--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -373,7 +373,7 @@ fn resolve_and_type_check(
     let mut args = Vec::new();
     let mut mutable_ref_objects = Vec::new();
     let mut by_value_objects = BTreeMap::new();
-    #[cfg(debug_assertions)]
+    #[allow(unused_mut)]
     let mut num_immutable_objects = 0;
     let num_objects = object_args.len();
 


### PR DESCRIPTION
Building in release mode complains about `num_immutable_objects` not found.
Unfortunately macros in Rust works at runtime instead of compile time. So all variables in the macro are still compiled. They cannot be mixed with attributes which are compile time controls.