### PR TITLE
[Sui Framework] Better types and API's in ID module

### DIFF
--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -614,7 +614,7 @@ async fn test_handle_move_transaction() {
 
     // Check that gas is properly deducted.
     // If the number changes, we want to verify that the change is intended.
-    let gas_cost = 53;
+    let gas_cost = 54;
     let gas_payment_object = authority_state
         .get_object(&gas_payment_object_id)
         .await

--- a/sui_core/src/unit_tests/data/hero/sources/Hero.move
+++ b/sui_core/src/unit_tests/data/hero/sources/Hero.move
@@ -4,7 +4,7 @@ module Examples::Hero {
     use Examples::TrustedCoin::EXAMPLE;
     use Sui::Coin::{Self, Coin};
     use Sui::Event;
-    use Sui::ID::{Self, VersionedID, IDBytes};
+    use Sui::ID::{Self, ID, VersionedID};
     use Sui::Math;
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
@@ -61,9 +61,9 @@ module Examples::Hero {
         /// Address of the user that slayed the boar
         slayer_address: address,
         /// ID of the Hero that slayed the boar
-        hero: IDBytes,
+        hero: ID,
         /// ID of the now-deceased boar
-        boar: IDBytes,
+        boar: ID,
     }
 
     /// Address of the admin account that receives payment for swords
@@ -137,8 +137,8 @@ module Examples::Hero {
         // let the world know about the hero's triumph by emitting an event!
         Event::emit(BoarSlainEvent {
             slayer_address: TxContext::get_signer_address(ctx),
-            hero: *ID::get_inner(&hero.id),
-            boar: *ID::get_inner(&boar_id),
+            hero: *ID::inner(&hero.id),
+            boar: *ID::inner(&boar_id),
         });
         ID::delete(boar_id);
 

--- a/sui_programmability/examples/sources/Hero.move
+++ b/sui_programmability/examples/sources/Hero.move
@@ -4,7 +4,7 @@ module Examples::Hero {
     use Examples::TrustedCoin::EXAMPLE;
     use Sui::Coin::{Self, Coin};
     use Sui::Event;
-    use Sui::ID::{Self, VersionedID, IDBytes};
+    use Sui::ID::{Self, ID, VersionedID};
     use Sui::Math;
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
@@ -61,9 +61,9 @@ module Examples::Hero {
         /// Address of the user that slayed the boar
         slayer_address: address,
         /// ID of the Hero that slayed the boar
-        hero: IDBytes,
+        hero: ID,
         /// ID of the now-deceased boar
-        boar: IDBytes,
+        boar: ID,
     }
 
     /// Address of the admin account that receives payment for swords
@@ -137,8 +137,8 @@ module Examples::Hero {
         // let the world know about the hero's triumph by emitting an event!
         Event::emit(BoarSlainEvent {
             slayer_address: TxContext::get_signer_address(ctx),
-            hero: *ID::get_inner(&hero.id),
-            boar: *ID::get_inner(&boar_id),
+            hero: *ID::inner(&hero.id),
+            boar: *ID::inner(&boar_id),
         });
         ID::delete(boar_id);
 

--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -2,7 +2,7 @@ module Sui::Collection {
     use Std::Errors;
     use Std::Option::{Self, Option};
     use Std::Vector::Self;
-    use Sui::ID::{Self, VersionedID, IDBytes};
+    use Sui::ID::{Self, ID, VersionedID};
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
 
@@ -17,7 +17,7 @@ module Sui::Collection {
 
     struct Collection has key {
         id: VersionedID,
-        objects: vector<IDBytes>,
+        objects: vector<ID>,
         max_capacity: u64,
     }
 
@@ -34,7 +34,7 @@ module Sui::Collection {
         );
         Collection {
             id: TxContext::new_id(ctx),
-            objects: Vector::empty<IDBytes>(),
+            objects: Vector::empty(),
             max_capacity,
         }
     }
@@ -56,24 +56,24 @@ module Sui::Collection {
             size(c) + 1 <= c.max_capacity,
             Errors::limit_exceeded(EMAX_CAPACITY_EXCEEDED)
         );
-        let id_bytes = ID::get_id_bytes(&object);
-        if (contains(c, id_bytes)) {
+        let id = ID::id(&object);
+        if (contains(c, id)) {
             abort EOBJECT_DOUBLE_ADD
         };
-        Vector::push_back(&mut c.objects, *id_bytes);
+        Vector::push_back(&mut c.objects, *id);
         Transfer::transfer_to_object(object, c);
     }
 
     /// Check whether the collection contains a specific object,
     /// identified by the object id in bytes.
-    public fun contains(c: &Collection, id_bytes: &IDBytes): bool {
-        Option::is_some(&find(c, id_bytes))
+    public fun contains(c: &Collection, id: &ID): bool {
+        Option::is_some(&find(c, id))
     }
 
     /// Remove and return the object from the collection.
     /// Abort if the object is not found.
     public fun remove<T: key>(c: &mut Collection, object: T): T {
-        let idx = find(c, ID::get_id_bytes(&object));
+        let idx = find(c, ID::id(&object));
         if (Option::is_none(&idx)) {
             abort EOBJECT_DOUBLE_ADD
         };
@@ -100,11 +100,11 @@ module Sui::Collection {
 
     /// Look for the object identified by `id_bytes` in the collection.
     /// Returns the index if found, none if not found.
-    fun find(c: &Collection, id_bytes: &IDBytes): Option<u64> {
+    fun find(c: &Collection, id: &ID): Option<u64> {
         let i = 0;
         let len = size(c);
         while (i < len) {
-            if (Vector::borrow(&c.objects, i) == id_bytes) {
+            if (Vector::borrow(&c.objects, i) == id) {
                 return Option::some(i)
             };
             i = i + 1;

--- a/sui_programmability/framework/sources/Escrow.move
+++ b/sui_programmability/framework/sources/Escrow.move
@@ -2,7 +2,7 @@
 /// trusts a third party for liveness, but not
 /// safety.
 module Sui::Escrow {
-    use Sui::ID::{Self, IDBytes, VersionedID};
+    use Sui::ID::{Self, ID, VersionedID};
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
 
@@ -17,7 +17,7 @@ module Sui::Escrow {
         // TODO: this is probably a bad idea if the object is mutable.
         // that can be fixed by asking for an additional approval
         // from `sender`, but let's keep it simple for now.
-        exchange_for: IDBytes,
+        exchange_for: ID,
         /// the escrowed object
         escrowed: T,
     }
@@ -31,7 +31,7 @@ module Sui::Escrow {
     public fun create<T: key + store, ExchangeForT: key + store>(
         recipient: address,
         third_party: address,
-        exchange_for: IDBytes,
+        exchange_for: ID,
         escrowed: T,
         ctx: &mut TxContext
     ) {
@@ -70,8 +70,8 @@ module Sui::Escrow {
         assert!(&sender1 == &recipient2, ETODO);
         assert!(&sender2 == &recipient1, ETODO);
         // check object ID compatibility
-        assert!(ID::get_id_bytes(&escrowed1) == &exchange_for2, ETODO);
-        assert!(ID::get_id_bytes(&escrowed2) == &exchange_for1, ETODO);
+        assert!(ID::id(&escrowed1) == &exchange_for2, ETODO);
+        assert!(ID::id(&escrowed2) == &exchange_for1, ETODO);
         // everything matches. do the swap!
         Transfer::transfer(escrowed1, sender2);
         Transfer::transfer(escrowed2, sender1)

--- a/sui_programmability/framework/sources/Geniteam.move
+++ b/sui_programmability/framework/sources/Geniteam.move
@@ -1,5 +1,5 @@
 module Sui::Geniteam {
-    use Sui::ID::{Self, VersionedID, IDBytes};
+    use Sui::ID::{Self, ID, VersionedID};
     use Sui::TxContext::{Self, TxContext};
     use Sui::Transfer;
     use Std::ASCII::{Self, String};
@@ -119,13 +119,13 @@ module Sui::Geniteam {
 
     /// Remove a monster from a farm.
     /// Aborts if the monster with the given ID is not found
-    public fun remove_monster_(self: &mut Farm, monster_id: &IDBytes): Monster {
+    public fun remove_monster_(self: &mut Farm, monster_id: &ID): Monster {
         let monsters = &mut self.pet_monsters;
         let num_monsters = Vector::length(monsters);
         let i = 0;
         while (i < num_monsters) {
             let m = Vector::borrow(monsters, i);
-            if (ID::get_inner(&m.id) == monster_id) {
+            if (ID::id(m) == monster_id) {
                 break
             };
             i = i + 1;
@@ -190,7 +190,8 @@ module Sui::Geniteam {
 
     /// Remove a monster from a farm amd transfer it to the transaction sender
     public fun remove_monster(self: &mut Farm, monster_id: vector<u8>, ctx: &mut TxContext) {
-        let monster = remove_monster_(self, &ID::new_bytes(monster_id));
+        // TODO: monster_id should be probably be `address`, but leaving this as-is to avoid breaking Geniteam
+        let monster = remove_monster_(self, &ID::new_from_bytes(monster_id));
         Transfer::transfer(monster, TxContext::get_signer_address(ctx))
     }
 

--- a/sui_programmability/framework/sources/ID.move
+++ b/sui_programmability/framework/sources/ID.move
@@ -1,19 +1,50 @@
 /// Sui object identifiers
 module Sui::ID {
     use Std::BCS;
-    // TODO(): bring this back
-    //friend Sui::TxContext;
+    use Std::Vector;
 
-    /// Version of a ID created by the current transaction.
+    friend Sui::Transfer;
+    friend Sui::TxContext;
+
+    #[test_only]
+    friend Sui::TestScenario;
+    
+    /// Version of an object ID created by the current transaction.
     const INITIAL_VERSION: u64 = 0;
 
+    /// Number of bytes in an object ID
+    const ID_SIZE: u64 = 20;
+
+    /// Attempting to construct an object ID with the wrong number of bytes--expected 20.
+    const EBAD_ID_LENGTH: u64 = 0;
+
     /// Globally unique identifier of an object. This is a privileged type
-    /// that can only be derived from a `TxContext`
-    /// VersionedID doesn't have drop capability, which means to delete an VersionedID (when
-    /// deleting an object), one must explicitly call the delete function.
+    /// that can only be derived from a `TxContext`.
+    // Currently, this is not exposed and is thus somewhat redundant, but
+    // in the future we may want a type representing a globally unique ID
+    // without a version.
+    struct UniqueID has store {
+        id: ID
+    }
+
+    /// An object ID. Unlike `UniqueID`, this is *not* guaranteed to be globally
+    /// unique--anyone can create an `ID`, and ID's can be freely copied and dropped
+    /// Useful for comparing with `UniqueID`'s.
+    struct ID has store, drop, copy {
+        // We use `address` instead of `vector<u8>` here because `address` has a more
+        // compact serialization. `address` is serialized as a BCS fixed-length sequence,
+        // which saves us the length prefix we would pay for if this were `vector<u8>`.
+        // See https://github.com/diem/bcs#fixed-and-variable-length-sequences.
+        bytes: address
+    }
+
+    /// A globally unique ID paired with a version. Similar to `UniqueID`,
+    /// this is a privileged type that can only be derived from a `TxContext`
+    /// VersionedID doesn't have the `drop` ability, so deleting a `VersionedID`
+    /// requires a call to `ID::delete`
     struct VersionedID has store {
-        id: IDBytes,
-        /// Version number for the VersionedID. The version number is incremented each
+        id: UniqueID,
+        /// Version number for the object. The version number is incremented each
         /// time the object with this VersionedID is passed to a non-failing transaction
         /// either by value or by mutable reference.
         /// Note: if the object with this VersionedID gets wrapped in another object, the
@@ -21,65 +52,101 @@ module Sui::ID {
         version: u64
     }
 
-    /// Underlying representation of an ID.
-    /// Unlike ID, not a privileged type--can be freely copied and created
-    struct IDBytes has store, drop, copy {
-        bytes: address
+    // --- constructors ---
+
+    /// Create an `ID` from an address
+    public fun new(a: address): ID {
+        ID { bytes: a }
     }
 
-    /// Create a new VersionedID. Only callable by TxContext
-    // TODO (): bring this back once we can support `friend`
-    //public(friend) fun new(bytes: vector<u8>): VersionedID {
-    public fun new(bytes: address): VersionedID {
-        VersionedID { id: IDBytes { bytes }, version: INITIAL_VERSION }
+    /// Create an `ID` from raw bytes.
+    /// Aborts with `EBAD_ID_LENGTH` if the length of `bytes` is not `ID_SIZE`
+    public fun new_from_bytes(bytes: vector<u8>): ID {
+        if (Vector::length(&bytes) != ID_SIZE) {
+            abort(EBAD_ID_LENGTH)
+        };
+        ID { bytes: bytes_to_address(bytes) }
+    }
+   
+    /// Create a new `VersionedID`. Only callable by `TxContext`.
+    /// This is the only way to create either a `VersionedID` or a `UniqueID`.
+    public(friend) fun new_versioned_id(bytes: address): VersionedID {
+        VersionedID { id: UniqueID { id: ID { bytes } }, version: INITIAL_VERSION }
     }
 
-    /// Create a new ID bytes for comparison with existing ID's.
-    public fun new_bytes(bytes: vector<u8>): IDBytes {
-        IDBytes { bytes: bytes_to_address(bytes) }
+    // --- reads ---
+
+    /// Get the underyling `ID` of `obj`
+    public fun id<T: key>(obj: &T): &ID {
+        let versioned_id = get_versioned_id(obj);
+        inner(versioned_id)
     }
 
-    /// Get the underyling `IDBytes` of `id`
-    public fun get_inner(id: &VersionedID): &IDBytes {
-        &id.id
+    /// Get raw bytes for the underyling `ID` of `obj`
+    public fun id_bytes<T: key>(obj: &T): vector<u8> {
+        let versioned_id = get_versioned_id(obj);
+        inner_bytes(versioned_id)
+    }
+ 
+    /// Get the raw bytes of `id`
+    public fun bytes(id: &ID): vector<u8> {
+        BCS::to_bytes(&id.bytes)
     }
 
-    /// Get the `IDBytes` of `obj`
-    public fun get_id_bytes<T: key>(obj: &T): &IDBytes {
-        &get_id(obj).id
+    /// Get the inner `ID` of `versioned_id`
+    public fun inner(versioned_id: &VersionedID): &ID {
+        &versioned_id.id.id
     }
 
-    /// Get the `version` of `obj`
-    public fun get_version<T: key>(obj: &T): u64 {
-        *&get_id(obj).version
+    /// Get the raw bytes of a `versioned_id`'s inner `ID`
+    public fun inner_bytes(versioned_id: &VersionedID): vector<u8> {
+        bytes(inner(versioned_id))
+    }
+
+    /// Get the id of `obj` as an address.
+    // Only used by `Transfer` and `TestSecnario`, but may expose in the future
+    public(friend) fun id_address<T: key>(obj: &T): address {
+        let id = id(obj);
+        id.bytes
+    }
+
+    /// Get the `version` of `obj`. 
+    // Private and unused for now, but may expose in the future
+    fun version<T: key>(obj: &T): u64 {
+        let versioned_id = get_versioned_id(obj);
+        versioned_id.version
     }
 
     /// Return `true` if `obj` was created by the current transaction,
-    /// `false` otherwise.
-    public fun created_by_current_tx<T: key>(obj: &T): bool {
-        get_version(obj) == INITIAL_VERSION
+    /// `false` otherwise. 
+    // Private and unused for now, but may expose in the future
+    fun created_by_current_tx<T: key>(obj: &T): bool {
+        version(obj) == INITIAL_VERSION
     }
 
-    /// Get the raw bytes of `i` in its underlying representation
-    // TODO: we should probably not expose that this is an `address`
-    public fun get_bytes(i: &IDBytes): &address {
-        &i.bytes
+    /// Get the VersionedID for `obj`. 
+    // Safe because Sui has an extra
+    // bytecode verifier pass that forces every struct with
+    // the `key` ability to have a distinguished `VersionedID` field.
+    // Private for now, but may expose in the future.
+    native fun get_versioned_id<T: key>(obj: &T): &VersionedID;
+
+    // --- destructors --- 
+
+    /// Delete `id`. This is the only way to eliminate a `VersionedID`.
+    // This exists to inform Sui of object deletions. When an object
+    // gets unpacked, the programmer will have to do something with its
+    // `VersionedID`. The implementation of this function emits a deleted
+    // system event so Sui knows to process the object deletion
+    public fun delete(versioned_id: VersionedID) {
+        let VersionedID { id, version: _ } = versioned_id;
+        delete_id(id)
     }
 
-    /// Get the raw bytes of `i` as a vector
-    public fun get_bytes_as_vec(i: &IDBytes): vector<u8> {
-        BCS::to_bytes(get_bytes(i))
-    }
+    native fun delete_id(id: UniqueID);
 
-    /// Get the VersionedID for `obj`. Safe because sui has an extra
-    /// bytecode verifier pass that forces every struct with
-    /// the `key` ability to have a distinguished `VersionedID` field.
-    public native fun get_id<T: key>(obj: &T): &VersionedID;
+    // --- internal functions --- 
 
-    public native fun bytes_to_address(bytes: vector<u8>): address;
-
-    /// When an object is being deleted through unpacking, the 
-    /// delete function must be called on the id to inform Sui
-    /// regarding the deletion of the object.
-    public native fun delete(id: VersionedID);
+    /// Convert raw bytes into an address
+    native fun bytes_to_address(bytes: vector<u8>): address;   
 }

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -34,7 +34,8 @@ module Sui::Transfer {
     /// Transfer ownership of `obj` to another object `owner`.
     // TODO: Add option to freeze after transfer.
     public fun transfer_to_object<T: key, R: key>(obj: T, owner: &mut R) {
-        transfer_to_object_id(obj, *ID::get_bytes(ID::get_id_bytes(owner)));
+        let owner_id = ID::id_address(owner);
+        transfer_to_object_id(obj, owner_id);
     }
 
     /// Transfer ownership of `obj` to another object with `id`.

--- a/sui_programmability/framework/sources/TxContext.move
+++ b/sui_programmability/framework/sources/TxContext.move
@@ -1,12 +1,11 @@
 module Sui::TxContext {
+    use Std::Signer;
+    use Sui::ID::{Self, VersionedID};
+
     #[test_only]
     use Std::Errors;
     #[test_only]
     use Std::Vector;
-
-    use Std::Signer;
-
-    use Sui::ID::{Self, VersionedID};
 
     /// Number of bytes in an inputs_hash (which will be the transaction digest)
     const INPUTS_HASH_LENGTH: u64 = 32;
@@ -18,7 +17,6 @@ module Sui::TxContext {
     /// This is a privileged object created by the VM and passed into `main`
     struct TxContext has drop {
         /// The signer of the current transaction
-        // TODO: use vector<signer> if we want to support multi-agent
         signer: signer,
         /// Hash of all the input objects to this transaction
         inputs_hash: vector<u8>,
@@ -43,14 +41,15 @@ module Sui::TxContext {
         self.ids_created
     }
 
-    /// Generate a new object ID
+    /// Generate a new, globally unqiue object ID with version 0
     public fun new_id(ctx: &mut TxContext): VersionedID {
         let ids_created = ctx.ids_created;
-        let id = ID::new(fresh_id(*&ctx.inputs_hash, ids_created));
+        let id = ID::new_versioned_id(fresh_id(*&ctx.inputs_hash, ids_created));
         ctx.ids_created = ids_created + 1;
         id
     }
 
+    /// Native function for deriving an ID via hash(inputs_hash || ids_created || domain_separator)
     native fun fresh_id(inputs_hash: vector<u8>, ids_created: u64): address;
 
     // ==== test-only functions ====
@@ -91,6 +90,7 @@ module Sui::TxContext {
         inputs_hash
     }
 
+    #[test_only]
     /// Test-only function for creating a new signer from `signer_address`.
     native fun new_signer_from_address(signer_address: address): signer;
 }

--- a/sui_programmability/framework/src/natives/id.rs
+++ b/sui_programmability/framework/src/natives/id.rs
@@ -36,7 +36,7 @@ pub fn bytes_to_address(
     Ok(NativeResult::ok(cost, smallvec![Value::address(addr)]))
 }
 
-pub fn get_id(
+pub fn get_versioned_id(
     context: &mut NativeContext,
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
@@ -53,7 +53,7 @@ pub fn get_id(
     Ok(NativeResult::ok(cost, smallvec![id_field]))
 }
 
-pub fn delete(
+pub fn delete_id(
     context: &mut NativeContext,
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
@@ -63,8 +63,11 @@ pub fn delete(
 
     let obj = pop_arg!(args, Struct);
     // All of the following unwraps are safe by construction because a properly verified
-    // bytecode ensures that the parameter must be of ID type with the correct fields.
-    // Get the `id` field of the ID struct, which is of type IDBytes.
+    // bytecode ensures that the parameter must be of type UniqueID with the correct fields:
+    // ```
+    // UniqueID { id: ID { bytes: address } }
+    // ```
+    // Get the `id` field of the UniqueID struct, which is of type ID
     let id_field = obj
         .unpack()
         .unwrap()
@@ -72,7 +75,7 @@ pub fn delete(
         .unwrap()
         .value_as::<Struct>()
         .unwrap();
-    // Get the inner address of type IDBytes.
+    // Get the inner address of the ID type
     let id = id_field.unpack().unwrap().next().unwrap();
 
     // TODO: what should the cost of this be?

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -17,8 +17,8 @@ pub fn all_natives(
     const SUI_NATIVES: &[(&str, &str, NativeFunction)] = &[
         ("Event", "emit", event::emit),
         ("ID", "bytes_to_address", id::bytes_to_address),
-        ("ID", "delete", id::delete),
-        ("ID", "get_id", id::get_id),
+        ("ID", "delete_id", id::delete_id),
+        ("ID", "get_versioned_id", id::get_versioned_id),
         (
             "TestScenario",
             "deleted_object_ids",

--- a/sui_programmability/framework/src/natives/transfer.rs
+++ b/sui_programmability/framework/src/natives/transfer.rs
@@ -43,7 +43,7 @@ pub fn transfer_internal(
 }
 
 /// Implementation of Move native function
-/// `transfer_to_object_id<T: key>(obj: T, id: IDBytes)`
+/// `transfer_to_object_id<T: key>(obj: T, id: address)`
 pub fn transfer_to_object_id(
     context: &mut NativeContext,
     mut ty_args: Vec<Type>,

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -18,16 +18,16 @@ module Sui::CollectionTests {
         assert!(Collection::size(&collection) == 0, ECOLLECTION_SIZE_MISMATCH);
 
         let obj1 = Object { id: TxContext::new_id(&mut ctx) };
-        let id_bytes1 = *ID::get_id_bytes(&obj1);
+        let id1 = *ID::id(&obj1);
         let obj2 = Object { id: TxContext::new_id(&mut ctx) };
-        let id_bytes2 = *ID::get_id_bytes(&obj2);
+        let id2 = *ID::id(&obj2);
 
         Collection::add(&mut collection, obj1);
         Collection::add(&mut collection, obj2);
         assert!(Collection::size(&collection) == 2, ECOLLECTION_SIZE_MISMATCH);
 
-        assert!(Collection::contains(&collection, &id_bytes1), EOBJECT_NOT_FOUND);
-        assert!(Collection::contains(&collection, &id_bytes2), EOBJECT_NOT_FOUND);
+        assert!(Collection::contains(&collection, &id1), EOBJECT_NOT_FOUND);
+        assert!(Collection::contains(&collection, &id2), EOBJECT_NOT_FOUND);
 
         Collection::transfer(collection, TxContext::get_signer_address(&ctx));
     }

--- a/sui_programmability/framework/tests/IDTests.move
+++ b/sui_programmability/framework/tests/IDTests.move
@@ -12,10 +12,10 @@ module Sui::IDTests {
     #[test]
     fun test_get_id() {
         let ctx = TxContext::dummy();
-        let id = TxContext::new_id(&mut ctx);
-        let id_bytes = *ID::get_inner(&id);
-        let obj = Object { id };
-        assert!(ID::get_inner(ID::get_id(&obj)) == &id_bytes, ID_BYTES_MISMATCH);
+        let versioned_id = TxContext::new_id(&mut ctx);
+        let obj_id = *ID::inner(&versioned_id);
+        let obj = Object { id: versioned_id };
+        assert!(*ID::id(&obj) == obj_id, ID_BYTES_MISMATCH);
         let Object { id } = obj;
         ID::delete(id);
     }

--- a/sui_programmability/framework/tests/TestScenarioTests.move
+++ b/sui_programmability/framework/tests/TestScenarioTests.move
@@ -180,7 +180,7 @@ module Sui::TestScenarioTests {
         let id_bytes;
         {
             let id = TestScenario::new_id(&mut scenario);
-            id_bytes = *ID::get_inner(&id);
+            id_bytes = *ID::inner(&id);
             let obj = Object { id, value: 100 };
             Transfer::transfer(obj, copy tx2_sender);
             // sender cannot access the object
@@ -192,7 +192,7 @@ module Sui::TestScenarioTests {
             assert!(TestScenario::can_remove_object<Object>(&scenario), 1);
             let received_obj = TestScenario::remove_object<Object>(&mut scenario);
             let Object { id: received_id, value } = received_obj;
-            assert!(ID::get_inner(&received_id) == &id_bytes, ID_BYTES_MISMATCH);
+            assert!(ID::inner(&received_id) == &id_bytes, ID_BYTES_MISMATCH);
             assert!(value == 100, VALUE_MISMATCH);
             ID::delete(received_id);
         };

--- a/sui_types/src/id.rs
+++ b/sui_types/src/id.rs
@@ -15,26 +15,35 @@ use crate::{
 };
 
 pub const ID_MODULE_NAME: &IdentStr = ident_str!("ID");
+pub const VERSIONED_ID_STRUCT_NAME: &IdentStr = ident_str!("VersionedID");
+pub const UNIQUE_ID_STRUCT_NAME: &IdentStr = ident_str!("UniqueID");
 pub const ID_STRUCT_NAME: &IdentStr = ID_MODULE_NAME;
-pub const ID_BYTES_STRUCT_NAME: &IdentStr = ident_str!("IDBytes");
 
 /// Rust version of the Move Sui::ID::VersionedID type
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VersionedID {
-    id: IDBytes,
+    id: UniqueID,
     version: u64,
 }
 
-/// Rust version of the Move Sui::ID::IDBytes type
+/// Rust version of the Move Sui::ID::UniqueID type
 #[derive(Debug, Serialize, Deserialize)]
-struct IDBytes {
+struct UniqueID {
+    id: ID,
+}
+
+/// Rust version of the Move Sui::ID::ID type
+#[derive(Debug, Serialize, Deserialize)]
+struct ID {
     bytes: ObjectID,
 }
 
 impl VersionedID {
     pub fn new(bytes: ObjectID, version: SequenceNumber) -> Self {
         Self {
-            id: IDBytes::new(bytes),
+            id: UniqueID {
+                id: { ID { bytes } },
+            },
             version: version.value(),
         }
     }
@@ -42,14 +51,14 @@ impl VersionedID {
     pub fn type_() -> StructTag {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,
-            name: ID_STRUCT_NAME.to_owned(),
+            name: VERSIONED_ID_STRUCT_NAME.to_owned(),
             module: ID_MODULE_NAME.to_owned(),
             type_params: Vec::new(),
         }
     }
 
     pub fn object_id(&self) -> &ObjectID {
-        &self.id.bytes
+        &self.id.id.bytes
     }
 
     pub fn version(&self) -> SequenceNumber {
@@ -66,7 +75,7 @@ impl VersionedID {
             fields: vec![
                 MoveFieldLayout::new(
                     ident_str!("id").to_owned(),
-                    MoveTypeLayout::Struct(IDBytes::layout()),
+                    MoveTypeLayout::Struct(UniqueID::layout()),
                 ),
                 MoveFieldLayout::new(ident_str!("version").to_owned(), MoveTypeLayout::U64),
             ],
@@ -74,15 +83,32 @@ impl VersionedID {
     }
 }
 
-impl IDBytes {
-    pub fn new(bytes: ObjectID) -> Self {
-        Self { bytes }
-    }
-
+impl UniqueID {
     pub fn type_() -> StructTag {
         StructTag {
             address: SUI_FRAMEWORK_ADDRESS,
-            name: ID_BYTES_STRUCT_NAME.to_owned(),
+            name: UNIQUE_ID_STRUCT_NAME.to_owned(),
+            module: ID_MODULE_NAME.to_owned(),
+            type_params: Vec::new(),
+        }
+    }
+
+    pub fn layout() -> MoveStructLayout {
+        MoveStructLayout::WithTypes {
+            type_: Self::type_(),
+            fields: vec![MoveFieldLayout::new(
+                ident_str!("id").to_owned(),
+                MoveTypeLayout::Struct(ID::layout()),
+            )],
+        }
+    }
+}
+
+impl ID {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            name: ID_STRUCT_NAME.to_owned(),
             module: ID_MODULE_NAME.to_owned(),
             type_params: Vec::new(),
         }


### PR DESCRIPTION
Big cleanup of the ID module that should hopefully help with usability. Probably best to look at the `ID` module first, then check on its callers to make sure the code looks better.

- Get rid of `IDBytes`, which is not very intuitive. The equivalent type is now called `ID`.
- Rename functions for getting `ID`'s or a `vector<u8>` encoding of an ID from an object. These are likely to be the most commonly used, so tried to give them concise names and sensible type signatures.
- Introduce abort code for `new_from_bytes`
- Hid functions that let the programmer read the `version` of the object
- Hid functions that let the programmer see that an ID is encoded as an `address` under the hood. We may want the flexibility to change this.
- Introduce a `UniqueID` type to represent a globally unique ID. This isn't currently exposed to users and is technically redundant (i.e., could replace it with `ID` without any consequences), but keeping it to preserve the conceptual distinction between (1) unprivileged ID's that can be constructed by anyone, (2) privileged ID's that are guaranteed to be globally unique, (3) privileged versioned ID's. (2) may be useful in the future.
- Lot of doc comments and general reorg.

Closes https://github.com/MystenLabs/fastnft/issues/498, https://github.com/MystenLabs/fastnft/issues/500, https://github.com/MystenLabs/fastnft/issues/499