### PR TITLE
Bump Move version

### DIFF
--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -49,11 +49,11 @@ http = "0.2.6"
 hyper = "0.14.17"
 schemars = "0.8.8"
 
-move-package = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-core-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe", features = ["address20"] }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-package = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a", features = ["address20"] }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 
 once_cell = "1.9.0"
 

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -30,11 +30,11 @@ sui-framework = { path = "../sui_programmability/framework" }
 sui-network = { path = "../network_utils" }
 sui-types = { path = "../sui_types" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-core-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe", features = ["address20"] }
-move-package = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a", features = ["address20"] }
+move-package = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a36c852c30729a16ee3c8a6a863f654887f0c30e"}
 

--- a/sui_programmability/adapter/Cargo.toml
+++ b/sui_programmability/adapter/Cargo.toml
@@ -13,17 +13,17 @@ bcs = "0.1.3"
 once_cell = "1.9.0"
 structopt = "0.3.26"
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-core-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe", features = ["address20"] }
-move-cli = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a", features = ["address20"] }
+move-cli = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 
 sui-framework = { path = "../framework" }
 sui-verifier = { path = "../verifier" }
 sui-types = { path = "../../sui_types" }
 
 [dev-dependencies]
-move-package = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-package = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }

--- a/sui_programmability/framework/Cargo.toml
+++ b/sui_programmability/framework/Cargo.toml
@@ -15,15 +15,15 @@ num_enum = "0.5.6"
 sui-types = { path = "../../sui_types" }
 sui-verifier = { path = "../verifier" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-cli = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-core-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe", features = ["address20"] }
-move-package = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-stdlib = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-unit-test = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-cli = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a", features = ["address20"] }
+move-package = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-stdlib = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-unit-test = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 
 
 [package.metadata.cargo-udeps.ignore]

--- a/sui_programmability/verifier/Cargo.toml
+++ b/sui_programmability/verifier/Cargo.toml
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-core-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe", features = ["address20"] }
-move-disassembler = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-ir-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a", features = ["address20"] }
+move-disassembler = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-ir-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 
 sui-types = { path = "../../sui_types" }

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -27,10 +27,10 @@ static_assertions = "1.1.0"
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="a36c852c30729a16ee3c8a6a863f654887f0c30e"}
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-core-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe", features = ["address20"] }
-move-disassembler = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
-move-ir-types = { git = "https://github.com/diem/move", rev = "b4162e11ebcd6e33571f12737120309ab835fdfe" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a", features = ["address20"] }
+move-disassembler = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
+move-ir-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 sha2 = "0.10.2"
 


### PR DESCRIPTION
To include https://github.com/diem/move/pull/110
which bumps regex version to 1.5.5.