### PR TITLE
chore: start replacement FastNFT => Sui

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-## Contributing to FastPay
+## Contributing to Sui
 
 To contribute, ensure that you have the latest version of the codebase. To clone the repository, run the following:
 ```bash
-$ git clone https://github.com/novifinancial/fastpay.git
+$ git clone https://github.com/mystenlabs/fastnft.git
 $ cd fastpay
 $ cargo build --all --all-targets
 $ cargo test

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# FastNFT (pre-alpha)
+# Sui (pre-alpha)
 
-[![Build Status](https://github.com/novifinancial/fastpay/actions/workflows/rust.yml/badge.svg)](https://github.com/novifinancial/fastpay/actions/workflows/rust.yml)
+[![Build Status](https://github.com/mystenlabs/fastnft/actions/workflows/rust.yml/badge.svg)](https://github.com/mystenlabs/fastnft/actions/workflows/rust.yml)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE.md)
 
-This repository is dedicated to sharing material related to the FastPay protocol, developed at Novi Financial (formerly Calibra). Software is provided for research-purpose only and is not meant to be used in production.
+This repository is dedicated to sharing material related to the Sui protocol, developed at Novi Financial (formerly Calibra). Software is provided for research-purpose only and is not meant to be used in production.
 
 ## Summary
 
-FastNFT extends FastPay by allowing objects to be transacted.
+Sui extends Sui by allowing objects to be transacted.
 
-FastPay allows a set of distributed authorities, some of which are Byzantine, to maintain a high-integrity and availability settlement system for pre-funded payments. It can be used to settle payments in a native unit of value (crypto-currency), or as a financial side-infrastructure to support retail payments in fiat currencies. FastPay is based on Byzantine Consistent Broadcast as its core primitive, foregoing the expenses of full atomic commit channels (consensus). The resulting system has low-latency for both confirmation and payment finality. Remarkably, each authority can be sharded across many machines to allow unbounded horizontal scalability. Our experiments demonstrate intra-continental confirmation latency of less than 100ms, making FastPay applicable to point of sale payments. In laboratory environments, we achieve over 80,000 transactions per second with 20 authorities---surpassing the requirements of current retail card payment networks, while significantly increasing their robustness.
+Sui allows a set of distributed authorities, some of which are Byzantine, to maintain a high-integrity and availability settlement system for pre-funded payments. It can be used to settle payments in a native unit of value (crypto-currency), or as a financial side-infrastructure to support retail payments in fiat currencies. Sui is based on Byzantine Consistent Broadcast as its core primitive, foregoing the expenses of full atomic commit channels (consensus). The resulting system has low-latency for both confirmation and payment finality. Remarkably, each authority can be sharded across many machines to allow unbounded horizontal scalability. Our experiments demonstrate intra-continental confirmation latency of less than 100ms, making Sui applicable to point of sale payments. In laboratory environments, we achieve over 80,000 transactions per second with 20 authorities---surpassing the requirements of current retail card payment networks, while significantly increasing their robustness.
 
-## Quickstart with FastNFT Prototype
+## Quickstart with Sui Prototype
 
 ```bash
 cargo build --release
@@ -22,7 +22,7 @@ killall server
 
 # Create DB dirs and configuration files for 4 authorities.
 # * Private server states are stored in `server*.json`.
-# * `committee.json` is the public description of the FastPay committee.
+# * `committee.json` is the public description of the Sui committee.
 for I in 1 2 3 4
 do
     mkdir ./db"$I"
@@ -76,7 +76,7 @@ cd ../..
 
 ## References
 
-* FastNFT is based on FastPay: [FastPay: High-Performance Byzantine Fault Tolerant Settlement](https://arxiv.org/pdf/2003.11506.pdf)
+* Sui is based on FastPay: [FastPay: High-Performance Byzantine Fault Tolerant Settlement](https://arxiv.org/pdf/2003.11506.pdf)
 
 ## Contributing
 

--- a/fastx_programmability/verifier/src/id_immutable_verifier.rs
+++ b/fastx_programmability/verifier/src/id_immutable_verifier.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! The ID field of structs with key ability is immutable since it represents a
-//! FastNFT object ID. The only way to mutate a field is to write into
+//! Sui object ID. The only way to mutate a field is to write into
 //! a mutable reference borrowed through MutBorrowField/MutBorrowFieldGeneric
 //! bytecode. This verifier checks that such bytecode is never operated on
 //! an ID field.

--- a/fastx_programmability/verifier/src/id_leak_verifier.rs
+++ b/fastx_programmability/verifier/src/id_leak_verifier.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-//! Objects whose struct type has key ability represent FastNFT objects.
+//! Objects whose struct type has key ability represent Sui objects.
 //! They have unique IDs that should never be reused. This verifier makes
-//! sure that the id field of FastNFT objects never get leaked.
+//! sure that the id field of Sui objects never get leaked.
 //! Unpack is the only bytecode that could extract the id field out of
-//! a FastNFT object. From there, we track the flow of the value and make
+//! a Sui object. From there, we track the flow of the value and make
 //! sure it can never get leaked outside of the function. There are four
 //! ways it can happen:
 //! 1. Returned


### PR DESCRIPTION
Happy to park this until #357 #381 #388 #392 (and maybe #337) merge, and add the rebase-breaking commit switching the ~430 missing instances to Sui then.

Or we can get started with this fragment.