### PR TITLE
explorer-client: basic api functionality

### DIFF
--- a/explorer/client/.env.development
+++ b/explorer/client/.env.development
@@ -3,3 +3,6 @@ REACT_APP_REPORT_VITALS_METHOD=console
 
 # Stop react-scripts start from opening a browser - not visible to the app
 BROWSER=none
+# In dev mode we proxy all the requests to HOST/api to the following server
+# We can use .local env files to override this
+PROXY_API_SERVER=http://localhost:8080

--- a/explorer/client/.env.development
+++ b/explorer/client/.env.development
@@ -3,6 +3,7 @@ REACT_APP_REPORT_VITALS_METHOD=console
 
 # Stop react-scripts start from opening a browser - not visible to the app
 BROWSER=none
+REACT_APP_MOCK_API=true
 # In dev mode we proxy all the requests to HOST/api to the following server
 # We can use .local env files to override this
 PROXY_API_SERVER=http://localhost:8080

--- a/explorer/client/package-lock.json
+++ b/explorer/client/package-lock.json
@@ -9,12 +9,15 @@
             "version": "0.1.0",
             "dependencies": {
                 "classnames": "^2.3.1",
+                "query-string": "^7.1.1",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-router-dom": "^6.2.1",
+                "swr": "^1.2.2",
                 "web-vitals": "^2.1.4"
             },
             "devDependencies": {
+                "@faker-js/faker": "^6.0.0-alpha.7",
                 "@testing-library/jest-dom": "^5.16.2",
                 "@testing-library/react": "^12.1.2",
                 "@testing-library/user-event": "^13.5.0",
@@ -25,6 +28,8 @@
                 "autoprefixer": "^10.4.2",
                 "concurrently": "^7.0.0",
                 "eslint-config-prettier": "^8.3.0",
+                "http-proxy-middleware": "^2.0.3",
+                "msw": "^0.38.1",
                 "onchange": "^7.1.0",
                 "postcss": "^8.4.6",
                 "prettier": "2.5.1",
@@ -2151,6 +2156,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@faker-js/faker": {
+            "version": "6.0.0-alpha.7",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.7.tgz",
+            "integrity": "sha512-T2nYE8+EfzfkRMLMSm7UvgC7fZ2KkKEyCMeyPVS0q2cuvENbt1SjWyu0bOJ0JqBbTs1g+gYMWMFMXspWlzNVmQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -2899,6 +2914,33 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@mswjs/cookies": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
+            "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/set-cookie-parser": "^2.4.0",
+                "set-cookie-parser": "^2.4.6"
+            }
+        },
+        "node_modules/@mswjs/interceptors": {
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.13.3.tgz",
+            "integrity": "sha512-YGC25Rp7ugywBL1bqvy1fJ9HHvQJ9yEJcYLbHdsQCiQ89zmnY0b0ZfJAMqXHhTOHV6oKaunN7y0fdWkRlfuTIg==",
+            "dev": true,
+            "dependencies": {
+                "@open-draft/until": "^1.0.3",
+                "@xmldom/xmldom": "^0.7.5",
+                "debug": "^4.3.3",
+                "headers-polyfill": "^3.0.3",
+                "outvariant": "^1.2.1",
+                "strict-event-emitter": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=12.x"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2933,6 +2975,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@open-draft/until": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+            "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+            "dev": true
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.5.4",
@@ -3661,6 +3709,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/cookie": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+            "dev": true
+        },
         "node_modules/@types/eslint": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -3767,6 +3821,12 @@
                 "jest-diff": "^27.0.0",
                 "pretty-format": "^27.0.0"
             }
+        },
+        "node_modules/@types/js-levenshtein": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+            "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+            "dev": true
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.9",
@@ -3897,6 +3957,15 @@
             "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/set-cookie-parser": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+            "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+            "dev": true,
+            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -4323,6 +4392,15 @@
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@xtuc/ieee754": {
@@ -5158,6 +5236,26 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5195,6 +5293,17 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/bluebird": {
@@ -5338,6 +5447,30 @@
             "dev": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-from": {
@@ -5524,6 +5657,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
         "node_modules/check-types": {
             "version": "11.1.2",
             "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -5625,6 +5764,39 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+            "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -5634,6 +5806,15 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/clone-regexp": {
@@ -6622,7 +6803,6 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -6675,6 +6855,15 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "dependencies": {
+                "clone": "^1.0.2"
             }
         },
         "node_modules/define-lazy-prop": {
@@ -8125,6 +8314,32 @@
                 }
             ]
         },
+        "node_modules/external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "dependencies": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/external-editor/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8207,6 +8422,21 @@
                 "bser": "2.1.1"
             }
         },
+        "node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8267,6 +8497,14 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/filter-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+            "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/finalhandler": {
@@ -8842,6 +9080,15 @@
             "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
             "dev": true
         },
+        "node_modules/graphql": {
+            "version": "16.3.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+            "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+            }
+        },
         "node_modules/gzip-size": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -8943,6 +9190,12 @@
             "bin": {
                 "he": "bin/he"
             }
