### PR TITLE
Add ChildRef in Move

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -34,6 +34,10 @@ use crate::authority_batch::{BatchSender, BroadcastReceiver, BroadcastSender};
 #[path = "unit_tests/authority_tests.rs"]
 pub mod authority_tests;
 
+#[cfg(test)]
+#[path = "unit_tests/move_integration_tests.rs"]
+pub mod move_integration_tests;
+
 mod temporary_store;
 use temporary_store::AuthorityTemporaryStore;
 

--- a/sui_core/src/unit_tests/data/object_owner/Move.toml
+++ b/sui_core/src/unit_tests/data/object_owner/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ObjectOwner"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui_programmability/framework" }
+
+[addresses]
+ObjectOwner = "0x0"
+
+[dev-addresses]
+ObjectOwner = "0x0"

--- a/sui_core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
+++ b/sui_core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
@@ -1,0 +1,58 @@
+module ObjectOwner::ObjectOwner {
+    use Std::Option::{Self, Option};
+    use Sui::ID::{Self, VersionedID};
+    use Sui::Transfer::{Self, ChildRef};
+    use Sui::TxContext::{Self, TxContext};
+
+    struct Parent has key {
+        id: VersionedID,
+        child: Option<ChildRef<Child>>,
+    }
+
+    struct Child has key {
+        id: VersionedID,
+    }
+
+    public fun create_child(ctx: &mut TxContext) {
+        Transfer::transfer(
+            Child { id: TxContext::new_id(ctx) },
+            TxContext::sender(ctx),
+        );
+    }
+
+    public fun create_parent(ctx: &mut TxContext) {
+        Transfer::transfer(
+            Parent { id: TxContext::new_id(ctx), child: Option::none() },
+            TxContext::sender(ctx),
+        );
+    }
+
+    public fun add_child(parent: &mut Parent, child: Child, _ctx: &mut TxContext) {
+        let child_ref = Transfer::transfer_to_object(child, parent);
+        Option::fill(&mut parent.child, child_ref);
+    }
+
+    // Call to mutate_child will fail if its owned by a parent,
+    // since all owners must be in the arguments for authentication.
+    public fun mutate_child(_child: &mut Child, _ctx: &mut TxContext) {}
+
+    // This should always succeeds, even when child is not owned by parent.
+    public fun mutate_child_with_parent(_child: &mut Child, _parent: &mut Parent, _ctx: &mut TxContext) {}
+
+    public fun transfer_child(parent: &mut Parent, child: Child, new_parent: &mut Parent, _ctx: &mut TxContext) {
+        let child_ref = Option::extract(&mut parent.child);
+        let new_child_ref = Transfer::transfer_child_to_object(child, child_ref, new_parent);
+        Option::fill(&mut new_parent.child, new_child_ref);
+    }
+
+    public fun remove_child(parent: &mut Parent, child: Child, ctx: &mut TxContext) {
+        let child_ref = Option::extract(&mut parent.child);
+        Transfer::transfer_child_to_address(child, child_ref, TxContext::sender(ctx));
+    }
+
+    // Call to delete_child can fail if it's still owned by a parent.
+    public fun delete_child(child: Child, _parent: &mut Parent, _ctx: &mut TxContext) {
+        let Child { id } = child;
+        ID::delete(id);
+    }
+}

