### PR TITLE
[docs] Fleshed out Move docs using sui-move CLI a bit more

### DIFF
--- a/sui_programmability/examples/Move.toml
+++ b/sui_programmability/examples/Move.toml
@@ -5,3 +5,8 @@ version = "0.0.1"
 [dependencies]
 Sui = { local = "../framework" }
 
+[addresses]
+Examples = "0x0"
+
+[dev-addresses]
+Examples = "0x0"


### PR DESCRIPTION
Rewritten the Move-related docs describing how to write/test Move code with sui-move CLI to better match the overall structure of the docs.

I also fleshed out the doc a bit more, adding description of structs and documentation on how to write and build a simple module.