+        },
+        "node_modules/headers-polyfill": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.3.tgz",
+            "integrity": "sha512-Ak5m549Y+5vBtWNnIUcyARJjF0tQpINuy3+vOqG8tK/qjF0itYhAPgrzJc0zsZJh7AX8PalzICMPuWIqHpZlEA==",
+            "dev": true
         },
         "node_modules/history": {
             "version": "5.2.0",
@@ -9249,6 +9502,26 @@
                 "node": ">=4"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -9368,6 +9641,110 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
+        },
+        "node_modules/inquirer": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+            "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.2.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/inquirer/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/rxjs": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+            "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/internal-slot": {
             "version": "1.0.3",
@@ -9553,6 +9930,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -9570,6 +9956,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-node-process": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+            "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+            "dev": true
         },
         "node_modules/is-number": {
             "version": "7.0.0",
@@ -9739,6 +10131,18 @@
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/is-weakref": {
             "version": "1.0.2",
@@ -11720,6 +12124,15 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12039,6 +12452,92 @@
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/log-symbols/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/log-symbols/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/log-symbols/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
@@ -12441,6 +12940,174 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "node_modules/msw": {
+            "version": "0.38.1",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-0.38.1.tgz",
+            "integrity": "sha512-4BMEc54nX12UzOAxw6cB31tEytuxfTPwmGoBrItCHoD9Aj9ZLO9aoBaZjCA1W0wfiYcd7sjekLpnT0lE/uR0qA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "@mswjs/cookies": "^0.1.7",
+                "@mswjs/interceptors": "^0.13.3",
+                "@open-draft/until": "^1.0.3",
+                "@types/cookie": "^0.4.1",
+                "@types/js-levenshtein": "^1.1.1",
+                "chalk": "4.1.1",
+                "chokidar": "^3.4.2",
+                "cookie": "^0.4.2",
+                "graphql": "^16.3.0",
+                "headers-polyfill": "^3.0.3",
+                "inquirer": "^8.2.0",
+                "is-node-process": "^1.0.1",
+                "js-levenshtein": "^1.1.6",
+                "node-fetch": "^2.6.7",
+                "path-to-regexp": "^6.2.0",
+                "statuses": "^2.0.0",
+                "strict-event-emitter": "^0.2.0",
+                "type-fest": "^1.2.2",
+                "yargs": "^17.3.1"
+            },
+            "bin": {
+                "msw": "cli/index.js"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mswjs"
+            }
+        },
+        "node_modules/msw/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/msw/node_modules/chalk": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/msw/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/msw/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/msw/node_modules/cookie": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/msw/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/msw/node_modules/path-to-regexp": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+            "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
+            "dev": true
+        },
+        "node_modules/msw/node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/msw/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/msw/node_modules/type-fest": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/msw/node_modules/yargs": {
+            "version": "17.3.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+            "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/msw/node_modules/yargs-parser": {
+            "version": "21.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+            "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/multicast-dns": {
             "version": "6.2.3",
             "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -12458,6 +13125,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
+        "node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "node_modules/nanoid": {
@@ -12501,6 +13174,48 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+            "dev": true
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/node-forge": {
@@ -12860,6 +13575,114 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dev": true,
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ora/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/ora/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ora/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/outvariant": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.2.1.tgz",
+            "integrity": "sha512-bcILvFkvpMXh66+Ubax/inxbKRyWTUiiFIW2DWkiS79wakrLGn3Ydy+GvukadiyfZjaL6C7YhIem4EZSM282wA==",
+            "dev": true
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
@@ -14565,6 +15388,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/query-string": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+            "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+            "dependencies": {
+                "decode-uri-component": "^0.2.0",
+                "filter-obj": "^1.1.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -15401,6 +16241,19 @@
                 "node": ">=10"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15507,6 +16360,15 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
             }
         },
         "node_modules/run-parallel": {
@@ -15828,6 +16690,12 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/set-cookie-parser": {
+            "version": "2.4.8",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+            "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+            "dev": true
+        },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -16122,6 +16990,14 @@
                 "specificity": "bin/specificity"
             }
         },
+        "node_modules/split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -16168,6 +17044,23 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/strict-event-emitter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz",
+            "integrity": "sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==",
+            "dev": true,
+            "dependencies": {
+                "events": "^3.3.0"
+            }
+        },
+        "node_modules/strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/string_decoder": {
@@ -16743,6 +17636,14 @@
                 "boolbase": "~1.0.0"
             }
         },
+        "node_modules/swr": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-1.2.2.tgz",
+            "integrity": "sha512-ky0BskS/V47GpW8d6RU7CPsr6J8cr7mQD6+do5eky3bM0IyJaoi3vO8UhvrzJaObuTlGhPl2szodeB2dUd76Xw==",
+            "peerDependencies": {
+                "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -17070,6 +17971,12 @@
             "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
             "dev": true
         },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
         "node_modules/thunky": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -17081,6 +17988,18 @@
             "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
             "dev": true
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -17558,6 +18477,15 @@
             "dev": true,
             "dependencies": {
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "dependencies": {
+                "defaults": "^1.0.3"
             }
         },
         "node_modules/web-vitals": {
@@ -20005,6 +20933,12 @@
                 }
             }
         },
+        "@faker-js/faker": {
+            "version": "6.0.0-alpha.7",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.7.tgz",
+            "integrity": "sha512-T2nYE8+EfzfkRMLMSm7UvgC7fZ2KkKEyCMeyPVS0q2cuvENbt1SjWyu0bOJ0JqBbTs1g+gYMWMFMXspWlzNVmQ==",
+            "dev": true
+        },
         "@humanwhocodes/config-array": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -20574,6 +21508,30 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@mswjs/cookies": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
