### PR TITLE
ci: fix job that detects changes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
+    - uses: actions/checkout@v2
     - name: Detect Changes
       uses: dorny/paths-filter@v2.10.2
       id: diff

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -6,6 +6,7 @@ jobs:
     outputs:
       isClient: ${{ steps.diff.outputs.isClient }}
     steps:
+    - uses: actions/checkout@v2
     - name: Detect Changes
       uses: dorny/paths-filter@v2.10.2
       id: diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
+    - uses: actions/checkout@v2
     - name: Detect Changes
       uses: dorny/paths-filter@v2.10.2
       id: diff


### PR DESCRIPTION
After merging #630 the job that is used to detect changes was failing with the following error.
<img width="1201" alt="Screenshot 2022-03-07 at 10 46 01" src="https://user-images.githubusercontent.com/10210143/157016860-3e486bb6-1bea-4224-9457-8781e42ba537.png">
based on the message I assume that the repo is not present and that's why it fails. So hope this will fix it.

#426 