### PR TITLE
refactor: Switch logging from log + env_logger to tracing + tracing_subscriber

### DIFF
--- a/fastpay/Cargo.toml
+++ b/fastpay/Cargo.toml
@@ -10,9 +10,7 @@ edition = "2021"
 anyhow = "1.0.53"
 bytes = "1.1.0"
 clap = "3.0.13"
-env_logger = "0.9.0"
 futures = "0.3.19"
-log = "0.4.14"
 net2 = "0.2.37"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
@@ -30,6 +28,8 @@ rocksdb = "0.17.0"
 hex = "0.4.3"
 async-trait = "0.1.52"
 serde_with = "1.11.0"
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", features = ["time", "env-filter"] }
 
 bcs = "0.1.3"
 fastpay_core = { path = "../fastpay_core" }

--- a/fastpay/src/network.rs
+++ b/fastpay/src/network.rs
@@ -8,10 +8,10 @@ use fastx_types::{error::*, messages::*, serialize::*};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::FutureExt;
-use log::*;
 use std::io;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::time;
+use tracing::*;
 
 pub struct Server {
     base_address: String,

--- a/fastpay/src/transport.rs
+++ b/fastpay/src/transport.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::future;
-use log::*;
 use std::io::ErrorKind;
 use std::{collections::HashMap, convert::TryInto, io, sync::Arc};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -11,6 +10,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::{TcpListener, TcpStream},
 };
+use tracing::*;
 
 #[cfg(test)]
 #[path = "unit_tests/transport_tests.rs"]


### PR DESCRIPTION
## Why?
This switches the code base to [tokio/tracing](https://github.com/tokio-rs/tracing).

1. tracing's notion of Spans allows us to instrument logs with context that lets us make sense of the application's state, even in a concurrent or distributed context. The [announcement on the tokio blog](https://tokio.rs/blog/2019-08-tracing) is a pretty compact intro to the gist of it.
2. This gives us access to the tracing ecosystem, see https://github.com/MystenLabs/narwhal/pull/26 for more details

## What
More specifically, this PR transforms the "rails" of logging from using log + event_logger to using tracing, and thereby opens the ability to open Spans or use the `#[instrument]` macro.

It keeps full backward-compatibility with the prior logs as far as Rust is concerned. 

Of course, **this is not the hard part**. The hard part is to use `tracing` wisely. 

## What do we do now? (next steps)

Shave yaks!
```rust
pub fn shave_the_yak(yak: &mut Yak) {
    // create and enter a span to represent the scope
    let span = span!(Level::TRACE, "shave_the_yak", ?yak);
    let _enter = span.enter();

    // Since the span is annotated with the yak, it is part of the context
    // for everything happening inside the span. Therefore, we don't need
    // to add it to the message for this event, as the `log` crate does.
    info!(target: "yak_events", "Commencing yak shaving");
    loop {
        match find_a_razor() {
            Ok(razor) => {
                // We can add the razor as a field rather than formatting it
                // as part of the message, allowing subscribers to consume it
                // in a more structured manner:
                info!({ %razor }, "Razor located");
                yak.shave(razor);
                break;
            }
            Err(err) => {
                // However, we can also create events with formatted messages,
                // just as we would for log records.
                warn!("Unable to locate a razor: {}, retrying", err);
            }
        }
    }
}
```

## Caveat
It may mess up the fabric benchmarking files, which I'm no longer sure we maintain. If it does, it would be because of different time printing formats, in particular it's a bit difficult to make tracing produce the wonky timestamps of log. As a consequence the python scripts may need massaging to handle RFC 3339 instead of ISO8601. I don't think it matters at this stage, but YMMV.