+            "integrity": "sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==",
+            "dev": true,
+            "requires": {
+                "@types/set-cookie-parser": "^2.4.0",
+                "set-cookie-parser": "^2.4.6"
+            }
+        },
+        "@mswjs/interceptors": {
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.13.3.tgz",
+            "integrity": "sha512-YGC25Rp7ugywBL1bqvy1fJ9HHvQJ9yEJcYLbHdsQCiQ89zmnY0b0ZfJAMqXHhTOHV6oKaunN7y0fdWkRlfuTIg==",
+            "dev": true,
+            "requires": {
+                "@open-draft/until": "^1.0.3",
+                "@xmldom/xmldom": "^0.7.5",
+                "debug": "^4.3.3",
+                "headers-polyfill": "^3.0.3",
+                "outvariant": "^1.2.1",
+                "strict-event-emitter": "^0.2.0"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -20599,6 +21557,12 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@open-draft/until": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+            "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+            "dev": true
         },
         "@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.5.4",
@@ -21100,6 +22064,12 @@
                 "@types/node": "*"
             }
         },
+        "@types/cookie": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+            "dev": true
+        },
         "@types/eslint": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -21206,6 +22176,12 @@
                 "jest-diff": "^27.0.0",
                 "pretty-format": "^27.0.0"
             }
+        },
+        "@types/js-levenshtein": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz",
+            "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
+            "dev": true
         },
         "@types/json-schema": {
             "version": "7.0.9",
@@ -21336,6 +22312,15 @@
             "dev": true,
             "requires": {
                 "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "@types/set-cookie-parser": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
+            "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
+            "dev": true,
+            "requires": {
                 "@types/node": "*"
             }
         },
@@ -21660,6 +22645,12 @@
                 "@webassemblyjs/ast": "1.11.1",
                 "@xtuc/long": "4.2.2"
             }
+        },
+        "@xmldom/xmldom": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
+            "dev": true
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -22292,6 +23283,12 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
+        },
         "batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -22321,6 +23318,17 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
+        },
+        "bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -22443,6 +23451,16 @@
             "dev": true,
             "requires": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "buffer-from": {
@@ -22579,6 +23597,12 @@
             "integrity": "sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ==",
             "dev": true
         },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
         "check-types": {
             "version": "11.1.2",
             "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -22658,6 +23682,27 @@
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true
         },
+        "cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^3.1.0"
+            }
+        },
+        "cli-spinners": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+            "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+            "dev": true
+        },
+        "cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "dev": true
+        },
         "cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -22668,6 +23713,12 @@
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
             }
+        },
+        "clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "dev": true
         },
         "clone-regexp": {
             "version": "2.2.0",
@@ -23395,8 +24446,7 @@
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "dedent": {
             "version": "0.7.0",
@@ -23437,6 +24487,15 @@
             "dev": true,
             "requires": {
                 "execa": "^5.0.0"
+            }
+        },
+        "defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "dev": true,
+            "requires": {
+                "clone": "^1.0.2"
             }
         },
         "define-lazy-prop": {
@@ -24534,6 +25593,28 @@
                 }
             }
         },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
+            }
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -24609,6 +25690,15 @@
                 "bser": "2.1.1"
             }
         },
+        "figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
         "file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -24651,6 +25741,11 @@
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
+        },
+        "filter-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+            "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
         },
         "finalhandler": {
             "version": "1.1.2",
@@ -25061,6 +26156,12 @@
             "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
             "dev": true
         },
+        "graphql": {
+            "version": "16.3.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+            "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+            "dev": true
+        },
         "gzip-size": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -25128,6 +26229,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true
+        },
+        "headers-polyfill": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.0.3.tgz",
+            "integrity": "sha512-Ak5m549Y+5vBtWNnIUcyARJjF0tQpINuy3+vOqG8tK/qjF0itYhAPgrzJc0zsZJh7AX8PalzICMPuWIqHpZlEA==",
             "dev": true
         },
         "history": {
@@ -25365,6 +26472,12 @@
                 "harmony-reflect": "^1.4.6"
             }
         },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
+        },
         "ignore": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -25452,6 +26565,88 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
+        },
+        "inquirer": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+            "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.2.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "rxjs": {
+                    "version": "7.5.4",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+                    "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "internal-slot": {
             "version": "1.0.3",
@@ -25577,6 +26772,12 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "dev": true
+        },
         "is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -25587,6 +26788,12 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
             "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "dev": true
+        },
+        "is-node-process": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
+            "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
             "dev": true
         },
         "is-number": {
@@ -25696,6 +26903,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
         },
         "is-weakref": {
@@ -27177,6 +28390,12 @@
                 }
             }
         },
