### PR TITLE
[Client Refactoring 5] Split `download_owned_objects`

### DIFF
--- a/fastpay_core/src/unit_tests/client_tests.rs
+++ b/fastpay_core/src/unit_tests/client_tests.rs
@@ -2474,10 +2474,7 @@ async fn test_object_store() {
         let _ = client1.sync_client_state().await.unwrap();
     }
     // Try to download objects which are not already in storage
-    client1
-        .download_owned_objects_from_all_authorities()
-        .await
-        .unwrap();
+    client1.download_owned_objects_not_in_db().await.unwrap();
 
     // Gas object should be in storage now
     assert_eq!(client1.store.objects.iter().count(), 1);
@@ -2556,14 +2553,8 @@ async fn test_object_store_transfer() {
     }
 
     // Try to download objects which are not already in storage
-    client1
-        .download_owned_objects_from_all_authorities()
-        .await
-        .unwrap();
-    client2
-        .download_owned_objects_from_all_authorities()
-        .await
-        .unwrap();
+    client1.download_owned_objects_not_in_db().await.unwrap();
+    client2.download_owned_objects_not_in_db().await.unwrap();
 
     // Gas object and another object should be in storage now for client 1
     assert_eq!(client1.store.objects.iter().count(), 2);


### PR DESCRIPTION
This PR rename the functions to make them more clear in terms of what they do. For example, `download_owned_objects_not_in_db(&self)` to better reflect the fact that we are downloading owned objects that are not in the db. Other renamings are similar. This also split the function into stateful and stateless counterparts that make the ready for the final refactoring.