### PR TITLE
[Sui Framework] Clean up TxContext API's

### DIFF
--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/CustomObjectTemplate.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/CustomObjectTemplate.move
@@ -96,7 +96,7 @@ module Examples::CustomObjectTemplate {
         write_field(to_write, v + int_input);
         transfer(to_consume, recipient);
         // demonstrate creating a new object for the sender
-        let sender = TxContext::get_signer_address(ctx);
+        let sender = TxContext::sender(ctx);
         Transfer::transfer(create(ctx), sender)
     }
 

--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/TicTacToe.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/TicTacToe.move
@@ -74,7 +74,7 @@ module Examples::TicTacToe {
             x_address: x_address,
             o_address: o_address,
         };
-        Transfer::transfer(game, TxContext::get_signer_address(ctx));
+        Transfer::transfer(game, TxContext::sender(ctx));
         let cap = MarkMintCap {
             id: TxContext::new_id(ctx),
             game_id: copy game_id,
@@ -174,7 +174,7 @@ module Examples::TicTacToe {
         cap.remaining_supply = cap.remaining_supply - 1;
         Mark {
             id: TxContext::new_id(ctx),
-            player: TxContext::get_signer_address(ctx),
+            player: TxContext::sender(ctx),
             row,
             col,
         }

--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/TrustedCoin.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/TrustedCoin.move
@@ -14,12 +14,12 @@ module Examples::TrustedCoin {
         // Get a treasury cap for the coin and give it to the transaction
         // sender
         let treasury_cap = Coin::create_currency<EXAMPLE>(EXAMPLE{}, ctx);
-        Transfer::transfer(treasury_cap, TxContext::get_signer_address(ctx))
+        Transfer::transfer(treasury_cap, TxContext::sender(ctx))
     }
 
     public fun mint(treasury_cap: &mut TreasuryCap<EXAMPLE>, amount: u64, ctx: &mut TxContext) {
         let coin = Coin::mint<EXAMPLE>(amount, treasury_cap, ctx);
-        Coin::transfer(coin, TxContext::get_signer_address(ctx));
+        Coin::transfer(coin, TxContext::sender(ctx));
     }
 
     public fun transfer(treasury_cap: TreasuryCap<EXAMPLE>, recipient: address, _ctx: &mut TxContext) {

--- a/sui/src/unit_tests/data/custom_genesis_package_2/sources/M1.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_2/sources/M1.move
@@ -11,6 +11,6 @@ module Test::M1 {
     // initializer that should be executed upon publishing this module
     fun init(ctx: &mut TxContext, value: u64) {
         let singleton = Object { id: TxContext::new_id(ctx), value };
-        Transfer::transfer(singleton, TxContext::get_signer_address(ctx))
+        Transfer::transfer(singleton, TxContext::sender(ctx))
     }
 }

--- a/sui_core/src/unit_tests/data/hero/sources/Hero.move
+++ b/sui_core/src/unit_tests/data/hero/sources/Hero.move
@@ -96,7 +96,7 @@ module Examples::Hero {
     fun init(ctx: &mut TxContext) {
         let admin = admin();
         // ensure this is being initialized by the expected admin authenticator
-        assert!(&TxContext::get_signer_address(ctx) == &admin, ENOT_ADMIN);
+        assert!(&TxContext::sender(ctx) == &admin, ENOT_ADMIN);
         Transfer::transfer(
             GameAdmin {
                 id: TxContext::new_id(ctx),
@@ -136,7 +136,7 @@ module Examples::Hero {
         };
         // let the world know about the hero's triumph by emitting an event!
         Event::emit(BoarSlainEvent {
-            slayer_address: TxContext::get_signer_address(ctx),
+            slayer_address: TxContext::sender(ctx),
             hero: *ID::inner(&hero.id),
             boar: *ID::inner(&boar_id),
         });
@@ -222,7 +222,7 @@ module Examples::Hero {
     public fun acquire_hero(payment: Coin<EXAMPLE>, ctx: &mut TxContext) {
         let sword = create_sword(payment, ctx);
         let hero = create_hero(sword, ctx);
-        Transfer::transfer(hero, TxContext::get_signer_address(ctx))
+        Transfer::transfer(hero, TxContext::sender(ctx))
     }
 
     /// Anyone can create a hero if they have a sword. All heros start with the

--- a/sui_core/src/unit_tests/data/hero/sources/TrustedCoin.move
+++ b/sui_core/src/unit_tests/data/hero/sources/TrustedCoin.move
@@ -14,12 +14,12 @@ module Examples::TrustedCoin {
         // Get a treasury cap for the coin and give it to the transaction
         // sender
         let treasury_cap = Coin::create_currency<EXAMPLE>(EXAMPLE{}, ctx);
-        Transfer::transfer(treasury_cap, TxContext::get_signer_address(ctx))
+        Transfer::transfer(treasury_cap, TxContext::sender(ctx))
     }
 
     public fun mint(treasury_cap: &mut TreasuryCap<EXAMPLE>, amount: u64, ctx: &mut TxContext) {
         let coin = Coin::mint<EXAMPLE>(amount, treasury_cap, ctx);
-        Coin::transfer(coin, TxContext::get_signer_address(ctx));
+        Coin::transfer(coin, TxContext::sender(ctx));
     }
 
     public fun transfer(treasury_cap: TreasuryCap<EXAMPLE>, recipient: address, _ctx: &mut TxContext) {

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init/sources/M1.move
@@ -12,6 +12,6 @@ module Test::M1 {
     fun init(ctx: &mut TxContext) {
         let value = 42;
         let singleton = Object { id: TxContext::new_id(ctx), value };
-        Transfer::transfer(singleton, TxContext::get_signer_address(ctx))
+        Transfer::transfer(singleton, TxContext::sender(ctx))
     }
 }

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init_param/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init_param/sources/M1.move
@@ -11,6 +11,6 @@ module Test::M1 {
     // initializer that should be executed upon publishing this module
     fun init(ctx: &mut TxContext, value: u64) {
         let singleton = Object { id: TxContext::new_id(ctx), value };
-        Transfer::transfer(singleton, TxContext::get_signer_address(ctx))
+        Transfer::transfer(singleton, TxContext::sender(ctx))
     }
 }

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init_public/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init_public/sources/M1.move
@@ -12,6 +12,6 @@ module Test::M1 {
     public fun init(ctx: &mut TxContext) {
         let value = 42;
         let singleton = Object { id: TxContext::new_id(ctx), value };
-        Transfer::transfer(singleton, TxContext::get_signer_address(ctx))
+        Transfer::transfer(singleton, TxContext::sender(ctx))
     }
 }

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init_ret/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init_ret/sources/M1.move
@@ -12,7 +12,7 @@ module Test::M1 {
     fun init(ctx: &mut TxContext): u64 {
         let value = 42;
         let singleton = Object { id: TxContext::new_id(ctx), value };
-        Transfer::transfer(singleton, TxContext::get_signer_address(ctx));
+        Transfer::transfer(singleton, TxContext::sender(ctx));
         value
     }
 }

--- a/sui_programmability/examples/sources/CombinableObjects.move
+++ b/sui_programmability/examples/sources/CombinableObjects.move
@@ -16,7 +16,7 @@ module Examples::CombinableObjects {
     }
 
     struct Sandwich has key {
-        id: VersionedID
+        id: VersionedID,
     }
 
     /// Address selling ham, bread, etc
@@ -46,12 +46,12 @@ module Examples::CombinableObjects {
     /// Combine the `ham` and `bread` into a delicious sandwich
     public fun make_sandwich(
         ham: Ham, bread: Bread, ctx: &mut TxContext
-    ): Sandwich {
+    ) {
         let Ham { id: ham_id } = ham;
         let Bread { id: bread_id } = bread;
         ID::delete(ham_id);
         ID::delete(bread_id);
-        Sandwich { id: TxContext::new_id(ctx) }
+        Transfer::transfer(Sandwich { id: TxContext::new_id(ctx) }, TxContext::sender(ctx))
     }
 
     fun admin(): address {

--- a/sui_programmability/examples/sources/CustomObjectTemplate.move
+++ b/sui_programmability/examples/sources/CustomObjectTemplate.move
@@ -96,7 +96,7 @@ module Examples::CustomObjectTemplate {
         write_field(to_write, v + int_input);
         transfer(to_consume, recipient);
         // demonstrate creating a new object for the sender
-        let sender = TxContext::get_signer_address(ctx);
+        let sender = TxContext::sender(ctx);
         Transfer::transfer(create(ctx), sender)
     }
 

--- a/sui_programmability/examples/sources/EconMod.move
+++ b/sui_programmability/examples/sources/EconMod.move
@@ -47,7 +47,7 @@ module Examples::EconMod {
             HelpMeSlayThisMonster {
                 id: TxContext::new_id(ctx),
                 monster,
-                monster_owner: TxContext::get_signer_address(ctx),
+                monster_owner: TxContext::sender(ctx),
                 helper_reward
             },
             helper

--- a/sui_programmability/examples/sources/Hero.move
+++ b/sui_programmability/examples/sources/Hero.move
@@ -96,7 +96,7 @@ module Examples::Hero {
     fun init(ctx: &mut TxContext) {
         let admin = admin();
         // ensure this is being initialized by the expected admin authenticator
-        assert!(&TxContext::get_signer_address(ctx) == &admin, ENOT_ADMIN);
+        assert!(&TxContext::sender(ctx) == &admin, ENOT_ADMIN);
         Transfer::transfer(
             GameAdmin {
                 id: TxContext::new_id(ctx),
@@ -136,7 +136,7 @@ module Examples::Hero {
         };
         // let the world know about the hero's triumph by emitting an event!
         Event::emit(BoarSlainEvent {
-            slayer_address: TxContext::get_signer_address(ctx),
+            slayer_address: TxContext::sender(ctx),
             hero: *ID::inner(&hero.id),
             boar: *ID::inner(&boar_id),
         });
@@ -222,7 +222,7 @@ module Examples::Hero {
     public fun acquire_hero(payment: Coin<EXAMPLE>, ctx: &mut TxContext) {
         let sword = create_sword(payment, ctx);
         let hero = create_hero(sword, ctx);
-        Transfer::transfer(hero, TxContext::get_signer_address(ctx))
+        Transfer::transfer(hero, TxContext::sender(ctx))
     }
 
     /// Anyone can create a hero if they have a sword. All heros start with the

--- a/sui_programmability/examples/sources/HeroMod.move
+++ b/sui_programmability/examples/sources/HeroMod.move
@@ -63,7 +63,7 @@ module Examples::HeroMod {
                 token_supply_max,
                 monster_max,
             },
-            TxContext::get_signer_address(ctx)
+            TxContext::sender(ctx)
         )
     }
 

--- a/sui_programmability/examples/sources/TicTacToe.move
+++ b/sui_programmability/examples/sources/TicTacToe.move
@@ -74,7 +74,7 @@ module Examples::TicTacToe {
             x_address: x_address,
             o_address: o_address,
         };
-        Transfer::transfer(game, TxContext::get_signer_address(ctx));
+        Transfer::transfer(game, TxContext::sender(ctx));
         let cap = MarkMintCap {
             id: TxContext::new_id(ctx),
             game_id: copy game_id,
@@ -174,7 +174,7 @@ module Examples::TicTacToe {
         cap.remaining_supply = cap.remaining_supply - 1;
         Mark {
             id: TxContext::new_id(ctx),
-            player: TxContext::get_signer_address(ctx),
+            player: TxContext::sender(ctx),
             row,
             col,
         }

--- a/sui_programmability/examples/sources/TrustedCoin.move
+++ b/sui_programmability/examples/sources/TrustedCoin.move
@@ -14,12 +14,12 @@ module Examples::TrustedCoin {
         // Get a treasury cap for the coin and give it to the transaction
         // sender
         let treasury_cap = Coin::create_currency<EXAMPLE>(EXAMPLE{}, ctx);
-        Transfer::transfer(treasury_cap, TxContext::get_signer_address(ctx))
+        Transfer::transfer(treasury_cap, TxContext::sender(ctx))
     }
 
     public fun mint(treasury_cap: &mut TreasuryCap<EXAMPLE>, amount: u64, ctx: &mut TxContext) {
         let coin = Coin::mint<EXAMPLE>(amount, treasury_cap, ctx);
-        Coin::transfer(coin, TxContext::get_signer_address(ctx));
+        Coin::transfer(coin, TxContext::sender(ctx));
     }
 
     public fun transfer(treasury_cap: TreasuryCap<EXAMPLE>, recipient: address, _ctx: &mut TxContext) {

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -55,7 +55,7 @@ module Sui::Coin {
     /// and the remaining balance is left is `self`.
     public fun split<T>(self: &mut Coin<T>, split_amount: u64, ctx: &mut TxContext) {
         let new_coin = withdraw(self, split_amount, ctx);
-        Transfer::transfer(new_coin, TxContext::get_signer_address(ctx));
+        Transfer::transfer(new_coin, TxContext::sender(ctx));
     }
 
     /// Split coin `self` into multiple coins, each with balance specified

--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -41,7 +41,7 @@ module Sui::Collection {
 
     /// Create a new Collection and transfer it to the signer.
     public fun create(ctx: &mut TxContext) {
-        Transfer::transfer(new(ctx), TxContext::get_signer_address(ctx))
+        Transfer::transfer(new(ctx), TxContext::sender(ctx))
     }
 
     /// Returns the size of the collection.
@@ -84,7 +84,7 @@ module Sui::Collection {
     /// Remove the object from the collection, and then transfer it to the signer.
     public fun remove_and_take<T: key>(c: &mut Collection, object: T, ctx: &mut TxContext) {
         let object = remove(c, object);
-        Transfer::transfer(object, TxContext::get_signer_address(ctx));
+        Transfer::transfer(object, TxContext::sender(ctx));
     }
 
     /// Transfer the entire collection to `recipient`.

--- a/sui_programmability/framework/sources/Escrow.move
+++ b/sui_programmability/framework/sources/Escrow.move
@@ -35,7 +35,7 @@ module Sui::Escrow {
         escrowed: T,
         ctx: &mut TxContext
     ) {
-        let sender = TxContext::get_signer_address(ctx);
+        let sender = TxContext::sender(ctx);
         let id = TxContext::new_id(ctx);
         // escrow the object with the trusted third party
         Transfer::transfer(

--- a/sui_programmability/framework/sources/GAS.move
+++ b/sui_programmability/framework/sources/GAS.move
@@ -14,7 +14,7 @@ module Sui::GAS {
     fun init(ctx: &mut TxContext) {
         // Get a treasury cap for the coin and give it to the transaction sender
         let treasury_cap = Coin::create_currency(GAS{}, ctx);
-        Transfer::transfer(treasury_cap, TxContext::get_signer_address(ctx))
+        Transfer::transfer(treasury_cap, TxContext::sender(ctx))
     }
 
     /// Transfer to a recipient

--- a/sui_programmability/framework/sources/Geniteam.move
+++ b/sui_programmability/framework/sources/Geniteam.move
@@ -143,7 +143,7 @@ module Sui::Geniteam {
     ) {
         let farm = create_farm_(farm_name, farm_img_id, total_monster_slots, ctx);
         let player = create_player_(player_name, farm, ctx);
-        Transfer::transfer(player, TxContext::get_signer_address(ctx))
+        Transfer::transfer(player, TxContext::sender(ctx))
     }
 
     /// Update the attributes of a player
@@ -178,7 +178,7 @@ module Sui::Geniteam {
             monster_description,
             ctx
         );
-        Transfer::transfer(monster, TxContext::get_signer_address(ctx))
+        Transfer::transfer(monster, TxContext::sender(ctx))
     }
 
     /// Add a monster to a farm
@@ -192,7 +192,7 @@ module Sui::Geniteam {
     public fun remove_monster(self: &mut Farm, monster_id: vector<u8>, ctx: &mut TxContext) {
         // TODO: monster_id should be probably be `address`, but leaving this as-is to avoid breaking Geniteam
         let monster = remove_monster_(self, &ID::new_from_bytes(monster_id));
-        Transfer::transfer(monster, TxContext::get_signer_address(ctx))
+        Transfer::transfer(monster, TxContext::sender(ctx))
     }
 
     /// Update the attributes of a farm

--- a/sui_programmability/framework/sources/ID.move
+++ b/sui_programmability/framework/sources/ID.move
@@ -52,7 +52,7 @@ module Sui::ID {
         version: u64
     }
 
-    // --- constructors ---
+    // === constructors ===
 
     /// Create an `ID` from an address
     public fun new(a: address): ID {
@@ -74,7 +74,7 @@ module Sui::ID {
         VersionedID { id: UniqueID { id: ID { bytes } }, version: INITIAL_VERSION }
     }
 
-    // --- reads ---
+    // === reads ===
 
     /// Get the underyling `ID` of `obj`
     public fun id<T: key>(obj: &T): &ID {
@@ -131,7 +131,7 @@ module Sui::ID {
     // Private for now, but may expose in the future.
     native fun get_versioned_id<T: key>(obj: &T): &VersionedID;
 
-    // --- destructors --- 
+    // === destructors ===
 
     /// Delete `id`. This is the only way to eliminate a `VersionedID`.
     // This exists to inform Sui of object deletions. When an object
@@ -145,7 +145,7 @@ module Sui::ID {
 
     native fun delete_id(id: UniqueID);
 
-    // --- internal functions --- 
+    // === internal functions ===
 
     /// Convert raw bytes into an address
     native fun bytes_to_address(bytes: vector<u8>): address;   

--- a/sui_programmability/framework/sources/ObjectBasics.move
+++ b/sui_programmability/framework/sources/ObjectBasics.move
@@ -55,12 +55,12 @@ module Sui::ObjectBasics {
     }
 
     public fun wrap(o: Object, ctx: &mut TxContext) {
-        Transfer::transfer(Wrapper { id: TxContext::new_id(ctx), o }, TxContext::get_signer_address(ctx))
+        Transfer::transfer(Wrapper { id: TxContext::new_id(ctx), o }, TxContext::sender(ctx))
     }
 
     public fun unwrap(w: Wrapper, ctx: &mut TxContext) {
         let Wrapper { id, o } = w;
         ID::delete(id);
-        Transfer::transfer(o, TxContext::get_signer_address(ctx))
+        Transfer::transfer(o, TxContext::sender(ctx))
     }
 }

--- a/sui_programmability/framework/sources/TestScenario.move
+++ b/sui_programmability/framework/sources/TestScenario.move
@@ -125,7 +125,7 @@ module Sui::TestScenario {
     /// only succeeds when the object to choose is unambiguous. In cases where there are multiple `T`'s, 
     /// the caller should resolve the ambiguity by using `remove_object_by_id`.
     public fun remove_object<T: key>(scenario: &mut Scenario): T {
-        let sender = get_signer_address(scenario);
+        let sender = sender(scenario);
         remove_unique_object(scenario, sender)
     }
 
@@ -175,13 +175,13 @@ module Sui::TestScenario {
         // to do (e.g.) `delete_object_for_testing(t)` instead.
         // TODO: do this with a special test-only event to enable writing tests that look directly at system events
         // like transfers. the current scheme will perturb the count of transfer events.
-        Transfer::transfer(t, get_signer_address(scenario))
+        Transfer::transfer(t, sender(scenario))
     }
 
     /// Return `true` if a call to `remove_object<T>(scenario)` will succeed
     public fun can_remove_object<T: key>(scenario: &Scenario): bool {
         let objects: vector<T> = get_inventory<T>(
-            get_signer_address(scenario),
+            sender(scenario),
             last_tx_start_index(scenario)
         );
         let res = !Vector::is_empty(&objects);
@@ -200,8 +200,8 @@ module Sui::TestScenario {
     }
 
     /// Return the sender of the current tx in this `scenario`
-    public fun get_signer_address(scenario: &Scenario): address {
-        TxContext::get_signer_address(&scenario.ctx)
+    public fun sender(scenario: &Scenario): address {
+        TxContext::sender(&scenario.ctx)
     }
 
     /// Return the number of concluded transactions in this scenario.

--- a/sui_programmability/framework/sources/TxContext.move
+++ b/sui_programmability/framework/sources/TxContext.move
@@ -7,87 +7,94 @@ module Sui::TxContext {
     #[test_only]
     use Std::Vector;
 
-    /// Number of bytes in an inputs_hash (which will be the transaction digest)
-    const INPUTS_HASH_LENGTH: u64 = 32;
+    /// Number of bytes in an tx hash (which will be the transaction digest)
+    const TX_HASH_LENGTH: u64 = 32;
 
-    /// Expected an inputs_hash of length 32, but found a different length
-    const EBAD_INPUTS_HASH_LENGTH: u64 = 0;
+    /// Expected an tx hash of length 32, but found a different length
+    const EBAD_TX_HASH_LENGTH: u64 = 0;
 
     /// Information about the transaction currently being executed.
-    /// This is a privileged object created by the VM and passed into `main`
+    /// This cannot be constructed by a transaction--it is a privileged object created by 
+    /// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
     struct TxContext has drop {
-        /// The signer of the current transaction
+        /// A `signer` wrapping the address of the user that signed the current transaction
         signer: signer,
-        /// Hash of all the input objects to this transaction
-        inputs_hash: vector<u8>,
+        /// Hash of the current transaction
+        tx_hash: vector<u8>,
         /// Counter recording the number of fresh id's created while executing
-        /// this transaction
+        /// this transaction. Always 0 at the start of a transaction
         ids_created: u64
-    }
-
-    /// Return the signer of the current transaction
-    public fun get_signer(self: &TxContext): &signer {
-        &self.signer
     }
 
     /// Return the address of the user that signed the current
     /// transaction
-    public fun get_signer_address(self: &TxContext): address {
+    public fun sender(self: &TxContext): address {
         Signer::address_of(&self.signer)
     }
 
-    /// Return the number of id's created by the current transaction
-    public fun get_ids_created(self: &TxContext): u64 {
-        self.ids_created
+    /// Return a `signer` for the user that signed the current transaction
+    public fun signer_(self: &TxContext): &signer {
+        &self.signer
     }
 
     /// Generate a new, globally unqiue object ID with version 0
     public fun new_id(ctx: &mut TxContext): VersionedID {
         let ids_created = ctx.ids_created;
-        let id = ID::new_versioned_id(fresh_id(*&ctx.inputs_hash, ids_created));
+        let id = ID::new_versioned_id(fresh_id(*&ctx.tx_hash, ids_created));
         ctx.ids_created = ids_created + 1;
         id
     }
 
-    /// Native function for deriving an ID via hash(inputs_hash || ids_created || domain_separator)
-    native fun fresh_id(inputs_hash: vector<u8>, ids_created: u64): address;
+    /// Return the number of id's created by the current transaction.
+    /// Hidden for now, but may expose later
+    fun ids_created(self: &TxContext): u64 {
+        self.ids_created
+    }
+
+    /// Native function for deriving an ID via hash(tx_hash || ids_created || domain_separator)
+    native fun fresh_id(tx_hash: vector<u8>, ids_created: u64): address;
 
     // ==== test-only functions ====
 
     #[test_only]
     /// Create a `TxContext` for testing
-    public fun new(signer: signer, inputs_hash: vector<u8>, ids_created: u64): TxContext {
+    public fun new(signer: signer, tx_hash: vector<u8>, ids_created: u64): TxContext {
         assert!(
-            Vector::length(&inputs_hash) == INPUTS_HASH_LENGTH,
-            Errors::invalid_argument(EBAD_INPUTS_HASH_LENGTH)
+            Vector::length(&tx_hash) == TX_HASH_LENGTH,
+            Errors::invalid_argument(EBAD_TX_HASH_LENGTH)
         );
-        TxContext { signer, inputs_hash, ids_created }
+        TxContext { signer, tx_hash, ids_created }
     }
 
     #[test_only]
-    /// Create a `TxContext` with sender `a` for testing, and an inputs hash derived from `hint`
+    /// Create a `TxContext` with sender `a` for testing, and a tx hash derived from `hint`
     public fun new_from_address(a: address, hint: u8): TxContext {
-        new(new_signer_from_address(a), dummy_inputs_hash_with_hint(hint), 0)
+        new(new_signer_from_address(a), dummy_tx_hash_with_hint(hint), 0)
     }
 
     #[test_only]
     /// Create a dummy `TxContext` for testing
     public fun dummy(): TxContext {
-        let inputs_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
-        new(new_signer_from_address(@0x0), inputs_hash, 0)
+        let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+        new(new_signer_from_address(@0x0), tx_hash, 0)
     }
 
     #[test_only]
     /// Utility for creating 256 unique input hashes
-    fun dummy_inputs_hash_with_hint(hint: u8): vector<u8> {
-        let inputs_hash = Vector::empty<u8>();
+    fun dummy_tx_hash_with_hint(hint: u8): vector<u8> {
+        let tx_hash = Vector::empty<u8>();
         let i = 0;
-        while (i < INPUTS_HASH_LENGTH - 1) {
-            Vector::push_back(&mut inputs_hash, 0u8);
+        while (i < TX_HASH_LENGTH - 1) {
+            Vector::push_back(&mut tx_hash, 0u8);
             i = i + 1;
         };
-        Vector::push_back(&mut inputs_hash, hint);
-        inputs_hash
+        Vector::push_back(&mut tx_hash, hint);
+        tx_hash
+    }
+
+    #[test_only]
+    public fun get_ids_created(self: &TxContext): u64 {
+        ids_created(self)
     }
 
     #[test_only]

--- a/sui_programmability/framework/src/natives/tx_context.rs
+++ b/sui_programmability/framework/src/natives/tx_context.rs
@@ -24,11 +24,11 @@ pub fn fresh_id(
     debug_assert!(args.len() == 2);
 
     let ids_created = pop_arg!(args, u64);
-    let inputs_hash = pop_arg!(args, Vec<u8>);
+    let tx_hash = pop_arg!(args, Vec<u8>);
 
     // TODO(https://github.com/MystenLabs/fastnft/issues/58): finalize digest format
     // unwrap safe because all digests in Move are serialized from the Rust `TransactionDigest`
-    let digest = TransactionDigest::try_from(inputs_hash.as_slice()).unwrap();
+    let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
     let id = Value::address(AccountAddress::from(digest.derive_id(ids_created)));
 
     // TODO: choose cost

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -29,7 +29,7 @@ module Sui::CollectionTests {
         assert!(Collection::contains(&collection, &id1), EOBJECT_NOT_FOUND);
         assert!(Collection::contains(&collection, &id2), EOBJECT_NOT_FOUND);
 
-        Collection::transfer(collection, TxContext::get_signer_address(&ctx));
+        Collection::transfer(collection, TxContext::sender(&ctx));
     }
 
     #[test]
@@ -39,7 +39,7 @@ module Sui::CollectionTests {
         // Sui::Collection::DEFAULT_MAX_CAPACITY is not readable outside the module
         let max_capacity = 65536;
         let collection = Collection::new_with_max_capacity(&mut ctx, max_capacity + 1);
-        Collection::transfer(collection, TxContext::get_signer_address(&ctx));
+        Collection::transfer(collection, TxContext::sender(&ctx));
     }
 
     #[test]
@@ -47,7 +47,7 @@ module Sui::CollectionTests {
     fun test_init_with_zero() {
         let ctx = TxContext::dummy();
         let collection = Collection::new_with_max_capacity(&mut ctx, 0);
-        Collection::transfer(collection, TxContext::get_signer_address(&ctx));
+        Collection::transfer(collection, TxContext::sender(&ctx));
     }
 
     #[test]
@@ -60,6 +60,6 @@ module Sui::CollectionTests {
         Collection::add(&mut collection, obj1);
         let obj2 = Object { id: TxContext::new_id(&mut ctx) };
         Collection::add(&mut collection, obj2);
-        Collection::transfer(collection, TxContext::get_signer_address(&ctx));
+        Collection::transfer(collection, TxContext::sender(&ctx));
     }
 }

--- a/sui_programmability/verifier/tests/param_typecheck_verification_test.rs
+++ b/sui_programmability/verifier/tests/param_typecheck_verification_test.rs
@@ -66,7 +66,7 @@ fn add_tx_context(builder: &mut ModuleBuilder) -> StructInfo {
         vec![
             ("signer", SignatureToken::Struct(signer.handle)),
             (
-                "inputs_hash",
+                "tx_hash",
                 SignatureToken::Vector(Box::new(SignatureToken::U8)),
             ),
             ("ids_created", SignatureToken::U64),


### PR DESCRIPTION
* Rename the rather wordy `get_signer_address` to `sender`. I think this should also be more intuitive, especially for folks coming from Eth.
* Rename `get_signer` to `signer_` (can't use `signer` because it's a keyword). This actually isn't used anywhere yet, but is valuable for code that wants to authenticate the sender of transaction, but doesn't need to create new ID's--such code can ask for a `&signer` rather than a `&mut TxContext`.
* Hide `ids_created`, which we probably don't want folks outside the module calling because it is difficult to reason about.
* Refactor all the callers