+        "js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+            "dev": true
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -27432,6 +28651,67 @@
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
+        },
+        "log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -27733,6 +29013,129 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
+        "msw": {
+            "version": "0.38.1",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-0.38.1.tgz",
+            "integrity": "sha512-4BMEc54nX12UzOAxw6cB31tEytuxfTPwmGoBrItCHoD9Aj9ZLO9aoBaZjCA1W0wfiYcd7sjekLpnT0lE/uR0qA==",
+            "dev": true,
+            "requires": {
+                "@mswjs/cookies": "^0.1.7",
+                "@mswjs/interceptors": "^0.13.3",
+                "@open-draft/until": "^1.0.3",
+                "@types/cookie": "^0.4.1",
+                "@types/js-levenshtein": "^1.1.1",
+                "chalk": "4.1.1",
+                "chokidar": "^3.4.2",
+                "cookie": "^0.4.2",
+                "graphql": "^16.3.0",
+                "headers-polyfill": "^3.0.3",
+                "inquirer": "^8.2.0",
+                "is-node-process": "^1.0.1",
+                "js-levenshtein": "^1.1.6",
+                "node-fetch": "^2.6.7",
+                "path-to-regexp": "^6.2.0",
+                "statuses": "^2.0.0",
+                "strict-event-emitter": "^0.2.0",
+                "type-fest": "^1.2.2",
+                "yargs": "^17.3.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+                    "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "cookie": {
+                    "version": "0.4.2",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+                    "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "path-to-regexp": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+                    "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
+                    "dev": true
+                },
+                "statuses": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "17.3.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+                    "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.3",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^21.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "21.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+                    "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+                    "dev": true
+                }
+            }
+        },
         "multicast-dns": {
             "version": "6.2.3",
             "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -27747,6 +29150,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
         "nanoid": {
@@ -27781,6 +29190,39 @@
             "requires": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+                    "dev": true
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+                    "dev": true
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "dev": true,
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
             }
         },
         "node-forge": {
@@ -28046,6 +29488,86 @@
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.3"
             }
+        },
+        "ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "dev": true,
+            "requires": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "outvariant": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.2.1.tgz",
+            "integrity": "sha512-bcILvFkvpMXh66+Ubax/inxbKRyWTUiiFIW2DWkiS79wakrLGn3Ydy+GvukadiyfZjaL6C7YhIem4EZSM282wA==",
+            "dev": true
         },
         "p-limit": {
             "version": "3.1.0",
@@ -29185,6 +30707,17 @@
             "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
             "dev": true
         },
+        "query-string": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+            "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+            "requires": {
+                "decode-uri-component": "^0.2.0",
+                "filter-obj": "^1.1.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            }
+        },
         "queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -29813,6 +31346,16 @@
             "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
             "dev": true
         },
+        "restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "dev": true,
+            "requires": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
         "retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -29891,6 +31434,12 @@
                     }
                 }
             }
+        },
+        "run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true
         },
         "run-parallel": {
             "version": "1.2.0",
@@ -30141,6 +31690,12 @@
                 "send": "0.17.2"
             }
         },
+        "set-cookie-parser": {
+            "version": "2.4.8",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
+            "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+            "dev": true
+        },
         "setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -30385,6 +31940,11 @@
             "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
             "dev": true
         },
+        "split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -30425,6 +31985,20 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
             "dev": true
+        },
+        "strict-event-emitter": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.0.tgz",
+            "integrity": "sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==",
+            "dev": true,
+            "requires": {
+                "events": "^3.3.0"
+            }
+        },
+        "strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "string_decoder": {
             "version": "1.3.0",
@@ -30873,6 +32447,12 @@
                 }
             }
         },
+        "swr": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-1.2.2.tgz",
+            "integrity": "sha512-ky0BskS/V47GpW8d6RU7CPsr6J8cr7mQD6+do5eky3bM0IyJaoi3vO8UhvrzJaObuTlGhPl2szodeB2dUd76Xw==",
+            "requires": {}
+        },
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -31103,6 +32683,12 @@
             "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
             "dev": true
         },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
         "thunky": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -31114,6 +32700,15 @@
             "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
             "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
         },
         "tmpl": {
             "version": "1.0.5",
@@ -31489,6 +33084,15 @@
             "dev": true,
             "requires": {
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "dev": true,
+            "requires": {
+                "defaults": "^1.0.3"
             }
         },
         "web-vitals": {

--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "devDependencies": {
+        "@faker-js/faker": "^6.0.0-alpha.7",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -13,6 +14,8 @@
         "autoprefixer": "^10.4.2",
         "concurrently": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
+        "http-proxy-middleware": "^2.0.3",
+        "msw": "^0.38.1",
         "onchange": "^7.1.0",
         "postcss": "^8.4.6",
         "prettier": "2.5.1",
@@ -26,9 +29,11 @@
     },
     "dependencies": {
         "classnames": "^2.3.1",
+        "query-string": "^7.1.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",
+        "swr": "^1.2.2",
         "web-vitals": "^2.1.4"
     },
     "scripts": {
@@ -57,5 +62,8 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
+    },
+    "msw": {
+        "workerDirectory": "public"
     }
 }

--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -49,7 +49,8 @@
         "stylelint:check": "stylelint \"**/*.{css,scss}\"",
         "stylelint:fix": "npm run stylelint:check -- --fix",
         "lint": "npm run eslint:check && npm run prettier:check && npm run stylelint:check",
-        "lint:fix": "npm run eslint:fix && npm run prettier:fix && npm run stylelint:fix"
+        "lint:fix": "npm run eslint:fix && npm run prettier:fix && npm run stylelint:fix",
+        "msw:update": "msw init ./public --save=false"
     },
     "browserslist": {
         "production": [
@@ -62,8 +63,5 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
-    },
-    "msw": {
-        "workerDirectory": "public"
     }
 }

