### PR TITLE
[NFT Mirroring] Allow CORS

### DIFF
--- a/nft_mirror/oracle_server/src/index.ts
+++ b/nft_mirror/oracle_server/src/index.ts
@@ -25,6 +25,17 @@ const app: Application = express();
 app.use(morgan('tiny'));
 app.use(express.static('public'));
 
+// Set up CORS Policy
+// TODO: update the allowed origin before launch
+app.use(function (_, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header(
+        'Access-Control-Allow-Headers',
+        'Origin, X-Requested-With, Content-Type, Accept'
+    );
+    next();
+});
+
 // Use body parser to read sent json payloads
 app.use(
     bodyParser.urlencoded({


### PR DESCRIPTION
The frontend is getting CORS error. Following https://enable-cors.org/server_expressjs.html to resolve the error.