### PR TITLE
Fix reversed AuthorityStore ALL_OBJ_VER flag

### DIFF
--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -16,9 +16,9 @@ use typed_store::rocks::{open_cf, DBBatch, DBMap};
 use std::sync::atomic::Ordering;
 use typed_store::{reopen, traits::Map};
 
-pub type AuthorityStore = SuiDataStore<true>;
+pub type AuthorityStore = SuiDataStore<false>;
 #[allow(dead_code)]
-pub type ReplicaStore = SuiDataStore<false>;
+pub type ReplicaStore = SuiDataStore<true>;
 
 /// ALL_OBJ_VER determines whether we want to store all past
 /// versions of every object in the store. Authority doesn't store


### PR DESCRIPTION
oops.
AuthorityStore should not store all versions of objects.
This fix might improve benchmark perf as well?