### PR TITLE
Add TicTacToe game

### DIFF
--- a/sui_programmability/examples/sources/TicTacToe.move
+++ b/sui_programmability/examples/sources/TicTacToe.move
@@ -1,0 +1,251 @@
+module Examples::TicTacToe {
+    use Std::Option::{Self, Option};
+    use Std::Vector;
+
+    use FastX::Address::Address;
+    use FastX::ID::{Self, ID, IDBytes};
+    use FastX::Event;
+    use FastX::Transfer;
+    use FastX::TxContext::{Self, TxContext};
+
+    // Game status
+    const IN_PROGRESS: u8 = 0;
+    const X_WIN: u8 = 1;
+    const O_WIN: u8 = 2;
+    const DRAW: u8 = 3;
+
+    // Error codes
+    const INVALID_LOCATION: u64 = 0;
+    const NO_MORE_MARK: u64 = 1;
+
+    struct TicTacToe has key {
+        id: ID,
+        gameboard: vector<vector<Option<Mark>>>,
+        cur_turn: u8,
+        game_status: u8,
+        x_address: Address,
+        o_address: Address,
+    }
+
+    struct MarkMintCap has key {
+        id: ID,
+        game_id: IDBytes,
+        remaining_supply: u8,
+    }
+
+    struct Mark has key, store {
+        id: ID,
+        player: Address,
+        row: u64,
+        col: u64,
+    }
+
+    struct Trophy has key {
+        id: ID,
+    }
+
+    struct MarkSentEvent has copy, drop {
+        // The Object ID of the game object
+        game_id: IDBytes,
+        // The object ID of the mark sent
+        mark_id: IDBytes,
+    }
+
+    struct GameEndEvent has copy, drop {
+        // The Object ID of the game object
+        game_id: IDBytes,
+    }
+
+    /// `x_address` and `o_address` are the account address of the two players.
+    public fun create_game(x_address: Address, o_address: Address, ctx: &mut TxContext) {
+        // TODO: Validate sender address, only GameAdmin can create games.
+
+        let id = TxContext::new_id(ctx);
+        let game_id_bytes = *ID::get_inner(&id);
+        let gameboard = vector[
+            vector[Option::none(), Option::none(), Option::none()],
+            vector[Option::none(), Option::none(), Option::none()],
+            vector[Option::none(), Option::none(), Option::none()],
+        ];
+        let game = TicTacToe {
+            id,
+            gameboard,
+            cur_turn: 0,
+            game_status: IN_PROGRESS,
+            x_address: copy x_address,
+            o_address: copy o_address,
+        };
+        Transfer::transfer(game, TxContext::get_signer_address(ctx));
+        let cap = MarkMintCap {
+            id: TxContext::new_id(ctx),
+            game_id: copy game_id_bytes,
+            remaining_supply: 5,
+        };
+        Transfer::transfer(cap, x_address);
+        let cap = MarkMintCap {
+            id: TxContext::new_id(ctx),
+            game_id: game_id_bytes,
+            remaining_supply: 5,
+        };
+        Transfer::transfer(cap, o_address);
+    }
+
+    /// Generate a new mark intended for location (row, col).
+    /// This new mark is not yet placed, just transferred to the game.
+    public fun send_mark_to_game(cap: &mut MarkMintCap, game_address: Address, row: u64, col: u64, ctx: &mut TxContext) {
+        if (row > 2 || col > 2) {
+            abort INVALID_LOCATION
+        };
+        let mark = mint_mark(cap, row, col, ctx);
+        // Once an event is emitted, it should be observed by a game server.
+        // The game server will then call `place_mark` to place this mark.
+        Event::emit(MarkSentEvent {
+            game_id: *&cap.game_id,
+            mark_id: *ID::get_id_bytes(&mark),
+        });
+        Transfer::transfer(mark, game_address);
+    }
+
+    public fun place_mark(game: &mut TicTacToe, mark: Mark, ctx: &mut TxContext) {
+        // If we are placing the mark at the wrong turn, or if game has ended,
+        // destroy the mark.
+        let addr = get_cur_turn_address(game);
+        if (game.game_status != IN_PROGRESS || &addr != &mark.player) {
+            delete_mark(mark);
+            return
+        };
+        let cell = get_cell_mut_ref(game, mark.row, mark.col);
+        if (Option::is_some(cell)) {
+            // There is already a mark in the desired location.
+            // Destroy the mark.
+            delete_mark(mark);
+            return
+        };
+        Option::fill(cell, mark);
+        update_winner(game);
+        game.cur_turn = game.cur_turn + 1;
+
+        if (game.game_status != IN_PROGRESS) {
+            // Notify the server that the game ended so that it can delete the game.
+            Event::emit(GameEndEvent { game_id: *ID::get_id_bytes(game) });
+            if (game.game_status == X_WIN) {
+                Transfer::transfer( Trophy { id: TxContext::new_id(ctx) }, *&game.x_address);
+            } else if (game.game_status == O_WIN) {
+                Transfer::transfer( Trophy { id: TxContext::new_id(ctx) }, *&game.o_address);
+            }
+        }
+    }
+
+    public fun delete_game(game: TicTacToe, _ctx: &mut TxContext) {
+        let TicTacToe { id, gameboard, cur_turn: _, game_status: _, x_address: _, o_address: _ } = game;
+        while (Vector::length(&gameboard) > 0) {
+            let row = Vector::pop_back(&mut gameboard);
+            while (Vector::length(&row) > 0) {
+                let element = Vector::pop_back(&mut row);
+                if (Option::is_some(&element)) {
+                    let mark = Option::extract(&mut element);
+                    delete_mark(mark);
+                };
+                Option::destroy_none(element);
+            };
+            Vector::destroy_empty(row);
+        };
+        Vector::destroy_empty(gameboard);
+        ID::delete(id);
+    }
+
+    public fun delete_trophy(trophy: Trophy, _ctx: &mut TxContext) {
+        let Trophy { id } = trophy;
+        ID::delete(id);
+    }
+
+    public fun delete_cap(cap: MarkMintCap, _ctx: &mut TxContext) {
+        let MarkMintCap { id, game_id: _, remaining_supply: _ } = cap;
+        ID::delete(id);
+    }
+
+    fun mint_mark(cap: &mut MarkMintCap, row: u64, col: u64, ctx: &mut TxContext): Mark {
+        if (cap.remaining_supply == 0) {
+            abort NO_MORE_MARK
+        };
+        cap.remaining_supply = cap.remaining_supply - 1;
+        Mark {
+            id: TxContext::new_id(ctx),
+            player: TxContext::get_signer_address(ctx),
+            row,
+            col,
+        }
+    }
+
+    fun get_cur_turn_address(game: &TicTacToe): Address {
+        if (game.cur_turn % 2 == 0) {
+            *&game.x_address
+        } else {
+            *&game.o_address
+        }
+    }
+
+    fun get_cell_ref(game: &TicTacToe, row: u64, col: u64): &Option<Mark> {
+        Vector::borrow(Vector::borrow(&game.gameboard, row), col)
+    }
+
+    fun get_cell_mut_ref(game: &mut TicTacToe, row: u64, col: u64): &mut Option<Mark> {
+        Vector::borrow_mut(Vector::borrow_mut(&mut game.gameboard, row), col)
+    }
+
+    fun update_winner(game: &mut TicTacToe) {
+        // Check all rows
+        check_for_winner(game, 0, 0, 0, 1, 0, 2);
+        check_for_winner(game, 1, 0, 1, 1, 1, 2);
+        check_for_winner(game, 2, 0, 2, 1, 2, 2);
+
+        // Check all columns
+        check_for_winner(game, 0, 0, 1, 0, 2, 0);
+        check_for_winner(game, 0, 1, 1, 1, 2, 1);
+        check_for_winner(game, 0, 2, 1, 2, 2, 2);
+
+        // Check diagonals
+        check_for_winner(game, 0, 0, 1, 1, 2, 2);
+        check_for_winner(game, 2, 0, 1, 1, 0, 2);
+
+        // Check if we have a draw
+        if (game.cur_turn == 9) {
+            game.game_status = DRAW;
+        };
+    }
+
+    fun check_for_winner(game: &mut TicTacToe, row1: u64, col1: u64, row2: u64, col2: u64, row3: u64, col3: u64) {
+        if (game.game_status != IN_PROGRESS) {
+            return
+        };
+        let result = check_all_equal(game, row1, col1, row2, col2, row3, col3);
+        if (Option::is_some(&result)) {
+            let winner = Option::extract(&mut result);
+            game.game_status = if (&winner == &game.x_address) {
+                X_WIN
+            } else {
+                O_WIN
+            };
+        };
+    }
+
+    fun check_all_equal(game: &TicTacToe, row1: u64, col1: u64, row2: u64, col2: u64, row3: u64, col3: u64): Option<Address> {
+        let cell1 = get_cell_ref(game, row1, col1);
+        let cell2 = get_cell_ref(game, row2, col2);
+        let cell3 = get_cell_ref(game, row3, col3);
+        if (Option::is_some(cell1) && Option::is_some(cell2) && Option::is_some(cell3)) {
+            let cell1_player = *&Option::borrow(cell1).player;
+            let cell2_player = *&Option::borrow(cell2).player;
+            let cell3_player = *&Option::borrow(cell3).player;
+            if (&cell1_player == &cell2_player && &cell1_player == &cell3_player) {
+                return Option::some(cell1_player)
+            };
+        };
+        Option::none()
+    }
+
+    fun delete_mark(mark: Mark) {
+        let Mark { id, player: _, row: _, col: _ } = mark;
+        ID::delete(id);
+    }
+}

