### PR TITLE
Enforce previous tx set in active input objects

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -358,6 +358,7 @@ impl AuthorityState {
             gas::deduct_gas(&mut gas_object, *gas_used);
             temporary_store.write_object(gas_object);
         }
+        // We must ensure that even in the case of failure, ensure to advance seq# and update previous tx
         temporary_store.ensure_active_inputs_mutated();
         Ok((temporary_store, status))
     }

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -88,6 +88,7 @@ impl AuthorityTemporaryStore {
                 let mut object = self.objects[id].clone();
                 // Active input object must be Move object.
                 object.data.try_as_move_mut().unwrap().increment_version();
+                object.previous_transaction = self.tx_digest;
                 self.written.insert(*id, object);
             }
         }
@@ -220,7 +221,7 @@ impl Storage for AuthorityTemporaryStore {
         caller.
     */
 
-    fn write_object(&mut self, mut object: Object) {
+    fn write_object(&mut self, object: Object) {
         // there should be no write after delete
         debug_assert!(self.deleted.get(&object.id()) == None);
         // Check it is not read-only
@@ -233,9 +234,10 @@ impl Storage for AuthorityTemporaryStore {
             }
         }
 
+        // TODO: do we still need this?
         // The adapter is not very disciplined at filling in the correct
         // previous transaction digest, so we ensure it is correct here.
-        object.previous_transaction = self.tx_digest;
+        // object.previous_transaction = self.tx_digest;
         self.written.insert(object.id(), object);
     }
 

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -511,6 +511,7 @@ fn process_successful_execution<
     }
 
     // 4. Mutable objects mutated during tx (by value Structs, a.k.a consumed): update the contents/owner, previous_tx, incr the seq #
+    // This step is handled as part of `handle_transfer`
 
     // process events to identify transfers, freezes
     let mut gas_used = 0;

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -321,7 +321,8 @@ fn test_object_basics() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(storage.updated().len(), 2);
+    // Although obj2 contents are not changed, we update its previous tx and seq #
+    assert_eq!(storage.updated().len(), 3);
     assert!(storage.created().is_empty());
     assert!(storage.deleted().is_empty());
     // test than an event was emitted as expected

--- a/sui_types/src/move_package.rs
+++ b/sui_types/src/move_package.rs
@@ -33,6 +33,7 @@ pub struct TypeCheckSuccess {
     pub args: Vec<Vec<u8>>,
     pub by_value_objects: BTreeMap<ObjectID, Object>,
     pub mutable_ref_objects: Vec<Object>,
+    pub read_only_refs: Vec<Object>,
 }
 
 // serde_bytes::ByteBuf is an analog of Vec<u8> with built-in fast serialization.
@@ -210,6 +211,7 @@ pub fn resolve_and_type_check(
     let mut num_immutable_objects = 0;
     #[cfg(debug_assertions)]
     let num_objects = object_args.len();
+    let mut read_only_refs = vec![];
 
     let ty_args: Vec<Type> = type_args.iter().map(|t| Type::from(t.clone())).collect();
     for (idx, object) in object_args.into_iter().enumerate() {
@@ -240,6 +242,7 @@ pub fn resolve_and_type_check(
                         {
                             num_immutable_objects += 1
                         }
+                        read_only_refs.push(object);
                     }
                     Type::Struct { .. } => {
                         if object.is_read_only() {
@@ -293,6 +296,7 @@ pub fn resolve_and_type_check(
         args,
         by_value_objects,
         mutable_ref_objects,
+        read_only_refs,
     })
 }
 


### PR DESCRIPTION
Taking steps to ensure `previous_transaction` field is set in client as described in https://github.com/MystenLabs/fastnft/issues/312.
Disabled the hack described [here](https://github.com/MystenLabs/fastnft/issues/312#issue-1118494966) to show that the changes work fine, however I'm not opposed to keeping the hack as a fail-safe.
Need input on what else could be missing and if any edge cases.

Note:
1. This is WIP
2. I feel we can clean things up generally for example: updating all the object info in one place
3. How should the client handle cases where the object it fetches after an execution does not have the right `previous_transaction`?
4. Need more tests in authority, adapter, client