### PR TITLE
Added a parent iterator by `object_id` or `(object_id,version)`

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -497,4 +497,16 @@ impl AuthorityState {
     ) -> Result<Vec<Option<Object>>, FastPayError> {
         self._database.get_objects(_objects)
     }
+
+    /// Returns all parents (object_ref and transaction digests) that match an object_id, at
+    /// any object version, or optionally at a specific version.
+    pub async fn get_parent_iterator(
+        &self,
+        object_id: ObjectID,
+        seq: Option<SequenceNumber>,
+    ) -> Result<Vec<(ObjectRef, TransactionDigest)>, FastPayError> {
+        {
+            self._database.get_parent_iterator(object_id, seq)
+        }
+    }
 }

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -767,7 +767,7 @@ async fn test_handle_confirmation_order_ok() {
                 .unwrap();
             authority_state.read_certificate(&refx).await.unwrap()
         },
-        Some(certified_transfer_order)
+        Some(certified_transfer_order.clone())
     );
 
     // Check locks are set and archived correctly
@@ -780,6 +780,15 @@ async fn test_handle_confirmation_order_ok() {
         .await
         .expect("Exists")
         .is_none());
+
+    // Check that all the parents are returned.
+    assert!(
+        authority_state.get_parent_iterator(object_id, None).await
+            == Ok(vec![(
+                (object_id, 1.into(), new_account.digest()),
+                certified_transfer_order.order.digest()
+            )])
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Now the authority provide facilities to look up parents of object by object_id rather than object_ref, and optionally for a specific (numerical) version.