### PR TITLE
Change Client publish API to take package bytes instead of path

### DIFF
--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -4,8 +4,10 @@ use crate::config::{Config, WalletConfig};
 use crate::sui_json::{resolve_move_function_args, SuiJsonValue};
 use core::fmt;
 use std::fmt::{Debug, Display, Formatter};
+use std::path::Path;
 use sui_core::authority_client::AuthorityClient;
 use sui_core::client::{Client, ClientAddressManager};
+use sui_framework::build_move_package_to_bytes;
 use sui_types::base_types::{decode_bytes_hex, ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::get_key_pair;
 use sui_types::gas_coin::GasCoin;
@@ -167,9 +169,10 @@ impl WalletCommands {
                     .into_object()?
                     .to_object_reference();
 
+                let compiled_modules = build_move_package_to_bytes(Path::new(path))?;
                 let (cert, effects) = context
                     .address_manager
-                    .publish(*sender, path.clone(), gas_obj_ref, *gas_budget)
+                    .publish(*sender, compiled_modules, gas_obj_ref, *gas_budget)
                     .await?;
 
                 if matches!(effects.status, ExecutionStatus::Failure { .. }) {

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::value::MoveStructLayout;
-use sui_framework::build_move_package_to_bytes;
 use sui_types::crypto::Signature;
 use sui_types::error::SuiResult;
 use sui_types::{
@@ -25,7 +24,7 @@ use sui_types::{
 use typed_store::rocks::open_cf;
 use typed_store::Map;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -170,7 +169,7 @@ pub trait Client {
     async fn publish(
         &mut self,
         signer: SuiAddress,
-        package_source_files_path: String,
+        package_bytes: Vec<Vec<u8>>,
         gas_object_ref: ObjectRef,
         gas_budget: u64,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error>;
@@ -711,16 +710,14 @@ where
     async fn publish(
         &mut self,
         signer: SuiAddress,
-        package_source_files_path: String,
+        package_bytes: Vec<Vec<u8>>,
         gas_object_ref: ObjectRef,
         gas_budget: u64,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        // Try to compile the package at the given path
-        let compiled_modules = build_move_package_to_bytes(Path::new(&package_source_files_path))?;
         let move_publish_transaction = Transaction::new_module(
             signer,
             gas_object_ref,
-            compiled_modules,
+            package_bytes,
             gas_budget,
             self.get_account(&signer)?.secret(),
         );


### PR DESCRIPTION
As described in #613, eventually the API calls will be over the wire, and the source files will not be on the same machine as the gateway service. Hence the API needs to take the package bytes as input, instead of the source file path.
The two tests in client_tests also become irrelevant.