--- a/explorer/client/public/mockServiceWorker.js
+++ b/explorer/client/public/mockServiceWorker.js
@@ -1,0 +1,343 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.38.1).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '02f4ad4a2797f85668baf196e553d929';
+const bypassHeaderName = 'x-msw-bypass';
+const activeClientIds = new Set();
+
+self.addEventListener('install', function () {
+    return self.skipWaiting();
+});
+
+self.addEventListener('activate', async function (event) {
+    return self.clients.claim();
+});
+
+self.addEventListener('message', async function (event) {
+    const clientId = event.source.id;
+
+    if (!clientId || !self.clients) {
+        return;
+    }
+
+    const client = await self.clients.get(clientId);
+
+    if (!client) {
+        return;
+    }
+
+    const allClients = await self.clients.matchAll();
+
+    switch (event.data) {
+        case 'KEEPALIVE_REQUEST': {
+            sendToClient(client, {
+                type: 'KEEPALIVE_RESPONSE',
+            });
+            break;
+        }
+
+        case 'INTEGRITY_CHECK_REQUEST': {
+            sendToClient(client, {
+                type: 'INTEGRITY_CHECK_RESPONSE',
+                payload: INTEGRITY_CHECKSUM,
+            });
+            break;
+        }
+
+        case 'MOCK_ACTIVATE': {
+            activeClientIds.add(clientId);
+
+            sendToClient(client, {
+                type: 'MOCKING_ENABLED',
+                payload: true,
+            });
+            break;
+        }
+
+        case 'MOCK_DEACTIVATE': {
+            activeClientIds.delete(clientId);
+            break;
+        }
+
+        case 'CLIENT_CLOSED': {
+            activeClientIds.delete(clientId);
+
+            const remainingClients = allClients.filter((client) => {
+                return client.id !== clientId;
+            });
+
+            // Unregister itself when there are no more clients
+            if (remainingClients.length === 0) {
+                self.registration.unregister();
+            }
+
+            break;
+        }
+    }
+});
+
+// Resolve the "main" client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+    const client = await self.clients.get(event.clientId);
+
+    if (client.frameType === 'top-level') {
+        return client;
+    }
+
+    const allClients = await self.clients.matchAll();
+
+    return allClients
+        .filter((client) => {
+            // Get only those clients that are currently visible.
+            return client.visibilityState === 'visible';
+        })
+        .find((client) => {
+            // Find the client ID that's recorded in the
+            // set of clients that have registered the worker.
+            return activeClientIds.has(client.id);
+        });
+}
+
+async function handleRequest(event, requestId) {
+    const client = await resolveMainClient(event);
+    const response = await getResponse(event, client, requestId);
+
+    // Send back the response clone for the "response:*" life-cycle events.
+    // Ensure MSW is active and ready to handle the message, otherwise
+    // this message will pend indefinitely.
+    if (client && activeClientIds.has(client.id)) {
+        (async function () {
+            const clonedResponse = response.clone();
+            sendToClient(client, {
+                type: 'RESPONSE',
+                payload: {
+                    requestId,
+                    type: clonedResponse.type,
+                    ok: clonedResponse.ok,
+                    status: clonedResponse.status,
+                    statusText: clonedResponse.statusText,
+                    body:
+                        clonedResponse.body === null
+                            ? null
+                            : await clonedResponse.text(),
+                    headers: serializeHeaders(clonedResponse.headers),
+                    redirected: clonedResponse.redirected,
+                },
+            });
+        })();
+    }
+
+    return response;
+}
+
+async function getResponse(event, client, requestId) {
+    const { request } = event;
+    const requestClone = request.clone();
+    const getOriginalResponse = () => fetch(requestClone);
+
+    // Bypass mocking when the request client is not active.
+    if (!client) {
+        return getOriginalResponse();
+    }
+
+    // Bypass initial page load requests (i.e. static assets).
+    // The absence of the immediate/parent client in the map of the active clients
+    // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+    // and is not ready to handle requests.
+    if (!activeClientIds.has(client.id)) {
+        return await getOriginalResponse();
+    }
+
+    // Bypass requests with the explicit bypass header
+    if (requestClone.headers.get(bypassHeaderName) === 'true') {
+        const cleanRequestHeaders = serializeHeaders(requestClone.headers);
+
+        // Remove the bypass header to comply with the CORS preflight check.
+        delete cleanRequestHeaders[bypassHeaderName];
+
+        const originalRequest = new Request(requestClone, {
+            headers: new Headers(cleanRequestHeaders),
+        });
+
+        return fetch(originalRequest);
+    }
+
+    // Send the request to the client-side MSW.
+    const reqHeaders = serializeHeaders(request.headers);
+    const body = await request.text();
+
+    const clientMessage = await sendToClient(client, {
+        type: 'REQUEST',
+        payload: {
+            id: requestId,
+            url: request.url,
+            method: request.method,
+            headers: reqHeaders,
+            cache: request.cache,
+            mode: request.mode,
+            credentials: request.credentials,
+            destination: request.destination,
+            integrity: request.integrity,
+            redirect: request.redirect,
+            referrer: request.referrer,
+            referrerPolicy: request.referrerPolicy,
+            body,
+            bodyUsed: request.bodyUsed,
+            keepalive: request.keepalive,
+        },
+    });
+
+    switch (clientMessage.type) {
+        case 'MOCK_SUCCESS': {
+            return delayPromise(
+                () => respondWithMock(clientMessage),
+                clientMessage.payload.delay
+            );
+        }
+
+        case 'MOCK_NOT_FOUND': {
+            return getOriginalResponse();
+        }
+
+        case 'NETWORK_ERROR': {
+            const { name, message } = clientMessage.payload;
+            const networkError = new Error(message);
+            networkError.name = name;
+
+            // Rejecting a request Promise emulates a network error.
+            throw networkError;
+        }
+
+        case 'INTERNAL_ERROR': {
+            const parsedBody = JSON.parse(clientMessage.payload.body);
+
+            console.error(
+                `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+                request.method,
+                request.url
+            );
+
+            return respondWithMock(clientMessage);
+        }
+    }
+
+    return getOriginalResponse();
+}
+
+self.addEventListener('fetch', function (event) {
+    const { request } = event;
+    const accept = request.headers.get('accept') || '';
+
+    // Bypass server-sent events.
+    if (accept.includes('text/event-stream')) {
+        return;
+    }
+
+    // Bypass navigation requests.
+    if (request.mode === 'navigate') {
+        return;
+    }
+
+    // Opening the DevTools triggers the "only-if-cached" request
+    // that cannot be handled by the worker. Bypass such requests.
+    if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+        return;
+    }
+
+    // Bypass all requests when there are no active clients.
+    // Prevents the self-unregistered worked from handling requests
+    // after it's been deleted (still remains active until the next reload).
+    if (activeClientIds.size === 0) {
+        return;
+    }
+
+    const requestId = uuidv4();
+
+    return event.respondWith(
+        handleRequest(event, requestId).catch((error) => {
+            if (error.name === 'NetworkError') {
+                console.warn(
+                    '[MSW] Successfully emulated a network error for the "%s %s" request.',
+                    request.method,
+                    request.url
+                );
+                return;
+            }
+
+            // At this point, any exception indicates an issue with the original request/response.
+            console.error(
+                `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+                request.method,
+                request.url,
+                `${error.name}: ${error.message}`
+            );
+        })
+    );
+});
+
+function serializeHeaders(headers) {
+    const reqHeaders = {};
+    headers.forEach((value, name) => {
+        reqHeaders[name] = reqHeaders[name]
+            ? [].concat(reqHeaders[name]).concat(value)
+            : value;
+    });
+    return reqHeaders;
+}
+
+function sendToClient(client, message) {
+    return new Promise((resolve, reject) => {
+        const channel = new MessageChannel();
+
+        channel.port1.onmessage = (event) => {
+            if (event.data && event.data.error) {
+                return reject(event.data.error);
+            }
+
+            resolve(event.data);
+        };
+
+        client.postMessage(JSON.stringify(message), [channel.port2]);
+    });
+}
+
+function delayPromise(cb, duration) {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(cb()), duration);
+    });
+}
+
+function respondWithMock(clientMessage) {
+    return new Response(clientMessage.payload.body, {
+        ...clientMessage.payload,
+        headers: clientMessage.payload.headers,
+    });
+}
+
+function uuidv4() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(
+        /[xy]/g,
+        function (c) {
+            const r = (Math.random() * 16) | 0;
+            const v = c == 'x' ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+        }
+    );
+}

