### PR TITLE
explorer-client: add latest transactions

### DIFF
--- a/explorer/client/src/__tests__/App.test.tsx
+++ b/explorer/client/src/__tests__/App.test.tsx
@@ -90,4 +90,23 @@ describe('App component', () => {
         fireEvent.click(screen.getByRole('link', { name: /logo/i }));
         expectHome();
     });
+
+    describe('latest transactions', () => {
+        it('shows latest transactions on home page', () => {
+            render(<App />, { wrapper: MemoryRouter });
+            expect(screen.getByText('Transaction ID')).toBeInTheDocument();
+        });
+        it('navigates to transaction details when clicked', () => {
+            const history = createMemoryHistory();
+            render(
+                <HistoryRouter history={history}>
+                    <App />
+                </HistoryRouter>
+            );
+            fireEvent.click(screen.getByText(/A1dddd/));
+            expect(history.location.pathname).toBe(
+                '/transactions/A1dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+            );
+        });
+    });
 });

--- a/explorer/client/src/components/accounts/account-id/AccountID.tsx
+++ b/explorer/client/src/components/accounts/account-id/AccountID.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+
+import TruncatedLabel from '../../truncated-label/TruncatedLabel';
+
+type AccountIDProps = {
+    id: string;
+};
+
+function AccountID({ id }: AccountIDProps) {
+    // TODO: link to details page when available
+    return <TruncatedLabel label={id} />;
+}
+
+export default memo(AccountID);

--- a/explorer/client/src/components/objects/object-id/ObjectID.tsx
+++ b/explorer/client/src/components/objects/object-id/ObjectID.tsx
@@ -1,0 +1,15 @@
+import { memo } from 'react';
+
+import TruncatedLabel from '../../truncated-label/TruncatedLabel';
+
+type ObjectIDProps = {
+    id: string;
+    size?: 'small' | 'normal';
+};
+
+function ObjectID({ id, size = 'normal' }: ObjectIDProps) {
+    // TODO: link to details page when available
+    return <TruncatedLabel label={id} size={size} />;
+}
+
+export default memo(ObjectID);

--- a/explorer/client/src/components/page-layout/PageLayout.module.css
+++ b/explorer/client/src/components/page-layout/PageLayout.module.css
@@ -1,0 +1,3 @@
+.page {
+    @apply mx-[5vw] mt-[3vw] mb-[5vw];
+}

--- a/explorer/client/src/components/page-layout/PageLayout.tsx
+++ b/explorer/client/src/components/page-layout/PageLayout.tsx
@@ -1,0 +1,15 @@
+import { memo } from 'react';
+
+import styles from './PageLayout.module.css';
+
+import type { ReactNode } from 'react';
+
+type PageLayoutProps = {
+    children: ReactNode[] | ReactNode;
+};
+
+function PageLayout({ children }: PageLayoutProps) {
+    return <div className={styles.page}>{children}</div>;
+}
+
+export default memo(PageLayout);

--- a/explorer/client/src/components/transactions/transaction-id/TransactionID.tsx
+++ b/explorer/client/src/components/transactions/transaction-id/TransactionID.tsx
@@ -1,0 +1,18 @@
+import { memo } from 'react';
+import { Link } from 'react-router-dom';
+
+import TruncatedLabel from '../../truncated-label/TruncatedLabel';
+
+type TransactionIDProps = {
+    id: string;
+};
+
+function TransactionID({ id }: TransactionIDProps) {
+    return (
+        <Link to={`/transactions/${id}`}>
+            <TruncatedLabel label={id} />
+        </Link>
+    );
+}
+
+export default memo(TransactionID);

--- a/explorer/client/src/components/transactions/transaction-status/TransactionStatus.tsx
+++ b/explorer/client/src/components/transactions/transaction-status/TransactionStatus.tsx
@@ -1,0 +1,18 @@
+import { memo } from 'react';
+
+import { TransactionStatus as TxStatus } from '../types';
+
+type TransactionStatusProps = {
+    status: TxStatus;
+};
+
+const statusToLabel = {
+    [TxStatus.success]: '✔ Success',
+    [TxStatus.fail]: '✕ Fail',
+};
+
+function TransactionStatus({ status }: TransactionStatusProps) {
+    return <span>{statusToLabel[status]}</span>;
+}
+
+export default memo(TransactionStatus);

