### PR TITLE
Update and rename CONTRIBUTING.md to doc/src/contribute/index.md

### DIFF
--- a/doc/src/contribute/index.md
+++ b/doc/src/contribute/index.md
@@ -26,5 +26,6 @@ To submit your pull request:
 
 * Learn [about Mysten Labs](https://mystenlabs.com/) the company on our public site.
 * Read the [Sui Smart Contract Platform](../../paper/sui.pdf) white paper.
+* * Implementing [logging](observability.md) in Sui to observe the behavior of your development.
 * Find related [research papers](research-papers.md).
 * See and adhere to our [code of conduct](code-of-conduct.md).


### PR DESCRIPTION
Repurpose existing CONTRIBUTING page as the Contribute section landing page
Add sub- and related pages to bottom for further reading