### PR TITLE
[Object Ownership #4] Prevent circular ownership

### DIFF
--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -151,6 +151,8 @@ pub enum FastPayError {
     AbortedExecution { error: String },
     #[error("Invalid move event: {error:?}.")]
     InvalidMoveEvent { error: String },
+    #[error("Circular object ownership detected")]
+    CircularObjectOwnership,
 
     // Gas related errors
     #[error("Gas budget set higher than max: {error:?}.")]

--- a/fastx_types/src/unit_tests/serialize_tests.rs
+++ b/fastx_types/src/unit_tests/serialize_tests.rs
@@ -242,7 +242,7 @@ fn test_info_response() {
     let resp1 = ObjectInfoResponse {
         object_and_lock: Some(ObjectResponse {
             object: Object::with_id_owner_for_testing(dbg_object_id(0x20), dbg_addr(0x20)),
-            lock: Some(vote.clone()),
+            lock: Some(vote),
         }),
         parent_certificate: None,
     };


### PR DESCRIPTION
This PR is also part of #99.
One potential issue that could happen is creating circular ownership: after transferring the owner of an object to another object, the ownership chain forms a cycle.
There are two ways to go about this:
1. We constrain the input objects such that only the object at the bottom of the ownership chain can be by-value, all other objects must be by-reference. This way you cannot transfer any objects to another object that would point to something lower on the chain.
2. We catch it when processing a transfer event, and detect cycles at that time.

This PR goes with 2 for now, mostly because 1 would put limitations on the expressiveness of the programmability. For instance, we cannot express an intent where we want to either give out a bundle of objects or give out a specific item in that bundle.
It comes with the trade-off that we are only able to catch circular ownership after finishing the execution, instead of at order handling phase, leading to more gas charges for a failed transaction.


TODO: There are a few more things left:
1. Make native transfer also support transfer to object.
2. Make Client storage support object owning other objects.
3. Add tests.