### PR TITLE
Object schema endpoint

### DIFF
--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -30,10 +30,13 @@ use tracing::{error, info};
 use std::sync::{Arc, Mutex};
 use sui::gateway::{EmbeddedGatewayConfig, GatewayType};
 
+const REST_SERVER_PORT: u16 = 5000;
+const REST_SERVER_ADDR_IPV4: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+
 #[tokio::main]
 async fn main() -> Result<(), String> {
     let config_dropshot: ConfigDropshot = ConfigDropshot {
-        bind_address: SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 5001)),
+        bind_address: SocketAddr::from((REST_SERVER_ADDR_IPV4, REST_SERVER_PORT)),
         ..Default::default()
     };
 


### PR DESCRIPTION
Allows getting object schema using: `/object_schema/{object_id}`
**Note:**
Ideally we should combine this with `/object_info` and have `/object/info` and `/object/schema`, however dependent services might break. I want to see who is already using the existing endpoints so I can update them.
The response is very verbose and repetitive. Need to clean up
Sample for Gas object
~~~
{
	"schema": {
		"WithTypes": {
			"fields": [
				{
					"layout": {
						"struct": {
							"WithTypes": {
								"fields": [
									{
										"layout": {
											"struct": {
												"WithTypes": {
													"fields": [
														{
															"layout": {
																"struct": {
																	"WithTypes": {
																		"fields": [
																			{
																				"layout": "address",
																				"name": "bytes"
																			}
																		],
																		"type_": {
																			"address": "0000000000000000000000000000000000000002",
																			"module": "ID",
																			"name": "ID",
																			"type_args": []
																		}
																	}
																}
															},
															"name": "id"
														}
													],
													"type_": {
														"address": "0000000000000000000000000000000000000002",
														"module": "ID",
														"name": "UniqueID",
														"type_args": []
													}
												}
											}
										},
										"name": "id"
									},
									{
										"layout": "u64",
										"name": "version"
									}
								],
								"type_": {
									"address": "0000000000000000000000000000000000000002",
									"module": "ID",
									"name": "VersionedID",
									"type_args": []
								}
							}
						}
					},
					"name": "id"
				},
				{
					"layout": "u64",
					"name": "value"
				}
			],
			"type_": {
				"address": "0000000000000000000000000000000000000002",
				"module": "Coin",
				"name": "Coin",
				"type_args": [
					{
						"struct": {
							"address": "0000000000000000000000000000000000000002",
							"module": "GAS",
							"name": "GAS",
							"type_args": []
						}
					}
				]
			}
		}
	}
}
~~~
