### PR TITLE
Add gas logic for transfer orders

### DIFF
--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -157,10 +157,9 @@ fn test_object_basics() {
     let mut storage = InMemoryStorage::new(genesis.objects.clone());
 
     // 0. Create a gas object for gas payment. Note that we won't really use it because we won't be providing a gas budget.
-    let gas_object = Object::with_id_owner_gas_for_testing(
+    let gas_object = Object::with_id_owner_for_testing(
         ObjectID::random(),
         base_types::FastPayAddress::default(),
-        MAX_GAS,
     );
     storage.write_object(gas_object.clone());
     storage.flush();
@@ -298,10 +297,9 @@ fn test_move_call_insufficient_gas() {
     let mut storage = InMemoryStorage::new(genesis.objects.clone());
 
     // 0. Create a gas object for gas payment.
-    let gas_object = Object::with_id_owner_gas_for_testing(
+    let gas_object = Object::with_id_owner_for_testing(
         ObjectID::random(),
         base_types::FastPayAddress::default(),
-        MAX_GAS,
     );
     storage.write_object(gas_object.clone());
     storage.flush();

--- a/fastx_types/src/gas.rs
+++ b/fastx_types/src/gas.rs
@@ -95,6 +95,11 @@ pub fn calculate_module_publish_cost(module_bytes: &[Vec<u8>]) -> u64 {
     module_bytes.iter().map(|v| v.len() as u64).sum::<u64>() + MIN_MOVE_PUBLISH_GAS
 }
 
+pub fn calculate_object_transfer_cost(object: &Object) -> u64 {
+    // TODO: Figure out object transfer gas formula.
+    (object.data.try_as_move().unwrap().contents.len() / 2) as u64
+}
+
 pub fn calculate_object_creation_cost(object: &Object) -> u64 {
     // TODO: Figure out object creation gas formula.
     object.data.try_as_move().unwrap().contents.len() as u64

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -25,6 +25,7 @@ pub struct Transfer {
     pub sender: FastPayAddress,
     pub recipient: Address,
     pub object_ref: ObjectRef,
+    pub gas_payment: ObjectRef,
     pub user_data: UserData,
 }
 
@@ -229,7 +230,7 @@ impl Order {
     pub fn input_objects(&self) -> Vec<ObjectRef> {
         match &self.kind {
             OrderKind::Transfer(t) => {
-                vec![t.object_ref]
+                vec![t.object_ref, t.gas_payment]
             }
             OrderKind::Call(c) => {
                 let mut call_inputs = Vec::with_capacity(2 + c.object_arguments.len());
@@ -257,6 +258,15 @@ impl Order {
                 );
                 &c.gas_payment.0
             }
+        }
+    }
+
+    pub fn gas_payment_object_id(&self) -> &ObjectID {
+        use OrderKind::*;
+        match &self.kind {
+            Transfer(t) => &t.gas_payment.0,
+            Publish(m) => &m.gas_payment.0,
+            Call(c) => &c.gas_payment.0,
         }
     }
 

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -191,7 +191,8 @@ impl Object {
     }
 
     pub fn with_id_owner_for_testing(id: ObjectID, owner: FastPayAddress) -> Self {
-        Self::with_id_owner_gas_for_testing(id, owner, 0)
+        // For testing, we provide sufficient gas by default.
+        Self::with_id_owner_gas_for_testing(id, owner, 100000_u64)
     }
 
     // TODO: this should be test-only, but it's still used in bench and server

--- a/fastx_types/src/unit_tests/messages_tests.rs
+++ b/fastx_types/src/unit_tests/messages_tests.rs
@@ -24,6 +24,11 @@ fn test_signed_values() {
         ),
         sender: a1,
         recipient: Address::FastPay(a2),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer.clone(), &sec1);
@@ -61,6 +66,11 @@ fn test_certificates() {
         ),
         sender: a1,
         recipient: Address::FastPay(a2),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer.clone(), &sec1);

--- a/fastx_types/src/unit_tests/serialize_tests.rs
+++ b/fastx_types/src/unit_tests/serialize_tests.rs
@@ -64,6 +64,11 @@ fn test_order() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let transfer_order = Order::new_transfer(transfer, &sender_key);
@@ -86,6 +91,11 @@ fn test_order() {
         ),
         sender: sender_name,
         recipient: Address::FastPay(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let transfer_order2 = Order::new_transfer(transfer2, &sender_key);
@@ -111,6 +121,11 @@ fn test_vote() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer, &sender_key);
@@ -139,6 +154,11 @@ fn test_cert() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer, &sender_key);
@@ -175,6 +195,11 @@ fn test_info_response() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer, &sender_key);
@@ -250,6 +275,11 @@ fn test_time_order() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
 
@@ -286,6 +316,11 @@ fn test_time_vote() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer, &sender_key);
@@ -328,6 +363,11 @@ fn test_time_cert() {
         ),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0)),
+        gas_payment: (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::new([0; 32]),
+        ),
         user_data: UserData::default(),
     };
     let order = Order::new_transfer(transfer, &sender_key);


### PR DESCRIPTION
In https://github.com/MystenLabs/fastnft/pull/119 we added gas logic for move related orders. This PR adds gas logic for transfer orders.
It does the following:
1. Added a `gas_payment field` to `Transfer` order, representing the gas object.
2. Adjusted all related interfaces in client and authority to pass around the gas object.
3. In authority, deduct gas when executing the Transfer order.
4. Added `gas_payment_object_id` to Order type.
5. Adjusted all tests to reflect the change.

Mostly ready for review.
TODO: Need to add a few tests that checks the gas when sending Transfer order.