### PR TITLE
[objects] client stores object layouts and uses them to pretty-print …

### DIFF
--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -166,9 +166,11 @@ impl WalletCommands {
                 let client_state = context.get_or_create_client_state(owner)?;
                 let object_read = client_state.get_object_info(*id).await?;
                 let object = object_read.object()?;
-                println!("{}", object);
                 if *deep {
-                    println!("Full Info: {:#?}", object);
+                    let layout = object_read.layout()?;
+                    println!("{}", object.to_json(layout)?);
+                } else {
+                    println!("{}", object);
                 }
             }
             WalletCommands::Call {

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -578,7 +578,7 @@ where
             .sync_all_owned_objects(self.address, Duration::from_secs(60))
             .await?;
 
-        for (object, option_cert) in active_object_certs {
+        for (object, option_layout, option_cert) in active_object_certs {
             let object_ref = object.to_object_reference();
             let (object_id, sequence_number, _) = object_ref;
             self.store
@@ -589,6 +589,13 @@ where
                 self.store
                     .certificates
                     .insert(&cert.order.digest(), &cert)?;
+            }
+            // Save the object layout, if any
+            if let Some(layout) = option_layout {
+                if let Some(type_) = object.type_() {
+                    // TODO: sanity check to add: if we're overwriting an old layout, it should be the same as the new one
+                    self.store.object_layouts.insert(type_, &layout)?;
+                }
             }
         }
 

--- a/sui_core/src/client/client_store.rs
+++ b/sui_core/src/client/client_store.rs
@@ -1,4 +1,6 @@
 use super::*;
+use move_core_types::language_storage::StructTag;
+use move_core_types::value::MoveStructLayout;
 use rocksdb::{DBWithThreadMode, MultiThreaded};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -11,6 +13,7 @@ const OBJ_REF_CF_NAME: &str = "object_refs";
 const TX_DIGEST_TO_CERT_CF_NAME: &str = "object_certs";
 const PENDING_ORDERS_CF_NAME: &str = "pending_orders";
 const OBJECT_CF_NAME: &str = "objects";
+const OBJECT_LAYOUTS_CF_NAME: &str = "object_layouts";
 
 const MANAGED_ADDRESS_PATHS_CF_NAME: &str = "managed_address_paths";
 const MANAGED_ADDRESS_SUBDIR: &str = "managed_addresses";
@@ -103,6 +106,10 @@ pub struct ClientSingleAddressStore {
     /// Map from object ref to actual object to track object history
     /// There can be duplicates and we never delete objects
     pub objects: DBMap<ObjectRef, Object>,
+    /// Map from Move object type to the layout of the object's Move contents.
+    /// Should contain the layouts for all object types in `objects`, and
+    /// possibly more.
+    pub object_layouts: DBMap<StructTag, MoveStructLayout>,
 }
 
 impl ClientSingleAddressStore {
@@ -117,6 +124,7 @@ impl ClientSingleAddressStore {
                 OBJ_REF_CF_NAME,
                 TX_DIGEST_TO_CERT_CF_NAME,
                 OBJECT_CF_NAME,
+                OBJECT_LAYOUTS_CF_NAME,
             ],
         );
 
@@ -127,6 +135,7 @@ impl ClientSingleAddressStore {
             object_refs: client_store::reopen_db(&db, OBJ_REF_CF_NAME),
             object_certs: client_store::reopen_db(&db, TX_DIGEST_TO_CERT_CF_NAME),
             objects: client_store::reopen_db(&db, OBJECT_CF_NAME),
+            object_layouts: client_store::reopen_db(&db, OBJECT_LAYOUTS_CF_NAME),
         }
     }
 }

--- a/sui_types/src/coin.rs
+++ b/sui_types/src/coin.rs
@@ -5,6 +5,7 @@ use move_core_types::{
     ident_str,
     identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
+    value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
 };
 use serde::{Deserialize, Serialize};
 
@@ -52,5 +53,18 @@ impl Coin {
 
     pub fn to_bcs_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).unwrap()
