### PR TITLE
Allow building/testing framework code

### DIFF
--- a/sui/src/sui-move.rs
+++ b/sui/src/sui-move.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use colored::Colorize;
 use std::path::Path;
 use structopt::clap::App;
 use structopt::StructOpt;
@@ -15,19 +16,29 @@ pub enum MoveCommands {
     /// Run all Move unit tests
     #[structopt(name = "test")]
     Test,
-    // TODO: Add dev_mode as configurable option
 }
 
 impl MoveCommands {
-    pub fn execute(&self, path: &Path) -> Result<(), anyhow::Error> {
+    pub fn execute(&self, path: &Path, is_std_framework: bool) -> Result<(), anyhow::Error> {
         match self {
             Self::Build => {
-                sui_framework::build_and_verify_user_package(path, false)?;
+                Self::build(path, is_std_framework)?;
+                println!("{}", "Build Successful".bold().green());
+                println!("Artifacts path: {:?}", path.join("build"));
             }
             Self::Test => {
-                sui_framework::build_and_verify_user_package(path, true).unwrap();
+                Self::build(path, is_std_framework)?;
                 sui_framework::run_move_unit_tests(path)?;
             }
+        }
+        Ok(())
+    }
+
+    fn build(path: &Path, is_std_framework: bool) -> Result<(), anyhow::Error> {
+        if is_std_framework {
+            sui_framework::get_sui_framework_modules(path)?;
+        } else {
+            sui_framework::build_and_verify_user_package(path)?;
         }
         Ok(())
     }
@@ -43,6 +54,9 @@ struct MoveOpt {
     /// Path to the Move project root.
     #[structopt(long, default_value = "./")]
     path: String,
+    /// Whether we are building/testing the std/framework code.
+    #[structopt(long)]
+    std: bool,
     /// Subcommands.
     #[structopt(subcommand)]
     cmd: MoveCommands,
@@ -52,5 +66,5 @@ fn main() -> Result<(), anyhow::Error> {
     let app: App = MoveOpt::clap();
     let options = MoveOpt::from_clap(&app.get_matches());
     let path = options.path;
-    options.cmd.execute(path.as_ref())
+    options.cmd.execute(path.as_ref(), options.std)
 }

--- a/sui_programmability/framework/src/lib.rs
+++ b/sui_programmability/framework/src/lib.rs
@@ -147,9 +147,9 @@ pub fn build_move_package(
     }
 }
 
-pub fn build_and_verify_user_package(path: &Path, dev_mode: bool) -> SuiResult {
+pub fn build_and_verify_user_package(path: &Path) -> SuiResult {
     let build_config = BuildConfig {
-        dev_mode,
+        dev_mode: false,
         ..Default::default()
     };
     let modules = build_move_package(path, build_config, false)?;
@@ -218,7 +218,7 @@ fn run_examples_move_unit_tests() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../examples")
             .join(example);
-        build_and_verify_user_package(&path, true).unwrap();
+        build_and_verify_user_package(&path).unwrap();
         run_move_unit_tests(&path).unwrap();
     }
 }


### PR DESCRIPTION
Add `--std` option to `sui-move` to allow for building and testing the std/framework Move code.
Also removing the dev_mode param, since its only usage is to change the package address, which isn't needed in Sui.
Added nicer output when build successfully.