### PR TITLE
Change `transfer_object` to `transfer_coin` in Client API

### DIFF
--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -315,7 +315,7 @@ impl WalletCommands {
 
                 let (cert, effects) = context
                     .address_manager
-                    .transfer_object(*from, *object_id, *gas, *to, signature_callback)
+                    .transfer_coin(*from, *object_id, *gas, *to, signature_callback)
                     .await?;
                 let time_total = time_start.elapsed().as_micros();
 

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -520,14 +520,12 @@ impl AuthorityState {
         }
         temporary_store.write_object(gas_object);
 
-        if output_object.is_read_only() {
+        if let Err(err) = output_object.transfer(recipient) {
             return Ok(ExecutionStatus::Failure {
                 gas_used: gas::MIN_OBJ_TRANSFER_GAS,
-                error: Box::new(SuiError::CannotTransferReadOnlyObject),
+                error: Box::new(err),
             });
         }
-
-        output_object.transfer(recipient);
         temporary_store.write_object(output_object);
         Ok(ExecutionStatus::Success { gas_used })
     }

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -498,7 +498,7 @@ async fn test_initiating_valid_transfer() {
         (sender, SequenceNumber::from(0))
     );
     let (certificate, _) = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id_1,
             gas_object,
@@ -548,7 +548,7 @@ async fn test_initiating_valid_transfer_despite_bad_authority() {
     let (sender, sender_key) = get_key_pair();
     let mut client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
     let (certificate, _) = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -593,7 +593,7 @@ async fn test_initiating_transfer_low_funds() {
     let (sender, sender_key) = get_key_pair();
     let mut client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
     assert!(client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id_2,
             gas_object,
@@ -649,7 +649,7 @@ async fn test_bidirectional_transfer() {
     );
     // Transfer object to client.
     let (certificate, _) = client
-        .transfer_object(
+        .transfer_coin(
             addr1,
             object_id,
             gas_object1,
@@ -694,7 +694,7 @@ async fn test_bidirectional_transfer() {
 
     // Transfer the object back to Client1
     client
-        .transfer_object(
+        .transfer_coin(
             addr2,
             object_id,
             gas_object2,
@@ -727,7 +727,7 @@ async fn test_bidirectional_transfer() {
 
     // Should fail if Client 2 double spend the object
     assert!(client
-        .transfer_object(
+        .transfer_coin(
             addr2,
             object_id,
             gas_object2,
@@ -796,7 +796,7 @@ async fn test_client_state_sync_with_transferred_object() {
 
     // Transfer object to client.
     client
-        .transfer_object(
+        .transfer_coin(
             addr1,
             object_id,
             gas_object_id,
@@ -1393,7 +1393,7 @@ async fn test_transfer_object_error() {
     // Test 1: Double spend
     let object_id = *objects.next().unwrap();
     client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -1403,7 +1403,7 @@ async fn test_transfer_object_error() {
         .await
         .unwrap();
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -1427,7 +1427,7 @@ async fn test_transfer_object_error() {
         .unwrap();
 
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             obj.id(),
             gas_object,
@@ -1451,7 +1451,7 @@ async fn test_transfer_object_error() {
         .unwrap();
 
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -1481,7 +1481,7 @@ async fn test_transfer_object_error() {
         .unwrap();
 
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -1685,7 +1685,7 @@ async fn test_object_store_transfer() {
 
     // Transfer object to client.
     let _certificate = client
-        .transfer_object(
+        .transfer_coin(
             addr1,
             object_id,
             gas_object1,
@@ -1712,7 +1712,7 @@ async fn test_object_store_transfer() {
 
     // Transfer the object back to Client1
     let _certificate = client
-        .transfer_object(
+        .transfer_coin(
             addr2,
             object_id,
             gas_object2,
@@ -2293,7 +2293,7 @@ async fn test_transfer_pending_transactions() {
     // Test 1: Normal transfer
     let object_id = *objects.next().unwrap();
     client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -2317,7 +2317,7 @@ async fn test_transfer_pending_transactions() {
         .unwrap();
 
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             obj.id(),
             gas_object,
@@ -2348,7 +2348,7 @@ async fn test_transfer_pending_transactions() {
         .unwrap();
 
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,
@@ -2382,7 +2382,7 @@ async fn test_transfer_pending_transactions() {
         .unwrap();
     // Try to use those objects in another transaction
     let result = client
-        .transfer_object(
+        .transfer_coin(
             sender,
             object_id,
             gas_object,

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -306,203 +306,205 @@ SuiError:
               SEQ:
                 TYPENAME: SuiError
     1:
-      CannotTransferReadOnlyObject: UNIT
+      TransferImmutableError: UNIT
     2:
+      TransferSharedError: UNIT
+    3:
+      TransferNonCoinError: UNIT
+    4:
       MoveObjectAsPackage:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    3:
-      UnexpectedOwnerType: UNIT
-    4:
-      UnsupportedSharedObjectError: UNIT
     5:
+      UnexpectedOwnerType: UNIT
+    6:
+      UnsupportedSharedObjectError: UNIT
+    7:
       InvalidSignature:
         STRUCT:
           - error: STR
-    6:
-      IncorrectSigner: UNIT
-    7:
-      UnknownSigner: UNIT
     8:
-      CertificateRequiresQuorum: UNIT
+      IncorrectSigner: UNIT
     9:
+      UnknownSigner: UNIT
+    10:
+      CertificateRequiresQuorum: UNIT
+    11:
       UnexpectedSequenceNumber:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_sequence:
               TYPENAME: SequenceNumber
-    10:
+    12:
       ConflictingTransaction:
         STRUCT:
           - pending_transaction:
               TYPENAME: Transaction
-    11:
+    13:
       ErrorWhileProcessingTransaction: UNIT
-    12:
+    14:
       ErrorWhileProcessingTransactionTransaction:
         STRUCT:
           - err: STR
-    13:
+    15:
       ErrorWhileProcessingConfirmationTransaction:
         STRUCT:
           - err: STR
-    14:
+    16:
       ErrorWhileRequestingCertificate: UNIT
-    15:
+    17:
       ErrorWhileProcessingPublish:
         STRUCT:
           - err: STR
-    16:
+    18:
       ErrorWhileProcessingMoveCall:
         STRUCT:
           - err: STR
-    17:
+    19:
       ErrorWhileRequestingInformation: UNIT
-    18:
+    20:
       ObjectFetchFailed:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - err: STR
-    19:
+    21:
       MissingEalierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    20:
+    22:
       UnexpectedTransactionIndex: UNIT
-    21:
+    23:
       CertificateNotfound:
         STRUCT:
           - certificate_digest:
               TYPENAME: TransactionDigest
-    22:
+    24:
       ParentNotfound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - sequence:
               TYPENAME: SequenceNumber
-    23:
-      UnknownSenderAccount: UNIT
-    24:
-      CertificateAuthorityReuse: UNIT
     25:
-      InvalidSequenceNumber: UNIT
+      UnknownSenderAccount: UNIT
     26:
-      SequenceOverflow: UNIT
+      CertificateAuthorityReuse: UNIT
     27:
-      SequenceUnderflow: UNIT
+      InvalidSequenceNumber: UNIT
     28:
-      WrongShard: UNIT
+      SequenceOverflow: UNIT
     29:
-      InvalidCrossShardUpdate: UNIT
+      SequenceUnderflow: UNIT
     30:
-      InvalidAuthenticator: UNIT
+      WrongShard: UNIT
     31:
-      InvalidAddress: UNIT
+      InvalidCrossShardUpdate: UNIT
     32:
-      InvalidTransactionDigest: UNIT
+      InvalidAuthenticator: UNIT
     33:
+      InvalidAddress: UNIT
+    34:
+      InvalidTransactionDigest: UNIT
+    35:
       InvalidObjectDigest:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_digest:
               TYPENAME: ObjectDigest
-    34:
-      InvalidDecoding: UNIT
-    35:
-      UnexpectedMessage: UNIT
     36:
-      DuplicateObjectRefInput: UNIT
+      InvalidDecoding: UNIT
     37:
+      UnexpectedMessage: UNIT
+    38:
+      DuplicateObjectRefInput: UNIT
+    39:
       ClientIoError:
         STRUCT:
           - error: STR
-    38:
-      TransferImmutableError: UNIT
-    39:
+    40:
       ModuleLoadFailure:
         STRUCT:
           - error: STR
-    40:
+    41:
       ModuleVerificationFailure:
         STRUCT:
           - error: STR
-    41:
+    42:
       ModuleDeserializationFailure:
         STRUCT:
           - error: STR
-    42:
+    43:
       ModulePublishFailure:
         STRUCT:
           - error: STR
-    43:
+    44:
       ModuleBuildFailure:
         STRUCT:
           - error: STR
-    44:
+    45:
       DependentPackageNotFound:
         STRUCT:
           - package_id:
               TYPENAME: ObjectID
-    45:
+    46:
       MoveUnitTestFailure:
         STRUCT:
           - error: STR
-    46:
+    47:
       FunctionNotFound:
         STRUCT:
           - error: STR
-    47:
+    48:
       ModuleNotFound:
         STRUCT:
           - module_name: STR
-    48:
+    49:
       InvalidFunctionSignature:
         STRUCT:
           - error: STR
-    49:
+    50:
       TypeError:
         STRUCT:
           - error: STR
-    50:
+    51:
       AbortedExecution:
         STRUCT:
           - error: STR
-    51:
+    52:
       InvalidMoveEvent:
         STRUCT:
           - error: STR
-    52:
-      CircularObjectOwnership: UNIT
     53:
+      CircularObjectOwnership: UNIT
+    54:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    54:
+    55:
       InsufficientGas:
         STRUCT:
           - error: STR
-    55:
-      InvalidTxUpdate: UNIT
     56:
-      TransactionLockExists: UNIT
+      InvalidTxUpdate: UNIT
     57:
-      TransactionLockDoesNotExist: UNIT
+      TransactionLockExists: UNIT
     58:
-      TransactionLockReset: UNIT
+      TransactionLockDoesNotExist: UNIT
     59:
+      TransactionLockReset: UNIT
+    60:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    60:
+    61:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -510,26 +512,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    61:
+    62:
       BadObjectType:
         STRUCT:
           - error: STR
-    62:
-      MoveExecutionFailure: UNIT
     63:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     64:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     65:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     66:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     67:
+      AuthorityUpdateFailure: UNIT
+    68:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    68:
+    69:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -540,33 +542,33 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    69:
+    70:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    70:
-      BatchErrorSender: UNIT
     71:
+      BatchErrorSender: UNIT
+    72:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    72:
-      ObjectSerializationError: UNIT
     73:
-      ConcurrentTransactionError: UNIT
+      ObjectSerializationError: UNIT
     74:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     75:
-      TooManyIncorrectAuthorities: UNIT
+      IncorrectRecipientError: UNIT
     76:
-      IncorrectGasSplit: UNIT
+      TooManyIncorrectAuthorities: UNIT
     77:
-      IncorrectGasMerge: UNIT
+      IncorrectGasSplit: UNIT
     78:
-      AccountNotFound: UNIT
+      IncorrectGasMerge: UNIT
     79:
+      AccountNotFound: UNIT
+    80:
       AccountExists: UNIT
 Transaction:
   STRUCT:

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -35,8 +35,12 @@ pub enum SuiError {
     // Object misuse issues
     #[error("Error acquiring lock for object(s): {:?}", errors)]
     LockErrors { errors: Vec<SuiError> },
-    #[error("Attempt to transfer read-only object.")]
-    CannotTransferReadOnlyObject,
+    #[error("Attempt to transfer a read-only object.")]
+    TransferImmutableError,
+    #[error("Attempt to transfer a shared object.")]
+    TransferSharedError,
+    #[error("Attempt to transfer an object that's not a coin.")]
+    TransferNonCoinError,
     #[error("A move package is expected, instead a move object is passed: {object_id}")]
     MoveObjectAsPackage { object_id: ObjectID },
     #[error("Expecting a singler owner, shared ownership found")]
@@ -132,8 +136,6 @@ pub enum SuiError {
     DuplicateObjectRefInput,
     #[error("Network error while querying service: {:?}.", error)]
     ClientIoError { error: String },
-    #[error("Cannot transfer immutable object.")]
-    TransferImmutableError,
 
     // Move module publishing related errors
     #[error("Failed to load the Move module, reason: {error:?}.")]


### PR DESCRIPTION
As described in #612 , we only support native transfer of the coin objects, and we don't intend to support native transfer of arbitrary objects in the near term (maybe until we figure out how to use capability to express transferability of Move struct types).
This PR updates the Client API to reflect this restriction.
Also cleaned up the checks on the authority side for code reuse.

Do we also need to make any document changes?
