### PR TITLE
fix: fix build of rust-rocksdb with a patch dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ debug = true
 
 [profile.bench]
 debug = true
+
+# Stopgap, remove when https://github.com/rust-rocksdb/rust-rocksdb/issues/602 is fixed
+[patch.crates-io]
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb/", rev="626ff7e79dca107f76e347c3e1ea9cdabbd9d679" }
+librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb/", rev="626ff7e79dca107f76e347c3e1ea9cdabbd9d679" }


### PR DESCRIPTION
rocksdb and librocksdb-sys depend on each other and since a recent upstream commit, rocksdb point at an outdated version of librocksdb-sys, while librocksdb-sys may be bad. This intercepts the versions they query out of crates.io and puts them in agreement: the older version of librocksdb-sys as of a few h ago.

Upstream issue:
https://github.com/rust-rocksdb/rust-rocksdb/issues/602

patch to be removed when it's fixed
