### PR TITLE
Emit events for object deletion

### DIFF
--- a/fastpay_core/src/authority_aggregator.rs
+++ b/fastpay_core/src/authority_aggregator.rs
@@ -924,7 +924,7 @@ where
             .await?;
 
         let (_obj_ref, tx_digest) = object_map.keys().last().unwrap();
-        return Ok(transaction_map[tx_digest].clone());
+        Ok(transaction_map[tx_digest].clone())
     }
 
     /// Find the highest sequence number that is known to a quorum of authorities.

--- a/fastx_programmability/adapter/src/adapter.rs
+++ b/fastx_programmability/adapter/src/adapter.rs
@@ -384,6 +384,10 @@ fn process_successful_execution<
                 state_view,
                 &mut object_owner_map,
             ),
+            EventType::DeleteObjectID => {
+                // TODO: Process deleted object event.
+                Ok(())
+            }
             EventType::User => {
                 match type_ {
                     TypeTag::Struct(s) => state_view.log_event(Event::new(s, event_bytes)),

--- a/fastx_programmability/examples/sources/CombinableObjects.move
+++ b/fastx_programmability/examples/sources/CombinableObjects.move
@@ -4,7 +4,7 @@ module Examples::CombinableObjects {
     use Examples::TrustedCoin::EXAMPLE;
     use FastX::Address::{Self, Address};
     use FastX::Coin::{Self, Coin};
-    use FastX::ID::ID;
+    use FastX::ID::{Self, ID};
     use FastX::Transfer;
     use FastX::TxContext::{Self, TxContext};
 
@@ -48,8 +48,10 @@ module Examples::CombinableObjects {
     public fun make_sandwich(
         ham: Ham, bread: Bread, ctx: &mut TxContext
     ): Sandwich {
-        let Ham { id: _ } = ham;
-        let Bread { id: _ } = bread;
+        let Ham { id: ham_id } = ham;
+        let Bread { id: bread_id } = bread;
+        ID::delete(ham_id);
+        ID::delete(bread_id);
         Sandwich { id: TxContext::new_id(ctx) }
     }
 

--- a/fastx_programmability/examples/sources/EconMod.move
+++ b/fastx_programmability/examples/sources/EconMod.move
@@ -7,7 +7,7 @@ module Examples::EconMod {
     use Examples::Hero::Hero;
     use FastX::Address::Address;
     use FastX::Coin::{Self, Coin};
-    use FastX::ID::ID;
+    use FastX::ID::{Self, ID};
     use FastX::Transfer;
     use FastX::TxContext::{Self, TxContext};
 
@@ -61,11 +61,12 @@ module Examples::EconMod {
         hero: &Hero, wrapper: HelpMeSlayThisMonster, ctx: &mut TxContext,
     ): Coin<RUM> {
         let HelpMeSlayThisMonster {
-            id: _,
+            id,
             monster,
             monster_owner,
             helper_reward
         } = wrapper;
+        ID::delete(id);
         let owner_reward = HeroMod::slay(hero, monster);
         let helper_reward = Coin::withdraw(&mut owner_reward, helper_reward, ctx);
         Transfer::transfer(owner_reward, monster_owner);
@@ -76,11 +77,12 @@ module Examples::EconMod {
     /// to, and are willing to kindly return the monster to its owner.
     public fun return_to_owner(wrapper: HelpMeSlayThisMonster) {
         let HelpMeSlayThisMonster {
-            id: _,
+            id,
             monster,
             monster_owner,
             helper_reward: _
         } = wrapper;
+        ID::delete(id);
         HeroMod::transfer_monster(monster, monster_owner)
     }
 

--- a/fastx_programmability/examples/sources/Hero.move
+++ b/fastx_programmability/examples/sources/Hero.move
@@ -140,7 +140,9 @@ module Examples::Hero {
             slayer_address: TxContext::get_signer_address(ctx),
             hero: *ID::get_inner(&hero.id),
             boar: *ID::get_inner(&boar_id),
-        })
+        });
+        ID::delete(boar_id);
+
     }
 
     /// Strength of the hero when attacking
@@ -173,7 +175,8 @@ module Examples::Hero {
 
     /// Heal the weary hero with a potion
     public fun heal(hero: &mut Hero, potion: Potion) {
-        let Potion { id: _, potency } = potion;
+        let Potion { id, potency } = potion;
+        ID::delete(id);
         let new_hp = hero.hp + potency;
         // cap hero's HP at MAX_HP to avoid int overflows
         hero.hp = Math::min(new_hp, MAX_HP)

--- a/fastx_programmability/examples/sources/HeroMod.move
+++ b/fastx_programmability/examples/sources/HeroMod.move
@@ -8,7 +8,7 @@
 module Examples::HeroMod {
     use Examples::Hero::{Self, Hero};
     use FastX::Address::Address;
-    use FastX::ID::ID;
+    use FastX::ID::{Self, ID};
     use FastX::Coin::{Self, Coin, TreasuryCap };
     use FastX::Transfer;
     use FastX::TxContext::{Self, TxContext};
@@ -74,7 +74,8 @@ module Examples::HeroMod {
     /// exchange.
     /// Aborts if the hero is not strong enough to slay the monster
     public fun slay(hero: &Hero, monster: SeaMonster): Coin<RUM> {
-        let SeaMonster { id: _, reward } = monster;
+        let SeaMonster { id, reward } = monster;
+        ID::delete(id);
         // Hero needs strength greater than the reward value to defeat the
         // monster
         assert!(

--- a/fastx_programmability/framework/sources/Coin.move
+++ b/fastx_programmability/framework/sources/Coin.move
@@ -1,6 +1,6 @@
 module FastX::Coin {
     use FastX::Address::{Self, Address};
-    use FastX::ID::ID;
+    use FastX::ID::{Self, ID};
     use FastX::Transfer;
     use FastX::TxContext::{Self, TxContext};
     use Std::Errors;
@@ -34,7 +34,8 @@ module FastX::Coin {
     /// Consume the coin `c` and add its value to `self`.
     /// Aborts if `c.value + self.value > U64_MAX`
     public fun join<T>(self: &mut Coin<T>, c: Coin<T>) {
-        let Coin { id: _, value } = c;
+        let Coin { id, value } = c;
+        ID::delete(id);
         self.value = self.value + value
     }
 
@@ -72,7 +73,8 @@ module FastX::Coin {
 
     /// Destroy a coin with value zero
     public fun destroy_zero<T>(c: Coin<T>) {
-        let Coin { id: _, value } = c;
+        let Coin { id, value } = c;
+        ID::delete(id);
         assert!(value == 0, Errors::invalid_argument(ENONZERO))
     }
 
@@ -104,7 +106,8 @@ module FastX::Coin {
     /// Destroy the coin `c` and decrease the total supply in `cap`
     /// accordingly.
     public fun burn<T>(c: Coin<T>, cap: &mut TreasuryCap<T>) {
-        let Coin { id: _, value } = c;
+        let Coin { id, value } = c;
+        ID::delete(id);
         cap.total_supply = cap.total_supply - value
     }
 

--- a/fastx_programmability/framework/sources/Escrow.move
+++ b/fastx_programmability/framework/sources/Escrow.move
@@ -52,19 +52,21 @@ module FastX::Escrow {
         obj1: EscrowedObj<T1, T2>, obj2: EscrowedObj<T1, T2>
     ) {
         let EscrowedObj {
-            id: _,
+            id: id1,
             sender: sender1,
             recipient: recipient1,
             exchange_for: exchange_for1,
             escrowed: escrowed1,
         } = obj1;
         let EscrowedObj {
-            id: _,
+            id: id2,
             sender: sender2,
             recipient: recipient2,
             exchange_for: exchange_for2,
             escrowed: escrowed2,
         } = obj2;
+        ID::delete(id1);
+        ID::delete(id2);
         // check sender/recipient compatibility
         assert!(&sender1 == &recipient2, ETODO);
         assert!(&sender2 == &recipient1, ETODO);
@@ -81,8 +83,9 @@ module FastX::Escrow {
         obj: EscrowedObj<T, ExchangeForT>,
     ) {
         let EscrowedObj {
-            id: _, sender, recipient: _, exchange_for: _, escrowed
+            id, sender, recipient: _, exchange_for: _, escrowed
         } = obj;
+        ID::delete(id);
         Transfer::transfer(escrowed, sender)
     }
 }

--- a/fastx_programmability/framework/sources/ID.move
+++ b/fastx_programmability/framework/sources/ID.move
@@ -8,7 +8,9 @@ module FastX::ID {
 
     /// Globally unique identifier of an object. This is a privileged type
     /// that can only be derived from a `TxContext`
-    struct ID has store, drop {
+    /// ID doesn't have drop capability, which means to delete an ID (when
+    /// deleting an object), one must explicitly call the delete function.
+    struct ID has store {
         id: IDBytes,
         /// Version number for the ID. The version number is incremented each
         /// time the object with this ID is passed to a non-failing transaction
@@ -68,4 +70,9 @@ module FastX::ID {
     public native fun get_id<T: key>(obj: &T): &ID;
 
     public native fun bytes_to_address(bytes: vector<u8>): address;
+
+    /// When an object is being deleted through unpacking, the 
+    /// delete function must be called on the id to inform Sui
+    /// regarding the deletion of the object.
+    public native fun delete(id: ID);
 }

--- a/fastx_programmability/framework/sources/ObjectBasics.move
+++ b/fastx_programmability/framework/sources/ObjectBasics.move
@@ -2,7 +2,7 @@
 module FastX::ObjectBasics {
     use FastX::Address;
     use FastX::Event;
-    use FastX::ID::ID;
+    use FastX::ID::{Self, ID};
     use FastX::TxContext::{Self, TxContext};
     use FastX::Transfer;
 
@@ -51,7 +51,8 @@ module FastX::ObjectBasics {
     }
 
     public fun delete(o: Object, _ctx: &mut TxContext) {
-        let Object { id: _, value: _ } = o;
+        let Object { id, value: _ } = o;
+        ID::delete(id);
     }
 
     public fun wrap(o: Object, ctx: &mut TxContext) {
@@ -59,7 +60,8 @@ module FastX::ObjectBasics {
     }
 
     public fun unwrap(w: Wrapper, ctx: &mut TxContext) {
-        let Wrapper { id: _, o } = w;
+        let Wrapper { id, o } = w;
+        ID::delete(id);
         Transfer::transfer(o, TxContext::get_signer_address(ctx))
     }
 }

--- a/fastx_programmability/framework/src/lib.rs
+++ b/fastx_programmability/framework/src/lib.rs
@@ -25,6 +25,11 @@ pub enum EventType {
     TransferToAddressAndFreeze,
     /// System event: transfer object to another object
     TransferToObject,
+    /// System event: an object ID is deleted. This does not necessarily
+    /// mean an object is being deleted. However whenever an object is being
+    /// deleted, the object ID must be deleted and this event will be
+    /// emitted.
+    DeleteObjectID,
     /// User-defined event
     User,
 }

--- a/fastx_programmability/framework/src/natives/id.rs
+++ b/fastx_programmability/framework/src/natives/id.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::EventType;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::native_functions::NativeContext;
@@ -9,7 +10,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeResult},
     pop_arg,
-    values::{StructRef, Value},
+    values::{Struct, StructRef, Value},
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
@@ -50,4 +51,36 @@ pub fn get_id(
     let cost = native_gas(context.cost_table(), NativeCostIndex::SIGNER_BORROW, 0);
 
     Ok(NativeResult::ok(cost, smallvec![id_field]))
+}
+
+pub fn delete(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let obj = pop_arg!(args, Struct);
+    // All of the following unwraps are safe by construction because a properly verified
+    // bytecode ensures that the parameter must be of ID type with the correct fields.
+    // Get the `id` field of the ID struct, which is of type IDBytes.
+    let id_field = obj
+        .unpack()
+        .unwrap()
+        .next()
+        .unwrap()
+        .value_as::<Struct>()
+        .unwrap();
+    // Get the inner address of type IDBytes.
+    let id = id_field.unpack().unwrap().next().unwrap();
+
+    // TODO: what should the cost of this be?
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 0);
+
+    if !context.save_event(vec![], EventType::DeleteObjectID as u64, Type::Address, id)? {
+        return Ok(NativeResult::err(cost, 0));
+    }
+
+    Ok(NativeResult::ok(cost, smallvec![]))
 }

--- a/fastx_programmability/framework/src/natives/mod.rs
+++ b/fastx_programmability/framework/src/natives/mod.rs
@@ -16,6 +16,7 @@ pub fn all_natives(
     const FASTX_NATIVES: &[(&str, &str, NativeFunction)] = &[
         ("Event", "emit", event::emit),
         ("ID", "bytes_to_address", id::bytes_to_address),
+        ("ID", "delete", id::delete),
         ("ID", "get_id", id::get_id),
         ("Transfer", "transfer_internal", transfer::transfer_internal),
         (

--- a/fastx_programmability/framework/tests/CollectionTests.move
+++ b/fastx_programmability/framework/tests/CollectionTests.move
@@ -7,7 +7,7 @@ module FastX::CollectionTests {
     const COLLECTION_SIZE_MISMATCH: u64 = 0;
     const OBJECT_NOT_FOUND: u64 = 1;
 
-    struct Object has key, drop {
+    struct Object has key {
         id: ID,
     }
 

--- a/fastx_programmability/framework/tests/IDTests.move
+++ b/fastx_programmability/framework/tests/IDTests.move
@@ -5,7 +5,7 @@ module FastX::IDTests {
 
     const ID_BYTES_MISMATCH: u64 = 0;
 
-    struct Object has key, drop {
+    struct Object has key {
         id: ID::ID,
     }
 
@@ -16,5 +16,7 @@ module FastX::IDTests {
         let id_bytes = *ID::get_inner(&id);
         let obj = Object { id };
         assert!(ID::get_inner(ID::get_id(&obj)) == &id_bytes, ID_BYTES_MISMATCH);
+        let Object { id } = obj;
+        ID::delete(id);
     }
 }

--- a/fastx_programmability/framework/tests/TxContextTests.move
+++ b/fastx_programmability/framework/tests/TxContextTests.move
@@ -1,5 +1,6 @@
 #[test_only]
 module FastX::TxContextTests {
+    use FastX::ID;
     use FastX::TxContext;
 
     #[test]
@@ -11,8 +12,10 @@ module FastX::TxContextTests {
         let id2 = TxContext::new_id(&mut ctx);
 
         // new_id should always produce fresh ID's
-        assert!(id1 != id2, 1);
+        assert!(&id1 != &id2, 1);
         assert!(TxContext::get_ids_created(&ctx) == 2, 2);
+        ID::delete(id1);
+        ID::delete(id2);
     }
 
 }


### PR DESCRIPTION
This PR is to address https://github.com/MystenLabs/fastnft/issues/405.
It allows us to get notified when an object is being deleted, which allows us to distinguish between wrapped object and deleted object.

The core of this change includes:
1. Added `delete` function to `ID` module which is a native function where we can emit events.
2. Removed `drop` capability of `ID` module, forcing developers to call `delete` function defined above when an object is being deleted (the only way an object is deleted is through unpacking, which would generate an ID variable).
3. Fix all Move code where ID is not deleted explicitly.
4. In verifier, we detect any leak of ID. Mark the `delete` function a safe exception to the leak rule.
5. Added native function implementation of the `delete` function, which emits an `DeleteObject` event.

The `DeleteObject` event isn't processed yet in the adapter. That will come in a separate PR. But some ideas are:
1. Now that we can tell apart with delete and wrapping, we could introduce another special digest for wrapping (similar to OBJECT_DIGEST_DELETED).
2. We could add a new BTreeSet in authority store to track wrapped objects.