### PR TITLE
[objects] authority can return object layout to client in ObjectInfoR…

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -28,6 +28,7 @@ sui-network = { path = "../network_utils" }
 sui-types = { path = "../sui_types" }
 
 move-binary-format = { git = "https://github.com/diem/move", rev="1e5e36cb1fede8073c8688886a0943bb5bfe40d5" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev="1e5e36cb1fede8073c8688886a0943bb5bfe40d5" }
 move-core-types = { git = "https://github.com/diem/move", rev="1e5e36cb1fede8073c8688886a0943bb5bfe40d5", features=["address20"] }
 move-package = { git = "https://github.com/diem/move", rev="1e5e36cb1fede8073c8688886a0943bb5bfe40d5" }
 move-vm-runtime = { git = "https://github.com/diem/move", rev="1e5e36cb1fede8073c8688886a0943bb5bfe40d5" }

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -451,3 +451,22 @@ impl AuthorityStore {
         }))
     }
 }
+
+impl ModuleResolver for AuthorityStore {
+    type Error = SuiError;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        match self.get_object(module_id.address())? {
+            Some(o) => match &o.data {
+                Data::Package(c) => Ok(c
+                    .get(module_id.name().as_str())
+                    .cloned()
+                    .map(|m| m.into_vec())),
+                _ => Err(SuiError::BadObjectType {
+                    error: "Expected module object".to_string(),
+                }),
+            },
+            None => Ok(None),
+        }
+    }
+}

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -427,11 +427,17 @@ where
                 // None if the object was deleted at this authority
                 //
                 // NOTE: here we could also be gathering the locked orders to see if we could make a cert.
-                let (object_option, signed_order_option) =
-                    if let Some(ObjectResponse { object, lock }) = object_and_lock {
-                        (Some(object), lock)
+                // TODO: pass along layout_option so the client can store it
+                let (object_option, signed_order_option, _layout_option) =
+                    if let Some(ObjectResponse {
+                        object,
+                        lock,
+                        layout,
+                    }) = object_and_lock
+                    {
+                        (Some(object), lock, layout)
                     } else {
-                        (None, None)
+                        (None, None, None)
                     };
 
                 // Update the map with the information from this authority
@@ -1072,6 +1078,8 @@ where
         let request = ObjectInfoRequest {
             object_id,
             request_sequence_number: None,
+            // TODO: allow caller to specify layout
+            request_layout: None,
         };
 
         // For now assume all authorities. Assume they're all honest

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::object::{Object, OBJECT_START_VERSION};
+use crate::object::{Object, ObjectFormatOptions, OBJECT_START_VERSION};
 
 use super::{base_types::*, committee::Committee, error::*, event::Event};
 
@@ -10,7 +10,7 @@ use super::{base_types::*, committee::Committee, error::*, event::Event};
 mod messages_tests;
 
 use move_binary_format::{access::ModuleAccess, CompiledModule};
-use move_core_types::{identifier::Identifier, language_storage::TypeTag};
+use move_core_types::{identifier::Identifier, language_storage::TypeTag, value::MoveStructLayout};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashSet},
@@ -124,6 +124,8 @@ pub struct ObjectInfoRequest {
     pub object_id: ObjectID,
     /// The version of the object for which the parent certificate is sought.
     pub request_sequence_number: Option<SequenceNumber>,
+    /// If true, the request will return the layout of the object in the given format
+    pub request_layout: Option<ObjectFormatOptions>,
 }
 
 impl From<ObjectRef> for ObjectInfoRequest {
@@ -131,6 +133,7 @@ impl From<ObjectRef> for ObjectInfoRequest {
         ObjectInfoRequest {
             object_id: object_ref.0,
             request_sequence_number: Some(object_ref.1),
+            request_layout: None,
         }
     }
 }
@@ -140,6 +143,7 @@ impl From<ObjectID> for ObjectInfoRequest {
         ObjectInfoRequest {
             object_id,
             request_sequence_number: None,
+            request_layout: None,
         }
     }
 }
@@ -157,6 +161,9 @@ pub struct ObjectResponse {
     /// Order the object is locked on in this authority.
     /// None if the object is not currently locked by this authority.
     pub lock: Option<SignedOrder>,
+    /// Schema of the Move value inside this object.
+    /// None if the object is a Move package, or the request did not ask for the layout
+    pub layout: Option<MoveStructLayout>,
 }
 
 /// This message provides information about the latest object and its lock

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -51,10 +51,12 @@ fn test_info_request() {
     let req1 = ObjectInfoRequest {
         object_id: dbg_object_id(0x20),
         request_sequence_number: None,
+        request_layout: None,
     };
     let req2 = ObjectInfoRequest {
         object_id: dbg_object_id(0x20),
         request_sequence_number: Some(SequenceNumber::from(129)),
+        request_layout: None,
     };
 
     let buf1 = serialize_object_info_request(&req1);
@@ -244,6 +246,7 @@ fn test_info_response() {
         object_and_lock: Some(ObjectResponse {
             object: object.clone(),
             lock: Some(vote),
+            layout: None,
         }),
         parent_certificate: None,
         requested_object_reference: Some(object.to_object_reference()),


### PR DESCRIPTION
…equest

More progress on interpreting object bytes inside the client.

- Modify the authority's `ObjectInfoRequest` to allow the client to (optionally) request the `MoveStructLayout` for an object in a variety of formats
- Modify the authority's `ObjectInfoResponse` to return the layout if requested
- Implement the appropriate traits in the authority to allow computing the layout from its local DB

Note: three approaches to this were discussed in https://github.com/MystenLabs/fastnft/pull/397 and there was a general consensus that the third one (ask clients to store packages + use this to compute a layout locally) was preferred. However, after looking into this a bit, I concluded that this will be a major change to the client, which is not great because we need to start piping out JSON objects into the client service API's ASAP to unblock Geniteam (ideally today!).

In addition to the prioritization, I think approach (3) doesn't help a client who wants to get a structured view of an object that is not owned by them. Asking such a user to download every module related that object just to look at it + go through the dance of computing a layout from these modules doesn't seem great. Thus, I think exposing a way to ask an authority for the layout is reasonable even if we also implement approach (3).