### PR TITLE
Remove nightly build from github action to unblock PRs due to ICE bug in rust 1.61.0-nightly 

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly]
+        toolchain: [stable]
         os: [ubuntu]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There are a few issues opened in rust repo

https://github.com/rust-lang/rust/issues/94998
https://github.com/rust-lang/rust/issues/95001
https://github.com/rust-lang/rust/issues/94986