### PR TITLE
Add Owner enum to support shared objects

### DIFF
--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -163,8 +163,7 @@ pub async fn genesis(
         genesis_conf.sui_framework_lib_path
     );
     let sui_lib = sui_framework::get_sui_framework_modules(&genesis_conf.sui_framework_lib_path)?;
-    let lib_object =
-        Object::new_package(sui_lib, SuiAddress::default(), TransactionDigest::genesis());
+    let lib_object = Object::new_package(sui_lib, TransactionDigest::genesis());
     preload_modules.push(lib_object);
 
     info!(
@@ -172,11 +171,7 @@ pub async fn genesis(
         genesis_conf.move_framework_lib_path
     );
     let move_lib = sui_framework::get_move_stdlib_modules(&genesis_conf.move_framework_lib_path)?;
-    let lib_object = Object::new_package(
-        move_lib,
-        SuiAddress::default(),
-        TransactionDigest::genesis(),
-    );
+    let lib_object = Object::new_package(move_lib, TransactionDigest::genesis());
     preload_modules.push(lib_object);
 
     // Build custom move packages
@@ -195,8 +190,7 @@ pub async fn genesis(
                 &mut TxContext::new(&SuiAddress::default(), TransactionDigest::genesis()),
             )?;
 
-            let object =
-                Object::new_package(modules, SuiAddress::default(), TransactionDigest::genesis());
+            let object = Object::new_package(modules, TransactionDigest::genesis());
             info!("Loaded package [{}] from {:?}.", object.id(), path);
             // Writing package id to network.conf for user to retrieve later.
             config.loaded_move_packages.push((path, object.id()));

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -157,7 +157,11 @@ impl WalletCommands {
                 gas_budget,
             } => {
                 // Find owner of gas object
-                let sender = &context.address_manager.get_object_owner(*gas).await?;
+                let sender = &context
+                    .address_manager
+                    .get_object_owner(*gas)
+                    .await?
+                    .get_single_owner_address()?;
                 let client_state = context.get_or_create_client_state(sender)?;
                 let gas_obj_ref = client_state.object_ref(*gas)?;
 
@@ -186,7 +190,11 @@ impl WalletCommands {
                 gas,
                 gas_budget,
             } => {
-                let sender = &context.address_manager.get_object_owner(*gas).await?;
+                let sender = &context
+                    .address_manager
+                    .get_object_owner(*gas)
+                    .await?
+                    .get_single_owner_address()?;
                 let client_state = context.get_or_create_client_state(sender)?;
 
                 let package_obj_info = client_state.get_object_info(*package).await?;
@@ -221,7 +229,11 @@ impl WalletCommands {
             }
 
             WalletCommands::Transfer { to, object_id, gas } => {
-                let from = &context.address_manager.get_object_owner(*gas).await?;
+                let from = &context
+                    .address_manager
+                    .get_object_owner(*gas)
+                    .await?
+                    .get_single_owner_address()?;
                 let client_state = context.get_or_create_client_state(from)?;
                 let time_start = Instant::now();
                 let (cert, effects) = client_state.transfer_object(*object_id, *gas, *to).await?;

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -21,7 +21,7 @@ use sui_types::{
     error::{SuiError, SuiResult},
     fp_bail, fp_ensure, gas,
     messages::*,
-    object::{Data, Object},
+    object::{Data, Object, Owner},
     storage::Storage,
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
@@ -110,32 +110,47 @@ impl AuthorityState {
                     }
                 );
 
-                if object.is_read_only() {
-                    // Gas object must not be immutable.
+                // If the object is the gas object, check that it is not shared object
+                // and there is enough gas.
+                if object_kind.object_id() == transaction.gas_payment_object_ref().0 {
                     fp_ensure!(
-                        object_id != transaction.gas_payment_object_ref().0,
+                        matches!(object.owner, Owner::SingleOwner(..)),
                         SuiError::InsufficientGas {
-                            error: "Gas object should not be immutable".to_string()
+                            error: "Gas object cannot be shared object".to_string()
                         }
                     );
-                    // Checks for read-only objects end here.
-                    return Ok(());
-                }
-
-                // Additional checks for mutable objects
-                // Check the object owner is either the transaction sender, or
-                // another mutable object in the input.
-                fp_ensure!(
-                    transaction.sender_address() == object.owner
-                        || mutable_object_addresses.contains(&object.owner),
-                    SuiError::IncorrectSigner
-                );
-
-                if object_id == transaction.gas_payment_object_ref().0 {
                     gas::check_gas_requirement(transaction, object)?;
                 }
+
+                // If the object is the transfer object, check that it is not shared object.
+                if let TransactionKind::Transfer(t) = &transaction.data.kind {
+                    if object_kind.object_id() == t.object_ref.0 {
+                        fp_ensure!(
+                            matches!(object.owner, Owner::SingleOwner(..)),
+                            SuiError::TransferImmutableError
+                        );
+                    }
+                }
+
+                match object.owner {
+                    Owner::SharedImmutable => {
+                        // Nothing else to check for SharedImmutable.
+                    }
+                    Owner::SingleOwner(owner) => {
+                        // Check the object owner is either the transaction sender, or
+                        // another mutable object in the input.
+                        fp_ensure!(
+                            transaction.sender_address() == owner
+                                || mutable_object_addresses.contains(&owner),
+                            SuiError::IncorrectSigner
+                        );
+                    }
+                    Owner::SharedMutable => {
+                        return Err(SuiError::UnsupportedSharedObjectError);
+                    }
+                };
             }
-        };
+        }
         Ok(())
     }
 
@@ -302,7 +317,6 @@ impl AuthorityState {
         // unwraps here are safe because we built `inputs`
         let mut gas_object = inputs.pop().unwrap();
 
-        let sender = transaction.sender_address();
         let status = match transaction.data.kind {
             TransactionKind::Transfer(t) => AuthorityState::transfer(
                 &mut temporary_store,
@@ -332,7 +346,6 @@ impl AuthorityState {
                 &mut temporary_store,
                 self._native_functions.clone(),
                 m.modules,
-                sender,
                 tx_ctx,
                 m.gas_budget,
                 gas_object.clone(),

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -1001,6 +1001,7 @@ where
 
     /// Return owner address and sequence number of an object backed by a quorum of authorities.
     /// NOTE: This is only reliable in the synchronous model, with a sufficient timeout value.
+    /// This function doesn't work for shared objects that don't have an exclusive owner.
     #[cfg(test)]
     async fn get_latest_owner(&self, object_id: ObjectID) -> (SuiAddress, SequenceNumber) {
         let (object_infos, _certificates) = self
@@ -1008,7 +1009,10 @@ where
             .await
             .unwrap(); // Not safe, but want to blow up if testing.
         let (top_ref, obj) = object_infos.iter().last().unwrap();
-        (obj.0.as_ref().unwrap().owner, top_ref.0 .1)
+        (
+            obj.0.as_ref().unwrap().get_signle_owner().unwrap(),
+            top_ref.0 .1,
+        )
     }
 
     pub async fn execute_transaction(

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -275,6 +275,38 @@ async fn test_handle_transfer_transaction_ok() {
 }
 
 #[tokio::test]
+async fn test_transfer_immutable() {
+    let (sender, sender_key) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let authority_state = init_state_with_ids(vec![(sender, object_id)]).await;
+    let gas_object = authority_state
+        .get_object(&object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let genesis_package_objects = genesis::clone_genesis_modules();
+    let package_object_ref = get_genesis_package_by_module(&genesis_package_objects, "ID");
+    // We are trying to transfer the genesis package object, which is immutable.
+    let transfer_transaction = init_transfer_transaction(
+        sender,
+        &sender_key,
+        recipient,
+        package_object_ref,
+        gas_object.to_object_reference(),
+    );
+    let result = authority_state
+        .handle_transaction(transfer_transaction.clone())
+        .await;
+    assert_eq!(
+        result.unwrap_err(),
+        SuiError::LockErrors {
+            errors: vec![SuiError::TransferImmutableError]
+        }
+    );
+}
+
+#[tokio::test]
 async fn test_handle_transfer_zero_balance() {
     let (sender, sender_key) = get_key_pair();
     let recipient = dbg_addr(2);
@@ -1581,7 +1613,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 3);
     assert_eq!(
         authority.get_object(&obj1).await.unwrap().unwrap().owner,
-        obj2.into(),
+        SuiAddress::from(obj2),
     );
 
     // Try to transfer obj1 to obj3, this time it will fail since obj1 is now owned by obj2,
@@ -1677,7 +1709,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 3);
     assert_eq!(
         authority.get_object(&obj1).await.unwrap().unwrap().owner,
-        obj2.into(),
+        SuiAddress::from(obj2),
     );
 }
 

--- a/sui_programmability/adapter/src/genesis.rs
+++ b/sui_programmability/adapter/src/genesis.rs
@@ -6,10 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use sui_framework::{self, DEFAULT_FRAMEWORK_PATH};
 use sui_types::error::SuiResult;
-use sui_types::{
-    base_types::{SuiAddress, TransactionDigest},
-    object::Object,
-};
+use sui_types::{base_types::TransactionDigest, object::Object};
 
 static GENESIS: Lazy<Mutex<Genesis>> = Lazy::new(|| {
     Mutex::new(create_genesis_module_objects(&PathBuf::from(DEFAULT_FRAMEWORK_PATH)).unwrap())
@@ -29,10 +26,9 @@ fn create_genesis_module_objects(lib_dir: &Path) -> SuiResult<Genesis> {
     let sui_modules = sui_framework::get_sui_framework_modules(lib_dir)?;
     let std_modules =
         sui_framework::get_move_stdlib_modules(&lib_dir.join("deps").join("move-stdlib"))?;
-    let owner = SuiAddress::default();
     let objects = vec![
-        Object::new_package(sui_modules, owner, TransactionDigest::genesis()),
-        Object::new_package(std_modules, owner, TransactionDigest::genesis()),
+        Object::new_package(sui_modules, TransactionDigest::genesis()),
+        Object::new_package(std_modules, TransactionDigest::genesis()),
     ];
     Ok(Genesis { objects })
 }

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -14,7 +14,7 @@ use sui_types::{
     crypto::get_key_pair,
     error::SuiResult,
     gas_coin::GAS,
-    object::Data,
+    object::{Data, Owner},
     storage::Storage,
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
@@ -554,7 +554,6 @@ fn test_publish_module_insufficient_gas() {
         &mut storage,
         native_functions,
         module_bytes,
-        base_types::SuiAddress::default(),
         &mut tx_context,
         GAS_BUDGET,
         gas_object,
@@ -626,7 +625,7 @@ fn test_transfer_and_freeze() {
     storage.flush();
     let obj1 = storage.read_object(&id1).unwrap();
     assert!(obj1.is_read_only());
-    assert!(obj1.owner == addr2);
+    assert!(obj1.owner == Owner::SharedImmutable);
 
     // 3. Call transfer again and it should fail.
     let pure_args = vec![bcs::to_bytes(&AccountAddress::from(addr1)).unwrap()];
@@ -848,7 +847,6 @@ fn test_publish_module_linker_error() {
         &mut storage,
         native_functions,
         module_bytes,
-        base_types::SuiAddress::default(),
         &mut tx_context,
         GAS_BUDGET,
         gas_object,
@@ -891,7 +889,6 @@ fn test_publish_module_non_zero_address() {
         &mut storage,
         native_functions,
         module_bytes,
-        base_types::SuiAddress::default(),
         &mut tx_context,
         GAS_BUDGET,
         gas_object,
@@ -977,7 +974,6 @@ fn publish_from_src(
         storage,
         natives.clone(),
         all_module_bytes,
-        base_types::SuiAddress::default(),
         &mut tx_context,
         gas_budget,
         gas_object,

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -39,6 +39,10 @@ pub enum SuiError {
     CannotTransferReadOnlyObject,
     #[error("A move package is expected, instead a move object is passed: {object_id}")]
     MoveObjectAsPackage { object_id: ObjectID },
+    #[error("Expecting a singler owner, shared ownership found")]
+    UnexpectedOwnerType,
+    #[error("Shared mutable object not yet supported")]
+    UnsupportedSharedObjectError,
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::crypto::{sha3_hash, AuthoritySignature, BcsSignable, Signature};
-use crate::object::{Object, ObjectFormatOptions, OBJECT_START_VERSION};
+use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
 
 use super::{base_types::*, committee::Committee, error::*, event::Event};
 
@@ -280,14 +280,14 @@ pub struct TransactionEffects {
     // The transaction digest
     pub transaction_digest: TransactionDigest,
     // ObjectRef and owner of new objects created.
-    pub created: Vec<(ObjectRef, SuiAddress)>,
+    pub created: Vec<(ObjectRef, Owner)>,
     // ObjectRef and owner of mutated objects, including gas object.
-    pub mutated: Vec<(ObjectRef, SuiAddress)>,
+    pub mutated: Vec<(ObjectRef, Owner)>,
     // Object Refs of objects now deleted (the old refs).
     pub deleted: Vec<ObjectRef>,
     // The updated gas object reference. Have a dedicated field for convenient access.
     // It's also included in mutated.
-    pub gas_object: (ObjectRef, SuiAddress),
+    pub gas_object: (ObjectRef, Owner),
     /// The events emitted during execution. Note that only successful transactions emit events
     pub events: Vec<Event>,
     /// The set of transaction digests this transaction depends on.
@@ -298,12 +298,12 @@ impl TransactionEffects {
     /// Return an iterator that iterates through both mutated and
     /// created objects.
     /// It doesn't include deleted objects.
-    pub fn mutated_and_created(&self) -> impl Iterator<Item = &(ObjectRef, SuiAddress)> {
+    pub fn mutated_and_created(&self) -> impl Iterator<Item = &(ObjectRef, Owner)> {
         self.mutated.iter().chain(self.created.iter())
     }
 
     /// Return an iterator of mutated objects, but excluding the gas object.
-    pub fn mutated_excluding_gas(&self) -> impl Iterator<Item = &(ObjectRef, SuiAddress)> {
+    pub fn mutated_excluding_gas(&self) -> impl Iterator<Item = &(ObjectRef, Owner)> {
         self.mutated.iter().filter(|o| *o != &self.gas_object)
     }
 }

--- a/sui_types/src/move_call.rs
+++ b/sui_types/src/move_call.rs
@@ -119,7 +119,7 @@ pub fn resolve_and_type_check(
                 // check that m.type_ matches the parameter types of the function
                 match &param_type {
                     Type::MutableReference(inner_t) => {
-                        if m.is_read_only() {
+                        if object.is_read_only() {
                             return Err(SuiError::TypeError {
                                 error: format!(
                                     "Argument {} is expected to be mutable, immutable object found",
@@ -138,7 +138,7 @@ pub fn resolve_and_type_check(
                         }
                     }
                     Type::Struct { .. } => {
-                        if m.is_read_only() {
+                        if object.is_read_only() {
                             return Err(SuiError::TypeError {
                                 error: format!(
                                     "Argument {} is expected to be mutable, immutable object found",

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -39,7 +39,6 @@ pub struct MoveObject {
     pub type_: StructTag,
     #[serde_as(as = "Bytes")]
     contents: Vec<u8>,
-    read_only: bool,
 }
 
 /// Byte encoding of a 64 byte unsigned integer in BCS
@@ -61,11 +60,7 @@ pub struct ObjectFormatOptions {
 
 impl MoveObject {
     pub fn new(type_: StructTag, contents: Vec<u8>) -> Self {
-        Self {
-            type_,
-            contents,
-            read_only: false,
-        }
+        Self { type_, contents }
     }
 
     pub fn id(&self) -> ObjectID {
@@ -130,14 +125,6 @@ impl MoveObject {
 
     pub fn into_contents(self) -> Vec<u8> {
         self.contents
-    }
-
-    pub fn is_read_only(&self) -> bool {
-        self.read_only
-    }
-
-    pub fn freeze(&mut self) {
-        self.read_only = true;
     }
 
     /// Get a `MoveStructLayout` for `self`.
@@ -336,12 +323,43 @@ impl Data {
     }
 }
 
+// TODO: We don't distinguish between an account owner and an object owner.
+// They are both represented as SingleOwner. We should cosnider adding a variant
+// since it can be useful to tell whether an object is owned by object or address.
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Deserialize, Serialize, Hash)]
+pub enum Owner {
+    /// Object is excluslive owned by a single address, and is mutable.
+    SingleOwner(SuiAddress),
+    /// Object is shared, can be used by any address, and is mutable.
+    SharedMutable,
+    /// Object is immutable, and hence ownership doesn't matter.
+    SharedImmutable,
+}
+
+impl Owner {
+    pub fn get_single_owner_address(&self) -> SuiResult<SuiAddress> {
+        match self {
+            Self::SingleOwner(address) => Ok(*address),
+            Self::SharedMutable | Self::SharedImmutable => Err(SuiError::UnexpectedOwnerType),
+        }
+    }
+}
+
+impl std::cmp::PartialEq<SuiAddress> for Owner {
+    fn eq(&self, other: &SuiAddress) -> bool {
+        match self {
+            Self::SingleOwner(address) => address == other,
+            Self::SharedMutable | Self::SharedImmutable => false,
+        }
+    }
+}
+
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct Object {
     /// The meat of the object
     pub data: Data,
-    /// The owner address that unlocks this object (eg. hashes of public key, or object id)
-    pub owner: SuiAddress,
+    /// The owner that unlocks this object
+    pub owner: Owner,
     /// The digest of the transaction that created or last mutated this object
     pub previous_transaction: TransactionDigest,
 }
@@ -350,11 +368,7 @@ impl BcsSignable for Object {}
 
 impl Object {
     /// Create a new Move object
-    pub fn new_move(
-        o: MoveObject,
-        owner: SuiAddress,
-        previous_transaction: TransactionDigest,
-    ) -> Self {
+    pub fn new_move(o: MoveObject, owner: Owner, previous_transaction: TransactionDigest) -> Self {
         Object {
             data: Data::Move(o),
             owner,
@@ -364,20 +378,35 @@ impl Object {
 
     pub fn new_package(
         modules: Vec<CompiledModule>,
-        owner: SuiAddress,
         previous_transaction: TransactionDigest,
     ) -> Self {
         Object {
             data: Data::Package(MovePackage::from(&modules)),
-            owner,
+            owner: Owner::SharedImmutable,
             previous_transaction,
         }
     }
 
     pub fn is_read_only(&self) -> bool {
-        match &self.data {
-            Data::Move(m) => m.is_read_only(),
-            Data::Package(_) => true,
+        match &self.owner {
+            Owner::SingleOwner(_) | Owner::SharedMutable => false,
+            Owner::SharedImmutable => true,
+        }
+    }
+
+    pub fn get_signle_owner(&self) -> Option<SuiAddress> {
+        match &self.owner {
+            Owner::SingleOwner(owner) => Some(*owner),
+            Owner::SharedMutable | Owner::SharedImmutable => None,
+        }
+    }
+
+    // It's a common pattern to retrieve both the owner and object ID
+    // together, if it's owned by a singler owner.
+    pub fn get_single_owner_and_id(&self) -> Option<(SuiAddress, ObjectID)> {
+        match &self.owner {
+            Owner::SingleOwner(owner) => Some((*owner, self.id())),
+            Owner::SharedMutable | Owner::SharedImmutable => None,
         }
     }
 
@@ -427,7 +456,7 @@ impl Object {
                     "Invalid transfer: only transfer of GasCoin is supported"
                 );
 
-                self.owner = new_owner;
+                self.owner = Owner::SingleOwner(new_owner);
                 m.increment_version();
             }
             Data::Package(_) => panic!("Cannot transfer a module object"),
@@ -443,10 +472,9 @@ impl Object {
         let data = Data::Move(MoveObject {
             type_: GasCoin::type_(),
             contents: GasCoin::new(id, version, gas).to_bcs_bytes(),
-            read_only: false,
         });
         Self {
-            owner,
+            owner: Owner::SingleOwner(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
         }
@@ -469,10 +497,9 @@ impl Object {
         let data = Data::Move(MoveObject {
             type_: GasCoin::type_(),
             contents: bcs::to_bytes(&obj).unwrap(),
-            read_only: false,
         });
         Self {
-            owner,
+            owner: Owner::SingleOwner(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
         }


### PR DESCRIPTION
This PR is a preparation step for #195. We need to support different types of owners such as shared ownership in our object model first.
This PR does the following:
1. Add a new Owner enum that can represent SinglerOwner, SharedImmutable and SharedMutable. SharedMutable is currently unimplemented when encountered in authority.
2. Now that we express mutability in ownership, we no longer need the read_only field in object model. Removing the read_only field.
3. The much bigger refactoring that's caused by (1) and (2): in the existing implementation, every object has an owner, even including immutable objects. But because immutable objects no longer have an owner with this PR, we need to fix all places that are making such assumption.

Need to fix all tests. Sending out early for RFC.

TODO:
There is one thing that I didn't touch, and we need to fix: where to store immutable objects on the client store. Currently they are stored in individual account stores. But this will need to change after this PR because immutable objects no longer have an owner. A much larger refactoring is needed to properly support that.