### PR TITLE
fix: Remove a bunch of clones in batch DB operations

### DIFF
--- a/fastpay_core/Cargo.toml
+++ b/fastpay_core/Cargo.toml
@@ -28,7 +28,7 @@ move-package = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102
 move-vm-runtime = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "2e829074f40c9ef852ecd6808b80d083174c778b" }
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "232c44e88e69eb54fe80dab247adcd1b643aeb8c" }
 
 [dev-dependencies]
 fdlimit = "0.2.1"

--- a/fastx_types/Cargo.toml
+++ b/fastx_types/Cargo.toml
@@ -23,7 +23,7 @@ serde_bytes = "0.11.5"
 serde_with = "1.11.0"
 static_assertions = "0.3.4"
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "2e829074f40c9ef852ecd6808b80d083174c778b" }
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "232c44e88e69eb54fe80dab247adcd1b643aeb8c" }
 
 move-binary-format = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2" }
 move-core-types = { git = "https://github.com/diem/move", rev="62b5a5075378ae6a7102bbfc1fb33b57ba6125d2", features=["address20"] }


### PR DESCRIPTION
Those clones were uneeded and are removed as part of an upstream fix.

This is an adaptation to https://github.com/MystenLabs/mysten-infra/pull/9.
~I will upgrade the commit pointer once we have the final (merged) commit there.~