### PR TITLE
Always charge gas even when execution failed

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -5,9 +5,8 @@ use fastx_adapter::{adapter, genesis};
 use fastx_types::{
     base_types::*,
     committee::Committee,
-    error::FastPayError,
-    fp_bail, fp_ensure,
-    gas::{calculate_object_transfer_cost, check_gas_requirement, deduct_gas},
+    error::{FastPayError, FastPayResult},
+    fp_bail, fp_ensure, gas,
     messages::*,
     object::{Data, Object},
     storage::Storage,
@@ -136,7 +135,7 @@ impl AuthorityState {
             );
 
             if &object_id == order.gas_payment_object_id() {
-                check_gas_requirement(&order, &object)?;
+                gas::check_gas_requirement(&order, &object)?;
             }
 
             /* The call to self.set_order_lock checks the lock is not conflicting,
@@ -210,33 +209,41 @@ impl AuthorityState {
         let transaction_digest = certificate.order.digest();
         let mut tx_ctx = TxContext::new(order.sender(), transaction_digest);
 
-        // Order-specific logic
-        let mut temporary_store = AuthorityTemporaryStore::new(self, &inputs);
-        let status_result = match order.kind {
-            OrderKind::Transfer(t) => {
-                debug_assert!(
-                    inputs.len() == 2,
-                    "Expecting two inputs: gas and object to be transferred"
-                );
-                // unwraps here are safe because we built `inputs`
-                let mut gas_object = inputs.pop().unwrap();
-                deduct_gas(
-                    &mut gas_object,
-                    calculate_object_transfer_cost(&inputs[0]) as i128,
-                )?;
-                temporary_store.write_object(gas_object);
+        let (temporary_store, status) = self.execute_order(order, inputs, &mut tx_ctx);
 
-                let mut output_object = inputs.pop().unwrap();
-                output_object.transfer(match t.recipient {
-                    Address::Primary(_) => FastPayAddress::default(),
-                    Address::FastPay(addr) => addr,
-                });
-                temporary_store.write_object(output_object);
-                Ok(())
+        // Update the database in an atomic manner
+        let to_signed_effects = temporary_store.to_signed_effects(
+            &self.name,
+            &self.secret,
+            &transaction_digest,
+            status,
+        );
+        self.update_state(temporary_store, certificate, to_signed_effects)
+            .await // Returns the OrderInfoResponse
+    }
+
+    fn execute_order(
+        &self,
+        order: Order,
+        mut inputs: Vec<Object>,
+        tx_ctx: &mut TxContext,
+    ) -> (AuthorityTemporaryStore, ExecutionStatus) {
+        let mut temporary_store = AuthorityTemporaryStore::new(self, &inputs);
+        // unwraps here are safe because we built `inputs`
+        let mut gas_object = inputs.pop().unwrap();
+
+        let (result, fail_gas) = match order.kind {
+            OrderKind::Transfer(t) => {
+                let result = AuthorityState::transfer(
+                    &mut temporary_store,
+                    inputs,
+                    t.recipient,
+                    gas_object.clone(),
+                );
+                (result, gas::MIN_OBJ_TRANSFER_GAS)
             }
             OrderKind::Call(c) => {
                 // unwraps here are safe because we built `inputs`
-                let gas_object = inputs.pop().unwrap();
                 let package = inputs.pop().unwrap();
                 adapter::execute(
                     &mut temporary_store,
@@ -248,38 +255,54 @@ impl AuthorityState {
                     inputs,
                     c.pure_arguments,
                     c.gas_budget,
-                    gas_object,
+                    gas_object.clone(),
                     tx_ctx,
                 )
             }
-
             OrderKind::Publish(m) => {
-                let gas_object = inputs.pop().unwrap();
-                adapter::publish(
+                let result = adapter::publish(
                     &mut temporary_store,
                     self.native_functions.clone(),
                     m.modules,
                     m.sender,
-                    &mut tx_ctx,
-                    gas_object,
-                )
+                    tx_ctx,
+                    gas_object.clone(),
+                );
+                (result, gas::MIN_MOVE_PUBLISH_GAS)
             }
         };
+        if result.is_err() {
+            // Roll back the temporary store if execution or gas deduction failed.
+            temporary_store.reset();
+            // This gas deduction cannot fail.
+            gas::deduct_gas(&mut gas_object, fail_gas);
+            temporary_store.write_object(gas_object);
+        }
 
-        let status = match status_result {
+        let status = match result {
             Ok(()) => ExecutionStatus::Success,
             Err(err) => ExecutionStatus::Failure(Box::new(err)),
         };
+        (temporary_store, status)
+    }
 
-        // Update the database in an atomic manner
-        let to_signed_effects = temporary_store.to_signed_effects(
-            &self.name,
-            &self.secret,
-            &transaction_digest,
-            status,
-        );
-        self.update_state(temporary_store, certificate, to_signed_effects)
-            .await // Returns the OrderInfoResponse
+    fn transfer(
+        temporary_store: &mut AuthorityTemporaryStore,
+        mut inputs: Vec<Object>,
+        recipient: Address,
+        mut gas_object: Object,
+    ) -> FastPayResult {
+        let gas_used = gas::calculate_object_transfer_cost(&inputs[0]);
+        gas::try_deduct_gas(&mut gas_object, gas_used)?;
+        temporary_store.write_object(gas_object);
+
+        let mut output_object = inputs.pop().unwrap();
+        output_object.transfer(match recipient {
+            Address::Primary(_) => FastPayAddress::default(),
+            Address::FastPay(addr) => addr,
+        });
+        temporary_store.write_object(output_object);
+        Ok(())
     }
 
     pub async fn handle_account_info_request(

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -721,7 +721,14 @@ async fn test_handle_confirmation_order_gas() {
             .await
     };
     let result = run_test_with_gas(10).await;
-    let err_string = result.unwrap_err().to_string();
+    let err_string = result
+        .unwrap()
+        .signed_effects
+        .unwrap()
+        .effects
+        .status
+        .unwrap_err()
+        .to_string();
     assert!(err_string.contains("Gas balance is 10, not enough to pay 16"));
     let result = run_test_with_gas(20).await;
     assert!(result.is_ok());

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -166,8 +166,9 @@ fn call(
         pure_args,
         gas_budget,
         gas_object,
-        TxContext::random_for_testing_only(),
+        &TxContext::random_for_testing_only(),
     )
+    .0
 }
 
 /// Exercise test functions that create, transfer, read, update, and delete objects

--- a/fastx_types/src/gas.rs
+++ b/fastx_types/src/gas.rs
@@ -19,9 +19,9 @@ macro_rules! ok_or_gas_error {
     };
 }
 
-const MIN_MOVE_CALL_GAS: u64 = 10;
-const MIN_MOVE_PUBLISH_GAS: u64 = 10;
-const MIN_OBJ_TRANSFER_GAS: u64 = 8;
+pub const MIN_MOVE_CALL_GAS: u64 = 10;
+pub const MIN_MOVE_PUBLISH_GAS: u64 = 10;
+pub const MIN_OBJ_TRANSFER_GAS: u64 = 8;
 
 pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> FastPayResult {
     match &order.kind {
@@ -68,28 +68,34 @@ pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> FastPayResul
     }
 }
 
-/// Subtract the gas balance of \p gas_object by \p amount.
-/// \p amount being positive means gas deduction; \p amount being negative
-/// means gas refund.
-pub fn deduct_gas(gas_object: &mut Object, amount: i128) -> FastPayResult {
-    let gas_coin = GasCoin::try_from(&*gas_object)?;
-    let balance = gas_coin.value() as i128;
-    let new_balance = balance - amount;
+/// Try subtract the gas balance of \p gas_object by \p amount.
+pub fn try_deduct_gas(gas_object: &mut Object, amount: u64) -> FastPayResult {
+    // The object must be a gas coin as we have checked in order handle phase.
+    let gas_coin = GasCoin::try_from(&*gas_object).unwrap();
+    let balance = gas_coin.value();
     ok_or_gas_error!(
-        new_balance >= 0,
+        balance >= amount,
         format!("Gas balance is {}, not enough to pay {}", balance, amount)
     )?;
-    ok_or_gas_error!(
-        new_balance <= u64::MAX as i128,
-        format!(
-            "Gas balance is {}, overflow after reclaiming {}",
-            balance, -amount
-        )
-    )?;
-    let new_gas_coin = GasCoin::new(*gas_coin.id(), gas_object.version(), new_balance as u64);
+    let new_gas_coin = GasCoin::new(*gas_coin.id(), gas_object.version(), balance - amount);
     let move_object = gas_object.data.try_as_move_mut().unwrap();
     move_object.update_contents(bcs::to_bytes(&new_gas_coin).unwrap());
     Ok(())
+}
+
+pub fn check_gas_balance(gas_object: &Object, amount: u64) -> FastPayResult {
+    let balance = get_gas_balance(gas_object)?;
+    ok_or_gas_error!(
+        balance >= amount,
+        format!("Gas balance is {}, not enough to pay {}", balance, amount)
+    )
+}
+
+/// Subtract the gas balance of \p gas_object by \p amount.
+/// This function should not fail, and should only be called in cases when
+/// we know for sure there is enough balance.
+pub fn deduct_gas(gas_object: &mut Object, amount: u64) {
+    try_deduct_gas(gas_object, amount).unwrap();
 }
 
 pub fn get_gas_balance(gas_object: &Object) -> FastPayResult<u64> {
@@ -115,4 +121,10 @@ pub fn calculate_object_creation_cost(object: &Object) -> u64 {
 pub fn calculate_object_deletion_refund(object: &Object) -> u64 {
     // TODO: Figure out object creation gas formula.
     (object.data.try_as_move().unwrap().contents().len() / 2) as u64
+}
+
+pub fn aggregate_gas(gas_used: u64, gas_refund: u64) -> u64 {
+    // Cap gas refund by half of gas_used.
+    let gas_refund = std::cmp::min(gas_used / 2, gas_refund);
+    gas_used - gas_refund
 }

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -131,6 +131,26 @@ pub enum ExecutionStatus {
     Failure(Box<FastPayError>),
 }
 
+impl ExecutionStatus {
+    pub fn unwrap(&self) {
+        match self {
+            ExecutionStatus::Success => (),
+            ExecutionStatus::Failure(_) => {
+                panic!("Unable to unwrap() on {:?}", self);
+            }
+        }
+    }
+
+    pub fn unwrap_err(&self) -> &FastPayError {
+        match self {
+            ExecutionStatus::Success => {
+                panic!("Unable to unwrap() on {:?}", self);
+            }
+            ExecutionStatus::Failure(err) => err,
+        }
+    }
+}
+
 /// The response from processing an order or a certified order
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct OrderEffects {


### PR DESCRIPTION
This PR changes the flow of authority execution such that:
1. Gas will be charged even when the execution failed.
2. TemporaryStore's object state is guaranteed to be consistent even if execution failed.
This should close #164 and #165.

A detailed summary of the change:
1. The execution of the order is extracted out to a `execute_order` function, that returns the temporary store and execution status. The store is guaranteed to be consistent: gas object is always mutated, and no other objects are mutated if status is Fail.
2. Added `transfer` function to execute the transfer order.
3. Inside each of `transfer`, `adapter::execute`, `adapter::publish`, gas will be charged on the `gas_object` (as early as possible in the case of transfer and publish). If execution failed or gas charge failed, they all return Err.
4. In the case of `adapter::execute`, it's slightly more complicated: if it failed, we would charge the amount of gas that's used (returned as well).
5. If above fails, we reset storage and charge minimum gas (i.e. fail_gas).
6. 
TODO: This need a ton of extra tests. I am going to add a bunch of tests in both authority_tests and adapter_tests to reflect it, but that would be in a separate PR to avoid this one getting too large.