### PR TITLE
Switch to 20 bytes ObjectID

### DIFF
--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -37,7 +37,7 @@ fastx-adapter = { path = "../fastx_programmability/adapter" }
 fastx-types = { path = "../fastx_types" }
 
 move-package = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
-move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
+move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }
 move-bytecode-verifier = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 
 [[bin]]

--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -23,7 +23,7 @@ fastx-framework = { path = "../fastx_programmability/framework" }
 fastx-types = { path = "../fastx_types" }
 
 move-binary-format = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
-move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
+move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }
 move-package = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-vm-runtime = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 

--- a/fastpay_core/src/authority/authority_store.rs
+++ b/fastpay_core/src/authority/authority_store.rs
@@ -79,7 +79,7 @@ impl AuthorityStore {
             .owner_index
             .iter()
             // The object id [0; 16] is the smallest possible
-            .skip_to(&(account, AccountAddress::from([0; 16])))?
+            .skip_to(&(account, AccountAddress::ZERO))?
             .take_while(|((owner, _id), _object_ref)| (owner == &account))
             .map(|((_owner, _id), object_ref)| object_ref)
             .collect())

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -421,9 +421,8 @@ async fn test_handle_move_order() {
         MAX_GAS,
         &sender_key,
     );
-    // 34 is for bytecode execution, 24 is for object creation.
     // If the number changes, we want to verify that the change is intended.
-    let gas_cost = 34 + 24;
+    let gas_cost = 62;
     let effects = send_and_confirm_order(&mut authority_state, order)
         .await
         .unwrap()
@@ -766,7 +765,7 @@ async fn test_handle_confirmation_order_gas() {
         .unwrap_err()
         .1
         .to_string();
-    assert!(err_string.contains("Gas balance is 10, not enough to pay 16"));
+    assert!(err_string.contains("Gas balance is 10, not enough to pay 18"));
     let result = run_test_with_gas(20).await;
     assert!(result.is_ok());
 }

--- a/fastx_programmability/adapter/Cargo.toml
+++ b/fastx_programmability/adapter/Cargo.toml
@@ -16,7 +16,7 @@ structopt = "0.3.25"
 move-binary-format = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-bytecode-utils = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-bytecode-verifier = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
-move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
+move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }
 move-cli = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-vm-runtime = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -505,7 +505,7 @@ fn test_publish_module_insufficient_gas() {
         .unwrap_err()
         .1
         .to_string()
-        .contains("Gas balance is 30, not enough to pay 58"));
+        .contains("Gas balance is 30, not enough to pay"));
 }
 
 #[test]

--- a/fastx_programmability/framework/Cargo.toml
+++ b/fastx_programmability/framework/Cargo.toml
@@ -17,7 +17,7 @@ fastx-verifier = { path = "../verifier" }
 move-binary-format = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-bytecode-verifier = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-cli = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
-move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
+move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }
 move-package = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-stdlib = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-unit-test = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }

--- a/fastx_programmability/verifier/Cargo.toml
+++ b/fastx_programmability/verifier/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 [dependencies]
 move-binary-format = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-bytecode-verifier = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
-move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
+move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }
 
 fastx-types = { path = "../../fastx_types" }

--- a/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
+++ b/fastx_programmability/verifier/tests/struct_with_key_verification_test.rs
@@ -97,8 +97,8 @@ fn key_struct_id_field_incorrect_type() {
 #[test]
 fn key_struct_id_field_incorrect_struct_address() {
     let (mut module, _) = ModuleBuilder::default();
-    let new_module_idx =
-        module.add_module(AccountAddress::new([1u8; AccountAddress::LENGTH]), "ID");
+    let addr = AccountAddress::new([1u8; AccountAddress::LENGTH]);
+    let new_module_idx = module.add_module(addr, "ID");
     let fake_id_struct = module.add_struct(
         new_module_idx,
         "ID",
@@ -111,7 +111,11 @@ fn key_struct_id_field_incorrect_struct_address() {
         AbilitySet::EMPTY | Ability::Key,
         vec![("id", SignatureToken::Struct(fake_id_struct.handle))],
     );
-    assert!(verify_module(module.get_module()).unwrap_err().to_string().contains(&format!("First field of struct S must be of type {}::ID::ID, 01010101010101010101010101010101::ID::ID type found", FASTX_FRAMEWORK_ADDRESS)));
+    let err_str = verify_module(module.get_module()).unwrap_err().to_string();
+    assert!(err_str.contains(&format!(
+        "First field of struct S must be of type {}::ID::ID, {}::ID::ID type found",
+        FASTX_FRAMEWORK_ADDRESS, addr
+    )));
 }
 
 #[test]

--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -25,4 +25,4 @@ serde_with = "1.11.0"
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "2e829074f40c9ef852ecd6808b80d083174c778b" }
 
 move-binary-format = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
-move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
+move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }

--- a/fastx_types/src/lib.rs
+++ b/fastx_types/src/lib.rs
@@ -25,11 +25,13 @@ pub mod serialize;
 pub mod storage;
 
 /// 0x1-- account address where Move stdlib modules are stored
-pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::new([
-    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8,
-]);
+pub const MOVE_STDLIB_ADDRESS: AccountAddress = AccountAddress::ONE;
 
 /// 0x2-- account address where fastX framework modules are stored
-pub const FASTX_FRAMEWORK_ADDRESS: AccountAddress = AccountAddress::new([
-    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8,
-]);
+pub const FASTX_FRAMEWORK_ADDRESS: AccountAddress = get_hex_address_two();
+
+const fn get_hex_address_two() -> AccountAddress {
+    let mut addr = [0u8; AccountAddress::LENGTH];
+    addr[AccountAddress::LENGTH - 1] = 2u8;
+    AccountAddress::new(addr)
+}

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -54,9 +54,9 @@ pub struct CoinObject {
 /// Byte encoding of a 64 byte unsigned integer in BCS
 type BcsU64 = [u8; 8];
 /// Index marking the end of the object's ID + the beginning of its version
-const ID_END_INDEX: usize = 16;
+const ID_END_INDEX: usize = AccountAddress::LENGTH;
 /// Index marking the end of the object's version + the beginning of type-specific data
-const VERSION_END_INDEX: usize = 24;
+const VERSION_END_INDEX: usize = ID_END_INDEX + 8;
 
 impl MoveObject {
     pub fn new(type_: StructTag, contents: Vec<u8>) -> Self {


### PR DESCRIPTION
This PR switches to use 20-bytes for ObjectID.
Mostly straightforward changes to make the type consistent.