### PR TITLE
[Object Ownership #2] Add trasfer_to_object API in Transfer.move

### DIFF
--- a/fastx_programmability/framework/sources/Transfer.move
+++ b/fastx_programmability/framework/sources/Transfer.move
@@ -1,6 +1,6 @@
 module FastX::Transfer {
     use FastX::Address::{Self, Address};
-    //use FastX::ID::IDBytes;
+    use FastX::ID::{Self, IDBytes};
 
     /// Transfers are implemented by emitting a
     /// special `TransferEvent` that the fastX adapter
@@ -33,11 +33,12 @@ module FastX::Transfer {
 
     native fun transfer_internal<T: key>(obj: T, recipient: vector<u8>, should_freeze: bool);
 
-    /*/// Transfer ownership of `obj` to another object `id`. Afterward, `obj`
-    /// can only be used in a transaction that also includes the object with
-    /// `id`.
-    /// WARNING: Use with caution. Improper use can create ownership cycles
-    /// between objects, which will cause all objects involved in the cycle to
-    /// be locked.
-    public native fun transfer_to_id<T: key>(obj: T, id: IDBytes);*/
+    /// Transfer ownership of `obj` to another object `owner`.
+    // TODO: Add option to freeze after transfer.
+    public fun transfer_to_object<T: key, R: key>(obj: T, owner: &mut R) {
+        transfer_to_object_id(obj, *ID::get_id_bytes(owner));
+    }
+
+    /// Transfer ownership of `obj` to another object with `id`.
+    native fun transfer_to_object_id<T: key>(obj: T, id: IDBytes);
 }

--- a/fastx_programmability/framework/src/lib.rs
+++ b/fastx_programmability/framework/src/lib.rs
@@ -20,9 +20,11 @@ const MAX_UNIT_TEST_INSTRUCTIONS: u64 = 100_000;
 #[repr(u8)]
 pub enum EventType {
     /// System event: transfer between addresses
-    Transfer,
+    TransferToAddress,
     /// System event: freeze, then transfer between addresses
-    TransferAndFreeze,
+    TransferToAddressAndFreeze,
+    /// System event: transfer object to another object
+    TransferToObject,
     /// User-defined event
     User,
 }

--- a/fastx_programmability/framework/src/natives/mod.rs
+++ b/fastx_programmability/framework/src/natives/mod.rs
@@ -17,6 +17,11 @@ pub fn all_natives(
         ("Event", "emit", event::emit),
         ("ID", "bytes_to_address", id::bytes_to_address),
         ("Transfer", "transfer_internal", transfer::transfer_internal),
+        (
+            "Transfer",
+            "transfer_to_object_id",
+            transfer::transfer_to_object_id,
+        ),
         ("TxContext", "fresh_id", tx_context::fresh_id),
     ];
     FASTX_NATIVES

--- a/fastx_programmability/framework/src/natives/transfer.rs
+++ b/fastx_programmability/framework/src/natives/transfer.rs
@@ -15,12 +15,12 @@ use smallvec::smallvec;
 use std::collections::VecDeque;
 
 /// Implementation of Move native function
-/// `transfer_internal<T: key>(event: TransferEvent<T>)`
+/// `transfer_internal<T: key>(obj: T, recipient: vector<u8>, should_freeze: bool)`
 /// Here, we simply emit this event. The fastX adapter
 /// treats this as a special event that is handled
-/// differently from user events--for each `TransferEvent`,
+/// differently from user events:
 /// the adapter will change the owner of the object
-/// in question to `TransferEvent.recipient`
+/// in question to `recipient`.
 pub fn transfer_internal(
     context: &mut NativeContext,
     mut ty_args: Vec<Type>,
@@ -33,19 +33,44 @@ pub fn transfer_internal(
     let should_freeze = pop_arg!(args, bool);
     let recipient = pop_arg!(args, Vec<u8>);
     let transferred_obj = args.pop_back().unwrap();
-
     let event_type = if should_freeze {
-        EventType::TransferAndFreeze
+        EventType::TransferToAddressAndFreeze
     } else {
-        EventType::Transfer
-    } as u64;
+        EventType::TransferToAddress
+    };
+    transfer_common(context, ty, transferred_obj, recipient, event_type)
+}
 
+/// Implementation of Move native function
+/// `transfer_to_object_id<T: key>(obj: T, id: IDBytes)`
+pub fn transfer_to_object_id(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 2);
+
+    let ty = ty_args.pop().unwrap();
+    let recipient = pop_arg!(args, Vec<u8>);
+    let transferred_obj = args.pop_back().unwrap();
+    let event_type = EventType::TransferToObject;
+    transfer_common(context, ty, transferred_obj, recipient, event_type)
+}
+
+fn transfer_common(
+    context: &mut NativeContext,
+    ty: Type,
+    transferred_obj: Value,
+    recipient: Vec<u8>,
+    event_type: EventType,
+) -> PartialVMResult<NativeResult> {
     // Charge a constant native gas cost here, since
     // we will charge it properly when processing
     // all the events in adapter.
     // TODO: adjust native_gas cost size base.
     let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 1);
-    if !context.save_event(recipient, event_type, ty, transferred_obj)? {
+    if !context.save_event(recipient, event_type as u64, ty, transferred_obj)? {
         return Ok(NativeResult::err(cost, 0));
     }
 


### PR DESCRIPTION
This is the second step towards #99.
It allows us to transfer an object to another object in Move.
To do so we added a `transfer_to_object` API in the Transfer module, which then invokes a native function to emit the corresponding event.
Latter in the adapter we process the event and change the owner accordingly.