### PR TITLE
Implement the move module for cross-chain airdrop

### DIFF
--- a/sui/src/keystore.rs
+++ b/sui/src/keystore.rs
@@ -82,6 +82,12 @@ impl SuiKeystore {
         let store = serde_json::to_string_pretty(&self.keys.values().collect::<Vec<_>>()).unwrap();
         Ok(fs::write(&self.path, store)?)
     }
+
+    pub fn add_key(&mut self, address: SuiAddress, keypair: KeyPair) -> Result<(), anyhow::Error> {
+        self.keys.insert(address, keypair);
+        self.save()?;
+        Ok(())
+    }
 }
 
 pub struct SuiKeystoreSigner {

--- a/sui_programmability/framework/tests/CrossChainAirdropTests.move
+++ b/sui_programmability/framework/tests/CrossChainAirdropTests.move
@@ -17,7 +17,6 @@ module Sui::CrossChainAirdropTests {
     const SOURCE_CONTRACT_ADDRESS: vector<u8> = x"BC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
     const SOURCE_TOKEN_ID: u64 = 101;
     const NAME: vector<u8> = b"BoredApeYachtClub";
-    const SYMBOL: vector<u8> = b"BAYC";
     const TOKEN_URI: vector<u8> = b"ipfs://QmeSjSinHpPnmXmspMjwiXyN6zS4E9zccariGR3jxcaWtq/101";
 
     struct Object has key {
@@ -68,7 +67,6 @@ module Sui::CrossChainAirdropTests {
                 SOURCE_CONTRACT_ADDRESS,
                 token_id,
                 NAME,
-                SYMBOL,
                 TOKEN_URI,
                 ctx,
             );


### PR DESCRIPTION
This PR implements the Move component as mentioned in the [NFT Mirroring design doc ](https://docs.google.com/document/d/17zO1DyH2XgghRc6XVwakDk57GibC0kdbMWu5b3i6gic/edit#bookmark=id.if1gggupne2k). The goal of this PR is not to write a rigorous and production ready contract with all the features in ERC-721 standard, but just to have a minimal version to unblock the MVP before GDC.

The major TODOs are(in separate PRs)
- Represent `token_id` in `u256` (see discussion in https://github.com/MystenLabs/fastnft/pull/616)
- Implement the [Sparse Set](https://mysten-labs.slack.com/archives/C034G5FUZ6G/p1646168126903109?thread_ts=1646149115.852669&cid=C034G5FUZ6G). Right now the time complexity for checking the uniqueness of `(eth_contract_address, eth_token_id)` is O(M+N) where M is the number of mirrored ETH contracts and N is the max number of claimed token ids for a given eth contract address). Implementing the sparse set will reduce the time complexity to O(1) but will take more efforts.
