### PR TITLE
Update and rename doc/src/key-concepts.md to doc/src/build/index.md

### DIFF
--- a/doc/src/build/index.md
+++ b/doc/src/build/index.md
@@ -1,8 +1,12 @@
+---
+title: Build
+---
+
 ## Key Concepts
 - [Authorities](authorities.md)
 - [Objects](objects.md)
-- [Programmability](programmability.md)
 - [Transactions](transactions.md)
+- TODO: Programmability
 - TODO: clients
 - TODO: state sync
 - TODO: reconfiguration


### PR DESCRIPTION
Make Build landing page out of Key Concepts
Move Programming broken link to TODO list for inclusion in follow-up bug
And modify title for content generator