### PR TITLE
A few fixes/improvements to sui Move test framework

### DIFF
--- a/sui/src/sui-move.rs
+++ b/sui/src/sui-move.rs
@@ -15,6 +15,7 @@ pub enum MoveCommands {
     /// Run all Move unit tests
     #[structopt(name = "test")]
     Test,
+    // TODO: Add dev_mode as configurable option
 }
 
 impl MoveCommands {
@@ -24,6 +25,7 @@ impl MoveCommands {
                 sui_framework::build_and_verify_user_package(path, false)?;
             }
             Self::Test => {
+                sui_framework::build_and_verify_user_package(path, true).unwrap();
                 sui_framework::run_move_unit_tests(path)?;
             }
         }

--- a/sui_programmability/framework/sources/Address.move
+++ b/sui_programmability/framework/sources/Address.move
@@ -72,4 +72,18 @@ module FastX::Address {
     public fun dummy_signer(): Signer {
         new_signer(x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
     }
+
+    #[test_only]
+    /// Create a dummy `Signer` for testing
+    /// All bytes will be 0 except the last byte, which will be `hint`.
+    public fun dummy_signer_with_hint(hint: u8): Signer {
+        let bytes = Vector::empty<u8>();
+        let i = 0;
+        while (i < ADDRESS_LENGTH - 1) {
+            Vector::push_back(&mut bytes, 0u8);
+            i = i + 1;
+        };
+        Vector::push_back(&mut bytes, hint);
+        new_signer(bytes)
+    }
 }

--- a/sui_programmability/framework/sources/TxContext.move
+++ b/sui_programmability/framework/sources/TxContext.move
@@ -1,6 +1,17 @@
 module FastX::TxContext {
+    #[test_only]
+    use Std::Errors;
+    #[test_only]
+    use Std::Vector;
+
     use FastX::ID::{Self, ID};
     use FastX::Address::{Self, Address, Signer};
+
+    /// Number of bytes in an inputs_hash (which will be the transaction digest)
+    const INPUTS_HASH_LENGTH: u64 = 32;
+
+    /// Expected an inputs_hash of length 32, but found a different length
+    const EBAD_INPUTS_HASH_LENGTH: u64 = 0;
 
     /// Information about the transaction currently being executed.
     /// This is a privileged object created by the VM and passed into `main`
@@ -46,6 +57,10 @@ module FastX::TxContext {
     #[test_only]
     /// Create a `TxContext` for testing
     public fun new(signer: Signer, inputs_hash: vector<u8>, ids_created: u64): TxContext {
+        assert!(
+            Vector::length(&inputs_hash) == INPUTS_HASH_LENGTH,
+            Errors::invalid_argument(EBAD_INPUTS_HASH_LENGTH)
+        );
         TxContext { signer, inputs_hash, ids_created }
     }
 
@@ -54,5 +69,19 @@ module FastX::TxContext {
     public fun dummy(): TxContext {
         let inputs_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
         new(Address::dummy_signer(), inputs_hash, 0)
+    }
+
+    #[test_only]
+    /// Create a dummy `TxContext` for testing
+    /// Use the `hint` to set the address and input hash.
+    public fun dummy_with_hint(hint: u8): TxContext {
+        let inputs_hash = Vector::empty<u8>();
+        let i = 0;
+        while (i < INPUTS_HASH_LENGTH - 1) {
+            Vector::push_back(&mut inputs_hash, 0u8);
+            i = i + 1;
+        };
+        Vector::push_back(&mut inputs_hash, hint);
+        new(Address::dummy_signer_with_hint(hint), inputs_hash, 0)
     }
 }

--- a/sui_programmability/framework/src/lib.rs
+++ b/sui_programmability/framework/src/lib.rs
@@ -179,10 +179,7 @@ pub fn run_move_unit_tests(path: &Path) -> SuiResult {
 
     let result = cli::run_move_unit_tests(
         path,
-        BuildConfig {
-            dev_mode: false,
-            ..Default::default()
-        },
+        BuildConfig::default(),
         UnitTestingConfig::default_with_bound(Some(MAX_UNIT_TEST_INSTRUCTIONS)),
         natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS),
         /* compute_coverage */ false,
@@ -199,26 +196,15 @@ pub fn run_move_unit_tests(path: &Path) -> SuiResult {
     }
 }
 
-#[cfg(test)]
-fn get_examples() -> Vec<CompiledModule> {
-    let mut framework_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    framework_dir.push("../examples/");
-    let build_config = BuildConfig {
-        dev_mode: false,
-        ..Default::default()
-    };
-    let modules = build_move_package(&framework_dir, build_config, true).unwrap();
-    verify_modules(&modules).unwrap();
-    modules
-}
-
-#[test]
-fn check_that_move_code_can_be_built_verified_tested() {
-    get_sui_framework_modules();
-    get_examples();
-}
-
 #[test]
 fn run_framework_move_unit_tests() {
+    get_sui_framework_modules();
     run_move_unit_tests(Path::new(env!("CARGO_MANIFEST_DIR"))).unwrap();
+}
+
+#[test]
+fn run_examples_move_unit_tests() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../examples");
+    build_and_verify_user_package(&path, true).unwrap();
+    run_move_unit_tests(&path).unwrap();
 }


### PR DESCRIPTION
This PR fixes an issue and adds a few utility functions to help with testing in Move:
1. Running unit tests doesn't automatically build the package. Make it so that it always build the package. This also fixes a test failure seen previously.
2. Added a few functions in TxContext to help with context generation.