### PR TITLE
[benchmarking] Enforce minimum committee size of 4

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -47,7 +47,7 @@ struct ClientServerBenchmark {
     /// Base port number
     #[structopt(long, default_value = "9555")]
     port: u16,
-    /// Size of the Sui committee
+    /// Size of the Sui committee. Minimum size is 4 to tolerate one fault
     #[structopt(long, default_value = "10")]
     committee_size: usize,
     /// Maximum number of requests in flight (0 for blocking client)
@@ -89,6 +89,9 @@ impl std::fmt::Display for BenchmarkType {
         write!(f, "{:?}", self)
     }
 }
+
+const MIN_COMMITTEE_SIZE: usize = 4;
+
 fn main() {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let subscriber_builder =
@@ -96,6 +99,12 @@ fn main() {
     let subscriber = subscriber_builder.with_writer(std::io::stderr).finish();
     set_global_default(subscriber).expect("Failed to set subscriber");
     let benchmark = ClientServerBenchmark::from_args();
+    assert!(
+        benchmark.committee_size >= MIN_COMMITTEE_SIZE,
+        "Found committee size of {:?}, but minimum committee size is {:?}",
+        benchmark.committee_size,
+        MIN_COMMITTEE_SIZE
+    );
     let (state, transactions) = benchmark.make_structures();
 
     // Make multi-threaded runtime for the authority


### PR DESCRIPTION
I was trying to get single-node network numbers by running with `--committee-size 1`, but this causes the crash below for any committee size less than 4. Enforce the minimum committee size to ensure others don't make the same mistake.

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', sui/src/bench.rs:262:48
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/panicking.rs:116:14
   2: core::panicking::panic
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/panicking.rs:48:5
   3: core::option::Option<T>::unwrap
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/option.rs:729:21
   4: bench::ClientServerBenchmark::make_structures
             at ./src/bench.rs:262:36
   5: bench::main
             at ./src/bench.rs:99:33
   6: core::ops::function::FnOnce::call_once
             at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```