### PR TITLE
Add `update_object` native function in TestScenario

### DIFF
--- a/sui_programmability/framework/sources/TestScenario.move
+++ b/sui_programmability/framework/sources/TestScenario.move
@@ -4,7 +4,6 @@
 #[test_only]
 module Sui::TestScenario {
     use Sui::ID::{Self, ID, VersionedID};
-    use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
     use Std::Vector;
 
@@ -170,12 +169,11 @@ module Sui::TestScenario {
         assert!(is_mem, ECANT_RETURN_OBJECT);
         Vector::remove(removed, idx);
 
-        // Model object return as a self transfer. Because the events are the source of truth for all object values
-        // in the inventory, we must put any state change future txes want to see in an event. It would not be safe
+        // Update the object content in the inventory.
+        // Because the events are the source of truth for all object values in the inventory,
+        // we must put any state change future txes want to see in an event. It would not be safe
         // to do (e.g.) `delete_object_for_testing(t)` instead.
-        // TODO: do this with a special test-only event to enable writing tests that look directly at system events
-        // like transfers. the current scheme will perturb the count of transfer events.
-        Transfer::transfer(t, sender(scenario))
+        update_object(t)
     }
 
     /// Return `true` if a call to `remove_object<T>(scenario)` will succeed
@@ -278,4 +276,7 @@ module Sui::TestScenario {
 
     /// Emit a special, test-only event recording that `object_id` was wrapped
     native fun emit_wrapped_object_event(object_id: vector<u8>);
+
+    /// Update the content of an object in the inventory.
+    native fun update_object<T: key>(obj: T);
 }

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -43,6 +43,11 @@ pub fn all_natives(
         ("TestScenario", "num_events", test_scenario::num_events),
         (
             "TestScenario",
+            "update_object",
+            test_scenario::update_object,
+        ),
+        (
+            "TestScenario",
             "transferred_object_ids",
             test_scenario::transferred_object_ids,
         ),


### PR DESCRIPTION
Right now we use transfer to mimic returning an object back to the inventory.
This is not ideal because it will mix up with real transfers. I will also not allow us properly detect issues such as transferring a shared object.
This PR adds a native function that emits a new test-only event for updating the object.
It does the following, specifically:
1. When returning an object, call the `update_object` native function. This function checks that we are not mutating an immutable object. And also emit a `UPDATE_OBJECT_EVENT`.
2. When processing transfers, now that we know these transfers are all real, we can detect cases where a shared object is being transferred.
3. Added error codes for the above two cases and return them. Added tests.

Some potential TODOs:
1. We can only detect transferring shared object at a late time when we process the inventory. Ideally we want to detect it when an object is being transferred. One idea to do this is to emit a special event when calling `TestScenario::begin`, and then when processing a transfer, we look at the first event to see if we are in the test mode. If we are in the test mode, we could then process the inventory at that time.
2. When any of the errors happen, we only return an abort_code, which is not very meaningful to developers (the fact that the error may be delayed makes it even worse). We need to think about how we may be able to make this more debuggable.