### PR TITLE
[bench] Check failure instead

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -313,7 +313,7 @@ impl ClientServerBenchmark {
                 match reply_message {
                     Ok(SerializedMessage::OrderResp(res)) => {
                         if let Some(e) = res.signed_effects {
-                            if matches!(e.effects.status, ExecutionStatus::Success { .. }) {
+                            if matches!(e.effects.status, ExecutionStatus::Failure { .. }) {
                                 info!("Execution Error {:?}", e.effects.status);
                             }
                         }


### PR DESCRIPTION
Recently checked-in code was checking wrong condition which was causing bench to fail.

New output
```
mbp> ./bench                 
2022-02-11T17:39:10.786969Z  INFO bench: Starting benchmark: OrdersAndCerts
2022-02-11T17:39:10.786992Z  INFO bench: Preparing accounts.
2022-02-11T17:39:10.788004Z  INFO bench: Open database on path: "/var/folders/3m/hnrdf4892mj0df4tqf55pm_m0000gn/T/DB_62E9BA2901F290AC8DFBEEFF5D47F88696EDCC9D"
2022-02-11T17:39:13.271578Z  INFO bench: Preparing transactions.
2022-02-11T17:39:18.101200Z  INFO sui_core::authority_server: Listening to TCP traffic on 127.0.0.1:9555
2022-02-11T17:39:19.102849Z  INFO bench: Number of TCP connections: 10
2022-02-11T17:39:19.102885Z  INFO bench: Set max_in_flight to 100
2022-02-11T17:39:19.102894Z  INFO bench: Sending requests.
2022-02-11T17:39:19.106835Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.106853Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.106862Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.106920Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.106941Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.107060Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.107238Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.107506Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.107989Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.108074Z  INFO sui_network::network: Sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:19.262125Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 5000 packets
2022-02-11T17:39:19.409265Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 10000 packets
2022-02-11T17:39:19.560164Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 15000 packets
2022-02-11T17:39:19.719591Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 20000 packets
2022-02-11T17:39:19.880501Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 25000 packets
2022-02-11T17:39:19.995159Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:19.999518Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.000847Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.002753Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.004320Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.006495Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.008625Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.012098Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.012256Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.023400Z  INFO sui_network::network: In flight 100 Remaining 5000
2022-02-11T17:39:20.038895Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 30000 packets
2022-02-11T17:39:20.189881Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 35000 packets
2022-02-11T17:39:20.338458Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 40000 packets
2022-02-11T17:39:20.488017Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 45000 packets
2022-02-11T17:39:20.640090Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 50000 packets
2022-02-11T17:39:20.801791Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 55000 packets
2022-02-11T17:39:20.973137Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 60000 packets
2022-02-11T17:39:21.139812Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 65000 packets
2022-02-11T17:39:21.292218Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 70000 packets
2022-02-11T17:39:21.449718Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 75000 packets
2022-02-11T17:39:21.604504Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.613943Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.623422Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.627805Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.637807Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.638963Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.640398Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.640525Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.643901Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.645601Z  INFO sui_core::authority_server: 127.0.0.1:9555 has processed 80000 packets
2022-02-11T17:39:21.647358Z  INFO sui_network::network: Done sending TCP requests to 127.0.0.1:9555
2022-02-11T17:39:21.647529Z  INFO bench: Received 80000 responses.
2022-02-11T17:39:21.801410Z  WARN bench: Completed benchmark for OrdersAndCerts
Total time: 2544601us, items: 40000, tx/sec: 15719.556818534615

```