### PR TITLE
[Move] Change transfer_and_freeze to freeze_object

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -149,7 +149,7 @@ impl AuthorityState {
                     if object_kind.object_id() == t.object_ref.0 {
                         fp_ensure!(
                             matches!(object.owner, Owner::SingleOwner(..)),
-                            SuiError::TransferImmutableError
+                            SuiError::TransferSharedError
                         );
                     }
                 }

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -301,7 +301,7 @@ async fn test_transfer_immutable() {
     assert_eq!(
         result.unwrap_err(),
         SuiError::LockErrors {
-            errors: vec![SuiError::TransferImmutableError]
+            errors: vec![SuiError::TransferSharedError]
         }
     );
 }

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -980,10 +980,9 @@ async fn test_move_calls_object_transfer() {
 }
 
 #[tokio::test]
-async fn test_move_calls_object_transfer_and_freeze() {
+async fn test_move_calls_freeze_object() {
     let (mut client, authority_clients) = make_address_manager(4).await;
     let (addr1, key1) = make_account(&mut client);
-    let (addr2, _) = make_account(&mut client);
 
     let object_value: u64 = 100;
     let gas_object_id = ObjectID::random();
@@ -1027,18 +1026,17 @@ async fn test_move_calls_object_transfer_and_freeze() {
     let new_obj_ref = client_object(&mut client, new_obj_ref.0).await.0;
     gas_object_ref = client_object(&mut client, gas_object_ref.0).await.0;
 
-    let pure_args = vec![bcs::to_bytes(&AccountAddress::from(addr2)).unwrap()];
     let call_response = client
         .move_call(
             addr1,
             framework_obj_ref,
             ident_str!("ObjectBasics").to_owned(),
-            ident_str!("transfer_and_freeze").to_owned(),
+            ident_str!("freeze_object").to_owned(),
             Vec::new(),
             gas_object_ref,
             vec![new_obj_ref],
             vec![],
-            pure_args,
+            vec![],
             GAS_VALUE_FOR_TESTING / 2,
             signature_callback(&key1),
         )

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -306,205 +306,203 @@ SuiError:
               SEQ:
                 TYPENAME: SuiError
     1:
-      TransferImmutableError: UNIT
-    2:
       TransferSharedError: UNIT
-    3:
+    2:
       TransferNonCoinError: UNIT
-    4:
+    3:
       MoveObjectAsPackage:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    5:
+    4:
       UnexpectedOwnerType: UNIT
-    6:
+    5:
       UnsupportedSharedObjectError: UNIT
-    7:
+    6:
       InvalidSignature:
         STRUCT:
           - error: STR
-    8:
+    7:
       IncorrectSigner: UNIT
-    9:
+    8:
       UnknownSigner: UNIT
-    10:
+    9:
       CertificateRequiresQuorum: UNIT
-    11:
+    10:
       UnexpectedSequenceNumber:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_sequence:
               TYPENAME: SequenceNumber
-    12:
+    11:
       ConflictingTransaction:
         STRUCT:
           - pending_transaction:
               TYPENAME: Transaction
-    13:
+    12:
       ErrorWhileProcessingTransaction: UNIT
-    14:
+    13:
       ErrorWhileProcessingTransactionTransaction:
         STRUCT:
           - err: STR
-    15:
+    14:
       ErrorWhileProcessingConfirmationTransaction:
         STRUCT:
           - err: STR
-    16:
+    15:
       ErrorWhileRequestingCertificate: UNIT
-    17:
+    16:
       ErrorWhileProcessingPublish:
         STRUCT:
           - err: STR
-    18:
+    17:
       ErrorWhileProcessingMoveCall:
         STRUCT:
           - err: STR
-    19:
+    18:
       ErrorWhileRequestingInformation: UNIT
-    20:
+    19:
       ObjectFetchFailed:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - err: STR
-    21:
+    20:
       MissingEalierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    22:
+    21:
       UnexpectedTransactionIndex: UNIT
-    23:
+    22:
       CertificateNotfound:
         STRUCT:
           - certificate_digest:
               TYPENAME: TransactionDigest
-    24:
+    23:
       ParentNotfound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - sequence:
               TYPENAME: SequenceNumber
-    25:
+    24:
       UnknownSenderAccount: UNIT
-    26:
+    25:
       CertificateAuthorityReuse: UNIT
-    27:
+    26:
       InvalidSequenceNumber: UNIT
-    28:
+    27:
       SequenceOverflow: UNIT
-    29:
+    28:
       SequenceUnderflow: UNIT
-    30:
+    29:
       WrongShard: UNIT
-    31:
+    30:
       InvalidCrossShardUpdate: UNIT
-    32:
+    31:
       InvalidAuthenticator: UNIT
-    33:
+    32:
       InvalidAddress: UNIT
-    34:
+    33:
       InvalidTransactionDigest: UNIT
-    35:
+    34:
       InvalidObjectDigest:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_digest:
               TYPENAME: ObjectDigest
-    36:
+    35:
       InvalidDecoding: UNIT
-    37:
+    36:
       UnexpectedMessage: UNIT
-    38:
+    37:
       DuplicateObjectRefInput: UNIT
-    39:
+    38:
       ClientIoError:
         STRUCT:
           - error: STR
-    40:
+    39:
       ModuleLoadFailure:
         STRUCT:
           - error: STR
-    41:
+    40:
       ModuleVerificationFailure:
         STRUCT:
           - error: STR
-    42:
+    41:
       ModuleDeserializationFailure:
         STRUCT:
           - error: STR
-    43:
+    42:
       ModulePublishFailure:
         STRUCT:
           - error: STR
-    44:
+    43:
       ModuleBuildFailure:
         STRUCT:
           - error: STR
-    45:
+    44:
       DependentPackageNotFound:
         STRUCT:
           - package_id:
               TYPENAME: ObjectID
-    46:
+    45:
       MoveUnitTestFailure:
         STRUCT:
           - error: STR
-    47:
+    46:
       FunctionNotFound:
         STRUCT:
           - error: STR
-    48:
+    47:
       ModuleNotFound:
         STRUCT:
           - module_name: STR
-    49:
+    48:
       InvalidFunctionSignature:
         STRUCT:
           - error: STR
-    50:
+    49:
       TypeError:
         STRUCT:
           - error: STR
-    51:
+    50:
       AbortedExecution:
         STRUCT:
           - error: STR
-    52:
+    51:
       InvalidMoveEvent:
         STRUCT:
           - error: STR
-    53:
+    52:
       CircularObjectOwnership: UNIT
-    54:
+    53:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    55:
+    54:
       InsufficientGas:
         STRUCT:
           - error: STR
-    56:
+    55:
       InvalidTxUpdate: UNIT
-    57:
+    56:
       TransactionLockExists: UNIT
-    58:
+    57:
       TransactionLockDoesNotExist: UNIT
-    59:
+    58:
       TransactionLockReset: UNIT
-    60:
+    59:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    61:
+    60:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -512,26 +510,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    62:
+    61:
       BadObjectType:
         STRUCT:
           - error: STR
-    63:
+    62:
       MoveExecutionFailure: UNIT
-    64:
+    63:
       ObjectInputArityViolation: UNIT
-    65:
+    64:
       ExecutionInvariantViolation: UNIT
-    66:
+    65:
       AuthorityInformationUnavailable: UNIT
-    67:
+    66:
       AuthorityUpdateFailure: UNIT
-    68:
+    67:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    69:
+    68:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -542,33 +540,33 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    70:
+    69:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    71:
+    70:
       BatchErrorSender: UNIT
-    72:
+    71:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    73:
+    72:
       ObjectSerializationError: UNIT
-    74:
+    73:
       ConcurrentTransactionError: UNIT
-    75:
+    74:
       IncorrectRecipientError: UNIT
-    76:
+    75:
       TooManyIncorrectAuthorities: UNIT
-    77:
+    76:
       IncorrectGasSplit: UNIT
-    78:
+    77:
       IncorrectGasMerge: UNIT
-    79:
+    78:
       AccountNotFound: UNIT
-    80:
+    79:
       AccountExists: UNIT
 Transaction:
   STRUCT:

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -532,21 +532,19 @@ fn process_successful_execution<
             .expect("Safe because event_type is derived from an EventType enum")
         {
             EventType::TransferToAddress => handle_transfer(
-                SuiAddress::try_from(recipient.as_slice()).unwrap(),
+                Owner::SingleOwner(SuiAddress::try_from(recipient.as_slice()).unwrap()),
                 type_,
                 event_bytes,
-                false, /* should_freeze */
                 tx_digest,
                 &mut by_value_objects,
                 &mut gas_used,
                 state_view,
                 &mut object_owner_map,
             ),
-            EventType::TransferToAddressAndFreeze => handle_transfer(
-                SuiAddress::try_from(recipient.as_slice()).unwrap(),
+            EventType::FreezeObject => handle_transfer(
+                Owner::SharedImmutable,
                 type_,
                 event_bytes,
-                true, /* should_freeze */
                 tx_digest,
                 &mut by_value_objects,
                 &mut gas_used,
@@ -554,10 +552,9 @@ fn process_successful_execution<
                 &mut object_owner_map,
             ),
             EventType::TransferToObject => handle_transfer(
-                ObjectID::try_from(recipient.borrow()).unwrap().into(),
+                Owner::SingleOwner(ObjectID::try_from(recipient.borrow()).unwrap().into()),
                 type_,
                 event_bytes,
-                false, /* should_freeze */
                 tx_digest,
                 &mut by_value_objects,
                 &mut gas_used,
@@ -601,10 +598,9 @@ fn handle_transfer<
     E: Debug,
     S: ResourceResolver<Error = E> + ModuleResolver<Error = E> + Storage,
 >(
-    recipient: SuiAddress,
+    recipient: Owner,
     type_: TypeTag,
     contents: Vec<u8>,
-    should_freeze: bool,
     tx_digest: TransactionDigest,
     by_value_objects: &mut BTreeMap<ObjectID, Object>,
     gas_used: &mut u64,
@@ -625,32 +621,29 @@ fn handle_transfer<
             // freshly created, this means that its version will now be 1.
             // thus, all objects in the global object pool have version > 0
             move_obj.increment_version();
-            let new_owner = if should_freeze {
-                Owner::SharedImmutable
-            } else {
-                Owner::SingleOwner(recipient)
-            };
-            let obj = Object::new_move(move_obj, new_owner, tx_digest);
+            let obj = Object::new_move(move_obj, recipient, tx_digest);
             if old_object.is_none() {
                 // Charge extra gas based on object size if we are creating a new object.
                 *gas_used += gas::calculate_object_creation_cost(&obj);
             }
             let obj_address: SuiAddress = obj.id().into();
-            // Below we check whether the transfer introduced any circular ownership.
-            // We know that for any mutable object, all its ancenstors (if it was owned by another object)
-            // must be in the input as well. Prior to this we have recored the original ownership mapping
-            // in object_owner_map. For any new transfer, we trace the new owner through the ownership
-            // chain to see if a cycle is detected.
-            // TODO: Set a constant upper bound to the depth of the new ownership chain.
             object_owner_map.remove(&obj_address);
-            let mut parent = recipient;
-            while parent != obj_address && object_owner_map.contains_key(&parent) {
-                parent = *object_owner_map.get(&parent).unwrap();
+            if let Ok(new_owner) = recipient.get_single_owner_address() {
+                // Below we check whether the transfer introduced any circular ownership.
+                // We know that for any mutable object, all its ancenstors (if it was owned by another object)
+                // must be in the input as well. Prior to this we have recored the original ownership mapping
+                // in object_owner_map. For any new transfer, we trace the new owner through the ownership
+                // chain to see if a cycle is detected.
+                // TODO: Set a constant upper bound to the depth of the new ownership chain.
+                let mut parent = new_owner;
+                while parent != obj_address && object_owner_map.contains_key(&parent) {
+                    parent = *object_owner_map.get(&parent).unwrap();
+                }
+                if parent == obj_address {
+                    return Err(SuiError::CircularObjectOwnership);
+                }
+                object_owner_map.insert(obj_address, new_owner);
             }
-            if parent == obj_address {
-                return Err(SuiError::CircularObjectOwnership);
-            }
-            object_owner_map.insert(obj_address, recipient);
 
             state_view.write_object(obj);
         }

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -566,9 +566,8 @@ fn test_publish_module_insufficient_gas() {
 }
 
 #[test]
-fn test_transfer_and_freeze() {
+fn test_freeze() {
     let addr1 = base_types::get_new_address();
-    let addr2 = base_types::get_new_address();
 
     let native_functions =
         sui_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS);
@@ -606,18 +605,17 @@ fn test_transfer_and_freeze() {
     let obj1 = storage.read_object(&id1).unwrap();
     assert!(!obj1.is_read_only());
 
-    // 2. Call transfer_and_freeze.
-    let pure_args = vec![bcs::to_bytes(&AccountAddress::from(addr2)).unwrap()];
+    // 2. Call freeze_object.
     call(
         &mut storage,
         &native_functions,
         "ObjectBasics",
-        "transfer_and_freeze",
+        "freeze_object",
         gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         vec![obj1],
-        pure_args,
+        vec![],
     )
     .unwrap()
     .unwrap();

--- a/sui_programmability/framework/sources/ObjectBasics.move
+++ b/sui_programmability/framework/sources/ObjectBasics.move
@@ -30,8 +30,8 @@ module Sui::ObjectBasics {
         Transfer::transfer(o, recipient)
     }
 
-    public fun transfer_and_freeze(o: Object, recipient: address, _ctx: &mut TxContext) {
-        Transfer::transfer_and_freeze(o, recipient)
+    public fun freeze_object(o: Object, _ctx: &mut TxContext) {
+        Transfer::freeze_object(o)
     }
 
     public fun transfer_to_object(o: Object, owner: &mut Object, _ctx: &mut TxContext) {

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -19,25 +19,15 @@ module Sui::Transfer {
         transfer_internal(obj, recipient, false)
     }
 
-    /// Transfer ownership of `obj` to `recipient` and then freeze
-    /// `obj`. After freezing `obj` becomes immutable and can no
-    /// longer be transfered or mutated.
-    /// If you just want to freeze an object, you can set the `recipient`
-    /// to the current owner of `obj` and it will only be frozen without
-    /// being transfered.
-    public fun transfer_and_freeze<T: key>(obj: T, recipient: address) {
-        transfer_internal(obj, recipient, true)
-    }
-
-    native fun transfer_internal<T: key>(obj: T, recipient: address, should_freeze: bool);
-
     /// Transfer ownership of `obj` to another object `owner`.
-    // TODO: Add option to freeze after transfer.
     public fun transfer_to_object<T: key, R: key>(obj: T, owner: &mut R) {
         let owner_id = ID::id_address(owner);
-        transfer_to_object_id(obj, owner_id);
+        transfer_internal(obj, owner_id, true);
     }
 
-    /// Transfer ownership of `obj` to another object with `id`.
-    native fun transfer_to_object_id<T: key>(obj: T, id: address);
+    /// Freeze `obj`. After freezing `obj` becomes immutable and can no
+    /// longer be transfered or mutated.
+    public native fun freeze_object<T: key>(obj: T);
+
+    native fun transfer_internal<T: key>(obj: T, recipient: address, to_object: bool);
 }

--- a/sui_programmability/framework/src/lib.rs
+++ b/sui_programmability/framework/src/lib.rs
@@ -25,10 +25,10 @@ pub const DEFAULT_FRAMEWORK_PATH: &str = env!("CARGO_MANIFEST_DIR");
 pub enum EventType {
     /// System event: transfer between addresses
     TransferToAddress,
-    /// System event: freeze, then transfer between addresses
-    TransferToAddressAndFreeze,
     /// System event: transfer object to another object
     TransferToObject,
+    /// System event: freeze object
+    FreezeObject,
     /// System event: an object ID is deleted. This does not necessarily
     /// mean an object is being deleted. However whenever an object is being
     /// deleted, the object ID must be deleted and this event will be

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -46,11 +46,7 @@ pub fn all_natives(
             test_scenario::transferred_object_ids,
         ),
         ("Transfer", "transfer_internal", transfer::transfer_internal),
-        (
-            "Transfer",
-            "transfer_to_object_id",
-            transfer::transfer_to_object_id,
-        ),
+        ("Transfer", "freeze_object", transfer::freeze_object),
         ("TxContext", "fresh_id", tx_context::fresh_id),
         (
             "TxContext",

--- a/sui_programmability/framework/src/natives/transfer.rs
+++ b/sui_programmability/framework/src/natives/transfer.rs
@@ -16,7 +16,7 @@ use smallvec::smallvec;
 use std::collections::VecDeque;
 
 /// Implementation of Move native function
-/// `transfer_internal<T: key>(obj: T, recipient: vector<u8>, should_freeze: bool)`
+/// `transfer_internal<T: key>(obj: T, recipient: vector<u8>, to_object: bool)`
 /// Here, we simply emit this event. The sui adapter
 /// treats this as a special event that is handled
 /// differently from user events:
@@ -31,49 +31,43 @@ pub fn transfer_internal(
     debug_assert!(args.len() == 3);
 
     let ty = ty_args.pop().unwrap();
-    let should_freeze = pop_arg!(args, bool);
+    let to_object = pop_arg!(args, bool);
     let recipient = pop_arg!(args, AccountAddress);
     let transferred_obj = args.pop_back().unwrap();
-    let event_type = if should_freeze {
-        EventType::TransferToAddressAndFreeze
+    let event_type = if to_object {
+        EventType::TransferToObject
     } else {
         EventType::TransferToAddress
     };
-    transfer_common(context, ty, transferred_obj, recipient, event_type)
-}
-
-/// Implementation of Move native function
-/// `transfer_to_object_id<T: key>(obj: T, id: address)`
-pub fn transfer_to_object_id(
-    context: &mut NativeContext,
-    mut ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
-) -> PartialVMResult<NativeResult> {
-    debug_assert!(ty_args.len() == 1);
-    debug_assert!(args.len() == 2);
-
-    let ty = ty_args.pop().unwrap();
-    let recipient = pop_arg!(args, AccountAddress);
-    let transferred_obj = args.pop_back().unwrap();
-    let event_type = EventType::TransferToObject;
-    transfer_common(context, ty, transferred_obj, recipient, event_type)
-}
-
-fn transfer_common(
-    context: &mut NativeContext,
-    ty: Type,
-    transferred_obj: Value,
-    recipient: AccountAddress,
-    event_type: EventType,
-) -> PartialVMResult<NativeResult> {
     // Charge a constant native gas cost here, since
     // we will charge it properly when processing
     // all the events in adapter.
     // TODO: adjust native_gas cost size base.
     let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 1);
-    if !context.save_event(recipient.to_vec(), event_type as u64, ty, transferred_obj)? {
-        return Ok(NativeResult::err(cost, 0));
+    if context.save_event(recipient.to_vec(), event_type as u64, ty, transferred_obj)? {
+        Ok(NativeResult::ok(cost, smallvec![]))
+    } else {
+        Ok(NativeResult::err(cost, 0))
     }
+}
 
-    Ok(NativeResult::ok(cost, smallvec![]))
+/// Implementation of Move native function
+/// `freeze_object<T: key>(obj: T)`
+pub fn freeze_object(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let obj = args.pop_back().unwrap();
+    let event_type = EventType::FreezeObject;
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 1);
+    if context.save_event(vec![], event_type as u64, ty, obj)? {
+        Ok(NativeResult::ok(cost, smallvec![]))
+    } else {
+        Ok(NativeResult::err(cost, 0))
+    }
 }

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -35,8 +35,6 @@ pub enum SuiError {
     // Object misuse issues
     #[error("Error acquiring lock for object(s): {:?}", errors)]
     LockErrors { errors: Vec<SuiError> },
-    #[error("Attempt to transfer a read-only object.")]
-    TransferImmutableError,
     #[error("Attempt to transfer a shared object.")]
     TransferSharedError,
     #[error("Attempt to transfer an object that's not a coin.")]


### PR DESCRIPTION
We used to have `transfer_and_freeze` in Move API where a recipient is specified. This no longer makes sense since an immutable object is shared and hence does not have an owner. There is no need to specify a recipient when freezing an object.
This PR removes the recipient from the freeze API and rename it to `freeze_object`.
The event name and tests are also changed to reflect this.
The transfer to address API and transfer to object API are merged as a cleanup too.
Similar cleanups in test_scenario.rs.