### PR TITLE
Make publish call response structured

### DIFF
--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -149,7 +149,7 @@ impl AuthorityServer {
                 Err(RecvError::Lagged(number_skipped)) => {
                     // We tell the client they are too slow to consume, and
                     // stop.
-                    return Err(SuiError::SubscriptionItemsDropedError(number_skipped));
+                    return Err(SuiError::SubscriptionItemsDroppedError(number_skipped));
                 }
             }
         }

--- a/sui_core/src/gateway_state/gateway_responses.rs
+++ b/sui_core/src/gateway_state/gateway_responses.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use std::fmt;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
+use sui_types::base_types::ObjectRef;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::CertifiedTransaction;
 use sui_types::object::Object;
@@ -66,6 +67,42 @@ impl Display for MergeCoinResponse {
 
         let coin = GasCoin::try_from(&self.updated_coin).map_err(fmt::Error::custom)?;
         writeln!(writer, "Updated Coin : {}", coin)?;
+        let gas_coin = GasCoin::try_from(&self.updated_gas).map_err(fmt::Error::custom)?;
+        writeln!(writer, "Updated Gas : {}", gas_coin)?;
+        write!(f, "{}", writer)
+    }
+}
+
+#[derive(Serialize)]
+pub struct PublishResponse {
+    /// Certificate of the transaction
+    pub certificate: CertifiedTransaction,
+    /// The newly published package object reference.
+    pub package: ObjectRef,
+    /// List of Move objects created as part of running the module initializers in the package
+    pub created_objects: Vec<Object>,
+    /// The updated gas payment object after deducting payment
+    pub updated_gas: Object,
+}
+
+impl Display for PublishResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut writer = String::new();
+        writeln!(writer, "----- Certificate ----")?;
+        write!(writer, "{}", self.certificate)?;
+        writeln!(writer, "----- Publish Results ----")?;
+        writeln!(
+            writer,
+            "The newly published package object: {:?}",
+            self.package
+        )?;
+        writeln!(
+            writer,
+            "List of objects created by running module initializers:"
+        )?;
+        for obj in &self.created_objects {
+            writeln!(writer, "{}", obj)?;
+        }
         let gas_coin = GasCoin::try_from(&self.updated_gas).map_err(fmt::Error::custom)?;
         writeln!(writer, "Updated Gas : {}", gas_coin)?;
         write!(f, "{}", writer)

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -22,7 +22,7 @@ use sui_framework::build_move_package_to_bytes;
 use sui_types::crypto::Signature;
 use sui_types::crypto::{get_key_pair, KeyPair};
 use sui_types::gas_coin::GasCoin;
-use sui_types::object::{Data, Object, Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION};
+use sui_types::object::{Data, Object, Owner, GAS_VALUE_FOR_TESTING};
 use typed_store::Map;
 
 use signature::{Error, Signer};
@@ -1141,22 +1141,6 @@ async fn test_move_calls_object_delete() {
     }
 }
 
