### PR TITLE
Remove Order.package object ref TODO

### DIFF
--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -31,7 +31,11 @@ pub struct Transfer {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveCall {
-    // TODO: For package object, we only need object id, as it's always read-only.
+    // Although `package` represents a read-only Move package,
+    // we still want to use a reference instead of just object ID.
+    // This allows a client to be able to validate the package object
+    // used in an order (through the object digest) without having to
+    // re-execute the order on a quorum of authorities.
     pub package: ObjectRef,
     pub module: Identifier,
     pub function: Identifier,


### PR DESCRIPTION
As discussed in https://github.com/MystenLabs/fastnft/pull/489, we don't want to use object ID to replace object ref for Order.package even though it's read-only.