### PR TITLE
refactor: replace strum with name_variant

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -36,7 +36,7 @@ move-core-types = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582
 move-package = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 move-vm-runtime = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a36c852c30729a16ee3c8a6a863f654887f0c30e"}
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "97a056f85555fa2afe497d6abb7cf6bf8faa63cf"}
 
 [dev-dependencies]
 fdlimit = "0.2.1"

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -24,10 +24,9 @@ serde_json = "1.0.79"
 serde_with = "1.12.0"
 signature = "1.5.0"
 static_assertions = "1.1.0"
-strum = "0.24.0"
-strum_macros = "0.24.0"
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="a36c852c30729a16ee3c8a6a863f654887f0c30e"}
+name_variant = { git = "https://github.com/MystenLabs/mysten-infra", rev ="97a056f85555fa2afe497d6abb7cf6bf8faa63cf"}
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="97a056f85555fa2afe497d6abb7cf6bf8faa63cf"}
 
 move-binary-format = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }
 move-bytecode-utils = { git = "https://github.com/diem/move", rev = "584bfc8c5f8e582223581975106ffa2545677e2a" }


### PR DESCRIPTION
This is a follow-up to #706 that replaces the import of `strum` and `strum-macros` with our homegrown crate `name_variant`, which is proposed for addition in mysten-infra here:
https://github.com/MystenLabs/mysten-infra/pull/34