### PR TITLE
Return FastPayResult<ExecutionStatus> from adapter

### DIFF
--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -63,7 +63,7 @@ impl AuthorityTemporaryStore {
 
     /// For every object from active_inputs (i.e. all mutable objects), if they are not
     /// mutated during the order execution, force mutating them by incrementing the
-    /// sequence number.
+    /// sequence number. This is required to achieve safety.
     pub fn ensure_active_inputs_mutated(&mut self) {
         for (id, _seq, _) in self.active_inputs.iter() {
             if !self.written.contains_key(id) && !self.deleted.contains(id) {

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -712,6 +712,7 @@ async fn test_handle_confirmation_order_gas() {
         .effects
         .status
         .unwrap_err()
+        .1
         .to_string();
     assert!(err_string.contains("Gas balance is 10, not enough to pay 16"));
     let result = run_test_with_gas(20).await;

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -152,7 +152,7 @@ fn call(
     type_args: Vec<TypeTag>,
     object_args: Vec<Object>,
     pure_args: Vec<Vec<u8>>,
-) -> FastPayResult {
+) -> FastPayResult<ExecutionStatus> {
     let package = storage.find_package(module_name).unwrap();
 
     let vm = adapter::new_move_vm(native_functions.clone()).expect("No errors");
@@ -170,7 +170,6 @@ fn call(
         gas_object,
         &TxContext::random_for_testing_only(),
     )
-    .0
 }
 
 /// Exercise test functions that create, transfer, read, update, and delete objects
@@ -464,7 +463,9 @@ fn test_move_call_insufficient_gas() {
         pure_args,
     );
     assert!(response
+        .unwrap()
         .unwrap_err()
+        .1
         .to_string()
         .contains("VMError with status OUT_OF_GAS"));
 }
@@ -500,7 +501,9 @@ fn test_publish_module_insufficient_gas() {
         gas_object,
     );
     assert!(response
+        .unwrap()
         .unwrap_err()
+        .1
         .to_string()
         .contains("Gas balance is 30, not enough to pay 58"));
 }
@@ -585,7 +588,9 @@ fn test_transfer_and_freeze() {
         pure_args,
     );
     assert!(result
+        .unwrap()
         .unwrap_err()
+        .1
         .to_string()
         .contains("Argument 0 is expected to be mutable, immutable object found"));
 
@@ -604,7 +609,9 @@ fn test_transfer_and_freeze() {
         pure_args,
     );
     assert!(result
+        .unwrap()
         .unwrap_err()
+        .1
         .to_string()
         .contains("Argument 0 is expected to be mutable, immutable object found"));
 }

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -128,25 +128,30 @@ pub struct OrderInfoResponse {
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum ExecutionStatus {
     Success,
-    Failure(Box<FastPayError>),
+    // Gas used in the failed case, and the error.
+    // TODO: Eventually we should return gas_used in both cases.
+    Failure {
+        gas_used: u64,
+        error: Box<FastPayError>,
+    },
 }
 
 impl ExecutionStatus {
     pub fn unwrap(&self) {
         match self {
             ExecutionStatus::Success => (),
-            ExecutionStatus::Failure(_) => {
+            ExecutionStatus::Failure { .. } => {
                 panic!("Unable to unwrap() on {:?}", self);
             }
         }
     }
 
-    pub fn unwrap_err(&self) -> &FastPayError {
+    pub fn unwrap_err(&self) -> (u64, &FastPayError) {
         match self {
             ExecutionStatus::Success => {
                 panic!("Unable to unwrap() on {:?}", self);
             }
-            ExecutionStatus::Failure(err) => err,
+            ExecutionStatus::Failure { gas_used, error } => (*gas_used, error),
         }
     }
 }


### PR DESCRIPTION
All order execution functions now return `FastPayResult<ExecutionStatus>`. The result indicates whether there is system issue. `ExecutionStatus` indicates the actual execution result. In the case of `ExecutionStatus::Failure`, we also include gas used for gas charge in the fail case.