### PR TITLE
Add entry functions check & list

### DIFF
--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -202,15 +202,13 @@ fn call(
 fn get_genesis_package_by_module(genesis_objects: &[Object], module: &str) -> Object {
     genesis_objects
         .iter()
-        .find_map(|o| match o.data.try_as_package() {
-            Some(p) => {
-                if p.serialized_module_map().keys().any(|name| name == module) {
-                    Some(o.clone())
-                } else {
-                    None
+        .find_map(|o| {
+            if let Some(q) = o.data.try_as_package() {
+                if q.serialized_module_map().keys().any(|name| name == module) {
+                    return Some(o.clone());
                 }
             }
-            None => None,
+            None
         })
         .unwrap()
 }

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.78"
 serde_with = "1.11.0"
 signature = "1.5.0"
 static_assertions = "1.1.0"
+match_opt = "0.1.2"
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="d04c29e686aba380e6f9fc0c60a2dfdb974c5f8a"}
 

--- a/sui_types/src/move_package.rs
+++ b/sui_types/src/move_package.rs
@@ -149,11 +149,7 @@ impl MovePackage {
             .iter()
             .filter_map(|f| {
                 let fn_sig = Function::new(&compiled_module, f);
-
-                match Self::check_entry_function(&fn_sig.1) {
-                    Ok(_) => Some(fn_sig),
-                    Err(_) => None,
-                }
+                match_opt::match_opt!(Self::check_entry_function(&fn_sig.1), Ok(_) => fn_sig)
             })
             .collect())
     }


### PR DESCRIPTION
Part of efforts to make Move calls easier to perform from CLI/REST etc.
Added listing entry functions in a module
Will expose this to the CLI in future so folks can see which functions they can call, and how to call them.

**Note:**
I would ideally love to place MovePackage tests in some standalone `unit_tests/MovePackage.rs`, however testing MovePackage in isolation is tricky because we need to test Sui specific things, which also depend on base-types and this creates a circular dependency.
So my current solution is to test MovePackage from higher level systems.