### PR TITLE
Change Object to be a module package

### DIFF
--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -188,7 +188,7 @@ impl ModuleResolver for AuthorityTemporaryStore {
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         match self.read_object(module_id.address()) {
             Some(o) => match &o.data {
-                Data::Module(c) => Ok(Some(c.clone())),
+                Data::Package(c) => Ok(c.get(module_id.name().as_str()).cloned()),
                 _ => Err(FastPayError::BadObjectType {
                     error: "Expected module object".to_string(),
                 }),

--- a/fastx_programmability/adapter/src/genesis.rs
+++ b/fastx_programmability/adapter/src/genesis.rs
@@ -5,80 +5,52 @@ use crate::adapter;
 use anyhow::Result;
 use fastx_framework::{self};
 use fastx_types::{
-    base_types::{
-        FastPayAddress, TransactionDigest, TxContext, TX_CONTEXT_ADDRESS, TX_CONTEXT_MODULE_NAME,
-        TX_CONTEXT_STRUCT_NAME,
-    },
-    coin::{COIN_ADDRESS, COIN_MODULE_NAME, COIN_STRUCT_NAME},
-    gas_coin::{GAS_ADDRESS, GAS_MODULE_NAME, GAS_STRUCT_NAME},
-    id::{ID_ADDRESS, ID_MODULE_NAME, ID_STRUCT_NAME},
+    base_types::{FastPayAddress, TransactionDigest, TxContext},
     object::Object,
-    FASTX_FRAMEWORK_ADDRESS, MOVE_STDLIB_ADDRESS,
-};
-use move_binary_format::access::ModuleAccess;
-use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    FASTX_FRAMEWORK_ADDRESS, FASTX_FRAMEWORK_OBJECT_ID, MOVE_STDLIB_ADDRESS, MOVE_STDLIB_OBJECT_ID,
 };
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use once_cell::sync::Lazy;
-use std::{collections::BTreeMap, sync::Mutex};
+use std::sync::Mutex;
 
-pub static GENESIS: Lazy<Mutex<Genesis>> =
+static GENESIS: Lazy<Mutex<Genesis>> =
     Lazy::new(|| Mutex::new(create_genesis_module_objects().unwrap()));
 
-pub struct Genesis {
+struct Genesis {
     pub objects: Vec<Object>,
     pub native_functions: NativeFunctionTable,
+}
+
+pub fn clone_genesis_data() -> (Vec<Object>, NativeFunctionTable) {
+    let genesis = GENESIS.lock().unwrap();
+    (genesis.objects.clone(), genesis.native_functions.clone())
 }
 
 /// Create and return objects wrapping the genesis modules for fastX
 fn create_genesis_module_objects() -> Result<Genesis> {
     let mut tx_context = TxContext::new(TransactionDigest::genesis());
-    let mut modules = fastx_framework::get_framework_modules()?;
-    let sub_map = adapter::generate_module_ids(&mut modules, &mut tx_context)?;
-    let mut native_functions =
-        fastx_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, FASTX_FRAMEWORK_ADDRESS);
-    // Rewrite native function table to reflect address substitutions. Otherwise, natives will fail to link
-    for native in native_functions.iter_mut() {
-        let old_id = ModuleId::new(native.0, native.1.to_owned());
-        if let Some(new_id) = sub_map.get(&old_id) {
-            native.0 = *new_id.address();
-            // substitution should not change module names
-            assert_eq!(native.1, new_id.name().to_owned());
-        }
+    let modules = fastx_framework::get_framework_packages()?;
+    let packages = adapter::generate_package_info_map(modules, &mut tx_context)?;
+    let fastx_framework_addr = packages[&FASTX_FRAMEWORK_ADDRESS].0;
+    let move_stdlib_addr = packages[&MOVE_STDLIB_ADDRESS].0;
+    if fastx_framework_addr != FASTX_FRAMEWORK_OBJECT_ID {
+        panic!(
+            "FastX framework address doesn't match, expecting: {:#X?}",
+            fastx_framework_addr
+        );
     }
+    if move_stdlib_addr != MOVE_STDLIB_OBJECT_ID {
+        panic!(
+            "Move stdlib address doesn't match, expecting: {:#X?}",
+            move_stdlib_addr
+        );
+    }
+    let native_functions =
+        fastx_framework::natives::all_natives(move_stdlib_addr, fastx_framework_addr);
     let owner = FastPayAddress::default();
-    let expected_addresses: BTreeMap<&IdentStr, (AccountAddress, &IdentStr)> = vec![
-        (COIN_MODULE_NAME, (COIN_ADDRESS, COIN_STRUCT_NAME)),
-        (GAS_MODULE_NAME, (GAS_ADDRESS, GAS_STRUCT_NAME)),
-        (ID_MODULE_NAME, (ID_ADDRESS, ID_STRUCT_NAME)),
-        (
-            TX_CONTEXT_MODULE_NAME,
-            (TX_CONTEXT_ADDRESS, TX_CONTEXT_STRUCT_NAME),
-        ),
-    ]
-    .into_iter()
-    .collect();
-    let objects = modules
-        .into_iter()
-        .map(|m| {
-            let self_id = m.self_id();
-            // check that modules the runtime needs to know about have the expected names and addresses
-            // if these assertions fail, it's likely because the corresponding constants need to be updated
-            if let Some((address, struct_name)) = expected_addresses.get(self_id.name()) {
-                assert!(
-                    self_id.address() == address,
-                    "Found new address for {}: {}",
-                    self_id.name(),
-                    self_id.address()
-                );
-                assert_eq!(
-                    m.identifier_at(m.struct_handle_at(m.struct_defs[0].struct_handle).name),
-                    *struct_name
-                );
-            }
-            Object::new_module(m, owner, TransactionDigest::genesis())
-        })
+    let objects = packages
+        .into_values()
+        .map(|(_, modules)| Object::new_package(modules, owner, TransactionDigest::genesis()))
         .collect();
     Ok(Genesis {
         objects,

--- a/fastx_programmability/framework/src/lib.rs
+++ b/fastx_programmability/framework/src/lib.rs
@@ -16,14 +16,15 @@ pub mod natives;
 const MAX_UNIT_TEST_INSTRUCTIONS: u64 = 100_000;
 
 /// Return all the modules of the fastX framework and its dependencies in topologically
-/// sorted dependency order (leaves first)
-pub fn get_framework_modules() -> Result<Vec<CompiledModule>> {
+/// sorted dependency order (leaves first). The packages are organized
+/// as a map from the address to all modules in that address.
+pub fn get_framework_packages() -> Result<Vec<CompiledModule>> {
     let include_examples = false;
     let verify = true;
-    get_framework_modules_(include_examples, verify)
+    get_framework_packages_(include_examples, verify)
 }
 
-fn get_framework_modules_(include_examples: bool, verify: bool) -> Result<Vec<CompiledModule>> {
+fn get_framework_packages_(include_examples: bool, verify: bool) -> Result<Vec<CompiledModule>> {
     // TODO: prune unused deps from Move stdlib instead of using an explicit denylist.
     // The manually curated list are modules that do not pass the FastX verifier
     let denylist = vec![
@@ -32,7 +33,7 @@ fn get_framework_modules_(include_examples: bool, verify: bool) -> Result<Vec<Co
         ModuleId::new(MOVE_STDLIB_ADDRESS, ident_str!("GUID").to_owned()),
     ];
     let package = build(include_examples)?;
-    let filtered_modules = package
+    let filtered_modules: Vec<CompiledModule> = package
         .transitive_compiled_modules()
         .iter_modules_owned()
         .into_iter()
@@ -62,7 +63,7 @@ fn build(include_examples: bool) -> Result<CompiledPackage> {
 fn check_that_move_code_can_be_built_verified_testsd() {
     let include_examples = true;
     let verify = true;
-    get_framework_modules_(include_examples, verify).unwrap();
+    get_framework_packages_(include_examples, verify).unwrap();
     // ideally this would be a separate test, but doing so introduces
     // races because of https://github.com/diem/diem/issues/10102
     run_move_unit_tests();

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -84,11 +84,6 @@ pub struct TransactionDigest([u8; TRANSACTION_DIGEST_LENGTH]);
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
 pub struct ObjectDigest([u8; 32]); // We use SHA3-256 hence 32 bytes here
 
-// TODO: migrate TxContext type + these constants to a separate file
-/// 0x81D51F48E5DFC02DBC8F6003517274F7
-pub const TX_CONTEXT_ADDRESS: AccountAddress = AccountAddress::new([
-    0x81, 0xD5, 0x1F, 0x48, 0xE5, 0xDF, 0xC0, 0x2D, 0xBC, 0x8F, 0x60, 0x03, 0x51, 0x72, 0x74, 0xF7,
-]);
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("TxContext");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = TX_CONTEXT_MODULE_NAME;
 

--- a/fastx_types/src/coin.rs
+++ b/fastx_types/src/coin.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::{
-    account_address::AccountAddress,
     ident_str,
     identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
@@ -11,14 +10,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     base_types::{ObjectID, SequenceNumber},
-    gas_coin::{GAS_ADDRESS, GAS_MODULE_NAME, GAS_STRUCT_NAME},
+    gas_coin::{GAS_MODULE_NAME, GAS_STRUCT_NAME},
     id::ID,
+    FASTX_FRAMEWORK_OBJECT_ID,
 };
 
-/// 0x2CD564FF647DB701AFE7B1E8A3F1A31B
-pub const COIN_ADDRESS: AccountAddress = AccountAddress::new([
-    0x2C, 0xD5, 0x64, 0xFF, 0x64, 0x7D, 0xB7, 0x01, 0xAF, 0xE7, 0xB1, 0xE8, 0xA3, 0xF1, 0xA3, 0x1B,
-]);
 pub const COIN_MODULE_NAME: &IdentStr = ident_str!("Coin");
 pub const COIN_STRUCT_NAME: &IdentStr = COIN_MODULE_NAME;
 
@@ -36,7 +32,7 @@ impl Coin {
 
     pub fn type_(type_param: StructTag) -> StructTag {
         StructTag {
-            address: GAS_ADDRESS,
+            address: FASTX_FRAMEWORK_OBJECT_ID,
             name: GAS_STRUCT_NAME.to_owned(),
             module: GAS_MODULE_NAME.to_owned(),
             type_params: vec![TypeTag::Struct(type_param)],

--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -110,6 +110,8 @@ pub enum FastPayError {
     // Move call related errors
     #[error("Function resolution failure: {error:?}.")]
     FunctionNotFound { error: String },
+    #[error("Module not found in package: {module_name:?}.")]
+    ModuleNotFound { module_name: String },
     #[error("Function signature is invalid: {error:?}.")]
     InvalidFunctionSignature { error: String },
     #[error("Type error while binding function arguments: {error:?}.")]

--- a/fastx_types/src/gas_coin.rs
+++ b/fastx_types/src/gas_coin.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{
-    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::StructTag,
-};
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
@@ -13,12 +11,9 @@ use crate::{
     error::{FastPayError, FastPayResult},
     id::ID,
     object::{Data, MoveObject, Object},
+    FASTX_FRAMEWORK_OBJECT_ID,
 };
 
-/// 0x01B3B1DD18A3B775FE0E0D4B873C0AA0
-pub const GAS_ADDRESS: AccountAddress = AccountAddress::new([
-    0x01, 0xB3, 0xB1, 0xDD, 0x18, 0xA3, 0xB7, 0x75, 0xFE, 0x0E, 0x0D, 0x4B, 0x87, 0x3C, 0x0A, 0xA0,
-]);
 pub const GAS_MODULE_NAME: &IdentStr = ident_str!("GAS");
 pub const GAS_STRUCT_NAME: &IdentStr = GAS_MODULE_NAME;
 
@@ -37,7 +32,7 @@ impl GasCoin {
 
     pub fn type_() -> StructTag {
         Coin::type_(StructTag {
-            address: GAS_ADDRESS,
+            address: FASTX_FRAMEWORK_OBJECT_ID,
             name: GAS_STRUCT_NAME.to_owned(),
             module: GAS_MODULE_NAME.to_owned(),
             type_params: Vec::new(),
@@ -83,7 +78,7 @@ impl TryFrom<&Object> for GasCoin {
     fn try_from(value: &Object) -> FastPayResult<GasCoin> {
         match &value.data {
             Data::Move(obj) => obj.try_into(),
-            Data::Module(_) => Err(FastPayError::TypeError {
+            Data::Package(_) => Err(FastPayError::TypeError {
                 error: format!("Gas object type is not a gas coin: {:?}", value),
             }),
         }

--- a/fastx_types/src/lib.rs
+++ b/fastx_types/src/lib.rs
@@ -33,3 +33,13 @@ pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::new([
 pub const FASTX_FRAMEWORK_ADDRESS: AccountAddress = AccountAddress::new([
     0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8,
 ]);
+
+/// 0xFDC6D587C83A348E456B034E1E0C31E9, object ID of the move stdlib package.
+pub const MOVE_STDLIB_OBJECT_ID: AccountAddress = AccountAddress::new([
+    0xFD, 0xC6, 0xD5, 0x87, 0xC8, 0x3A, 0x34, 0x8E, 0x45, 0x6B, 0x03, 0x4E, 0x1E, 0x0C, 0x31, 0xE9,
+]);
+
+/// 0x6D3FFC5213ED4DF6802CD4535D3C18F6, object ID of the fastx framework package.
+pub const FASTX_FRAMEWORK_OBJECT_ID: AccountAddress = AccountAddress::new([
+    0x6D, 0x3F, 0xFC, 0x52, 0x13, 0xED, 0x4D, 0xF6, 0x80, 0x2C, 0xD4, 0x53, 0x5D, 0x3C, 0x18, 0xF6,
+]);

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -31,7 +31,8 @@ pub struct Transfer {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveCall {
     pub sender: FastPayAddress,
-    pub module: ObjectRef,
+    pub package: ObjectRef,
+    pub module: Identifier,
     pub function: Identifier,
     pub type_arguments: Vec<TypeTag>,
     pub gas_payment: ObjectRef,
@@ -205,7 +206,8 @@ impl Order {
     #[allow(clippy::too_many_arguments)]
     pub fn new_move_call(
         sender: FastPayAddress,
-        module: ObjectRef,
+        package: ObjectRef,
+        module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
         gas_payment: ObjectRef,
@@ -216,6 +218,7 @@ impl Order {
     ) -> Self {
         let kind = OrderKind::Call(MoveCall {
             sender,
+            package,
             module,
             function,
             type_arguments,
@@ -275,7 +278,7 @@ impl Order {
             OrderKind::Call(c) => {
                 let mut call_inputs = Vec::with_capacity(2 + c.object_arguments.len());
                 call_inputs.extend(c.object_arguments.clone());
-                call_inputs.push(c.module);
+                call_inputs.push(c.package);
                 call_inputs.push(c.gas_payment);
                 call_inputs
             }


### PR DESCRIPTION
Previously, an `Object` can be either a Move object, or a Move module. 
Each module has an internal address (because Move expects it). In Diem, such address is simply where the module is published to, and multiple modules can be published to the same address.
However in FastX, since each module has a different address, even modules from the same package will have different addresses. This makes it extremely inconvenient to program with dependencies, because when you have dependencies to modules from the same package, you have to use different addresses to refer them. For instance, FastX::ObjectBasics has a different address than FastX::Transfer, which has a different address than FastX::Coin, and etc.

This PR changes the `Object` (in the modules case) to be a package, which is a collection of modules that are published together and belong to the same address. To facilitate fast lookup, it is in the form of a map from module name to the underline serialized module.

To summarize the list of changes made by this PR:
1. The Data enum now has `Package(MovePackage)` instead of `Module(Vec<u8>)`, which is defined as `BTreeMap<String, Vec<u8>>`. When fetching the ID of the Package, it picks the ID of the first module in it, as all modules share the same address in the same package.
2. A Move call order now need to also pass the module name along with the package object. @oxade  for the client
3. `generate_module_ids` in adapter is changed to `generate_package_info_map`. It goes over all modules, group them by address to generate a list of packages, each package has a new id.
4. All the hardcoded addresses from different modules in the fastx framework can be removed.
5. Also had some issues with genesis deadlocking. Changed the access to genesis so that no one can lock it from outside (and hence no deadlock).