### PR TITLE
Add execution engine

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -29,7 +29,10 @@ use sui_types::{
 };
 use tracing::*;
 
-use crate::authority_batch::{BatchSender, BroadcastReceiver, BroadcastSender};
+use crate::{
+    authority_batch::{BatchSender, BroadcastReceiver, BroadcastSender},
+    execution_engine,
+};
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
@@ -40,7 +43,7 @@ pub mod authority_tests;
 pub mod move_integration_tests;
 
 mod temporary_store;
-use temporary_store::AuthorityTemporaryStore;
+pub use temporary_store::AuthorityTemporaryStore;
 
 mod authority_store;
 pub use authority_store::AuthorityStore;
@@ -447,8 +450,16 @@ impl AuthorityState {
         let mut tx_ctx = TxContext::new(&transaction.sender_address(), transaction_digest);
 
         let gas_object_id = transaction.gas_payment_object_ref().0;
-        let (temporary_store, status) =
-            self.execute_transaction(transaction, inputs, &mut tx_ctx)?;
+        let mut temporary_store =
+            AuthorityTemporaryStore::new(self._database.clone(), &inputs, tx_ctx.digest());
+        let status = execution_engine::execute_transaction(
+            &mut temporary_store,
+            transaction,
+            inputs,
+            &mut tx_ctx,
+            &self.move_vm,
+            self._native_functions.clone(),
+        )?;
         debug!(
             gas_used = status.gas_used(),
             "Finished execution of transaction with status {:?}", status
@@ -477,62 +488,6 @@ impl AuthorityState {
         }
 
         Ok(resp)
-    }
-
-    fn execute_transaction(
-        &self,
-        transaction: Transaction,
-        mut inputs: Vec<Object>,
-        tx_ctx: &mut TxContext,
-    ) -> SuiResult<(AuthorityTemporaryStore<AuthorityStore>, ExecutionStatus)> {
-        let mut temporary_store =
-            AuthorityTemporaryStore::new(self._database.clone(), &inputs, tx_ctx.digest());
-        // unwraps here are safe because we built `inputs`
-        let mut gas_object = inputs.pop().unwrap();
-
-        let status = match transaction.data.kind {
-            TransactionKind::Transfer(t) => AuthorityState::transfer(
-                &mut temporary_store,
-                inputs,
-                t.recipient,
-                gas_object.clone(),
-            ),
-            TransactionKind::Call(c) => {
-                // unwraps here are safe because we built `inputs`
-                let package = inputs.pop().unwrap();
-                adapter::execute(
-                    &self.move_vm,
-                    &mut temporary_store,
-                    self._native_functions.clone(),
-                    package,
-                    &c.module,
-                    &c.function,
-                    c.type_arguments,
-                    inputs,
-                    c.pure_arguments,
-                    c.gas_budget,
-                    gas_object.clone(),
-                    tx_ctx,
-                )
-            }
-            TransactionKind::Publish(m) => adapter::publish(
-                &mut temporary_store,
-                self._native_functions.clone(),
-                m.modules,
-                tx_ctx,
-                m.gas_budget,
-                gas_object.clone(),
-            ),
-        }?;
-        if let ExecutionStatus::Failure { gas_used, .. } = &status {
-            // Roll back the temporary store if execution failed.
-            temporary_store.reset();
-            // This gas deduction cannot fail.
-            gas::deduct_gas(&mut gas_object, *gas_used);
-            temporary_store.write_object(gas_object);
-        }
-        temporary_store.ensure_active_inputs_mutated();
-        Ok((temporary_store, status))
     }
 
     /// Process certificates coming from the consensus. It is crucial that this function is only
@@ -571,41 +526,6 @@ impl AuthorityState {
             transaction,
             certificate.clone(),
         )
-    }
-
-    fn transfer(
-        temporary_store: &mut AuthorityTemporaryStore<AuthorityStore>,
-        mut inputs: Vec<Object>,
-        recipient: SuiAddress,
-        mut gas_object: Object,
-    ) -> SuiResult<ExecutionStatus> {
-        if !inputs.len() == 1 {
-            return Ok(ExecutionStatus::Failure {
-                gas_used: gas::MIN_OBJ_TRANSFER_GAS,
-                error: Box::new(SuiError::ObjectInputArityViolation),
-            });
-        }
-
-        // Safe to do pop due to check !is_empty()
-        let mut output_object = inputs.pop().unwrap();
-
-        let gas_used = gas::calculate_object_transfer_cost(&output_object);
-        if let Err(err) = gas::try_deduct_gas(&mut gas_object, gas_used) {
-            return Ok(ExecutionStatus::Failure {
-                gas_used: gas::MIN_OBJ_TRANSFER_GAS,
-                error: Box::new(err),
-            });
-        }
-        temporary_store.write_object(gas_object);
-
-        if let Err(err) = output_object.transfer(recipient) {
-            return Ok(ExecutionStatus::Failure {
-                gas_used: gas::MIN_OBJ_TRANSFER_GAS,
-                error: Box::new(err),
-            });
-        }
-        temporary_store.write_object(output_object);
-        Ok(ExecutionStatus::Success { gas_used })
     }
 
     pub async fn handle_transaction_info_request(

--- a/sui_core/src/execution_engine.rs
+++ b/sui_core/src/execution_engine.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use crate::authority::AuthorityTemporaryStore;
+use move_vm_runtime::native_functions::NativeFunctionTable;
+use sui_adapter::adapter;
+use sui_types::{
+    base_types::{SuiAddress, TxContext},
+    error::{SuiError, SuiResult},
+    gas,
+    messages::{ExecutionStatus, Transaction, TransactionKind},
+    object::Object,
+    storage::{BackingPackageStore, Storage},
+};
+
+pub fn execute_transaction<S: BackingPackageStore>(
+    temporary_store: &mut AuthorityTemporaryStore<S>,
+    transaction: Transaction,
+    mut inputs: Vec<Object>,
+    tx_ctx: &mut TxContext,
+    move_vm: &Arc<adapter::MoveVM>,
+    native_functions: NativeFunctionTable,
+) -> SuiResult<ExecutionStatus> {
+    // unwraps here are safe because we built `inputs`
+    let mut gas_object = inputs.pop().unwrap();
+
+    let status = match transaction.data.kind {
+        TransactionKind::Transfer(t) => {
+            transfer(temporary_store, inputs, t.recipient, gas_object.clone())
+        }
+        TransactionKind::Call(c) => {
+            // unwraps here are safe because we built `inputs`
+            let package = inputs.pop().unwrap();
+            adapter::execute(
+                move_vm,
+                temporary_store,
+                native_functions,
+                package,
+                &c.module,
+                &c.function,
+                c.type_arguments,
+                inputs,
+                c.pure_arguments,
+                c.gas_budget,
+                gas_object.clone(),
+                tx_ctx,
+            )
+        }
+        TransactionKind::Publish(m) => adapter::publish(
+            temporary_store,
+            native_functions,
+            m.modules,
+            tx_ctx,
+            m.gas_budget,
+            gas_object.clone(),
+        ),
+    }?;
+    if let ExecutionStatus::Failure { gas_used, .. } = &status {
+        // Roll back the temporary store if execution failed.
+        temporary_store.reset();
+        // This gas deduction cannot fail.
+        gas::deduct_gas(&mut gas_object, *gas_used);
+        temporary_store.write_object(gas_object);
+    }
+    temporary_store.ensure_active_inputs_mutated();
+    Ok(status)
+}
+
+fn transfer<S>(
+    temporary_store: &mut AuthorityTemporaryStore<S>,
+    mut inputs: Vec<Object>,
+    recipient: SuiAddress,
+    mut gas_object: Object,
+) -> SuiResult<ExecutionStatus> {
+    if !inputs.len() == 1 {
+        return Ok(ExecutionStatus::Failure {
+            gas_used: gas::MIN_OBJ_TRANSFER_GAS,
+            error: Box::new(SuiError::ObjectInputArityViolation),
+        });
+    }
+
+    // Safe to do pop due to check !is_empty()
+    let mut output_object = inputs.pop().unwrap();
+
+    let gas_used = gas::calculate_object_transfer_cost(&output_object);
+    if let Err(err) = gas::try_deduct_gas(&mut gas_object, gas_used) {
+        return Ok(ExecutionStatus::Failure {
+            gas_used: gas::MIN_OBJ_TRANSFER_GAS,
+            error: Box::new(err),
+        });
+    }
+    temporary_store.write_object(gas_object);
+
+    if let Err(err) = output_object.transfer(recipient) {
+        return Ok(ExecutionStatus::Failure {
+            gas_used: gas::MIN_OBJ_TRANSFER_GAS,
+            error: Box::new(err),
+        });
+    }
+    temporary_store.write_object(output_object);
+    Ok(ExecutionStatus::Success { gas_used })
+}

--- a/sui_core/src/lib.rs
+++ b/sui_core/src/lib.rs
@@ -9,4 +9,5 @@ pub mod authority_client;
 pub mod authority_server;
 pub mod client;
 pub mod consensus_handler;
+pub mod execution_engine;
 pub mod safe_client;


### PR DESCRIPTION
This PR extracts out the transaction execution code out of authority, and put them into a new module called `execution_engine`. This will allow us to share the execution engine in other places, such as local execution.