### PR TITLE
Replace Libra's CoC with Diem's

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
-Please see Libra's
-[Code of Conduct](https://developers.libra.org/docs/policies/code-of-conduct),
+Please see Diem's
+[Code of Conduct](https://developers.diem.com/docs/policies/code-of-conduct/),
 which describes the expectations for interactions within the community.


### PR DESCRIPTION
The Libra link was broken, redirecting to the Diem site. So I found the code of conduct there and fixed the link and text to match.