### PR TITLE
Generalize hex encode and decode functions

### DIFF
--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -12,20 +12,14 @@ use sui_network::transport;
 
 #[derive(Serialize, Deserialize)]
 pub struct AccountInfo {
-    #[serde(
-        serialize_with = "address_as_hex",
-        deserialize_with = "address_from_hex"
-    )]
+    #[serde(serialize_with = "bytes_as_hex", deserialize_with = "bytes_from_hex")]
     pub address: SuiAddress,
     pub key_pair: KeyPair,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthorityInfo {
-    #[serde(
-        serialize_with = "address_as_hex",
-        deserialize_with = "address_from_hex"
-    )]
+    #[serde(serialize_with = "bytes_as_hex", deserialize_with = "bytes_from_hex")]
     pub address: SuiAddress,
     pub host: String,
     pub base_port: u16,
@@ -33,10 +27,7 @@ pub struct AuthorityInfo {
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthorityPrivateInfo {
-    #[serde(
-        serialize_with = "address_as_hex",
-        deserialize_with = "address_from_hex"
-    )]
+    #[serde(serialize_with = "bytes_as_hex", deserialize_with = "bytes_from_hex")]
     pub address: SuiAddress,
     pub key_pair: KeyPair,
     pub host: String,

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use structopt::StructOpt;
 use sui_core::authority::{AuthorityState, AuthorityStore};
 use sui_core::authority_server::AuthorityServer;
-use sui_types::base_types::{encode_address_hex, get_key_pair, ObjectID, SequenceNumber};
+use sui_types::base_types::{encode_bytes_hex, get_key_pair, ObjectID, SequenceNumber};
 use sui_types::committee::Committee;
 use sui_types::object::Object;
 use tracing::{error, info};
@@ -97,7 +97,7 @@ async fn genesis(config: &mut NetworkConfig) -> Result<(), anyhow::Error> {
             key_pair,
             host: "127.0.0.1".to_string(),
             port: port_allocator.next_port().expect("No free ports"),
-            db_path: authorities_db_path.join(encode_address_hex(&address)),
+            db_path: authorities_db_path.join(encode_bytes_hex(&address)),
         };
         authority_info.push(AuthorityInfo {
             address,

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -3,7 +3,7 @@ use std::fs::read_dir;
 use std::time::Duration;
 use sui::config::{AccountInfo, NetworkConfig, WalletConfig};
 use sui::wallet_commands::{WalletCommands, WalletContext};
-use sui_types::base_types::{encode_address_hex, get_key_pair};
+use sui_types::base_types::{encode_bytes_hex, get_key_pair};
 use tokio::task;
 use tracing_test::traced_test;
 
@@ -73,7 +73,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
     // Check log output contains all addresses
     for address in context.config.accounts.iter().map(|info| info.address) {
-        assert!(logs_contain(&*encode_address_hex(&address)));
+        assert!(logs_contain(&*encode_bytes_hex(&address)));
     }
 
     Ok(())

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -5,7 +5,7 @@ use sui_core::authority_client::AuthorityClient;
 use sui_core::client::{Client, ClientAddressManager, ClientState};
 use sui_network::network::NetworkClient;
 use sui_types::base_types::{
-    decode_address_hex, encode_address_hex, get_key_pair, AuthorityName, ObjectID, PublicKeyBytes,
+    decode_bytes_hex, encode_bytes_hex, get_key_pair, AuthorityName, ObjectID, PublicKeyBytes,
     SuiAddress,
 };
 use sui_types::committee::Committee;
@@ -36,7 +36,7 @@ pub enum WalletCommands {
     #[structopt(name = "object")]
     Object {
         /// Owner address
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         owner: PublicKeyBytes,
 
         /// Object ID of the object to fetch
@@ -52,7 +52,7 @@ pub enum WalletCommands {
     #[structopt(name = "publish")]
     Publish {
         /// Sender address
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         sender: PublicKeyBytes,
 
         /// Path to directory containing a Move package
@@ -72,7 +72,7 @@ pub enum WalletCommands {
     #[structopt(name = "call")]
     Call {
         /// Sender address
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         sender: PublicKeyBytes,
         /// Object ID of the package, which contains the module
         #[structopt(long)]
@@ -107,11 +107,11 @@ pub enum WalletCommands {
     #[structopt(name = "transfer")]
     Transfer {
         /// Sender address
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         from: PublicKeyBytes,
 
         /// Recipient address
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         to: PublicKeyBytes,
 
         /// Object to transfer, in 20 bytes Hex string
@@ -125,7 +125,7 @@ pub enum WalletCommands {
     /// Synchronize client state with authorities.
     #[structopt(name = "sync")]
     SyncClientState {
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         address: PublicKeyBytes,
     },
 
@@ -141,7 +141,7 @@ pub enum WalletCommands {
     #[structopt(name = "objects")]
     Objects {
         /// Address of the account
-        #[structopt(long, parse(try_from_str = decode_address_hex))]
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
         address: PublicKeyBytes,
     },
 }
@@ -253,7 +253,7 @@ impl WalletCommands {
                     context.address_manager.get_managed_address_states().len()
                 );
                 for address in context.address_manager.get_managed_address_states().keys() {
-                    info!("{}", encode_address_hex(address));
+                    info!("{}", encode_bytes_hex(address));
                 }
             }
 
@@ -281,7 +281,7 @@ impl WalletCommands {
                 context.get_or_create_client_state(&address)?;
                 info!(
                     "Created new keypair for address : {}",
-                    encode_address_hex(&address)
+                    encode_bytes_hex(&address)
                 );
             }
         }


### PR DESCRIPTION
The hex encode and decode functions are written specifically for `SuiAddress`. But they can be more generic. Specifically, we can convert something to hex as long as it can be converted to a slice; and similarly we can convert something from hex as long as it can be converted to from a vector.