### PR TITLE
[authority] Compute and store `.to_object_reference()` once.

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -200,7 +200,7 @@ impl ClientServerBenchmark {
                 };
 
                 assert!(object.version() == SequenceNumber::from(0));
-                let object_ref = object.to_object_reference();
+                let object_ref = object.compute_object_reference();
                 state.init_transaction_lock(object_ref).await;
                 account_objects.push((address, object.clone(), keypair));
                 state.insert_object(object).await;
@@ -208,7 +208,7 @@ impl ClientServerBenchmark {
                 let gas_object_id = ObjectID::random();
                 let gas_object = Object::with_id_owner_for_testing(gas_object_id, address);
                 assert!(gas_object.version() == SequenceNumber::from(0));
-                let gas_object_ref = gas_object.to_object_reference();
+                let gas_object_ref = gas_object.compute_object_reference();
                 state.init_transaction_lock(gas_object_ref).await;
                 gas_objects.push(gas_object.clone());
                 state.insert_object(gas_object).await;
@@ -221,8 +221,8 @@ impl ClientServerBenchmark {
         let mut transactions: Vec<Bytes> = Vec::new();
         let mut next_recipient: SuiAddress = get_key_pair().0;
         for ((account_addr, object, secret), gas_obj) in account_objects.iter().zip(gas_objects) {
-            let object_ref = object.to_object_reference();
-            let gas_object_ref = gas_obj.to_object_reference();
+            let object_ref = object.compute_object_reference();
+            let gas_object_ref = gas_obj.compute_object_reference();
 
             let data = if self.use_move {
                 // TODO: authority should not require seq# or digets for package in Move calls. Use dummy values

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -287,7 +287,7 @@ async fn make_server_with_genesis_ctx(
 
     for object in preload_objects {
         state
-            .init_transaction_lock(object.to_object_reference())
+            .init_transaction_lock(object.compute_object_reference())
             .await;
         state.insert_object(object.clone()).await;
     }

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -926,8 +926,8 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     let dumy_obj = Object::with_id_owner_for_testing(ObjectID::random(), address);
     // Get the created objects
     let (mut created_obj1, mut created_obj2) = (
-        dumy_obj.to_object_reference(),
-        dumy_obj.to_object_reference(),
+        dumy_obj.compute_object_reference(),
+        dumy_obj.compute_object_reference(),
     );
 
     if let WalletCommandResult::Publish(
@@ -1044,8 +1044,8 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         } else {
             assert!(false);
             (
-                dumy_obj.to_object_reference(),
-                dumy_obj.to_object_reference(),
+                dumy_obj.compute_object_reference(),
+                dumy_obj.compute_object_reference(),
             )
         };
 

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -219,7 +219,7 @@ impl WalletCommands {
                 let gas_object_read = context.gateway.get_object_info(*gas).await?;
                 let gas_object = gas_object_read.object()?;
                 let sender = gas_object.owner.get_owner_address()?;
-                let gas_obj_ref = gas_object.to_object_reference();
+                let gas_obj_ref = gas_object.compute_object_reference();
 
                 let compiled_modules = build_move_package_to_bytes(Path::new(path))?;
                 let (cert, effects) = context
@@ -299,13 +299,13 @@ impl WalletCommands {
                     .get_object_info(*gas)
                     .await?
                     .into_object()?
-                    .to_object_reference();
+                    .compute_object_reference();
 
                 // Fetch the objects for the object args
                 let mut object_args_refs = Vec::new();
                 for obj_id in object_ids {
                     let obj_info = context.gateway.get_object_info(obj_id).await?;
-                    object_args_refs.push(obj_info.object()?.to_object_reference());
+                    object_args_refs.push(obj_info.object()?.compute_object_reference());
                 }
 
                 let (cert, effects) = context

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -599,7 +599,7 @@ impl AuthorityState {
                             // Read only objects have no locks.
                             None
                         } else {
-                            self.get_transaction_lock(&object.to_object_reference())
+                            self.get_transaction_lock(&object.compute_object_reference())
                                 .await?
                         };
                         let layout = match request_layout {

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -350,7 +350,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     /// Insert an object
     pub fn insert_object(&self, object: Object) -> Result<(), SuiError> {
         self.objects.insert(&object.id(), &object)?;
-        let object_ref = object.to_object_reference();
+        let object_ref = object.compute_object_reference();
 
         // Update the index
         if let Some(address) = object.get_single_owner() {

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -309,7 +309,7 @@ impl AccountState {
     pub fn insert_object(&self, object: Object) -> SuiResult {
         self.store
             .objects
-            .insert(&object.to_object_reference(), &object)?;
+            .insert(&object.compute_object_reference(), &object)?;
         Ok(())
     }
 
@@ -319,7 +319,7 @@ impl AccountState {
         option_layout: Option<MoveStructLayout>,
         option_cert: Option<CertifiedTransaction>,
     ) -> SuiResult {
-        let object_ref = object.to_object_reference();
+        let object_ref = object.compute_object_reference();
         let (object_id, _seqnum, _) = object_ref;
 
         self.store.object_refs.insert(&object_id, &object_ref)?;
@@ -616,7 +616,7 @@ where
         while let Some(resp) = receiver.recv().await {
             // Persists them to disk
             if let Ok(o) = resp {
-                err_object_refs.remove(&o.to_object_reference());
+                err_object_refs.remove(&o.compute_object_reference());
                 account.insert_object(o)?;
             }
         }

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -135,7 +135,7 @@ impl<C> SafeClient<C> {
                     // Since we are requesting the latest version, we should validate that if the object's
                     // reference actually match with the one from the responded object reference.
                     fp_ensure!(
-                        object_and_lock.object.to_object_reference() == obj_ref,
+                        object_and_lock.object.compute_object_reference() == obj_ref,
                         SuiError::ByzantineAuthoritySuspicion {
                             authority: self.address
                         }

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -79,8 +79,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
     );
     let (_unknown_address, unknown_key) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone();
@@ -97,13 +97,13 @@ async fn test_handle_transfer_transaction_bad_signature() {
         .unwrap()
         .unwrap();
     assert!(authority_state
-        .get_transaction_lock(&object.to_object_reference())
+        .get_transaction_lock(&object.compute_object_reference())
         .await
         .unwrap()
         .is_none());
 
     assert!(authority_state
-        .get_transaction_lock(&object.to_object_reference())
+        .get_transaction_lock(&object.compute_object_reference())
         .await
         .unwrap()
         .is_none());
@@ -133,8 +133,8 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         unknown_address,
         &unknown_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
     );
 
     assert!(authority_state
@@ -148,13 +148,13 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         .unwrap()
         .unwrap();
     assert!(authority_state
-        .get_transaction_lock(&object.to_object_reference())
+        .get_transaction_lock(&object.compute_object_reference())
         .await
         .unwrap()
         .is_none());
 
     assert!(authority_state
-        .get_transaction_lock(&object.to_object_reference())
+        .get_transaction_lock(&object.compute_object_reference())
         .await
         .unwrap()
         .is_none());
@@ -210,8 +210,8 @@ async fn test_handle_transfer_transaction_ok() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
     );
 
     let test_object = authority_state
@@ -242,7 +242,7 @@ async fn test_handle_transfer_transaction_ok() {
         .unwrap()
         .unwrap();
     let pending_confirmation = authority_state
-        .get_transaction_lock(&object.to_object_reference())
+        .get_transaction_lock(&object.compute_object_reference())
         .await
         .unwrap()
         .unwrap();
@@ -289,7 +289,7 @@ async fn test_transfer_immutable() {
         &sender_key,
         recipient,
         package_object_ref,
-        gas_object.to_object_reference(),
+        gas_object.compute_object_reference(),
     );
     let result = authority_state
         .handle_transaction(transfer_transaction.clone())
@@ -321,14 +321,14 @@ async fn test_handle_transfer_zero_balance() {
     authority_state
         .init_transaction_lock((gas_object_id, 0.into(), gas_object.digest()))
         .await;
-    let gas_object_ref = gas_object.to_object_reference();
+    let gas_object_ref = gas_object.compute_object_reference();
     authority_state.insert_object(gas_object).await;
 
     let transfer_transaction = init_transfer_transaction(
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
+        object.compute_object_reference(),
         gas_object_ref,
     );
 
@@ -395,7 +395,7 @@ async fn test_publish_dependent_module_ok() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
     let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
-    let gas_payment_object_ref = gas_payment_object.to_object_reference();
+    let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // create a genesis state that contains the gas object and genesis modules
     let genesis_module_objects = genesis::clone_genesis_packages();
     let genesis_module = match &genesis_module_objects[0].data {
@@ -448,7 +448,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let gas_seq = SequenceNumber::new();
     let gas_payment_object =
         Object::with_id_owner_gas_for_testing(gas_payment_object_id, gas_seq, sender, gas_balance);
-    let gas_payment_object_ref = gas_payment_object.to_object_reference();
+    let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
 
     let module = file_format::empty_module();
@@ -486,7 +486,7 @@ async fn test_publish_non_existing_dependent_module() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
     let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
-    let gas_payment_object_ref = gas_payment_object.to_object_reference();
+    let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // create a genesis state that contains the gas object and genesis modules
     let genesis_module_objects = genesis::clone_genesis_packages();
     let genesis_module = match &genesis_module_objects[0].data {
@@ -552,7 +552,7 @@ async fn test_publish_module_insufficient_gas() {
         sender,
         gas_balance,
     );
-    let gas_payment_object_ref = gas_payment_object.to_object_reference();
+    let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     let authority = init_state_with_objects(vec![gas_payment_object]).await;
 
     let module = file_format::empty_module();
@@ -626,7 +626,7 @@ async fn test_handle_move_transaction_insufficient_budget() {
     let (sender, sender_key) = get_key_pair();
     let gas_payment_object_id = ObjectID::random();
     let gas_payment_object = Object::with_id_owner_for_testing(gas_payment_object_id, sender);
-    let gas_payment_object_ref = gas_payment_object.to_object_reference();
+    let gas_payment_object_ref = gas_payment_object.compute_object_reference();
     // find the function Object::create and call it to create a new object
     let genesis_package_objects = genesis::clone_genesis_packages();
     let package_object_ref =
@@ -683,8 +683,8 @@ async fn test_handle_transfer_transaction_double_spend() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
     );
 
     let signed_transaction = authority_state
@@ -719,8 +719,8 @@ async fn test_handle_confirmation_transaction_unknown_sender() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
         &authority_state,
     );
 
@@ -772,8 +772,8 @@ async fn test_handle_confirmation_transaction_bad_sequence_number() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
         &authority_state,
     );
 
@@ -835,8 +835,8 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         address,
         &key,
         address,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
         &authority_state,
     );
     let response = authority_state
@@ -883,14 +883,14 @@ async fn test_handle_confirmation_transaction_gas() {
         authority_state
             .init_transaction_lock((gas_object_id, 0.into(), gas_object.digest()))
             .await;
-        let gas_object_ref = gas_object.to_object_reference();
+        let gas_object_ref = gas_object.compute_object_reference();
         authority_state.insert_object(gas_object).await;
 
         let certified_transfer_transaction = init_certified_transfer_transaction(
             sender,
             &sender_key,
             recipient,
-            object.to_object_reference(),
+            object.compute_object_reference(),
             gas_object_ref,
             &authority_state,
         );
@@ -937,8 +937,8 @@ async fn test_handle_confirmation_transaction_ok() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
         &authority_state,
     );
 
@@ -1026,8 +1026,8 @@ async fn test_handle_confirmation_transaction_idempotent() {
         sender,
         &sender_key,
         recipient,
-        object.to_object_reference(),
-        gas_object.to_object_reference(),
+        object.compute_object_reference(),
+        gas_object.compute_object_reference(),
         &authority_state,
     );
 
@@ -1426,7 +1426,7 @@ pub async fn init_state_with_objects<I: IntoIterator<Item = Object>>(objects: I)
     let state = init_state().await;
 
     for o in objects {
-        let obj_ref = o.to_object_reference();
+        let obj_ref = o.compute_object_reference();
         state.insert_object(o).await;
         state.init_transaction_lock(obj_ref).await;
     }
@@ -1481,7 +1481,7 @@ fn get_genesis_package_by_module(genesis_objects: &[Object], module: &str) -> Ob
         .find_map(|o| match o.data.try_as_package() {
             Some(p) => {
                 if p.serialized_module_map().keys().any(|name| name == module) {
-                    Some(o.to_object_reference())
+                    Some(o.compute_object_reference())
                 } else {
                     None
                 }
@@ -1505,7 +1505,7 @@ pub async fn call_move(
     pure_args: Vec<Vec<u8>>,
 ) -> SuiResult<TransactionEffects> {
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
-    let gas_object_ref = gas_object.unwrap().to_object_reference();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut object_args = vec![];
     for id in object_arg_ids {
         object_args.push(
@@ -1514,7 +1514,7 @@ pub async fn call_move(
                 .await
                 .unwrap()
                 .unwrap()
-                .to_object_reference(),
+                .compute_object_reference(),
         );
     }
     let data = TransactionData::new_move_call(
@@ -1599,7 +1599,7 @@ async fn shared_object() {
     // Initialize an authority with a (owned) gas object and a shared object.
     let gas_object_id = ObjectID::random();
     let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    let gas_object_ref = gas_object.to_object_reference();
+    let gas_object_ref = gas_object.compute_object_reference();
 
     let shared_object_id = ObjectID::random();
     let shared_object = {

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -833,7 +833,7 @@ async fn test_move_calls_object_create() {
             .next()
             .unwrap()
             .1
-            .to_object_reference();
+            .compute_object_reference();
 
     // When creating an ObjectBasics object, we provide the value (u64) and address which will own the object
     let pure_args = vec![
@@ -894,7 +894,7 @@ async fn test_move_calls_object_transfer() {
             .next()
             .unwrap()
             .1
-            .to_object_reference();
+            .compute_object_reference();
 
     // When creating an ObjectBasics object, we provide the value (u64) and address which will own the object
     let pure_args = vec![
@@ -984,7 +984,7 @@ async fn test_move_calls_freeze_object() {
             .next()
             .unwrap()
             .1
-            .to_object_reference();
+            .compute_object_reference();
 
     // When creating an ObjectBasics object, we provide the value (u64) and address which will own the object
     let pure_args = vec![
@@ -1073,7 +1073,7 @@ async fn test_move_calls_object_delete() {
             .next()
             .unwrap()
             .1
-            .to_object_reference();
+            .compute_object_reference();
 
     // When creating an ObjectBasics object, we provide the value (u64) and address which will own the object
     let pure_args = vec![
@@ -1173,7 +1173,7 @@ async fn test_module_publish_and_call_good() {
             .next()
             .unwrap()
             .1
-            .to_object_reference();
+            .compute_object_reference();
 
     // Provide path to well formed package sources
     let mut hero_path = env!("CARGO_MANIFEST_DIR").to_owned();
@@ -1250,12 +1250,15 @@ async fn test_module_publish_and_call_good() {
     let call_resp = client
         .move_call(
             addr1,
-            new_obj.object().unwrap().to_object_reference(),
+            new_obj.object().unwrap().compute_object_reference(),
             ident_str!("TrustedCoin").to_owned(),
             ident_str!("mint").to_owned(),
             vec![],
             gas_object_ref,
-            vec![tres_cap_obj_info.object().unwrap().to_object_reference()],
+            vec![tres_cap_obj_info
+                .object()
+                .unwrap()
+                .compute_object_reference()],
             vec![],
             vec![42u64.to_le_bytes().to_vec()],
             1000,
@@ -1299,7 +1302,7 @@ async fn test_module_publish_file_path() {
             .next()
             .unwrap()
             .1
-            .to_object_reference();
+            .compute_object_reference();
 
     // Compile
     let mut hero_path = env!("CARGO_MANIFEST_DIR").to_owned();
@@ -1409,7 +1412,7 @@ async fn test_transfer_object_error() {
     get_account(&client, sender)
         .store()
         .object_refs
-        .insert(&obj.id(), &obj.to_object_reference())
+        .insert(&obj.id(), &obj.compute_object_reference())
         .unwrap();
 
     let result = client
@@ -1533,7 +1536,7 @@ async fn test_object_store() {
             .unwrap()
             .1
             .clone();
-    let gas_object_ref = gas_object.clone().to_object_reference();
+    let gas_object_ref = gas_object.clone().compute_object_reference();
     // Ensure that object store is empty
     assert!(get_account(&client, addr1).store().objects.is_empty());
 
@@ -1740,7 +1743,7 @@ async fn auth_object(authority: &LocalAuthorityClient, object_id: ObjectID) -> (
         .unwrap();
 
     let object = response.object_and_lock.unwrap().object;
-    (object.to_object_reference(), object)
+    (object.compute_object_reference(), object)
 }
 
 #[tokio::test]
@@ -2298,7 +2301,7 @@ async fn test_transfer_pending_transactions() {
     get_account(&client, sender)
         .store()
         .object_refs
-        .insert(&obj.id(), &obj.to_object_reference())
+        .insert(&obj.id(), &obj.compute_object_reference())
         .unwrap();
 
     let result = client

--- a/sui_core/src/unit_tests/move_integration_tests.rs
+++ b/sui_core/src/unit_tests/move_integration_tests.rs
@@ -508,7 +508,7 @@ async fn build_and_publish_test_package(
         .collect();
 
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
-    let gas_object_ref = gas_object.unwrap().to_object_reference();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
     let data = TransactionData::new_module(*sender, gas_object_ref, all_module_bytes, MAX_GAS);
     let signature = Signature::new(&data, &*sender_key);

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -356,7 +356,7 @@ impl Object {
         matches!(&self.data, Data::Package(_))
     }
 
-    pub fn to_object_reference(&self) -> ObjectRef {
+    pub fn compute_object_reference(&self) -> ObjectRef {
         (self.id(), self.version(), self.digest())
     }
 

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -231,7 +231,7 @@ fn test_info_response() {
             layout: None,
         }),
         parent_certificate: None,
-        requested_object_reference: Some(object.to_object_reference()),
+        requested_object_reference: Some(object.compute_object_reference()),
     };
     let resp2 = resp1.clone();
     let resp3 = resp1.clone();


### PR DESCRIPTION
We used co call `.to_object_reference()` over and over again as part of certificate processing. Now we do it once upon inserting an object into the temporary store, and re-use it elsewhere.