### PR TITLE
Move authority_store and temp store to sui_types

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -16,6 +16,7 @@ use sui_adapter::genesis;
 use sui_core::{authority::*, authority_server::AuthorityServer};
 use sui_network::{network::NetworkClient, transport};
 use sui_types::crypto::{get_key_pair, AuthoritySignature, Signature};
+use sui_types::datastore::AuthorityStore;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::{base_types::*, committee::*, messages::*, object::Object, serialize::*};
 use tokio::runtime::Runtime;

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -10,11 +10,12 @@ use futures::future::join_all;
 use move_binary_format::CompiledModule;
 use move_package::BuildConfig;
 use structopt::StructOpt;
+use sui_types::datastore::AuthorityStore;
 use tracing::{error, info};
 
 use sui_adapter::adapter::generate_package_id;
 use sui_adapter::genesis;
-use sui_core::authority::{AuthorityState, AuthorityStore};
+use sui_core::authority::AuthorityState;
 use sui_core::authority_server::AuthorityServer;
 use sui_types::base_types::{SequenceNumber, TxContext};
 use sui_types::committee::Committee;

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -15,7 +15,6 @@ rand = "0.7.3"
 bytes = "1.1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1.17.0", features = ["full"] }
-parking_lot = "0.12.0"
 itertools = "0.10.3"
 async-trait = "0.1.52"
 tempfile = "3.3.0"

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -4,13 +4,10 @@
 
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::module_cache::ModuleCache;
-use move_core_types::{
-    language_storage::{ModuleId, StructTag},
-    resolver::{ModuleResolver, ResourceResolver},
-};
+use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
     pin::Pin,
     sync::Arc,
 };
