### PR TITLE
fix: Use tempfile to streamline temporary directory creation for DB in tests

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -24,3 +24,6 @@ move-vm-runtime = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4
 
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "b6bb469e0752222b1c990b1d8f39c69d4dbf12a9" }
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -12,9 +12,6 @@ use std::{
 };
 use tokio::runtime::Runtime;
 
-use std::env;
-use std::fs;
-
 #[derive(Clone)]
 struct LocalAuthorityClient(Arc<Mutex<AuthorityState>>);
 
@@ -69,11 +66,9 @@ fn init_local_authorities(
     let mut clients = HashMap::new();
     for (address, secret) in key_pairs {
         // Random directory for the DB
-        let dir = env::temp_dir();
-        let path = dir.join(format!("DB_{:?}", ObjectID::random()));
-        fs::create_dir(&path).unwrap();
+        let dir = tempfile::tempdir();
 
-        let state = AuthorityState::new(committee.clone(), address, secret, path);
+        let state = AuthorityState::new(committee.clone(), address, secret, dir.unwrap());
         clients.insert(address, LocalAuthorityClient::new(state));
     }
     (clients, committee)
@@ -100,11 +95,9 @@ fn init_local_authorities_bad_1(
     let mut clients = HashMap::new();
     for (address, secret) in key_pairs {
         // Random directory
-        let dir = env::temp_dir();
-        let path = dir.join(format!("DB_{:?}", ObjectID::random()));
-        fs::create_dir(&path).unwrap();
+        let dir = tempfile::tempdir();
 
-        let state = AuthorityState::new(committee.clone(), address, secret, path);
+        let state = AuthorityState::new(committee.clone(), address, secret, dir.unwrap());
         clients.insert(address, LocalAuthorityClient::new(state));
     }
     (clients, committee)


### PR DESCRIPTION
This just adds a dev-dependency. It does not modify the path creation in the benchmark.