### PR TITLE
Remove object reference for package object in Order

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -212,15 +212,11 @@ impl ClientServerBenchmark {
 
             let order = if self.use_move {
                 // TODO: authority should not require seq# or digets for package in Move calls. Use dummy values
-                let framework_obj_ref = (
-                    ObjectID::from(SUI_FRAMEWORK_ADDRESS),
-                    SequenceNumber::new(),
-                    ObjectDigest::new([0; 32]),
-                );
+                let framework_obj_id = ObjectID::from(SUI_FRAMEWORK_ADDRESS);
 
                 Order::new_move_call(
                     *account_addr,
-                    framework_obj_ref,
+                    framework_obj_id,
                     ident_str!("GAS").to_owned(),
                     ident_str!("transfer").to_owned(),
                     Vec::new(),

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -198,7 +198,7 @@ impl WalletCommands {
                 let client_state = context.get_or_create_client_state(sender)?;
 
                 let package_obj_info = client_state.get_object_info(*package).await?;
-                let package_obj_ref = package_obj_info.object().unwrap().to_object_reference();
+                let package_obj_id = package_obj_info.object().unwrap().id();
 
                 // Fetch the object info for the gas obj
                 let gas_obj_ref = *client_state
@@ -215,7 +215,7 @@ impl WalletCommands {
 
                 let (cert, effects) = client_state
                     .move_call(
-                        package_obj_ref,
+                        package_obj_id,
                         module.to_owned(),
                         function.to_owned(),
                         type_args.clone(),

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -117,7 +117,7 @@ pub trait Client {
     /// Call move functions in the module in the given package, with args supplied
     async fn move_call(
         &mut self,
-        package_object_ref: ObjectRef,
+        package_object_id: ObjectID,
         module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
@@ -299,11 +299,11 @@ where
     }
 
     #[cfg(test)]
-    pub async fn get_framework_object_ref(&mut self) -> Result<ObjectRef, anyhow::Error> {
+    pub async fn get_framework_object_id(&mut self) -> Result<ObjectID, anyhow::Error> {
         let info = self
             .get_object_info(ObjectID::from(SUI_FRAMEWORK_ADDRESS))
             .await?;
-        Ok(info.reference()?)
+        Ok(info.reference()?.0)
     }
 
     async fn execute_transaction_inner(
@@ -607,7 +607,7 @@ where
 
     async fn move_call(
         &mut self,
-        package_object_ref: ObjectRef,
+        package_object_id: ObjectID,
         module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
@@ -618,7 +618,7 @@ where
     ) -> Result<(CertifiedOrder, OrderEffects), anyhow::Error> {
         let move_call_order = Order::new_move_call(
             self.address,
-            package_object_ref,
+            package_object_id,
             module,
             function,
             type_arguments,

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -1357,7 +1357,7 @@ async fn test_hero() {
     for (obj_ref, _) in &effects.created {
         let new_obj = authority.get_object(&obj_ref.0).await.unwrap().unwrap();
         if let Data::Package(_) = &new_obj.data {
-            package_object = Some(obj_ref);
+            package_object = Some(&obj_ref.0);
             successful_checks += 1;
         } else if let Data::Move(move_obj) = &new_obj.data {
             if move_obj.type_.module == Identifier::new("Hero").unwrap()
@@ -1740,13 +1740,13 @@ fn init_certified_transfer_order(
         .unwrap()
 }
 
-fn get_genesis_package_by_module(genesis_objects: &[Object], module: &str) -> ObjectRef {
+fn get_genesis_package_by_module(genesis_objects: &[Object], module: &str) -> ObjectID {
     genesis_objects
         .iter()
         .find_map(|o| match o.data.try_as_package() {
             Some(p) => {
                 if p.keys().any(|name| name == module) {
-                    Some(o.to_object_reference())
+                    Some(o.id())
                 } else {
                     None
                 }
@@ -1761,7 +1761,7 @@ async fn call_move(
     gas_object_id: &ObjectID,
     sender: &SuiAddress,
     sender_key: &KeyPair,
-    package: &ObjectRef,
+    package: &ObjectID,
     module: Identifier,
     function: Identifier,
     type_args: Vec<TypeTag>,
@@ -1809,14 +1809,14 @@ async fn call_framework_code(
     pure_args: Vec<Vec<u8>>,
 ) -> SuiResult<OrderEffects> {
     let (genesis_package_objects, _) = genesis::clone_genesis_data();
-    let package_object_ref = get_genesis_package_by_module(&genesis_package_objects, module);
+    let package_object_id = get_genesis_package_by_module(&genesis_package_objects, module);
 
     call_move(
         authority,
         gas_object_id,
         sender,
         sender_key,
-        &package_object_ref,
+        &package_object_id,
         ident_str!(module).to_owned(),
         ident_str!(function).to_owned(),
         type_args,

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -139,7 +139,7 @@ fn order_create(
     secret: &dyn signature::Signer<Signature>,
     dest: SuiAddress,
     value: u64,
-    framework_obj_ref: ObjectRef,
+    framework_obj_id: ObjectID,
     gas_object_ref: ObjectRef,
 ) -> Order {
     // When creating an ObjectBasics object, we provide the value (u64) and address which will own the object
@@ -151,7 +151,7 @@ fn order_create(
 
     Order::new_move_call(
         src,
-        framework_obj_ref,
+        framework_obj_id,
         ident_str!("ObjectBasics").to_owned(),
         ident_str!("create").to_owned(),
         Vec::new(),
@@ -169,14 +169,14 @@ fn order_transfer(
     secret: &dyn signature::Signer<Signature>,
     dest: SuiAddress,
     object_ref: ObjectRef,
-    framework_obj_ref: ObjectRef,
+    framework_obj_id: ObjectID,
     gas_object_ref: ObjectRef,
 ) -> Order {
     let pure_args = vec![bcs::to_bytes(&dest.to_vec()).unwrap()];
 
     Order::new_move_call(
         src,
-        framework_obj_ref,
+        framework_obj_id,
         ident_str!("ObjectBasics").to_owned(),
         ident_str!("transfer").to_owned(),
         Vec::new(),
@@ -194,14 +194,14 @@ fn order_set(
     secret: &dyn signature::Signer<Signature>,
     object_ref: ObjectRef,
     value: u64,
-    framework_obj_ref: ObjectRef,
+    framework_obj_id: ObjectID,
     gas_object_ref: ObjectRef,
 ) -> Order {
     let pure_args = vec![bcs::to_bytes(&value).unwrap()];
 
     Order::new_move_call(
         src,
-        framework_obj_ref,
+        framework_obj_id,
         ident_str!("ObjectBasics").to_owned(),
         ident_str!("set_value").to_owned(),
         Vec::new(),
@@ -218,12 +218,12 @@ fn order_delete(
     src: SuiAddress,
     secret: &dyn signature::Signer<Signature>,
     object_ref: ObjectRef,
-    framework_obj_ref: ObjectRef,
+    framework_obj_id: ObjectID,
     gas_object_ref: ObjectRef,
 ) -> Order {
     Order::new_move_call(
         src,
-        framework_obj_ref,
+        framework_obj_id,
         ident_str!("ObjectBasics").to_owned(),
         ident_str!("delete").to_owned(),
         Vec::new(),
@@ -766,7 +766,7 @@ async fn test_move_calls_object_create() {
 
     let object_value: u64 = 100;
     let gas_object_id = ObjectID::random();
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
 
     // Populate authorities with obj data
     let gas_object_ref = fund_account_with_same_objects(
@@ -788,7 +788,7 @@ async fn test_move_calls_object_create() {
     ];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("create").to_owned(),
             Vec::new(),
@@ -824,7 +824,7 @@ async fn test_move_calls_object_transfer() {
 
     let object_value: u64 = 100;
     let gas_object_id = ObjectID::random();
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
 
     // Populate authorities with obj data
     let mut gas_object_ref = fund_account_with_same_objects(
@@ -846,7 +846,7 @@ async fn test_move_calls_object_transfer() {
     ];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("create").to_owned(),
             Vec::new(),
@@ -868,7 +868,7 @@ async fn test_move_calls_object_transfer() {
     let pure_args = vec![bcs::to_bytes(&client2.address().to_vec()).unwrap()];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("transfer").to_owned(),
             Vec::new(),
@@ -912,7 +912,7 @@ async fn test_move_calls_object_transfer_and_freeze() {
 
     let object_value: u64 = 100;
     let gas_object_id = ObjectID::random();
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
 
     // Populate authorities with obj data
     let mut gas_object_ref = fund_account_with_same_objects(
@@ -934,7 +934,7 @@ async fn test_move_calls_object_transfer_and_freeze() {
     ];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("create").to_owned(),
             Vec::new(),
@@ -955,7 +955,7 @@ async fn test_move_calls_object_transfer_and_freeze() {
     let pure_args = vec![bcs::to_bytes(&client2.address().to_vec()).unwrap()];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("transfer_and_freeze").to_owned(),
             Vec::new(),
@@ -999,7 +999,7 @@ async fn test_move_calls_object_delete() {
 
     let object_value: u64 = 100;
     let gas_object_id = ObjectID::random();
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
 
     // Populate authorities with obj data
     let mut gas_object_ref = fund_account_with_same_objects(
@@ -1021,7 +1021,7 @@ async fn test_move_calls_object_delete() {
     ];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("create").to_owned(),
             Vec::new(),
@@ -1040,7 +1040,7 @@ async fn test_move_calls_object_delete() {
 
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("delete").to_owned(),
             Vec::new(),
@@ -1178,7 +1178,7 @@ async fn test_module_publish_and_call_good() {
     //Try to call a function in TrustedCoin module
     let call_resp = client1
         .move_call(
-            new_obj.object().unwrap().to_object_reference(),
+            new_obj.object().unwrap().id(),
             ident_str!("TrustedCoin").to_owned(),
             ident_str!("mint").to_owned(),
             vec![],
@@ -1792,7 +1792,7 @@ async fn test_get_all_owned_objects() {
     let auth_vec: Vec<_> = authority_clients.values().cloned().collect();
 
     let mut client1 = make_client(authority_clients.clone(), committee.clone());
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
     let mut client2 = make_client(authority_clients.clone(), committee.clone());
 
     let gas_object1 = ObjectID::random();
@@ -1810,7 +1810,7 @@ async fn test_get_all_owned_objects() {
         client1.secret(),
         client1.address(),
         100,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_1,
     );
 
@@ -1858,7 +1858,7 @@ async fn test_get_all_owned_objects() {
         client1.address(),
         client1.secret(),
         created_ref,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_del,
     );
 
@@ -1901,7 +1901,7 @@ async fn test_sync_all_owned_objects() {
     let auth_vec: Vec<_> = authority_clients.values().cloned().collect();
 
     let mut client1 = make_client(authority_clients.clone(), committee.clone());
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
     let client2 = make_client(authority_clients.clone(), committee.clone());
 
     let gas_object1 = ObjectID::random();
@@ -1921,7 +1921,7 @@ async fn test_sync_all_owned_objects() {
         client1.secret(),
         client1.address(),
         100,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_1,
     );
 
@@ -1931,7 +1931,7 @@ async fn test_sync_all_owned_objects() {
         client1.secret(),
         client1.address(),
         101,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_2,
     );
 
@@ -1977,7 +1977,7 @@ async fn test_sync_all_owned_objects() {
         client1.address(),
         client1.secret(),
         new_ref_1,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_del,
     );
 
@@ -1988,7 +1988,7 @@ async fn test_sync_all_owned_objects() {
         client1.secret(),
         client2.address(),
         new_ref_2,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_trans,
     );
 
@@ -2036,7 +2036,7 @@ async fn test_process_order() {
     let auth_vec: Vec<_> = authority_clients.values().cloned().collect();
 
     let mut client1 = make_client(authority_clients.clone(), committee.clone());
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
 
     let gas_object1 = ObjectID::random();
     let gas_object2 = ObjectID::random();
@@ -2055,7 +2055,7 @@ async fn test_process_order() {
         client1.secret(),
         client1.address(),
         100,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_1,
     );
 
@@ -2076,7 +2076,7 @@ async fn test_process_order() {
         client1.secret(),
         new_ref_1,
         100,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_set,
     );
 
@@ -2101,7 +2101,7 @@ async fn test_process_certificate() {
     let auth_vec: Vec<_> = authority_clients.values().cloned().collect();
 
     let mut client1 = make_client(authority_clients.clone(), committee.clone());
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
 
     let gas_object1 = ObjectID::random();
     let gas_object2 = ObjectID::random();
@@ -2120,7 +2120,7 @@ async fn test_process_certificate() {
         client1.secret(),
         client1.address(),
         100,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_1,
     );
 
@@ -2147,7 +2147,7 @@ async fn test_process_certificate() {
         client1.secret(),
         new_ref_1,
         100,
-        framework_obj_ref,
+        framework_obj_id,
         gas_ref_set,
     );
 
@@ -2310,7 +2310,7 @@ async fn test_address_manager() {
 
     // Confirm expected behavior
     assert_eq!(client1.store().objects.iter().count(), 2);
-    let framework_obj_ref = client1.get_framework_object_ref().await.unwrap();
+    let framework_obj_id = client1.get_framework_object_id().await.unwrap();
     let sample_auth = &authority_clients.iter().next().unwrap().1;
 
     // Make a transaction
@@ -2321,7 +2321,7 @@ async fn test_address_manager() {
     ];
     let call_response = client1
         .move_call(
-            framework_obj_ref,
+            framework_obj_id,
             ident_str!("ObjectBasics").to_owned(),
             ident_str!("create").to_owned(),
             Vec::new(),

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -30,8 +30,7 @@ pub struct Transfer {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveCall {
-    // TODO: For package object, we only need object id, as it's always read-only.
-    pub package: ObjectRef,
+    pub package: ObjectID,
     pub module: Identifier,
     pub function: Identifier,
     pub type_arguments: Vec<TypeTag>,
@@ -404,7 +403,7 @@ impl Order {
     #[allow(clippy::too_many_arguments)]
     pub fn new_move_call(
         sender: SuiAddress,
-        package: ObjectRef,
+        package: ObjectID,
         module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
@@ -484,7 +483,7 @@ impl Order {
                         .map(InputObjectKind::MoveObject)
                         .collect::<Vec<_>>(),
                 );
-                call_inputs.push(InputObjectKind::MovePackage(c.package.0));
+                call_inputs.push(InputObjectKind::MovePackage(c.package));
                 call_inputs
             }
             OrderKind::Publish(m) => {


### PR DESCRIPTION
Package object is always immutable, and hence can never change. We don't need to pass object ref for it. object id only is sufficient.