### PR TITLE
Include genesis when creating new AuthorityState

### DIFF
--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -25,6 +25,7 @@ strum_macros = "0.23.1"
 num_cpus = "1.13.1"
 
 fastpay_core = { path = "../fastpay_core" }
+fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-types = { path = "../fastx_types" }
 
 [[bin]]

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -853,7 +853,7 @@ async fn test_authority_persist() {
     let mut opts = rocksdb::Options::default();
     opts.set_max_open_files(max_files_authority_tests());
     let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
-    let authority = AuthorityState::new(
+    let authority = AuthorityState::new_without_genesis_for_testing(
         committee.clone(),
         authority_address,
         authority_key.copy(),
@@ -878,7 +878,12 @@ async fn test_authority_persist() {
     let mut opts = rocksdb::Options::default();
     opts.set_max_open_files(max_files_authority_tests());
     let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
-    let authority2 = AuthorityState::new(committee, authority_address, authority_key, store);
+    let authority2 = AuthorityState::new_without_genesis_for_testing(
+        committee,
+        authority_address,
+        authority_key,
+        store,
+    );
     let obj2 = authority2.object_state(&object_id).await.unwrap();
 
     // Check the object is present
@@ -906,7 +911,12 @@ fn init_state() -> AuthorityState {
     let mut opts = rocksdb::Options::default();
     opts.set_max_open_files(max_files_authority_tests());
     let store = Arc::new(AuthorityStore::open(path, Some(opts)));
-    AuthorityState::new(committee, authority_address, authority_key, store)
+    AuthorityState::new_without_genesis_for_testing(
+        committee,
+        authority_address,
+        authority_key,
+        store,
+    )
 }
 
 #[cfg(test)]

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -93,7 +93,12 @@ fn init_local_authorities(
         let mut opts = rocksdb::Options::default();
         opts.set_max_open_files(max_files_client_tests());
         let store = Arc::new(AuthorityStore::open(path, Some(opts)));
-        let state = AuthorityState::new(committee.clone(), address, secret, store);
+        let state = AuthorityState::new_without_genesis_for_testing(
+            committee.clone(),
+            address,
+            secret,
+            store,
+        );
         clients.insert(address, LocalAuthorityClient::new(state));
     }
     (clients, committee)
@@ -127,7 +132,12 @@ fn init_local_authorities_bad_1(
         let mut opts = rocksdb::Options::default();
         opts.set_max_open_files(max_files_client_tests());
         let store = Arc::new(AuthorityStore::open(path, Some(opts)));
-        let state = AuthorityState::new(committee.clone(), address, secret, store);
+        let state = AuthorityState::new_without_genesis_for_testing(
+            committee.clone(),
+            address,
+            secret,
+            store,
+        );
         clients.insert(address, LocalAuthorityClient::new(state));
     }
     (clients, committee)


### PR DESCRIPTION
When creating AuthorityState, there needs to be an option to include the genesis objects. Also need to setup the native functions properly when genesis is available.
This will be needed by both the server and the bench.