### PR TITLE
Bugfix/randomize cli db path

### DIFF
--- a/fastpay/src/client.rs
+++ b/fastpay/src/client.rs
@@ -14,7 +14,6 @@ use fastx_types::object::Object;
 use futures::stream::StreamExt;
 use std::{
     collections::{BTreeMap, HashSet},
-    env,
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -687,7 +686,7 @@ fn main() {
                 accounts_config.update_from_state(&client_state);
                 info!("Updating recipient's local balance");
 
-                let client2_db_path = env::temp_dir().join("CLIENT_DB_1");
+                let client2_db_path = tempdir().unwrap().into_path();
                 // TODO: client should manage multiple addresses instead of each addr having DBs
                 // https://github.com/MystenLabs/fastnft/issues/332
                 let mut recipient_client_state = make_client_state_and_try_sync(


### PR DESCRIPTION
This PR helps protect users from themselves in case they don't clean up the old DBs.
We just randomize the DB paths on each CLI command
This is okay since we still load the previous state to the new DB from the config file
This CLI will be deprecated in favor of the new interactive CLI