### PR TITLE
[framework] use local dep for Move stdlib

### DIFF
--- a/fastx_programmability/framework/Move.toml
+++ b/fastx_programmability/framework/Move.toml
@@ -3,7 +3,10 @@ name = "FastX"
 version = "0.0.1"
 
 [dependencies]
-MoveStdlib = { git = "https://github.com/diem/diem.git", subdir="language/move-stdlib", rev = "346301f33b3489bb4e486ae6c0aa5e030223b492" }
+# Using a local dep for the Move stdlib instead of a git dep to avoid the overhead of fetching the git dep in
+# CI. The local dep is an unmodified version of the upstream stdlib
+MoveStdlib = { local = "deps/move-stdlib" }
+#MoveStdlib = { git = "https://github.com/diem/diem.git", subdir="language/move-stdlib", rev = "346301f33b3489bb4e486ae6c0aa5e030223b492" }
 
 [addresses]
 Std = "0x1"

--- a/fastx_programmability/framework/deps/move-stdlib/Move.toml
+++ b/fastx_programmability/framework/deps/move-stdlib/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "MoveStdlib"
+version = "1.5.0"
+
+[addresses]
+Std = "_"
+
+[dev-addresses]
+Std = "0x1"

--- a/fastx_programmability/framework/deps/move-stdlib/sources/ASCII.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/ASCII.move
@@ -1,0 +1,149 @@
+/// The `ASCII` module defines basic string and char newtypes in Move that verify
+/// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
+module Std::ASCII {
+    use Std::Vector;
+    use Std::Errors;
+    use Std::Option::{Self, Option};
+
+    /// An invalid ASCII character was encountered when creating an ASCII string.
+    const EINVALID_ASCII_CHARACTER: u64 = 0;
+
+   /// The `String` struct holds a vector of bytes that all represent
+   /// valid ASCII characters. Note that these ASCII characters may not all
+   /// be printable. To determine if a `String` contains only "printable"
+   /// characters you should use the `all_characters_printable` predicate
+   /// defined in this module.
+   struct String has copy, drop, store {
+       bytes: vector<u8>,
+   }
+   spec String {
+       invariant forall i in 0..len(bytes): is_valid_char(bytes[i]);
+   }
+
+   /// An ASCII character.
+   struct Char has copy, drop, store {
+       byte: u8,
+   }
+   spec Char {
+       invariant is_valid_char(byte);
+   }
+
+    /// Convert a `byte` into a `Char` that is checked to make sure it is valid ASCII.
+    public fun char(byte: u8): Char {
+        assert!(is_valid_char(byte), Errors::invalid_argument(EINVALID_ASCII_CHARACTER));
+        Char { byte }
+    }
+    spec char {
+        aborts_if !is_valid_char(byte) with Errors::INVALID_ARGUMENT;
+    }
+
+    /// Convert a vector of bytes `bytes` into an `String`. Aborts if
+    /// `bytes` contains non-ASCII characters.
+    public fun string(bytes: vector<u8>): String {
+       let x = try_string(bytes);
+       assert!(
+            Option::is_some(&x),
+            Errors::invalid_argument(EINVALID_ASCII_CHARACTER)
+       );
+       Option::destroy_some(x)
+    }
+    spec string {
+        aborts_if exists i in 0..len(bytes): !is_valid_char(bytes[i]) with Errors::INVALID_ARGUMENT;
+    }
+
+    /// Convert a vector of bytes `bytes` into an `String`. Returns
+    /// `Some(<ascii_string>)` if the `bytes` contains all valid ASCII
+    /// characters. Otherwise returns `None`.
+    public fun try_string(bytes: vector<u8>): Option<String> {
+       let len = Vector::length(&bytes);
+       let i = 0;
+       while ({
+           spec {
+               invariant i <= len;
+               invariant forall j in 0..i: is_valid_char(bytes[j]);
+           };
+           i < len
+       }) {
+           let possible_byte = *Vector::borrow(&bytes, i);
+           if (!is_valid_char(possible_byte)) return Option::none();
+           i = i + 1;
+       };
+       spec {
+           assert i == len;
+           assert forall j in 0..len: is_valid_char(bytes[j]);
+       };
+       Option::some(String { bytes })
+    }
+
+    /// Returns `true` if all characters in `string` are printable characters
+    /// Returns `false` otherwise. Not all `String`s are printable strings.
+    public fun all_characters_printable(string: &String): bool {
+       let len = Vector::length(&string.bytes);
+       let i = 0;
+       while ({
+           spec {
+               invariant i <= len;
+               invariant forall j in 0..i: is_printable_char(string.bytes[j]);
+           };
+           i < len
+       }) {
+           let byte = *Vector::borrow(&string.bytes, i);
+           if (!is_printable_char(byte)) return false;
+           i = i + 1;
+       };
+       spec {
+           assert i == len;
+           assert forall j in 0..len: is_printable_char(string.bytes[j]);
+       };
+       true
+    }
+    spec all_characters_printable {
+        ensures result ==> (forall j in 0..len(string.bytes): is_printable_char(string.bytes[j]));
+    }
+
+    public fun push_char(string: &mut String, char: Char) {
+        Vector::push_back(&mut string.bytes, char.byte);
+    }
+    spec push_char {
+        ensures len(string.bytes) == len(old(string.bytes)) + 1;
+    }
+
+    public fun pop_char(string: &mut String): Char {
+        Char { byte: Vector::pop_back(&mut string.bytes) }
+    }
+    spec pop_char {
+        ensures len(string.bytes) == len(old(string.bytes)) - 1;
+    }
+
+    public fun length(string: &String): u64 {
+        Vector::length(as_bytes(string))
+    }
+
+    /// Get the inner bytes of the `string` as a reference
+    public fun as_bytes(string: &String): &vector<u8> {
+       &string.bytes
+    }
+
+    /// Unpack the `string` to get its backing bytes
+    public fun into_bytes(string: String): vector<u8> {
+       let String { bytes } = string;
+       bytes
+    }
+
+    /// Unpack the `char` into its underlying byte.
+    public fun byte(char: Char): u8 {
+       let Char { byte } = char;
+       byte
+    }
+
+    /// Returns `true` if `byte` is a valid ASCII character. Returns `false` otherwise.
+    public fun is_valid_char(byte: u8): bool {
+       byte <= 0x7F
+    }
+
+    /// Returns `true` if `byte` is an printable ASCII character. Returns `false` otherwise.
+    public fun is_printable_char(byte: u8): bool {
+       byte >= 0x20 && // Disallow metacharacters
+       byte <= 0x7E // Don't allow DEL metacharacter
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/BCS.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/BCS.move
@@ -1,0 +1,17 @@
+/// Utility for converting a Move value to its binary representation in BCS (Binary Canonical
+/// Serialization). BCS is the binary encoding for Move resources and other non-module values
+/// published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more
+/// details on BCS.
+module Std::BCS {
+    /// Return the binary representation of `v` in BCS (Binary Canonical Serialization) format
+    native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
+
+    // ==============================
+    // Module Specification
+    spec module {} // switch to module documentation context
+
+    spec module {
+        /// Native function which is defined in the prover's prelude.
+        native fun serialize<MoveValue>(v: &MoveValue): vector<u8>;
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/BitVector.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/BitVector.move
@@ -1,0 +1,162 @@
+module Std::BitVector {
+    use Std::Vector;
+    use Std::Errors;
+
+    /// The provided index is out of bounds
+    const EINDEX: u64 = 0;
+    /// An invalid length of bitvector was given
+    const ELENGTH: u64 = 1;
+
+    const WORD_SIZE: u64 = 1;
+    /// The maximum allowed bitvector size
+    const MAX_SIZE: u64 = 1024;
+
+    struct BitVector has copy, drop, store {
+        length: u64,
+        bit_field: vector<bool>,
+    }
+
+    public fun new(length: u64): BitVector {
+        assert!(length > 0, Errors::invalid_argument(ELENGTH));
+        assert!(length < MAX_SIZE, Errors::invalid_argument(ELENGTH));
+        let counter = 0;
+        let bit_field = Vector::empty();
+        while ({spec {
+            invariant counter <= length;
+            invariant len(bit_field) == counter;
+        };
+            (counter < length)}) {
+            Vector::push_back(&mut bit_field, false);
+            counter = counter + 1;
+        };
+        spec {
+            assert counter == length;
+            assert len(bit_field) == length;
+        };
+
+        BitVector {
+            length,
+            bit_field,
+        }
+    }
+    spec new {
+        include NewAbortsIf;
+        ensures result.length == length;
+        ensures len(result.bit_field) == length;
+    }
+    spec schema NewAbortsIf {
+        length: u64;
+        aborts_if length <= 0 with Errors::INVALID_ARGUMENT;
+        aborts_if length >= MAX_SIZE with Errors::INVALID_ARGUMENT;
+    }
+
+    /// Set the bit at `bit_index` in the `bitvector` regardless of its previous state.
+    public fun set(bitvector: &mut BitVector, bit_index: u64) {
+        assert!(bit_index < Vector::length(&bitvector.bit_field), Errors::invalid_argument(EINDEX));
+        let x = Vector::borrow_mut(&mut bitvector.bit_field, bit_index);
+        *x = true;
+    }
+    spec set {
+        include SetAbortsIf;
+        ensures bitvector.bit_field[bit_index];
+    }
+    spec schema SetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with Errors::INVALID_ARGUMENT;
+    }
+
+    /// Unset the bit at `bit_index` in the `bitvector` regardless of its previous state.
+    public fun unset(bitvector: &mut BitVector, bit_index: u64) {
+        assert!(bit_index < Vector::length(&bitvector.bit_field), Errors::invalid_argument(EINDEX));
+        let x = Vector::borrow_mut(&mut bitvector.bit_field, bit_index);
+        *x = false;
+    }
+    spec set {
+        include UnsetAbortsIf;
+        ensures bitvector.bit_field[bit_index];
+    }
+    spec schema UnsetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with Errors::INVALID_ARGUMENT;
+    }
+
+    /// Shift the `bitvector` left by `amount`. If `amount` is greater than the
+    /// bitvector's length the bitvector will be zeroed out.
+    public fun shift_left(bitvector: &mut BitVector, amount: u64) {
+        if (amount >= bitvector.length) {
+           let len = Vector::length(&bitvector.bit_field);
+           let i = 0;
+           while (i < len) {
+               let elem = Vector::borrow_mut(&mut bitvector.bit_field, i);
+               *elem = false;
+               i = i + 1;
+           };
+        } else {
+            let i = amount;
+
+            while (i < bitvector.length) {
+                if (is_index_set(bitvector, i)) set(bitvector, i - amount)
+                else unset(bitvector, i - amount);
+                i = i + 1;
+            };
+
+            i = bitvector.length - amount;
+
+            while (i < bitvector.length) {
+                unset(bitvector, i);
+                i = i + 1;
+            };
+        }
+    }
+
+    /// Return the value of the bit at `bit_index` in the `bitvector`. `true`
+    /// represents "1" and `false` represents a 0
+    public fun is_index_set(bitvector: &BitVector, bit_index: u64): bool {
+        assert!(bit_index < Vector::length(&bitvector.bit_field), Errors::invalid_argument(EINDEX));
+        *Vector::borrow(&bitvector.bit_field, bit_index)
+    }
+    spec is_index_set {
+        include IsIndexSetAbortsIf;
+        ensures result == bitvector.bit_field[bit_index];
+    }
+    spec schema IsIndexSetAbortsIf {
+        bitvector: BitVector;
+        bit_index: u64;
+        aborts_if bit_index >= length(bitvector) with Errors::INVALID_ARGUMENT;
+    }
+    spec fun spec_is_index_set(bitvector: BitVector, bit_index: u64): bool {
+        if (bit_index >= length(bitvector)) {
+            false
+        } else {
+            bitvector.bit_field[bit_index]
+        }
+    }
+
+    /// Return the length (number of usable bits) of this bitvector
+    public fun length(bitvector: &BitVector): u64 {
+        Vector::length(&bitvector.bit_field)
+    }
+
+    /// Returns the length of the longest sequence of set bits starting at (and
+    /// including) `start_index` in the `bitvector`. If there is no such
+    /// sequence, then `0` is returned.
+    public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
+        assert!(start_index < bitvector.length, Errors::invalid_argument(EINDEX));
+        let index = start_index;
+
+        // Find the greatest index in the vector such that all indices less than it are set.
+        while (index < bitvector.length) {
+            if (!is_index_set(bitvector, index)) break;
+            index = index + 1;
+        };
+
+        index - start_index
+    }
+
+    #[test_only]
+    public fun word_size(): u64 {
+        WORD_SIZE
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Capability.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Capability.move
@@ -1,0 +1,199 @@
+/// A module which defines the basic concept of
+/// [*capabilities*](https://en.wikipedia.org/wiki/Capability-based_security) for managing access control.
+///
+/// EXPERIMENTAL
+///
+/// # Overview
+///
+/// A capability is a unforgeable token which testifies that a signer has authorized a certain operation.
+/// The token is valid during the transaction where it is obtained. Since the type `Capability::Cap` has
+/// no ability to be stored in global memory, capabilities cannot leak out of a transaction. For every function
+/// called within a transaction which has a capability as a parameter, it is guaranteed that the capability
+/// has been obtained via a proper signer-based authorization step previously in the transaction's execution.
+///
+/// ## Usage
+///
+/// Initializing and acquiring capabilities is usually encapsulated in a module with a type
+/// tag which can only be constructed by this module.
+///
+/// ```
+/// module Pkg::Feature {
+///   use Std::Capability::Cap;
+///
+///   /// A type tag used in Cap<Feature>. Only this module can create an instance,
+///   /// and there is no public function other than Self::acquire which returns a value of this type.
+///   /// This way, this module has full control how Cap<Feature> is given out.
+///   struct Feature has drop {}
+///
+///   /// Initializes this module.
+///   public fun initialize(s: &signer) {
+///     // Create capability. This happens once at module initialization time.
+///     // One needs to provide a witness for being the owner of Feature
+///     // in the 2nd parameter.
+///     <<additional conditions allowing to initialize this capability>>
+///     Capability::create<Feature>(s, &Feature{});
+///   }
+///
+///   /// Acquires the capability to work with this feature.
+///   public fun acquire(s: &signer): Cap<Feature> {
+///     <<additional conditions allowing to acquire this capability>>
+///     Capability::acquire<Feature>(s, &Feature{});
+///   }
+///
+///   /// Does something related to the feature. The caller must pass a Cap<Feature>.
+///   public fun do_something(_cap: Cap<Feature>) { ... }
+/// }
+/// ```
+///
+/// ## Delegation
+///
+/// Capabilities come with the optional feature of *delegation*. Via `Self::delegate`, an owner of a capability
+/// can designate another signer to be also capable of acquiring the capability. Like the original creator,
+/// the delegate needs to present his signer to obtain the capability in his transactions. Delegation can
+/// be revoked via `Self::revoke`, removing this access right from the delegate.
+///
+/// While the basic authorization mechanism for delegates is the same as with core capabilities, the
+/// target of delegation might be subject of restrictions which need to be specified and verified. This can
+/// be done via global invariants in the specification language. For example, in order to prevent delegation
+/// all together for a capability, one can use the following invariant:
+///
+/// ```
+///   invariant forall a: address where Capability::spec_has_cap<Feature>(a):
+///               len(Capability::spec_delegates<Feature>(a)) == 0;
+/// ```
+///
+/// Similarly, the following invariant would enforce that delegates, if existent, must satisfy a certain
+/// predicate:
+///
+/// ```
+///   invariant forall a: address where Capability::spec_has_cap<Feature>(a):
+///               forall d in Capability::spec_delegates<Feature>(a):
+///                  is_valid_delegate_for_feature(d);
+/// ```
+///
+module Std::Capability {
+    use Std::Errors;
+    use Std::Signer;
+    use Std::Vector;
+
+    const ECAP: u64 = 0;
+    const EDELEGATE: u64 = 1;
+
+    /// The token representing an acquired capability. Cannot be stored in memory, but copied and dropped freely.
+    struct Cap<phantom Feature> has copy, drop {
+        root: address
+    }
+
+    /// A linear version of a capability token. This can be used if an acquired capability should be enforced
+    /// to be used only once for an authorization.
+    struct LinearCap<phantom Feature> has drop {
+        root: address
+    }
+
+    /// An internal data structure for representing a configured capability.
+    struct CapState<phantom Feature> has key {
+        delegates: vector<address>
+    }
+
+    /// An internal data structure for representing a configured delegated capability.
+    struct CapDelegateState<phantom Feature> has key {
+        root: address
+    }
+
+    /// Creates a new capability class, owned by the passed signer. A caller must pass a witness that
+    /// they own the `Feature` type parameter.
+    public fun create<Feature>(owner: &signer, _feature_witness: &Feature) {
+        let addr = Signer::address_of(owner);
+        assert!(!exists<CapState<Feature>>(addr), Errors::already_published(ECAP));
+        move_to<CapState<Feature>>(owner, CapState{ delegates: Vector::empty() });
+    }
+
+    /// Acquires a capability token. Only the owner of the capability class, or an authorized delegate,
+    /// can succeed with this operation. A caller must pass a witness that they own the `Feature` type
+    /// parameter.
+    public fun acquire<Feature>(requester: &signer, _feature_witness: &Feature): Cap<Feature>
+    acquires CapState, CapDelegateState {
+        Cap<Feature>{root: validate_acquire<Feature>(requester)}
+    }
+
+    /// Acquires a linear capability token. It is up to the module which owns `Feature` to decide
+    /// whether to expose a linear or non-linear capability.
+    public fun acquire_linear<Feature>(requester: &signer, _feature_witness: &Feature): LinearCap<Feature>
+    acquires CapState, CapDelegateState {
+        LinearCap<Feature>{root: validate_acquire<Feature>(requester)}
+    }
+
+    /// Helper to validate an acquire. Returns the root address of the capability.
+    fun validate_acquire<Feature>(requester: &signer): address
+    acquires CapState, CapDelegateState {
+        let addr = Signer::address_of(requester);
+        if (exists<CapDelegateState<Feature>>(addr)) {
+            let root_addr = borrow_global<CapDelegateState<Feature>>(addr).root;
+            // double check that requester is actually registered as a delegate
+            assert!(exists<CapState<Feature>>(root_addr), Errors::invalid_state(EDELEGATE));
+            assert!(Vector::contains(&borrow_global<CapState<Feature>>(root_addr).delegates, &addr),
+                   Errors::invalid_state(EDELEGATE));
+            root_addr
+        } else {
+            assert!(exists<CapState<Feature>>(addr), Errors::not_published(ECAP));
+            addr
+        }
+    }
+
+    /// Returns the root address associated with the given capability token. Only the owner
+    /// of the feature can do this.
+    public fun root_addr<Feature>(cap: Cap<Feature>, _feature_witness: &Feature): address {
+        cap.root
+    }
+
+    /// Returns the root address associated with the given linear capability token.
+    public fun linear_root_addr<Feature>(cap: LinearCap<Feature>, _feature_witness: &Feature): address {
+        cap.root
+    }
+
+    /// Registers a delegation relation. If the relation already exists, this function does
+    /// nothing.
+    // TODO: explore whether this should be idempotent like now or abort
+    public fun delegate<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, to: &signer)
+    acquires CapState {
+        let addr = Signer::address_of(to);
+        if (exists<CapDelegateState<Feature>>(addr)) return;
+        move_to(to, CapDelegateState<Feature>{root: cap.root});
+        add_element(&mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, addr);
+    }
+
+    /// Revokes a delegation relation. If no relation exists, this function does nothing.
+    // TODO: explore whether this should be idempotent like now or abort
+    public fun revoke<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, from: address)
+    acquires CapState, CapDelegateState
+    {
+        if (!exists<CapDelegateState<Feature>>(from)) return;
+        let CapDelegateState{root: _root} = move_from<CapDelegateState<Feature>>(from);
+        remove_element(&mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, &from);
+    }
+
+    /// Helper to remove an element from a vector.
+    fun remove_element<E: drop>(v: &mut vector<E>, x: &E) {
+        let (found, index) = Vector::index_of(v, x);
+        if (found) {
+            Vector::remove(v, index);
+        }
+    }
+
+    /// Helper to add an element to a vector.
+    fun add_element<E: drop>(v: &mut vector<E>, x: E) {
+        if (!Vector::contains(v, &x)) {
+            Vector::push_back(v, x)
+        }
+    }
+
+    /// Helper specification function to check whether a capability exists at address.
+    spec fun spec_has_cap<Feature>(addr: address): bool {
+        exists<CapState<Feature>>(addr)
+    }
+
+    /// Helper specification function to obtain the delegates of a capability.
+    spec fun spec_delegates<Feature>(addr: address): vector<address> {
+        global<CapState<Feature>>(addr).delegates
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Errors.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Errors.move
@@ -1,0 +1,131 @@
+/// Module defining error codes used in Move aborts throughout the framework.
+///
+/// A `u64` error code is constructed from two values:
+///
+///  1. The *error category* which is encoded in the lower 8 bits of the code. Error categories are
+///     declared in this module and are globally unique across the Diem framework. There is a limited
+///     fixed set of predefined categories, and the framework is guaranteed to use those consistently.
+///
+///  2. The *error reason* which is encoded in the remaining 56 bits of the code. The reason is a unique
+///     number relative to the module which raised the error and can be used to obtain more information about
+///     the error at hand. It is mostly used for diagnosis purposes. Error reasons may change over time as the
+///     framework evolves.
+///
+/// >TODO: determine what kind of stability guarantees we give about reasons/associated module.
+module Std::Errors {
+    /// A function to create an error from from a category and a reason.
+    fun make(category: u8, reason: u64): u64 {
+        (category as u64) + (reason << 8)
+    }
+    spec make {
+        pragma opaque = true;
+        ensures [concrete] result == category + (reason << 8);
+        aborts_if [abstract] false;
+        ensures [abstract] result == category;
+    }
+
+    /// The system is in a state where the performed operation is not allowed. Example: call to a function only allowed
+    /// in genesis.
+    const INVALID_STATE: u8 = 1;
+
+    /// The signer of a transaction does not have the expected address for this operation. Example: a call to a function
+    /// which publishes a resource under a particular address.
+    const REQUIRES_ADDRESS: u8 = 2;
+
+    /// The signer of a transaction does not have the expected  role for this operation. Example: a call to a function
+    /// which requires the signer to have the role of treasury compliance.
+    const REQUIRES_ROLE: u8 = 3;
+
+    /// The signer of a transaction does not have a required capability.
+    const REQUIRES_CAPABILITY: u8 = 4;
+
+    /// A resource is required but not published. Example: access to non-existing AccountLimits resource.
+    const NOT_PUBLISHED: u8 = 5;
+
+    /// Attempting to publish a resource that is already published. Example: calling an initialization function
+    /// twice.
+    const ALREADY_PUBLISHED: u8 = 6;
+
+    /// An argument provided to an operation is invalid. Example: a signing key has the wrong format.
+    const INVALID_ARGUMENT: u8 = 7;
+
+    /// A limit on an amount, e.g. a currency, is exceeded. Example: withdrawal of money after account limits window
+    /// is exhausted.
+    const LIMIT_EXCEEDED: u8 = 8;
+
+    /// An internal error (bug) has occurred.
+    const INTERNAL: u8 = 10;
+
+    /// A custom error category for extension points.
+    const CUSTOM: u8 = 255;
+
+    public fun invalid_state(reason: u64): u64 { make(INVALID_STATE, reason) }
+    spec invalid_state {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == INVALID_STATE;
+    }
+
+    public fun requires_address(reason: u64): u64 { make(REQUIRES_ADDRESS, reason) }
+    spec requires_address {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == REQUIRES_ADDRESS;
+    }
+
+    public fun requires_role(reason: u64): u64 { make(REQUIRES_ROLE, reason) }
+    spec requires_role {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == REQUIRES_ROLE;
+    }
+
+    public fun requires_capability(reason: u64): u64 { make(REQUIRES_CAPABILITY, reason) }
+    spec requires_capability {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == REQUIRES_CAPABILITY;
+    }
+
+    public fun not_published(reason: u64): u64 { make(NOT_PUBLISHED, reason) }
+    spec not_published {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == NOT_PUBLISHED;
+    }
+
+    public fun already_published(reason: u64): u64 { make(ALREADY_PUBLISHED, reason) }
+    spec already_published {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == ALREADY_PUBLISHED;
+    }
+
+    public fun invalid_argument(reason: u64): u64 { make(INVALID_ARGUMENT, reason) }
+    spec invalid_argument {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == INVALID_ARGUMENT;
+    }
+
+    public fun limit_exceeded(reason: u64): u64 { make(LIMIT_EXCEEDED, reason) }
+    spec limit_exceeded {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == LIMIT_EXCEEDED;
+    }
+
+    public fun internal(reason: u64): u64 { make(INTERNAL, reason) }
+    spec internal {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == INTERNAL;
+    }
+
+    public fun custom(reason: u64): u64 { make(CUSTOM, reason) }
+    spec custom {
+        pragma opaque = true;
+        aborts_if false;
+        ensures result == CUSTOM;
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Event.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Event.move
@@ -1,0 +1,89 @@
+/// The Event module defines an `EventHandleGenerator` that is used to create
+/// `EventHandle`s with unique GUIDs. It contains a counter for the number
+/// of `EventHandle`s it generates. An `EventHandle` is used to count the number of
+/// events emitted to a handle and emit events to the event store.
+module Std::Event {
+    use Std::BCS;
+    use Std::GUID::{Self, GUID};
+
+    /// Wrapper for a GUID for layout compatibility with legacy EventHandle id's
+    // This is a hack for layout compatibility. The old EventHandle.guid was a 24 byte vector<u8>
+    // created from `append(u64 counter bytes, account address bytes)`. This dummy struct mimics
+    // the BCS layout of the old value.
+    // Note: the reason why this works is somewhat subtle. The BCS encoding for a vector V of
+    // length N is `uleb128_encoded_bytes(N) | contents(V)`
+    // (see https://github.com/diem/bcs#fixed-and-variable-length-sequences).
+    // uleb128_encoded_bytes(24) fits into 1 byte, so using len_bytes: u8 is what we want here
+    struct GUIDWrapper has store, drop { len_bytes: u8, guid: GUID }
+
+    /// A handle for an event such that:
+    /// 1. Other modules can emit events to this handle.
+    /// 2. Storage can use this handle to prove the total number of events that happened in the past.
+    struct EventHandle<phantom T: drop + store> has store {
+        /// Total number of events emitted to this event stream.
+        counter: u64,
+        /// A globally unique ID for this event stream.
+        guid: GUIDWrapper,
+    }
+
+    /// Deprecated. Only kept around so Diem clients know how to deserialize existing EventHandleGenerator's
+    struct EventHandleGenerator has key {
+        // A monotonically increasing counter
+        counter: u64,
+        addr: address,
+    }
+
+    /// Use EventHandleGenerator to generate a unique event handle for `sig`
+    public fun new_event_handle<T: drop + store>(account: &signer): EventHandle<T> {
+        // must be 24 for compatibility with legacy Event ID's--see comment on GUIDWrapper
+        let len_bytes = 24u8;
+         EventHandle<T> {
+            counter: 0,
+            guid: GUIDWrapper { len_bytes, guid: GUID::create(account) }
+        }
+    }
+
+    /// Emit an event with payload `msg` by using `handle_ref`'s key and counter.
+    public fun emit_event<T: drop + store>(handle_ref: &mut EventHandle<T>, msg: T) {
+        write_to_event_store<T>(BCS::to_bytes(&handle_ref.guid.guid), handle_ref.counter, msg);
+        handle_ref.counter = handle_ref.counter + 1;
+    }
+
+    /// Return the GUIID associated with this EventHandle
+    public fun guid<T: drop + store>(handle_ref: &EventHandle<T>): &GUID {
+        &handle_ref.guid.guid
+    }
+
+    /// Log `msg` as the `count`th event associated with the event stream identified by `guid`
+    native fun write_to_event_store<T: drop + store>(guid: vector<u8>, count: u64, msg: T);
+
+    /// Destroy a unique handle.
+    public fun destroy_handle<T: drop + store>(handle: EventHandle<T>) {
+        EventHandle<T> { counter: _, guid: _ } = handle;
+    }
+
+    // ****************** TEST-ONLY FUNCTIONS **************
+
+    #[test_only]
+    public fun create_guid_wrapper_for_test<T: drop + store>(s: &signer): GUIDWrapper {
+        let EventHandle<T> { counter: _, guid } = new_event_handle<T>(s);
+        guid
+    }
+
+    // ****************** SPECIFICATIONS *******************
+    spec module {} // switch documentation context to module
+
+    spec module {
+        /// Functions of the event module are mocked out using the intrinsic
+        /// pragma. They are implemented in the prover's prelude.
+        pragma intrinsic = true;
+
+        /// Determines equality between the guids of two event handles. Since fields of intrinsic
+        /// structs cannot be accessed, this function is provided.
+        fun spec_guid_eq<T>(h1: EventHandle<T>, h2: EventHandle<T>): bool {
+            // The implementation currently can just use native equality since the mocked prover
+            // representation does not have the `counter` field.
+            h1 == h2
+        }
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/FixedPoint32.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/FixedPoint32.move
@@ -1,0 +1,166 @@
+/// Defines a fixed-point numeric type with a 32-bit integer part and
+/// a 32-bit fractional part.
+
+module Std::FixedPoint32 {
+
+    use Std::Errors;
+
+    /// Define a fixed-point numeric type with 32 fractional bits.
+    /// This is just a u64 integer but it is wrapped in a struct to
+    /// make a unique type. This is a binary representation, so decimal
+    /// values may not be exactly representable, but it provides more
+    /// than 9 decimal digits of precision both before and after the
+    /// decimal point (18 digits total). For comparison, double precision
+    /// floating-point has less than 16 decimal digits of precision, so
+    /// be careful about using floating-point to convert these values to
+    /// decimal.
+    struct FixedPoint32 has copy, drop, store { value: u64 }
+
+    ///> TODO: This is a basic constant and should be provided somewhere centrally in the framework.
+    const MAX_U64: u128 = 18446744073709551615;
+
+    /// The denominator provided was zero
+    const EDENOMINATOR: u64 = 0;
+    /// The quotient value would be too large to be held in a `u64`
+    const EDIVISION: u64 = 1;
+    /// The multiplied value would be too large to be held in a `u64`
+    const EMULTIPLICATION: u64 = 2;
+    /// A division by zero was encountered
+    const EDIVISION_BY_ZERO: u64 = 3;
+    /// The computed ratio when converting to a `FixedPoint32` would be unrepresentable
+    const ERATIO_OUT_OF_RANGE: u64 = 4;
+
+    /// Multiply a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the product. This will abort if the product
+    /// overflows.
+    public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64 {
+        // The product of two 64 bit values has 128 bits, so perform the
+        // multiplication with u128 types and keep the full 128 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (val as u128) * (multiplier.value as u128);
+        // The unscaled product has 32 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 32;
+        // Check whether the value is too large.
+        assert!(product <= MAX_U64, Errors::limit_exceeded(EMULTIPLICATION));
+        (product as u64)
+    }
+    spec multiply_u64 {
+        pragma opaque;
+        include MultiplyAbortsIf;
+        ensures result == spec_multiply_u64(val, multiplier);
+    }
+    spec schema MultiplyAbortsIf {
+        val: num;
+        multiplier: FixedPoint32;
+        aborts_if spec_multiply_u64(val, multiplier) > MAX_U64 with Errors::LIMIT_EXCEEDED;
+    }
+    spec fun spec_multiply_u64(val: num, multiplier: FixedPoint32): num {
+        (val * multiplier.value) >> 32
+    }
+
+    /// Divide a u64 integer by a fixed-point number, truncating any
+    /// fractional part of the quotient. This will abort if the divisor
+    /// is zero or if the quotient overflows.
+    public fun divide_u64(val: u64, divisor: FixedPoint32): u64 {
+        // Check for division by zero.
+        assert!(divisor.value != 0, Errors::invalid_argument(EDIVISION_BY_ZERO));
+        // First convert to 128 bits and then shift left to
+        // add 32 fractional zero bits to the dividend.
+        let scaled_value = (val as u128) << 32;
+        let quotient = scaled_value / (divisor.value as u128);
+        // Check whether the value is too large.
+        assert!(quotient <= MAX_U64, Errors::limit_exceeded(EDIVISION));
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (quotient as u64)
+    }
+    spec divide_u64 {
+        pragma opaque;
+        include DivideAbortsIf;
+        ensures result == spec_divide_u64(val, divisor);
+    }
+    spec schema DivideAbortsIf {
+        val: num;
+        divisor: FixedPoint32;
+        aborts_if divisor.value == 0 with Errors::INVALID_ARGUMENT;
+        aborts_if spec_divide_u64(val, divisor) > MAX_U64 with Errors::LIMIT_EXCEEDED;
+    }
+    spec fun spec_divide_u64(val: num, divisor: FixedPoint32): num {
+        (val << 32) / divisor.value
+    }
+
+    /// Create a fixed-point value from a rational number specified by its
+    /// numerator and denominator. Calling this function should be preferred
+    /// for using `Self::create_from_raw_value` which is also available.
+    /// This will abort if the denominator is zero. It will also
+    /// abort if the numerator is nonzero and the ratio is not in the range
+    /// 2^-32 .. 2^32-1. When specifying decimal fractions, be careful about
+    /// rounding errors: if you round to display N digits after the decimal
+    /// point, you can use a denominator of 10^N to avoid numbers where the
+    /// very small imprecision in the binary representation could change the
+    /// rounding, e.g., 0.0125 will round down to 0.012 instead of up to 0.013.
+    public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32 {
+        // If the denominator is zero, this will abort.
+        // Scale the numerator to have 64 fractional bits and the denominator
+        // to have 32 fractional bits, so that the quotient will have 32
+        // fractional bits.
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        assert!(scaled_denominator != 0, Errors::invalid_argument(EDENOMINATOR));
+        let quotient = scaled_numerator / scaled_denominator;
+        assert!(quotient != 0 || numerator == 0, Errors::invalid_argument(ERATIO_OUT_OF_RANGE));
+        // Return the quotient as a fixed-point number. We first need to check whether the cast
+        // can succeed.
+        assert!(quotient <= MAX_U64, Errors::limit_exceeded(ERATIO_OUT_OF_RANGE));
+        FixedPoint32 { value: (quotient as u64) }
+    }
+    spec create_from_rational {
+        pragma opaque;
+        include CreateFromRationalAbortsIf;
+        ensures result == spec_create_from_rational(numerator, denominator);
+    }
+    spec schema CreateFromRationalAbortsIf {
+        numerator: u64;
+        denominator: u64;
+        let scaled_numerator = numerator << 64;
+        let scaled_denominator = denominator << 32;
+        let quotient = scaled_numerator / scaled_denominator;
+        aborts_if scaled_denominator == 0 with Errors::INVALID_ARGUMENT;
+        aborts_if quotient == 0 && scaled_numerator != 0 with Errors::INVALID_ARGUMENT;
+        aborts_if quotient > MAX_U64 with Errors::LIMIT_EXCEEDED;
+    }
+    spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint32 {
+        FixedPoint32{value: (numerator << 64) / (denominator << 32)}
+    }
+
+    /// Create a fixedpoint value from a raw value.
+    public fun create_from_raw_value(value: u64): FixedPoint32 {
+        FixedPoint32 { value }
+    }
+    spec create_from_raw_value {
+        pragma opaque;
+        aborts_if false;
+        ensures result.value == value;
+    }
+
+    /// Accessor for the raw u64 value. Other less common operations, such as
+    /// adding or subtracting FixedPoint32 values, can be done using the raw
+    /// values directly.
+    public fun get_raw_value(num: FixedPoint32): u64 {
+        num.value
+    }
+
+    /// Returns true if the ratio is zero.
+    public fun is_zero(num: FixedPoint32): bool {
+        num.value == 0
+    }
+
+    // **************** SPECIFICATIONS ****************
+
+    spec module {} // switch documentation context to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/GUID.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/GUID.move
@@ -1,0 +1,112 @@
+/// A module for generating globally unique identifiers
+module Std::GUID {
+    use Std::Signer;
+
+    /// A generator for new GUIDs.
+    struct Generator has key {
+        /// A monotonically increasing counter
+        counter: u64,
+    }
+
+    /// A globally unique identifier derived from the sender's address and a counter
+    struct GUID has drop, store {
+        id: ID
+    }
+
+    /// A non-privileged identifier that can be freely created by anyone. Useful for looking up GUID's.
+    struct ID has copy, drop, store {
+        /// If creation_num is `i`, this is the `i+1`th GUID created by `addr`
+        creation_num: u64,
+        /// Address that created the GUID
+        addr: address
+    }
+
+    /// A capability to create a privileged identifier on behalf of the given address
+    struct CreateCapability has key, store, drop {
+        addr: address
+    }
+
+    /// GUID generator must be published ahead of first usage of `create_with_capability` function.
+    const EGUID_GENERATOR_NOT_PUBLISHED: u64 = 0;
+
+    /// Generates a capability to create the privileged GUID on behalf of the signer
+    // (also makes sure that the Generator is published under the signer account)
+    public fun gen_create_capability(account: &signer): CreateCapability {
+        let addr = Signer::address_of(account);
+        if (!exists<Generator>(addr)) {
+            move_to(account, Generator { counter: 0 })
+        };
+        CreateCapability { addr }
+    }
+
+    /// Create a non-privileged id from `addr` and `creation_num`
+    public fun create_id(addr: address, creation_num: u64): ID {
+        ID { creation_num, addr }
+    }
+
+    public fun create_with_capability(addr: address, _cap: &CreateCapability): GUID acquires Generator {
+        assert!(exists<Generator>(addr), EGUID_GENERATOR_NOT_PUBLISHED);
+        create_impl(addr)
+    }
+
+    /// Create and return a new GUID. Creates a `Generator` under `account`
+    /// if it does not already have one
+    public fun create(account: &signer): GUID acquires Generator {
+        let addr = Signer::address_of(account);
+        if (!exists<Generator>(addr)) {
+            move_to(account, Generator { counter: 0 })
+        };
+        create_impl(addr)
+    }
+
+    fun create_impl(addr: address): GUID acquires Generator {
+        let generator = borrow_global_mut<Generator>(addr);
+        let creation_num = generator.counter;
+        generator.counter = creation_num + 1;
+        GUID { id: ID { creation_num, addr } }
+    }
+
+    /// Publish a Generator resource under `account`
+    public fun publish_generator(account: &signer) {
+        move_to(account, Generator { counter: 0 })
+    }
+
+    /// Get the non-privileged ID associated with a GUID
+    public fun id(guid: &GUID): ID {
+        *&guid.id
+    }
+
+    /// Return the account address that created the GUID
+    public fun creator_address(guid: &GUID): address {
+        guid.id.addr
+    }
+
+    /// Return the account address that created the GUID::ID
+    public fun id_creator_address(id: &ID): address {
+        id.addr
+    }
+
+    /// Return the creation number associated with the GUID
+    public fun creation_num(guid: &GUID): u64 {
+        guid.id.creation_num
+    }
+
+    /// Return the creation number associated with the GUID::ID
+    public fun id_creation_num(id: &ID): u64 {
+        id.creation_num
+    }
+
+    /// Return true if the GUID's ID is `id`
+    public fun eq_id(guid: &GUID, id: &ID): bool {
+        &guid.id == id
+    }
+
+    /// Return the number of the next GUID to be created by `addr`
+    public fun get_next_creation_num(addr: address): u64 acquires Generator {
+        if (!exists<Generator>(addr)) {
+            0
+        } else {
+            borrow_global<Generator>(addr).counter
+        }
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Hash.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Hash.move
@@ -1,0 +1,8 @@
+/// Module which defines SHA hashes for byte vectors.
+///
+/// The functions in this module are natively declared both in the Move runtime
+/// as in the Move prover's prelude.
+module Std::Hash {
+    native public fun sha2_256(data: vector<u8>): vector<u8>;
+    native public fun sha3_256(data: vector<u8>): vector<u8>;
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Option.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Option.move
@@ -1,0 +1,248 @@
+/// This module defines the Option type and its methods to represent and handle an optional value.
+module Std::Option {
+    use Std::Errors;
+    use Std::Vector;
+
+    /// Abstraction of a value that may or may not be present. Implemented with a vector of size
+    /// zero or one because Move bytecode does not have ADTs.
+    struct Option<Element> has copy, drop, store {
+        vec: vector<Element>
+    }
+    spec Option {
+        /// The size of vector is always less than equal to 1
+        /// because it's 0 for "none" or 1 for "some".
+        invariant len(vec) <= 1;
+    }
+
+    /// The `Option` is in an invalid state for the operation attempted.
+    /// The `Option` is `Some` while it should be `None`.
+    const EOPTION_IS_SET: u64 = 0;
+    /// The `Option` is in an invalid state for the operation attempted.
+    /// The `Option` is `None` while it should be `Some`.
+    const EOPTION_NOT_SET: u64 = 1;
+
+    /// Return an empty `Option`
+    public fun none<Element>(): Option<Element> {
+        Option { vec: Vector::empty() }
+    }
+    spec none {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_none<Element>();
+    }
+    spec fun spec_none<Element>(): Option<Element> {
+        Option{ vec: vec() }
+    }
+
+    /// Return an `Option` containing `e`
+    public fun some<Element>(e: Element): Option<Element> {
+        Option { vec: Vector::singleton(e) }
+    }
+    spec some {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_some(e);
+    }
+    spec fun spec_some<Element>(e: Element): Option<Element> {
+        Option{ vec: vec(e) }
+    }
+
+    /// Return true if `t` does not hold a value
+    public fun is_none<Element>(t: &Option<Element>): bool {
+        Vector::is_empty(&t.vec)
+    }
+    spec is_none {
+        pragma opaque;
+        aborts_if false;
+        ensures result == is_none(t);
+    }
+
+    /// Return true if `t` holds a value
+    public fun is_some<Element>(t: &Option<Element>): bool {
+        !Vector::is_empty(&t.vec)
+    }
+    spec is_some {
+        pragma opaque;
+        aborts_if false;
+        ensures result == is_some(t);
+    }
+
+    /// Return true if the value in `t` is equal to `e_ref`
+    /// Always returns `false` if `t` does not hold a value
+    public fun contains<Element>(t: &Option<Element>, e_ref: &Element): bool {
+        Vector::contains(&t.vec, e_ref)
+    }
+    spec contains {
+        pragma opaque;
+        aborts_if false;
+        ensures result == spec_contains(t, e_ref);
+    }
+    spec fun spec_contains<Element>(t: Option<Element>, e: Element): bool {
+        is_some(t) && borrow(t) == e
+    }
+
+    /// Return an immutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun borrow<Element>(t: &Option<Element>): &Element {
+        assert!(is_some(t), Errors::invalid_argument(EOPTION_NOT_SET));
+        Vector::borrow(&t.vec, 0)
+    }
+    spec borrow {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Return a reference to the value inside `t` if it holds one
+    /// Return `default_ref` if `t` does not hold a value
+    public fun borrow_with_default<Element>(t: &Option<Element>, default_ref: &Element): &Element {
+        let vec_ref = &t.vec;
+        if (Vector::is_empty(vec_ref)) default_ref
+        else Vector::borrow(vec_ref, 0)
+    }
+    spec borrow_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default_ref);
+    }
+
+    /// Return the value inside `t` if it holds one
+    /// Return `default` if `t` does not hold a value
+    public fun get_with_default<Element: copy + drop>(
+        t: &Option<Element>,
+        default: Element,
+    ): Element {
+        let vec_ref = &t.vec;
+        if (Vector::is_empty(vec_ref)) default
+        else *Vector::borrow(vec_ref, 0)
+    }
+    spec get_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default);
+    }
+
+    /// Convert the none option `t` to a some option by adding `e`.
+    /// Aborts if `t` already holds a value
+    public fun fill<Element>(t: &mut Option<Element>, e: Element) {
+        let vec_ref = &mut t.vec;
+        if (Vector::is_empty(vec_ref)) Vector::push_back(vec_ref, e)
+        else abort Errors::invalid_argument(EOPTION_IS_SET)
+    }
+    spec fill {
+        pragma opaque;
+        aborts_if is_some(t) with Errors::INVALID_ARGUMENT;
+        ensures is_some(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Convert a `some` option to a `none` by removing and returning the value stored inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun extract<Element>(t: &mut Option<Element>): Element {
+        assert!(is_some(t), Errors::invalid_argument(EOPTION_NOT_SET));
+        Vector::pop_back(&mut t.vec)
+    }
+    spec extract {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(old(t));
+        ensures is_none(t);
+    }
+
+    /// Return a mutable reference to the value inside `t`
+    /// Aborts if `t` does not hold a value
+    public fun borrow_mut<Element>(t: &mut Option<Element>): &mut Element {
+        assert!(is_some(t), Errors::invalid_argument(EOPTION_NOT_SET));
+        Vector::borrow_mut(&mut t.vec, 0)
+    }
+    spec borrow_mut {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Swap the old value inside `t` with `e` and return the old value
+    /// Aborts if `t` does not hold a value
+    public fun swap<Element>(t: &mut Option<Element>, e: Element): Element {
+        assert!(is_some(t), Errors::invalid_argument(EOPTION_NOT_SET));
+        let vec_ref = &mut t.vec;
+        let old_value = Vector::pop_back(vec_ref);
+        Vector::push_back(vec_ref, e);
+        old_value
+    }
+    spec swap {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(old(t));
+        ensures is_some(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Swap the old value inside `t` with `e` and return the old value;
+    /// or if there is no old value, fill it with `e`.
+    /// Different from swap(), swap_or_fill() allows for `t` not holding a value.
+    public fun swap_or_fill<Element>(t: &mut Option<Element>, e: Element): Option<Element> {
+        let vec_ref = &mut t.vec;
+        let old_value = if (Vector::is_empty(vec_ref)) none()
+            else some(Vector::pop_back(vec_ref));
+        Vector::push_back(vec_ref, e);
+        old_value
+    }
+    spec swap_or_fill {
+        pragma opaque;
+        ensures result == old(t);
+        ensures borrow(t) == e;
+    }
+
+    /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
+    public fun destroy_with_default<Element: drop>(t: Option<Element>, default: Element): Element {
+        let Option { vec } = t;
+        if (Vector::is_empty(&mut vec)) default
+        else Vector::pop_back(&mut vec)
+    }
+    spec destroy_with_default {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (if (is_some(t)) borrow(t) else default);
+    }
+
+    /// Unpack `t` and return its contents
+    /// Aborts if `t` does not hold a value
+    public fun destroy_some<Element>(t: Option<Element>): Element {
+        assert!(is_some(&t), Errors::invalid_argument(EOPTION_NOT_SET));
+        let Option { vec } = t;
+        let elem = Vector::pop_back(&mut vec);
+        Vector::destroy_empty(vec);
+        elem
+    }
+    spec destroy_some {
+        pragma opaque;
+        include AbortsIfNone<Element>;
+        ensures result == borrow(t);
+    }
+
+    /// Unpack `t`
+    /// Aborts if `t` holds a value
+    public fun destroy_none<Element>(t: Option<Element>) {
+        assert!(is_none(&t), Errors::invalid_argument(EOPTION_IS_SET));
+        let Option { vec } = t;
+        Vector::destroy_empty(vec)
+    }
+    spec destroy_none {
+        pragma opaque;
+        aborts_if is_some(t) with Errors::INVALID_ARGUMENT;
+    }
+
+    spec module {} // switch documentation context back to module level
+
+    spec module {
+        pragma aborts_if_is_strict;
+    }
+
+    /// # Helper Schema
+
+    spec schema AbortsIfNone<Element> {
+        t: Option<Element>;
+        aborts_if is_none(t) with Errors::INVALID_ARGUMENT;
+    }
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Signer.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Signer.move
@@ -1,0 +1,21 @@
+module Std::Signer {
+    // Borrows the address of the signer
+    // Conceptually, you can think of the `signer` as being a struct wrapper arround an
+    // address
+    // ```
+    // struct Signer has drop { addr: address }
+    // ```
+    // `borrow_address` borrows this inner field
+    native public fun borrow_address(s: &signer): &address;
+
+    // Copies the address of the signer
+    public fun address_of(s: &signer): address {
+        *borrow_address(s)
+    }
+
+    /// Return true only if `s` is a transaction signer. This is a spec function only available in spec.
+    spec native fun is_txn_signer(s: signer): bool;
+
+    /// Return true only if `a` is a transaction signer address. This is a spec function only available in spec.
+    spec native fun is_txn_signer_addr(a: address): bool;
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/UnitTest.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/UnitTest.move
@@ -1,0 +1,12 @@
+#[test_only]
+/// Module providing testing functionality. Only included for tests.
+module Std::UnitTest {
+    /// Return a `num_signers` number of unique signer values. No ordering or
+    /// starting value guarantees are made, only that the order and values of
+    /// the signers in the returned vector is deterministic.
+    ///
+    /// This function is also used to poison modules compiled in `test` mode.
+    /// This will cause a linking failure if an attempt is made to publish a
+    /// test module in a VM that isn't in unit test mode.
+    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
+}

--- a/fastx_programmability/framework/deps/move-stdlib/sources/Vector.move
+++ b/fastx_programmability/framework/deps/move-stdlib/sources/Vector.move
@@ -1,0 +1,189 @@
+/// A variable-sized container that can hold any type. Indexing is 0-based, and
+/// vectors are growable. This module has many native functions.
+/// Verification of modules that use this one uses model functions that are implemented
+/// directly in Boogie. The specification language has built-in functions operations such
+/// as `singleton_vector`. There are some helper functions defined here for specifications in other
+/// modules as well.
+///
+/// >Note: We did not verify most of the
+/// Move functions here because many have loops, requiring loop invariants to prove, and
+/// the return on investment didn't seem worth it for these simple functions.
+module Std::Vector {
+
+    /// The index into the vector is out of bounds
+    const EINDEX_OUT_OF_BOUNDS: u64 = 0;
+
+    /// Create an empty vector.
+    native public fun empty<Element>(): vector<Element>;
+
+    /// Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    /// Acquire an immutable reference to the `i`th element of the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    /// Add element `e` to the end of the vector `v`.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    /// Return a mutable reference to the `i`th element in the vector `v`.
+    /// Aborts if `i` is out of bounds.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, i: u64): &mut Element;
+
+    /// Pop an element from the end of vector `v`.
+    /// Aborts if `v` is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    /// Destroy the vector `v`.
+    /// Aborts if `v` is not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    /// Swaps the elements at the `i`th and `j`th indices in the vector `v`.
+    /// Aborts if `i`or `j` is out of bounds.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    /// Return an vector of size one containing element `e`.
+    public fun singleton<Element>(e: Element): vector<Element> {
+        let v = empty();
+        push_back(&mut v, e);
+        v
+    }
+    spec singleton {
+        // TODO: when using opaque here, we get verification errors.
+        // pragma opaque;
+        aborts_if false;
+        ensures result == vec(e);
+    }
+
+    /// Reverses the order of the elements in the vector `v` in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+    spec reverse {
+        pragma intrinsic = true;
+    }
+
+
+    /// Pushes all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+    spec append {
+        pragma intrinsic = true;
+    }
+    spec is_empty {
+        pragma intrinsic = true;
+    }
+
+
+    /// Return `true` if the vector `v` has no elements and `false` otherwise.
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    /// Return true if `e` is in the vector `v`.
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+    spec contains {
+        pragma intrinsic = true;
+    }
+
+    /// Return `(true, i)` if `e` is in the vector `v` at index `i`.
+    /// Otherwise, returns `(false, 0)`.
+    public fun index_of<Element>(v: &vector<Element>, e: &Element): (bool, u64) {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return (true, i);
+            i = i + 1;
+        };
+        (false, 0)
+    }
+    spec index_of {
+        pragma intrinsic = true;
+    }
+
+    /// Remove the `i`th element of the vector `v`, shifting all subsequent elements.
+    /// This is O(n) and preserves ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+    spec remove {
+        pragma intrinsic = true;
+    }
+
+    /// Swap the `i`th element of the vector `v` with the last element and then pop the vector.
+    /// This is O(1), but does not preserve ordering of elements in the vector.
+    /// Aborts if `i` is out of bounds.
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        assert!(!is_empty(v), EINDEX_OUT_OF_BOUNDS);
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+    spec swap_remove {
+        pragma intrinsic = true;
+    }
+
+    // =================================================================
+    // Module Specification
+
+    spec module {} // Switch to module documentation context
+
+    /// # Helper Functions
+
+    spec module {
+        /// Check if `v1` is equal to the result of adding `e` at the end of `v2`
+        fun eq_push_back<Element>(v1: vector<Element>, v2: vector<Element>, e: Element): bool {
+            len(v1) == len(v2) + 1 &&
+            v1[len(v1)-1] == e &&
+            v1[0..len(v1)-1] == v2[0..len(v2)]
+        }
+
+        /// Check if `v` is equal to the result of concatenating `v1` and `v2`
+        fun eq_append<Element>(v: vector<Element>, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v) == len(v1) + len(v2) &&
+            v[0..len(v1)] == v1 &&
+            v[len(v1)..len(v)] == v2
+        }
+
+        /// Check `v1` is equal to the result of removing the first element of `v2`
+        fun eq_pop_front<Element>(v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1 == v2[1..len(v2)]
+        }
+
+        /// Check that `v1` is equal to the result of removing the element at index `i` from `v2`.
+        fun eq_remove_elem_at_index<Element>(i: u64, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1[0..i] == v2[0..i] &&
+            v1[i..len(v1)] == v2[i + 1..len(v2)]
+        }
+    }
+
+}


### PR DESCRIPTION
This will improve CI performance, as well as local build performance after a Diem version upgrade.

- Copy the latest Move stdlib package over from diem
- Use a local dep on this package rather than a git dep. This will allow CI to build the FastX frmework without downloading the entire diem repo.