### PR TITLE
[Client Refactoring 2] Add a stateless version of `execution_transaction`

### DIFF
--- a/fastpay_core/src/authority_client.rs
+++ b/fastpay_core/src/authority_client.rs
@@ -8,11 +8,11 @@ use fastx_types::{error::FastPayError, messages::*, serialize::*};
 #[async_trait]
 pub trait AuthorityAPI {
     /// Initiate a new order to a FastPay or Primary account.
-    async fn handle_order(&mut self, order: Order) -> Result<OrderInfoResponse, FastPayError>;
+    async fn handle_order(&self, order: Order) -> Result<OrderInfoResponse, FastPayError>;
 
     /// Confirm an order to a FastPay or Primary account.
     async fn handle_confirmation_order(
-        &mut self,
+        &self,
         order: ConfirmationOrder,
     ) -> Result<OrderInfoResponse, FastPayError>;
 
@@ -47,14 +47,14 @@ impl AuthorityClient {
 #[async_trait]
 impl AuthorityAPI for AuthorityClient {
     /// Initiate a new transfer to a FastPay or Primary account.
-    async fn handle_order(&mut self, order: Order) -> Result<OrderInfoResponse, FastPayError> {
+    async fn handle_order(&self, order: Order) -> Result<OrderInfoResponse, FastPayError> {
         let response = self.0.send_recv_bytes(serialize_order(&order)).await?;
         deserialize_order_info(response)
     }
 
     /// Confirm a transfer to a FastPay or Primary account.
     async fn handle_confirmation_order(
-        &mut self,
+        &self,
         order: ConfirmationOrder,
     ) -> Result<OrderInfoResponse, FastPayError> {
         let response = self

--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -42,14 +42,14 @@ struct LocalAuthorityClient(Arc<Mutex<AuthorityState>>);
 
 #[async_trait]
 impl AuthorityAPI for LocalAuthorityClient {
-    async fn handle_order(&mut self, order: Order) -> Result<OrderInfoResponse, FastPayError> {
+    async fn handle_order(&self, order: Order) -> Result<OrderInfoResponse, FastPayError> {
         let state = self.0.clone();
         let result = state.lock().await.handle_order(order).await;
         result
     }
 
     async fn handle_confirmation_order(
-        &mut self,
+        &self,
         order: ConfirmationOrder,
     ) -> Result<OrderInfoResponse, FastPayError> {
         let state = self.0.clone();


### PR DESCRIPTION
To make it easier to move `execution_transaction` to AuthorityAggregator, we first introduce a stateless version of it, and call it from the stateful version. This stateless version will then latter be moved to AuthorityAggregator.
The reason I am doing it this way is to make PRs less intrusive / easier to review, and make the refactoring more smooth. It also allows other people to continue working on the client core.
Most of this PR is straightforwards as most functions called are already stateless.
The only thing I needed to change is to move around the update of local objects. There are two of them, once in the `execution_transaction`, while the other one in `execute_transaction_without_confirmation`. The one in `execute_transaction_without_confirmation` is unnecessary and can be removed.