### PR TITLE
Sequence number increment should not fail

### DIFF
--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -119,10 +119,9 @@ fn make_benchmark_transfer_orders(
             ),
         };
         debug!("Preparing transfer order: {:?}", transfer);
-        account.object_ids.insert(
-            object_id,
-            account.object_ids[&object_id].increment().unwrap(),
-        );
+        account
+            .object_ids
+            .insert(object_id, account.object_ids[&object_id].increment());
         next_recipient = account.address;
         let order = Order::new_transfer(transfer.clone(), &account.key);
         orders.push(order.clone());

--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -230,7 +230,7 @@ impl AuthorityState {
                 output_object.transfer(match t.recipient {
                     Address::Primary(_) => FastPayAddress::default(),
                     Address::FastPay(addr) => addr,
-                })?;
+                });
                 temporary_store.write_object(output_object);
                 Ok(())
             }
@@ -300,7 +300,7 @@ impl AuthorityState {
 
             // Get the Transaction Digest that created the object
             let parent_iterator = self
-                .get_parent_iterator(request.object_id, Some(seq.increment()?))
+                .get_parent_iterator(request.object_id, Some(seq.increment()))
                 .await?;
             let (_, transaction_digest) = parent_iterator
                 .first()

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -527,7 +527,7 @@ where
                     let certificate = requester.query(number).await?;
                     entry.push(certificate);
                 }
-                number = number.increment().unwrap_or_else(|_| SequenceNumber::max());
+                number = number.increment();
             }
         }
         Ok(sent_certificates)
@@ -593,8 +593,7 @@ where
             let mut new_next_sequence_number = self.next_sequence_number(object_id)?;
 
             if seq >= new_next_sequence_number {
-                new_next_sequence_number =
-                    seq.increment().unwrap_or_else(|_| SequenceNumber::max());
+                new_next_sequence_number = seq.increment();
             }
 
             self.certificates
@@ -897,7 +896,7 @@ where
                         *certificate.order.object_id(),
                         vec![certificate.clone()],
                         CommunicateAction::SynchronizeNextSequenceNumber(
-                            transfer.object_ref.1.increment()?,
+                            transfer.object_ref.1.increment(),
                         ),
                     )
                     .await?;
