### PR TITLE
Add endpoint to get managed addresses

### DIFF
--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -346,14 +346,13 @@ async fn get_addresses(
     let server_context = rqctx.context();
     // TODO: Find a better way to utilize wallet context here that does not require 'take()'
     let wallet_context = server_context.wallet_context.lock().unwrap().take();
-    if wallet_context.is_none() {
-        return Err(HttpError::for_client_error(
+    let mut wallet_context = wallet_context.ok_or_else(|| {
+        HttpError::for_client_error(
             None,
             StatusCode::FAILED_DEPENDENCY,
             "Wallet Context does not exist.".to_string(),
-        ));
-    }
-    let mut wallet_context = wallet_context.unwrap();
+        )
+    })?;
 
     let addresses: Vec<SuiAddress> = wallet_context
         .address_manager


### PR DESCRIPTION
This is the second of a series of PR's that will implement the client service API described as part of the [GDC Eng Deliverables](https://docs.google.com/document/d/1NPovLImNOgsxGo1-crCHW-lrGgRNztqek3BI-p0Cfeg/edit#heading=h.iegrbr3xc14i)

The endpoints that are included in this PR are:

Get Addresses: Retrieve all managed accounts.
curl --location --request GET 'http://localhost:5000/wallet/addresses'