### PR TITLE
Only update authrority if it may be out-of-date

### DIFF
--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -860,7 +860,14 @@ where
                             return res;
                         }
 
-                        // If we got an error, we try to update the authority.
+                        // LockErrors indicate the authority may be out-of-date.
+                        // We only attempt to update authority and retry if we are seeing LockErrors.
+                        // For any other error, we stop here and return.
+                        if !matches!(res, Err(SuiError::LockErrors { .. })) {
+                            return res;
+                        }
+
+                        // If we got LockErrors, we try to update the authority.
                         let _result = self
                             .sync_certificate_to_authority_with_timeout(
                                 ConfirmationOrder::new(cert_ref.clone()),


### PR DESCRIPTION
Currently we always try to update an authority and retry order execution as long as the transaction failed to execute.
This is bad because the order could fail due to invalid object input or other reasons. We only want to do this when we know the transaction failed due to being out-of-date.