### PR TITLE
[Move] Bag and Collection types

### DIFF
--- a/sui_programmability/framework/sources/Bag.move
+++ b/sui_programmability/framework/sources/Bag.move
@@ -1,0 +1,126 @@
+/// A Bag is a heterogeneous collection of objects with arbitrary types, i.e.
+/// the objects in the bag don't need to be of the same type.
+/// These objects are not stored in the Bag directly, instead only a reference
+/// to their IDs are stored as a proof of ownership. Sui tracks the ownership
+/// and is aware that the Bag owns those objects in it. Only the owner of the Bag
+/// could mutate the objects in the Bag.
+/// Bag is different from the Collection type in that Collection
+/// only supports owning objects of the same type.
+module Sui::Bag {
+    use Std::Errors;
+    use Std::Option::{Self, Option};
+    use Std::Vector::Self;
+    use Sui::ID::{Self, ID, VersionedID};
+    use Sui::Transfer;
+    use Sui::TxContext::{Self, TxContext};
+
+    // Error codes
+    /// When removing an object from the collection, EOBJECT_NOT_FOUND
+    /// will be triggered if the object is not owned by the collection.
+    const EOBJECT_NOT_FOUND: u64 = 0;
+
+    /// Adding the same object to the collection twice is not allowed.
+    const EOBJECT_DOUBLE_ADD: u64 = 1;
+
+    /// The max capacity set for the collection cannot exceed the hard limit
+    /// which is DEFAULT_MAX_CAPACITY.
+    const EINVALID_MAX_CAPACITY: u64 = 2;
+
+    /// Trying to add object to the collection when the collection is
+    /// already at its maximum capacity.
+    const EMAX_CAPACITY_EXCEEDED: u64 = 3;
+
+    // TODO: this is a placeholder number
+    const DEFAULT_MAX_CAPACITY: u64 = 65536;
+
+    struct Bag has key {
+        id: VersionedID,
+        objects: vector<ID>,
+        max_capacity: u64,
+    }
+
+    /// Create a new Bag and return it.
+    public fun new(ctx: &mut TxContext): Bag {
+        new_with_max_capacity(ctx, DEFAULT_MAX_CAPACITY)
+    }
+
+    /// Create a new Bag with custom size limit and return it.
+    public fun new_with_max_capacity(ctx: &mut TxContext, max_capacity: u64): Bag {
+        assert!(
+            max_capacity <= DEFAULT_MAX_CAPACITY && max_capacity > 0 ,
+            Errors::limit_exceeded(EINVALID_MAX_CAPACITY)
+        );
+        Bag {
+            id: TxContext::new_id(ctx),
+            objects: Vector::empty(),
+            max_capacity,
+        }
+    }
+
+    /// Create a new Bag and transfer it to the signer.
+    public fun create(ctx: &mut TxContext) {
+        Transfer::transfer(new(ctx), TxContext::sender(ctx))
+    }
+
+    /// Returns the size of the Bag.
+    public fun size(c: &Bag): u64 {
+        Vector::length(&c.objects)
+    }
+
+    /// Add a new object to the Bag.
+    /// Abort if the object is already in the Bag.
+    public fun add<T: key>(c: &mut Bag, object: T) {
+        assert!(
+            size(c) + 1 <= c.max_capacity,
+            Errors::limit_exceeded(EMAX_CAPACITY_EXCEEDED)
+        );
+        let id = ID::id(&object);
+        if (contains(c, id)) {
+            abort EOBJECT_DOUBLE_ADD
+        };
+        Vector::push_back(&mut c.objects, *id);
+        Transfer::transfer_to_object_unsafe(object, c);
+    }
+
+    /// Check whether the Bag contains a specific object,
+    /// identified by the object id in bytes.
+    public fun contains(c: &Bag, id: &ID): bool {
+        Option::is_some(&find(c, id))
+    }
+
+    /// Remove and return the object from the Bag.
+    /// Abort if the object is not found.
+    public fun remove<T: key>(c: &mut Bag, object: T): T {
+        let idx = find(c, ID::id(&object));
+        if (Option::is_none(&idx)) {
+            abort EOBJECT_NOT_FOUND
+        };
+        Vector::remove(&mut c.objects, *Option::borrow(&idx));
+        object
+    }
+
+    /// Remove the object from the Bag, and then transfer it to the signer.
+    public fun remove_and_take<T: key>(c: &mut Bag, object: T, ctx: &mut TxContext) {
+        let object = remove(c, object);
+        Transfer::transfer(object, TxContext::sender(ctx));
+    }
+
+    /// Transfer the entire Bag to `recipient`.
+    public fun transfer(c: Bag, recipient: address, _ctx: &mut TxContext) {
+        Transfer::transfer(c, recipient)
+    }
+
+    /// Look for the object identified by `id_bytes` in the Bag.
+    /// Returns the index if found, none if not found.
+    fun find(c: &Bag, id: &ID): Option<u64> {
+        let i = 0;
+        let len = size(c);
+        while (i < len) {
+            if (Vector::borrow(&c.objects, i) == id) {
+                return Option::some(i)
+            };
+            i = i + 1;
+        };
+        return Option::none()
+    }
+}

