### PR TITLE
Add object owning object tests

### DIFF
--- a/fastx_programmability/framework/sources/ObjectBasics.move
+++ b/fastx_programmability/framework/sources/ObjectBasics.move
@@ -35,6 +35,10 @@ module FastX::ObjectBasics {
         Transfer::transfer_and_freeze(o, Address::new(recipient))
     }
 
+    public fun transfer_to_object(o: Object, owner: &mut Object, _ctx: &mut TxContext) {
+        Transfer::transfer_to_object(o, owner)
+    }
+
     public fun set_value(o: &mut Object, value: u64, _ctx: &mut TxContext) {
         o.value = value;   
     }

--- a/fastx_programmability/framework/sources/Transfer.move
+++ b/fastx_programmability/framework/sources/Transfer.move
@@ -1,6 +1,6 @@
 module FastX::Transfer {
     use FastX::Address::{Self, Address};
-    use FastX::ID::{Self, IDBytes};
+    use FastX::ID;
 
     /// Transfers are implemented by emitting a
     /// special `TransferEvent` that the fastX adapter
@@ -36,9 +36,9 @@ module FastX::Transfer {
     /// Transfer ownership of `obj` to another object `owner`.
     // TODO: Add option to freeze after transfer.
     public fun transfer_to_object<T: key, R: key>(obj: T, owner: &mut R) {
-        transfer_to_object_id(obj, *ID::get_id_bytes(owner));
+        transfer_to_object_id(obj, *ID::get_bytes(ID::get_id_bytes(owner)));
     }
 
     /// Transfer ownership of `obj` to another object with `id`.
-    native fun transfer_to_object_id<T: key>(obj: T, id: IDBytes);
+    native fun transfer_to_object_id<T: key>(obj: T, id: address);
 }

--- a/fastx_programmability/framework/src/natives/transfer.rs
+++ b/fastx_programmability/framework/src/natives/transfer.rs
@@ -3,6 +3,7 @@
 
 use crate::EventType;
 use move_binary_format::errors::PartialVMResult;
+use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::native_functions::NativeContext;
 use move_vm_types::{
     gas_schedule::NativeCostIndex,
@@ -52,7 +53,7 @@ pub fn transfer_to_object_id(
     debug_assert!(args.len() == 2);
 
     let ty = ty_args.pop().unwrap();
-    let recipient = pop_arg!(args, Vec<u8>);
+    let recipient = pop_arg!(args, AccountAddress).to_vec();
     let transferred_obj = args.pop_back().unwrap();
     let event_type = EventType::TransferToObject;
     transfer_common(context, ty, transferred_obj, recipient, event_type)


### PR DESCRIPTION
This PR adds tests that exercise various scenarios of having objects owning objects.
In do so also found some minor issues in the transfer function interface and fixed it.