### PR TITLE
[RFC] decoupling sequence numbers from replay protection

### DIFF
--- a/fastpay/src/bench.rs
+++ b/fastpay/src/bench.rs
@@ -201,12 +201,8 @@ impl ClientServerBenchmark {
             let gas_object_ref = gas_obj.to_object_reference();
 
             let order = if self.use_move {
-                // TODO: authority should not require seq# or digets for package in Move calls. Use dummy values
-                let framework_obj_ref = (
-                    FASTX_FRAMEWORK_ADDRESS,
-                    SequenceNumber::new(),
-                    ObjectDigest::new([0; 32]),
-                );
+                // TODO: authority should not require seq# or digests for package in Move calls. Use dummy values
+                let framework_obj_ref = (FASTX_FRAMEWORK_ADDRESS, ObjectDigest::new([0; 32]));
 
                 Order::new_move_call(
                     *account_addr,

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -136,10 +136,8 @@ fn make_benchmark_transfer_orders(
             gas_payment: gas_object_ref,
         };
         debug!("Preparing transfer order: {:?}", transfer);
-        let (object_id, seq, digest) = object_ref;
-        account
-            .object_refs
-            .insert(object_id, (object_id, seq.increment(), digest));
+        let (object_id, digest) = object_ref;
+        account.object_refs.insert(object_id, (object_id, digest));
         next_recipient = account.address;
         let order = Order::new_transfer(transfer.clone(), &account.key);
         orders.push(order.clone());
@@ -313,19 +311,19 @@ fn show_object_effects(order_effects: OrderEffects) {
     if !order_effects.created.is_empty() {
         println!("Created Objects:");
         for (obj, _) in order_effects.created {
-            println!("{:?} {:?} {:?}", obj.0, obj.1, obj.2);
+            println!("{:?} {:?}", obj.0, obj.1);
         }
     }
     if !order_effects.mutated.is_empty() {
         println!("Mutated Objects:");
-        for (obj, _) in order_effects.mutated {
-            println!("{:?} {:?} {:?}", obj.0, obj.1, obj.2);
+        for obj in order_effects.mutated {
+            println!("{:?} {:?}", obj.0, obj.1);
         }
     }
     if !order_effects.deleted.is_empty() {
         println!("Deleted Objects:");
         for obj in order_effects.deleted {
-            println!("{:?} {:?} {:?}", obj.0, obj.1, obj.2);
+            println!("{:?} {:?}", obj.0, obj.1);
         }
     }
 }

--- a/fastpay/src/server.rs
+++ b/fastpay/src/server.rs
@@ -49,7 +49,7 @@ fn make_server(
         .await;
         for initial_state_cfg_entry in &initial_accounts_config.config {
             let address = &initial_state_cfg_entry.address;
-            for (object_id, _, _) in &initial_state_cfg_entry.object_refs {
+            for (object_id, _) in &initial_state_cfg_entry.object_refs {
                 let object = Object::with_id_owner_for_testing(*object_id, *address);
 
                 state.init_order_lock(object.to_object_reference()).await;

--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -65,7 +65,7 @@ impl AuthorityTemporaryStore {
     /// mutated during the order execution, force mutating them by incrementing the
     /// sequence number. This is required to achieve safety.
     pub fn ensure_active_inputs_mutated(&mut self) {
-        for (id, _seq, _) in self.active_inputs.iter() {
+        for (id, _) in self.active_inputs.iter() {
             if !self.written.contains_key(id) && !self.deleted.contains(id) {
                 let mut object = self.objects[id].clone();
                 // Active input object must be Move object.

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -82,7 +82,8 @@ pub type AuthorityName = PublicKeyBytes;
 // addresses, either by changing Move to allow different address lengths or by decoupling
 // addresses and ID's
 pub type ObjectID = AccountAddress;
-pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
+pub type ObjectRef = (ObjectID, ObjectDigest);
+pub type VersionedObjectRef = (ObjectRef, SequenceNumber);
 
 // We use SHA3-256 hence 32 bytes here
 const TRANSACTION_DIGEST_LENGTH: usize = 32;

--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -40,14 +40,6 @@ pub enum FastPayError {
     // Certificate verification
     #[error("Signatures in a certificate must form a quorum")]
     CertificateRequiresQuorum,
-    #[error(
-        "The given sequence ({received_sequence:?}) number must match the next expected sequence ({expected_sequence:?}) number of the account"
-    )]
-    UnexpectedSequenceNumber {
-        object_id: ObjectID,
-        expected_sequence: SequenceNumber,
-        received_sequence: SequenceNumber,
-    },
     #[error("Conflicting order already received: {pending_confirmation:?}")]
     ConflictingOrder { pending_confirmation: Order },
     #[error("Transfer order was processed but no signature was produced by authority")]
@@ -66,12 +58,8 @@ pub enum FastPayError {
     FailedToCommunicateWithQuorum { err: String },
     #[error("An invalid answer was returned by the authority while requesting information")]
     ErrorWhileRequestingInformation,
-    #[error(
-         "Cannot confirm a transfer while previous transfer orders are still pending confirmation: {current_sequence_number:?}"
-    )]
-    MissingEalierConfirmations {
-        current_sequence_number: VersionNumber,
-    },
+    #[error("Cannot confirm a transfer while previous order has not been confirmed")]
+    MissingEalierConfirmations { missing: TransactionDigest },
     // Synchronization validation
     #[error("Transaction index must increase by one")]
     UnexpectedTransactionIndex,
@@ -82,8 +70,6 @@ pub enum FastPayError {
     UnknownSenderAccount,
     #[error("Signatures in a certificate must be from different authorities.")]
     CertificateAuthorityReuse,
-    #[error("Sequence numbers above the maximal value are not usable for transfers.")]
-    InvalidSequenceNumber,
     #[error("Sequence number overflow.")]
     SequenceOverflow,
     #[error("Sequence number underflow.")]
@@ -96,7 +82,7 @@ pub enum FastPayError {
     InvalidAuthenticator,
     #[error("Invalid transaction digest.")]
     InvalidTransactionDigest,
-    #[error("Invalid Object digest.")]
+    #[error("Object digest contained in ObjRef does not match the digest of the stored object")]
     InvalidObjectDigest,
     #[error("Cannot deserialize.")]
     InvalidDecoding,

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -16,7 +16,7 @@ use crate::FASTX_FRAMEWORK_ADDRESS;
 use crate::{
     base_types::{
         sha3_hash, BcsSignable, FastPayAddress, ObjectDigest, ObjectID, ObjectRef, SequenceNumber,
-        TransactionDigest,
+        TransactionDigest, VersionedObjectRef,
     },
     gas_coin::GasCoin,
 };
@@ -243,7 +243,11 @@ impl Object {
     }
 
     pub fn to_object_reference(&self) -> ObjectRef {
-        (self.id(), self.version(), self.digest())
+        (self.id(), self.digest())
+    }
+
+    pub fn to_versioned_object_reference(&self) -> VersionedObjectRef {
+        (self.to_object_reference(), self.version())
     }
 
     pub fn id(&self) -> ObjectID {

--- a/fastx_types/src/unit_tests/messages_tests.rs
+++ b/fastx_types/src/unit_tests/messages_tests.rs
@@ -17,18 +17,10 @@ fn test_signed_values() {
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: a1,
         recipient: Address::FastPay(a2),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer.clone(), &sec1);
     let bad_order = Order::new_transfer(transfer, &sec2);
@@ -58,18 +50,10 @@ fn test_certificates() {
     let committee = Committee::new(authorities);
 
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: a1,
         recipient: Address::FastPay(a2),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer.clone(), &sec1);
     let bad_order = Order::new_transfer(transfer, &sec2);

--- a/fastx_types/src/unit_tests/serialize_tests.rs
+++ b/fastx_types/src/unit_tests/serialize_tests.rs
@@ -57,18 +57,10 @@ fn test_order() {
     let (sender_name, sender_key) = get_key_pair();
 
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let transfer_order = Order::new_transfer(transfer, &sender_key);
 
@@ -83,18 +75,10 @@ fn test_order() {
 
     let (sender_name, sender_key) = get_key_pair();
     let transfer2 = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::FastPay(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let transfer_order2 = Order::new_transfer(transfer2, &sender_key);
 
@@ -112,18 +96,10 @@ fn test_order() {
 fn test_vote() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer, &sender_key);
 
@@ -144,18 +120,10 @@ fn test_vote() {
 fn test_cert() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer, &sender_key);
     let mut cert = CertifiedOrder {
@@ -184,18 +152,10 @@ fn test_cert() {
 fn test_info_response() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer, &sender_key);
 
@@ -251,18 +211,10 @@ fn test_info_response() {
 fn test_time_order() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
 
     let mut buf = Vec::new();
@@ -291,18 +243,10 @@ fn test_time_order() {
 fn test_time_vote() {
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0x20)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer, &sender_key);
 
@@ -337,18 +281,10 @@ fn test_time_cert() {
     let count = 100;
     let (sender_name, sender_key) = get_key_pair();
     let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        object_ref: (ObjectID::random(), ObjectDigest::new([0; 32])),
         sender: sender_name,
         recipient: Address::Primary(dbg_addr(0)),
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
+        gas_payment: (ObjectID::random(), ObjectDigest::new([0; 32])),
     };
     let order = Order::new_transfer(transfer, &sender_key);
     let mut cert = CertifiedOrder {


### PR DESCRIPTION
In FastX, replay protection comes from the presence of all `ObjectRef` inputs in the `LockMap`, not from sequence numbers. This is an experimental PR that takes steps toward removing all sequence number-related checks from the authority code to demonstrate this.

A follow-up to this PR could redefine `ObjectRef` to remove sequence numbers altogether. This would allow clients to stop tracking sequence numbers locally and sending them over the wire.