### PR TITLE
OrderEffects.mutated should include gas_object

### DIFF
--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -129,8 +129,7 @@ impl AuthorityTemporaryStore {
             mutated: self
                 .written
                 .iter()
-                // Exclude gas_object from the mutated list.
-                .filter(|(id, _)| *id != gas_object_id && self.objects.contains_key(*id))
+                .filter(|(id, _)| self.objects.contains_key(*id))
                 .map(|(_, object)| (object.to_object_reference(), object.owner))
                 .collect(),
             deleted: self

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -421,7 +421,7 @@ where
 
         let mut objs_to_download = Vec::new();
 
-        for &(object_ref, owner) in effects.all_mutated() {
+        for &(object_ref, owner) in effects.mutated_and_created() {
             let (object_id, seq, _) = object_ref;
             let old_seq = self
                 .store

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -809,10 +809,10 @@ async fn test_move_calls_object_create() {
     ));
     // Nothing should be deleted during a creation
     assert!(order_effects.deleted.is_empty());
-    // A new object is created.
+    // A new object is created. Gas is mutated.
     assert_eq!(
         (order_effects.created.len(), order_effects.mutated.len()),
-        (1, 0)
+        (1, 1)
     );
     assert_eq!(order_effects.gas_object.0 .0, gas_object_id);
 }
@@ -890,11 +890,11 @@ async fn test_move_calls_object_transfer() {
     // Nothing should be deleted during a transfer
     assert!(order_effects.deleted.is_empty());
     // The object being transfered will be in mutated.
-    assert_eq!(order_effects.mutated.len(), 1);
+    assert_eq!(order_effects.mutated.len(), 2);
     // Confirm the items
     assert_eq!(order_effects.gas_object.0 .0, gas_object_id);
 
-    let (transferred_obj_ref, _) = order_effects.mutated[0];
+    let (transferred_obj_ref, _) = *order_effects.mutated_excluding_gas().next().unwrap();
     assert_ne!(gas_object_ref, transferred_obj_ref);
 
     assert_eq!(transferred_obj_ref.0, new_obj_ref.0);
@@ -976,10 +976,10 @@ async fn test_move_calls_object_transfer_and_freeze() {
     ));
     // Nothing should be deleted during a transfer
     assert!(order_effects.deleted.is_empty());
-    // Item being transfered is mutated.
-    assert_eq!(order_effects.mutated.len(), 1);
+    // Item being transfered is mutated. Plus gas object.
+    assert_eq!(order_effects.mutated.len(), 2);
 
-    let (transferred_obj_ref, _) = order_effects.mutated[0];
+    let (transferred_obj_ref, _) = *order_effects.mutated_excluding_gas().next().unwrap();
     assert_ne!(gas_object_ref, transferred_obj_ref);
 
     assert_eq!(transferred_obj_ref.0, new_obj_ref.0);
@@ -1061,8 +1061,8 @@ async fn test_move_calls_object_delete() {
     ));
     // Object be deleted during a delete
     assert_eq!(order_effects.deleted.len(), 1);
-    // No item is mutated.
-    assert_eq!(order_effects.mutated.len(), 0);
+    // Only gas is mutated.
+    assert_eq!(order_effects.mutated.len(), 1);
     // Confirm the items
     assert_eq!(order_effects.gas_object.0 .0, gas_object_id);
 

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -269,12 +269,12 @@ pub struct OrderEffects {
     pub transaction_digest: TransactionDigest,
     // ObjectRef and owner of new objects created.
     pub created: Vec<(ObjectRef, SuiAddress)>,
-    // ObjectRef and owner of mutated objects.
-    // mutated does not include gas object or created objects.
+    // ObjectRef and owner of mutated objects, including gas object.
     pub mutated: Vec<(ObjectRef, SuiAddress)>,
     // Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
-    // The updated gas object reference.
+    // The updated gas object reference. Have a dedicated field for convenient access.
+    // It's also included in mutated.
     pub gas_object: (ObjectRef, SuiAddress),
     /// The events emitted during execution. Note that only successful transactions emit events
     pub events: Vec<Event>,
@@ -283,14 +283,16 @@ pub struct OrderEffects {
 }
 
 impl OrderEffects {
-    /// Return an iterator that iterates throguh all mutated objects,
-    /// including all from mutated, created and the gas_object.
-    /// It doesn't include deleted.
-    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, SuiAddress)> {
-        self.mutated
-            .iter()
-            .chain(self.created.iter())
-            .chain(std::iter::once(&self.gas_object))
+    /// Return an iterator that iterates through both mutated and
+    /// created objects.
+    /// It doesn't include deleted objects.
+    pub fn mutated_and_created(&self) -> impl Iterator<Item = &(ObjectRef, SuiAddress)> {
+        self.mutated.iter().chain(self.created.iter())
+    }
+
+    /// Return an iterator of mutated objects, but excluding the gas object.
+    pub fn mutated_excluding_gas(&self) -> impl Iterator<Item = &(ObjectRef, SuiAddress)> {
+        self.mutated.iter().filter(|o| *o != &self.gas_object)
     }
 }
 


### PR DESCRIPTION
It's likely more clear to have mutated include gas_object.
This PR changes to that, and introduce an extra function that allows for getting mutated objects excluding gas for convenience.