### PR TITLE
Add `Collection` module to fastx framework

### DIFF
--- a/fastx_programmability/framework/sources/Collection.move
+++ b/fastx_programmability/framework/sources/Collection.move
@@ -1,0 +1,93 @@
+module FastX::Collection {
+    use Std::Option::{Self, Option};
+    use Std::Vector::Self;
+    use FastX::Address::{Self, Address};
+    use FastX::ID::{Self, ID, IDBytes};
+    use FastX::Transfer;
+    use FastX::TxContext::{Self, TxContext};
+
+    const OBJECT_NOT_FOUND: u64 = 0;
+    const OBJECT_DOUBLE_ADD: u64 = 1;
+
+    struct Collection has key {
+        id: ID,
+        objects: vector<IDBytes>,
+    }
+
+    /// Create a new Collection and return it.
+    public fun new(ctx: &mut TxContext): Collection {
+        Collection {
+            id: TxContext::new_id(ctx),
+            objects: Vector::empty<IDBytes>(),
+        }
+    }
+
+    /// Create a new Collection and transfer it to the signer.
+    public fun create(ctx: &mut TxContext) {
+        Transfer::transfer(new(ctx), TxContext::get_signer_address(ctx))
+    }
+
+    /// Returns the size of the collection.
+    public fun size(c: &Collection): u64 {
+        Vector::length(&c.objects)
+    }
+
+    /// Add a new object to the collection.
+    /// Abort if the object is already in the collection.
+    public fun add<T: key>(c: &mut Collection, object: T) {
+        let id_bytes = ID::get_id_bytes(&object);
+        if (contains(c, id_bytes)) {
+            abort OBJECT_DOUBLE_ADD
+        };
+        Vector::push_back(&mut c.objects, *id_bytes);
+        Transfer::transfer_to_object(object, c);
+    }
+
+    /// Check whether the collection contains a specific object,
+    /// identified by the object id in bytes.
+    public fun contains(c: &Collection, id_bytes: &IDBytes): bool {
+        Option::is_some(&find(c, id_bytes))
+    }
+
+    /// Remove and return the object from the collection.
+    /// Abort if the object is not found.
+    public fun remove<T: key>(c: &mut Collection, object: T): T {
+        let idx = find(c, ID::get_id_bytes(&object));
+        if (Option::is_none(&idx)) {
+            abort OBJECT_NOT_FOUND
+        };
+        Vector::remove(&mut c.objects, *Option::borrow(&idx));
+        object
+    }
+
+    /// Remove the object from the collection, and then transfer it to the signer.
+    public fun remove_and_take<T: key>(c: &mut Collection, object: T, ctx: &mut TxContext) {
+        let object = remove(c, object);
+        Transfer::transfer(object, TxContext::get_signer_address(ctx));
+    }
+
+    /// Transfer the entire collection to `recipient`.
+    /// This function can be called as an entry function, as it has TxContext as input.
+    public fun transfer_entry(c: Collection, recipient: vector<u8>, _ctx: &mut TxContext) {
+        transfer(c, Address::new(recipient))
+    }
+
+    /// Transfer the entire collection to `recipient`.
+    public fun transfer(c: Collection, recipient: Address) {
+        Transfer::transfer(c, recipient)
+    }
+
+    /// Look for the object identified by `id_bytes` in the collection.
+    /// Returns the index if found, none if not found.
+    fun find(c: &Collection, id_bytes: &IDBytes): Option<u64> {
+        let i = 0;
+        let len = size(c);
+        while (i < len) {
+            if (Vector::borrow(&c.objects, i) == id_bytes) {
+                return Option::some(i)
+            };
+            i = i + 1;
+        };
+        return Option::none()
+    }
+}

--- a/fastx_programmability/framework/tests/CollectionTests.move
+++ b/fastx_programmability/framework/tests/CollectionTests.move
@@ -1,0 +1,34 @@
+#[test_only]
+module FastX::CollectionTests {
+    use FastX::Collection;
+    use FastX::ID::{Self, ID};
+    use FastX::TxContext;
+
+    const COLLECTION_SIZE_MISMATCH: u64 = 0;
+    const OBJECT_NOT_FOUND: u64 = 1;
+
+    struct Object has key, drop {
+        id: ID,
+    }
+
+    #[test]
+    fun test_collection_add() {
+        let ctx = TxContext::dummy();
+        let collection = Collection::new(&mut ctx);
+        assert!(Collection::size(&collection) == 0, COLLECTION_SIZE_MISMATCH);
+
+        let obj1 = Object { id: TxContext::new_id(&mut ctx) };
+        let id_bytes1 = *ID::get_id_bytes(&obj1);
+        let obj2 = Object { id: TxContext::new_id(&mut ctx) };
+        let id_bytes2 = *ID::get_id_bytes(&obj2);
+
+        Collection::add(&mut collection, obj1);
+        Collection::add(&mut collection, obj2);
+        assert!(Collection::size(&collection) == 2, COLLECTION_SIZE_MISMATCH);
+
+        assert!(Collection::contains(&collection, &id_bytes1), OBJECT_NOT_FOUND);
+        assert!(Collection::contains(&collection, &id_bytes2), OBJECT_NOT_FOUND);
+
+        Collection::transfer(collection, TxContext::get_signer_address(&ctx));
+    }
+}


### PR DESCRIPTION
This PR adds `Collection`, a heterogeneous object collection that owns a list of objects with potentially different types. This is a modules that demonstrates how object ownership can be used.

There are some other issues preventing us from exposing the `add` function as entry points: https://github.com/MystenLabs/fastnft/issues/348