### PR TITLE
Support retrieve last received object in Move tests

### DIFF
--- a/sui_programmability/framework/sources/TestHelper.move
+++ b/sui_programmability/framework/sources/TestHelper.move
@@ -1,0 +1,17 @@
+#[test_only]
+module FastX::TestHelper {
+    use FastX::Address;
+    use FastX::TxContext::{Self, TxContext};
+
+    /// Returns the object last received (through transfer) by signer of `ctx`.
+    /// It can be from either a normal transfer or freeze_after_transfer.
+    /// This function can only be used in testing because any change to the object
+    /// could result in inconsistency with Sui storage in a prod system.
+    public fun get_last_received_object<T: key>(ctx: &TxContext): T {
+        get_last_received_object_internal(Address::into_bytes(TxContext::get_signer_address(ctx)))
+    }
+
+    native fun get_last_received_object_internal<T: key>(signer_address: vector<u8>): T;
+
+    // TODO: Add more APIs
+}

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -3,6 +3,7 @@
 
 mod event;
 mod id;
+mod test_helper;
 mod transfer;
 mod tx_context;
 
@@ -18,6 +19,11 @@ pub fn all_natives(
         ("ID", "bytes_to_address", id::bytes_to_address),
         ("ID", "delete", id::delete),
         ("ID", "get_id", id::get_id),
+        (
+            "TestHelper",
+            "get_last_received_object_internal",
+            test_helper::get_last_received_object,
+        ),
         ("Transfer", "transfer_internal", transfer::transfer_internal),
         (
             "Transfer",

--- a/sui_programmability/framework/src/natives/test_helper.rs
+++ b/sui_programmability/framework/src/natives/test_helper.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::EventType;
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::NativeContext;
+use move_vm_types::{
+    gas_schedule::NativeCostIndex,
+    loaded_data::runtime_types::Type,
+    natives::function::{native_gas, NativeResult},
+    pop_arg,
+    values::Value,
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub fn get_last_received_object(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let signer = pop_arg!(args, Vec<u8>);
+
+    // Gas amount doesn't matter as this is test only.
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 0);
+
+    let mut transfer_events =
+        context
+            .events()
+            .iter()
+            .rev()
+            .filter(|(recipient, event_type, _, _, _)| {
+                (*event_type == EventType::TransferToAddress as u64
+                    || *event_type == EventType::TransferToAddressAndFreeze as u64)
+                    && recipient == &signer
+            });
+    let latest_event = transfer_events.next();
+    match latest_event {
+        Some((_, _, _, _, obj)) => Ok(NativeResult::ok(cost, smallvec![obj.copy_value()?])),
+        None => Ok(NativeResult::err(cost, 0)),
+    }
+}

--- a/sui_programmability/framework/tests/TestHelperTests.move
+++ b/sui_programmability/framework/tests/TestHelperTests.move
@@ -1,0 +1,30 @@
+#[test_only]
+module FastX::TestHelperTests {
+    use FastX::ID;
+    use FastX::TestHelper;
+    use FastX::Transfer;
+    use FastX::TxContext;
+
+    const ID_BYTES_MISMATCH: u64 = 0;
+    const VALUE_MISMATCH: u64 = 1;
+
+    struct Object has key {
+        id: ID::ID,
+        value: u64,
+    }
+
+    #[test]
+    fun test_transfer() {
+        let ctx = TxContext::dummy();
+        let id = TxContext::new_id(&mut ctx);
+        let id_bytes = *ID::get_inner(&id);
+        let obj = Object { id, value: 100 };
+        Transfer::transfer(obj, TxContext::get_signer_address(&ctx));
+
+        let received_obj = TestHelper::get_last_received_object(&ctx);
+        let Object { id: received_id, value } = received_obj;
+        assert!(ID::get_inner(&received_id) == &id_bytes, ID_BYTES_MISMATCH);
+        assert!(value == 100, VALUE_MISMATCH);
+        ID::delete(received_id);
+    }
+}


### PR DESCRIPTION
Add a new test-only Move library function that allows us to retrieve the most recent object received through transfer by the current signer. This will allow us to inspect the received object without exiting Move, and unblock many ways to test move code.
Added a test.