### PR TITLE
[storage] fix: used the typed_store error type

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -27,7 +27,8 @@ move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d
 move-package = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 move-vm-runtime = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "0ef3f1fedcfbf3dfe0eeea65e05de073b7c25733" }
+
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "2e829074f40c9ef852ecd6808b80d083174c778b" }
 
 [dev-dependencies]
 fdlimit = "0.2.1"

--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -22,6 +22,7 @@ hex = "0.4.3"
 serde_bytes = "0.11.5"
 serde_with = "1.11.0"
 
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "2e829074f40c9ef852ecd6808b80d083174c778b" }
 
 move-binary-format = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }
 move-core-types = { git = "https://github.com/diem/move", rev="d253bf1c21314679d17e6935116f30baf409f264" }

--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -153,7 +153,7 @@ pub enum FastPayError {
     #[error("Execution invariant violated")]
     ExecutionInvariantViolation,
     #[error("Storage error")]
-    StorageError,
+    StorageError(#[from] typed_store::rocks::TypedStoreError),
 }
 
 pub type FastPayResult<T = ()> = Result<T, FastPayError>;


### PR DESCRIPTION
This demonstrates the use of the following PR:
https://github.com/MystenLabs/mysten-infra/pull/6

Please go and review the mysten-infra PR, once it's merged I'll update dependency pointers here.

This updates the `typed_store` version to one with a TypedStore error type, rather than using `eyre::Error`.
As a consequence, it allows a more fine-grained conversion of store errors to `FastPay::StorageError`.