### PR TITLE
Temporarily disable a few flaky tests in cli_tests

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -107,6 +107,8 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+// TODO: Re-enable after we fix this test.
+#[ignore]
 #[traced_test]
 #[tokio::test]
 async fn test_objects_command() -> Result<(), anyhow::Error> {
@@ -273,6 +275,8 @@ async fn test_custom_genesis_with_custom_move_package() -> Result<(), anyhow::Er
     Ok(())
 }
 
+// TODO: Re-enable after we fix this test.
+#[ignore]
 #[traced_test]
 #[tokio::test]
 async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
@@ -327,6 +331,8 @@ async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+// TODO: Re-enable after we fix this test.
+#[ignore]
 #[traced_test]
 #[tokio::test]
 async fn test_gas_command() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
A few tests in cli_tests are failing very frequently (>70%) of the time.
We need to investigate into these failures and fix them.
Temporarily disabling it now because they are too flaky. We can re-enable them once we fix the flakiness.