### PR TITLE
Cleanup handling of delete id edge case

### DIFF
--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -111,14 +111,6 @@ impl AuthorityTemporaryStore {
                 entry.0 = entry.0.increment();
             }
         }
-        // self.deleted contains all object IDs that were passed through ID::delete_id.
-        // However that doesn't necessarily indicate an object was deleted, if the object
-        // didn't show up in the input. There are two cases, one is that the object just got
-        // unwrapped, and another is just deletion of an ID that doesn't belong to a previous
-        // existing object. The second case can be filtered out.
-        self.deleted.retain(|id, (_version, kind)| {
-            kind != &DeleteKind::NotExistInInput || unwrapped_object_ids.contains(id)
-        });
     }
 
     pub fn to_signed_effects(

--- a/sui_types/src/storage.rs
+++ b/sui_types/src/storage.rs
@@ -9,8 +9,12 @@ use crate::{
 
 #[derive(Debug, PartialEq)]
 pub enum DeleteKind {
-    ExistInInput,
-    NotExistInInput,
+    /// An object is provided in the call input, and gets deleted.
+    Normal,
+    /// An object is not provided in the call input, but gets unwrapped
+    /// from another object, and then gets deleted.
+    UnwrapThenDelete,
+    /// An object is provided in the call input, and gets wrapped into another object.
     Wrap,
 }
 
@@ -22,7 +26,7 @@ pub trait Storage {
 
     fn write_object(&mut self, object: Object);
 
-    /// Record an event that happened during execution  
+    /// Record an event that happened during execution
     fn log_event(&mut self, event: Event);
 
     fn delete_object(&mut self, id: &ObjectID, version: SequenceNumber, kind: DeleteKind);


### PR DESCRIPTION
#734 added the ability to infer ids created in the current transaction. We can take advantage of such information to know which of the deleted ids that were created in the same transaction (which we don't care about), and which deleted ids are real object ids from the past.