### PR TITLE
Fix a bug where post-VM gas cost not capped by gas budget

### DIFF
--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -214,8 +214,22 @@ fn execute_internal<
                 // Cap total_gas by gas_budget in the fail case.
                 return ExecutionStatus::new_failure(cmp::min(total_gas, gas_budget), err);
             }
-            ExecutionStatus::Success {
-                gas_used: total_gas,
+            // gas_budget should be enough to pay not only the VM excution cost,
+            // but also the cost to process all events, such as transfers.
+            if total_gas > gas_budget {
+                ExecutionStatus::new_failure(
+                    gas_budget,
+                    SuiError::InsufficientGas {
+                        error: format!(
+                            "Total gas used ({}) exceeds gas budget ({})",
+                            total_gas, gas_budget
+                        ),
+                    },
+                )
+            } else {
+                ExecutionStatus::Success {
+                    gas_used: total_gas,
+                }
             }
         }
         // charge for all computations so far

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -478,8 +478,9 @@ fn test_move_call_insufficient_gas() {
     let mut storage = InMemoryStorage::new(genesis_objects);
 
     // 0. Create a gas object for gas payment.
+    let gas_object_id = ObjectID::random();
     let gas_object =
-        Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
+        Object::with_id_owner_for_testing(gas_object_id, base_types::SuiAddress::default());
     storage.write_object(gas_object.clone());
     storage.flush();
 
@@ -499,12 +500,30 @@ fn test_move_call_insufficient_gas() {
         20, // This budget is not enough to execute all bytecode.
         Vec::new(),
         Vec::new(),
-        pure_args,
+        pure_args.clone(),
     );
     let err = response.unwrap().unwrap_err();
     assert!(err.1.to_string().contains("VMError with status OUT_OF_GAS"));
     // Provided gas_budget will be deducted as gas.
     assert_eq!(err.0, 20);
+
+    // Trying again with a different gas budget.
+    let gas_object = storage.read_object(&gas_object_id).unwrap();
+    let response = call(
+        &mut storage,
+        &native_functions,
+        "ObjectBasics",
+        "create",
+        gas_object,
+        50, // This budget is enough to execute bytecode, but not enough for processing transfer events.
+        Vec::new(),
+        Vec::new(),
+        pure_args,
+    );
+    let err = response.unwrap().unwrap_err();
+    assert!(matches!(err.1, SuiError::InsufficientGas { .. }));
+    // Provided gas_budget will be deducted as gas.
+    assert_eq!(err.0, 50);
 }
 
 #[test]


### PR DESCRIPTION
Currently for a Move call, we are only capping the VM execution gas usage by the gas budget. However the gas cost of post-VM processing (e.g. processing transfer events) needs to be capped by the same gas budget as well.
We were not able to catch this in the test because the test only contains a case where the gas is not enough for VM execution.
Fixed this in adapter, and added an extra test case for this.