### PR TITLE
Delete unnecessary code in Client::transfer_object

### DIFF
--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -817,7 +817,7 @@ where
     /// At that point (and after) enough authorities are up to date with all objects
     /// needed to process the certificate that a submission should succeed. However,
     /// in case an authority returns an error, we do try to bring it up to speed.
-    pub async fn process_certificate(
+    async fn process_certificate(
         &self,
         certificate: CertifiedOrder,
         timeout_after_quorum: Duration,

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -535,14 +535,6 @@ where
             &*self.secret,
         );
         let (certificate, effects) = self.execute_transaction(order).await?;
-        self.authorities
-            .process_certificate(certificate.clone(), Duration::from_secs(60))
-            .await?;
-
-        // remove object from local storage if the recipient is not us.
-        if recipient != self.address {
-            self.remove_object_info(&object_id)?;
-        }
 
         Ok((certificate, effects))
     }


### PR DESCRIPTION
We already call `process_certificates` as part of `execute_transaction`.
We also already handle deleted object as part of `update_objects_from_order_info` at the end of transaction execution.
`process_certificates` should be a private function of AuthorityAggregator instead of public API.