### PR TITLE
Fix panic on referencing deleted obj

### DIFF
--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -177,7 +177,7 @@ impl Storage for AuthorityTemporaryStore {
                 .get(id)
                 .expect("Internal invariant: object must exist to be deleted.")
                 .to_object_reference(),
-        );   
+        );
     }
 }
 


### PR DESCRIPTION
If a contract causes a delete, Adapter [deletes](https://github.com/MystenLabs/fastnft/blob/bugfix/authority-obj-delete-panic/fastx_programmability/adapter/src/adapter.rs#L296) the object [(here)](https://github.com/MystenLabs/fastnft/blob/main/fastpay_core/src/authority/temporary_store.rs#L175) from the StateView  [object map](https://github.com/MystenLabs/fastnft/blob/main/fastpay_core/src/authority/temporary_store.rs#L12) and pushes the deleted object to the [ list of deleted objects](https://github.com/MystenLabs/fastnft/blob/main/fastpay_core/src/authority/temporary_store.rs#L15) for use later when updating its eventual state.

However after Adapter execution, Authority tries to update its object state by [searching](https://github.com/MystenLabs/fastnft/blob/main/fastpay_core/src/authority/authority_store.rs#L334) its object map however the object was removed, which causes panic.

A proposed solution is to not delete the object from the object map until the update stage.

See issue: https://github.com/MystenLabs/fastnft/issues/196