### PR TITLE
[framework] use NFT<T> standard in cross-chain airdrop

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -167,10 +167,14 @@ async fn test_cross_chain_airdrop() -> Result<(), anyhow::Error> {
     let token = airdrop_call_move_and_get_created_object(args, gas_object_id, &mut context).await?;
 
     // Verify the airdrop token
-    assert_eq!(token["contents"]["type"], ("0x2::CrossChainAirdrop::NFT"));
-    let fields = &token["contents"]["fields"];
     assert_eq!(
-        fields["source_token_id"]["fields"]["id"],
+        token["contents"]["type"],
+        ("0x2::NFT::NFT<0x2::CrossChainAirdrop::ERC721>")
+    );
+    let nft_data = &token["contents"]["fields"]["data"];
+    let erc721_metadata = &nft_data["fields"]["metadata"];
+    assert_eq!(
+        erc721_metadata["fields"]["token_id"]["fields"]["id"],
         AIRDROP_SOURCE_TOKEN_ID
     );
 

--- a/sui_programmability/framework/sources/ERC721Metadata.move
+++ b/sui_programmability/framework/sources/ERC721Metadata.move
@@ -1,0 +1,55 @@
+module Sui::ERC721Metadata {
+    use Std::ASCII;
+    use Sui::Url::{Self, Url};
+    use Sui::UTF8;
+
+    // TODO: add symbol()?
+    /// A wrapper type for the ERC721 metadata standard https://eips.ethereum.org/EIPS/eip-721
+    struct ERC721Metadata has store {       
+        /// The token id associated with the source contract on Ethereum
+        token_id: TokenID,
+        /// A descriptive name for a collection of NFTs in this contract. 
+        /// This corresponds to the `name()` method in the
+        /// ERC721Metadata interface in EIP-721.
+        name: UTF8::String,        
+        /// A distinct Uniform Resource Identifier (URI) for a given asset.
+        /// This corresponds to the `tokenURI()` method in the ERC721Metadata 
+        /// interface in EIP-721.
+        token_uri: Url,    
+    }
+
+    // TODO: replace u64 with u256 once the latter is supported
+    // <https://github.com/MystenLabs/fastnft/issues/618>
+    /// An ERC721 token ID
+    struct TokenID has store, copy {
+        id: u64,
+    }
+
+    /// Construct a new ERC721Metadata from the given inputs. Does not perform any validation
+    /// on `token_uri` or `name`
+    public fun new(token_id: TokenID, name: vector<u8>, token_uri: vector<u8>): ERC721Metadata {
+        // Note: this will abort if `token_uri` is not valid ASCII
+        let uri_str = ASCII::string(token_uri);
+        ERC721Metadata { 
+            token_id,
+            name: UTF8::string_unsafe(name),
+            token_uri: Url::new_unsafe(uri_str),
+        }
+    }
+
+    public fun new_token_id(id: u64): TokenID {
+        TokenID { id }
+    }
+
+    public fun token_id(self: &ERC721Metadata): &TokenID {
+        &self.token_id
+    }
+
+    public fun token_uri(self: &ERC721Metadata): &Url {
+        &self.token_uri
+    }
+
+    public fun name(self: &ERC721Metadata): &UTF8::String {
+        &self.name
+    }
+}

--- a/sui_programmability/framework/sources/NFT.move
+++ b/sui_programmability/framework/sources/NFT.move
@@ -3,17 +3,17 @@ module Sui::NFT {
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
 
-    /// An ERC721-like non-fungible token with mutable custom metadata.
-    /// The custom metadata must be provided by a separate module instantiating
+    /// An ERC721-like non-fungible token with mutable custom data.
+    /// The custom data must be provided by a separate module instantiating
     /// this struct with a particular `T`. We will henceforth refer to the author
     /// of this module as "the creator".
     struct NFT<T: store> has key, store {
         id: VersionedID,
         /// Mutable custom metadata to be defined elsewhere
-        metadata: T,
+        data: T,
     }
 
-    /// Create a new NFT with the given metadata.
+    /// Create a new NFT with the given data.
     /// It is the creator's responsibility to restrict access
     /// to minting. The recommended mechanism for this is to restrict
     /// the ability to mint a value of type `T`--e.g., if the
@@ -21,9 +21,9 @@ module Sui::NFT {
     /// the code for creating `T` should maintain a counter to
     /// enforce this.
     public fun mint<T: store>(
-        metadata: T, ctx: &mut TxContext
+        data: T, ctx: &mut TxContext
     ): NFT<T> {
-        NFT { id: TxContext::new_id(ctx), metadata }
+        NFT { id: TxContext::new_id(ctx), data }
     }
 
     /// Burn `nft` and return its medatada.
@@ -34,9 +34,9 @@ module Sui::NFT {
     /// burn fee of 10 coins, the code for collecting this
     /// fee should gate the destruction of `T`.
     public fun burn<T: store>(nft: NFT<T>): T {
-        let NFT { id, metadata } = nft;
+        let NFT { id, data } = nft;
         ID::delete(id);
-        metadata
+        data
     }
 
     /// Send NFT to `recipient`
@@ -44,19 +44,19 @@ module Sui::NFT {
         Transfer::transfer(nft, recipient)
     }
 
-    /// Get an immutable reference to `nft`'s metadata
-    public fun metadata<T: store>(nft: &NFT<T>): &T {
-        &nft.metadata
+    /// Get an immutable reference to `nft`'s data
+    public fun data<T: store>(nft: &NFT<T>): &T {
+        &nft.data
     }
 
-    /// Get a mutable reference to `nft`'s metadata.
-    /// If the creator wishes for the metadata to be immutable or
+    /// Get a mutable reference to `nft`'s data.
+    /// If the creator wishes for the data to be immutable or
     /// enforce application-specific mutability policies on the
     /// `T`, the recommended mechanism for this is to
     /// - (1) avoid giving `T` the `drop` ability
     /// - (2) enforce the policy inside the module that defines `T`
     /// on a field-by-field basis.
-    public fun metadata_mut<T: store>(nft: &mut NFT<T>): &mut T {
-        &mut nft.metadata
+    public fun data_mut<T: store>(nft: &mut NFT<T>): &mut T {
+        &mut nft.data
     }
 }

--- a/sui_programmability/framework/sources/UTF8.move
+++ b/sui_programmability/framework/sources/UTF8.move
@@ -1,0 +1,37 @@
+module Sui::UTF8 {
+    use Std::ASCII;
+    use Std::Option::Option;
+
+    /// Wrapper type that should be interpreted as a UTF8 string by clients
+    struct String has store, copy, drop {
+        bytes: vector<u8>
+    }
+
+    // TODO: also include validating constructor
+    /// Construct a UTF8 string from `bytes`. Does not
+    /// perform any validation
+    public fun string_unsafe(bytes: vector<u8>): String {
+        String { bytes }
+    }
+
+    /// Construct a UTF8 string from the ASCII string `s`
+    public fun from_ascii(s: ASCII::String): String {
+        String { bytes: ASCII::into_bytes(s) }
+    }
+
+    /// Try to convert `self` to an ASCCI string
+    public fun try_into_ascii(self: String): Option<ASCII::String> {
+        ASCII::try_string(self.bytes)
+    }
+
+    /// Return the underyling bytes of `self`
+    public fun bytes(self: &String): &vector<u8> {
+        &self.bytes
+    }
+
+    /// Consume `self` and return its underlying bytes
+    public fun into_bytes(self: String): vector<u8> {
+        let String { bytes } = self;
+        bytes
+    }
+}

--- a/sui_programmability/framework/sources/Url.move
+++ b/sui_programmability/framework/sources/Url.move
@@ -29,7 +29,7 @@ module Sui::Url {
     // === constructors ===
 
     /// Create a `Url`, with no validation
-    public fun new_unsafe_url(url: String): Url {
+    public fun new_unsafe(url: String): Url {
         Url { url }
     }
 

--- a/sui_programmability/framework/tests/CrossChainAirdropTests.move
+++ b/sui_programmability/framework/tests/CrossChainAirdropTests.move
@@ -3,7 +3,8 @@
 
 #[test_only]
 module Sui::CrossChainAirdropTests {
-    use Sui::CrossChainAirdrop::{Self, CrossChainAirdropOracle, NFT};
+    use Sui::CrossChainAirdrop::{Self, CrossChainAirdropOracle, ERC721};
+    use Sui::NFT::NFT;
     use Sui::ID::{VersionedID};
     use Sui::TestScenario::{Self, Scenario};
 
@@ -77,6 +78,6 @@ module Sui::CrossChainAirdropTests {
     fun owns_object(scenario: &mut Scenario, owner: &address): bool{
         // Verify the token has been transfer to the recipient
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_remove_object<NFT>(scenario)
+        TestScenario::can_remove_object<NFT<ERC721>>(scenario)
     }
 }

--- a/sui_programmability/framework/tests/UrlTests.move
+++ b/sui_programmability/framework/tests/UrlTests.move
@@ -11,7 +11,7 @@ module Sui::UrlTests {
         // url strings are not currently validated
         let url_str = ASCII::string(x"414243454647");
 
-        let url = Url::new_unsafe_url(url_str);
+        let url = Url::new_unsafe(url_str);
         assert!(Url::inner_url(&url) == url_str, URL_STRING_MISMATCH);
     }
 
@@ -23,7 +23,7 @@ module Sui::UrlTests {
         // length too short
         let hash = x"badf012345";
 
-        let url = Url::new_unsafe_url(url_str);
+        let url = Url::new_unsafe(url_str);
         let _ = Url::new_unsafe_url_commitment(url, hash);
     }
 
@@ -34,7 +34,7 @@ module Sui::UrlTests {
         // 32 bytes
         let hash = x"1234567890123456789012345678901234567890abcdefabcdefabcdefabcdef";
 
-        let url = Url::new_unsafe_url(url_str);
+        let url = Url::new_unsafe(url_str);
         let url_commit = Url::new_unsafe_url_commitment(url, hash);
 
         assert!(Url::url_commitment_resource_hash(&url_commit) == hash, EHASH_LENGTH_MISMATCH);


### PR DESCRIPTION
- Introduce `UTF8` string type
- Pull out `ERC721Metadata` into its own type with more structure (uses `UTF8` + `Url` where appropriate)
- Use `NFT<T>` in `CrossChainAirdrop`