### PR TITLE
Add ChildRef::is_child

### DIFF
--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -118,7 +118,7 @@ module Sui::Collection {
         let len = size(c);
         while (i < len) {
             let child_ref = Vector::borrow(&c.objects, i);
-            if (Transfer::child_id(child_ref) == id) {
+            if (Transfer::is_child_unsafe(child_ref,  id)) {
                 return Option::some(i)
             };
             i = i + 1;

--- a/sui_programmability/framework/sources/Geniteam.move
+++ b/sui_programmability/framework/sources/Geniteam.move
@@ -1,7 +1,7 @@
 module Sui::Geniteam {
     use Sui::Bag::{Self, Bag};
     use Sui::Collection::{Self, Collection};
-    use Sui::ID::{Self, VersionedID};
+    use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};
     use Std::Option::{Self, Option};
     use Sui::Transfer::{Self, ChildRef};
@@ -135,8 +135,10 @@ module Sui::Geniteam {
         );
 
         // Check if this is the right collection
-        assert!(Transfer::child_id(&farm.pet_monsters) == ID::id(pet_monsters),
-                EMONSTER_COLLECTION_NOT_OWNED_BY_FARM);
+        assert!(
+            Transfer::is_child(&farm.pet_monsters, pet_monsters),
+            EMONSTER_COLLECTION_NOT_OWNED_BY_FARM,
+        );
 
         // TODO: Decouple adding monster to farm from creating a monster.
         // Add it to the collection
@@ -149,8 +151,10 @@ module Sui::Geniteam {
         ctx: &mut TxContext
     ) {
         // Check if this is the right collection
-        assert!(Transfer::child_id(&player.inventory) == ID::id(inventory),
-                EINVENTORY_NOT_OWNED_BY_PLAYER);
+        assert!(
+            Transfer::is_child(&player.inventory, inventory),
+            EINVENTORY_NOT_OWNED_BY_PLAYER,
+        );
 
         // Create the farm cosmetic object
         let farm_cosmetic = FarmCosmetic {
@@ -168,8 +172,10 @@ module Sui::Geniteam {
         ctx: &mut TxContext
     ) {
         // Check if this is the right collection
-        assert!(Transfer::child_id(&player.inventory) == ID::id(inventory),
-                EINVENTORY_NOT_OWNED_BY_PLAYER);
+        assert!(
+            Transfer::is_child(&player.inventory, inventory),
+            EINVENTORY_NOT_OWNED_BY_PLAYER,
+        );
 
         // Create the farm cosmetic object
         let monster_cosmetic = MonsterCosmetic {

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -3,6 +3,8 @@ module Sui::Transfer {
 
     // To allow access to transfer_to_object_unsafe.
     friend Sui::Bag;
+    // To allow access to is_child_unsafe.
+    friend Sui::Collection;
 
     // When transferring a child object, this error is thrown if the child object
     // doesn't match the ChildRef that represents the onwershp.
@@ -20,9 +22,20 @@ module Sui::Transfer {
         child_id: ID,
     }
 
-    /// Getter for ChildRefs child id.
-    public fun child_id<T: key>(child_ref: &ChildRef<T>): &ID {
-        &child_ref.child_id
+    /// Check whether the `child` object is actually the child object
+    /// owned by the parent through the given `child_ref`.
+    public fun is_child<T: key>(child_ref: &ChildRef<T>, child: &T): bool {
+        &child_ref.child_id == ID::id(child)
+    }
+
+    /// Check whether the `child_ref`'s child_id is `id`.
+    /// This is less safe compared to `is_child` because we won't be able to check
+    /// whether the type of the child object is the same as what `ChildRef` represents.
+    /// We should always call `is_child` whenever we can.
+    /// This is currently only exposed to friend classes. If there turns out to be
+    /// general needs, we can open it up.
+    public(friend) fun is_child_unsafe<T: key>(child_ref: &ChildRef<T>, id: &ID): bool {
+        &child_ref.child_id == id
     }
 
     /// Transfers are implemented by emitting a


### PR DESCRIPTION
It's a common need to check whether a `child_ref` points to a specific child object.
Add `is_child` for this purpose. It also enforces the type parameter on `ChildRef` is the same as the type of the child object, which helps avoid mistakes of mixing up the types (as we have seen in #777).
However, there are also cases (still questionable) we need to check the id against a naked id instead of child object. In this case, we also introduce the unsafe version, but only expose it to a limited number of friend classes in the framework.
If in the future we see this a common need, we could open it up.