### PR TITLE
Use fixed-length address as object owner

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -73,7 +73,7 @@ impl AuthorityState {
         order: &Order,
         object_kind: InputObjectKind,
         object: &Object,
-        mutable_object_ids: &HashSet<ObjectID>,
+        mutable_object_addresses: &HashSet<SuiAddress>,
     ) -> SuiResult {
         match object_kind {
             InputObjectKind::MovePackage(package_id) => {
@@ -121,18 +121,13 @@ impl AuthorityState {
                 }
 
                 // Additional checks for mutable objects
-                // Check the transaction sender is also the object owner
-                // If the object is owned by another object, we make sure the owner object
-                // is also a mutable input to this order.
-                match &object.owner {
-                    // TODO: More detailed error message for IncorrectSigner.
-                    Authenticator::Address(addr) => {
-                        fp_ensure!(order.sender() == addr, SuiError::IncorrectSigner);
-                    }
-                    Authenticator::Object(id) => {
-                        fp_ensure!(mutable_object_ids.contains(id), SuiError::IncorrectSigner);
-                    }
-                };
+                // Check the object owner is either the transaction sender, or
+                // another mutable object in the input.
+                fp_ensure!(
+                    order.sender() == &object.owner
+                        || mutable_object_addresses.contains(&object.owner),
+                    SuiError::IncorrectSigner
+                );
 
                 if &object_id == order.gas_payment_object_id() {
                     gas::check_gas_requirement(order, object)?;
@@ -162,10 +157,10 @@ impl AuthorityState {
         let ids: Vec<_> = input_objects.iter().map(|kind| kind.object_id()).collect();
 
         let objects = self.get_objects(&ids[..]).await?;
-        let mutable_object_ids: HashSet<_> = objects
+        let mutable_object_addresses: HashSet<_> = objects
             .iter()
             .flat_map(|opt_obj| match opt_obj {
-                Some(obj) if !obj.is_read_only() => Some(obj.id()),
+                Some(obj) if !obj.is_read_only() => Some(obj.id().into()),
                 _ => None,
             })
             .collect();
@@ -179,7 +174,7 @@ impl AuthorityState {
                 }
             };
 
-            match self.check_one_lock(order, object_kind, &object, &mutable_object_ids) {
+            match self.check_one_lock(order, object_kind, &object, &mutable_object_addresses) {
                 Ok(()) => all_objects.push((object_kind, object)),
                 Err(e) => {
                     errors.push(e);
@@ -374,7 +369,7 @@ impl AuthorityState {
             });
         }
 
-        output_object.transfer(Authenticator::Address(recipient));
+        output_object.transfer(recipient);
         temporary_store.write_object(output_object);
         Ok(ExecutionStatus::Success { gas_used })
     }

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -25,7 +25,7 @@ pub struct AuthorityStore {
     /// composite key of the SuiAddress of their owner and the object ID of the object.
     /// This composite index allows an efficient iterator to list all objected currently owned
     /// by a specific user, and their object reference.
-    owner_index: DBMap<(Authenticator, ObjectID), ObjectRef>,
+    owner_index: DBMap<(SuiAddress, ObjectID), ObjectRef>,
 
     /// This is map between the transaction digest and signed orders found in the `order_lock`.
     /// NOTE: after a lock is deleted the corresponding entry here could be deleted, but right
@@ -109,13 +109,12 @@ impl AuthorityStore {
     // Methods to read the store
 
     pub fn get_account_objects(&self, account: SuiAddress) -> Result<Vec<ObjectRef>, SuiError> {
-        let auth = Authenticator::Address(account);
         Ok(self
             .owner_index
             .iter()
             // The object id 0 is the smallest possible
-            .skip_to(&(auth, ObjectID::ZERO))?
-            .take_while(|((owner, _id), _object_ref)| (owner == &auth))
+            .skip_to(&(account, ObjectID::ZERO))?
+            .take_while(|((owner, _id), _object_ref)| (owner == &account))
             .map(|((_owner, _id), object_ref)| object_ref)
             .collect())
     }

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -951,7 +951,7 @@ where
     /// Return owner address and sequence number of an object backed by a quorum of authorities.
     /// NOTE: This is only reliable in the synchronous model, with a sufficient timeout value.
     #[cfg(test)]
-    async fn get_latest_owner(&self, object_id: ObjectID) -> (Authenticator, SequenceNumber) {
+    async fn get_latest_owner(&self, object_id: ObjectID) -> (SuiAddress, SequenceNumber) {
         let (object_infos, _certificates) = self
             .get_object_by_id(object_id, Duration::from_secs(60))
             .await

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -429,13 +429,13 @@ where
                 .unwrap_or_default();
             // only update if data is new
             if old_seq < seq {
-                if owner.is_address(&self.address) {
+                if owner == self.address {
                     self.insert_object_info(&object_ref, &parent_tx_digest)?;
                     objs_to_download.push(object_ref);
                 } else {
                     self.remove_object_info(&object_id)?;
                 }
-            } else if old_seq == seq && owner.is_address(&self.address) {
+            } else if old_seq == seq && owner == self.address {
                 // ObjectRef can be 1 version behind because it's only updated after confirmation.
                 self.store.object_refs.insert(&object_id, &object_ref)?;
             }

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -553,7 +553,7 @@ async fn test_handle_move_order() {
         .await
         .unwrap()
         .unwrap();
-    assert!(created_obj.owner.is_address(&sender));
+    assert_eq!(created_obj.owner, sender);
     assert_eq!(created_obj.id(), created_object_id);
     assert_eq!(created_obj.version(), OBJECT_START_VERSION);
 
@@ -903,7 +903,7 @@ async fn test_handle_confirmation_order_ok() {
         .await
         .unwrap()
         .unwrap();
-    assert!(new_account.owner.is_address(&recipient));
+    assert_eq!(new_account.owner, recipient);
     assert_eq!(next_sequence_number, new_account.version());
     assert_eq!(None, info.signed_order);
     let opt_cert = {
@@ -1288,7 +1288,7 @@ async fn test_authority_persist() {
 
     // Check the object is present
     assert_eq!(obj2.id(), object_id);
-    assert!(obj2.owner.is_address(&recipient));
+    assert_eq!(obj2.owner, recipient);
 }
 
 #[tokio::test]
@@ -1404,7 +1404,7 @@ async fn test_hero() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     assert_eq!(effects.mutated.len(), 1); // cap
     let (coin, coin_owner) = effects.created[0];
-    assert!(coin_owner.is_address(&player));
+    assert_eq!(coin_owner, player);
 
     // 5. Purchase a sword using 500 coin. This sword will have magic = 4, sword_strength = 5.
     let effects = call_move(
@@ -1424,9 +1424,9 @@ async fn test_hero() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     assert_eq!(effects.mutated.len(), 1); // coin
     let (hero, hero_owner) = effects.created[0];
-    assert!(hero_owner.is_address(&player));
+    assert_eq!(hero_owner, player);
     // The payment goes to the admin.
-    assert!(effects.mutated[0].1.is_address(&admin));
+    assert_eq!(effects.mutated[0].1, admin);
 
     // 6. Verify the hero is what we exepct with strength 5.
     let effects = call_move(
@@ -1467,7 +1467,7 @@ async fn test_hero() {
     .unwrap();
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     let (boar, boar_owner) = effects.created[0];
-    assert!(boar_owner.is_address(&player));
+    assert_eq!(boar_owner, player);
 
     // 8. Slay the boar!
     let effects = call_move(
@@ -1531,7 +1531,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 2);
     assert_eq!(
         authority.get_object(&obj1).await.unwrap().unwrap().owner,
-        Authenticator::Object(obj2)
+        obj2.into(),
     );
 
     // Try to transfer obj1 to obj3, this time it will fail since obj1 is now owned by obj2,
@@ -1589,7 +1589,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 1);
     assert_eq!(
         authority.get_object(&obj2).await.unwrap().unwrap().owner,
-        Authenticator::Address(sender2)
+        sender2
     );
 
     // Sender 1 try to transfer obj1 to obj2 again.
@@ -1627,7 +1627,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 2);
     assert_eq!(
         authority.get_object(&obj1).await.unwrap().unwrap().owner,
-        Authenticator::Object(obj2)
+        obj2.into(),
     );
 }
 

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -453,17 +453,11 @@ fn test_initiating_valid_transfer() {
     let mut sender = rt.block_on(init_local_client_state(authority_objects));
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id_1)),
-        (
-            Authenticator::Address(sender.address()),
-            SequenceNumber::from(0)
-        )
+        (sender.address(), SequenceNumber::from(0))
     );
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id_2)),
-        (
-            Authenticator::Address(sender.address()),
-            SequenceNumber::from(0)
-        )
+        (sender.address(), SequenceNumber::from(0))
     );
     let (certificate, _) = rt
         .block_on(sender.transfer_object(object_id_1, gas_object, recipient))
@@ -477,14 +471,11 @@ fn test_initiating_valid_transfer() {
     assert!(sender.store().pending_orders.is_empty());
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id_1)),
-        (Authenticator::Address(recipient), SequenceNumber::from(1))
+        (recipient, SequenceNumber::from(1))
     );
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id_2)),
-        (
-            Authenticator::Address(sender.address()),
-            SequenceNumber::from(0)
-        )
+        (sender.address(), SequenceNumber::from(0))
     );
     // valid since our test authority should not update its certificate set
     compare_certified_orders(
@@ -523,7 +514,7 @@ fn test_initiating_valid_transfer_despite_bad_authority() {
     assert!(sender.store().pending_orders.is_empty());
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id)),
-        (Authenticator::Address(recipient), SequenceNumber::from(1))
+        (recipient, SequenceNumber::from(1))
     );
     // valid since our test authority shouldn't update its certificate set
     compare_certified_orders(
@@ -562,10 +553,7 @@ fn test_initiating_transfer_low_funds() {
     // assert_eq!(sender.pending_transfer, None);
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id_1)),
-        (
-            Authenticator::Address(sender.address()),
-            SequenceNumber::from(0)
-        ),
+        (sender.address(), SequenceNumber::from(0)),
     );
     assert_eq!(
         rt.block_on(sender.authorities().get_latest_owner(object_id_2))
@@ -600,18 +588,12 @@ async fn test_bidirectional_transfer() {
     // Confirm client1 have ownership of the object.
     assert_eq!(
         client1.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client1.address()),
-            SequenceNumber::from(0)
-        )
+        (client1.address(), SequenceNumber::from(0))
     );
     // Confirm client2 doesn't have ownership of the object.
     assert_eq!(
         client2.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client1.address()),
