### PR TITLE
fix update_farm Move method

### DIFF
--- a/sui_programmability/framework/sources/Geniteam.move
+++ b/sui_programmability/framework/sources/Geniteam.move
@@ -194,9 +194,9 @@ module FastX::Geniteam {
         Transfer::transfer(monster, TxContext::get_signer_address(ctx))
     }
 
-    /// Update the attributes of a farm
-    public fun update_farm(self: &mut Farm, level: u64, _ctx: &mut TxContext) {
-        self.level = level;
+    /// Update the attributes of a player's farm
+    public fun update_farm(self: &mut Player, level: u64, _ctx: &mut TxContext) {
+        self.farm.level = level;
     }
 
     /// Add cosmetics to a farm's first slot


### PR DESCRIPTION
what it says - the `update_farm` method isn't usable as-is because the Farm's object ID isn't publicly accessible.

Will update Postman / Geniteam doc with this change once merged