### PR TITLE
Add gas and created to OrderEffects

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -210,6 +210,7 @@ impl AuthorityState {
         let transaction_digest = certificate.order.digest();
         let mut tx_ctx = TxContext::new(order.sender(), transaction_digest);
 
+        let gas_object_id = *order.gas_payment_object_id();
         let (temporary_store, status) = self.execute_order(order, inputs, &mut tx_ctx)?;
 
         // Update the database in an atomic manner
@@ -218,6 +219,7 @@ impl AuthorityState {
             &self.secret,
             &transaction_digest,
             status,
+            &gas_object_id,
         );
         self.update_state(temporary_store, certificate, to_signed_effects)
             .await // Returns the OrderInfoResponse

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -710,7 +710,7 @@ where
             let digest = cert.order.digest();
             self.certificates.insert(digest, cert);
 
-            for ((object_id, seq, _), owner) in v.effects.mutated {
+            for &((object_id, seq, _), owner) in v.effects.all_mutated() {
                 let old_seq = self.object_ids.get(&object_id).cloned().unwrap_or_default();
                 fp_ensure!(
                     old_seq < seq,

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -163,11 +163,28 @@ pub struct OrderEffects {
     pub status: ExecutionStatus,
     // The transaction digest
     pub transaction_digest: TransactionDigest,
-    // ObjectRefs containing mutated or new objects
+    // ObjectRef and owner of new objects created.
+    pub created: Vec<(ObjectRef, FastPayAddress)>,
+    // ObjectRef and owner of mutated objects.
+    // mutated does not include gas object or created objects.
     pub mutated: Vec<(ObjectRef, FastPayAddress)>,
     // Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
+    // The updated gas object reference.
+    pub gas_object: (ObjectRef, FastPayAddress),
     // TODO: add events here too.
+}
+
+impl OrderEffects {
+    /// Return an iterator that iterates throguh all mutated objects,
+    /// including all from mutated, created and the gas_object.
+    /// It doesn't include deleted.
+    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, FastPayAddress)> {
+        self.mutated
+            .iter()
+            .chain(self.created.iter())
+            .chain(std::iter::once(&self.gas_object))
+    }
 }
 
 impl BcsSignable for OrderEffects {}


### PR DESCRIPTION
When processing `OrderEffects`, we only have a list of mutated objects, which contains anything that was mutated, created, and also include the gas object which is always mutated.
This makes it very inconvenient to know which is which.
This PR adds two extra elements to `OrderEffects`, `gas_object` and `created`. They will not be in the `mutated` list. This makes it a lot easier to tell what happened to the objects.
This closes #244.