### PR TITLE
[move] Adds Coin::zero()

### DIFF
--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -99,7 +99,7 @@ module Sui::Coin {
 
     /// Make any Coin with a zero value. Useful for placeholding
     /// bids/payments or preemptively making empty balances.
-    public fun zero()<T>(): Coin<T> {
+    public fun zero<T>(ctx: &mut TxContext): Coin<T> {
         Coin { id: TxContext::new_id(ctx), value: 0 }
     }
 


### PR DESCRIPTION
Allows making empty Coin instances for empty balances or for placeholders in modules such as the one in #756.