### PR TITLE
fix: Log the server's listening information at start rather than at config

### DIFF
--- a/network_utils/src/transport.rs
+++ b/network_utils/src/transport.rs
@@ -71,6 +71,13 @@ where
     let handle = {
         // see https://fly.io/blog/the-tokio-1-x-upgrade/#tcplistener-from_std-needs-to-be-set-to-nonblocking
         let std_listener = std::net::TcpListener::bind(address)?;
+
+        if let Ok(local_addr) = std_listener.local_addr() {
+            let host = local_addr.ip();
+            let port = local_addr.port();
+            info!("Listening to TCP traffic on {host}:{port}");
+        }
+
         std_listener.set_nonblocking(true)?;
         let listener = TcpListener::from_std(std_listener)?;
 

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -31,10 +31,6 @@ impl AuthorityServer {
     }
 
     pub async fn spawn(self) -> Result<SpawnedServer, io::Error> {
-        info!(
-            "Listening to TCP traffic on {}:{}",
-            self.server.base_address, self.server.base_port
-        );
         let address = format!("{}:{}", self.server.base_address, self.server.base_port);
         let buffer_size = self.server.buffer_size;
 


### PR DESCRIPTION
We end up logging host + port binding information we attempt rather than the one that is actually obtained. This leads to:
- false positives,
- logging the wrong port in case the argument is zero.

Fixed by logging once we actually bind.