### PR TITLE
Clean up authority_tests

### DIFF
--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -137,7 +137,7 @@ pub enum ExecutionStatus {
 }
 
 impl ExecutionStatus {
-    pub fn unwrap(&self) {
+    pub fn unwrap(self) {
         match self {
             ExecutionStatus::Success => (),
             ExecutionStatus::Failure { .. } => {
@@ -146,12 +146,12 @@ impl ExecutionStatus {
         }
     }
 
-    pub fn unwrap_err(&self) -> (u64, &FastPayError) {
+    pub fn unwrap_err(self) -> (u64, FastPayError) {
         match self {
             ExecutionStatus::Success => {
                 panic!("Unable to unwrap() on {:?}", self);
             }
-            ExecutionStatus::Failure { gas_used, error } => (*gas_used, error),
+            ExecutionStatus::Failure { gas_used, error } => (gas_used, *error),
         }
     }
 }


### PR DESCRIPTION
A few things in authority_tests that need to be cleaned up:
1. We were not always checking the execution_status after handle confirmation. This also closes #169.
2. A few tests were out-of-dated (from fastpay time)