### PR TITLE
[NFC] Remove confusing template typename

### DIFF
--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -30,18 +30,15 @@ mod client_tests;
 
 pub type AsyncResult<'a, T, E> = future::BoxFuture<'a, Result<T, E>>;
 
-pub struct AuthorityAggregator<AuthorityAPI> {
+pub struct AuthorityAggregator<A> {
     /// Our Sui committee.
     pub committee: Committee,
     /// How to talk to this committee.
-    authority_clients: BTreeMap<AuthorityName, SafeClient<AuthorityAPI>>,
+    authority_clients: BTreeMap<AuthorityName, SafeClient<A>>,
 }
 
-impl<AuthorityAPI> AuthorityAggregator<AuthorityAPI> {
-    pub fn new(
-        committee: Committee,
-        authority_clients: BTreeMap<AuthorityName, AuthorityAPI>,
-    ) -> Self {
+impl<A> AuthorityAggregator<A> {
+    pub fn new(committee: Committee, authority_clients: BTreeMap<AuthorityName, A>) -> Self {
         Self {
             committee: committee.clone(),
             authority_clients: authority_clients

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -85,7 +85,7 @@ impl<A> ClientAddressManager<A> {
     }
 }
 
-pub struct ClientState<AuthorityAPI> {
+pub struct ClientState<A> {
     /// Our Sui address.
     address: SuiAddress,
     // TODO: We will need to embed pub_key into secret.
@@ -93,7 +93,7 @@ pub struct ClientState<AuthorityAPI> {
     /// Our signature key.
     secret: StableSyncSigner,
     /// Authority entry point.
-    authorities: AuthorityAggregator<AuthorityAPI>,
+    authorities: AuthorityAggregator<A>,
     /// Persistent store for client
     store: client_store::ClientSingleAddressStore,
 }


### PR DESCRIPTION
Naming the type `AuthorityAPI` doesn't bound it, it's confusing to name it that way.
Revert to simple type name instead.