### PR TITLE
Use address in the wallet config for module initialization during genesis

### DIFF
--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -205,7 +205,12 @@ pub async fn genesis(
     let sui_lib = sui_framework::get_sui_framework_modules(&genesis_conf.sui_framework_lib_path)?;
     preload_modules.push(sui_lib);
 
-    let mut genesis_ctx = genesis::get_genesis_context();
+    // TODO: allow custom address to be used after the Gateway refactoring
+    // Default to use the last address in the wallet config for initializing modules.
+    // If there's no address in wallet config, then use 0x0
+    let null_address = SuiAddress::default();
+    let module_init_address = addresses.last().unwrap_or(&null_address);
+    let mut genesis_ctx = genesis::get_genesis_context_with_custom_address(module_init_address);
     // Build custom move packages
     if !genesis_conf.move_packages.is_empty() {
         info!(

--- a/sui/src/unit_tests/data/custom_genesis_package_2/sources/M1.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_2/sources/M1.move
@@ -7,11 +7,10 @@ module Test::M1 {
         id: VersionedID,
         value: u64,
     }
-    const ADMIN: address = @0xa5e6dbcf33730ace6ec8b400ff4788c1f150ff7e;
 
     // initializer that should be executed upon publishing this module
     fun init(ctx: &mut TxContext) {
         let singleton = Object { id: TxContext::new_id(ctx), value: 12 };
-        Transfer::transfer(singleton, ADMIN)
+        Transfer::transfer(singleton, TxContext::sender(ctx))
     }
 }

--- a/sui_programmability/adapter/src/genesis.rs
+++ b/sui_programmability/adapter/src/genesis.rs
@@ -30,7 +30,11 @@ pub fn clone_genesis_packages() -> Vec<Object> {
 }
 
 pub fn get_genesis_context() -> TxContext {
-    TxContext::new(&SuiAddress::default(), TransactionDigest::genesis())
+    get_genesis_context_with_custom_address(&SuiAddress::default())
+}
+
+pub fn get_genesis_context_with_custom_address(address: &SuiAddress) -> TxContext {
+    TxContext::new(address, TransactionDigest::genesis())
 }
 
 /// Create and return objects wrapping the genesis modules for sui

--- a/sui_programmability/framework/sources/CrossChainAirdrop.move
+++ b/sui_programmability/framework/sources/CrossChainAirdrop.move
@@ -46,10 +46,6 @@ module Sui::CrossChainAirdrop {
         metadata: ERC721Metadata,
     }
 
-    /// Address of the Oracle
-    // TODO: Change this to something else before testnet launch
-    const ORACLE_ADDRESS: address = @0xCEF1A51D2AA1226E54A1ACB85CFC58A051125A49;
-
     // Error codes
 
     /// Trying to claim a token that has already been claimed
@@ -57,13 +53,12 @@ module Sui::CrossChainAirdrop {
 
     /// Create the `Orcacle` capability and hand it off to the oracle
     fun init(ctx: &mut TxContext) {
-        let oracle = oracle_address();
         Transfer::transfer(
             CrossChainAirdropOracle {
                 id: TxContext::new_id(ctx),
                 managed_contracts: Vector::empty(),
             },
-            oracle
+            TxContext::sender(ctx)
         )
     }
 
@@ -127,10 +122,6 @@ module Sui::CrossChainAirdrop {
             index = index + 1;
         };
         false
-    }
-
-    public fun oracle_address(): address {
-        ORACLE_ADDRESS
     }
 
     #[test_only]

--- a/sui_programmability/framework/tests/CrossChainAirdropTests.move
+++ b/sui_programmability/framework/tests/CrossChainAirdropTests.move
@@ -14,6 +14,7 @@ module Sui::CrossChainAirdropTests {
     const ETOKEN_ID_CLAIMED: u64 = 0;
     const EOBJECT_NOT_FOUND: u64 = 1;
 
+    const ORACLE_ADDRESS: address = @0x1000;
     const RECIPIENT_ADDRESS: address = @0x10;
     const SOURCE_CONTRACT_ADDRESS: vector<u8> = x"BC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
     const SOURCE_TOKEN_ID: u64 = 101;
@@ -48,13 +49,12 @@ module Sui::CrossChainAirdropTests {
     }
 
     fun init(): (Scenario, address) {
-        let oracle_address = CrossChainAirdrop::oracle_address();
-        let scenario = TestScenario::begin(&oracle_address);
+        let scenario = TestScenario::begin(&ORACLE_ADDRESS);
         {
             let ctx = TestScenario::ctx(&mut scenario);
             CrossChainAirdrop::test_init(ctx);
         };
-        (scenario, oracle_address)
+        (scenario, ORACLE_ADDRESS)
     }
 
     fun claim_token(scenario: &mut Scenario, oracle_address: &address, token_id: u64) {


### PR DESCRIPTION
## Problem

The oracle object for `SuiEcho` needs to be transferred to some trusted address during module initialization in genesis
https://github.com/MystenLabs/sui/blob/03d1e844f6744c566c0d8d358d44287aee4c0315/sui_programmability/framework/sources/CrossChainAirdrop.move#L59-L68

Right now we are using a hardcoded address, and this presents a few problems:
1. To be able to test the flow in Rust, we need to [expose](https://github.com/MystenLabs/sui/blob/03d1e844f6744c566c0d8d358d44287aee4c0315/sui/src/unit_tests/cli_tests.rs#L216-L220) the private key of this address
2. At the moment, the REST server owns the wallet([subject](https://docs.google.com/document/d/1kw224Dvj0t9HtlhELSUuyfqaf3scwM3Vkpk3uwD9oqs/edit#heading=h.f8xk33cvqmo0) to change), and it's unsafe to transmit the private key of this oracle address from the oracle server to the REST server over the network.

## Solution
We will transfer the oracle object to the address that initializes the modules during genesis. The question is what should this genesis address be?

Right now this address is default to be "0x00...000". This PR replaces it with the last address in the wallet config so that the oracle object can be transferred to an address controlled by the wallet. This is a simple but temporary solution that unblocks GDC. 

After we are done with the migration to manage keys on client(as opposed to the REST server), the client should specify the address they want to use for initializing modules when calling `/genesis`




