### PR TITLE
[Object Ownership #1] Add Authenticator

### DIFF
--- a/fastpay_core/src/authority.rs
+++ b/fastpay_core/src/authority.rs
@@ -112,7 +112,7 @@ impl AuthorityState {
                 // Additional checks for mutable objects
                 // Check the transaction sender is also the object owner
                 fp_ensure!(
-                    order.sender() == &object.owner,
+                    object.owner.is_address(order.sender()),
                     FastPayError::IncorrectSigner
                 );
 
@@ -340,7 +340,7 @@ impl AuthorityState {
             });
         }
 
-        output_object.transfer(recipient);
+        output_object.transfer(Authenticator::Address(recipient));
         temporary_store.write_object(output_object);
         Ok(ExecutionStatus::Success)
     }

--- a/fastpay_core/src/client.rs
+++ b/fastpay_core/src/client.rs
@@ -616,7 +616,7 @@ where
     async fn get_strong_majority_owner(
         &self,
         object_id: ObjectID,
-    ) -> Option<(FastPayAddress, SequenceNumber)> {
+    ) -> Option<(Authenticator, SequenceNumber)> {
         let request = ObjectInfoRequest {
             object_id,
             request_sequence_number: None,
@@ -1073,12 +1073,12 @@ where
                     .unwrap_or_default();
                 // only update if data is new
                 if old_seq < seq {
-                    if owner == self.address {
+                    if owner.is_address(&self.address) {
                         self.insert_object(&object_ref, &digest);
                     } else {
                         self.remove_object(&object_id);
                     }
-                } else if old_seq == seq && owner == self.address {
+                } else if old_seq == seq && owner.is_address(&self.address) {
                     // ObjectRef can be 1 version behind because it's only updated after confirmation.
                     self.object_refs.insert(object_id, object_ref);
                 }

--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -515,7 +515,7 @@ async fn test_handle_move_order() {
         .object_state(&created_object_id)
         .await
         .unwrap();
-    assert_eq!(created_obj.owner, sender,);
+    assert!(created_obj.owner.is_address(&sender));
     assert_eq!(created_obj.id(), created_object_id);
     assert_eq!(created_obj.version(), OBJECT_START_VERSION);
 
@@ -808,7 +808,7 @@ async fn test_handle_confirmation_order_ok() {
     // Key check: the ownership has changed
 
     let new_account = authority_state.object_state(&object_id).await.unwrap();
-    assert_eq!(recipient, new_account.owner);
+    assert!(new_account.owner.is_address(&recipient));
     assert_eq!(next_sequence_number, new_account.version());
     assert_eq!(None, info.signed_order);
     let opt_cert = {
@@ -1068,7 +1068,7 @@ async fn test_authority_persist() {
 
     // Check the object is present
     assert_eq!(obj2.id(), object_id);
-    assert_eq!(obj2.owner, recipient);
+    assert!(obj2.owner.is_address(&recipient));
 }
 
 async fn call_move(
@@ -1169,7 +1169,7 @@ async fn test_hero() {
     .await;
     assert_eq!(effects.status, ExecutionStatus::Success);
     let (admin_object, admin_object_owner) = effects.created[0];
-    assert_eq!(admin_object_owner, admin);
+    assert!(admin_object_owner.is_address(&admin));
 
     // 5. Create Trusted Coin Treasury.
     let effects = call_move(
@@ -1186,7 +1186,7 @@ async fn test_hero() {
     .await;
     assert_eq!(effects.status, ExecutionStatus::Success);
     let (cap, cap_owner) = effects.created[0];
-    assert_eq!(cap_owner, player);
+    assert!(cap_owner.is_address(&player));
 
     // 6. Mint 500 EXAMPLE TrustedCoin.
     let effects = call_move(
@@ -1204,7 +1204,7 @@ async fn test_hero() {
     assert_eq!(effects.status, ExecutionStatus::Success);
     assert_eq!(effects.mutated.len(), 1); // cap
     let (coin, coin_owner) = effects.created[0];
-    assert_eq!(coin_owner, player);
+    assert!(coin_owner.is_address(&player));
 
     // 7. Purchase a sword using 500 coin. This sword will have magic = 4, sword_strength = 5.
     let effects = call_move(
@@ -1222,9 +1222,9 @@ async fn test_hero() {
     assert_eq!(effects.status, ExecutionStatus::Success);
     assert_eq!(effects.mutated.len(), 1); // coin
     let (hero, hero_owner) = effects.created[0];
-    assert_eq!(hero_owner, player);
+    assert!(hero_owner.is_address(&player));
     // The payment goes to the admin.
-    assert_eq!(effects.mutated[0].1, admin);
+    assert!(effects.mutated[0].1.is_address(&admin));
 
     // 8. Verify the hero is what we exepct with strength 5.
     let effects = call_move(
@@ -1261,7 +1261,7 @@ async fn test_hero() {
     .await;
     assert_eq!(effects.status, ExecutionStatus::Success);
     let (boar, boar_owner) = effects.created[0];
-    assert_eq!(boar_owner, player);
+    assert!(boar_owner.is_address(&player));
 
     // 10. Slay the boar!
     let effects = call_move(

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -255,11 +255,17 @@ fn test_get_strong_majority_owner() {
         let client = init_local_client_state(authority_objects).await;
         assert_eq!(
             client.get_strong_majority_owner(object_id_1).await,
-            Some((client.address, SequenceNumber::from(0)))
+            Some((
+                Authenticator::Address(client.address),
+                SequenceNumber::from(0)
+            ))
         );
         assert_eq!(
             client.get_strong_majority_owner(object_id_2).await,
-            Some((client.address, SequenceNumber::from(0)))
+            Some((
+                Authenticator::Address(client.address),
+                SequenceNumber::from(0)
+            ))
         );
 
         let object_id_1 = ObjectID::random();
@@ -276,7 +282,10 @@ fn test_get_strong_majority_owner() {
         assert_eq!(client.get_strong_majority_owner(object_id_2).await, None);
         assert_eq!(
             client.get_strong_majority_owner(object_id_3).await,
-            Some((client.address, SequenceNumber::from(0)))
+            Some((
+                Authenticator::Address(client.address),
+                SequenceNumber::from(0)
+            ))
         );
     });
 }
@@ -298,11 +307,17 @@ fn test_initiating_valid_transfer() {
     let mut sender = rt.block_on(init_local_client_state(authority_objects));
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_1)),
-        Some((sender.address, SequenceNumber::from(0)))
+        Some((
+            Authenticator::Address(sender.address),
+            SequenceNumber::from(0)
+        ))
     );
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_2)),
-        Some((sender.address, SequenceNumber::from(0)))
+        Some((
+            Authenticator::Address(sender.address),
+            SequenceNumber::from(0)
+        ))
     );
     let certificate = rt
         .block_on(sender.transfer_object(object_id_1, gas_object, recipient))
@@ -316,11 +331,14 @@ fn test_initiating_valid_transfer() {
     assert_eq!(sender.pending_transfer, None);
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_1)),
-        Some((recipient, SequenceNumber::from(1)))
+        Some((Authenticator::Address(recipient), SequenceNumber::from(1)))
     );
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_2)),
-        Some((sender.address, SequenceNumber::from(0)))
+        Some((
+            Authenticator::Address(sender.address),
+            SequenceNumber::from(0)
+        ))
     );
     // valid since our test authority should not update its certificate set
     compare_certified_orders(
@@ -359,7 +377,7 @@ fn test_initiating_valid_transfer_despite_bad_authority() {
     assert_eq!(sender.pending_transfer, None);
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id)),
-        Some((recipient, SequenceNumber::from(1)))
+        Some((Authenticator::Address(recipient), SequenceNumber::from(1)))
     );
     // valid since our test authority shouldn't update its certificate set
     compare_certified_orders(
@@ -398,7 +416,10 @@ fn test_initiating_transfer_low_funds() {
     // assert_eq!(sender.pending_transfer, None);
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_1)),
-        Some((sender.address, SequenceNumber::from(0))),
+        Some((
+            Authenticator::Address(sender.address),
+            SequenceNumber::from(0)
+        )),
     );
     assert_eq!(
         rt.block_on(sender.get_strong_majority_owner(object_id_2)),
@@ -432,12 +453,18 @@ async fn test_bidirectional_transfer() {
     // Confirm client1 have ownership of the object.
     assert_eq!(
         client1.get_strong_majority_owner(object_id).await,
-        Some((client1.address, SequenceNumber::from(0)))
+        Some((
+            Authenticator::Address(client1.address),
+            SequenceNumber::from(0)
+        ))
     );
     // Confirm client2 doesn't have ownership of the object.
     assert_eq!(
         client2.get_strong_majority_owner(object_id).await,
-        Some((client1.address, SequenceNumber::from(0)))
+        Some((
+            Authenticator::Address(client1.address),
+            SequenceNumber::from(0)
+        ))
     );
     // Transfer object to client2.
     let certificate = client1
@@ -450,12 +477,18 @@ async fn test_bidirectional_transfer() {
     // Confirm client1 lose ownership of the object.
     assert_eq!(
         client1.get_strong_majority_owner(object_id).await,
-        Some((client2.address, SequenceNumber::from(1)))
+        Some((
+            Authenticator::Address(client2.address),
+            SequenceNumber::from(1)
+        ))
     );
     // Confirm client2 acquired ownership of the object.
     assert_eq!(
         client2.get_strong_majority_owner(object_id).await,
-        Some((client2.address, SequenceNumber::from(1)))
+        Some((
+            Authenticator::Address(client2.address),
+            SequenceNumber::from(1)
+        ))
     );
 
     // Confirm certificate is consistent between authorities and client.
@@ -474,7 +507,10 @@ async fn test_bidirectional_transfer() {
     // Confirm sequence number are consistent between clients.
     assert_eq!(
         client2.get_strong_majority_owner(object_id).await,
-        Some((client2.address, SequenceNumber::from(1)))
+        Some((
+            Authenticator::Address(client2.address),
+            SequenceNumber::from(1)
+        ))
     );
 
     // Transfer the object back to Client1
@@ -488,7 +524,10 @@ async fn test_bidirectional_transfer() {
     // Confirm client2 lose ownership of the object.
     assert_eq!(
         client2.get_strong_majority_owner(object_id).await,
-        Some((client1.address, SequenceNumber::from(2)))
+        Some((
+            Authenticator::Address(client1.address),
+            SequenceNumber::from(2)
+        ))
     );
     assert_eq!(
         client2.get_strong_majority_sequence_number(object_id).await,
@@ -497,7 +536,10 @@ async fn test_bidirectional_transfer() {
     // Confirm client1 acquired ownership of the object.
     assert_eq!(
         client1.get_strong_majority_owner(object_id).await,
-        Some((client1.address, SequenceNumber::from(2)))
+        Some((
+            Authenticator::Address(client1.address),
+            SequenceNumber::from(2)
+        ))
     );
 
     // Should fail if Client 2 double spend the object
@@ -539,7 +581,10 @@ fn test_receiving_unconfirmed_transfer() {
     // ..but not confirmed remotely, hence an unchanged balance and sequence number.
     assert_eq!(
         rt.block_on(client1.get_strong_majority_owner(object_id)),
-        Some((client1.address, SequenceNumber::from(0)))
+        Some((
+            Authenticator::Address(client1.address),
+            SequenceNumber::from(0)
+        ))
     );
     assert_eq!(
         rt.block_on(client1.get_strong_majority_sequence_number(object_id)),
@@ -549,7 +594,10 @@ fn test_receiving_unconfirmed_transfer() {
     rt.block_on(client2.receive_object(&certificate)).unwrap();
     assert_eq!(
         rt.block_on(client2.get_strong_majority_owner(object_id)),
-        Some((client2.address, SequenceNumber::from(1)))
+        Some((
+            Authenticator::Address(client2.address),
+            SequenceNumber::from(1)
+        ))
     );
 }
 
@@ -620,7 +668,10 @@ async fn test_client_state_sync_with_transferred_object() {
     // Confirm client2 acquired ownership of the object.
     assert_eq!(
         client2.get_strong_majority_owner(object_id).await,
-        Some((client2.address, SequenceNumber::from(1)))
+        Some((
+            Authenticator::Address(client2.address),
+            SequenceNumber::from(1)
+        ))
     );
 
     // Client 2's local object_id and cert should be empty before sync
@@ -903,7 +954,10 @@ async fn test_move_calls_object_transfer() {
         .unwrap();
 
     // Confirm new owner
-    assert_eq!(transferred_obj_info.object.owner, client2.address);
+    assert!(transferred_obj_info
+        .object
+        .owner
+        .is_address(&client2.address));
 }
 
 #[tokio::test]
@@ -1378,7 +1432,10 @@ async fn test_move_calls_object_transfer_and_freeze() {
         .unwrap();
 
     // Confirm new owner
-    assert_eq!(transferred_obj_info.object.owner, client2.address);
+    assert!(transferred_obj_info
+        .object
+        .owner
+        .is_address(&client2.address));
 
     // Confirm read only
     assert!(transferred_obj_info.object.is_read_only());

--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -7,8 +7,8 @@ use crate::bytecode_rewriter::ModuleHandleRewriter;
 use fastx_framework::EventType;
 use fastx_types::{
     base_types::{
-        FastPayAddress, ObjectID, TransactionDigest, TxContext, TX_CONTEXT_MODULE_NAME,
-        TX_CONTEXT_STRUCT_NAME,
+        Authenticator, FastPayAddress, ObjectID, TransactionDigest, TxContext,
+        TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
     },
     error::{FastPayError, FastPayResult},
     event::Event,
@@ -212,7 +212,7 @@ pub fn publish<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
     }
 
     // wrap the modules in an object, write it to the store
-    let package_object = Object::new_package(modules, sender, ctx.digest());
+    let package_object = Object::new_package(modules, Authenticator::Address(sender), ctx.digest());
     state_view.write_object(package_object);
 
     Ok(ExecutionStatus::Success)
@@ -409,7 +409,7 @@ fn handle_transfer<
             if should_freeze {
                 move_obj.freeze();
             }
-            let obj = Object::new_move(move_obj, recipient, tx_digest);
+            let obj = Object::new_move(move_obj, Authenticator::Address(recipient), tx_digest);
             if old_object.is_none() {
                 // Charge extra gas based on object size if we are creating a new object.
                 *gas_used += gas::calculate_object_creation_cost(&obj);

--- a/fastx_programmability/adapter/src/genesis.rs
+++ b/fastx_programmability/adapter/src/genesis.rs
@@ -3,7 +3,7 @@
 
 use fastx_framework::{self};
 use fastx_types::{
-    base_types::{FastPayAddress, TransactionDigest},
+    base_types::{Authenticator, FastPayAddress, TransactionDigest},
     object::Object,
     FASTX_FRAMEWORK_ADDRESS, MOVE_STDLIB_ADDRESS,
 };
@@ -31,8 +31,16 @@ fn create_genesis_module_objects() -> Genesis {
         fastx_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, FASTX_FRAMEWORK_ADDRESS);
     let owner = FastPayAddress::default();
     let objects = vec![
-        Object::new_package(fastx_modules, owner, TransactionDigest::genesis()),
-        Object::new_package(std_modules, owner, TransactionDigest::genesis()),
+        Object::new_package(
+            fastx_modules,
+            Authenticator::Address(owner),
+            TransactionDigest::genesis(),
+        ),
+        Object::new_package(
+            std_modules,
+            Authenticator::Address(owner),
+            TransactionDigest::genesis(),
+        ),
     ];
     Genesis {
         objects,

--- a/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/fastx_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -226,7 +226,7 @@ fn test_object_basics() {
     storage.flush();
     let mut obj1 = storage.read_object(&id1).unwrap();
     let mut obj1_seq = SequenceNumber::from(1);
-    assert_eq!(obj1.owner, addr1);
+    assert!(obj1.owner.is_address(&addr1));
     assert_eq!(obj1.version(), obj1_seq);
 
     // 2. Transfer obj1 to addr2
@@ -250,7 +250,7 @@ fn test_object_basics() {
     assert!(storage.deleted().is_empty());
     storage.flush();
     let transferred_obj = storage.read_object(&id1).unwrap();
-    assert_eq!(transferred_obj.owner, addr2);
+    assert!(transferred_obj.owner.is_address(&addr2));
     obj1_seq = obj1_seq.increment();
     assert_eq!(obj1.id(), transferred_obj.id());
     assert_eq!(transferred_obj.version(), obj1_seq);
@@ -315,7 +315,7 @@ fn test_object_basics() {
     );
     storage.flush();
     let updated_obj = storage.read_object(&id1).unwrap();
-    assert_eq!(updated_obj.owner, addr2);
+    assert!(updated_obj.owner.is_address(&addr2));
     obj1_seq = obj1_seq.increment();
     assert_eq!(updated_obj.version(), obj1_seq);
     assert_ne!(
@@ -587,7 +587,7 @@ fn test_transfer_and_freeze() {
     storage.flush();
     let obj1 = storage.read_object(&id1).unwrap();
     assert!(obj1.is_read_only());
-    assert_eq!(obj1.owner, addr2);
+    assert!(obj1.owner.is_address(&addr2));
 
     // 3. Call transfer again and it should fail.
     let pure_args = vec![bcs::to_bytes(&addr1.to_vec()).unwrap()];

--- a/fastx_types/src/base_types.rs
+++ b/fastx_types/src/base_types.rs
@@ -83,6 +83,28 @@ pub type AuthorityName = PublicKeyBytes;
 pub type ObjectID = AccountAddress;
 pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 
+/// An object can be either owned by an account address, or another object.
+// TODO: A few things to improve:
+// 1. We may want to support multiple signing schemas, rename Authenticator to Address,
+//    and rename the Address enum to Ed25519PublicKey, so that we could add more.
+// 2. We may want to make Authenticator a fix-sized array instead of having different size
+//    for different variants, through hashing.
+// Refer details to https://github.com/MystenLabs/fastnft/pull/292.
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Deserialize, PartialOrd, Ord, Serialize, Hash)]
+pub enum Authenticator {
+    Address(FastPayAddress),
+    Object(ObjectID),
+}
+
+impl Authenticator {
+    pub fn is_address(&self, address: &FastPayAddress) -> bool {
+        match self {
+            Self::Address(addr) => addr == address,
+            Self::Object(_) => false,
+        }
+    }
+}
+
 // We use SHA3-256 hence 32 bytes here
 const TRANSACTION_DIGEST_LENGTH: usize = 32;
 

--- a/fastx_types/src/messages.rs
+++ b/fastx_types/src/messages.rs
@@ -179,14 +179,14 @@ pub struct OrderEffects {
     // The transaction digest
     pub transaction_digest: TransactionDigest,
     // ObjectRef and owner of new objects created.
-    pub created: Vec<(ObjectRef, FastPayAddress)>,
+    pub created: Vec<(ObjectRef, Authenticator)>,
     // ObjectRef and owner of mutated objects.
     // mutated does not include gas object or created objects.
-    pub mutated: Vec<(ObjectRef, FastPayAddress)>,
+    pub mutated: Vec<(ObjectRef, Authenticator)>,
     // Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
     // The updated gas object reference.
-    pub gas_object: (ObjectRef, FastPayAddress),
+    pub gas_object: (ObjectRef, Authenticator),
     /// The events emitted during execution. Note that only successful transactions emit events
     pub events: Vec<Event>,
 }
@@ -195,7 +195,7 @@ impl OrderEffects {
     /// Return an iterator that iterates throguh all mutated objects,
     /// including all from mutated, created and the gas_object.
     /// It doesn't include deleted.
-    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, FastPayAddress)> {
+    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, Authenticator)> {
         self.mutated
             .iter()
             .chain(self.created.iter())

--- a/fastx_types/src/object.rs
+++ b/fastx_types/src/object.rs
@@ -15,8 +15,8 @@ use crate::id::ID;
 use crate::FASTX_FRAMEWORK_ADDRESS;
 use crate::{
     base_types::{
-        sha3_hash, BcsSignable, FastPayAddress, ObjectDigest, ObjectID, ObjectRef, SequenceNumber,
-        TransactionDigest,
+        sha3_hash, Authenticator, BcsSignable, FastPayAddress, ObjectDigest, ObjectID, ObjectRef,
+        SequenceNumber, TransactionDigest,
     },
     gas_coin::GasCoin,
 };
@@ -186,8 +186,8 @@ impl Data {
 pub struct Object {
     /// The meat of the object
     pub data: Data,
-    /// The authenticator that unlocks this object (eg. public key, or other)
-    pub owner: FastPayAddress,
+    /// The authenticator that unlocks this object (eg. public key, or object id)
+    pub owner: Authenticator,
     /// The digest of the order that created or last mutated this object
     pub previous_transaction: TransactionDigest,
 }
@@ -198,7 +198,7 @@ impl Object {
     /// Create a new Move object
     pub fn new_move(
         o: MoveObject,
-        owner: FastPayAddress,
+        owner: Authenticator,
         previous_transaction: TransactionDigest,
     ) -> Self {
         Object {
@@ -210,7 +210,7 @@ impl Object {
 
     pub fn new_package(
         modules: Vec<CompiledModule>,
-        owner: FastPayAddress,
+        owner: Authenticator,
         previous_transaction: TransactionDigest,
     ) -> Self {
         let serialized: MovePackage = modules
@@ -273,7 +273,7 @@ impl Object {
     }
 
     /// Change the owner of `self` to `new_owner`
-    pub fn transfer(&mut self, new_owner: FastPayAddress) {
+    pub fn transfer(&mut self, new_owner: Authenticator) {
         // TODO: these should be raised FastPayError's instead of panic's
         assert!(!self.is_read_only(), "Cannot transfer an immutable object");
         match &mut self.data {
@@ -302,7 +302,7 @@ impl Object {
             read_only: false,
         });
         Self {
-            owner,
+            owner: Authenticator::Address(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
         }
@@ -341,7 +341,7 @@ impl Object {
             read_only: false,
         });
         Self {
-            owner,
+            owner: Authenticator::Address(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
         }
@@ -362,7 +362,7 @@ impl Object {
             read_only: false,
         });
         Self {
-            owner,
+            owner: Authenticator::Address(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
         }


### PR DESCRIPTION
This is the first step to implement #99.
It adds a new `Authenticator` type that represent either a user account address or an object ID.
The owner of an object is now `Authenticator`.
This PR doesn't use it in anyway, but merely just try to get all code compile with this new type.