--- a/sui_core/src/unit_tests/move_integration_tests.rs
+++ b/sui_core/src/unit_tests/move_integration_tests.rs
@@ -1,0 +1,492 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::authority::authority_tests::{
+    call_move, init_state_with_ids, send_and_confirm_transaction,
+};
+
+use move_package::BuildConfig;
+use sui_types::{
+    crypto::KeyPair,
+    crypto::{get_key_pair, Signature},
+    messages::ExecutionStatus,
+    object::OBJECT_START_VERSION,
+};
+
+use std::env;
+use std::path::PathBuf;
+
+const MAX_GAS: u64 = 10000;
+
+#[tokio::test]
+async fn test_object_wrapping_unwrapping() {
+    let (sender, sender_key) = get_key_pair();
+    let gas = ObjectID::random();
+    let authority = init_state_with_ids(vec![(sender, gas)]).await;
+
+    let package =
+        build_and_publish_test_package(&authority, &sender, &sender_key, &gas, "object_wrapping")
+            .await;
+
+    // Create a Child object.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectWrapping",
+        "create_child",
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    let child_object_ref = effects.created[0].0;
+    assert_eq!(child_object_ref.1, OBJECT_START_VERSION);
+
+    // Create a Parent object, by wrapping the child object.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectWrapping",
+        "create_parent",
+        vec![],
+        vec![child_object_ref.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    // Child object is wrapped, Parent object is created.
+    assert_eq!(
+        (
+            effects.created.len(),
+            effects.deleted.len(),
+            effects.wrapped.len()
+        ),
+        (1, 0, 1)
+    );
+    let new_child_object_ref = effects.wrapped[0];
+    let expected_child_object_ref = (
+        child_object_ref.0,
+        child_object_ref.1.increment(),
+        ObjectDigest::OBJECT_DIGEST_WRAPPED,
+    );
+    // Make sure that the child's version gets increased after wrapped.
+    assert_eq!(new_child_object_ref, expected_child_object_ref);
+    check_latest_object_ref(&authority, &expected_child_object_ref).await;
+    let child_object_ref = new_child_object_ref;
+
+    let parent_object_ref = effects.created[0].0;
+    assert_eq!(parent_object_ref.1, OBJECT_START_VERSION);
+
+    // Extract the child out of the parent.
+    println!("before this call");
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectWrapping",
+        "extract_child",
+        vec![],
+        vec![parent_object_ref.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    // Check that the child shows up in unwrapped, not created.
+    // mutated contains parent and gas.
+    assert_eq!(
+        (
+            effects.mutated.len(),
+            effects.created.len(),
+            effects.unwrapped.len()
+        ),
+        (2, 0, 1)
+    );
+    // Make sure that version increments again when unwrapped.
+    assert_eq!(effects.unwrapped[0].0 .1, child_object_ref.1.increment());
+    check_latest_object_ref(&authority, &effects.unwrapped[0].0).await;
+    let child_object_ref = effects.unwrapped[0].0;
+
+    // Wrap the child to the parent again.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectWrapping",
+        "set_child",
+        vec![],
+        vec![parent_object_ref.0, child_object_ref.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    // Check that child object showed up in wrapped.
+    // mutated contains parent and gas.
+    assert_eq!((effects.mutated.len(), effects.wrapped.len()), (2, 1));
+    let expected_child_object_ref = (
+        child_object_ref.0,
+        child_object_ref.1.increment(),
+        ObjectDigest::OBJECT_DIGEST_WRAPPED,
+    );
+    assert_eq!(effects.wrapped[0], expected_child_object_ref);
+    check_latest_object_ref(&authority, &expected_child_object_ref).await;
+    let child_object_ref = effects.wrapped[0];
+    let parent_object_ref = effects.mutated_excluding_gas().next().unwrap().0;
+
+    // Now delete the parent object, which will in turn delete the child object.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectWrapping",
+        "delete_parent",
+        vec![],
+        vec![parent_object_ref.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    assert_eq!(effects.deleted.len(), 2);
+    // Check that both objects are marked as wrapped in the authority.
+    let expected_child_object_ref = (
+        child_object_ref.0,
+        child_object_ref.1.increment(),
+        ObjectDigest::OBJECT_DIGEST_DELETED,
+    );
+    assert!(effects.deleted.contains(&expected_child_object_ref));
+    check_latest_object_ref(&authority, &expected_child_object_ref).await;
+    let expected_parent_object_ref = (
+        parent_object_ref.0,
+        parent_object_ref.1.increment(),
+        ObjectDigest::OBJECT_DIGEST_DELETED,
+    );
+    assert!(effects.deleted.contains(&expected_parent_object_ref));
+    check_latest_object_ref(&authority, &expected_parent_object_ref).await;
+}
+
+#[tokio::test]
+async fn test_object_owning_another_object() {
+    let (sender, sender_key) = get_key_pair();
+    let gas = ObjectID::random();
+    let authority = init_state_with_ids(vec![(sender, gas)]).await;
+
+    let package =
+        build_and_publish_test_package(&authority, &sender, &sender_key, &gas, "object_owner")
+            .await;
+
+    // Create a parent.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "create_parent",
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+    let parent = effects.created[0].0;
+
+    // Create a child.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "create_child",
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+    let child = effects.created[0].0;
+
+    // Mutate the child directly should work fine.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "mutate_child",
+        vec![],
+        vec![child.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+
+    // Add the child to the parent.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "add_child",
+        vec![],
+        vec![parent.0, child.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+    let child_effect = effects
+        .mutated
+        .iter()
+        .find(|((id, _, _), _)| id == &child.0)
+        .unwrap();
+    // Check that the child is now owned by the parent.
+    assert_eq!(child_effect.1, parent.0);
+
+    // Mutate the child directly will now fail because we need the parent to authenticate.
+    let result = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "mutate_child",
+        vec![],
+        vec![child.0],
+        vec![],
+        vec![],
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Mutate the child with the parent will succeed.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "mutate_child_with_parent",
+        vec![],
+        vec![child.0, parent.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+
+    // Create another parent.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "create_parent",
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+    let new_parent = effects.created[0].0;
+
+    // Transfer the child to the new_parent.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "transfer_child",
+        vec![],
+        vec![parent.0, child.0, new_parent.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+    let child_effect = effects
+        .mutated
+        .iter()
+        .find(|((id, _, _), _)| id == &child.0)
+        .unwrap();
+    // Check that the child is now owned by the new parent.
+    assert_eq!(child_effect.1, new_parent.0);
+
+    // Delete the child. This should fail because the child is still owned by a parent,
+    // it cannot yet be deleted.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "delete_child",
+        vec![],
+        vec![child.0, new_parent.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        effects.status.unwrap_err().1,
+        SuiError::DeleteObjectOwnedObject
+    ));
+
+    // Remove the child from the parent.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "remove_child",
+        vec![],
+        vec![new_parent.0, child.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+
+    // Delete the child again. This time it will succeed because it's no longer owned by a parent.
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "ObjectOwner",
+        "delete_child",
+        vec![],
+        vec![child.0, new_parent.0],
+        vec![],
+        vec![],
+    )
+    .await
+    .unwrap();
+    assert!(effects.status.is_ok());
+}
+
+async fn build_and_publish_test_package(
+    authority: &AuthorityState,
+    sender: &SuiAddress,
+    sender_key: &KeyPair,
+    gas_object_id: &ObjectID,
+    test_dir: &str,
+) -> ObjectRef {
+    let build_config = BuildConfig::default();
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("src/unit_tests/data/");
+    path.push(test_dir);
+    let modules = sui_framework::build_move_package(&path, build_config, false).unwrap();
+
+    let all_module_bytes = modules
+        .iter()
+        .map(|m| {
+            let mut module_bytes = Vec::new();
+            m.serialize(&mut module_bytes).unwrap();
+            module_bytes
+        })
+        .collect();
+
+    let gas_object = authority.get_object(gas_object_id).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().to_object_reference();
+
+    let data = TransactionData::new_module(*sender, gas_object_ref, all_module_bytes, MAX_GAS);
+    let signature = Signature::new(&data, &*sender_key);
+    let transaction = Transaction::new(data, signature);
+    let effects = send_and_confirm_transaction(authority, transaction)
+        .await
+        .unwrap()
+        .signed_effects
+        .unwrap()
+        .effects;
+
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    effects.created[0].0
+}
+
+async fn check_latest_object_ref(authority: &AuthorityState, object_ref: &ObjectRef) {
+    let response = authority
+        .handle_object_info_request(ObjectInfoRequest {
+            object_id: object_ref.0,
+            request_kind: ObjectInfoRequestKind::LatestObjectInfo(None),
+        })
+        .await
+        .unwrap();
+    assert_eq!(&response.requested_object_reference.unwrap(), object_ref,);
+}

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -360,206 +360,208 @@ SuiError:
     5:
       UnsupportedSharedObjectError: UNIT
     6:
+      DeleteObjectOwnedObject: UNIT
+    7:
       InvalidSignature:
         STRUCT:
           - error: STR
-    7:
-      IncorrectSigner: UNIT
     8:
-      UnknownSigner: UNIT
+      IncorrectSigner: UNIT
     9:
-      CertificateRequiresQuorum: UNIT
+      UnknownSigner: UNIT
     10:
+      CertificateRequiresQuorum: UNIT
+    11:
       UnexpectedSequenceNumber:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_sequence:
               TYPENAME: SequenceNumber
-    11:
+    12:
       ConflictingTransaction:
         STRUCT:
           - pending_transaction:
               TYPENAME: Transaction
-    12:
-      ErrorWhileProcessingTransaction: UNIT
     13:
+      ErrorWhileProcessingTransaction: UNIT
+    14:
       ErrorWhileProcessingTransactionTransaction:
         STRUCT:
           - err: STR
-    14:
+    15:
       ErrorWhileProcessingConfirmationTransaction:
         STRUCT:
           - err: STR
-    15:
-      ErrorWhileRequestingCertificate: UNIT
     16:
+      ErrorWhileRequestingCertificate: UNIT
+    17:
       ErrorWhileProcessingPublish:
         STRUCT:
           - err: STR
-    17:
+    18:
       ErrorWhileProcessingMoveCall:
         STRUCT:
           - err: STR
-    18:
-      ErrorWhileRequestingInformation: UNIT
     19:
+      ErrorWhileRequestingInformation: UNIT
+    20:
       ObjectFetchFailed:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - err: STR
-    20:
+    21:
       MissingEalierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    21:
-      UnexpectedTransactionIndex: UNIT
     22:
+      UnexpectedTransactionIndex: UNIT
+    23:
       CertificateNotfound:
         STRUCT:
           - certificate_digest:
               TYPENAME: TransactionDigest
-    23:
+    24:
       ParentNotfound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - sequence:
               TYPENAME: SequenceNumber
-    24:
-      UnknownSenderAccount: UNIT
     25:
-      CertificateAuthorityReuse: UNIT
+      UnknownSenderAccount: UNIT
     26:
-      InvalidSequenceNumber: UNIT
+      CertificateAuthorityReuse: UNIT
     27:
-      SequenceOverflow: UNIT
+      InvalidSequenceNumber: UNIT
     28:
-      SequenceUnderflow: UNIT
+      SequenceOverflow: UNIT
     29:
-      WrongShard: UNIT
+      SequenceUnderflow: UNIT
     30:
-      InvalidCrossShardUpdate: UNIT
+      WrongShard: UNIT
     31:
-      InvalidAuthenticator: UNIT
+      InvalidCrossShardUpdate: UNIT
     32:
-      InvalidAddress: UNIT
+      InvalidAuthenticator: UNIT
     33:
-      InvalidTransactionDigest: UNIT
+      InvalidAddress: UNIT
     34:
+      InvalidTransactionDigest: UNIT
+    35:
       InvalidObjectDigest:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_digest:
               TYPENAME: ObjectDigest
-    35:
-      InvalidDecoding: UNIT
     36:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     37:
-      DuplicateObjectRefInput: UNIT
+      UnexpectedMessage: UNIT
     38:
+      DuplicateObjectRefInput: UNIT
+    39:
       ClientIoError:
         STRUCT:
           - error: STR
-    39:
-      TransferImmutableError: UNIT
     40:
+      TransferImmutableError: UNIT
+    41:
       TooManyItemsError:
         NEWTYPE: U64
-    41:
-      InvalidSequenceRangeError: UNIT
     42:
-      NoBatchesFoundError: UNIT
+      InvalidSequenceRangeError: UNIT
     43:
-      CannotSendClientMessageError: UNIT
+      NoBatchesFoundError: UNIT
     44:
+      CannotSendClientMessageError: UNIT
+    45:
       SubscriptionItemsDropedError:
         NEWTYPE: U64
-    45:
-      SubscriptionServiceClosed: UNIT
     46:
+      SubscriptionServiceClosed: UNIT
+    47:
       ModuleLoadFailure:
         STRUCT:
           - error: STR
-    47:
+    48:
       ModuleVerificationFailure:
         STRUCT:
           - error: STR
-    48:
+    49:
       ModuleDeserializationFailure:
         STRUCT:
           - error: STR
-    49:
+    50:
       ModulePublishFailure:
         STRUCT:
           - error: STR
-    50:
+    51:
       ModuleBuildFailure:
         STRUCT:
           - error: STR
-    51:
+    52:
       DependentPackageNotFound:
         STRUCT:
           - package_id:
               TYPENAME: ObjectID
-    52:
+    53:
       MoveUnitTestFailure:
         STRUCT:
           - error: STR
-    53:
+    54:
       FunctionNotFound:
         STRUCT:
           - error: STR
-    54:
+    55:
       ModuleNotFound:
         STRUCT:
           - module_name: STR
-    55:
+    56:
       InvalidFunctionSignature:
         STRUCT:
           - error: STR
-    56:
+    57:
       TypeError:
         STRUCT:
           - error: STR
-    57:
+    58:
       AbortedExecution:
         STRUCT:
           - error: STR
-    58:
+    59:
       InvalidMoveEvent:
         STRUCT:
           - error: STR
-    59:
-      CircularObjectOwnership: UNIT
     60:
+      CircularObjectOwnership: UNIT
+    61:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    61:
+    62:
       InsufficientGas:
         STRUCT:
           - error: STR
-    62:
-      InvalidTxUpdate: UNIT
     63:
-      TransactionLockExists: UNIT
+      InvalidTxUpdate: UNIT
     64:
-      TransactionLockDoesNotExist: UNIT
+      TransactionLockExists: UNIT
     65:
-      TransactionLockReset: UNIT
+      TransactionLockDoesNotExist: UNIT
     66:
+      TransactionLockReset: UNIT
+    67:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    67:
+    68:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -567,26 +569,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    68:
+    69:
       BadObjectType:
         STRUCT:
           - error: STR
-    69:
-      MoveExecutionFailure: UNIT
     70:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     71:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     72:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     73:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     74:
+      AuthorityUpdateFailure: UNIT
+    75:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    75:
+    76:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -597,33 +599,33 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    76:
+    77:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    77:
-      BatchErrorSender: UNIT
     78:
+      BatchErrorSender: UNIT
+    79:
       GenericAuthorityError:
         STRUCT:
           - error: STR
-    79:
+    80:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    80:
-      ObjectSerializationError: UNIT
     81:
-      ConcurrentTransactionError: UNIT
+      ObjectSerializationError: UNIT
     82:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     83:
-      TooManyIncorrectAuthorities: UNIT
+      IncorrectRecipientError: UNIT
     84:
-      IncorrectGasSplit: UNIT
+      TooManyIncorrectAuthorities: UNIT
     85:
+      IncorrectGasSplit: UNIT
+    86:
       IncorrectGasMerge: UNIT
 Transaction:
   STRUCT:

--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -15,6 +15,8 @@ module Sui::Collection {
     // TODO: this is a placeholder number
     const DEFAULT_MAX_CAPACITY: u64 = 65536;
 
+    // TODO: We should create a sepratate type called "Bag" to hold heterogeneous objects.
+    // And keep Collection to take objects of the same type.
     struct Collection has key {
         id: VersionedID,
         objects: vector<ID>,
@@ -61,7 +63,7 @@ module Sui::Collection {
             abort EOBJECT_DOUBLE_ADD
         };
         Vector::push_back(&mut c.objects, *id);
-        Transfer::transfer_to_object(object, c);
+        Transfer::transfer_to_object_unsafe(object, c);
     }
 
     /// Check whether the collection contains a specific object,

--- a/sui_programmability/framework/sources/ObjectBasics.move
+++ b/sui_programmability/framework/sources/ObjectBasics.move
@@ -34,10 +34,6 @@ module Sui::ObjectBasics {
         Transfer::freeze_object(o)
     }
 
-    public fun transfer_to_object(o: Object, owner: &mut Object, _ctx: &mut TxContext) {
-        Transfer::transfer_to_object(o, owner)
-    }
-
     public fun set_value(o: &mut Object, value: u64, _ctx: &mut TxContext) {
         o.value = value;
     }

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -1,5 +1,25 @@
 module Sui::Transfer {
-    use Sui::ID;
+    use Sui::ID::{Self, ID};
+
+    // To allow access to transfer_to_object_unsafe.
+    friend Sui::Collection;
+
+    // When transferring a child object, this error is thrown if the child object
+    // doesn't match the ChildRef that represents the onwershp.
+    const ECHILD_ID_MISMATCH: u64 = 0;
+
+    /// Represents a reference to a child object, whose type is T.
+    /// This is used to track ownership between objects.
+    /// Whenver an object is transferred to another object (and hence owned by object),
+    /// a ChildRef is created. A ChildRef cannot be dropped. When a child object is
+    /// transferred to a new parent object, the original ChildRef is dropped but a new
+    /// one will be created. The only way to fully destroy a ChildRef is to transfer the
+    /// object to an account address. Because of this, an object cannot be deleted when
+    /// it's still owned by another object.
+    struct ChildRef<phantom T: key> has store {
+        parent_id: ID,
+        child_id: ID,
+    }
 
     /// Transfers are implemented by emitting a
     /// special `TransferEvent` that the sui adapter
@@ -20,9 +40,41 @@ module Sui::Transfer {
     }
 
     /// Transfer ownership of `obj` to another object `owner`.
-    public fun transfer_to_object<T: key, R: key>(obj: T, owner: &mut R) {
+    /// Returns a non-droppable struct ChildRef that represents the ownership.
+    public fun transfer_to_object<T: key, R: key>(obj: T, owner: &mut R): ChildRef<T> {
+        let obj_id = *ID::id(&obj);
         let owner_id = ID::id_address(owner);
         transfer_internal(obj, owner_id, true);
+        ChildRef {
+            parent_id: ID::new(owner_id),
+            child_id: obj_id,
+        }
+    }
+
+    /// Similar to transfer_to_object, to transfer an object to another object.
+    /// However it does not return the ChildRef. This can be unsafe to use since there is
+    /// no longer guarantee that the ID stored in the parent actually represent ownership.
+    public(friend) fun transfer_to_object_unsafe<T: key, R: key>(obj: T, owner: &mut R) {
+        let ChildRef { parent_id: _, child_id: _ } = transfer_to_object(obj, owner);
+    }
+
+    /// Transfer a child object to new owner. This is one of the two ways that can
+    /// consume a ChildRef. It will return a ChildRef that represents the new ownership.
+    public fun transfer_child_to_object<T: key, R: key>(child: T, child_ref: ChildRef<T>, owner: &mut R): ChildRef<T> {
+        let ChildRef { parent_id: _, child_id } = child_ref;
+        assert!(&child_id == ID::id(&child), ECHILD_ID_MISMATCH);
+        transfer_to_object(child, owner)
+    }
+
+    /// Transfer a child object to an account address. This is one of the two ways that can
+    /// consume a ChildRef. No new ChildRef will be created, as the object is no longer
+    /// owned by an object.
+    // TODO: Figure out a way to make it easier to destroy a child object in one call.
+    // Currently one has to first transfer it to an address, and then delete it.
+    public fun transfer_child_to_address<T: key>(child: T, child_ref: ChildRef<T>, recipient: address) {
+        let ChildRef { parent_id: _, child_id } = child_ref;
+        assert!(&child_id == ID::id(&child), ECHILD_ID_MISMATCH);
+        transfer(child, recipient)
     }
 
     /// Freeze `obj`. After freezing `obj` becomes immutable and can no

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -9,6 +9,7 @@ mod tx_context;
 
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use move_vm_runtime::native_functions::{NativeFunction, NativeFunctionTable};
+use move_vm_types::values::{Struct, Value};
 
 pub fn all_natives(
     move_stdlib_addr: AccountAddress,
@@ -67,4 +68,25 @@ pub fn all_natives(
         })
         .chain(move_stdlib::natives::all_natives(move_stdlib_addr))
         .collect()
+}
+
+// Object { id: VersionedID { id: UniqueID { id: ID { bytes: address } } } .. }
+// Extract the first field of the struct 4 times to get the id bytes.
+pub fn get_object_id_bytes(object: Value) -> AccountAddress {
+    let id_bytes = get_nested_struct_field(object, &[0, 0, 0, 0]);
+    id_bytes.value_as::<AccountAddress>().unwrap()
+}
+
+// Extract a field valye that's nested inside value `v`. The offset of each nesting
+// is determined by `offsets`.
+pub fn get_nested_struct_field(mut v: Value, offsets: &[usize]) -> Value {
+    for offset in offsets {
+        v = get_nth_struct_field(v, *offset);
+    }
+    v
+}
+
+pub fn get_nth_struct_field(v: Value, n: usize) -> Value {
+    let mut itr = v.value_as::<Struct>().unwrap().unpack().unwrap();
+    itr.nth(n).unwrap()
 }

--- a/sui_programmability/framework/src/natives/test_scenario.rs
+++ b/sui_programmability/framework/src/natives/test_scenario.rs
@@ -11,7 +11,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeResult},
     pop_arg,
-    values::{Struct, Value},
+    values::Value,
 };
 use num_enum::TryFromPrimitive;
 use smallvec::smallvec;
@@ -20,6 +20,8 @@ use sui_types::{
     base_types::{ObjectID, SuiAddress},
     object::Owner,
 };
+
+use super::get_nested_struct_field;
 
 type Event = (Vec<u8>, u64, Type, MoveTypeLayout, Value);
 
@@ -39,33 +41,10 @@ struct OwnedObj {
 // TODO: add a native function that prints the log of transfers, deletes, wraps for debugging purposes
 type Inventory = BTreeMap<ObjectID, OwnedObj>;
 
-fn get_id(versioned_id: &Value) -> AccountAddress {
-    // All of the following unwraps are safe by construction because a properly verified
-    // bytecode ensures that the parameter must be of type UniqueID with the correct fields:
-    // ```
-    // VersionedID { id: UniqueID { id: ID { bytes: address } } .. }
-    // ```
-    versioned_id
-        .copy_value()
-        .unwrap()
-        .value_as::<Struct>()
-        .unwrap() // Convert to VersionedID
-        .unpack()
-        .unwrap()
-        .next() // Get id field of VersionedID
-        .unwrap()
-        .value_as::<Struct>() // Convert to UniqueID
-        .unwrap()
-        .unpack()
-        .unwrap()
-        .next()
-        .unwrap() // Get id field of UniqueID
-        .value_as::<Struct>() // Convert to ID
-        .unwrap()
-        .unpack()
-        .unwrap()
-        .next()
-        .unwrap()
+// The deleted id event contains the VersionedID.
+// We want to retrive the inner id bytes.
+fn get_deleted_id_bytes(id: &Value) -> AccountAddress {
+    get_nested_struct_field(id.copy_value().unwrap(), &[0, 0, 0])
         .value_as::<AccountAddress>()
         .unwrap()
 }
@@ -112,9 +91,8 @@ fn get_global_inventory(events: &[Event]) -> Inventory {
                 );
             }
             EventType::DeleteObjectID => {
-                let obj_id = get_id(val);
                 // note: obj_id may or may not be present in `inventory`--a useer can create an ID and delete it without associating it with a transferred object
-                inventory.remove(&obj_id.into());
+                inventory.remove(&get_deleted_id_bytes(val).into());
             }
             EventType::User => (),
         }
@@ -165,10 +143,7 @@ pub fn deleted_object_ids(
         .skip(tx_begin_idx)
         .filter_map(|(_, event_type_byte, _, _, val)| {
             if *event_type_byte == EventType::DeleteObjectID as u64 {
-                // TODO: for some reason, this creates internal type errors in the VM. Create a fresh value with the object ID instead
-                //Some(Value::copy_value(val).unwrap())
-                let id_bytes = get_id(val).to_vec();
-                Some(Value::vector_u8(id_bytes))
+                Some(Value::vector_u8(get_deleted_id_bytes(val).to_vec()))
             } else {
                 None
             }

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -45,6 +45,8 @@ pub enum SuiError {
     UnexpectedOwnerType,
     #[error("Shared mutable object not yet supported")]
     UnsupportedSharedObjectError,
+    #[error("An object that's owned by another object cannot be deleted or wrapped. It must be transerred to an account address first before deletion")]
+    DeleteObjectOwnedObject,
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -330,6 +330,14 @@ impl ExecutionStatus {
         }
     }
 
+    pub fn is_ok(&self) -> bool {
+        matches!(self, ExecutionStatus::Success { .. })
+    }
+
+    pub fn is_err(&self) -> bool {
+        matches!(self, ExecutionStatus::Failure { .. })
+    }
+
     pub fn unwrap(self) -> u64 {
         match self {
             ExecutionStatus::Success { gas_used } => gas_used,


### PR DESCRIPTION
This PR introduces a new type called `ChildRef` in Move. This is a non-droppable type that gets instantiated every time we transfer an object to another object. It represents the ownership created by such transfer.
The existence of this type guarantees that when an object owns another, such ownership is accurately represented in Move (instead of just using a raw ID, which can point to a non-existing object or represent an out-of-dated ownership).