--- a/explorer/client/src/api/Api.ts
+++ b/explorer/client/src/api/Api.ts
@@ -1,0 +1,55 @@
+import { stringifyUrl } from 'query-string';
+
+import type { SuiApi } from './api-definition';
+import type { StringifiableRecord } from 'query-string';
+
+type ApiPaths = keyof SuiApi;
+type GetPathMethods<Path extends string> = Path extends ApiPaths
+    ? keyof SuiApi[Path]
+    : never;
+type GetPathData<
+    Path extends string,
+    Method extends GetPathMethods<Path>,
+    DataKey
+> = Path extends ApiPaths
+    ? DataKey extends keyof SuiApi[Path][Method]
+        ? SuiApi[Path][Method][DataKey]
+        : never
+    : never;
+
+const API_PATH = '/api/';
+
+export async function request<
+    Path extends ApiPaths,
+    Method extends GetPathMethods<Path>
+>({
+    path,
+    method,
+    queryParams,
+    requestParams,
+}: {
+    path: Path;
+    method: Method;
+    queryParams?: GetPathData<Path, Method, 'queryParams'>;
+    requestParams?: GetPathData<Path, Method, 'requestParams'>;
+}): Promise<GetPathData<Path, Method, 200>> {
+    const resp = await fetch(
+        stringifyUrl({
+            url: `${API_PATH}${path}`,
+            query: queryParams as unknown as StringifiableRecord,
+        }),
+        {
+            headers: {
+                'Content-Type': 'application/json',
+                Accepts: 'application/json',
+            },
+            method,
+            body: requestParams ? JSON.stringify(requestParams) : undefined,
+        }
+    );
+    if (resp.ok) {
+        return await resp.json();
+    }
+    // TODO: better errors include status, extra info as json
+    throw new Error(await resp.text());
+}