+    }
+
+    pub fn layout(type_param: StructTag) -> MoveStructLayout {
+        MoveStructLayout::WithTypes {
+            type_: Self::type_(type_param),
+            fields: vec![
+                MoveFieldLayout::new(
+                    ident_str!("id").to_owned(),
+                    MoveTypeLayout::Struct(ID::layout()),
+                ),
+                MoveFieldLayout::new(ident_str!("value").to_owned(), MoveTypeLayout::U64),
+            ],
+        }
     }
 }

--- a/sui_types/src/gas_coin.rs
+++ b/sui_types/src/gas_coin.rs
@@ -5,6 +5,7 @@ use move_core_types::{
     ident_str,
     identifier::IdentStr,
     language_storage::{StructTag, TypeTag},
+    value::MoveStructLayout,
 };
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -68,6 +69,10 @@ impl GasCoin {
 
     pub fn to_object(&self) -> MoveObject {
         MoveObject::new(Self::type_(), self.to_bcs_bytes())
+    }
+
+    pub fn layout() -> MoveStructLayout {
+        Coin::layout(Self::type_())
     }
 }
 impl TryFrom<&MoveObject> for GasCoin {

--- a/sui_types/src/id.rs
+++ b/sui_types/src/id.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::{ident_str, identifier::IdentStr, language_storage::StructTag};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    language_storage::StructTag,
+    value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -11,6 +16,7 @@ use crate::{
 
 pub const ID_MODULE_NAME: &IdentStr = ident_str!("ID");
 pub const ID_STRUCT_NAME: &IdentStr = ID_MODULE_NAME;
+pub const ID_BYTES_STRUCT_NAME: &IdentStr = ident_str!("IDBytes");
 
 /// Rust version of the Move FastX::ID::ID type
 #[derive(Debug, Serialize, Deserialize)]
@@ -53,10 +59,42 @@ impl ID {
     pub fn to_bcs_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).unwrap()
     }
+
+    pub fn layout() -> MoveStructLayout {
+        MoveStructLayout::WithTypes {
+            type_: Self::type_(),
+            fields: vec![
+                MoveFieldLayout::new(
+                    ident_str!("id").to_owned(),
+                    MoveTypeLayout::Struct(IDBytes::layout()),
+                ),
+                MoveFieldLayout::new(ident_str!("version").to_owned(), MoveTypeLayout::U64),
+            ],
+        }
+    }
 }
 
 impl IDBytes {
     pub fn new(bytes: ObjectID) -> Self {
         Self { bytes }
+    }
+
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            name: ID_BYTES_STRUCT_NAME.to_owned(),
+            module: ID_MODULE_NAME.to_owned(),
+            type_params: Vec::new(),
+        }
+    }
+
+    pub fn layout() -> MoveStructLayout {
+        MoveStructLayout::WithTypes {
+            type_: Self::type_(),
+            fields: vec![MoveFieldLayout::new(
+                ident_str!("bytes").to_owned(),
+                MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
+            )],
+        }
     }
 }

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -133,7 +133,7 @@ impl From<ObjectRef> for ObjectInfoRequest {
         ObjectInfoRequest {
             object_id: object_ref.0,
             request_sequence_number: Some(object_ref.1),
-            request_layout: None,
+            request_layout: Some(ObjectFormatOptions::default()),
         }
     }
 }
@@ -143,7 +143,7 @@ impl From<ObjectID> for ObjectInfoRequest {
         ObjectInfoRequest {
             object_id,
             request_sequence_number: None,
-            request_layout: None,
+            request_layout: Some(ObjectFormatOptions::default()),
         }
     }
 }


### PR DESCRIPTION
…objects

- Add layouts to the client store
- By default, get_object requests ask for the object layout
- Object layouts from the response get propagated to the store
- When the CLI prints an object with --deep, it uses the layout (if available) to render the full object contents in JSON. We will need to do something similar in the REST API for get_object, but that is not yet in `main`