### PR TITLE
Move hero game to subdir

### DIFF
--- a/sui_programmability/examples/games/hero/Move.toml
+++ b/sui_programmability/examples/games/hero/Move.toml
@@ -1,0 +1,12 @@
+[package]
+name = "HeroGame"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../framework" }
+
+[addresses]
+HeroGame = "0x0"
+
+[dev-addresses]
+HeroGame = "0x0"

--- a/sui_programmability/examples/games/hero/sources/Hero.move
+++ b/sui_programmability/examples/games/hero/sources/Hero.move
@@ -1,6 +1,6 @@
 /// Example of a game character with basic attributes, inventory, and
 /// associated logic.
-module Games::Hero {
+module HeroGame::Hero {
     use Sui::Coin::{Self, Coin};
     use Sui::Event;
     use Sui::ID::{Self, ID, VersionedID};

--- a/sui_programmability/examples/games/hero/sources/SeaHero.move
+++ b/sui_programmability/examples/games/hero/sources/SeaHero.move
@@ -5,8 +5,8 @@
 /// earns RUM tokens for hero's owner.
 /// Note that this mod does not require special permissions from `Hero` module;
 /// anyone is free to create a mod like this.
-module Games::SeaHero {
-    use Games::Hero::{Self, Hero};
+module HeroGame::SeaHero {
+    use HeroGame::Hero::{Self, Hero};
     use Sui::ID::{Self, VersionedID};
     use Sui::Coin::{Self, Coin, TreasuryCap };
     use Sui::Transfer;

--- a/sui_programmability/examples/games/hero/sources/SeaHeroHelper.move
+++ b/sui_programmability/examples/games/hero/sources/SeaHeroHelper.move
@@ -4,9 +4,9 @@
 /// the monster for them in exchange for some of the reward.
 /// Anyone can create a mod like this--the permission of the `SeaHero` game
 /// is not required.
-module Games::SeaHeroHelper {
-    use Games::SeaHero::{Self, SeaMonster, RUM};
-    use Games::Hero::Hero;
+module HeroGame::SeaHeroHelper {
+    use HeroGame::SeaHero::{Self, SeaMonster, RUM};
+    use HeroGame::Hero::Hero;
     use Sui::Coin::{Self, Coin};
     use Sui::ID::{Self, VersionedID};
     use Sui::Transfer;


### PR DESCRIPTION
At the moment the hero game requires the sender to be a hardcoded address in the module initializer, which runs during module publish. This makes it impossible to publish the game package under examples.
The hardcoded admin is part of the game design: when purchasing stuff, the proceeds go to the admin. So we are going to redesign the game if we want the admin to not be hardcoded.
Moving hero to a sub-dir for now.