### PR TITLE
Return actual errors from aggregator map reduce

### DIFF
--- a/fastx_types/src/error.rs
+++ b/fastx_types/src/error.rs
@@ -58,8 +58,8 @@ pub enum FastPayError {
     },
     #[error("Conflicting order already received: {pending_order:?}")]
     ConflictingOrder { pending_order: Order },
-    #[error("Transfer order was processed but no signature was produced by authority")]
-    ErrorWhileProcessingTransferOrder,
+    #[error("Order was processed but no signature was produced by authority")]
+    ErrorWhileProcessingOrder,
     #[error("Transaction order processing failed: {err}")]
     ErrorWhileProcessingTransactionOrder { err: String },
     #[error("Confirmation order processing failed: {err}")]


### PR DESCRIPTION
This PR changes the aggregator to return all the errors it found rather than a generic uninformative error.
Hopefully this moves us forward in being able to report clearer errors to callers.

In this example, the gas budget is less than the gas value available.
Previously, this would've returned `Err(FastPayError::ErrorWhileProcessingTransferOrder)` as described here https://github.com/MystenLabs/fastnft/issues/414.
Now each error from each authority is retutned.

```
fastx>-$ call --package 0000000000000000000000000000000000000002 --module ObjectBasics --function create --gas 6818DBC01622EB70A152E351A8C3B4F177BCCF7F --pure-args 100u8 x\"1ae66458594b05d8abb87971f8eb35974562e908095376be329b3e0a421ec15b\" --gas-budget 1000000
Failed to achieve quorum between authorities, cause by : [
    "Error acquiring lock for object(s): [InsufficientGas { error: \"Gas balance is 1000, smaller than the budget 1000000 for move call.\" }]",
    "Error acquiring lock for object(s): [InsufficientGas { error: \"Gas balance is 1000, smaller than the budget 1000000 for move call.\" }]",
    "Error acquiring lock for object(s): [InsufficientGas { error: \"Gas balance is 1000, smaller than the budget 1000000 for move call.\" }]",
]
fastx>-$
```