### PR TITLE
Add `ObjectInfoRequestKind` with two different types: latest and past

### DIFF
--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -362,7 +362,11 @@ where
                 |_name, client| {
                     Box::pin(async move {
                         // Request and return an error if any
-                        let request = ObjectInfoRequest::from(object_id);
+                        // TODO: Expose layout format option.
+                        let request = ObjectInfoRequest::latest_object_info_request(
+                            object_id,
+                            Some(ObjectFormatOptions::default()),
+                        );
                         client.handle_object_info_request(request).await
                     })
                 },
@@ -1075,12 +1079,11 @@ where
     ) {
         let object_id = object_ref.0;
         // Prepare the request
-        let request = ObjectInfoRequest {
+        // TODO: We should let users decide what layout they want in the result.
+        let request = ObjectInfoRequest::latest_object_info_request(
             object_id,
-            request_sequence_number: None,
-            // TODO: allow caller to decide whether they want the layout, and which options. For now, we always ask, and get the default format
-            request_layout: Some(ObjectFormatOptions::default()),
-        };
+            Some(ObjectFormatOptions::default()),
+        );
 
         // For now assume all authorities. Assume they're all honest
         // This assumption is woeful, and should be fixed

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -1646,7 +1646,9 @@ async fn client_object(client: &mut dyn Client, object_id: ObjectID) -> (ObjectR
 #[allow(dead_code)]
 async fn auth_object(authority: &LocalAuthorityClient, object_id: ObjectID) -> (ObjectRef, Object) {
     let response = authority
-        .handle_object_info_request(ObjectInfoRequest::from(object_id))
+        .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
+            object_id, None,
+        ))
         .await
         .unwrap();
 
@@ -1778,7 +1780,9 @@ async fn get_latest_ref(authority: &LocalAuthorityClient, object_id: ObjectID) -
         requested_object_reference: Some(object_ref),
         ..
     }) = authority
-        .handle_object_info_request(ObjectInfoRequest::from(object_id))
+        .handle_object_info_request(ObjectInfoRequest::latest_object_info_request(
+            object_id, None,
+        ))
         .await
     {
         return object_ref;

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -60,16 +60,9 @@ fn test_error() {
 
 #[test]
 fn test_info_request() {
-    let req1 = ObjectInfoRequest {
-        object_id: dbg_object_id(0x20),
-        request_sequence_number: None,
-        request_layout: None,
-    };
-    let req2 = ObjectInfoRequest {
-        object_id: dbg_object_id(0x20),
-        request_sequence_number: Some(SequenceNumber::from(129)),
-        request_layout: None,
-    };
+    let req1 = ObjectInfoRequest::latest_object_info_request(dbg_object_id(0x20), None);
+    let req2 =
+        ObjectInfoRequest::past_object_info_request(dbg_object_id(0x20), SequenceNumber::from(129));
 
     let buf1 = serialize_object_info_request(&req1);
     let buf2 = serialize_object_info_request(&req2);


### PR DESCRIPTION
Currently even when we are requesting information regarding an older version of an object, we still always return the latest object content in the response. This is very confusing, and likely wasteful. It also makes the validity check logic in SafeClient hard to reason about. (some discussion here: https://mysten-labs.slack.com/archives/C02GD7J9HUM/p1645124209747649)

This PR split the two cases when we are requesting object info: latest object state and past object info.
This removes the confusion on what we are requesting/expecting from the authority, and make the response cheaper if we are only requesting past info.
However, it's interesting to note that we currently are not requesting past object info. All requests today are about the latest.