### PR TITLE
[deps] switch dep from diem to move

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -21,9 +21,9 @@ fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-framework = { path = "../fastx_programmability/framework" }
 fastx-types = { path = "../fastx_types" }
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-vm-runtime = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
 
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "0ef3f1fedcfbf3dfe0eeea65e05de073b7c25733" }

--- a/fastx_programmability/adapter/Cargo.toml
+++ b/fastx_programmability/adapter/Cargo.toml
@@ -13,12 +13,12 @@ bcs = "0.1.3"
 once_cell = "1.9.0"
 structopt = "0.3.25"
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-bytecode-utils = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-cli = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-vm-runtime = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-cli = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
 
 fastx-framework = { path = "../framework" }
 fastx-verifier = { path = "../verifier" }
@@ -26,7 +26,7 @@ fastx-types = { path = "../../fastx_types" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
-move-package = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-package = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
 
 [[bin]]
 name = "fastx"

--- a/fastx_programmability/framework/Cargo.toml
+++ b/fastx_programmability/framework/Cargo.toml
@@ -14,12 +14,12 @@ smallvec = "1.7.0"
 fastx-types = { path = "../../fastx_types" }
 fastx-verifier = { path = "../verifier" }
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-cli = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-package = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-stdlib = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-unit-test = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-vm-runtime = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-vm-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-cli = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-package = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-stdlib = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-unit-test = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-vm-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-bytecode-verifier = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
 
 fastx-types = { path = "../../fastx_types" }

--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -23,5 +23,5 @@ structopt = "0.3.25"
 thiserror = "1.0.30"
 rocksdb = "0.17.0"
 
-move-binary-format = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
-move-core-types = { git = "https://github.com/diem/diem", rev="346301f33b3489bb4e486ae6c0aa5e030223b492" }
+move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }

--- a/scripts/move_dependency.py
+++ b/scripts/move_dependency.py
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Mysten Labs
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
@@ -7,7 +7,7 @@ import re
 
 ROOT = os.path.join(os.path.dirname(__file__), "../")
 PATTERN = re.compile(
-    '(\s*)(.+) = { git = "https://github.com/.+/diem", (?:rev|branch)=".+" }(\s*)'
+    '(\s*)(.+) = { git = "https://github.com/.+/move", (?:rev|branch)=".+" }(\s*)'
 )
 
 
@@ -16,7 +16,7 @@ def parse_args():
     subparser = parser.add_subparsers(
         dest="command",
         description="""
-    Automatically manage the dependency path to Diem repository.
+    Automatically manage the dependency path to Move repository.
     Command "local" switches the dependency from git to local path.
     Command "upgrade" upgrades the git revision. A repository can be
     specified if we want to use a fork instead of upstream.
@@ -51,7 +51,7 @@ def scan_files(path, process_line, depth=0):
 
 
 def switch_to_local():
-    # Packages that don't directly map to a directory under diem/language
+    # Packages that don't directly map to a directory under move/language
     # go here as special cases. By default, we just use language/[name].
     path_map = {
         "move-bytecode-utils": "tools/move-bytecode-utils",
@@ -69,7 +69,7 @@ def switch_to_local():
             name = m.group(2)
             postfix = m.group(3)
             go_back = "".join(["../"] * (depth + 1))
-            return '{}{} = {{ path = "{}diem/language/{}" }}{}'.format(
+            return '{}{} = {{ path = "{}move/language/{}" }}{}'.format(
                 prefix, name, go_back, path_map.get(name, name), postfix
             )
         return line
@@ -85,7 +85,7 @@ def upgrade_revision(repo, rev, branch):
             prefix = m.group(1)
             name = m.group(2)
             postfix = m.group(3)
-            return '{}{} = {{ git = "https://github.com/{}/diem", {}="{}" }}{}'.format(
+            return '{}{} = {{ git = "https://github.com/{}/move", {}="{}" }}{}'.format(
                 prefix, name, repo,
                 "branch" if branch else "rev",
                 branch if branch else rev,


### PR DESCRIPTION
Move finally got its own repo, so we can kill all dependencies on Diem and have FastX depend only on Move. This updates both the Cargo.toml's and the dependency upgrade script. CI and build performance should both improve a bit as a result--the Move repo is much smaller than the Diem one.