--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -1,35 +1,56 @@
+/// The `Collection` type represents a collection of objects of the same type `T`.
+/// In contrast to `vector<T>` which stores the object in the vector directly,
+/// `Collection<T>` only tracks the ownership indirectly, by keeping a list of
+/// references to the object IDs.
+/// When using `vector<T>`, since the objects will be wrapped inside the vector,
+/// these objects will not be stored in the global object pool, and hence not
+/// directly accessible.
+/// Collection allows us to own a list of same-typed objects, but still able to
+/// access and operate on each individual object.
+/// In contrast to `Bag`, `Collection` requires all objects have the same type.
 module Sui::Collection {
     use Std::Errors;
     use Std::Option::{Self, Option};
     use Std::Vector::Self;
     use Sui::ID::{Self, ID, VersionedID};
-    use Sui::Transfer;
+    use Sui::Transfer::{Self, ChildRef};
     use Sui::TxContext::{Self, TxContext};
 
     // Error codes
+    /// When removing an object from the collection, EOBJECT_NOT_FOUND
+    /// will be triggered if the object is not owned by the collection.
     const EOBJECT_NOT_FOUND: u64 = 0;
+
+    /// Adding the same object to the collection twice is not allowed.
     const EOBJECT_DOUBLE_ADD: u64 = 1;
+
+    /// The max capacity set for the collection cannot exceed the hard limit
+    /// which is DEFAULT_MAX_CAPACITY.
     const EINVALID_MAX_CAPACITY: u64 = 2;
+
+    /// Trying to add object to the collection when the collection is
+    /// already at its maximum capacity.
     const EMAX_CAPACITY_EXCEEDED: u64 = 3;
 
     // TODO: this is a placeholder number
+    // We want to limit the capacity of collection because it requires O(N)
+    // for search and removals. We could relax the capacity constraint once
+    // we could use more efficient data structure such as set.
     const DEFAULT_MAX_CAPACITY: u64 = 65536;
 
-    // TODO: We should create a sepratate type called "Bag" to hold heterogeneous objects.
-    // And keep Collection to take objects of the same type.
-    struct Collection has key {
+    struct Collection<phantom T: key> has key {
         id: VersionedID,
-        objects: vector<ID>,
+        objects: vector<ChildRef<T>>,
         max_capacity: u64,
     }
 
     /// Create a new Collection and return it.
-    public fun new(ctx: &mut TxContext): Collection {
+    public fun new<T: key>(ctx: &mut TxContext): Collection<T> {
         new_with_max_capacity(ctx, DEFAULT_MAX_CAPACITY)
     }
 
     /// Create a new Collection with custom size limit and return it.
-    public fun new_with_max_capacity(ctx: &mut TxContext, max_capacity: u64): Collection {
+    public fun new_with_max_capacity<T: key>(ctx: &mut TxContext, max_capacity: u64): Collection<T> {
         assert!(
             max_capacity <= DEFAULT_MAX_CAPACITY && max_capacity > 0 ,
             Errors::limit_exceeded(EINVALID_MAX_CAPACITY)
@@ -42,71 +63,62 @@ module Sui::Collection {
     }
 
     /// Create a new Collection and transfer it to the signer.
-    public fun create(ctx: &mut TxContext) {
-        Transfer::transfer(new(ctx), TxContext::sender(ctx))
+    public fun create<T: key>(ctx: &mut TxContext) {
+        Transfer::transfer(new<T>(ctx), TxContext::sender(ctx))
     }
 
     /// Returns the size of the collection.
-    public fun size(c: &Collection): u64 {
+    public fun size<T: key>(c: &Collection<T>): u64 {
         Vector::length(&c.objects)
     }
 
     /// Add a new object to the collection.
     /// Abort if the object is already in the collection.
-    public fun add<T: key>(c: &mut Collection, object: T) {
+    public fun add<T: key>(c: &mut Collection<T>, object: T) {
         assert!(
             size(c) + 1 <= c.max_capacity,
             Errors::limit_exceeded(EMAX_CAPACITY_EXCEEDED)
         );
         let id = ID::id(&object);
-        if (contains(c, id)) {
-            abort EOBJECT_DOUBLE_ADD
-        };
-        Vector::push_back(&mut c.objects, *id);
-        Transfer::transfer_to_object_unsafe(object, c);
+        assert!(!contains(c, id), EOBJECT_DOUBLE_ADD);
+        let child_ref = Transfer::transfer_to_object(object, c);
+        Vector::push_back(&mut c.objects, child_ref);
     }
 
     /// Check whether the collection contains a specific object,
     /// identified by the object id in bytes.
-    public fun contains(c: &Collection, id: &ID): bool {
+    public fun contains<T: key>(c: &Collection<T>, id: &ID): bool {
         Option::is_some(&find(c, id))
     }
 
     /// Remove and return the object from the collection.
     /// Abort if the object is not found.
-    public fun remove<T: key>(c: &mut Collection, object: T): T {
+    public fun remove<T: key>(c: &mut Collection<T>, object: T): (T, ChildRef<T>) {
         let idx = find(c, ID::id(&object));
-        if (Option::is_none(&idx)) {
-            abort EOBJECT_NOT_FOUND
-        };
-        Vector::remove(&mut c.objects, *Option::borrow(&idx));
-        object
+        assert!(Option::is_some(&idx), EOBJECT_NOT_FOUND);
+        let child_ref = Vector::remove(&mut c.objects, *Option::borrow(&idx));
+        (object, child_ref)
     }
 
     /// Remove the object from the collection, and then transfer it to the signer.
-    public fun remove_and_take<T: key>(c: &mut Collection, object: T, ctx: &mut TxContext) {
-        let object = remove(c, object);
-        Transfer::transfer(object, TxContext::sender(ctx));
+    public fun remove_and_take<T: key>(c: &mut Collection<T>, object: T, ctx: &mut TxContext) {
+        let (object, child_ref) = remove(c, object);
+        Transfer::transfer_child_to_address(object, child_ref, TxContext::sender(ctx));
     }
 
     /// Transfer the entire collection to `recipient`.
-    /// This function can be called as an entry function, as it has TxContext as input.
-    public fun transfer_entry(c: Collection, recipient: address, _ctx: &mut TxContext) {
-        transfer(c, recipient)
-    }
-
-    /// Transfer the entire collection to `recipient`.
-    public fun transfer(c: Collection, recipient: address) {
+    public fun transfer<T: key>(c: Collection<T>, recipient: address, _ctx: &mut TxContext) {
         Transfer::transfer(c, recipient)
     }
 
     /// Look for the object identified by `id_bytes` in the collection.
     /// Returns the index if found, none if not found.
-    fun find(c: &Collection, id: &ID): Option<u64> {
+    fun find<T: key>(c: &Collection<T>, id: &ID): Option<u64> {
         let i = 0;
         let len = size(c);
         while (i < len) {
-            if (Vector::borrow(&c.objects, i) == id) {
+            let child_ref = Vector::borrow(&c.objects, i);
+            if (Transfer::child_id(child_ref) == id) {
                 return Option::some(i)
             };
             i = i + 1;

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -2,7 +2,7 @@ module Sui::Transfer {
     use Sui::ID::{Self, ID, VersionedID};
 
     // To allow access to transfer_to_object_unsafe.
-    friend Sui::Collection;
+    friend Sui::Bag;
 
     // When transferring a child object, this error is thrown if the child object
     // doesn't match the ChildRef that represents the onwershp.

--- a/sui_programmability/framework/tests/BagTests.move
+++ b/sui_programmability/framework/tests/BagTests.move
@@ -1,0 +1,83 @@
+#[test_only]
+module Sui::BagTests {
+    use Sui::Bag::{Self, Bag};
+    use Sui::ID::{Self, VersionedID};
+    use Sui::TestScenario;
+    use Sui::TxContext;
+
+    const EBAG_SIZE_MISMATCH: u64 = 0;
+    const EOBJECT_NOT_FOUND: u64 = 1;
+
+    struct Object1 has key {
+        id: VersionedID,
+    }
+
+    struct Object2 has key {
+        id: VersionedID,
+    }
+
+    #[test]
+    fun test_bag() {
+        let sender = @0x0;
+        let scenario = &mut TestScenario::begin(&sender);
+
+        // Create a new Bag and transfer it to the sender.
+        TestScenario::next_tx(scenario, &sender);
+        {
+            Bag::create(TestScenario::ctx(scenario));
+        };
+
+        // Add two objects of different types into the bag.
+        TestScenario::next_tx(scenario, &sender);
+        {
+            let bag = TestScenario::remove_object<Bag>(scenario);
+            assert!(Bag::size(&bag) == 0, EBAG_SIZE_MISMATCH);
+
+            let obj1 = Object1 { id: TxContext::new_id(TestScenario::ctx(scenario)) };
+            let id1 = *ID::id(&obj1);
+            let obj2 = Object2 { id: TxContext::new_id(TestScenario::ctx(scenario)) };
+            let id2 = *ID::id(&obj2);
+
+            Bag::add(&mut bag, obj1);
+            Bag::add(&mut bag, obj2);
+            assert!(Bag::size(&bag) == 2, EBAG_SIZE_MISMATCH);
+
+            assert!(Bag::contains(&bag, &id1), EOBJECT_NOT_FOUND);
+            assert!(Bag::contains(&bag, &id2), EOBJECT_NOT_FOUND);
+
+            TestScenario::return_object(scenario, bag);
+        };
+        // TODO: Test object removal once we can retrieve object owned objects from TestScenario.
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 520)]
+    fun test_init_with_invalid_max_capacity() {
+        let ctx = TxContext::dummy();
+        // Sui::Bag::DEFAULT_MAX_CAPACITY is not readable outside the module
+        let max_capacity = 65536;
+        let bag = Bag::new_with_max_capacity(&mut ctx, max_capacity + 1);
+        Bag::transfer(bag, TxContext::sender(&ctx), &mut ctx);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 520)]
+    fun test_init_with_zero() {
+        let ctx = TxContext::dummy();
+        let bag = Bag::new_with_max_capacity(&mut ctx, 0);
+        Bag::transfer(bag, TxContext::sender(&ctx), &mut ctx);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 776)]
+    fun test_exceed_max_capacity() {
+        let ctx = TxContext::dummy();
+        let bag = Bag::new_with_max_capacity(&mut ctx, 1);
+
+        let obj1 = Object1 { id: TxContext::new_id(&mut ctx) };
+        Bag::add(&mut bag, obj1);
+        let obj2 = Object2 { id: TxContext::new_id(&mut ctx) };
+        Bag::add(&mut bag, obj2);
+        Bag::transfer(bag, TxContext::sender(&ctx), &mut ctx);
+    }
+}

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -1,7 +1,8 @@
 #[test_only]
 module Sui::CollectionTests {
-    use Sui::Collection;
+    use Sui::Collection::{Self, Collection};
     use Sui::ID::{Self, VersionedID};
+    use Sui::TestScenario;
     use Sui::TxContext;
 
     const ECOLLECTION_SIZE_MISMATCH: u64 = 0;
@@ -12,54 +13,67 @@ module Sui::CollectionTests {
     }
 
     #[test]
-    fun test_collection_add() {
-        let ctx = TxContext::dummy();
-        let collection = Collection::new(&mut ctx);
-        assert!(Collection::size(&collection) == 0, ECOLLECTION_SIZE_MISMATCH);
+    fun test_collection() {
+        let sender = @0x0;
+        let scenario = &mut TestScenario::begin(&sender);
 
-        let obj1 = Object { id: TxContext::new_id(&mut ctx) };
-        let id1 = *ID::id(&obj1);
-        let obj2 = Object { id: TxContext::new_id(&mut ctx) };
-        let id2 = *ID::id(&obj2);
+        // Create a new Collection and transfer it to the sender.
+        TestScenario::next_tx(scenario, &sender);
+        {
+            Collection::create<Object>(TestScenario::ctx(scenario));
+        };
 
-        Collection::add(&mut collection, obj1);
-        Collection::add(&mut collection, obj2);
-        assert!(Collection::size(&collection) == 2, ECOLLECTION_SIZE_MISMATCH);
+        // Add two objects of different types into the collection.
+        TestScenario::next_tx(scenario, &sender);
+        {
+            let collection = TestScenario::remove_object<Collection<Object>>(scenario);
+            assert!(Collection::size(&collection) == 0, ECOLLECTION_SIZE_MISMATCH);
 
-        assert!(Collection::contains(&collection, &id1), EOBJECT_NOT_FOUND);
-        assert!(Collection::contains(&collection, &id2), EOBJECT_NOT_FOUND);
+            let obj1 = Object { id: TxContext::new_id(TestScenario::ctx(scenario)) };
+            let id1 = *ID::id(&obj1);
+            let obj2 = Object { id: TxContext::new_id(TestScenario::ctx(scenario)) };
+            let id2 = *ID::id(&obj2);
 
-        Collection::transfer(collection, TxContext::sender(&ctx));
+            Collection::add(&mut collection, obj1);
+            Collection::add(&mut collection, obj2);
+            assert!(Collection::size(&collection) == 2, ECOLLECTION_SIZE_MISMATCH);
+
+            assert!(Collection::contains(&collection, &id1), EOBJECT_NOT_FOUND);
+            assert!(Collection::contains(&collection, &id2), EOBJECT_NOT_FOUND);
+
+            TestScenario::return_object(scenario, collection);
+        };
+        // TODO: Test object removal once we can retrieve object owned objects from TestScenario.
     }
 
     #[test]
-    #[expected_failure(abort_code = 520)] 
+    #[expected_failure(abort_code = 520)]
     fun test_init_with_invalid_max_capacity() {
         let ctx = TxContext::dummy();
         // Sui::Collection::DEFAULT_MAX_CAPACITY is not readable outside the module
         let max_capacity = 65536;
-        let collection = Collection::new_with_max_capacity(&mut ctx, max_capacity + 1);
-        Collection::transfer(collection, TxContext::sender(&ctx));
+        let collection = Collection::new_with_max_capacity<Object>(&mut ctx, max_capacity + 1);
+        Collection::transfer(collection, TxContext::sender(&ctx), &mut ctx);
     }
 
     #[test]
-    #[expected_failure(abort_code = 520)] 
+    #[expected_failure(abort_code = 520)]
     fun test_init_with_zero() {
         let ctx = TxContext::dummy();
-        let collection = Collection::new_with_max_capacity(&mut ctx, 0);
-        Collection::transfer(collection, TxContext::sender(&ctx));
+        let collection = Collection::new_with_max_capacity<Object>(&mut ctx, 0);
+        Collection::transfer(collection, TxContext::sender(&ctx), &mut ctx);
     }
 
     #[test]
-    #[expected_failure(abort_code = 776)] 
+    #[expected_failure(abort_code = 776)]
     fun test_exceed_max_capacity() {
         let ctx = TxContext::dummy();
-        let collection = Collection::new_with_max_capacity(&mut ctx, 1);
+        let collection = Collection::new_with_max_capacity<Object>(&mut ctx, 1);
 
         let obj1 = Object { id: TxContext::new_id(&mut ctx) };
         Collection::add(&mut collection, obj1);
         let obj2 = Object { id: TxContext::new_id(&mut ctx) };
         Collection::add(&mut collection, obj2);
-        Collection::transfer(collection, TxContext::sender(&ctx));
+        Collection::transfer(collection, TxContext::sender(&ctx), &mut ctx);
     }
 }


### PR DESCRIPTION
This PR renames the current implementation of `Collection` to `Bag`, and make the `Collection` require same type of all objects in it.
Added tests.
Updated Geniteam code to reflect the change.
Also removed the `store` ability from all types in Geniteam, because they don't seem to be needed. Let me know if that's incorrect. @arun-koshy 