### PR TITLE
[chore] bump move version

### DIFF
--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -34,9 +34,9 @@ fastpay_core = { path = "../fastpay_core" }
 fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-types = { path = "../fastx_types" }
 
-move-package = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-package = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
 [[bin]]
 name = "client"

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -21,9 +21,9 @@ fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-framework = { path = "../fastx_programmability/framework" }
 fastx-types = { path = "../fastx_types" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-binary-format = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "0ef3f1fedcfbf3dfe0eeea65e05de073b7c25733" }

--- a/fastx_programmability/adapter/Cargo.toml
+++ b/fastx_programmability/adapter/Cargo.toml
@@ -13,12 +13,12 @@ bcs = "0.1.3"
 once_cell = "1.9.0"
 structopt = "0.3.25"
 
-move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-cli = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-binary-format = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-cli = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
 fastx-framework = { path = "../framework" }
 fastx-verifier = { path = "../verifier" }
@@ -26,7 +26,7 @@ fastx-types = { path = "../../fastx_types" }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
-move-package = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-package = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
 [[bin]]
 name = "fastx"

--- a/fastx_programmability/framework/Cargo.toml
+++ b/fastx_programmability/framework/Cargo.toml
@@ -14,15 +14,15 @@ smallvec = "1.7.0"
 fastx-types = { path = "../../fastx_types" }
 fastx-verifier = { path = "../verifier" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-cli = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-package = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-stdlib = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-unit-test = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-vm-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-binary-format = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-cli = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-package = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-stdlib = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-unit-test = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-vm-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
 
 [package.metadata.cargo-udeps.ignore]

--- a/fastx_programmability/framework/src/lib.rs
+++ b/fastx_programmability/framework/src/lib.rs
@@ -58,12 +58,9 @@ fn build(sub_dir: &str) -> Vec<CompiledModule> {
 #[test]
 fn check_that_move_code_can_be_built_verified_tested() {
     get_fastx_framework_modules();
-    // ideally this would be a separate test, but doing so introduces
-    // races because of https://github.com/diem/diem/issues/10102
-    run_move_unit_tests();
 }
 
-#[cfg(test)]
+#[test]
 fn run_move_unit_tests() {
     use fastx_types::{FASTX_FRAMEWORK_ADDRESS, MOVE_STDLIB_ADDRESS};
     use move_cli::package::cli::{self, UnitTestResult};

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-binary-format = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
 fastx-types = { path = "../../fastx_types" }

--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -21,5 +21,5 @@ thiserror = "1.0.30"
 hex = "0.4.3"
 
 
-move-binary-format = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
-move-core-types = { git = "https://github.com/diem/move", rev="98ed299a7e3a9223019c9bdf4dd92fea9faef860" }
+move-binary-format = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
+move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }


### PR DESCRIPTION
Take advantage of https://github.com/diem/move/pull/13, which will allow us to build Move packages concurrently without encountering flakiness due to races in the cache. Split a test that caused flakiness before to demonstrate that it works.

This will also allow us to move `ObjectBasics` out of the framework and into a test package, but I don't want to do that here because there are a few in-flight PR's that touch this module.