### PR TITLE
Consolidate TxContext and TxContextMove

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -208,7 +208,7 @@ impl AuthorityState {
 
         // Insert into the certificates map
         let transaction_digest = certificate.order.digest();
-        let mut tx_ctx = TxContext::new(transaction_digest);
+        let mut tx_ctx = TxContext::new(order.sender(), transaction_digest);
 
         // Order-specific logic
         let mut temporary_store = AuthorityTemporaryStore::new(self, &inputs);

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -285,7 +285,7 @@ async fn test_publish_dependent_module_ok() {
         vec![dependent_module_bytes],
         &sender_key,
     );
-    let dependent_module_id = TxContext::new(order.digest()).fresh_id();
+    let dependent_module_id = TxContext::new(&sender, order.digest()).fresh_id();
 
     // Object does not exist
     assert!(authority.object_state(&dependent_module_id).await.is_err());
@@ -313,7 +313,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let module_bytes = vec![module_bytes];
     let gas_cost = calculate_module_publish_cost(&module_bytes);
     let order = Order::new_module(sender, gas_payment_object_ref, module_bytes, &sender_key);
-    let _module_object_id = TxContext::new(order.digest()).fresh_id();
+    let _module_object_id = TxContext::new(&sender, order.digest()).fresh_id();
     let _response = send_and_confirm_order(&mut authority, order).await.unwrap();
 
     // check that the module actually got published

--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -532,7 +532,7 @@ fn resolve_and_type_check(
         }
     }
     args.append(&mut pure_args);
-    args.push(ctx.to_bcs_bytes_hack());
+    args.push(ctx.to_vec());
 
     Ok(TypeCheckSuccess {
         module_id,

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -166,7 +166,7 @@ fn call(
         pure_args,
         gas_budget,
         gas_object,
-        TxContext::random(),
+        TxContext::random_for_testing_only(),
     )
 }
 
@@ -487,7 +487,7 @@ fn test_publish_module_insufficient_gas() {
     module.serialize(&mut module_bytes).unwrap();
     let module_bytes = vec![module_bytes];
 
-    let mut tx_context = TxContext::random();
+    let mut tx_context = TxContext::random_for_testing_only();
     let response = adapter::publish(
         &mut storage,
         natives,
@@ -657,7 +657,7 @@ fn test_publish_module_linker_error() {
     dependent_module.serialize(&mut module_bytes).unwrap();
     let module_bytes = vec![module_bytes];
 
-    let mut tx_context = TxContext::random();
+    let mut tx_context = TxContext::random_for_testing_only();
     let response = adapter::publish(
         &mut storage,
         natives,


### PR DESCRIPTION
This will close #89.
Merge them so that we can properly pass it across Move/FastX boundary.