### PR TITLE
Make sure unwrapped object have the correct version number

### DIFF
--- a/fastpay_core/src/authority/authority_store.rs
+++ b/fastpay_core/src/authority/authority_store.rs
@@ -181,6 +181,16 @@ impl AuthorityStore {
         self.parent_sync.get(object_ref).map_err(|e| e.into())
     }
 
+    /// Batch version of `parent` function.
+    pub fn multi_get_parents(
+        &self,
+        object_refs: &[ObjectRef],
+    ) -> Result<Vec<Option<TransactionDigest>>, FastPayError> {
+        self.parent_sync
+            .multi_get(object_refs)
+            .map_err(|e| e.into())
+    }
+
     /// Returns all parents (object_ref and transaction digests) that match an object_id, at
     /// any object version, or optionally at a specific version.
     pub fn get_parent_iterator(
@@ -346,7 +356,7 @@ impl AuthorityStore {
         // Delete the old owner index entries
         write_batch = write_batch.delete_batch(&self.owner_index, old_object_owners)?;
 
-        // Index the certificate by the objects created
+        // Index the certificate by the objects mutated
         write_batch = write_batch.insert_batch(
             &self.parent_sync,
             written


### PR DESCRIPTION
This PR fixes https://github.com/MystenLabs/fastnft/issues/376.
If an object is deleted through wrapping and latter re-appeared through unwrapping, the `parent_sync` map will have two entries for this object with the same sequence number. When we try to return the latest one, we may return the wrong one.
To fix this, at the end of an order execution, we look at each mutated object, and check if they were deleted in the past. If so it means this object just got unwrapped, and we force incrementing their version number again.