-            SequenceNumber::from(0)
-        )
+        (client1.address(), SequenceNumber::from(0))
     );
     // Transfer object to client2.
     let (certificate, _) = client1
@@ -623,18 +605,12 @@ async fn test_bidirectional_transfer() {
     // Confirm client1 lose ownership of the object.
     assert_eq!(
         client1.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client2.address()),
-            SequenceNumber::from(1)
-        )
+        (client2.address(), SequenceNumber::from(1))
     );
     // Confirm client2 acquired ownership of the object.
     assert_eq!(
         client2.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client2.address()),
-            SequenceNumber::from(1)
-        )
+        (client2.address(), SequenceNumber::from(1))
     );
 
     // Confirm certificate is consistent between authorities and client.
@@ -654,10 +630,7 @@ async fn test_bidirectional_transfer() {
     // Confirm sequence number are consistent between clients.
     assert_eq!(
         client2.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client2.address()),
-            SequenceNumber::from(1)
-        )
+        (client2.address(), SequenceNumber::from(1))
     );
 
     // Transfer the object back to Client1
@@ -671,10 +644,7 @@ async fn test_bidirectional_transfer() {
     // Confirm client2 lose ownership of the object.
     assert_eq!(
         client2.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client1.address()),
-            SequenceNumber::from(2)
-        )
+        (client1.address(), SequenceNumber::from(2))
     );
     assert_eq!(
         client2
@@ -686,10 +656,7 @@ async fn test_bidirectional_transfer() {
     // Confirm client1 acquired ownership of the object.
     assert_eq!(
         client1.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client1.address()),
-            SequenceNumber::from(2)
-        )
+        (client1.address(), SequenceNumber::from(2))
     );
 
     // Should fail if Client 2 double spend the object
