### PR TITLE
Add comprehensive tests to adapter_tests

### DIFF
--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -137,7 +137,7 @@ pub enum ExecutionStatus {
 }
 
 impl ExecutionStatus {
-    pub fn unwrap(&self) {
+    pub fn unwrap(self) {
         match self {
             ExecutionStatus::Success => (),
             ExecutionStatus::Failure { .. } => {
@@ -146,12 +146,12 @@ impl ExecutionStatus {
         }
     }
 
-    pub fn unwrap_err(&self) -> (u64, &FastPayError) {
+    pub fn unwrap_err(self) -> (u64, FastPayError) {
         match self {
             ExecutionStatus::Success => {
                 panic!("Unable to unwrap() on {:?}", self);
             }
-            ExecutionStatus::Failure { gas_used, error } => (*gas_used, error),
+            ExecutionStatus::Failure { gas_used, error } => (gas_used, *error),
         }
     }
 }


### PR DESCRIPTION
This PR adds more tests to adapter_tests.
In doing so, also found a few issues and fixed them:
1. In adapter::publish, we were returning Err for some user errors. We should return ExecutionStatus::Failure instead.
2. In adapter_tests, we were passing MAX_GAS as budget. This is problematic as it equals the the balance of the object, and can fail on the second use (once we add the same check from handle_order to confirm_order).
3. A few nits on error messages.