### PR TITLE
[Move] Add `Transfer::delete_child_object`

### DIFF
--- a/sui_core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
+++ b/sui_core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
@@ -66,4 +66,12 @@ module ObjectOwner::ObjectOwner {
         let Child { id } = child;
         ID::delete(id);
     }
+
+    public fun delete_parent_and_child(parent: Parent, child: Child, _ctx: &mut TxContext) {
+        let Parent { id, child: child_ref_opt } = parent;
+        let child_ref = Option::extract(&mut child_ref_opt);
+        Option::destroy_none(child_ref_opt);
+        Transfer::delete_child_object(child, child_ref);
+        ID::delete(id);
+    }
 }

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -96,6 +96,16 @@ module Sui::Transfer {
         transfer(child, recipient)
     }
 
+    /// Delete the child object along with a ownership reference that shows this object
+    /// is owned by another object. Deleting both the child object and the reference
+    /// is safe because the ownership will also be destroyed, and hence there won't
+    /// be dangling reference to the child object through ownership.
+    public fun delete_child_object<T: key>(child: T, child_ref: ChildRef<T>) {
+        let ChildRef { parent_id: _, child_id } = child_ref;
+        assert!(&child_id == ID::id(&child), ECHILD_ID_MISMATCH);
+        delete_child_object_internal(child);
+    }
+
     /// Freeze `obj`. After freezing `obj` becomes immutable and can no
     /// longer be transferred or mutated.
     public native fun freeze_object<T: key>(obj: T);
@@ -112,4 +122,6 @@ module Sui::Transfer {
     public native fun share_object<T: key>(obj: T);
 
     native fun transfer_internal<T: key>(obj: T, recipient: address, to_object: bool);
+
+    native fun delete_child_object_internal<T: key>(child: T);
 }

--- a/sui_programmability/framework/src/lib.rs
+++ b/sui_programmability/framework/src/lib.rs
@@ -36,6 +36,8 @@ pub enum EventType {
     /// deleted, the object ID must be deleted and this event will be
     /// emitted.
     DeleteObjectID,
+    /// System event: a child object is deleted along with a child ref.
+    DeleteChildObject,
     /// User-defined event
     User,
 }

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -46,6 +46,11 @@ pub fn all_natives(
             "transferred_object_ids",
             test_scenario::transferred_object_ids,
         ),
+        (
+            "Transfer",
+            "delete_child_object_internal",
+            transfer::delete_child_object_internal,
+        ),
         ("Transfer", "transfer_internal", transfer::transfer_internal),
         ("Transfer", "freeze_object", transfer::freeze_object),
         ("Transfer", "share_object", transfer::share_object),

--- a/sui_programmability/framework/src/natives/test_scenario.rs
+++ b/sui_programmability/framework/src/natives/test_scenario.rs
@@ -21,7 +21,7 @@ use sui_types::{
     object::Owner,
 };
 
-use super::get_nested_struct_field;
+use super::{get_nested_struct_field, get_nth_struct_field};
 
 type Event = (Vec<u8>, u64, Type, MoveTypeLayout, Value);
 
@@ -85,6 +85,11 @@ fn get_global_inventory(events: &[Event]) -> Inventory {
             EventType::DeleteObjectID => {
                 // note: obj_id may or may not be present in `inventory`--a useer can create an ID and delete it without associating it with a transferred object
                 inventory.remove(&get_deleted_id_bytes(val).into());
+            }
+            EventType::DeleteChildObject => {
+                // val is an Sui object, with the first field as the versioned id.
+                let versioned_id = get_nth_struct_field(val.copy_value().unwrap(), 0);
+                inventory.remove(&get_deleted_id_bytes(&versioned_id).into());
             }
             EventType::User => (),
         }

--- a/sui_programmability/framework/src/natives/transfer.rs
+++ b/sui_programmability/framework/src/natives/transfer.rs
@@ -92,3 +92,25 @@ pub fn share_object(
         Ok(NativeResult::err(cost, 0))
     }
 }
+
+/// Implementation of Move native function
+/// `delete_child_object_internal<T: key>(child: T)`
+pub fn delete_child_object_internal(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let obj = args.pop_back().unwrap();
+    let event_type = EventType::DeleteChildObject;
+    // TODO: Decide the cost.
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 1);
+    if context.save_event(vec![], event_type as u64, ty, obj)? {
+        Ok(NativeResult::ok(cost, smallvec![]))
+    } else {
+        Ok(NativeResult::err(cost, 0))
+    }
+}


### PR DESCRIPTION
Previously we did not allow deleting an object that's owned by another object. This is to avoid leaving behind a dangling reference to the child ownership (through `ChildRef`), which would cause the parent object to stuck and can never be deleted (because there is no way to drop the ChildRef without the child object).
Hence in order to delete a child object, one has to first transfer it to an account address, before deleting it.
This PR provides a way to delete the child object directly, given that the ChildRef is also provided and deleted the same time.
This way we make sure there is no dangling reference left behind.