### PR TITLE
[fastx framework] Maintain object sequence numbers across unwrapping

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -133,7 +133,7 @@ impl ClientServerBenchmark {
                 let object_id: ObjectID = ObjectID::random();
 
                 let object = Object::with_id_owner_for_testing(object_id, keypair.0);
-                assert!(object.next_sequence_number == SequenceNumber::from(0));
+                assert!(object.version() == SequenceNumber::from(0));
                 let object_ref = object.to_object_reference();
                 state.init_order_lock(object_ref).await;
                 state.insert_object(object).await;
@@ -141,7 +141,7 @@ impl ClientServerBenchmark {
 
                 let gas_object_id = ObjectID::random();
                 let gas_object = Object::with_id_owner_for_testing(gas_object_id, keypair.0);
-                assert!(gas_object.next_sequence_number == SequenceNumber::from(0));
+                assert!(gas_object.version() == SequenceNumber::from(0));
                 let gas_object_ref = gas_object.to_object_reference();
                 state.init_order_lock(gas_object_ref).await;
                 state.insert_object(gas_object).await;

--- a/fastpay_core/src/authority/authority_store.rs
+++ b/fastpay_core/src/authority/authority_store.rs
@@ -54,7 +54,7 @@ impl AuthorityStore {
             .objects
             .iter()
             .filter(|(_, object)| object.owner == account)
-            .map(|(id, object)| (id, object.next_sequence_number, object.digest()))
+            .map(|(id, object)| (id, object.version(), object.digest()))
             .collect())
     }
 

--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -209,7 +209,7 @@ impl ResourceResolver for AuthorityTemporaryStore {
             Data::Move(m) => {
                 assert!(struct_tag == &m.type_, "Invariant violation: ill-typed object in storage or bad object request from caller\
 ");
-                Ok(Some(m.contents.clone()))
+                Ok(Some(m.contents().to_vec()))
             }
             other => unimplemented!(
                 "Bad object lookup: expected Move object, but got {:?}",

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -158,8 +158,7 @@ async fn fund_account<I: IntoIterator<Item = Vec<ObjectID>>>(
 ) {
     for (authority, object_ids) in authorities.into_iter().zip(object_ids.into_iter()) {
         for object_id in object_ids {
-            let mut object = Object::with_id_for_testing(object_id);
-            object.transfer(client.address);
+            let object = Object::with_id_owner_for_testing(object_id, client.address);
             let client_ref = authority.0.as_ref().try_lock().unwrap();
 
             client_ref

--- a/fastx_programmability/adapter/src/genesis.rs
+++ b/fastx_programmability/adapter/src/genesis.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use fastx_framework::{self};
 use fastx_types::{
     base_types::{
-        FastPayAddress, SequenceNumber, TransactionDigest, TxContext, TX_CONTEXT_ADDRESS,
-        TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
+        FastPayAddress, TransactionDigest, TxContext, TX_CONTEXT_ADDRESS, TX_CONTEXT_MODULE_NAME,
+        TX_CONTEXT_STRUCT_NAME,
     },
     coin::{COIN_ADDRESS, COIN_MODULE_NAME, COIN_STRUCT_NAME},
     gas_coin::{GAS_ADDRESS, GAS_MODULE_NAME, GAS_STRUCT_NAME},
@@ -77,12 +77,7 @@ fn create_genesis_module_objects() -> Result<Genesis> {
                     *struct_name
                 );
             }
-            Object::new_module(
-                m,
-                owner,
-                SequenceNumber::new(),
-                TransactionDigest::genesis(),
-            )
+            Object::new_module(m, owner, TransactionDigest::genesis())
         })
         .collect();
     Ok(Genesis {

--- a/fastx_programmability/framework/sources/ObjectBasics.move
+++ b/fastx_programmability/framework/sources/ObjectBasics.move
@@ -5,9 +5,14 @@ module FastX::ObjectBasics {
     use FastX::TxContext::{Self, TxContext};
     use FastX::Transfer;
 
-    struct Object has key {
+    struct Object has key, store {
         id: ID,
         value: u64,
+    }
+
+    struct Wrapper has key {
+        id: ID,
+        o: Object 
     }
 
     public fun create(value: u64, recipient: vector<u8>, ctx: &mut TxContext) {
@@ -28,6 +33,15 @@ module FastX::ObjectBasics {
 
     public fun delete(o: Object, _ctx: &mut TxContext) {
         let Object { id: _, value: _ } = o;
+    }
+
+    public fun wrap(o: Object, ctx: &mut TxContext) {
+        Transfer::transfer(Wrapper { id: TxContext::new_id(ctx), o }, TxContext::get_signer_address(ctx))
+    }
+
+    public fun unwrap(w: Wrapper, ctx: &mut TxContext) {
+        let Wrapper { id: _, o } = w;
+        Transfer::transfer(o, TxContext::get_signer_address(ctx))
     }
 
 }

--- a/fastx_programmability/framework/src/lib.rs
+++ b/fastx_programmability/framework/src/lib.rs
@@ -7,7 +7,6 @@ use fastx_verifier::verifier as fastx_bytecode_verifier;
 use move_binary_format::CompiledModule;
 use move_core_types::{ident_str, language_storage::ModuleId};
 use move_package::{compilation::compiled_package::CompiledPackage, BuildConfig};
-
 use std::path::PathBuf;
 
 pub mod natives;

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -279,6 +279,7 @@ impl std::fmt::Debug for PublicKeyBytes {
     }
 }
 
+// TODO: rename to version
 impl SequenceNumber {
     pub fn new() -> Self {
         SequenceNumber(0)
@@ -286,6 +287,10 @@ impl SequenceNumber {
 
     pub fn max() -> Self {
         SequenceNumber(0x7fff_ffff_ffff_ffff)
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
     }
 
     pub fn increment(self) -> Result<SequenceNumber, FastPayError> {

--- a/fastx_types/src/coin.rs
+++ b/fastx_types/src/coin.rs
@@ -10,7 +10,7 @@ use move_core_types::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    base_types::ObjectID,
+    base_types::{ObjectID, SequenceNumber},
     gas_coin::{GAS_ADDRESS, GAS_MODULE_NAME, GAS_STRUCT_NAME},
     id::ID,
 };
@@ -45,6 +45,10 @@ impl Coin {
 
     pub fn id(&self) -> &ObjectID {
         self.id.object_id()
+    }
+
+    pub fn version(&self) -> SequenceNumber {
+        self.id.version()
     }
 
     pub fn value(&self) -> u64 {

--- a/fastx_types/src/gas.rs
+++ b/fastx_types/src/gas.rs
@@ -86,10 +86,9 @@ pub fn deduct_gas(gas_object: &mut Object, amount: i128) -> FastPayResult {
             balance, -amount
         )
     )?;
-    let new_gas_coin = GasCoin::new(*gas_coin.id(), new_balance as u64);
-    gas_object.data.try_as_move_mut().unwrap().contents = bcs::to_bytes(&new_gas_coin).unwrap();
-    let sequence_number = gas_object.next_sequence_number.increment()?;
-    gas_object.next_sequence_number = sequence_number;
+    let new_gas_coin = GasCoin::new(*gas_coin.id(), gas_object.version(), new_balance as u64);
+    let move_object = gas_object.data.try_as_move_mut().unwrap();
+    move_object.update_contents(bcs::to_bytes(&new_gas_coin).unwrap())?;
     Ok(())
 }
 
@@ -105,15 +104,15 @@ pub fn calculate_module_publish_cost(module_bytes: &[Vec<u8>]) -> u64 {
 
 pub fn calculate_object_transfer_cost(object: &Object) -> u64 {
     // TODO: Figure out object transfer gas formula.
-    (object.data.try_as_move().unwrap().contents.len() / 2) as u64
+    (object.data.try_as_move().unwrap().contents().len() / 2) as u64
 }
 
 pub fn calculate_object_creation_cost(object: &Object) -> u64 {
     // TODO: Figure out object creation gas formula.
-    object.data.try_as_move().unwrap().contents.len() as u64
+    object.data.try_as_move().unwrap().contents().len() as u64
 }
 
 pub fn calculate_object_deletion_refund(object: &Object) -> u64 {
     // TODO: Figure out object creation gas formula.
-    (object.data.try_as_move().unwrap().contents.len() / 2) as u64
+    (object.data.try_as_move().unwrap().contents().len() / 2) as u64
 }

--- a/fastx_types/src/id.rs
+++ b/fastx_types/src/id.rs
@@ -6,7 +6,7 @@ use move_core_types::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::base_types::ObjectID;
+use crate::base_types::{ObjectID, SequenceNumber};
 
 /// 0x3C2B307C3239F61643AF5E9A09D7D0C9
 pub const ID_ADDRESS: AccountAddress = AccountAddress::new([
@@ -19,6 +19,7 @@ pub const ID_STRUCT_NAME: &IdentStr = ID_MODULE_NAME;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ID {
     id: IDBytes,
+    version: u64,
 }
 
 /// Rust version of the Move FastX::ID::IDBytes type
@@ -28,9 +29,10 @@ struct IDBytes {
 }
 
 impl ID {
-    pub fn new(bytes: ObjectID) -> Self {
+    pub fn new(bytes: ObjectID, version: SequenceNumber) -> Self {
         Self {
             id: IDBytes::new(bytes),
+            version: version.value(),
         }
     }
 
@@ -45,6 +47,10 @@ impl ID {
 
     pub fn object_id(&self) -> &ObjectID {
         &self.id.bytes
+    }
+
+    pub fn version(&self) -> SequenceNumber {
+        SequenceNumber::from(self.version)
     }
 
     pub fn to_bcs_bytes(&self) -> Vec<u8> {

--- a/fastx_types/src/unit_tests/base_types_tests.rs
+++ b/fastx_types/src/unit_tests/base_types_tests.rs
@@ -42,10 +42,39 @@ fn test_max_sequence_number() {
 #[test]
 fn test_gas_coin_ser_deser_roundtrip() {
     let id = ObjectID::random();
-    let coin = GasCoin::new(id, 10);
+    let coin = GasCoin::new(id, SequenceNumber::new(), 10);
     let coin_bytes = coin.to_bcs_bytes();
 
     let deserialized_coin: GasCoin = bcs::from_bytes(&coin_bytes).unwrap();
     assert_eq!(deserialized_coin.id(), coin.id());
     assert_eq!(deserialized_coin.value(), coin.value());
+    assert_eq!(deserialized_coin.version(), coin.version());
+}
+
+#[test]
+fn test_increment_version() {
+    let id = ObjectID::random();
+    let version = SequenceNumber::from(257);
+    let value = 10;
+    let coin = GasCoin::new(id, version, value);
+    assert_eq!(coin.id(), &id);
+    assert_eq!(coin.value(), value);
+    assert_eq!(coin.version(), version);
+
+    let mut coin_obj = coin.to_object();
+    assert_eq!(&coin_obj.id(), coin.id());
+    assert_eq!(coin_obj.version(), coin.version());
+
+    // update contents, which should increase sequence number, but leave
+    // everything else the same
+    let old_contents = coin_obj.contents().to_vec();
+    let old_type_specific_contents = coin_obj.type_specific_contents().to_vec();
+    coin_obj.update_contents(old_contents).unwrap();
+    assert_eq!(coin_obj.version(), version.increment().unwrap());
+    assert_eq!(&coin_obj.id(), coin.id());
+    assert_eq!(
+        coin_obj.type_specific_contents(),
+        old_type_specific_contents
+    );
+    assert!(GasCoin::try_from(&coin_obj).unwrap().value() == coin.value());
 }


### PR DESCRIPTION
 Trying approach (1) to addressing https://github.com/MystenLabs/fastnft/issues/98. In particular, this:
    
- Extends the Move `ID` type to include a `version`. This allows all Move objects to carry their version, and thus persist it across wrapping and unwrapping. But having it live inside `ID` saves us from having to rewrite the `ID`-related bytecode verifier passes or ask the programmer to write `struct S has key { id: ID, version: Version, ... }` to declare a FastX object. In fact, there are no changes from the programmer's perspective except that they can now read an object's version inside Move if they wish to.
- Removed `version` from the Rust object types, since it now lives in the Move-managed `contents` field. Added a variety of helper functions for reading and writing the `version from Rust.
- Changed the adapter to understand the new location of `version`. This actually simplifies the adapter code quite a bit.
- Added a test that demonstrates that sequence numbers are maintained correctly across wrapping and unwrapping.
    
There is one change introduced here that is important enough to mention separately *object versions now begin at 1*. That is, if a transaction creates and then transfers an object `X`, the version of `X` in the transaction effects will be 1, not 0. The reasons why this change is needed are somewhat subtle:
- This change happens because the adapter increments the sequence number of every transferred object.
- You could imagine asking the adapter to instead check whether a transferred object was created by the current transaction, passed as an input, or unwrapped + only incrementing the sequence number in the second two cases. However, if sequence numbers of freshly created objects started at 0, the adapter would actually not be able to tell the difference between a freshly created object `O1` (will have seq 0) and an object `O2` that was created (will have seq 0), then subsequently wrapped (will still have seq 0), and later unwrapped (will still have seq 0!).
- Another solution to this problem would be incrementing the sequence number of all objects passed as inputs to the transaction before beginning execution. This would allow freshly created objects to start at seq 0, but it would be slightly odd in that the programmer would pass in an object with seq `S`, but would see `S+1 if they try to read the sequence number from Move during the transaction. It seems most intuitive to maintain the invariant that the object you put into the transaction is exactly what you will read inside the transaction. In addition, that would require us to do the "created or transferred/unwrapped" special-casing described above, which makes the adapter a bit more complicated.