--- a/sui_programmability/examples/tests/TicTacToeTests.move
+++ b/sui_programmability/examples/tests/TicTacToeTests.move
@@ -1,0 +1,97 @@
+#[test_only]
+module Examples::TicTacToeTests {
+    use FastX::TxContext::{Self, TxContext};
+    use FastX::TestHelper;
+    use Examples::TicTacToe::{Self, Mark, MarkMintCap, TicTacToe, Trophy};
+
+    const SEND_MARK_FAILED: u64 = 0;
+    const UNEXPECTED_WINNER: u64 = 1;
+    const MARK_PLACEMENT_FAILED: u64 = 2;
+
+    #[test]
+    fun play_tictactoe() {
+        let admin_ctx = TxContext::dummy_with_hint(0);
+        let player_x_ctx = TxContext::dummy_with_hint(2);
+        let player_o_ctx = TxContext::dummy_with_hint(1);
+
+        // Create a game under admin.
+        TicTacToe::create_game(
+            TxContext::get_signer_address(&player_x_ctx),
+            TxContext::get_signer_address(&player_o_ctx),
+            &mut admin_ctx,
+        );
+        let game = TestHelper::get_last_received_object<TicTacToe>(&admin_ctx);
+        
+        let cap_x = TestHelper::get_last_received_object<MarkMintCap>(&player_x_ctx);
+        let cap_o = TestHelper::get_last_received_object<MarkMintCap>(&player_o_ctx);
+
+        // Player1 places an X in (1, 1).
+        place_mark(&mut game, &mut cap_x, 1, 1, &mut admin_ctx, &mut player_x_ctx);
+        /*
+        Current game board:
+        _|_|_
+        _|X|_
+         | |
+        */
+
+        // Player2 places an O in (0, 0).
+        place_mark(&mut game, &mut cap_x, 0, 0, &mut admin_ctx, &mut player_o_ctx);
+        /*
+        Current game board:
+        O|_|_
+        _|X|_
+         | |
+        */
+
+        // Player1 places an X in (0, 2).
+        place_mark(&mut game, &mut cap_x, 0, 2, &mut admin_ctx, &mut player_x_ctx);
+        /*
+        Current game board:
+        O|_|X
+        _|X|_
+         | |
+        */
+
+        // Player2 places an O in (1, 0).
+        place_mark(&mut game, &mut cap_x, 1, 0, &mut admin_ctx, &mut player_o_ctx);
+        /*
+        Current game board:
+        O|_|X
+        O|X|_
+         | |
+        */
+
+        // Opportunity for Player1! Player1 places an X in (2, 0).
+        place_mark(&mut game, &mut cap_x, 2, 0, &mut admin_ctx, &mut player_x_ctx);
+        /*
+        Current game board:
+        O|_|X
+        O|X|_
+        X| |
+        */
+        // Check that X has won!
+        let trophy = TestHelper::get_last_received_object<Trophy>(&mut player_x_ctx);
+        TicTacToe::delete_trophy(trophy, &mut player_x_ctx);
+
+        // Cleanup and delete all objects in the game.
+        TicTacToe::delete_game(game, &mut admin_ctx);
+        TicTacToe::delete_cap(cap_x, &mut player_x_ctx);
+        TicTacToe::delete_cap(cap_o, &mut player_o_ctx);
+    }
+
+    fun place_mark(
+        game: &mut TicTacToe,
+        cap: &mut MarkMintCap,
+        row: u64,
+        col: u64,
+        admin_ctx: &mut TxContext,
+        player_ctx: &mut TxContext,
+    ) {
+        // Step 1: Create a mark and send it to the game.
+        TicTacToe::send_mark_to_game(cap, TxContext::get_signer_address(admin_ctx), row, col, player_ctx);
+
+        // Step 2: Game places the mark on the game board.
+        let mark = TestHelper::get_last_received_object<Mark>(admin_ctx);
+        TicTacToe::place_mark(game, mark, admin_ctx);
+    }
+}


### PR DESCRIPTION
Added a TicTacToe NFT game written in Move.
Although the core logic of TicTacToe is simple, it's actually pretty difficult for me to program the entire contract.
It really takes some time for me to fit the game into Move + Sui programming model.
There are three parties of the game: GameAdmin, Player 1 and Player 2.
GameAdmin creates and owns the game board.
Each player takes turn to send a mark to the game board, the game server monitors the events, and once seeing a mark sent, try place that mark to the board.