--- a/explorer/client/src/api/UseSearch.ts
+++ b/explorer/client/src/api/UseSearch.ts
@@ -1,0 +1,11 @@
+import useSWR from 'swr';
+
+import { request } from './Api';
+
+function useSearch(term: string | null) {
+    return useSWR(term ? `GET search/${term}` : null, () =>
+        request({ path: `search/${term}` as 'search/{term}', method: 'get' })
+    );
+}
+
+export default useSearch;

--- a/explorer/client/src/api/UseTransaction.ts
+++ b/explorer/client/src/api/UseTransaction.ts
@@ -1,0 +1,14 @@
+import useSWR from 'swr';
+
+import { request } from './Api';
+
+function useTransaction(id: string | null) {
+    return useSWR(id ? `GET transactions/${id}` : null, () =>
+        request({
+            path: `transactions/${id}` as 'transactions/{id}',
+            method: 'get',
+        })
+    );
+}
+
+export default useTransaction;

--- a/explorer/client/src/api/UseTransactions.ts
+++ b/explorer/client/src/api/UseTransactions.ts
@@ -1,0 +1,14 @@
+import useSWR from 'swr';
+
+import { request } from './Api';
+
+function useTransactions() {
+    return useSWR(`GET transactions`, () =>
+        request({
+            path: `transactions`,
+            method: 'get',
+        })
+    );
+}
+
+export default useTransactions;

--- a/explorer/client/src/api/api-definition.ts
+++ b/explorer/client/src/api/api-definition.ts
@@ -1,0 +1,47 @@
+type TransactionID = string;
+enum TransactionStatus {
+    success = 'success',
+    fail = 'fail',
+}
+type AccountAddress = string;
+interface Transaction {
+    id: TransactionID;
+    sender: AccountAddress;
+    status: TransactionStatus;
+    created: Object[];
+    mutated: Object[];
+    deleted: Object[];
+}
+type ObjectID = string;
+type Object = {
+    id: ObjectID;
+} & Record<string, unknown>;
+enum SearchItemType {
+    transaction = 'tx',
+    object = 'obj',
+}
+interface SearchItem {
+    type: SearchItemType;
+    item: Transaction | Object;
+}
+type SearchResponse = SearchItem[];
+type TransactionResponse = Transaction;
+type TransactionsResponse = Transaction[];
+
+export type SuiApi = {
+    'search/{term}': {
+        get: {
+            200: SearchResponse;
+        };
+    };
+    transactions: {
+        get: {
+            200: TransactionsResponse;
+        };
+    };
+    'transactions/{id}': {
+        get: {
+            200: TransactionResponse;
+        };
+    };
+};

--- a/explorer/client/src/index.tsx
+++ b/explorer/client/src/index.tsx
@@ -7,13 +7,28 @@ import reportWebVitals from './utils/reportWebVitals';
 
 import './index.scss';
 
-ReactDOM.render(
-    <React.StrictMode>
-        <Router>
-            <App />
-        </Router>
-    </React.StrictMode>,
-    document.getElementById('root')
-);
+let init = Promise.resolve();
 
-reportWebVitals();
+if (
+    process.env.NODE_ENV === 'development' &&
+    process.env.REACT_APP_MOCK_API === 'true'
+) {
+    init = (async () => {
+        (await import('./mocks/api/browser-mock')).worker.start({
+            onUnhandledRequest: 'bypass',
+        });
+    })();
+}
+
+init.then(() => {
+    ReactDOM.render(
+        <React.StrictMode>
+            <Router>
+                <App />
+            </Router>
+        </React.StrictMode>,
+        document.getElementById('root')
+    );
+
+    reportWebVitals();
+});

--- a/explorer/client/src/mocks/api/browser-mock.ts
+++ b/explorer/client/src/mocks/api/browser-mock.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw';
+
+import handlers from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/explorer/client/src/mocks/api/data/objects.ts
+++ b/explorer/client/src/mocks/api/data/objects.ts
@@ -1,0 +1,8 @@
+import faker from '@faker-js/faker';
+
+export function getObject() {
+    return {
+        id: faker.datatype.hexaDecimal(32),
+        type: faker.datatype.uuid(),
+    };
+}

--- a/explorer/client/src/mocks/api/data/search.ts
+++ b/explorer/client/src/mocks/api/data/search.ts
@@ -1,0 +1,16 @@
+import faker from '@faker-js/faker';
+
+import { getObject } from './objects';
+import { getTransaction } from './transactions';
+
+export function getSearchResponse() {
+    const totalItems = faker.datatype.number(5);
+    return Array.from({ length: totalItems }, () => {
+        const type = faker.random.arrayElement(['tx', 'obj']);
+        const item = type === 'tx' ? getTransaction() : getObject();
+        return {
+            type,
+            item,
+        };
+    });
+}

--- a/explorer/client/src/mocks/api/data/transactions.ts
+++ b/explorer/client/src/mocks/api/data/transactions.ts
@@ -1,0 +1,18 @@
+import faker from '@faker-js/faker';
+
+export function getTransaction(id?: string) {
+    return {
+        id: id || faker.datatype.hexaDecimal(32),
+        sender: faker.datatype.hexaDecimal(32),
+        status: faker.random.arrayElement(['success', 'fail']),
+        created: Array.from({ length: faker.datatype.number(5) }, () =>
+            faker.datatype.hexaDecimal(32)
+        ),
+        mutated: Array.from({ length: faker.datatype.number(5) }, () =>
+            faker.datatype.hexaDecimal(32)
+        ),
+        deleted: Array.from({ length: faker.datatype.number(5) }, () =>
+            faker.datatype.hexaDecimal(32)
+        ),
+    };
+}