@@ -20,11 +17,11 @@ use sui_types::{
     batch::UpdateItem,
     committee::Committee,
     crypto::AuthoritySignature,
+    datastore::{AuthorityStore, AuthorityTemporaryStore},
     error::{SuiError, SuiResult},
-    fp_bail, fp_ensure, gas,
+    fp_ensure, gas,
     messages::*,
-    object::{Data, Object, Owner},
-    storage::{BackingPackageStore, DeleteKind, Storage},
+    object::{Object, Owner},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 use tracing::*;
@@ -41,12 +38,6 @@ pub mod authority_tests;
 #[cfg(test)]
 #[path = "unit_tests/move_integration_tests.rs"]
 pub mod move_integration_tests;
-
-mod temporary_store;
-pub use temporary_store::AuthorityTemporaryStore;
-
-mod authority_store;
-pub use authority_store::AuthorityStore;
 
 // based on https://github.com/diem/move/blob/62d48ce0d8f439faa83d05a4f5cd568d4bfcb325/language/tools/move-cli/src/sandbox/utils/mod.rs#L50
 const MAX_GAS_BUDGET: u64 = 18446744073709551615 / 1000 - 1;

--- a/sui_core/src/authority_batch.rs
+++ b/sui_core/src/authority_batch.rs
@@ -1,10 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::{AuthorityStore, StableSyncAuthoritySigner};
+use crate::authority::StableSyncAuthoritySigner;
 use std::sync::Arc;
 use sui_types::base_types::*;
 use sui_types::batch::*;
+use sui_types::datastore::AuthorityStore;
 use sui_types::error::{SuiError, SuiResult};
 
 use std::collections::BTreeMap;

--- a/sui_core/src/execution_engine.rs
+++ b/sui_core/src/execution_engine.rs
@@ -3,16 +3,15 @@
 
 use std::sync::Arc;
 
-use crate::authority::AuthorityTemporaryStore;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 use sui_adapter::adapter;
 use sui_types::{
     base_types::{SuiAddress, TxContext},
+    datastore::{AuthorityTemporaryStore, BackingPackageStore, Storage},
     error::{SuiError, SuiResult},
     gas,
     messages::{ExecutionStatus, Transaction, TransactionKind},
     object::Object,
-    storage::{BackingPackageStore, Storage},
 };
 
 pub fn execute_transaction<S: BackingPackageStore>(

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -17,10 +17,10 @@ use sui_types::{
     crypto::{get_key_pair, Signature},
     gas::{calculate_module_publish_cost, get_gas_balance},
     messages::Transaction,
-    object::{GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
+    object::{Data, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
 };
 
-use std::fs;
+use std::{collections::BTreeMap, fs};
 use std::{convert::TryInto, env};
 
 pub fn system_maxfiles() -> usize {

--- a/sui_core/src/unit_tests/client_tests.rs
+++ b/sui_core/src/unit_tests/client_tests.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::same_item_push)] // get_key_pair returns random elements
 
 use super::*;
-use crate::authority::{AuthorityState, AuthorityStore};
+use crate::authority::AuthorityState;
 use crate::gateway_state::gateway_store::AccountStore;
 use crate::gateway_state::{
     AccountState, AsyncTransactionSigner, GatewayAPI, GatewayState, StableSyncTransactionSigner,
@@ -21,6 +21,7 @@ use sui_adapter::genesis;
 use sui_framework::build_move_package_to_bytes;
 use sui_types::crypto::Signature;
 use sui_types::crypto::{get_key_pair, KeyPair};
+use sui_types::datastore::AuthorityStore;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{Data, Object, Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION};
 use typed_store::Map;

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -8,6 +8,7 @@ use move_binary_format::{errors::PartialVMResult, file_format::CompiledModule};
 use sui_framework::EventType;
 use sui_types::{
     base_types::*,
+    datastore::{DeleteKind, Storage},
     error::{SuiError, SuiResult},
     event::Event,
     gas,
@@ -15,7 +16,6 @@ use sui_types::{
     messages::ExecutionStatus,
     move_package::*,
     object::{MoveObject, Object, Owner},
-    storage::{DeleteKind, Storage},
 };
 use sui_verifier::verifier;
 

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -12,10 +12,10 @@ use std::{mem, path::PathBuf};
 use sui_types::{
     base_types::{self, SequenceNumber},
     crypto::get_key_pair,
+    datastore::{BackingPackageStore, Storage},
     error::SuiResult,
     gas_coin::GAS,
     object::{Data, Owner},
-    storage::{BackingPackageStore, Storage},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -19,11 +19,14 @@ serde-name = "0.2.0"
 sha3 = "0.9"
 thiserror = "1.0.30"
 hex = "0.4.3"
+parking_lot = "0.12.0"
+rocksdb = "0.18.0"
 serde_bytes = "0.11.5"
 serde_json = "1.0.79"
 serde_with = "1.12.0"
 signature = "1.5.0"
 static_assertions = "1.1.0"
+tracing = { version = "0.1.31", features = ["log"] }
 
 name_variant = { git = "https://github.com/MystenLabs/mysten-infra", rev ="97a056f85555fa2afe497d6abb7cf6bf8faa63cf"}
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="97a056f85555fa2afe497d6abb7cf6bf8faa63cf"}

--- a/sui_types/src/datastore.rs
+++ b/sui_types/src/datastore.rs
@@ -10,6 +10,12 @@ use crate::{
     object::Object,
 };
 
+mod sui_store;
+pub use sui_store::AuthorityStore;
+
+mod temporary_store;
+pub use temporary_store::AuthorityTemporaryStore;
+
 #[derive(Debug, PartialEq)]
 pub enum DeleteKind {
     /// An object is provided in the call input, and gets deleted.

--- a/sui_types/src/datastore/sui_store.rs
+++ b/sui_types/src/datastore/sui_store.rs
@@ -2,14 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
+use move_core_types::language_storage::ModuleId;
+use move_core_types::resolver::ModuleResolver;
 use rocksdb::Options;
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::path::Path;
 use std::sync::atomic::AtomicU64;
 
-use sui_types::base_types::SequenceNumber;
-use sui_types::batch::{SignedBatch, TxSequenceNumber};
+use crate::base_types::{ObjectDigest, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
+use crate::batch::{SignedBatch, TxSequenceNumber};
+use crate::error::SuiError;
+use crate::messages::{
+    CertifiedTransaction, SignedTransaction, SignedTransactionEffects, Transaction,
+    TransactionInfoResponse,
+};
 use tracing::warn;
 use typed_store::rocks::{open_cf, DBBatch, DBMap};
 

--- a/sui_types/src/datastore/temporary_store.rs
+++ b/sui_types/src/datastore/temporary_store.rs
@@ -1,9 +1,27 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use move_core_types::account_address::AccountAddress;
-use sui_types::event::Event;
 
-use super::*;
+use crate::{
+    base_types::{
+        AuthorityName, ObjectDigest, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
+    },
+    crypto::AuthoritySignature,
+    error::SuiError,
+    event::Event,
+    messages::{ExecutionStatus, SignedTransactionEffects, TransactionEffects},
+    object::{Data, Object},
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+    resolver::{ModuleResolver, ResourceResolver},
+};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
+
+use super::{BackingPackageStore, DeleteKind, Storage};
 
 pub type InnerTemporaryStore = (
     BTreeMap<ObjectID, Object>,

--- a/sui_types/src/lib.rs
+++ b/sui_types/src/lib.rs
@@ -18,6 +18,7 @@ pub mod batch;
 pub mod coin;
 pub mod committee;
 pub mod crypto;
+pub mod datastore;
 pub mod event;
 pub mod gas;
 pub mod gas_coin;
@@ -26,7 +27,6 @@ pub mod messages;
 pub mod move_package;
 pub mod object;
 pub mod serialize;
-pub mod storage;
 
 /// 0x1-- account address where Move stdlib modules are stored
 /// Same as the ObjectID


### PR DESCRIPTION
The stores will be shared by other components such as the gateway and replica. It's no longer a part of authority.
Moving them to sui_types under datastore directory.