### PR TITLE
Add move-unit-test to move_dependency.py name mapping

### DIFF
--- a/scripts/move_dependency.py
+++ b/scripts/move_dependency.py
@@ -58,6 +58,7 @@ def switch_to_local():
         "move-cli": "tools/move-cli",
         "move-core-types": "move-core/types",
         "move-package": "tools/move-package",
+        "move-unit-test": "tools/move-unit-test",
         "move-vm-runtime": "move-vm/runtime",
         "move-vm-types": "move-vm/types",
     }


### PR DESCRIPTION
Context: move_dependency.py is a script that allows for convenient switching between remote repo and local repo for the Move dependency (so that we could debug Move locally, if needed). When a new dependency is added, if its path within Move is not as straightforward as just `language/..`, we need to add the mapping so that it can switch to local dependency properly.