### PR TITLE
Distinguish between AddressOwner and ObjectOwner

### DIFF
--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -219,7 +219,7 @@ impl WalletCommands {
                     .address_manager
                     .get_object_owner(*gas)
                     .await?
-                    .get_single_owner_address()?;
+                    .get_owner_address()?;
                 let gas_obj_ref = context
                     .address_manager
                     .get_object_info(*gas)
@@ -263,7 +263,7 @@ impl WalletCommands {
                     .address_manager
                     .get_object_owner(*gas)
                     .await?
-                    .get_single_owner_address()?;
+                    .get_owner_address()?;
 
                 let package_obj_info = context.address_manager.get_object_info(*package).await?;
                 let package_obj = package_obj_info.object().clone()?;
@@ -343,7 +343,7 @@ impl WalletCommands {
                     .address_manager
                     .get_object_owner(*gas)
                     .await?
-                    .get_single_owner_address()?;
+                    .get_owner_address()?;
                 let time_start = Instant::now();
 
                 let (cert, effects) = context
@@ -413,7 +413,7 @@ impl WalletCommands {
                     .address_manager
                     .get_object_owner(*gas)
                     .await?
-                    .get_single_owner_address()?;
+                    .get_owner_address()?;
                 let response = context
                     .address_manager
                     .split_coin(
@@ -437,7 +437,7 @@ impl WalletCommands {
                     .address_manager
                     .get_object_owner(*gas)
                     .await?
-                    .get_single_owner_address()?;
+                    .get_owner_address()?;
                 let response = context
                     .address_manager
                     .merge_coins(

--- a/sui_core/src/client.rs
+++ b/sui_core/src/client.rs
@@ -585,7 +585,8 @@ where
                     account.remove_object_info(&object_id)?;
                     // TODO: Could potentially add this object_ref to the relevant account store
                 }
-            } else if old_seq == seq && owner == Owner::SingleOwner(address) {
+            } else if old_seq == seq && owner == Owner::AddressOwner(address) {
+                // TODO: Store objects owned by objects as well.
                 // ObjectRef can be 1 version behind because it's only updated after confirmation.
                 account.update_object_ref(&object_ref)?;
             }
@@ -798,7 +799,7 @@ where
         fp_ensure!(
             effects.mutated.len() == 2     // coin and gas
                && created.len() == split_amounts.len()
-               && created.iter().all(|(_, owner)| owner == &Owner::SingleOwner(signer)),
+               && created.iter().all(|(_, owner)| owner == &signer),
             SuiError::IncorrectGasSplit.into()
         );
         let updated_coin = self

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -1414,7 +1414,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 3);
     assert_eq!(
         authority.get_object(&obj1).await.unwrap().unwrap().owner,
-        SuiAddress::from(obj2),
+        obj2,
     );
 
     // Try to transfer obj1 to obj3, this time it will fail since obj1 is now owned by obj2,
@@ -1515,7 +1515,7 @@ async fn test_object_owning_another_object() {
     assert_eq!(effects.mutated.len(), 3);
     assert_eq!(
         authority.get_object(&obj1).await.unwrap().unwrap().owner,
-        SuiAddress::from(obj2),
+        obj2,
     );
 }
 

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -213,12 +213,16 @@ ObjectResponse:
 Owner:
   ENUM:
     0:
-      SingleOwner:
+      AddressOwner:
         NEWTYPE:
           TYPENAME: SuiAddress
     1:
-      SharedMutable: UNIT
+      ObjectOwner:
+        NEWTYPE:
+          TYPENAME: SuiAddress
     2:
+      SharedMutable: UNIT
+    3:
       SharedImmutable: UNIT
 PublicKeyBytes:
   NEWTYPESTRUCT: BYTES

--- a/sui_types/src/gas.rs
+++ b/sui_types/src/gas.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{SuiError, SuiResult},
     gas_coin::GasCoin,
     messages::{Transaction, TransactionKind},
-    object::Object,
+    object::{Object, Owner},
 };
 use std::convert::TryFrom;
 
@@ -26,6 +26,10 @@ pub const MIN_OBJ_TRANSFER_GAS: u64 = 8;
 
 pub fn check_gas_requirement(transaction: &Transaction, gas_object: &Object) -> SuiResult {
     debug_assert_eq!(transaction.gas_payment_object_ref().0, gas_object.id());
+    ok_or_gas_error!(
+        matches!(gas_object.owner, Owner::AddressOwner(..)),
+        "Gas object must be owned by the signer".to_string()
+    )?;
     match &transaction.data.kind {
         TransactionKind::Transfer(_) => {
             let balance = get_gas_balance(gas_object)?;


### PR DESCRIPTION
Inside `Owner` of an object, we distinguish the case of being owned by an address vs by an object.
Updates all code that's interacting with Owner.