### PR TITLE
fix: remove Hash + PartialEq on ConfirmedOrder and dependent structs

### DIFF
--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.30"
 hex = "0.4.3"
 serde_bytes = "0.11.5"
 serde_with = "1.11.0"
+static_assertions = "0.3.4"
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "2e829074f40c9ef852ecd6808b80d083174c778b" }
 


### PR DESCRIPTION
## What:
Remove impls of `Hash`, `PartialEq`, `Eq` on `CertifiedOrder` and dependents

## Why
It's a quick and easy way to check that certificates can't be used in a way that assumes the details of their signature set are meaningful. Certificate equivocation (change in signature set without loss of overall validity) is allowed.

We might indeed need to compare `CertifiedOrder`s in the future, in which case a comment at the point where a `static_assertions` will blow up offers guidance on what to do.

## Why not do more?

The reason this doesn't already implement the signature-agnostic way of comparing Certificates is to avoid misuse of that `Eq` implementation in a context where we do not have distinct `ValidCertifiedOrder` and `UncheckedCertifiedOrder` types.
Imagine you have a list of `CertifiedOrder`s L and an `Eq` function that's signature agnostic. You also have a deduplicate function on vecs that uses `Eq`:
- if all certificates are valid, should you call `dedup`? Probably yes,
- if all certificates have yet to be checked, should you call `dedup`? Probably not.

## But there's a lot of duplication of utility functions!

Yes. Those are used in a test context where doing the dangerous thing (testing certificates byte for byte) makes sense, either because one of:
- we check correct ser/de,
- we check an authority has not led to an update of our stores as a client, or of its own stores as an authority, under what should be an idempotent op

This could be implemented with less code duplication using a test feature (to make sure the utility functions can be exported across crates but only in a test context), but would lead to fighting Rust's feature unification. The ad-hoc utility functions are actually less trouble.

Contributes to #266