### PR TITLE
[Refactoring] Extract out common `OrderKind` fields

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -227,13 +227,13 @@ impl ClientServerBenchmark {
                     secret,
                 )
             } else {
-                let transfer = Transfer {
-                    sender: *account_addr,
-                    recipient: next_recipient,
+                Order::new_transfer(
+                    next_recipient,
                     object_ref,
-                    gas_payment: gas_object_ref,
-                };
-                Order::new_transfer(transfer, secret)
+                    *account_addr,
+                    gas_object_ref,
+                    secret,
+                )
             };
 
             // Set the next recipient to current
@@ -250,7 +250,7 @@ impl ClientServerBenchmark {
             };
             for i in 0..committee.quorum_threshold() {
                 let (pubx, secx) = keys.get(i).unwrap();
-                let sig = Signature::new(&certificate.order.kind, secx);
+                let sig = Signature::new(&certificate.order.data, secx);
                 certificate.signatures.push((*pubx, sig));
             }
 

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -73,7 +73,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
     // Check log output contains all addresses
     for address in context.config.accounts.iter().map(|info| info.address) {
-        assert!(logs_contain(&&*encode_address_hex(&address)));
+        assert!(logs_contain(&*encode_address_hex(&address)));
     }
 
     Ok(())

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -526,13 +526,13 @@ where
                     object_id: gas_payment,
                 })?;
 
-        let transfer = Transfer {
-            object_ref,
-            sender: self.address,
+        let order = Order::new_transfer(
             recipient,
+            object_ref,
+            self.address,
             gas_payment,
-        };
-        let order = Order::new_transfer(transfer, &*self.secret);
+            &*self.secret,
+        );
         let (certificate, effects) = self.execute_transaction(order).await?;
         self.authorities
             .process_certificate(certificate.clone(), Duration::from_secs(60))

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -1412,15 +1412,12 @@ fn test_transfer_object_error() {
     // Test 5: The client does not allow concurrent transfer;
     let object_id = *objects.next().unwrap();
     // Fabricate a fake pending transfer
-    let transfer = Transfer {
-        sender: sender.address(),
-        recipient: SuiAddress::random_for_testing_only(),
-        object_ref: (object_id, Default::default(), ObjectDigest::new([0; 32])),
-        gas_payment: (gas_object, Default::default(), ObjectDigest::new([0; 32])),
-    };
     sender
-        .lock_pending_order_objects(&Order::new(
-            OrderKind::Transfer(transfer),
+        .lock_pending_order_objects(&Order::new_transfer(
+            SuiAddress::random_for_testing_only(),
+            (object_id, Default::default(), ObjectDigest::new([0; 32])),
+            sender.address(),
+            (gas_object, Default::default(), ObjectDigest::new([0; 32])),
             &get_key_pair().1,
         ))
         .unwrap();
@@ -2242,17 +2239,13 @@ async fn test_transfer_pending_orders() {
 
     // Test 4: Conflicting orders touching same objects
     let object_id = *objects.next().unwrap();
-    // Fabricate a fake pending transfer
-    let transfer = Transfer {
-        sender: sender_state.address(),
-        recipient: SuiAddress::random_for_testing_only(),
-        object_ref: (object_id, Default::default(), ObjectDigest::new([0; 32])),
-        gas_payment: (gas_object, Default::default(), ObjectDigest::new([0; 32])),
-    };
-    // Simulate locking some objects
+    // Fabricate a fake pending transfer and simulate locking some objects
     sender_state
-        .lock_pending_order_objects(&Order::new(
-            OrderKind::Transfer(transfer),
+        .lock_pending_order_objects(&Order::new_transfer(
+            SuiAddress::random_for_testing_only(),
+            (object_id, Default::default(), ObjectDigest::new([0; 32])),
+            sender_state.address(),
+            (gas_object, Default::default(), ObjectDigest::new([0; 32])),
             &get_key_pair().1,
         ))
         .unwrap();

--- a/sui_types/src/gas.rs
+++ b/sui_types/src/gas.rs
@@ -24,9 +24,9 @@ pub const MIN_MOVE: u64 = 10;
 pub const MIN_OBJ_TRANSFER_GAS: u64 = 8;
 
 pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> SuiResult {
-    match &order.kind {
-        OrderKind::Transfer(t) => {
-            debug_assert_eq!(t.gas_payment.0, gas_object.id());
+    debug_assert_eq!(order.gas_payment_object_ref().0, gas_object.id());
+    match &order.data.kind {
+        OrderKind::Transfer(_) => {
             let balance = get_gas_balance(gas_object)?;
             ok_or_gas_error!(
                 balance >= MIN_OBJ_TRANSFER_GAS,
@@ -37,17 +37,17 @@ pub fn check_gas_requirement(order: &Order, gas_object: &Object) -> SuiResult {
             )
         }
         OrderKind::Call(op) => {
-            check_move_gas_requirement(gas_object, op.gas_payment, op.gas_budget)
+            check_move_gas_requirement(gas_object, order.gas_payment_object_ref(), op.gas_budget)
         }
         OrderKind::Publish(op) => {
-            check_move_gas_requirement(gas_object, op.gas_payment, op.gas_budget)
+            check_move_gas_requirement(gas_object, order.gas_payment_object_ref(), op.gas_budget)
         }
     }
 }
 
 pub fn check_move_gas_requirement(
     gas_object: &Object,
-    gas_payment: ObjectRef,
+    gas_payment: &ObjectRef,
     gas_budget: u64,
 ) -> SuiResult {
     debug_assert_eq!(gas_payment.0, gas_object.id());

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -5,6 +5,14 @@ use std::collections::BTreeMap;
 
 use super::*;
 
+fn random_object_ref() -> ObjectRef {
+    (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::new([0; 32]),
+    )
+}
+
 #[test]
 fn test_signed_values() {
     let mut authorities = BTreeMap::new();
@@ -16,22 +24,8 @@ fn test_signed_values() {
     authorities.insert(/* address */ a2, /* voting right */ 0);
     let committee = Committee::new(authorities);
 
-    let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
-        sender: a1,
-        recipient: a2,
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
-    };
-    let order = Order::new_transfer(transfer.clone(), &sec1);
-    let bad_order = Order::new_transfer(transfer, &sec2);
+    let order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec1);
+    let bad_order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec2);
 
     let v = SignedOrder::new(order.clone(), a1, &sec1);
     assert!(v.check(&committee).is_ok());
@@ -57,22 +51,8 @@ fn test_certificates() {
     authorities.insert(/* address */ a2, /* voting right */ 1);
     let committee = Committee::new(authorities);
 
-    let transfer = Transfer {
-        object_ref: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
-        sender: a1,
-        recipient: a2,
-        gas_payment: (
-            ObjectID::random(),
-            SequenceNumber::new(),
-            ObjectDigest::new([0; 32]),
-        ),
-    };
-    let order = Order::new_transfer(transfer.clone(), &sec1);
-    let bad_order = Order::new_transfer(transfer, &sec2);
+    let order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec1);
+    let bad_order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec2);
 
     let v1 = SignedOrder::new(order.clone(), a1, &sec1);
     let v2 = SignedOrder::new(order.clone(), a2, &sec2);


### PR DESCRIPTION
Inside each kind of `OrderKind`, they all share the same two fields: `sender` and `gas_payment`. These should be extracted and put together. Introduce a layer struct called `OrderData` to wrap `kind`, `sender` and `gas_payment`.
This will make it easier down the line when we start to refactor `sender` to Authenticator type.