### PR TITLE
Fix CLI config file serde and arg

### DIFF
--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -29,6 +29,7 @@ ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 rocksdb = "0.17.0"
 hex = "0.4.3"
 async-trait = "0.1.52"
+serde_with = "1.11.0"
 
 bcs = "0.1.3"
 fastpay_core = { path = "../fastpay_core" }

--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -354,10 +354,6 @@ enum ClientCommands {
     /// Transfer funds
     #[structopt(name = "transfer")]
     Transfer {
-        /// Sending address (must be one of our accounts)
-        #[structopt(long, parse(try_from_str = parse_public_key_bytes))]
-        from: PublicKeyBytes,
-
         /// Recipient address
         #[structopt(long, parse(try_from_str = parse_public_key_bytes))]
         to: PublicKeyBytes,
@@ -553,17 +549,18 @@ fn main() {
         }
 
         ClientCommands::Transfer {
-            from,
             to,
             object_id,
             gas_object_id,
         } => {
             let rt = Runtime::new().unwrap();
             rt.block_on(async move {
+                let owner = find_cached_owner_by_object_id(&accounts_config, gas_object_id)
+                    .expect("Cannot find owner for gas object");
                 let mut client_state = make_client_state(
                     &accounts_config,
                     &committee_config,
-                    from,
+                    *owner,
                     buffer_size,
                     send_timeout,
                     recv_timeout,

--- a/fastpay/src/config.rs
+++ b/fastpay/src/config.rs
@@ -10,6 +10,7 @@ use fastx_types::{
 use move_core_types::language_storage::TypeTag;
 use move_core_types::{identifier::Identifier, transaction_argument::TransactionArgument};
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, read_to_string, File, OpenOptions},
@@ -90,6 +91,7 @@ impl CommitteeConfig {
     }
 }
 
+#[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct UserAccount {
     #[serde(
@@ -100,6 +102,7 @@ pub struct UserAccount {
     pub key: KeyPair,
     pub object_ids: BTreeMap<ObjectID, SequenceNumber>,
     pub gas_object_ids: BTreeSet<ObjectID>, // Every id in gas_object_ids should also be in object_ids.
+    #[serde_as(as = "Vec<(_, _)>")]
     pub certificates: BTreeMap<TransactionDigest, CertifiedOrder>,
 }
 


### PR DESCRIPTION
Simple bugfixes

1. Serde issue with transaction digests serde was failing due to JSON mapping the BTreeMap as a dictionary with string keys, however transaction digest was not being converted to string key which caused failures.
Solution is to represent it as a vec in the cfg file
2. CLI had redundant `--from` argument. Removed it and derived sender from gas obj. Moving forward, we'll take the sender secret also