### PR TITLE
Cache object id at root level

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -412,7 +412,7 @@ impl AuthorityState {
             .or::<FastPayError>(Ok(None))?;
 
         Ok(ObjectInfoResponse {
-            object_id: object.id(),
+            object_id: object.id,
             owner: object.owner,
             next_sequence_number: object.version(),
             requested_certificate,

--- a/fastpay_core/src/authority/authority_store.rs
+++ b/fastpay_core/src/authority/authority_store.rs
@@ -147,12 +147,12 @@ impl AuthorityStore {
     /// Insert an object
     pub fn insert_object(&self, object: Object) -> Result<(), FastPayError> {
         self.objects
-            .insert(&object.id(), &object)
+            .insert(&object.id, &object)
             .map_err(|_| FastPayError::StorageError)?;
 
         // Update the index
         self.owner_index
-            .insert(&(object.owner, object.id()), &object.to_object_reference())
+            .insert(&(object.owner, object.id), &object.to_object_reference())
             .map_err(|_| FastPayError::StorageError)?;
 
         Ok(())

--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -15,7 +15,7 @@ impl AuthorityTemporaryStore {
     ) -> AuthorityTemporaryStore {
         AuthorityTemporaryStore {
             object_store: authority_state._database.clone(),
-            objects: _input_objects.iter().map(|v| (v.id(), v.clone())).collect(),
+            objects: _input_objects.iter().map(|v| (v.id, v.clone())).collect(),
             active_inputs: _input_objects
                 .iter()
                 .filter(|v| !v.is_read_only())
@@ -151,7 +151,7 @@ impl Storage for AuthorityTemporaryStore {
     fn write_object(&mut self, object: Object) {
         // Check it is not read-only
         #[cfg(test)] // Movevm should ensure this
-        if let Some(existing_object) = self.read_object(&object.id()) {
+        if let Some(existing_object) = self.read_object(&object.id) {
             if existing_object.is_read_only() {
                 // This is an internal invariant violation. Move only allows us to
                 // mutate objects if they are &mut so they cannot be read-only.
@@ -160,7 +160,7 @@ impl Storage for AuthorityTemporaryStore {
         }
 
         self.written.push(object.to_object_reference());
-        self.objects.insert(object.id(), object);
+        self.objects.insert(object.id, object);
     }
 
     fn delete_object(&mut self, id: &ObjectID) {

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -428,7 +428,7 @@ async fn test_handle_move_order() {
         .await
         .unwrap();
     assert_eq!(created_obj.owner, sender,);
-    assert_eq!(created_obj.id(), created_object_id);
+    assert_eq!(created_obj.id, created_object_id);
     assert_eq!(created_obj.version(), SequenceNumber::from(1));
 
     // Check that gas is properly deducted.
@@ -887,7 +887,7 @@ async fn test_authority_persist() {
     let obj2 = authority2.object_state(&object_id).await.unwrap();
 
     // Check the object is present
-    assert_eq!(obj2.id(), object_id);
+    assert_eq!(obj2.id, object_id);
     assert_eq!(obj2.owner, recipient);
 }
 

--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -445,7 +445,7 @@ fn resolve_and_type_check(
                     Type::Struct { .. } => {
                         // TODO(https://github.com/MystenLabs/fastnft/issues/96): check m.mutability
                         type_check_struct(&m.type_, &param_type)?;
-                        let res = by_value_objects.insert(object.id(), object);
+                        let res = by_value_objects.insert(object.id, object);
                         // should always pass due to earlier "no duplicate ID's" check
                         debug_assert!(res.is_none())
                     }

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -32,7 +32,7 @@ impl InMemoryStorage {
     pub fn new(objects: Vec<Object>) -> Self {
         let mut persistent = BTreeMap::new();
         for o in objects {
-            persistent.insert(o.id(), o);
+            persistent.insert(o.id, o);
         }
         Self {
             persistent,
@@ -90,7 +90,7 @@ impl Storage for InMemoryStorage {
 
     // buffer write to appropriate place in temporary storage
     fn write_object(&mut self, object: Object) {
-        let id = object.id();
+        let id = object.id;
         if self.persistent.contains_key(&id) {
             self.temporary.updated.insert(id, object);
         } else {
@@ -221,7 +221,7 @@ fn test_object_basics() {
     let transferred_obj = storage.read_object(&id1).unwrap();
     assert_eq!(transferred_obj.owner, addr2);
     obj1_seq = obj1_seq.increment().unwrap();
-    assert_eq!(obj1.id(), transferred_obj.id());
+    assert_eq!(obj1.id, transferred_obj.id);
     assert_eq!(transferred_obj.version(), obj1_seq);
     assert_eq!(
         obj1.data.try_as_move().unwrap().type_specific_contents(),

--- a/fastx_types/src/gas.rs
+++ b/fastx_types/src/gas.rs
@@ -26,7 +26,7 @@ const MIN_OBJ_TRANSFER_GAS: u64 = 8;
 pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> FastPayResult {
     match &order.kind {
         OrderKind::Transfer(t) => {
-            debug_assert_eq!(t.gas_payment.0, gas_object.id());
+            debug_assert_eq!(t.gas_payment.0, gas_object.id);
             let balance = get_gas_balance(gas_object)?;
             ok_or_gas_error!(
                 balance >= MIN_OBJ_TRANSFER_GAS,
@@ -37,7 +37,7 @@ pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> FastPayResul
             )
         }
         OrderKind::Publish(publish) => {
-            debug_assert_eq!(publish.gas_payment.0, gas_object.id());
+            debug_assert_eq!(publish.gas_payment.0, gas_object.id);
             let balance = get_gas_balance(gas_object)?;
             ok_or_gas_error!(
                 balance >= MIN_MOVE_PUBLISH_GAS,
@@ -48,7 +48,7 @@ pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> FastPayResul
             )
         }
         OrderKind::Call(call) => {
-            debug_assert_eq!(call.gas_payment.0, gas_object.id());
+            debug_assert_eq!(call.gas_payment.0, gas_object.id);
             ok_or_gas_error!(
                 call.gas_budget >= MIN_MOVE_CALL_GAS,
                 format!(

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -167,6 +167,8 @@ pub struct Object {
     pub owner: FastPayAddress,
     /// The digest of the order that created or last mutated this object
     pub previous_transaction: TransactionDigest,
+    /// ID of the object
+    pub id: ObjectID,
 }
 
 impl BcsSignable for Object {}
@@ -178,10 +180,12 @@ impl Object {
         owner: FastPayAddress,
         previous_transaction: TransactionDigest,
     ) -> Self {
+        let id = o.id();
         Object {
             data: Data::Move(o),
             owner,
             previous_transaction,
+            id,
         }
     }
 
@@ -196,6 +200,7 @@ impl Object {
             data: Data::Module(bytes),
             owner,
             previous_transaction,
+            id: *m.self_id().address(),
         }
     }
 
@@ -207,19 +212,7 @@ impl Object {
     }
 
     pub fn to_object_reference(&self) -> ObjectRef {
-        (self.id(), self.version(), self.digest())
-    }
-
-    pub fn id(&self) -> ObjectID {
-        use Data::*;
-
-        match &self.data {
-            Move(v) => v.id(),
-            Module(m) => {
-                // TODO: extract ID by peeking into the bytes instead of deserializing
-                *CompiledModule::deserialize(m).unwrap().self_id().address()
-            }
-        }
+        (self.id, self.version(), self.digest())
     }
 
     pub fn version(&self) -> SequenceNumber {
@@ -273,6 +266,7 @@ impl Object {
             owner,
             data,
             previous_transaction: TransactionDigest::genesis(),
+            id,
         }
     }
 


### PR DESCRIPTION
This will make it faster to load id. Also we are going to change how module object works, which will require an id field anyway.