### PR TITLE
Add dependent package objects to input_objects during module publish

### DIFF
--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -36,6 +36,8 @@ pub enum FastPayError {
     LockErrors { errors: Vec<FastPayError> },
     #[error("Attempt to transfer read-only object.")]
     CannotTransferReadOnlyObject,
+    #[error("A move package is expected, instead a move object is passed: {object_id}")]
+    MoveObjectAsPackage { object_id: ObjectID },
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]
@@ -133,6 +135,8 @@ pub enum FastPayError {
     ModulePublishFailure { error: String },
     #[error("Failed to build Move modules")]
     ModuleBuildFailure { error: String },
+    #[error("Dependent package not found on-chain: {package_id:?}")]
+    DependentPackageNotFound { package_id: ObjectID },
 
     // Move call related errors
     #[error("Function resolution failure: {error:?}.")]


### PR DESCRIPTION
This PR fixes #284.
The problem here is that during module publishing, we will eventually need to read more objects on-chain due to module dependency (the to-be-published package can depend on other package objects). We need to first check if these objects exist on-chain before executing the publishing.
If we don't do so, in the case when some authorities are out-of-sync and don't contain some of the dependent packages, we could end up charging failure gas, leading to inconsistent state!
This PR fixes it by adding these implicit dependencies to `input_objects` so that they are checked the same way just like other input objects.
One specialty here is that we don't have the digest when retrieving these dependency objects, and we don't care about it anyway since published packages never change on-chain. To handle this, we add an `InputType` enum that gets returned along with each input object to indicate their types. Doing so allows us to skip the digest check on the dependency objects. It also makes it slightly cleaner to check on transfer object and gas object.