### PR TITLE
Ensure all mutable objects are mutated

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -18,7 +18,7 @@ use move_core_types::{
 };
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -285,6 +285,7 @@ impl AuthorityState {
             Ok(()) => ExecutionStatus::Success,
             Err(err) => ExecutionStatus::Failure(Box::new(err)),
         };
+        temporary_store.ensure_active_inputs_mutated();
         (temporary_store, status)
     }
 

--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -3,16 +3,19 @@ use super::*;
 pub type InnerTemporaryStore = (
     BTreeMap<ObjectID, Object>,
     Vec<ObjectRef>,
-    BTreeMap<ObjectRef, Object>,
-    Vec<ObjectRef>,
+    BTreeMap<ObjectID, Object>,
+    BTreeSet<ObjectID>,
 );
 
 pub struct AuthorityTemporaryStore {
     object_store: Arc<AuthorityStore>,
     objects: BTreeMap<ObjectID, Object>,
     active_inputs: Vec<ObjectRef>, // Inputs that are not read only
-    written: BTreeMap<ObjectRef, Object>, // Objects written
-    deleted: Vec<ObjectRef>,       // Objects actively deleted
+    // TODO: We need to study whether it's worth to optimize the lookup of
+    // object reference by caching object reference in the map as well.
+    // Object reference calculation involves hashing which could be expensive.
+    written: BTreeMap<ObjectID, Object>, // Objects written
+    deleted: BTreeSet<ObjectID>,         // Objects actively deleted
 }
 
 impl AuthorityTemporaryStore {
@@ -31,7 +34,7 @@ impl AuthorityTemporaryStore {
                 .map(|v| v.to_object_reference())
                 .collect(),
             written: BTreeMap::new(),
-            deleted: Vec::new(),
+            deleted: BTreeSet::new(),
         }
     }
 
@@ -41,11 +44,11 @@ impl AuthorityTemporaryStore {
         &self.objects
     }
 