@@ -906,7 +905,7 @@ where
                         self.certificates.entry(certificate.order.digest())
                     {
                         self.object_ids
-                            .insert(transfer.object_ref.0, transfer.object_ref.1.increment()?);
+                            .insert(transfer.object_ref.0, transfer.object_ref.1.increment());
                         self.object_certs
                             .entry(transfer.object_ref.0)
                             .or_default()

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -327,7 +327,7 @@ async fn test_publish_module_no_dependencies_ok() {
     check_gas_object(
         &gas_payment_object,
         gas_balance - gas_cost,
-        gas_seq.increment().unwrap(),
+        gas_seq.increment(),
     )
 }
 
@@ -434,7 +434,7 @@ async fn test_handle_move_order() {
     check_gas_object(
         &gas_payment_object,
         gas_balance - gas_cost,
-        gas_seq.increment().unwrap(),
+        gas_seq.increment(),
     )
 }
 
@@ -568,7 +568,7 @@ async fn test_handle_confirmation_order_bad_sequence_number() {
         let o = sender_object.data.try_as_move_mut().unwrap();
         let old_contents = o.contents().to_vec();
         // update object contents, which will increment the sequence number
-        o.update_contents(old_contents).unwrap();
+        o.update_contents(old_contents);
         authority_state.insert_object(sender_object).await;
     }
 
@@ -581,7 +581,7 @@ async fn test_handle_confirmation_order_bad_sequence_number() {
 
     // Check that the new object is the one recorded.
     let new_account = authority_state.object_state(&object_id).await.unwrap();
-    assert_eq!(old_seq_num.increment().unwrap(), new_account.version());
+    assert_eq!(old_seq_num.increment(), new_account.version());
 
     // No recipient object was created.
     assert!(authority_state
@@ -746,7 +746,7 @@ async fn test_handle_confirmation_order_ok() {
 
     let old_account = authority_state.object_state(&object_id).await.unwrap();
     let mut next_sequence_number = old_account.version();
-    next_sequence_number = next_sequence_number.increment().unwrap();
+    next_sequence_number = next_sequence_number.increment();
 
     let info = authority_state
         .handle_confirmation_order(ConfirmationOrder::new(certified_transfer_order.clone()))

--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -274,7 +274,7 @@ fn process_successful_execution<
         obj.data
             .try_as_move_mut()
             .expect("We previously checked that mutable ref inputs are Move objects")
-            .update_contents(new_contents)?;
+            .update_contents(new_contents);
         state_view.write_object(obj);
     }
     // process events to identify transfers, freezes
@@ -298,7 +298,7 @@ fn process_successful_execution<
                 // increment the object version. note that if the transferred object was
                 // freshly created, this means that its version will now be 1.
                 // thus, all objects in the global object pool have version > 0
-                move_obj.increment_version()?;
+                move_obj.increment_version();
                 if should_freeze {
                     move_obj.freeze();
                 }

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -239,7 +239,7 @@ fn test_object_basics() {
     storage.flush();
     let transferred_obj = storage.read_object(&id1).unwrap();
     assert_eq!(transferred_obj.owner, addr2);
-    obj1_seq = obj1_seq.increment().unwrap();
+    obj1_seq = obj1_seq.increment();
     assert_eq!(obj1.id(), transferred_obj.id());
     assert_eq!(transferred_obj.version(), obj1_seq);
     assert_eq!(
@@ -297,7 +297,7 @@ fn test_object_basics() {
     storage.flush();
     let updated_obj = storage.read_object(&id1).unwrap();
     assert_eq!(updated_obj.owner, addr2);
-    obj1_seq = obj1_seq.increment().unwrap();
+    obj1_seq = obj1_seq.increment();
     assert_eq!(updated_obj.version(), obj1_seq);
     assert_ne!(
         obj1.data.try_as_move().unwrap().type_specific_contents(),
@@ -417,7 +417,7 @@ fn test_wrap_unwrap() {
     assert!(storage.read_object(&id2).is_none());
     let new_obj1 = storage.read_object(&id1).unwrap();
     // sequence # should increase after unwrapping
-    assert_eq!(new_obj1.version(), obj1_version.increment().unwrap());
+    assert_eq!(new_obj1.version(), obj1_version.increment());
     // type-specific contents should not change after unwrapping
     assert_eq!(
         new_obj1

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -342,12 +342,14 @@ impl SequenceNumber {
         self.0
     }
 
-    pub fn increment(self) -> Result<SequenceNumber, FastPayError> {
-        let val = self.0.checked_add(1);
-        match val {
-            None => Err(FastPayError::SequenceOverflow),
-            Some(val) => Ok(Self(val)),
-        }
+    #[must_use]
+    pub fn increment(self) -> SequenceNumber {
+        // TODO: Ensure this never overflow.
+        // Option 1: Freeze the object when sequence number reaches MAX.
+        // Option 2: Reject tx with MAX sequence number.
+        // Issue #182.
+        debug_assert_ne!(self.0, u64::MAX);
+        Self(self.0 + 1)
     }
 
     pub fn decrement(self) -> Result<SequenceNumber, FastPayError> {

--- a/fastx_types/src/gas.rs
+++ b/fastx_types/src/gas.rs
@@ -88,7 +88,7 @@ pub fn deduct_gas(gas_object: &mut Object, amount: i128) -> FastPayResult {
     )?;
     let new_gas_coin = GasCoin::new(*gas_coin.id(), gas_object.version(), new_balance as u64);
     let move_object = gas_object.data.try_as_move_mut().unwrap();
-    move_object.update_contents(bcs::to_bytes(&new_gas_coin).unwrap())?;
+    move_object.update_contents(bcs::to_bytes(&new_gas_coin).unwrap());
     Ok(())
 }
 

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -13,7 +13,6 @@ use crate::{
         sha3_hash, BcsSignable, FastPayAddress, ObjectDigest, ObjectID, ObjectRef, SequenceNumber,
         TransactionDigest,
     },
-    error::{FastPayError, FastPayResult},
     gas_coin::GasCoin,
 };
 
@@ -61,7 +60,7 @@ impl MoveObject {
     }
 
     /// Update the contents of this object and increment its version
-    pub fn update_contents(&mut self, new_contents: Vec<u8>) -> FastPayResult<()> {
+    pub fn update_contents(&mut self, new_contents: Vec<u8>) {
         #[cfg(debug_assertions)]
         let old_id = self.id();
         #[cfg(debug_assertions)]
@@ -76,17 +75,15 @@ impl MoveObject {
             debug_assert_eq!(self.version(), old_version);
         }
 
-        self.increment_version()?;
-        Ok(())
+        self.increment_version();
     }
 
     /// Increase the version of this object by one
-    pub fn increment_version(&mut self) -> FastPayResult<()> {
-        let new_version = self.version().increment()?;
+    pub fn increment_version(&mut self) {
+        let new_version = self.version().increment();
         // TODO: better bit tricks are probably possible here. for now, just do the obvious thing
         self.version_bytes_mut()
             .copy_from_slice(bcs::to_bytes(&new_version).unwrap().as_slice());
-        Ok(())
     }
 
     fn version_bytes(&self) -> &BcsU64 {
@@ -254,7 +251,7 @@ impl Object {
     }
 
     /// Change the owner of `self` to `new_owner`
-    pub fn transfer(&mut self, new_owner: FastPayAddress) -> Result<(), FastPayError> {
+    pub fn transfer(&mut self, new_owner: FastPayAddress) {
         // TODO: these should be raised FastPayError's instead of panic's
         assert!(!self.is_read_only(), "Cannot transfer an immutable object");
         match &mut self.data {
@@ -265,8 +262,7 @@ impl Object {
                 );
 
                 self.owner = new_owner;
-                m.increment_version()?;
-                Ok(())
+                m.increment_version();
             }
             Data::Package(_) => panic!("Cannot transfer a module object"),
         }

--- a/fastx_types/src/unit_tests/base_types_tests.rs
+++ b/fastx_types/src/unit_tests/base_types_tests.rs
@@ -69,8 +69,8 @@ fn test_increment_version() {
     // everything else the same
     let old_contents = coin_obj.contents().to_vec();
     let old_type_specific_contents = coin_obj.type_specific_contents().to_vec();
-    coin_obj.update_contents(old_contents).unwrap();
-    assert_eq!(coin_obj.version(), version.increment().unwrap());
+    coin_obj.update_contents(old_contents);
+    assert_eq!(coin_obj.version(), version.increment());
     assert_eq!(&coin_obj.id(), coin.id());
     assert_eq!(
         coin_obj.type_specific_contents(),


### PR DESCRIPTION
If we allow sequence number increment to fail, this could create two problems:
1. We could be violating the invariant where some mutable objects must be written in the temporary store after an order execution.
2. We could be prone to DDos attack (by keep using the MAX sequence number gas object)

We should assume it cannot overflow.
To enforce this, we could consider freeze the object when its sequence number reaches MAX.