### PR TITLE
Decouple `SuiAddress` and `PublicKeyBytes`

### DIFF
--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -20,15 +20,13 @@ pub struct AccountInfo {
 #[derive(Serialize, Deserialize)]
 pub struct AuthorityInfo {
     #[serde(serialize_with = "bytes_as_hex", deserialize_with = "bytes_from_hex")]
-    pub address: SuiAddress,
+    pub name: AuthorityName,
     pub host: String,
     pub base_port: u16,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthorityPrivateInfo {
-    #[serde(serialize_with = "bytes_as_hex", deserialize_with = "bytes_from_hex")]
-    pub address: SuiAddress,
     pub key_pair: KeyPair,
     pub host: String,
     pub port: u16,

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -52,7 +52,7 @@ async fn start_network(config: &NetworkConfig) -> Result<(), anyhow::Error> {
         config
             .authorities
             .iter()
-            .map(|info| (info.address, DEFAULT_WEIGHT))
+            .map(|info| (info.key_pair.public(), DEFAULT_WEIGHT))
             .collect(),
     );
 
@@ -91,20 +91,19 @@ async fn genesis(config: &mut NetworkConfig) -> Result<(), anyhow::Error> {
     info!("Creating new authorities...");
     let authorities_db_path = working_dir.join("authorities_db");
     for _ in 0..4 {
-        let (address, key_pair) = get_key_pair();
+        let (pub_key, key_pair) = get_key_pair();
         let info = AuthorityPrivateInfo {
-            address,
             key_pair,
             host: "127.0.0.1".to_string(),
             port: port_allocator.next_port().expect("No free ports"),
-            db_path: authorities_db_path.join(encode_bytes_hex(&address)),
+            db_path: authorities_db_path.join(encode_bytes_hex(&pub_key)),
         };
         authority_info.push(AuthorityInfo {
-            address,
+            name: pub_key,
             host: info.host.clone(),
             base_port: info.port,
         });
-        authorities.insert(info.address, 1);
+        authorities.insert(pub_key, 1);
         config.authorities.push(info);
     }
 
@@ -115,7 +114,8 @@ async fn genesis(config: &mut NetworkConfig) -> Result<(), anyhow::Error> {
 
     info!("Creating test objects...");
     for _ in 0..5 {
-        let (address, key_pair) = get_key_pair();
+        let (pub_key, key_pair) = get_key_pair();
+        let address = pub_key.into();
         new_addresses.push(AccountInfo { address, key_pair });
         for _ in 0..5 {
             let new_object = Object::with_id_owner_gas_coin_object_for_testing(
@@ -162,7 +162,7 @@ async fn make_server(
 
     let state = AuthorityState::new_with_genesis_modules(
         committee.clone(),
-        authority.address,
+        authority.key_pair.public(),
         Box::pin(authority.key_pair.copy()),
         store,
     )

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -62,8 +62,11 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
     // Add 3 accounts
     for _ in 0..3 {
         wallet_config.accounts.push({
-            let (address, key_pair) = get_key_pair();
-            AccountInfo { address, key_pair }
+            let (pub_key, key_pair) = get_key_pair();
+            AccountInfo {
+                address: pub_key.into(),
+                key_pair,
+            }
         });
     }
     let mut context = WalletContext::new(wallet_config)?;

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -124,7 +124,7 @@ impl AuthorityState {
                 // Check the object owner is either the transaction sender, or
                 // another mutable object in the input.
                 fp_ensure!(
-                    order.sender() == &object.owner
+                    order.sender_address() == object.owner
                         || mutable_object_addresses.contains(&object.owner),
                     SuiError::IncorrectSigner
                 );
@@ -258,7 +258,7 @@ impl AuthorityState {
             .collect();
 
         // Insert into the certificates map
-        let mut tx_ctx = TxContext::new(order.sender(), transaction_digest);
+        let mut tx_ctx = TxContext::new(&order.sender_address(), transaction_digest);
 
         let gas_object_id = order.gas_payment_object_ref().0;
         let (mut temporary_store, status) = self.execute_order(order, inputs, &mut tx_ctx)?;
@@ -291,7 +291,7 @@ impl AuthorityState {
         // unwraps here are safe because we built `inputs`
         let mut gas_object = inputs.pop().unwrap();
 
-        let sender = *order.sender();
+        let sender = order.sender_address();
         let status = match order.data.kind {
             OrderKind::Transfer(t) => AuthorityState::transfer(
                 &mut temporary_store,

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -53,11 +53,12 @@ impl<A> ClientAddressManager<A> {
     /// Get (if exists) or create a new managed address state
     pub fn get_or_create_state_mut(
         &mut self,
-        address: SuiAddress,
+        pub_key: PublicKeyBytes,
         secret: StableSyncSigner,
         committee: Committee,
         authority_clients: BTreeMap<AuthorityName, A>,
     ) -> Result<&mut ClientState<A>, SuiError> {
+        let address = pub_key.into();
         if let std::collections::btree_map::Entry::Vacant(e) = self.address_states.entry(address) {
             // Load the records if available
             let single_store = if self.store.is_managed_address(address)? {
@@ -67,7 +68,7 @@ impl<A> ClientAddressManager<A> {
                 self.store.manage_new_address(address)
             }?;
             e.insert(ClientState::new_for_manager(
-                address,
+                pub_key,
                 secret,
                 committee,
                 authority_clients,
@@ -79,7 +80,7 @@ impl<A> ClientAddressManager<A> {
     }
 
     /// Get all the states
-    pub fn get_managed_address_states(&self) -> &BTreeMap<PublicKeyBytes, ClientState<A>> {
+    pub fn get_managed_address_states(&self) -> &BTreeMap<SuiAddress, ClientState<A>> {
         &self.address_states
     }
 }
@@ -87,6 +88,8 @@ impl<A> ClientAddressManager<A> {
 pub struct ClientState<AuthorityAPI> {
     /// Our Sui address.
     address: SuiAddress,
+    // TODO: We will need to embed pub_key into secret.
+    pub_key: PublicKeyBytes,
     /// Our signature key.
     secret: StableSyncSigner,
     /// Authority entry point.
@@ -151,13 +154,14 @@ impl<A> ClientState<A> {
     #[cfg(test)]
     pub fn new(
         path: PathBuf,
-        address: SuiAddress,
+        pub_key: PublicKeyBytes,
         secret: StableSyncSigner,
         committee: Committee,
         authority_clients: BTreeMap<AuthorityName, A>,
     ) -> Result<Self, SuiError> {
         Ok(ClientState {
-            address,
+            address: pub_key.into(),
+            pub_key,
             secret,
             authorities: AuthorityAggregator::new(committee, authority_clients),
             store: client_store::ClientSingleAddressStore::new(path),
@@ -165,14 +169,15 @@ impl<A> ClientState<A> {
     }
 
     pub fn new_for_manager(
-        address: SuiAddress,
+        pub_key: PublicKeyBytes,
         secret: StableSyncSigner,
         committee: Committee,
         authority_clients: BTreeMap<AuthorityName, A>,
         store: client_store::ClientSingleAddressStore,
     ) -> Result<Self, SuiError> {
         Ok(ClientState {
-            address,
+            address: pub_key.into(),
+            pub_key,
             secret,
             authorities: AuthorityAggregator::new(committee, authority_clients),
             store,
@@ -181,6 +186,10 @@ impl<A> ClientState<A> {
 
     pub fn address(&self) -> SuiAddress {
         self.address
+    }
+
+    pub fn pub_key(&self) -> PublicKeyBytes {
+        self.pub_key
     }
 
     pub fn next_sequence_number(&self, object_id: &ObjectID) -> Result<SequenceNumber, SuiError> {
@@ -529,7 +538,7 @@ where
         let order = Order::new_transfer(
             recipient,
             object_ref,
-            self.address,
+            self.pub_key,
             gas_payment,
             &*self.secret,
         );
@@ -614,7 +623,7 @@ where
         gas_budget: u64,
     ) -> Result<(CertifiedOrder, OrderEffects), anyhow::Error> {
         let move_call_order = Order::new_move_call(
-            self.address,
+            self.pub_key,
             package_object_ref,
             module,
             function,
@@ -637,7 +646,7 @@ where
         // Try to compile the package at the given path
         let compiled_modules = build_move_package_to_bytes(Path::new(&package_source_files_path))?;
         let move_publish_order = Order::new_module(
-            self.address,
+            self.pub_key,
             gas_object_ref,
             compiled_modules,
             gas_budget,

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -14,11 +14,11 @@ use sui_types::{
 pub struct SafeClient<C> {
     authority_client: C,
     committee: Committee,
-    address: SuiAddress,
+    address: PublicKeyBytes,
 }
 
 impl<C> SafeClient<C> {
-    pub fn new(authority_client: C, committee: Committee, address: SuiAddress) -> Self {
+    pub fn new(authority_client: C, committee: Committee, address: PublicKeyBytes) -> Self {
         Self {
             authority_client,
             committee,

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -58,8 +58,11 @@ async fn test_handle_transfer_order_bad_signature() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (sender.into(), object_id),
+        (sender.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -105,7 +108,7 @@ async fn test_handle_transfer_order_bad_signature() {
 
 #[tokio::test]
 async fn test_handle_transfer_order_unknown_sender() {
-    let (sender, _) = get_key_pair();
+    let sender = get_new_address();
     let (unknown_address, unknown_key) = get_key_pair();
     let object_id: ObjectID = ObjectID::random();
     let gas_object_id = ObjectID::random();
@@ -188,8 +191,11 @@ async fn test_handle_transfer_order_ok() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (sender.into(), object_id),
+        (sender.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -266,7 +272,7 @@ async fn test_handle_transfer_zero_balance() {
     let (sender, sender_key) = get_key_pair();
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
-    let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+    let authority_state = init_state_with_ids(vec![(sender.into(), object_id)]).await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -275,8 +281,12 @@ async fn test_handle_transfer_zero_balance() {
 
     // Create a gas object with 0 balance.
     let gas_object_id = ObjectID::random();
-    let gas_object =
-        Object::with_id_owner_gas_for_testing(gas_object_id, SequenceNumber::new(), sender, 0);
+    let gas_object = Object::with_id_owner_gas_for_testing(
+        gas_object_id,
+        SequenceNumber::new(),
+        sender.into(),
+        0,
+    );
     authority_state
         .init_order_lock((gas_object_id, 0.into(), gas_object.digest()))
         .await;
@@ -351,7 +361,8 @@ fn check_gas_object(
 async fn test_publish_dependent_module_ok() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
-    let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
+    let gas_payment_object =
+        Object::with_id_owner_for_testing(gas_payment_object_id, sender.into());
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
     // create a genesis state that contains the gas object and genesis modules
     let (genesis_module_objects, _) = genesis::clone_genesis_data();
@@ -369,13 +380,13 @@ async fn test_publish_dependent_module_ok() {
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
 
     let order = Order::new_module(
-        sender,
+        sender_key.public(),
         gas_payment_object_ref,
         vec![dependent_module_bytes],
         MAX_GAS,
         &sender_key,
     );
-    let dependent_module_id = TxContext::new(&sender, order.digest()).fresh_id();
+    let dependent_module_id = TxContext::new(&sender.into(), order.digest()).fresh_id();
 
     // Object does not exist
     assert!(authority
@@ -397,8 +408,12 @@ async fn test_publish_module_no_dependencies_ok() {
     let gas_payment_object_id = ObjectID::random();
     let gas_balance = MAX_GAS;
     let gas_seq = SequenceNumber::new();
-    let gas_payment_object =
-        Object::with_id_owner_gas_for_testing(gas_payment_object_id, gas_seq, sender, gas_balance);
+    let gas_payment_object = Object::with_id_owner_gas_for_testing(
+        gas_payment_object_id,
+        gas_seq,
+        sender.into(),
+        gas_balance,
+    );
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
 
@@ -414,7 +429,7 @@ async fn test_publish_module_no_dependencies_ok() {
         MAX_GAS,
         &sender_key,
     );
-    let _module_object_id = TxContext::new(&sender, order.digest()).fresh_id();
+    let _module_object_id = TxContext::new(&sender.into(), order.digest()).fresh_id();
     let response = send_and_confirm_order(&authority, order).await.unwrap();
     response.signed_effects.unwrap().effects.status.unwrap();
 
@@ -438,7 +453,8 @@ async fn test_publish_module_no_dependencies_ok() {
 async fn test_publish_non_existing_dependent_module() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
-    let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
+    let gas_payment_object =
+        Object::with_id_owner_for_testing(gas_payment_object_id, sender.into());
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
     // create a genesis state that contains the gas object and genesis modules
     let (genesis_module_objects, _) = genesis::clone_genesis_data();
@@ -499,7 +515,7 @@ async fn test_publish_module_insufficient_gas() {
     let gas_payment_object = Object::with_id_owner_gas_for_testing(
         gas_payment_object_id,
         SequenceNumber::new(),
-        sender,
+        sender.into(),
         gas_balance,
     );
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
@@ -526,7 +542,8 @@ async fn test_publish_module_insufficient_gas() {
 async fn test_handle_move_order() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
-    let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
+    let gas_payment_object =
+        Object::with_id_owner_for_testing(gas_payment_object_id, sender.into());
     let gas_seq = gas_payment_object.version();
     let authority_state = init_state_with_objects(vec![gas_payment_object]).await;
 
@@ -550,7 +567,7 @@ async fn test_handle_move_order() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(created_obj.owner, sender);
+    assert_eq!(created_obj.owner, sender.into());
     assert_eq!(created_obj.id(), created_object_id);
     assert_eq!(created_obj.version(), OBJECT_START_VERSION);
 
@@ -576,7 +593,8 @@ async fn test_handle_move_order() {
 async fn test_handle_move_order_insufficient_budget() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
-    let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
+    let gas_payment_object =
+        Object::with_id_owner_for_testing(gas_payment_object_id, sender.into());
     let gas_payment_object_ref = gas_payment_object.to_object_reference();
     // find the function Object::create and call it to create a new object
     let (genesis_package_objects, _) = genesis::clone_genesis_data();
@@ -616,8 +634,11 @@ async fn test_handle_transfer_order_double_spend() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (sender.into(), object_id),
+        (sender.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -688,8 +709,11 @@ async fn test_handle_confirmation_order_bad_sequence_number() {
     let object_id: ObjectID = ObjectID::random();
     let recipient = dbg_addr(2);
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (sender.into(), object_id),
+        (sender.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -760,8 +784,11 @@ async fn test_handle_confirmation_order_receiver_equal_sender() {
     let (address, key) = get_key_pair();
     let object_id: ObjectID = ObjectID::random();
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(address, object_id), (address, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (address.into(), object_id),
+        (address.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -776,7 +803,7 @@ async fn test_handle_confirmation_order_receiver_equal_sender() {
     let certified_transfer_order = init_certified_transfer_order(
         address,
         &key,
-        address,
+        address.into(),
         object.to_object_reference(),
         gas_object.to_object_reference(),
         &authority_state,
@@ -805,7 +832,7 @@ async fn test_handle_confirmation_order_gas() {
         let (sender, sender_key) = get_key_pair();
         let recipient = dbg_addr(2);
         let object_id = ObjectID::random();
-        let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+        let authority_state = init_state_with_ids(vec![(sender.into(), object_id)]).await;
         let object = authority_state
             .get_object(&object_id)
             .await
@@ -817,7 +844,7 @@ async fn test_handle_confirmation_order_gas() {
         let gas_object = Object::with_id_owner_gas_for_testing(
             gas_object_id,
             SequenceNumber::new(),
-            sender,
+            sender.into(),
             gas,
         );
         authority_state
@@ -858,8 +885,11 @@ async fn test_handle_confirmation_order_ok() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (sender.into(), object_id),
+        (sender.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -945,8 +975,11 @@ async fn test_handle_confirmation_order_idempotent() {
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
     let gas_object_id = ObjectID::random();
-    let authority_state =
-        init_state_with_ids(vec![(sender, object_id), (sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![
+        (sender.into(), object_id),
+        (sender.into(), gas_object_id),
+    ])
+    .await;
     let object = authority_state
         .get_object(&object_id)
         .await
@@ -1003,7 +1036,7 @@ async fn test_handle_confirmation_order_idempotent() {
 async fn test_move_call_mutable_object_not_mutated() {
     let (sender, sender_key) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![(sender.into(), gas_object_id)]).await;
 
     let effects = create_move_object(&authority_state, &gas_object_id, &sender, &sender_key)
         .await
@@ -1059,7 +1092,7 @@ async fn test_move_call_mutable_object_not_mutated() {
 async fn test_move_call_delete() {
     let (sender, sender_key) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![(sender.into(), gas_object_id)]).await;
 
     let effects = create_move_object(&authority_state, &gas_object_id, &sender, &sender_key)
         .await
@@ -1112,7 +1145,7 @@ async fn test_move_call_delete() {
 async fn test_get_latest_parent_entry() {
     let (sender, sender_key) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    let authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
+    let authority_state = init_state_with_ids(vec![(sender.into(), gas_object_id)]).await;
 
     let effects = create_move_object(&authority_state, &gas_object_id, &sender, &sender_key)
         .await
@@ -1306,11 +1339,11 @@ async fn test_hero() {
         90, 106, 17, 10, 123, 200, 40, 18, 34, 173, 240, 91, 213, 72, 183, 249, 213, 210, 39, 181,
         105, 254, 59, 163,
     ]);
-    let admin_gas_object = Object::with_id_owner_for_testing(ObjectID::random(), admin);
+    let admin_gas_object = Object::with_id_owner_for_testing(ObjectID::random(), admin.into());
     let admin_gas_object_ref = admin_gas_object.to_object_reference();
 
     let (player, player_key) = get_key_pair();
-    let player_gas_object = Object::with_id_owner_for_testing(ObjectID::random(), player);
+    let player_gas_object = Object::with_id_owner_for_testing(ObjectID::random(), player.into());
     let player_gas_object_ref = player_gas_object.to_object_reference();
     let authority = init_state_with_objects(vec![admin_gas_object, player_gas_object]).await;
 
@@ -1401,7 +1434,7 @@ async fn test_hero() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     assert_eq!(effects.mutated.len(), 1); // cap
     let (coin, coin_owner) = effects.created[0];
-    assert_eq!(coin_owner, player);
+    assert_eq!(coin_owner, player.into());
 
     // 5. Purchase a sword using 500 coin. This sword will have magic = 4, sword_strength = 5.
     let effects = call_move(
@@ -1421,9 +1454,9 @@ async fn test_hero() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     assert_eq!(effects.mutated.len(), 1); // coin
     let (hero, hero_owner) = effects.created[0];
-    assert_eq!(hero_owner, player);
+    assert_eq!(hero_owner, player.into());
     // The payment goes to the admin.
-    assert_eq!(effects.mutated[0].1, admin);
+    assert_eq!(effects.mutated[0].1, admin.into());
 
     // 6. Verify the hero is what we exepct with strength 5.
     let effects = call_move(
@@ -1464,7 +1497,7 @@ async fn test_hero() {
     .unwrap();
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
     let (boar, boar_owner) = effects.created[0];
-    assert_eq!(boar_owner, player);
+    assert_eq!(boar_owner, player.into());
 
     // 8. Slay the boar!
     let effects = call_move(
@@ -1494,7 +1527,7 @@ async fn test_object_owning_another_object() {
     let (sender2, sender2_key) = get_key_pair();
     let gas1 = ObjectID::random();
     let gas2 = ObjectID::random();
-    let authority = init_state_with_ids(vec![(sender1, gas1), (sender2, gas2)]).await;
+    let authority = init_state_with_ids(vec![(sender1.into(), gas1), (sender2.into(), gas2)]).await;
 
     // Created 3 objects, all owned by sender1.
     let effects = create_move_object(&authority, &gas1, &sender1, &sender1_key)
@@ -1586,7 +1619,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 1);
     assert_eq!(
         authority.get_object(&obj2).await.unwrap().unwrap().owner,
-        sender2
+        sender2.into()
     );
 
     // Sender 1 try to transfer obj1 to obj2 again.
@@ -1696,7 +1729,7 @@ async fn init_state_with_object_id(address: SuiAddress, object: ObjectID) -> Aut
 
 #[cfg(test)]
 fn init_transfer_order(
-    sender: SuiAddress,
+    sender: PublicKeyBytes,
     secret: &KeyPair,
     recipient: SuiAddress,
     object_ref: ObjectRef,
@@ -1707,7 +1740,7 @@ fn init_transfer_order(
 
 #[cfg(test)]
 fn init_certified_transfer_order(
-    sender: SuiAddress,
+    sender: PublicKeyBytes,
     secret: &KeyPair,
     recipient: SuiAddress,
     object_ref: ObjectRef,

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -134,7 +134,7 @@ async fn extract_cert(
 
 #[cfg(test)]
 fn order_create(
-    src: SuiAddress,
+    src: PublicKeyBytes,
     secret: &dyn signature::Signer<ed25519_dalek::Signature>,
     dest: SuiAddress,
     value: u64,
@@ -163,7 +163,7 @@ fn order_create(
 
 #[cfg(test)]
 fn order_transfer(
-    src: SuiAddress,
+    src: PublicKeyBytes,
     secret: &dyn signature::Signer<ed25519_dalek::Signature>,
     dest: SuiAddress,
     object_ref: ObjectRef,
@@ -188,7 +188,7 @@ fn order_transfer(
 
 #[cfg(test)]
 fn order_set(
-    src: SuiAddress,
+    src: PublicKeyBytes,
     secret: &dyn signature::Signer<ed25519_dalek::Signature>,
     object_ref: ObjectRef,
     value: u64,
@@ -213,7 +213,7 @@ fn order_set(
 
 #[cfg(test)]
 fn order_delete(
-    src: SuiAddress,
+    src: PublicKeyBytes,
     secret: &dyn signature::Signer<ed25519_dalek::Signature>,
     object_ref: ObjectRef,
     framework_obj_ref: ObjectRef,
@@ -439,7 +439,7 @@ async fn init_local_client_state_with_bad_authority(
 #[test]
 fn test_initiating_valid_transfer() {
     let rt = Runtime::new().unwrap();
-    let (recipient, _) = get_key_pair();
+    let recipient = get_new_address();
     let object_id_1 = ObjectID::random();
     let object_id_2 = ObjectID::random();
     let gas_object = ObjectID::random();
@@ -492,7 +492,7 @@ fn test_initiating_valid_transfer() {
 #[test]
 fn test_initiating_valid_transfer_despite_bad_authority() {
     let rt = Runtime::new().unwrap();
-    let (recipient, _) = get_key_pair();
+    let recipient = get_new_address();
     let object_id = ObjectID::random();
     let gas_object = ObjectID::random();
     let authority_objects = vec![
@@ -531,7 +531,7 @@ fn test_initiating_valid_transfer_despite_bad_authority() {
 #[test]
 fn test_initiating_transfer_low_funds() {
     let rt = Runtime::new().unwrap();
-    let (recipient, _) = get_key_pair();
+    let recipient = get_new_address();
     let object_id_1 = ObjectID::random();
     let object_id_2 = ObjectID::random();
     let gas_object = ObjectID::random();
@@ -1337,7 +1337,7 @@ async fn test_module_publish_naughty_path() {
 #[test]
 fn test_transfer_object_error() {
     let rt = Runtime::new().unwrap();
-    let (recipient, _) = get_key_pair();
+    let recipient = get_new_address();
 
     let objects: Vec<ObjectID> = (0..10).map(|_| ObjectID::random()).collect();
     let gas_object = ObjectID::random();
@@ -1416,7 +1416,7 @@ fn test_transfer_object_error() {
         .lock_pending_order_objects(&Order::new_transfer(
             SuiAddress::random_for_testing_only(),
             (object_id, Default::default(), ObjectDigest::new([0; 32])),
-            sender.address(),
+            sender.pub_key(),
             (gas_object, Default::default(), ObjectDigest::new([0; 32])),
             &get_key_pair().1,
         ))
@@ -1795,7 +1795,7 @@ async fn test_get_all_owned_objects() {
     // Make a schedule of transactions
     let gas_ref_1 = get_latest_ref(&auth_vec[0], gas_object1).await;
     let create1 = order_create(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         client1.address(),
         100,
@@ -1844,7 +1844,7 @@ async fn test_get_all_owned_objects() {
     // Make a delete order
     let gas_ref_del = get_latest_ref(&auth_vec[0], gas_object1).await;
     let delete1 = order_delete(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         created_ref,
         framework_obj_ref,
@@ -1906,7 +1906,7 @@ async fn test_sync_all_owned_objects() {
     // Make a schedule of transactions
     let gas_ref_1 = get_latest_ref(&auth_vec[0], gas_object1).await;
     let create1 = order_create(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         client1.address(),
         100,
@@ -1916,7 +1916,7 @@ async fn test_sync_all_owned_objects() {
 
     let gas_ref_2 = get_latest_ref(&auth_vec[0], gas_object2).await;
     let create2 = order_create(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         client1.address(),
         101,
@@ -1963,7 +1963,7 @@ async fn test_sync_all_owned_objects() {
     // Make a delete order
     let gas_ref_del = get_latest_ref(&auth_vec[0], gas_object1).await;
     let delete1 = order_delete(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         new_ref_1,
         framework_obj_ref,
@@ -1973,7 +1973,7 @@ async fn test_sync_all_owned_objects() {
     // Make a transfer order
     let gas_ref_trans = get_latest_ref(&auth_vec[0], gas_object2).await;
     let transfer1 = order_transfer(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         client2.address(),
         new_ref_2,
@@ -2040,7 +2040,7 @@ async fn test_process_order() {
     // Make a schedule of transactions
     let gas_ref_1 = get_latest_ref(&auth_vec[0], gas_object1).await;
     let create1 = order_create(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         client1.address(),
         100,
@@ -2061,7 +2061,7 @@ async fn test_process_order() {
     // Make a schedule of transactions
     let gas_ref_set = get_latest_ref(&auth_vec[0], gas_object1).await;
     let create2 = order_set(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         new_ref_1,
         100,
@@ -2105,7 +2105,7 @@ async fn test_process_certificate() {
     // Make a schedule of transactions
     let gas_ref_1 = get_latest_ref(&auth_vec[0], gas_object1).await;
     let create1 = order_create(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         client1.address(),
         100,
@@ -2132,7 +2132,7 @@ async fn test_process_certificate() {
     // Make a schedule of transactions
     let gas_ref_set = get_latest_ref(&auth_vec[0], gas_object1).await;
     let create2 = order_set(
-        client1.address(),
+        client1.pub_key(),
         client1.secret(),
         new_ref_1,
         100,
@@ -2244,7 +2244,7 @@ async fn test_transfer_pending_orders() {
         .lock_pending_order_objects(&Order::new_transfer(
             SuiAddress::random_for_testing_only(),
             (object_id, Default::default(), ObjectDigest::new([0; 32])),
-            sender_state.address(),
+            sender_state.pub_key(),
             (gas_object, Default::default(), ObjectDigest::new([0; 32])),
             &get_key_pair().1,
         ))

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -486,7 +486,7 @@ fn process_successful_execution<
             .expect("Safe because event_type is derived from an EventType enum")
         {
             EventType::TransferToAddress => handle_transfer(
-                SuiAddress::try_from(recipient.borrow()).unwrap(),
+                SuiAddress::try_from(recipient.as_slice()).unwrap(),
                 type_,
                 event_bytes,
                 false, /* should_freeze */
@@ -497,7 +497,7 @@ fn process_successful_execution<
                 &mut object_owner_map,
             ),
             EventType::TransferToAddressAndFreeze => handle_transfer(
-                SuiAddress::try_from(recipient.borrow()).unwrap(),
+                SuiAddress::try_from(recipient.as_slice()).unwrap(),
                 type_,
                 event_bytes,
                 true, /* should_freeze */

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -203,8 +203,8 @@ fn call(
 /// Exercise test functions that create, transfer, read, update, and delete objects
 #[test]
 fn test_object_basics() {
-    let addr1 = base_types::get_key_pair().0;
-    let addr2 = base_types::get_key_pair().0;
+    let addr1 = base_types::get_new_address();
+    let addr2 = base_types::get_new_address();
 
     let (genesis_objects, native_functions) = genesis::clone_genesis_data();
     let mut storage = InMemoryStorage::new(genesis_objects);
@@ -542,8 +542,8 @@ fn test_publish_module_insufficient_gas() {
 
 #[test]
 fn test_transfer_and_freeze() {
-    let addr1 = base_types::get_key_pair().0;
-    let addr2 = base_types::get_key_pair().0;
+    let addr1 = base_types::get_new_address();
+    let addr2 = base_types::get_new_address();
 
     let (genesis_objects, native_functions) = genesis::clone_genesis_data();
     let mut storage = InMemoryStorage::new(genesis_objects);
@@ -971,7 +971,7 @@ fn test_simple_call() {
     // call published module function
     let obj_val = 42u64;
 
-    let addr = base_types::get_key_pair().0;
+    let addr = base_types::get_new_address();
     let pure_args = vec![
         obj_val.to_le_bytes().to_vec(),
         bcs::to_bytes(&addr.to_vec()).unwrap(),

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -108,6 +108,8 @@ pub enum SuiError {
     InvalidCrossShardUpdate,
     #[error("Invalid authenticator")]
     InvalidAuthenticator,
+    #[error("Invalid address")]
+    InvalidAddress,
     #[error("Invalid transaction digest.")]
     InvalidTransactionDigest,
     #[error(

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -24,8 +24,20 @@ fn test_signed_values() {
     authorities.insert(/* address */ a2, /* voting right */ 0);
     let committee = Committee::new(authorities);
 
-    let order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec1);
-    let bad_order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec2);
+    let order = Order::new_transfer(
+        a2.into(),
+        random_object_ref(),
+        a1,
+        random_object_ref(),
+        &sec1,
+    );
+    let bad_order = Order::new_transfer(
+        a2.into(),
+        random_object_ref(),
+        a1,
+        random_object_ref(),
+        &sec2,
+    );
 
     let v = SignedOrder::new(order.clone(), a1, &sec1);
     assert!(v.check(&committee).is_ok());
@@ -51,8 +63,20 @@ fn test_certificates() {
     authorities.insert(/* address */ a2, /* voting right */ 1);
     let committee = Committee::new(authorities);
 
-    let order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec1);
-    let bad_order = Order::new_transfer(a2, random_object_ref(), a1, random_object_ref(), &sec2);
+    let order = Order::new_transfer(
+        a2.into(),
+        random_object_ref(),
+        a1,
+        random_object_ref(),
+        &sec1,
+    );
+    let bad_order = Order::new_transfer(
+        a2.into(),
+        random_object_ref(),
+        a1,
+        random_object_ref(),
+        &sec2,
+    );
 
     let v1 = SignedOrder::new(order.clone(), a1, &sec1);
     let v2 = SignedOrder::new(order.clone(), a2, &sec2);


### PR DESCRIPTION
This is the next step for #318.
Currently we are using `SuiAddress` and `PublicKeyBytes` interchangeably. But they are different concept. Most of the time we should only be dealing with `SuiAddress`, which is a hash of `PublicKeyBytes` (or a hash of `ObjectID` when we represent object owners).
There should only be two places where `PublicKeyBytes` are used:
1. Signer/Signature: public key will be needed for signing and signature checking. And eventually the use of any public key should be hidden inside Signer/Signature so no outside code should even refer to it.
2. Authority name will be defined using `PublicKeyBytes`. There is no reason to use `SuiAddress` for Authority name. In the future we could consider supporting different schemas for authority as well but for now we will stick with what we have.

This PR does the following:
Base Types:
1. Created a new type `SuiAddress`, which is similar to `PublicKeyBytes` in many ways, but different.
2. Removed `Authenticator`. We no longer need this.

Authority:
1. `AuthorityInfo` struct should contain `AuthorityName`, instead of `SuiAddress`
2. `AuthorityPrivateInfo` doesn't need `address` field. 

Client:
1. `ClientState` now has a separate `address` field and `pub_key` field. This is a temporary state. Once we have a version of `StableSyncSigner` that can expose public key, we will remove the `pub_key` field.
2. `SafeClient`'s address needs to be `PublicKeyBytes`, instead of `SuiAddress`.

All over the code base:
Change the use from `PublicKeyBytes` to `SuiAddress` as much as I can (except in Authority config and cases where I need it for signing/validating)