### PR TITLE
Fix certificates issues in client after executing move calls

### DIFF
--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -294,7 +294,7 @@ fn find_cached_owner_by_object_id(
 fn show_object_effects(order_effects: OrderEffects) {
     if !order_effects.mutated.is_empty() {
         println!("Mutated Objects:");
-        for obj in order_effects.mutated {
+        for (obj, _) in order_effects.mutated {
             println!("{:?} {:?} {:?}", obj.0, obj.1, obj.2);
         }
     }

--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -68,7 +68,11 @@ impl AuthorityTemporaryStore {
         let effects = OrderEffects {
             status,
             transaction_digest: *transaction_digest,
-            mutated: self.written.keys().cloned().collect(),
+            mutated: self
+                .written
+                .iter()
+                .map(|(object_ref, object)| (*object_ref, object.owner))
+                .collect(),
             deleted: self.deleted.clone(),
         };
         let signature = Signature::new(&effects, secret);

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -421,8 +421,8 @@ async fn test_handle_move_order() {
     let mutated = res.signed_effects.unwrap().effects.mutated;
     assert_eq!(mutated.len(), 2);
 
-    let created_object_id = mutated[0].0; // res.object_id;
-                                          // check that order actually created an object with the expected ID, owner, sequence number
+    let created_object_id = mutated[0].0 .0; // res.object_id;
+                                             // check that order actually created an object with the expected ID, owner, sequence number
     let created_obj = authority_state
         .object_state(&created_object_id)
         .await

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -780,10 +780,10 @@ async fn test_move_calls_object_create() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
 
     assert!(gas_obj_idx.is_some());
-    let new_obj_ref = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
+    let (new_obj_ref, _) = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
     assert_ne!(gas_object_ref, *new_obj_ref);
 }
 
@@ -844,9 +844,9 @@ async fn test_move_calls_object_transfer() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
     // Get the object created from the call
-    let new_obj_ref = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
+    let (new_obj_ref, _) = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
     // Fetch the full object
     let new_obj = client1
         .get_object_info(ObjectInfoRequest {
@@ -896,10 +896,10 @@ async fn test_move_calls_object_transfer() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
 
     assert!(gas_obj_idx.is_some());
-    let transferred_obj_ref = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
+    let (transferred_obj_ref, _) = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
     assert_ne!(gas_object_ref, *transferred_obj_ref);
 
     assert_eq!(transferred_obj_ref.0, new_obj_ref.0);
@@ -974,9 +974,9 @@ async fn test_move_calls_object_transfer_and_freeze() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
     // Get the object created from the call
-    let new_obj_ref = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
+    let (new_obj_ref, _) = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
     // Fetch the full object
     let new_obj = client1
         .get_object_info(ObjectInfoRequest {
@@ -1026,10 +1026,10 @@ async fn test_move_calls_object_transfer_and_freeze() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
 
     assert!(gas_obj_idx.is_some());
-    let transferred_obj_ref = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
+    let (transferred_obj_ref, _) = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
     assert_ne!(gas_object_ref, *transferred_obj_ref);
 
     assert_eq!(transferred_obj_ref.0, new_obj_ref.0);
@@ -1106,9 +1106,9 @@ async fn test_move_calls_object_delete() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
     // Get the object created from the call
-    let new_obj_ref = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
+    let (new_obj_ref, _) = order_effects.mutated.get(gas_obj_idx.unwrap() ^ 1).unwrap();
     // Fetch the full object
     let new_obj = client1
         .get_object_info(ObjectInfoRequest {
@@ -1157,7 +1157,7 @@ async fn test_move_calls_object_delete() {
     let gas_obj_idx = order_effects
         .mutated
         .iter()
-        .position(|e| e.0 == gas_object_ref.0);
+        .position(|(e, _)| e.0 == gas_object_ref.0);
 
     assert_eq!(gas_obj_idx.unwrap(), 0);
     // Try to fetch the deleted object
@@ -1170,4 +1170,132 @@ async fn test_move_calls_object_delete() {
         .await;
 
     assert!(deleted_object_resp.is_err());
+}
+
+#[tokio::test]
+async fn test_move_calls_certs() {
+    let (authority_clients, committee) = init_local_authorities(1).await;
+    let mut client1 = make_client(authority_clients.clone(), committee.clone());
+    let mut client2 = make_client(authority_clients.clone(), committee);
+
+    let gas_object_id = ObjectID::random();
+
+    // TODO: authority should not require seq# or digest for package in Move calls. Use dummy values
+    let framework_obj_ref = (
+        FASTX_FRAMEWORK_ADDRESS,
+        SequenceNumber::new(),
+        ObjectDigest::new([0; 32]),
+    );
+
+    // Populate authorities with obj data
+    let authority_objects = vec![vec![gas_object_id]];
+
+    let gas_object_ref = fund_account(
+        authority_clients.values().collect(),
+        &mut client1,
+        authority_objects,
+    )
+    .await
+    .get(&gas_object_id)
+    .unwrap()
+    .to_object_reference();
+
+    // When creating an ObjectBasics object, we provide the value (u64) and address which will own the object
+    let object_value: u64 = 100;
+    let pure_args = vec![
+        object_value.to_le_bytes().to_vec(),
+        bcs::to_bytes(&client1.address.to_vec()).unwrap(),
+    ];
+
+    // Create new object with move
+    let (cert, effect) = client1
+        .move_call(
+            framework_obj_ref,
+            ident_str!("ObjectBasics").to_owned(),
+            ident_str!("create").to_owned(),
+            Vec::new(),
+            gas_object_ref,
+            Vec::new(),
+            pure_args,
+            GAS_VALUE_FOR_TESTING - 1, // Make sure budget is less than gas value
+        )
+        .await
+        .unwrap();
+
+    let (new_object_ref, _) = effect
+        .mutated
+        .iter()
+        .find(|((id, _, _), _)| id != &gas_object_id)
+        .unwrap();
+
+    let (gas_object_ref, _) = effect
+        .mutated
+        .iter()
+        .find(|((id, _, _), _)| id == &gas_object_id)
+        .unwrap();
+
+    let (new_object_id, _, _) = new_object_ref;
+
+    // Client 1 should have one certificate, one new object and one gas object, each with one associated certificate.
+    assert!(client1.certificates.contains_key(&cert.order.digest()));
+    assert_eq!(1, client1.certificates.len());
+    assert_eq!(2, client1.object_ids.len());
+    assert_eq!(2, client1.object_certs.len());
+    assert!(client1.object_certs.contains_key(&gas_object_id));
+    assert!(client1.object_certs.contains_key(&new_object_id));
+    assert_eq!(1, client1.object_certs.get(&gas_object_id).unwrap().len());
+    assert_eq!(1, client1.object_certs.get(&new_object_id).unwrap().len());
+    assert_eq!(
+        SequenceNumber::from(1),
+        client1.object_ids.get(&gas_object_id).unwrap().clone()
+    );
+    assert_eq!(
+        SequenceNumber::from(1),
+        client1.object_ids.get(&new_object_id).unwrap().clone()
+    );
+
+    // Transfer object with move
+    let pure_args = vec![bcs::to_bytes(&client2.address.to_vec()).unwrap()];
+    let (cert, _) = client1
+        .move_call(
+            framework_obj_ref,
+            ident_str!("ObjectBasics").to_owned(),
+            ident_str!("transfer").to_owned(),
+            Vec::new(),
+            gas_object_ref.clone(),
+            vec![new_object_ref.clone()],
+            pure_args,
+            GAS_VALUE_FOR_TESTING / 2, // Make sure budget is less than gas value
+        )
+        .await
+        .unwrap();
+
+    // Client 1 should have two certificate, one gas object, with two associated certificate.
+    assert!(client1.certificates.contains_key(&cert.order.digest()));
+    assert_eq!(2, client1.certificates.len());
+    assert_eq!(1, client1.object_ids.len());
+    assert_eq!(1, client1.object_certs.len());
+    assert!(client1.object_certs.contains_key(&gas_object_id));
+    assert_eq!(2, client1.object_certs.get(&gas_object_id).unwrap().len());
+    assert_eq!(
+        SequenceNumber::from(2),
+        client1.object_ids.get(&gas_object_id).unwrap().clone()
+    );
+
+    // Sync client 2
+    client2
+        .sync_client_state_with_random_authority()
+        .await
+        .unwrap();
+
+    // Client 2 should have 2 certificate, one new object, with two associated certificate.
+    assert_eq!(2, client2.certificates.len());
+    assert_eq!(1, client2.object_ids.len());
+    assert_eq!(1, client2.object_certs.len());
+    assert!(client2.object_certs.contains_key(&new_object_id));
+    assert_eq!(2, client2.object_certs.get(&new_object_id).unwrap().len());
+    assert_eq!(
+        SequenceNumber::from(2),
+        client2.object_ids.get(&new_object_id).unwrap().clone()
+    );
 }

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -139,7 +139,7 @@ pub struct OrderEffects {
     // The transaction digest
     pub transaction_digest: TransactionDigest,
     // ObjectRefs containing mutated or new objects
-    pub mutated: Vec<ObjectRef>,
+    pub mutated: Vec<(ObjectRef, FastPayAddress)>,
     // Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
     // TODO: add events here too.


### PR DESCRIPTION
* Added unit test to ensure certificates are stored correctly in client
* Added object's new owner info to `OrderEffects`'s mutated response
* Fixed various bugs