### PR TITLE
Added macro for polling boolean expression with timeout in unit test

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -209,13 +209,11 @@ async fn test_custom_genesis() -> Result<(), anyhow::Error> {
         .execute(&mut context)
         .await?;
 
-    count = 0;
     // confirm the object with custom object id.
-    while count < 50 && !logs_contain(format!("{}", object_id).as_str()) {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        count += 1;
-    }
-    assert!(count < 50);
+    retry_assert!(
+        logs_contain(format!("{}", object_id).as_str()),
+        Duration::from_millis(5000)
+    );
 
     network.abort();
     Ok(())


### PR DESCRIPTION
This macro simplifies the logic for retrying boolean expressions, e.g. checking server availability in test