### PR TITLE
Prevent fail on u8 overflow

### DIFF
--- a/fastpay_core/src/unit_tests/authority_tests.rs
+++ b/fastpay_core/src/unit_tests/authority_tests.rs
@@ -1165,6 +1165,7 @@ async fn test_get_latest_parent_entry() {
     // The objects just after the gas object also returns None
     let mut x = gas_object_id.to_vec();
     let last_index = x.len() - 1;
+    // Prevent overflow
     x[last_index] = u8::MAX - x[last_index];
     let unknown_object_id: ObjectID = x.try_into().unwrap();
     assert!(authority_state


### PR DESCRIPTION
This fixes https://github.com/MystenLabs/fastnft/issues/417

Rust will panic if overflow occurs in debug mode. u8 has relatively low probability of being 255 after a test run, hence the difficulty reproduce.
This fix subtracts instead of adds if at u8::MAX. The goal here is to create an offending object id, so it doesn't matter if add or subtract