-async fn get_package_obj(
-    client: &mut GatewayState<LocalAuthorityClient>,
-    objects: &[(ObjectRef, Owner)],
-    gas_object_ref: &ObjectRef,
-) -> Option<ObjectRead> {
-    let mut pkg_obj_opt = None;
-    for (new_obj_ref, _) in objects {
-        assert_ne!(gas_object_ref, new_obj_ref);
-        let new_obj = client.get_object_info(new_obj_ref.0).await.unwrap();
-        if let Data::Package(_) = new_obj.object().unwrap().data {
-            pkg_obj_opt = Some(new_obj);
-        }
-    }
-    pkg_obj_opt
-}
-
 #[tokio::test]
 async fn test_module_publish_and_call_good() {
     // Init the states
@@ -1180,7 +1164,7 @@ async fn test_module_publish_and_call_good() {
     hero_path.push_str("/src/unit_tests/data/hero/");
 
     let compiled_modules = build_move_package_to_bytes(Path::new(&hero_path)).unwrap();
-    let pub_res = client
+    let response = client
         .publish(
             addr1,
             compiled_modules,
@@ -1188,48 +1172,21 @@ async fn test_module_publish_and_call_good() {
             GAS_VALUE_FOR_TESTING / 2,
             signature_callback(&key1),
         )
-        .await;
-
-    let (_, published_effects) = pub_res.unwrap();
-
-    assert!(matches!(
-        published_effects.status,
-        ExecutionStatus::Success { .. }
-    ));
-
-    // A package obj and two objects resulting from two
-    // initializer runs in different modules should be created.
-    assert_eq!(published_effects.created.len(), 3);
-
-    // Verify gas obj
-    assert_eq!(published_effects.gas_object.0 .0, gas_object_ref.0);
-
-    for (new_obj_ref, _) in &published_effects.created {
-        assert_ne!(gas_object_ref, *new_obj_ref);
-    }
-
-    // find the package object and inspect it
-
-    let new_obj = get_package_obj(&mut client, &published_effects.created, &gas_object_ref)
         .await
         .unwrap();
 
-    // Version should be 1 for all modules
-    assert_eq!(new_obj.object().unwrap().version(), OBJECT_START_VERSION);
-    // Must be immutable
-    assert!(new_obj.object().unwrap().is_read_only());
+    // Two objects resulting from two initializer runs in different modules should be created.
+    assert_eq!(response.created_objects.len(), 2);
 
-    // StructTag type is not defined for package
-    assert!(new_obj.object().unwrap().type_().is_none());
+    // Verify gas obj
+    assert_eq!(response.updated_gas.id(), gas_object_ref.0);
 
-    // Data should be castable as a package
-    assert!(new_obj.object().unwrap().data.try_as_package().is_some());
+    let package = response.package;
 
     // This gets the treasury cap for the coin and gives it to the sender
     let mut tres_cap_opt = None;
-    for (new_obj_ref, _) in &published_effects.created {
-        let new_obj = client.get_object_info(new_obj_ref.0).await.unwrap();
-        if let Data::Move(move_obj) = &new_obj.object().unwrap().data {
+    for new_obj in &response.created_objects {
+        if let Data::Move(move_obj) = &new_obj.data {
             if move_obj.type_.module == Identifier::new("Coin").unwrap()
                 && move_obj.type_.name == Identifier::new("TreasuryCap").unwrap()
             {
@@ -1244,21 +1201,18 @@ async fn test_module_publish_and_call_good() {
     let (gas_object_ref, gas_object) = client_object(&mut client, gas_object_id).await;
 
     // Confirm we own this object
-    assert_eq!(tres_cap_obj_info.object().unwrap().owner, gas_object.owner);
+    assert_eq!(tres_cap_obj_info.owner, gas_object.owner);
 
     //Try to call a function in TrustedCoin module
     let call_resp = client
         .move_call(
             addr1,
-            new_obj.object().unwrap().compute_object_reference(),
+            package,
             ident_str!("TrustedCoin").to_owned(),
             ident_str!("mint").to_owned(),
             vec![],
             gas_object_ref,
-            vec![tres_cap_obj_info
-                .object()
-                .unwrap()
-                .compute_object_reference()],
+            vec![tres_cap_obj_info.compute_object_reference()],
             vec![],
             vec![42u64.to_le_bytes().to_vec()],
             1000,
@@ -1311,7 +1265,7 @@ async fn test_module_publish_file_path() {
     hero_path.push_str("/src/unit_tests/data/hero/Hero.move");
 
     let compiled_modules = build_move_package_to_bytes(Path::new(&hero_path)).unwrap();
-    let pub_resp = client
+    let response = client
         .publish(
             addr1,
             compiled_modules,
@@ -1319,45 +1273,19 @@ async fn test_module_publish_file_path() {
             GAS_VALUE_FOR_TESTING / 2,
             signature_callback(&key1),
         )
-        .await;
-
-    let (_, published_effects) = pub_resp.unwrap();
-
-    assert!(matches!(
-        published_effects.status,
-        ExecutionStatus::Success { .. }
-    ));
+        .await
+        .unwrap();
 
     // Even though we provided a path to Hero.move, the builder is
     // able to find the package root build all in the package,
     // including TrustedCoin module
     //
-    // Consequently,a package obj and two objects resulting from two
+    // Consequently, two objects resulting from two
     // initializer runs in different modules should be created.
-    assert_eq!(published_effects.created.len(), 3);
+    assert_eq!(response.created_objects.len(), 2);
 
     // Verify gas
-    assert_eq!(published_effects.gas_object.0 .0, gas_object_ref.0);
-
-    for (new_obj_ref, _) in &published_effects.created {
-        assert_ne!(gas_object_ref, *new_obj_ref);
-    }
-    // find the package object and inspect it
-
-    let new_obj = get_package_obj(&mut client, &published_effects.created, &gas_object_ref)
-        .await
-        .unwrap();
-
-    // Version should be 1 for all modules
-    assert_eq!(new_obj.object().unwrap().version(), OBJECT_START_VERSION);
-    // Must be immutable
-    assert!(new_obj.object().unwrap().is_read_only());
-
-    // StructTag type is not defined for package
-    assert!(new_obj.object().unwrap().type_().is_none());
-
-    // Data should be castable as a package
-    assert!(new_obj.object().unwrap().data.try_as_package().is_some());
+    assert_eq!(response.updated_gas.id(), gas_object_ref.0);
 }
 
 #[tokio::test]
@@ -1570,7 +1498,7 @@ async fn test_object_store() {
     hero_path.push_str("/src/unit_tests/data/hero/");
 
     let compiled_modules = build_move_package_to_bytes(Path::new(&hero_path)).unwrap();
-    let pub_res = client
+    let response = client
         .publish(
             addr1,
             compiled_modules,
@@ -1578,31 +1506,15 @@ async fn test_object_store() {
             GAS_VALUE_FOR_TESTING / 2,
             signature_callback(&key1),
         )
-        .await;
-
-    let (_, published_effects) = pub_res.as_ref().unwrap();
-
-    assert!(matches!(
-        published_effects.status,
-        ExecutionStatus::Success { .. }
-    ));
-
-    // A package obj and two objects resulting from two
-    // initializer runs in different modules should be created.
-    assert_eq!(published_effects.created.len(), 3);
-
-    // Verify gas obj
-    assert_eq!(published_effects.gas_object.0 .0, gas_object_ref.0);
-
-    for (new_obj_ref, _) in &published_effects.created {
-        assert_ne!(gas_object_ref, *new_obj_ref);
-    }
-
-    // find the package object and inspect it
-
-    let _new_obj = get_package_obj(&mut client, &published_effects.created, &gas_object_ref)
         .await
         .unwrap();
+
+    // Two objects resulting from two
+    // initializer runs in different modules should be created.
+    assert_eq!(response.created_objects.len(), 2);
+
+    // Verify gas obj
+    assert_eq!(response.updated_gas.id(), gas_object_ref.0);
 
     // New gas object should be in storage, so 1 new items, plus 3 from before
     // The published package is not in the store because it's not owned by anyone.

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -418,7 +418,7 @@ SuiError:
               TYPENAME: ObjectID
           - err: STR
     23:
-      MissingEalierConfirmations:
+      MissingEarlierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
@@ -487,7 +487,7 @@ SuiError:
     46:
       CannotSendClientMessageError: UNIT
     47:
-      SubscriptionItemsDropedError:
+      SubscriptionItemsDroppedError:
         NEWTYPE: U64
     48:
       SubscriptionServiceClosed: UNIT
@@ -630,9 +630,9 @@ SuiError:
     86:
       TooManyIncorrectAuthorities: UNIT
     87:
-      IncorrectGasSplit: UNIT
-    88:
-      IncorrectGasMerge: UNIT
+      InconsistentGatewayResult:
+        STRUCT:
+          - error: STR
 Transaction:
   STRUCT:
     - data:

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -89,7 +89,7 @@ pub enum SuiError {
     #[error("Object fetch failed for {object_id:?}, err {err:?}.")]
     ObjectFetchFailed { object_id: ObjectID, err: String },
     #[error("Object {object_id:?} at old version: {current_sequence_number:?}")]
-    MissingEalierConfirmations {
+    MissingEarlierConfirmations {
         object_id: ObjectID,
         current_sequence_number: VersionNumber,
     },
@@ -149,12 +149,12 @@ pub enum SuiError {
     TooManyItemsError(u64),
     #[error("The range specified is invalid.")]
     InvalidSequenceRangeError,
-    #[error("No batches mached the range requested.")]
+    #[error("No batches matched the range requested.")]
     NoBatchesFoundError,
     #[error("The channel to repond to the client returned an error.")]
     CannotSendClientMessageError,
     #[error("Subscription service had to drop {0} items")]
-    SubscriptionItemsDropedError(u64),
+    SubscriptionItemsDroppedError(u64),
     #[error("Subscription service closed.")]
     SubscriptionServiceClosed,
 
@@ -258,10 +258,8 @@ pub enum SuiError {
     IncorrectRecipientError,
     #[error("Too many authority errors were detected.")]
     TooManyIncorrectAuthorities,
-    #[error("Inconsistent gas coin split result.")]
-    IncorrectGasSplit,
-    #[error("Inconsistent gas coin merge result.")]
-    IncorrectGasMerge,
+    #[error("Inconsistent results observed in the Gateway. This should not happen and typically means there is a bug in the Sui implementation. Details: {error:?}")]
+    InconsistentGatewayResult { error: String },
 }
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;


### PR DESCRIPTION
Instead of returning raw certificates and effects, `publish` now returns a structured response defined by `PublishResponse`.
This is consistent with the direction we are going (similar to split and join).
