### PR TITLE
Add first persistence in client

### DIFF
--- a/fastpay_core/src/client/client_store.rs
+++ b/fastpay_core/src/client/client_store.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+use rocksdb::Options;
+
+use std::path::Path;
+use typed_store::rocks::{open_cf, DBMap};
+use typed_store::traits::Map;
+
+const PENDING_TRANSFER_KEY: &str = "PENDING_TRANSFER_KEY";
+
+pub struct ClientStore {
+    pending_transfer: DBMap<String, Order>,
+}
+
+impl ClientStore {
+    /// Open an client store by directory path
+    pub fn open<P: AsRef<Path>>(path: P, db_options: Option<Options>) -> ClientStore {
+        let db = open_cf(&path, db_options, &["pending_transfer"]).expect("Cannot open DB.");
+        ClientStore {
+            pending_transfer: DBMap::reopen(&db, Some("pending_transfer"))
+                .expect("Cannot open pending_transfer CF."),
+        }
+    }
+    // Get the pending tx if any
+    pub fn get_pending_transfer(&self) -> Result<Option<Order>, FastPayError> {
+        self.pending_transfer
+            .get(&PENDING_TRANSFER_KEY.to_string())
+            .map_err(|e| e.into())
+    }
+    // Set the pending tx if any
+    pub fn set_pending_transfer(&self, order: &Order) -> Result<(), FastPayError> {
+        self.pending_transfer
+            .insert(&PENDING_TRANSFER_KEY.to_string(), order)
+            .map_err(|e| e.into())
+    }
+    pub fn clear_pending_transfer(&self) -> Result<(), FastPayError> {
+        self.pending_transfer
+            .remove(&PENDING_TRANSFER_KEY.to_string())
+            .map_err(|e| e.into())
+    }
+}

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -304,7 +304,7 @@ fn test_initiating_valid_transfer() {
         sender.next_sequence_number(&object_id_1),
         Err(ObjectNotFound)
     );
-    assert_eq!(sender.pending_transfer, None);
+    assert_eq!(sender.store.get_pending_transfer().unwrap(), None);
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_1)),
         Some((recipient, SequenceNumber::from(1)))
@@ -343,7 +343,7 @@ fn test_initiating_valid_transfer_despite_bad_authority() {
         .block_on(sender.transfer_object(object_id, gas_object, recipient))
         .unwrap();
     assert_eq!(sender.next_sequence_number(&object_id), Err(ObjectNotFound));
-    assert_eq!(sender.pending_transfer, None);
+    assert_eq!(sender.store.get_pending_transfer().unwrap(), None);
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id)),
         Some((recipient, SequenceNumber::from(1)))
@@ -427,7 +427,7 @@ async fn test_bidirectional_transfer() {
         .await
         .unwrap();
 
-    assert_eq!(client1.pending_transfer, None);
+    assert_eq!(client1.store.get_pending_transfer().unwrap(), None);
 
     // Confirm client1 lose ownership of the object.
     assert_eq!(
@@ -464,7 +464,7 @@ async fn test_bidirectional_transfer() {
         .await
         .unwrap();
 
-    assert_eq!(client2.pending_transfer, None);
+    assert_eq!(client2.store.get_pending_transfer().unwrap(), None);
 
     // Confirm client2 lose ownership of the object.
     assert_eq!(
@@ -516,7 +516,7 @@ fn test_receiving_unconfirmed_transfer() {
         client1.next_sequence_number(&object_id),
         Ok(SequenceNumber::from(1))
     );
-    assert_eq!(client1.pending_transfer, None);
+    assert_eq!(client1.store.get_pending_transfer().unwrap(), None);
     // ..but not confirmed remotely, hence an unchanged balance and sequence number.
     assert_eq!(
         rt.block_on(client1.get_strong_majority_owner(object_id)),


### PR DESCRIPTION
First piece, part of https://github.com/MystenLabs/fastnft/issues/257

The goal here is to move towards persisting client state and objects, and hopefully be able to recover a client after a crash without too much syncing.

This PR starts by adding some basic storage logic and a simple use-case which checks for pending transfer.

_Overhauling the client to support persistence and recovery was reaching thousands of lines, so I chunked it out into small parts to avoid conflicting Patrick's work._

Next steps:
1. Client should store its own objects (and not just the refs). This allows more robust digest checks too and can avoud hitting authorities for downloads
2. Client should implement recovery on crash by loading its data structures from disk
3. Client should use deterministic path for DB
4. Client should archive sent certificates for later auditing/sanity checks 