### PR TITLE
Refactor Genesis Code

### DIFF
--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -313,15 +313,14 @@ async fn sui_start(
     let mut handles = FuturesUnordered::new();
 
     for authority in &state.config.authorities {
-        let server =
-            sui_commands::make_server(authority, &committee, vec![], &[], state.config.buffer_size)
-                .await
-                .map_err(|error| {
-                    custom_http_error(
-                        StatusCode::CONFLICT,
-                        format!("Unable to make server: {error}"),
-                    )
-                })?;
+        let server = sui_commands::make_server(authority, &committee, state.config.buffer_size)
+            .await
+            .map_err(|error| {
+                custom_http_error(
+                    StatusCode::CONFLICT,
+                    format!("Unable to make server: {error}"),
+                )
+            })?;
         handles.push(async move {
             match server.spawn().await {
                 Ok(server) => Ok(server),


### PR DESCRIPTION
It is confusing to see the usage of `genesis_ctx` and `pre_loaded_modules` in both `/sui/genesis` path and `sui/start` path. This PR remove the usage of genesis related code from the `/sui/start` code path.

https://github.com/MystenLabs/sui/blob/13c4e9f7f6000de661006e2a32b54ee740962b6f/sui/src/rest_server.rs#L279-L325

https://github.com/MystenLabs/sui/blob/13c4e9f7f6000de661006e2a32b54ee740962b6f/sui/src/sui_commands.rs#L248-L265