--- a/explorer/client/src/components/transactions/transactions-table/TransactionsTable.module.css
+++ b/explorer/client/src/components/transactions/transactions-table/TransactionsTable.module.css
@@ -1,0 +1,47 @@
+.table-container {
+    @apply overflow-y-auto rounded pt-5 pb-3 border-solid border-2;
+}
+
+.table {
+    @apply table-auto w-full border-collapse max-h-[60vh] block overflow-y-auto;
+}
+
+.table thead {
+    @apply sticky top-0 bg-white;
+}
+
+.row:nth-child(2n + 1) {
+    @apply bg-slate-100;
+}
+
+th.column {
+    @apply font-semibold;
+}
+
+.column {
+    @apply whitespace-nowrap pl-5 text-left;
+}
+
+.column-objs {
+    @apply max-w-[40vw] whitespace-normal;
+}
+
+.column:last-child {
+    @apply pr-5;
+}
+
+.objects {
+    @apply list-none p-0 m-0;
+}
+
+.object {
+    @apply inline-block align-top whitespace-nowrap mr-1;
+}
+
+.object:last-child {
+    @apply mr-0;
+}
+
+.extra {
+    @apply text-xs tracking-tight;
+}

--- a/explorer/client/src/components/transactions/transactions-table/TransactionsTable.tsx
+++ b/explorer/client/src/components/transactions/transactions-table/TransactionsTable.tsx
@@ -1,0 +1,89 @@
+import cn from 'classnames';
+import { memo } from 'react';
+
+import AccountID from '../../accounts/account-id/AccountID';
+import ObjectID from '../../objects/object-id/ObjectID';
+import TransactionID from '../transaction-id/TransactionID';
+import TransactionStatus from '../transaction-status/TransactionStatus';
+import styles from './TransactionsTable.module.css';
+
+import type { TransactionType } from '../types';
+
+type TransactionsTableProps = {
+    transactions: TransactionType[];
+};
+
+const headers = [
+    'Transaction ID',
+    'Sender',
+    'Status',
+    'Objects Created',
+    'Objects Mutated',
+    'Objects Deleted',
+];
+
+const clsColumn = styles.column;
+const OBJECTS_LIMIT = 2;
+
+function makeObjects(objs: string[]) {
+    return (
+        <td className={cn(clsColumn, styles['column-objs'])}>
+            {objs.length ? (
+                <ul className={styles.objects}>
+                    {objs.slice(0, OBJECTS_LIMIT).map((id) => (
+                        <li key={id} className={styles.object}>
+                            <ObjectID id={id} size="small" />
+                        </li>
+                    ))}
+                    {objs.length > OBJECTS_LIMIT ? (
+                        <li className={styles.object}>
+                            <span className={styles.extra}>
+                                +{objs.length - OBJECTS_LIMIT} more
+                            </span>
+                        </li>
+                    ) : null}
+                </ul>
+            ) : (
+                '-'
+            )}
+        </td>
+    );
+}
+
+function TransactionsTable({ transactions }: TransactionsTableProps) {
+    return (
+        <div className={styles['table-container']}>
+            <table className={styles['table']}>
+                <thead>
+                    <tr>
+                        {headers.map((txt) => (
+                            <th key={txt} className={clsColumn}>
+                                {txt}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {transactions.map((tx) => (
+                        <tr key={tx.id} className={styles.row}>
+                            <td className={clsColumn}>
+                                <TransactionID id={tx.id} />
+                            </td>
+                            <td className={clsColumn}>
+                                <AccountID id={tx.sender} />
+                            </td>
+                            <td className={clsColumn}>
+                                <TransactionStatus status={tx.status} />
+                            </td>
+                            {makeObjects(tx.created || [])}
+                            {makeObjects(tx.mutated || [])}
+                            {makeObjects(tx.deleted || [])}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default memo(TransactionsTable);

--- a/explorer/client/src/components/transactions/types.ts
+++ b/explorer/client/src/components/transactions/types.ts
@@ -1,0 +1,13 @@
+export enum TransactionStatus {
+    success = 'success',
+    fail = 'fail',
+}
+
+export type TransactionType = {
+    id: string;
+    sender: string;
+    created?: string[];
+    mutated?: string[];
+    deleted?: string[];
+    status: TransactionStatus;
+};

--- a/explorer/client/src/components/truncated-label/TruncatedLabel.module.css
+++ b/explorer/client/src/components/truncated-label/TruncatedLabel.module.css
@@ -1,0 +1,7 @@
+.label {
+    @apply truncate max-w-[10rem] min-w-[8rem] inline-block;
+}
+
+.label.small {
+    @apply max-w-[8rem] min-w-[5rem];
+}

--- a/explorer/client/src/components/truncated-label/TruncatedLabel.tsx
+++ b/explorer/client/src/components/truncated-label/TruncatedLabel.tsx
@@ -1,0 +1,19 @@
+import cn from 'classnames';
+import { memo } from 'react';
+
+import styles from './TruncatedLabel.module.css';
+
+type TruncatedLabelProps = {
+    label: string;
+    size?: 'small' | 'normal';
+};
+
+function TruncatedLabel({ label, size = 'normal' }: TruncatedLabelProps) {
+    return (
+        <span className={cn(styles.label, styles[size])} title={label}>
+            {label}
+        </span>
+    );
+}
+
+export default memo(TruncatedLabel);

--- a/explorer/client/src/pages/home/Home.tsx
+++ b/explorer/client/src/pages/home/Home.tsx
@@ -1,5 +1,44 @@
+import PageLayout from '../../components/page-layout/PageLayout';
+import TransactionsTable from '../../components/transactions/transactions-table/TransactionsTable';
+import { TransactionStatus } from '../../components/transactions/types';
+import txs from '../../utils/transaction_mock.json';
+
+import type { TransactionType } from '../../components/transactions/types';
+
+// TODO: mock data should be removed
+const latestTxs: TransactionType[] = Array.from(
+    { length: 15 },
+    (_, index) =>
+        (txs.data as TransactionType[])[index] || {
+            id: `tx${index}-sdasjdsajjdfladsjdajdaslnjkdaskdasljadslkjasdlk`,
+            sender: `sender${index}ldaskdjaopdasldaslkasljkaadslkadslkaslkd`,
+            status:
+                Math.random() < 0.5
+                    ? TransactionStatus.success
+                    : TransactionStatus.fail,
+            created: [
+                `cr-obj${index}-1-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+                `cr-obj${index}-2-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+                `cr-obj${index}-3-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+            ],
+            mutated: [
+                `mut-obj${index}-1-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+                `mut-obj${index}-2-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+            ],
+            deleted: [
+                `del-obj${index}-1-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+                `del-obj${index}-2-asdasdhjsladkjfhaskdjfhjkasdfhasf`,
+            ],
+        }
+);
+
 function Home() {
-    return <div>Latest Transactions</div>;
+    return (
+        <PageLayout>
+            <h2>Latest Transactions</h2>
+            <TransactionsTable transactions={latestTxs} />
+        </PageLayout>
+    );
 }
 
 export default Home;


### PR DESCRIPTION
* home page now shows latest transactions table using mock data (for demo purposes)
* table of transactions has a maximum height up to 60vh

<img width="1512" alt="Screenshot 2022-03-02 at 17 27 50" src="https://user-images.githubusercontent.com/10210143/156415636-a3115d94-547b-4d72-9620-d9aba8c2192d.png">

<img width="365" alt="Screenshot 2022-03-02 at 17 27 06" src="https://user-images.githubusercontent.com/10210143/156415740-c02819a9-ae59-4b22-aee1-04c4b6a72471.png">

<img width="380" alt="Screenshot 2022-03-02 at 13 29 32" src="https://user-images.githubusercontent.com/10210143/156371497-02928aae-6cc5-4e6e-b202-53be7ba3faa8.png">


https://user-images.githubusercontent.com/10210143/156415932-43b72e95-648d-4a98-8b0f-8b5de65502a3.mov


resolves #423 