### PR TITLE
[authority] Ensure Idempotent Reply

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -833,11 +833,6 @@ impl AuthorityState {
             .collect();
         Ok(filtered)
     }
-
-    #[cfg(test)]
-    pub fn database(&self) -> &Arc<AuthorityStore> {
-        &self._database
-    }
 }
 
 impl ModuleResolver for AuthorityState {

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -34,7 +34,7 @@ pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 pub struct MoveObject {
     pub type_: StructTag,
     #[serde_as(as = "Bytes")]
-    pub contents: Vec<u8>,
+    contents: Vec<u8>,
 }
 
 /// Byte encoding of a 64 byte unsigned integer in BCS


### PR DESCRIPTION
### What is done:
* Ensure a idempotent reply when a client submits a certificate containing a shared object.