### PR TITLE
Remove old ID address

### DIFF
--- a/fastx_types/src/id.rs
+++ b/fastx_types/src/id.rs
@@ -1,17 +1,14 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{
-    account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::StructTag,
-};
+use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
 
-use crate::base_types::{ObjectID, SequenceNumber};
+use crate::{
+    base_types::{ObjectID, SequenceNumber},
+    FASTX_FRAMEWORK_ADDRESS,
+};
 
-/// 0x3C2B307C3239F61643AF5E9A09D7D0C9
-pub const ID_ADDRESS: AccountAddress = AccountAddress::new([
-    0x3C, 0x2B, 0x30, 0x7C, 0x32, 0x39, 0xF6, 0x16, 0x43, 0xAF, 0x5E, 0x9A, 0x09, 0xD7, 0xD0, 0xC9,
-]);
 pub const ID_MODULE_NAME: &IdentStr = ident_str!("ID");
 pub const ID_STRUCT_NAME: &IdentStr = ID_MODULE_NAME;
 
@@ -38,7 +35,7 @@ impl ID {
 
     pub fn type_() -> StructTag {
         StructTag {
-            address: ID_ADDRESS,
+            address: FASTX_FRAMEWORK_ADDRESS,
             name: ID_STRUCT_NAME.to_owned(),
             module: ID_MODULE_NAME.to_owned(),
             type_params: Vec::new(),


### PR DESCRIPTION
The address in id.rs is out-of-dated. Remove it.
Unfortunately there is no place where we actually use it, so couldn't come up with a test for it.