### PR TITLE
AuthorityTemporaryStore::reset should not clear active_inputs

### DIFF
--- a/fastpay_core/src/authority/temporary_store.rs
+++ b/fastpay_core/src/authority/temporary_store.rs
@@ -175,7 +175,6 @@ impl AuthorityTemporaryStore {
 impl Storage for AuthorityTemporaryStore {
     /// Resets any mutations and deletions recorded in the store.
     fn reset(&mut self) {
-        self.active_inputs.clear();
         self.written.clear();
         self.deleted.clear();
         self.events.clear();


### PR DESCRIPTION
`active_inputs` is critical for removing order locks upon order execution failure. We should not clear it.