--- a/explorer/client/src/mocks/api/handlers/index.ts
+++ b/explorer/client/src/mocks/api/handlers/index.ts
@@ -1,0 +1,5 @@
+import { search } from './search';
+import { transaction, transactions } from './transactions';
+
+export const handlers = [search, transaction, transactions];
+export default handlers;

--- a/explorer/client/src/mocks/api/handlers/search.ts
+++ b/explorer/client/src/mocks/api/handlers/search.ts
@@ -1,0 +1,7 @@
+import { rest } from 'msw';
+
+import { getSearchResponse } from '../data/search';
+
+export const search = rest.get('/api/search/:term', (req, res, ctx) => {
+    return res(ctx.json(getSearchResponse()));
+});

--- a/explorer/client/src/mocks/api/handlers/transactions.ts
+++ b/explorer/client/src/mocks/api/handlers/transactions.ts
@@ -1,0 +1,22 @@
+import faker from '@faker-js/faker';
+import { rest } from 'msw';
+
+import { getTransaction } from '../data/transactions';
+
+export const transactions = rest.get('/api/transactions', (req, res, ctx) => {
+    return res(
+        ctx.json(
+            Array.from({ length: faker.datatype.number(15) }, getTransaction)
+        )
+    );
+});
+
+export const transaction = rest.get(
+    '/api/transactions/:id',
+    (req, res, ctx) => {
+        const id = Array.isArray(req.params.id)
+            ? req.params.id?.[0]
+            : req.params.id;
+        return res(ctx.json(getTransaction(id)));
+    }
+);

--- a/explorer/client/src/setupProxy.js
+++ b/explorer/client/src/setupProxy.js
@@ -1,0 +1,16 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const apiUrl = process.env.PROXY_API_SERVER || 'http://localhost:8080';
+
+module.exports = function (app) {
+    app.use(
+        '/api',
+        createProxyMiddleware({
+            target: apiUrl,
+            changeOrigin: true,
+            pathRewrite: {
+                '^/api': '/',
+            },
+        })
+    );
+};

--- a/explorer/server/api-spec.yaml
+++ b/explorer/server/api-spec.yaml
@@ -1,0 +1,133 @@
+openapi: 3.0.1
+info:
+  title: Initial API
+  version: 0.0.1
+paths:
+  /transactions:
+    get:
+      tags:
+        - Transactions
+      summary: Get transactions - when no params provided returns the last 10
+      parameters:
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - "time"
+              - "-time"
+              - "id"
+              - "-id"
+            default: "time"
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Transaction"
+  /transactions/{id}:
+    get:
+      tags:
+        - Transactions
+      summary: Get transaction by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of transaction to return
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Transaction"
+  /search/{term}:
+    get:
+      tags:
+        - Search
+      summary: Search for transactions or objects related to the search term
+      description: The items are sorted by relevance with the term
+      parameters:
+        - name: term
+          in: path
+          description: The term to search for
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - tx
+                        - obj
+                    item:
+                      oneOf:
+                        - $ref: "#/components/schemas/Transaction"
+                        - $ref: "#/components/schemas/Object"
+
+components:
+  schemas:
+    Transaction:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/TransactionID"
+        sender:
+          $ref: "#/components/schemas/AccountAddress"
+        status:
+          $ref: "#/components/schemas/TransactionStatus"
+        created:
+          type: array
+          description: Objects created in this transaction
+          items:
+            $ref: "#/components/schemas/ObjectID"
+        mutated:
+          type: array
+          description: Objects mutated in this transaction
+          items:
+            $ref: "#/components/schemas/ObjectID"
+        deleted:
+          type: array
+          description: Objects deleted in this transaction
+          items:
+            $ref: "#/components/schemas/ObjectID"
+    TransactionID:
+      type: string
+    TransactionStatus:
+      type: string
+      enum:
+        - success
+        - fail
+    Object:
+      type: object
+      properties:
+        id:
+          type: string
+    AccountAddress:
+      type: string
+    ObjectID:
+      type: string


### PR DESCRIPTION
* add proxy to api for dev server
  * all /api requests are proxied
  * uses env variable PROXY_API_SERVER for the api server url or a default one
  * adds various deps
* use msw for mocking api requests
  * msw setups a serviceworker on the client side and uses predefined handlers to serve mock responses/data
  * note: added npm script to update the serviceworker file that msw generates - we should run this (msw:update) when we update msw package. This was done mainly for linting because on fresh installs msw changes the file even when there are no other changes beside the formatting changes
  * REACT_APP_MOCK_API env variable can be used to disable mocking of Api
  * enabled only when the above variable is true and in dev mode
  * using faker to generate mock data
* use swr for fetching API data
  * adds api definitions as a temp solution until we have a way to generate it from the API spec
  * adds a request method for the API that supports types
  * adds hooks that use swr for search, transactions and transaction
* initial api spec
  * this will probably be auto-generated from the code in the future
  * used it for now to describe the initial API

resolves #455 