@@ -764,10 +731,7 @@ async fn test_client_state_sync_with_transferred_object() {
     // Confirm client2 acquired ownership of the object.
     assert_eq!(
         client2.authorities().get_latest_owner(object_id).await,
-        (
-            Authenticator::Address(client2.address()),
-            SequenceNumber::from(1)
-        )
+        (client2.address(), SequenceNumber::from(1))
     );
 
     // Client 2's local object_id and cert should be empty before sync
@@ -926,7 +890,7 @@ async fn test_move_calls_object_transfer() {
     let transferred_obj = client_object(&mut client1, new_obj_ref.0).await.1;
 
     // Confirm new owner
-    assert!(transferred_obj.owner.is_address(&client2.address()));
+    assert!(transferred_obj.owner == client2.address());
 }
 
 #[tokio::test]
@@ -1011,7 +975,7 @@ async fn test_move_calls_object_transfer_and_freeze() {
     let transferred_obj = client_object(&mut client1, new_obj_ref.0).await.1;
 
     // Confirm new owner
-    assert!(transferred_obj.owner.is_address(&client2.address()));
+    assert!(transferred_obj.owner == client2.address());
 
     // Confirm read only
     assert!(transferred_obj.is_read_only());
@@ -1101,7 +1065,7 @@ async fn test_move_calls_object_delete() {
 
 async fn get_package_obj(
     client: &mut ClientState<LocalAuthorityClient>,
-    objects: &[(ObjectRef, Authenticator)],
+    objects: &[(ObjectRef, SuiAddress)],
     gas_object_ref: &ObjectRef,
 ) -> Option<ObjectRead> {
     let mut pkg_obj_opt = None;
@@ -2053,7 +2017,7 @@ async fn test_sync_all_owned_objects() {
         2,
         owned_object
             .iter()
-            .filter(|(o, _, _)| o.owner.is_address(&client1.address()))
+            .filter(|(o, _, _)| o.owner == client1.address())
             .count()
     );
 }

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -11,10 +11,7 @@ use move_binary_format::{
 };
 use sui_framework::EventType;
 use sui_types::{
-    base_types::{
-        Authenticator, ObjectID, SuiAddress, TransactionDigest, TxContext, TX_CONTEXT_MODULE_NAME,
-        TX_CONTEXT_STRUCT_NAME,
-    },
+    base_types::*,
     error::{SuiError, SuiResult},
     event::Event,
     gas,
@@ -85,9 +82,7 @@ pub fn execute<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
 ) -> SuiResult<ExecutionStatus> {
     let mut object_owner_map = HashMap::new();
     for object in object_args.iter().filter(|obj| !obj.is_read_only()) {
-        if let Authenticator::Object(owner_object_id) = object.owner {
-            object_owner_map.insert(object.id(), owner_object_id);
-        }
+        object_owner_map.insert(object.id().into(), object.owner);
     }
     let TypeCheckSuccess {
         module_id,
@@ -154,7 +149,7 @@ fn execute_internal<
     args: Vec<Vec<u8>>,
     mutable_ref_objects: Vec<Object>,
     by_value_objects: BTreeMap<AccountAddress, Object>,
-    object_owner_map: HashMap<AccountAddress, AccountAddress>,
+    object_owner_map: HashMap<SuiAddress, SuiAddress>,
     gas_budget: u64, // gas budget for the current call operation
     ctx: &mut TxContext,
     for_publish: bool,
@@ -300,7 +295,7 @@ pub fn publish<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
     }
 
     // wrap the modules in an object, write it to the store
-    let package_object = Object::new_package(modules, Authenticator::Address(sender), ctx.digest());
+    let package_object = Object::new_package(modules, sender, ctx.digest());
     state_view.write_object(package_object);
 
     let mut total_gas_used = gas_cost;
@@ -472,7 +467,7 @@ fn process_successful_execution<
     mutable_refs: impl Iterator<Item = (Object, Vec<u8>)>,
     events: Vec<MoveEvent>,
     ctx: &TxContext,
-    mut object_owner_map: HashMap<ObjectID, ObjectID>,
+    mut object_owner_map: HashMap<SuiAddress, SuiAddress>,
 ) -> (u64, u64, SuiResult) {
     for (mut obj, new_contents) in mutable_refs {
         // update contents and increment sequence number
@@ -491,7 +486,7 @@ fn process_successful_execution<
             .expect("Safe because event_type is derived from an EventType enum")
         {
             EventType::TransferToAddress => handle_transfer(
-                Authenticator::Address(SuiAddress::try_from(recipient.borrow()).unwrap()),
+                SuiAddress::try_from(recipient.borrow()).unwrap(),
                 type_,
                 event_bytes,
                 false, /* should_freeze */
@@ -502,7 +497,7 @@ fn process_successful_execution<
                 &mut object_owner_map,
             ),
             EventType::TransferToAddressAndFreeze => handle_transfer(
-                Authenticator::Address(SuiAddress::try_from(recipient.borrow()).unwrap()),
+                SuiAddress::try_from(recipient.borrow()).unwrap(),
                 type_,
                 event_bytes,
                 true, /* should_freeze */
@@ -513,7 +508,7 @@ fn process_successful_execution<
                 &mut object_owner_map,
             ),
             EventType::TransferToObject => handle_transfer(
-                Authenticator::Object(ObjectID::try_from(recipient.borrow()).unwrap()),
+                ObjectID::try_from(recipient.borrow()).unwrap().into(),
                 type_,
                 event_bytes,
                 false, /* should_freeze */
@@ -560,7 +555,7 @@ fn handle_transfer<
     E: Debug,
     S: ResourceResolver<Error = E> + ModuleResolver<Error = E> + Storage,
 >(
-    recipient: Authenticator,
+    recipient: SuiAddress,
     type_: TypeTag,
     contents: Vec<u8>,
     should_freeze: bool,
@@ -568,7 +563,7 @@ fn handle_transfer<
     by_value_objects: &mut BTreeMap<ObjectID, Object>,
     gas_used: &mut u64,
     state_view: &mut S,
-    object_owner_map: &mut HashMap<ObjectID, ObjectID>,
+    object_owner_map: &mut HashMap<SuiAddress, SuiAddress>,
 ) -> SuiResult {
     match type_ {
         TypeTag::Struct(s_type) => {
@@ -592,24 +587,22 @@ fn handle_transfer<
                 // Charge extra gas based on object size if we are creating a new object.
                 *gas_used += gas::calculate_object_creation_cost(&obj);
             }
-            let obj_id = obj.id();
+            let obj_address: SuiAddress = obj.id().into();
             // Below we check whether the transfer introduced any circular ownership.
             // We know that for any mutable object, all its ancenstors (if it was owned by another object)
             // must be in the input as well. Prior to this we have recored the original ownership mapping
             // in object_owner_map. For any new transfer, we trace the new owner through the ownership
             // chain to see if a cycle is detected.
             // TODO: Set a constant upper bound to the depth of the new ownership chain.
-            object_owner_map.remove(&obj_id);
-            if let Authenticator::Object(owner_object_id) = recipient {
-                let mut parent = owner_object_id;
-                while parent != obj_id && object_owner_map.contains_key(&parent) {
-                    parent = *object_owner_map.get(&parent).unwrap();
-                }
-                if parent == obj_id {
-                    return Err(SuiError::CircularObjectOwnership);
-                }
-                object_owner_map.insert(obj_id, owner_object_id);
+            object_owner_map.remove(&obj_address);
+            let mut parent = recipient;
+            while parent != obj_address && object_owner_map.contains_key(&parent) {
+                parent = *object_owner_map.get(&parent).unwrap();
             }
+            if parent == obj_address {
+                return Err(SuiError::CircularObjectOwnership);
+            }
+            object_owner_map.insert(obj_address, recipient);
 
             state_view.write_object(obj);
         }

--- a/sui_programmability/adapter/src/genesis.rs
+++ b/sui_programmability/adapter/src/genesis.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use std::sync::Mutex;
 use sui_framework::{self};
 use sui_types::{
-    base_types::{Authenticator, SuiAddress, TransactionDigest},
+    base_types::{SuiAddress, TransactionDigest},
     object::Object,
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
@@ -31,16 +31,8 @@ fn create_genesis_module_objects() -> Genesis {
         sui_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS);
     let owner = SuiAddress::default();
     let objects = vec![
-        Object::new_package(
-            sui_modules,
-            Authenticator::Address(owner),
-            TransactionDigest::genesis(),
-        ),
-        Object::new_package(
-            std_modules,
-            Authenticator::Address(owner),
-            TransactionDigest::genesis(),
-        ),
+        Object::new_package(sui_modules, owner, TransactionDigest::genesis()),
+        Object::new_package(std_modules, owner, TransactionDigest::genesis()),
     ];
     Genesis {
         objects,

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -242,7 +242,7 @@ fn test_object_basics() {
     storage.flush();
     let mut obj1 = storage.read_object(&id1).unwrap();
     let mut obj1_seq = SequenceNumber::from(1);
-    assert!(obj1.owner.is_address(&addr1));
+    assert!(obj1.owner == addr1);
     assert_eq!(obj1.version(), obj1_seq);
 
     // 2. Transfer obj1 to addr2
@@ -266,7 +266,7 @@ fn test_object_basics() {
     assert!(storage.deleted().is_empty());
     storage.flush();
     let transferred_obj = storage.read_object(&id1).unwrap();
-    assert!(transferred_obj.owner.is_address(&addr2));
+    assert!(transferred_obj.owner == addr2);
     obj1_seq = obj1_seq.increment();
     assert_eq!(obj1.id(), transferred_obj.id());
     assert_eq!(transferred_obj.version(), obj1_seq);
@@ -331,7 +331,7 @@ fn test_object_basics() {
     );
     storage.flush();
     let updated_obj = storage.read_object(&id1).unwrap();
-    assert!(updated_obj.owner.is_address(&addr2));
+    assert!(updated_obj.owner == addr2);
     obj1_seq = obj1_seq.increment();
     assert_eq!(updated_obj.version(), obj1_seq);
     assert_ne!(
@@ -598,7 +598,7 @@ fn test_transfer_and_freeze() {
     storage.flush();
     let obj1 = storage.read_object(&id1).unwrap();
     assert!(obj1.is_read_only());
-    assert!(obj1.owner.is_address(&addr2));
+    assert!(obj1.owner == addr2);
 
     // 3. Call transfer again and it should fail.
     let pure_args = vec![bcs::to_bytes(&addr1.to_vec()).unwrap()];
@@ -994,7 +994,7 @@ fn test_simple_call() {
     let id = storage.get_created_keys().pop().unwrap();
     storage.flush();
     let obj = storage.read_object(&id).unwrap();
-    assert!(obj.owner.is_address(&addr));
+    assert!(obj.owner == addr);
     assert_eq!(obj.version(), SequenceNumber::from(1));
     let move_obj = obj.data.try_as_move().unwrap();
     assert_eq!(

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -259,14 +259,14 @@ pub struct OrderEffects {
     // The transaction digest
     pub transaction_digest: TransactionDigest,
     // ObjectRef and owner of new objects created.
-    pub created: Vec<(ObjectRef, Authenticator)>,
+    pub created: Vec<(ObjectRef, SuiAddress)>,
     // ObjectRef and owner of mutated objects.
     // mutated does not include gas object or created objects.
-    pub mutated: Vec<(ObjectRef, Authenticator)>,
+    pub mutated: Vec<(ObjectRef, SuiAddress)>,
     // Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
     // The updated gas object reference.
-    pub gas_object: (ObjectRef, Authenticator),
+    pub gas_object: (ObjectRef, SuiAddress),
     /// The events emitted during execution. Note that only successful transactions emit events
     pub events: Vec<Event>,
     /// The set of transaction digests this order depends on.
@@ -277,7 +277,7 @@ impl OrderEffects {
     /// Return an iterator that iterates throguh all mutated objects,
     /// including all from mutated, created and the gas_object.
     /// It doesn't include deleted.
-    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, Authenticator)> {
+    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, SuiAddress)> {
         self.mutated
             .iter()
             .chain(self.created.iter())

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -22,8 +22,8 @@ use move_core_types::{account_address::AccountAddress, language_storage::StructT
 use crate::error::SuiError;
 use crate::{
     base_types::{
-        sha3_hash, Authenticator, BcsSignable, ObjectDigest, ObjectID, ObjectRef, SequenceNumber,
-        SuiAddress, TransactionDigest,
+        sha3_hash, BcsSignable, ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress,
+        TransactionDigest,
     },
     gas_coin::GasCoin,
 };
@@ -264,8 +264,8 @@ impl Data {
 pub struct Object {
     /// The meat of the object
     pub data: Data,
-    /// The authenticator that unlocks this object (eg. public key, or object id)
-    pub owner: Authenticator,
+    /// The owner address that unlocks this object (eg. hashes of public key, or object id)
+    pub owner: SuiAddress,
     /// The digest of the order that created or last mutated this object
     pub previous_transaction: TransactionDigest,
 }
@@ -276,7 +276,7 @@ impl Object {
     /// Create a new Move object
     pub fn new_move(
         o: MoveObject,
-        owner: Authenticator,
+        owner: SuiAddress,
         previous_transaction: TransactionDigest,
     ) -> Self {
         Object {
@@ -288,7 +288,7 @@ impl Object {
 
     pub fn new_package(
         modules: Vec<CompiledModule>,
-        owner: Authenticator,
+        owner: SuiAddress,
         previous_transaction: TransactionDigest,
     ) -> Self {
         let serialized: MovePackage = modules
@@ -356,7 +356,7 @@ impl Object {
     }
 
     /// Change the owner of `self` to `new_owner`
-    pub fn transfer(&mut self, new_owner: Authenticator) {
+    pub fn transfer(&mut self, new_owner: SuiAddress) {
         // TODO: these should be raised SuiError's instead of panic's
         assert!(!self.is_read_only(), "Cannot transfer an immutable object");
         match &mut self.data {
@@ -385,7 +385,7 @@ impl Object {
             read_only: false,
         });
         Self {
-            owner: Authenticator::Address(owner),
+            owner,
             data,
             previous_transaction: TransactionDigest::genesis(),
         }
@@ -411,7 +411,7 @@ impl Object {
             read_only: false,
         });
         Self {
-            owner: Authenticator::Address(owner),
+            owner,
             data,
             previous_transaction: TransactionDigest::genesis(),
         }


### PR DESCRIPTION
This PR is the first step towards #318: Object owner should be a fixed length address, instead of `Authenticator`.
This PR sets object owner to be `SuiAddress`, and change everywhere else to make the code compile.
To minimize the changes in this PR, a lot of work are left out to future PRs, including:
1. We need to properly hash ObjectID into SuiAddress, instead of simply filling with 0s.
2. We haven't touched the part around `Authenticator`, which needs to be extended to support different signing schemes
3. We need to decouple `SuiAddress` and `PublicKeyBytes` as they are different concept.