-    pub fn written(&self) -> &BTreeMap<ObjectRef, Object> {
+    pub fn written(&self) -> &BTreeMap<ObjectID, Object> {
         &self.written
     }
 
-    pub fn deleted(&self) -> &Vec<ObjectRef> {
+    pub fn deleted(&self) -> &BTreeSet<ObjectID> {
         &self.deleted
     }
 
@@ -56,6 +59,20 @@ impl AuthorityTemporaryStore {
             self.check_invariants();
         }
         (self.objects, self.active_inputs, self.written, self.deleted)
+    }
+
+    /// For every object from active_inputs (i.e. all mutable objects), if they are not
+    /// mutated during the order execution, force mutating them by incrementing the
+    /// sequence number.
+    pub fn ensure_active_inputs_mutated(&mut self) {
+        for (id, _seq, _) in self.active_inputs.iter() {
+            if !self.written.contains_key(id) && !self.deleted.contains(id) {
+                let mut object = self.objects[id].clone();
+                // Active input object must be Move object.
+                object.data.try_as_move_mut().unwrap().increment_version();
+                self.written.insert(*id, object);
+            }
+        }
     }
 
     pub fn to_signed_effects(
@@ -71,9 +88,13 @@ impl AuthorityTemporaryStore {
             mutated: self
                 .written
                 .iter()
-                .map(|(object_ref, object)| (*object_ref, object.owner))
+                .map(|(_, object)| (object.to_object_reference(), object.owner))
                 .collect(),
-            deleted: self.deleted.clone(),
+            deleted: self
+                .deleted
+                .iter()
+                .map(|id| self.objects[id].to_object_reference())
+                .collect(),
         };
         let signature = Signature::new(&effects, secret);
 
@@ -93,7 +114,7 @@ impl AuthorityTemporaryStore {
         debug_assert!(
             {
                 let mut used = HashSet::new();
-                self.deleted.iter().all(move |elt| used.insert(elt.0))
+                self.deleted.iter().all(move |elt| used.insert(elt))
             },
             "Duplicate object reference in self.deleted."
         );
@@ -102,8 +123,8 @@ impl AuthorityTemporaryStore {
         debug_assert!(
             {
                 let mut used = HashSet::new();
-                self.written.iter().all(|(elt, _)| used.insert(elt.0));
-                self.deleted.iter().all(move |elt| used.insert(elt.0))
+                self.written.iter().all(|(elt, _)| used.insert(elt));
+                self.deleted.iter().all(move |elt| used.insert(elt))
             },
             "Object both written and deleted."
         );
@@ -112,10 +133,10 @@ impl AuthorityTemporaryStore {
         debug_assert!(
             {
                 let mut used = HashSet::new();
-                self.written.iter().all(|(elt, _)| used.insert(elt.0));
-                self.deleted.iter().all(|elt| used.insert(elt.0));
+                self.written.iter().all(|(elt, _)| used.insert(elt));
+                self.deleted.iter().all(|elt| used.insert(elt));
 
-                self.active_inputs.iter().all(|elt| !used.insert(elt.0))
+                self.active_inputs.iter().all(|elt| !used.insert(&elt.0))
             },
             "Mutable input neither written nor deleted."
         );
@@ -161,7 +182,7 @@ impl Storage for AuthorityTemporaryStore {
             }
         }
 
-        self.written.insert(object.to_object_reference(), object);
+        self.written.insert(object.id(), object);
     }
 
     fn delete_object(&mut self, id: &ObjectID) {
@@ -176,12 +197,8 @@ impl Storage for AuthorityTemporaryStore {
         }
 
         // Mark it for deletion
-        self.deleted.push(
-            self.objects
-                .get(id)
-                .expect("Internal invariant: object must exist to be deleted.")
-                .to_object_reference(),
-        );
+        debug_assert!(self.objects.get(id).is_some());
+        self.deleted.insert(*id);
     }
 }
 

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -370,19 +370,8 @@ async fn test_handle_move_order() {
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
     // find the function Object::create and call it to create a new object
     let (mut genesis_package_objects, native_functions) = genesis::clone_genesis_data();
-    let package_object_ref = genesis_package_objects
-        .iter()
-        .find_map(|o| match o.data.try_as_package() {
-            Some(p) => {
-                if p.keys().any(|name| name == "ObjectBasics") {
-                    Some(o.to_object_reference())
-                } else {
-                    None
-                }
-            }
-            None => None,
-        })
-        .unwrap();
+    let package_object_ref =
+        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
 
     genesis_package_objects.push(gas_payment_object);
     let mut authority_state = init_state_with_objects(genesis_package_objects).await;
@@ -454,19 +443,8 @@ async fn test_handle_move_order_insufficient_budget() {
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
     // find the function Object::create and call it to create a new object
     let (mut genesis_package_objects, native_functions) = genesis::clone_genesis_data();
-    let package_object_ref = genesis_package_objects
-        .iter()
-        .find_map(|o| match o.data.try_as_package() {
-            Some(p) => {
-                if p.keys().any(|name| name == "ObjectBasics") {
-                    Some(o.to_object_reference())
-                } else {
-                    None
-                }
-            }
-            None => None,
-        })
-        .unwrap();
+    let package_object_ref =
+        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
 
     genesis_package_objects.push(gas_payment_object);
     let mut authority_state = init_state_with_objects(genesis_package_objects).await;
@@ -836,6 +814,130 @@ async fn test_handle_confirmation_order_idempotent() {
 }
 
 #[tokio::test]
+async fn test_move_call_mutable_object_not_mutated() {
+    let (sender, sender_key) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let mut authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
+
+    let (genesis_package_objects, _) = genesis::clone_genesis_data();
+    let package_object_ref =
+        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+
+    let gas_object_ref = authority_state
+        .object_state(&gas_object_id)
+        .await
+        .unwrap()
+        .to_object_reference();
+    let order = Order::new_move_call(
+        sender,
+        package_object_ref,
+        ident_str!("ObjectBasics").to_owned(),
+        ident_str!("create").to_owned(),
+        Vec::new(),
+        gas_object_ref,
+        Vec::new(),
+        vec![
+            16u64.to_le_bytes().to_vec(),
+            bcs::to_bytes(&sender.to_vec()).unwrap(),
+        ],
+        1000,
+        &sender_key,
+    );
+    let effects = send_and_confirm_order(&mut authority_state, order)
+        .await
+        .unwrap()
+        .signed_effects
+        .unwrap()
+        .effects;
+    assert_eq!(effects.status, ExecutionStatus::Success);
+    assert_eq!(effects.mutated.len(), 2);
+    let new_object_ref1 = effects
+        .mutated
+        .iter()
+        .find(|((id, _, _), _)| id != &gas_object_id)
+        .unwrap()
+        .0;
+
+    let gas_object_ref = authority_state
+        .object_state(&gas_object_id)
+        .await
+        .unwrap()
+        .to_object_reference();
+    let order = Order::new_move_call(
+        sender,
+        package_object_ref,
+        ident_str!("ObjectBasics").to_owned(),
+        ident_str!("create").to_owned(),
+        Vec::new(),
+        gas_object_ref,
+        Vec::new(),
+        vec![
+            16u64.to_le_bytes().to_vec(),
+            bcs::to_bytes(&sender.to_vec()).unwrap(),
+        ],
+        1000,
+        &sender_key,
+    );
+    let effects = send_and_confirm_order(&mut authority_state, order)
+        .await
+        .unwrap()
+        .signed_effects
+        .unwrap()
+        .effects;
+    assert_eq!(effects.status, ExecutionStatus::Success);
+    assert_eq!(effects.mutated.len(), 2);
+    let new_object_ref2 = effects
+        .mutated
+        .iter()
+        .find(|((id, _, _), _)| id != &gas_object_id)
+        .unwrap()
+        .0;
+
+    let gas_object_ref = authority_state
+        .object_state(&gas_object_id)
+        .await
+        .unwrap()
+        .to_object_reference();
+    let order = Order::new_move_call(
+        sender,
+        package_object_ref,
+        ident_str!("ObjectBasics").to_owned(),
+        ident_str!("update").to_owned(),
+        Vec::new(),
+        gas_object_ref,
+        vec![new_object_ref1, new_object_ref2],
+        vec![],
+        1000,
+        &sender_key,
+    );
+    let effects = send_and_confirm_order(&mut authority_state, order)
+        .await
+        .unwrap()
+        .signed_effects
+        .unwrap()
+        .effects;
+    assert_eq!(effects.status, ExecutionStatus::Success);
+    assert_eq!(effects.mutated.len(), 3); // gas, new_object_ref1, new_object_ref2.
+                                          // Verify that both objects' version increased, even though only one object was updated.
+    assert_eq!(
+        authority_state
+            .object_state(&new_object_ref1.0)
+            .await
+            .unwrap()
+            .version(),
+        new_object_ref1.1.increment()
+    );
+    assert_eq!(
+        authority_state
+            .object_state(&new_object_ref2.0)
+            .await
+            .unwrap()
+            .version(),
+        new_object_ref2.1.increment()
+    );
+}
+
+#[tokio::test]
 async fn test_account_state_ok() {
     let sender = dbg_addr(1);
     let object_id = dbg_object_id(1);
@@ -1015,5 +1117,21 @@ fn init_certified_transfer_order(
     builder
         .append(vote.authority, vote.signature)
         .unwrap()
+        .unwrap()
+}
+
+fn get_genesis_package_by_module(genesis_objects: &[Object], module: &str) -> ObjectRef {
+    genesis_objects
+        .iter()
+        .find_map(|o| match o.data.try_as_package() {
+            Some(p) => {
+                if p.keys().any(|name| name == module) {
+                    Some(o.to_object_reference())
+                } else {
+                    None
+                }
+            }
+            None => None,
+        })
         .unwrap()
 }

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -1242,16 +1242,16 @@ async fn test_move_calls_certs() {
     assert_eq!(2, client1.object_ids.len());
     assert_eq!(2, client1.object_certs.len());
     assert!(client1.object_certs.contains_key(&gas_object_id));
-    assert!(client1.object_certs.contains_key(&new_object_id));
+    assert!(client1.object_certs.contains_key(new_object_id));
     assert_eq!(1, client1.object_certs.get(&gas_object_id).unwrap().len());
-    assert_eq!(1, client1.object_certs.get(&new_object_id).unwrap().len());
+    assert_eq!(1, client1.object_certs.get(new_object_id).unwrap().len());
     assert_eq!(
         SequenceNumber::from(1),
         client1.object_ids.get(&gas_object_id).unwrap().clone()
     );
     assert_eq!(
         SequenceNumber::from(1),
-        client1.object_ids.get(&new_object_id).unwrap().clone()
+        client1.object_ids.get(new_object_id).unwrap().clone()
     );
 
     // Transfer object with move
@@ -1262,8 +1262,8 @@ async fn test_move_calls_certs() {
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("transfer").to_owned(),
             Vec::new(),
-            gas_object_ref.clone(),
-            vec![new_object_ref.clone()],
+            *gas_object_ref,
+            vec![*new_object_ref],
             pure_args,
             GAS_VALUE_FOR_TESTING / 2, // Make sure budget is less than gas value
         )
@@ -1292,10 +1292,10 @@ async fn test_move_calls_certs() {
     assert_eq!(2, client2.certificates.len());
     assert_eq!(1, client2.object_ids.len());
     assert_eq!(1, client2.object_certs.len());
-    assert!(client2.object_certs.contains_key(&new_object_id));
-    assert_eq!(2, client2.object_certs.get(&new_object_id).unwrap().len());
+    assert!(client2.object_certs.contains_key(new_object_id));
+    assert_eq!(2, client2.object_certs.get(new_object_id).unwrap().len());
     assert_eq!(
         SequenceNumber::from(2),
-        client2.object_ids.get(&new_object_id).unwrap().clone()
+        client2.object_ids.get(new_object_id).unwrap().clone()
     );
 }


### PR DESCRIPTION
As discussed in https://mysten-labs.slack.com/archives/C02GD7J9HUM/p1642618186086000,
In some cases, mutable objects will not be mutated. For example:
1. If order execution failed in the middle.
2. Or if some objects are passed as read-only reference to Move functions.

The datastore expects every mutable objects' sequence number to increase.
This PR forces that at the end of the order execution. It does so by: Change `written`'s key from ObjectRef to ObjectID, and then change `deleted` into a BTreeSet of ObjectID. These two combined allows us to quickly discover which objects from `active_inputs` are not mutated.

Also added a test to verify that.

TODO:
Calling `to_object_reference()` on an object involves non-trivial cost (runs hash). So if we are doing a lot of repeat calls to `to_object_reference()` to `written` we could cache the reference in the map as well.