### PR TITLE
Support Batch Transaction

### DIFF
--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -76,7 +76,6 @@ impl SuiCommand {
                 } else {
                     GenesisConfig::default_genesis(working_dir)?
                 };
-
                 let (network_config, accounts, keystore) = genesis(genesis_conf).await?;
                 info!("Network genesis completed.");
                 let network_config = network_config.persisted(&network_path);

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -39,6 +39,10 @@ use crate::{
 pub mod authority_tests;
 
 #[cfg(test)]
+#[path = "unit_tests/batch_transaction_tests.rs"]
+mod batch_transaction_tests;
+
+#[cfg(test)]
 #[path = "unit_tests/move_integration_tests.rs"]
 pub mod move_integration_tests;
 
@@ -158,16 +162,6 @@ impl AuthorityState {
                     }
                 );
 
-                // If the object is the transfer object, check that it is not shared object.
-                if let TransactionKind::Transfer(t) = &transaction.data.kind {
-                    if object_kind.object_id() == t.object_ref.0 {
-                        fp_ensure!(
-                            matches!(object.owner, Owner::AddressOwner(..)),
-                            SuiError::TransferSharedError
-                        );
-                    }
-                }
-
                 match object.owner {
                     Owner::SharedImmutable => {
                         // Nothing else to check for SharedImmutable.
@@ -191,7 +185,9 @@ impl AuthorityState {
                         );
                     }
                     Owner::SharedMutable => {
-                        return Err(SuiError::UnsupportedSharedObjectError);
+                        // This object is a mutable shared object. However the transaction
+                        // specifies it as an owned object. This is inconsistent.
+                        return Err(SuiError::NotSharedObjectError);
                     }
                 };
             }
@@ -203,23 +199,58 @@ impl AuthorityState {
         Ok(())
     }
 
+    /// This function does 3 things:
+    /// 1. Check if the gas object has enough balance to pay for this transaction.
+    ///   Since the transaction may be a batch transaction, we need to walk through
+    ///   each single transaction in it and accumulate their gas cost. For Move call
+    ///   and publish we can simply use their budget, for transfer we will calculate
+    ///   the cost on the spot since it's deterministic (See comments inside the function).
+    /// 2. Check if the gas budget for each single transction is above some minimum amount.
+    ///   This can help reduce DDos attacks.
+    /// 3. Check that the objects used in transfers are mutable. We put the check here
+    ///   because this is the most convenient spot to check.
     fn check_gas_requirement(
         transaction: &Transaction,
         input_objects: &[(InputObjectKind, Object)],
     ) -> SuiResult {
-        // The last object in the input objects is always the gas object by construction.
-        let gas_object = &input_objects[input_objects.len() - 1].1;
-        match &transaction.data.kind {
-            TransactionKind::Transfer(_) => {
-                // The first object in the input objects is always the transfer object by construction.
-                let transfer_object = &input_objects[0].1;
-                gas::check_transfer_gas_requirement(gas_object, transfer_object)
-            }
-            TransactionKind::Call(op) => gas::check_move_gas_requirement(gas_object, op.gas_budget),
-            TransactionKind::Publish(op) => {
-                gas::check_move_gas_requirement(gas_object, op.gas_budget)
+        let mut total_cost = 0;
+        let mut idx = 0;
+        for tx in transaction.single_transactions() {
+            match tx {
+                SingleTransactionKind::Transfer(_) => {
+                    // Index access safe because the inputs were constructed in order.
+                    let transfer_object = &input_objects[idx].1;
+                    fp_ensure!(
+                        !transfer_object.is_read_only(),
+                        SuiError::TransferImmutableError
+                    );
+                    // TODO: Make Transfer transaction to also contain gas_budget.
+                    // By @gdanezis: Now his is the only part of this function that requires
+                    // an input object besides the gas object. It would be a major win if we
+                    // can get rid of the requirement to have all objects to check the transfer
+                    // requirement. If we can go this, then we could execute this check before
+                    // we check for signatures.
+                    // This would allow us to shore up out DoS defences: we only need to do a
+                    // read on the gas object balance before we do anything expensive,
+                    // such as checking signatures.
+                    total_cost += gas::calculate_object_transfer_cost(transfer_object);
+                    idx += tx.input_object_count();
+                }
+                SingleTransactionKind::Call(op) => {
+                    gas::check_move_gas_requirement(op.gas_budget)?;
+                    total_cost += op.gas_budget;
+                    idx += tx.input_object_count();
+                }
+                SingleTransactionKind::Publish(op) => {
+                    gas::check_move_gas_requirement(op.gas_budget)?;
+                    total_cost += op.gas_budget;
+                    // No need to update idx because Publish cannot show up in batch.
+                }
             }
         }
+        // The last element in the inputs is always gas object.
+        let gas_object = &input_objects.last().unwrap().1;
+        gas::check_gas_balance(gas_object, total_cost)
     }
 
     /// Check all the objects used in the transaction against the database, and ensure
@@ -228,17 +259,34 @@ impl AuthorityState {
         &self,
         transaction: &Transaction,
     ) -> Result<Vec<(InputObjectKind, Object)>, SuiError> {
-        let input_objects = transaction.input_objects();
+        let input_objects = transaction.input_objects()?;
 
         // These IDs act as authenticators that can own other objects.
         let objects = self.fetch_objects(&input_objects).await?;
-        let owned_object_authenticators: HashSet<_> = objects
-            .iter()
-            .flat_map(|opt_obj| match opt_obj {
-                Some(obj) if !obj.is_read_only() => Some(obj.id().into()),
-                _ => None,
-            })
-            .collect();
+
+        // Constructing the list of objects that could be used to authenticate other
+        // objects. Any mutable object (either shared or owned) can be used to
+        // authenticate other objects. Hence essentially we are building the list
+        // of mutable objects.
+        // We require that mutable objects cannot show up more than once.
+        // In [`SingleTransactionKind::input_objects`] we checked that there is no
+        // duplicate objects in the same SingleTransactionKind. However for a Batch
+        // Transaction, we still need to make sure that the same mutable object don't show
+        // up in more than one SingleTransactionKind.
+        // TODO: We should be able to allow the same shared mutable object to show up
+        // in more than one SingleTransactionKind. We need to ensure that their
+        // version number only increases once at the end of the Batch execution.
+        let mut owned_object_authenticators: HashSet<SuiAddress> = HashSet::new();
+        for object in objects.iter().flatten() {
+            if !object.is_read_only() {
+                fp_ensure!(
+                    owned_object_authenticators.insert(object.id().into()),
+                    SuiError::InvalidBatchTransaction {
+                        error: format!("Mutable object {} cannot appear in more than one single transactions in a batch", object.id()),
+                    }
+                );
+            }
+        }
 
         // Gather all objects and errors.
         let mut all_objects = Vec::with_capacity(input_objects.len());
@@ -252,7 +300,6 @@ impl AuthorityState {
                     continue;
                 }
             };
-
             // Check if the object contents match the type of lock we need for
             // this object.
             match self.check_one_lock(
@@ -267,17 +314,13 @@ impl AuthorityState {
                 }
             }
         }
-
         // If any errors with the locks were detected, we return all errors to give the client
         // a chance to update the authority if possible.
         if !errors.is_empty() {
             return Err(SuiError::LockErrors { errors });
         }
-
         fp_ensure!(!all_objects.is_empty(), SuiError::ObjectInputArityViolation);
-
         Self::check_gas_requirement(transaction, &all_objects)?;
-
         Ok(all_objects)
     }
 
@@ -285,17 +328,6 @@ impl AuthorityState {
         &self,
         input_objects: &[InputObjectKind],
     ) -> Result<Vec<Option<Object>>, SuiError> {
-        // There is at least one input
-        fp_ensure!(
-            !input_objects.is_empty(),
-            SuiError::ObjectInputArityViolation
-        );
-        // Ensure that there are no duplicate inputs
-        let mut used = HashSet::new();
-        if !input_objects.iter().all(|o| used.insert(o.object_id())) {
-            return Err(SuiError::DuplicateObjectRefInput);
-        }
-
         let ids: Vec<_> = input_objects.iter().map(|kind| kind.object_id()).collect();
 
         self.get_objects(&ids[..]).await
@@ -452,7 +484,7 @@ impl AuthorityState {
         let transaction_digest = *certificate.digest();
         let transaction = &certificate.transaction;
 
-        let objects_by_kind: Vec<_> = self.check_locks(transaction).await?;
+        let objects_by_kind = self.check_locks(transaction).await?;
 
         // At this point we need to check if any shared objects need locks,
         // and whether they have them.
@@ -466,14 +498,9 @@ impl AuthorityState {
             "Read inputs for transaction from DB"
         );
 
-        let inputs: Vec<_> = objects_by_kind
-            .into_iter()
-            .map(|(_, object)| object)
-            .collect();
-
-        let mut transaction_dependencies: BTreeSet<_> = inputs
+        let mut transaction_dependencies: BTreeSet<_> = objects_by_kind
             .iter()
-            .map(|object| object.previous_transaction)
+            .map(|(_, object)| object.previous_transaction)
             .collect();
 
         // Insert into the certificates map
@@ -481,11 +508,11 @@ impl AuthorityState {
 
         let gas_object_id = transaction.gas_payment_object_ref().0;
         let mut temporary_store =
-            AuthorityTemporaryStore::new(self._database.clone(), &inputs, tx_ctx.digest());
+            AuthorityTemporaryStore::new(self._database.clone(), &objects_by_kind, tx_ctx.digest());
         let status = execution_engine::execute_transaction(
             &mut temporary_store,
             transaction.clone(),
-            inputs,
+            objects_by_kind,
             &mut tx_ctx,
             &self.move_vm,
             self._native_functions.clone(),
@@ -774,15 +801,34 @@ impl AuthorityState {
     ) -> SuiResult {
         debug_assert!(ctx.digest() == TransactionDigest::genesis());
         let inputs = Transaction::input_objects_in_compiled_modules(&modules);
-        let input_objects = self
-            .fetch_objects(&inputs)
-            .await?
+        let input_objects = self.fetch_objects(&inputs).await?;
+        // When publishing genesis packages, since the std framework packages all have
+        // non-zero addresses, [`Transaction::input_objects_in_compiled_modules`] will consider
+        // them as dependencies even though they are not. Hence input_objects contain objects
+        // that don't exist on-chain because they are yet to be published.
+        #[cfg(debug_assertions)]
+        {
+            let to_be_published_addresses: HashSet<_> = modules
+                .iter()
+                .map(|module| *module.self_id().address())
+                .collect();
+            assert!(
+                // An object either exists on-chain, or is one of the packages to be published.
+                inputs
+                    .iter()
+                    .zip(input_objects.iter())
+                    .all(|(kind, obj_opt)| obj_opt.is_some()
+                        || to_be_published_addresses.contains(&kind.object_id()))
+            );
+        }
+        let filtered = inputs
             .into_iter()
-            .flatten()
+            .zip(input_objects.into_iter())
+            .filter_map(|(input, object_opt)| object_opt.map(|object| (input, object)))
             .collect::<Vec<_>>();
 
         let mut temporary_store =
-            AuthorityTemporaryStore::new(self._database.clone(), &input_objects, ctx.digest());
+            AuthorityTemporaryStore::new(self._database.clone(), &filtered, ctx.digest());
         let package_id = ObjectID::from(*modules[0].self_id().address());
         let natives = self._native_functions.clone();
         let vm = adapter::verify_and_link(&temporary_store, &modules, package_id, natives)?;

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -379,13 +379,12 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     }
 
     /// Read a lock for a specific (transaction, shared object) pair.
-    pub fn sequenced(
+    pub fn sequenced<'a>(
         &self,
         transaction_digest: &TransactionDigest,
-        object_ids: &[ObjectID],
+        object_ids: impl Iterator<Item = &'a ObjectID>,
     ) -> Result<Vec<Option<SequenceNumber>>, SuiError> {
         let keys: Vec<_> = object_ids
-            .iter()
             .map(|objid| (*transaction_digest, *objid))
             .collect();
 
@@ -793,7 +792,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
         for object_id in transaction.shared_input_objects() {
             sequenced_to_delete.push((*transaction_digest, *object_id));
             if self.get_object(object_id)?.is_none() {
-                schedule_to_delete.push(object_id);
+                schedule_to_delete.push(*object_id);
             }
         }
         write_batch = write_batch.delete_batch(&self.sequenced, sequenced_to_delete)?;
@@ -815,7 +814,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             let version = self.schedule.get(id)?.unwrap_or_default();
             sequenced_to_write.push(((*transaction_digest, *id), version));
             let next_version = version.increment();
-            schedule_to_write.push((id, next_version));
+            schedule_to_write.push((*id, next_version));
         }
 
         let mut write_batch = self.sequenced.batch();

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -730,7 +730,7 @@ where
         // Find out which objects are required by this transaction and
         // ensure they are synced on authorities.
         let required_ids: Vec<ObjectID> = transaction
-            .input_objects()
+            .input_objects()?
             .iter()
             .map(|o| o.object_id())
             .collect();

--- a/sui_core/src/execution_engine.rs
+++ b/sui_core/src/execution_engine.rs
@@ -10,7 +10,7 @@ use sui_types::{
     base_types::{SuiAddress, TxContext},
     error::{SuiError, SuiResult},
     gas,
-    messages::{ExecutionStatus, Transaction, TransactionKind},
+    messages::{ExecutionStatus, InputObjectKind, SingleTransactionKind, Transaction},
     object::Object,
     storage::{BackingPackageStore, Storage},
 };
@@ -18,61 +18,81 @@ use sui_types::{
 pub fn execute_transaction<S: BackingPackageStore>(
     temporary_store: &mut AuthorityTemporaryStore<S>,
     transaction: Transaction,
-    mut inputs: Vec<Object>,
+    mut objects_by_kind: Vec<(InputObjectKind, Object)>,
     tx_ctx: &mut TxContext,
     move_vm: &Arc<adapter::MoveVM>,
     native_functions: NativeFunctionTable,
 ) -> SuiResult<ExecutionStatus> {
     // unwraps here are safe because we built `inputs`
-    let mut gas_object = inputs.pop().unwrap();
-
-    let status = match transaction.data.kind {
-        TransactionKind::Transfer(t) => {
-            transfer(temporary_store, inputs, t.recipient, gas_object.clone())
-        }
-        TransactionKind::Call(c) => {
-            // unwraps here are safe because we built `inputs`
-            let package = inputs.pop().unwrap();
-            adapter::execute(
-                move_vm,
+    let mut gas_object = objects_by_kind.pop().unwrap().1;
+    let mut total_gas = 0;
+    // TODO: We only keep the last result for now.
+    // We should make the results a vector of results.
+    let mut last_results = vec![];
+    // TODO: Since we require all mutable objects to not show up more than
+    // once across single tx, we should be able to run them in parallel.
+    let mut object_input_iter = objects_by_kind.into_iter().map(|(_, object)| object);
+    for single_tx in transaction.into_single_transactions() {
+        let input_size = single_tx.input_object_count();
+        let status = match single_tx {
+            SingleTransactionKind::Transfer(t) => {
+                let inputs = object_input_iter.by_ref().take(input_size).collect();
+                transfer(temporary_store, inputs, t.recipient)
+            }
+            SingleTransactionKind::Call(c) => {
+                let mut inputs: Vec<_> = object_input_iter.by_ref().take(input_size).collect();
+                // unwraps here are safe because we built `inputs`
+                let package = inputs.pop().unwrap();
+                adapter::execute(
+                    move_vm,
+                    temporary_store,
+                    native_functions.clone(),
+                    package,
+                    &c.module,
+                    &c.function,
+                    c.type_arguments.clone(),
+                    inputs,
+                    c.pure_arguments.clone(),
+                    c.gas_budget,
+                    tx_ctx,
+                )
+            }
+            SingleTransactionKind::Publish(m) => adapter::publish(
                 temporary_store,
-                native_functions,
-                package,
-                &c.module,
-                &c.function,
-                c.type_arguments,
-                inputs,
-                c.pure_arguments,
-                c.gas_budget,
-                gas_object.clone(),
+                native_functions.clone(),
+                m.modules,
                 tx_ctx,
-            )
+                m.gas_budget,
+            ),
+        }?;
+        match status {
+            ExecutionStatus::Failure { gas_used, error } => {
+                // Roll back the temporary store if execution failed.
+                temporary_store.reset();
+                temporary_store.ensure_active_inputs_mutated();
+                total_gas += gas_used;
+                return Ok(ExecutionStatus::new_failure(total_gas, *error));
+            }
+            ExecutionStatus::Success { gas_used, results } => {
+                last_results = results;
+                total_gas += gas_used;
+            }
         }
-        TransactionKind::Publish(m) => adapter::publish(
-            temporary_store,
-            native_functions,
-            m.modules,
-            tx_ctx,
-            m.gas_budget,
-            gas_object.clone(),
-        ),
-    }?;
-    if let ExecutionStatus::Failure { gas_used, .. } = &status {
-        // Roll back the temporary store if execution failed.
-        temporary_store.reset();
-        // This gas deduction cannot fail.
-        gas::deduct_gas(&mut gas_object, *gas_used);
-        temporary_store.write_object(gas_object);
     }
+    gas::deduct_gas(&mut gas_object, total_gas);
+    temporary_store.write_object(gas_object);
+
     temporary_store.ensure_active_inputs_mutated();
-    Ok(status)
+    Ok(ExecutionStatus::Success {
+        gas_used: total_gas,
+        results: last_results,
+    })
 }
 
 fn transfer<S>(
     temporary_store: &mut AuthorityTemporaryStore<S>,
     mut inputs: Vec<Object>,
     recipient: SuiAddress,
-    mut gas_object: Object,
 ) -> SuiResult<ExecutionStatus> {
     if !inputs.len() == 1 {
         return Ok(ExecutionStatus::Failure {
@@ -85,13 +105,6 @@ fn transfer<S>(
     let mut output_object = inputs.pop().unwrap();
 
     let gas_used = gas::calculate_object_transfer_cost(&output_object);
-    if let Err(err) = gas::try_deduct_gas(&mut gas_object, gas_used) {
-        return Ok(ExecutionStatus::Failure {
-            gas_used: gas::MIN_OBJ_TRANSFER_GAS,
-            error: Box::new(err),
-        });
-    }
-    temporary_store.write_object(gas_object);
 
     if let Err(err) = output_object.transfer(recipient) {
         return Ok(ExecutionStatus::Failure {

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -412,7 +412,7 @@ impl AccountState {
     fn can_lock_or_unlock(&self, transaction: &Transaction) -> Result<bool, SuiError> {
         let iter_matches = self.store.pending_transactions.multi_get(
             &transaction
-                .input_objects()
+                .input_objects()?
                 .iter()
                 .map(|q| q.object_id())
                 .collect_vec(),
@@ -445,7 +445,7 @@ impl AccountState {
             .pending_transactions
             .multi_insert(
                 transaction
-                    .input_objects()
+                    .input_objects()?
                     .iter()
                     .map(|e| (e.object_id(), transaction.clone())),
             )
@@ -463,7 +463,7 @@ impl AccountState {
         }
         self.store
             .pending_transactions
-            .multi_remove(transaction.input_objects().iter().map(|e| e.object_id()))
+            .multi_remove(transaction.input_objects()?.iter().map(|e| e.object_id()))
             .map_err(|e| e.into())
     }
 }
@@ -507,7 +507,7 @@ where
         transaction: Transaction,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
         let account = self.get_or_create_account(transaction.sender_address())?;
-        for object_kind in &transaction.input_objects() {
+        for object_kind in &transaction.input_objects()? {
             let object_id = object_kind.object_id();
             let next_sequence_number = account
                 .highest_known_version(&object_id)

--- a/sui_core/src/generate_format.rs
+++ b/sui_core/src/generate_format.rs
@@ -15,7 +15,9 @@ use sui_types::{
     batch::UpdateItem,
     crypto::{get_key_pair, AuthoritySignature, Signature},
     error::SuiError,
-    messages::{CallResult, ExecutionStatus, ObjectInfoRequestKind, TransactionKind},
+    messages::{
+        CallResult, ExecutionStatus, ObjectInfoRequestKind, SingleTransactionKind, TransactionKind,
+    },
     object::{Data, Owner},
     serialize,
 };
@@ -42,7 +44,7 @@ fn get_registry() -> Result<Registry> {
     let sig: Signature = kp.sign(b"hello world");
     tracer.trace_value(&mut samples, &sig)?;
 
-    // ObjectID and SuiAddres are the same length
+    // ObjectID and SuiAddress are the same length
     let addr_bytes: [u8; ObjectID::LENGTH] = addr.as_ref().try_into().unwrap();
     let oid = ObjectID::from(addr_bytes);
     tracer.trace_value(&mut samples, &oid)?;
@@ -62,6 +64,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<TypeTag>(&samples)?;
     tracer.trace_type::<TypedStoreError>(&samples)?;
     tracer.trace_type::<ObjectInfoRequestKind>(&samples)?;
+    tracer.trace_type::<SingleTransactionKind>(&samples)?;
     tracer.trace_type::<TransactionKind>(&samples)?;
     tracer.trace_type::<MoveStructLayout>(&samples)?;
     tracer.trace_type::<MoveTypeLayout>(&samples)?;

--- a/sui_core/src/unit_tests/batch_transaction_tests.rs
+++ b/sui_core/src/unit_tests/batch_transaction_tests.rs
@@ -1,0 +1,226 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use bcs;
+
+use authority_tests::{
+    get_genesis_package_by_module, init_state_with_ids, send_and_confirm_transaction,
+};
+use move_binary_format::file_format;
+use move_core_types::{account_address::AccountAddress, ident_str};
+use sui_adapter::genesis;
+use sui_types::{
+    crypto::{get_key_pair, Signature},
+    messages::Transaction,
+};
+
+#[tokio::test]
+async fn test_batch_transaction_ok() -> anyhow::Result<()> {
+    // This test tests a sucecssful normal batch transaction.
+    // This batch transaction contains 100 transfers, and 100 Move calls.
+    let (sender, sender_key) = get_key_pair();
+    let (recipient, _) = get_key_pair();
+    const N: usize = 100;
+    const TOTAL: usize = N + 1;
+    let all_ids = (0..TOTAL).map(|_| ObjectID::random()).collect::<Vec<_>>();
+    let authority_state =
+        init_state_with_ids([sender; TOTAL].into_iter().zip(all_ids.clone().into_iter())).await;
+    let mut transactions = vec![];
+    for obj_id in all_ids.iter().take(N) {
+        transactions.push(SingleTransactionKind::Transfer(Transfer {
+            recipient,
+            object_ref: authority_state
+                .get_object(obj_id)
+                .await?
+                .unwrap()
+                .compute_object_reference(),
+        }));
+    }
+    let genesis_package_objects = genesis::clone_genesis_packages();
+    let package_object_ref =
+        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+    for _ in 0..N {
+        transactions.push(SingleTransactionKind::Call(MoveCall {
+            package: package_object_ref,
+            module: ident_str!("ObjectBasics").to_owned(),
+            function: ident_str!("create").to_owned(),
+            type_arguments: vec![],
+            object_arguments: vec![],
+            shared_object_arguments: vec![],
+            pure_arguments: vec![
+                16u64.to_le_bytes().to_vec(),
+                bcs::to_bytes(&AccountAddress::from(sender)).unwrap(),
+            ],
+            gas_budget: 500,
+        }));
+    }
+    let data = TransactionData::new(
+        TransactionKind::Batch(transactions),
+        sender,
+        authority_state
+            .get_object(&all_ids[N])
+            .await?
+            .unwrap()
+            .compute_object_reference(),
+    );
+    let signature = Signature::new(&data, &sender_key);
+    let tx = Transaction::new(data, signature);
+    let response = send_and_confirm_transaction(&authority_state, tx).await?;
+    let effects = response.signed_effects.unwrap().effects;
+    assert!(effects.status.is_ok());
+    assert_eq!((effects.created.len(), effects.mutated.len()), (N, N + 1),);
+    assert!(effects
+        .created
+        .iter()
+        .all(|(_, owner)| owner == &Owner::AddressOwner(sender)));
+    // N of the objects should now be owned by recipient.
+    assert_eq!(
+        effects
+            .mutated
+            .iter()
+            .filter(|(_, owner)| owner == &Owner::AddressOwner(recipient))
+            .count(),
+        N
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
+    // This test tests the case where the last transaction in a batch transaction would fail to execute.
+    // We make sure that the entire batch is rolled back, and only gas is charged.
+    let (sender, sender_key) = get_key_pair();
+    let (recipient, _) = get_key_pair();
+    const N: usize = 100;
+    const TOTAL: usize = N + 1;
+    let all_ids = (0..TOTAL).map(|_| ObjectID::random()).collect::<Vec<_>>();
+    let authority_state =
+        init_state_with_ids([sender; TOTAL].into_iter().zip(all_ids.clone().into_iter())).await;
+    let mut transactions = vec![];
+    for obj_id in all_ids.iter().take(N) {
+        transactions.push(SingleTransactionKind::Transfer(Transfer {
+            recipient,
+            object_ref: authority_state
+                .get_object(obj_id)
+                .await?
+                .unwrap()
+                .compute_object_reference(),
+        }));
+    }
+    let genesis_package_objects = genesis::clone_genesis_packages();
+    let package_object_ref =
+        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+    transactions.push(SingleTransactionKind::Call(MoveCall {
+        package: package_object_ref,
+        module: ident_str!("ObjectBasics").to_owned(),
+        function: ident_str!("create").to_owned(),
+        type_arguments: vec![],
+        object_arguments: vec![],
+        shared_object_arguments: vec![],
+        pure_arguments: vec![],
+        gas_budget: 500,
+    }));
+    let data = TransactionData::new(
+        TransactionKind::Batch(transactions),
+        sender,
+        authority_state
+            .get_object(&all_ids[N])
+            .await?
+            .unwrap()
+            .compute_object_reference(),
+    );
+    let signature = Signature::new(&data, &sender_key);
+    let tx = Transaction::new(data, signature);
+    let response = send_and_confirm_transaction(&authority_state, tx).await?;
+    let effects = response.signed_effects.unwrap().effects;
+    assert!(effects.status.is_err());
+    assert_eq!((effects.created.len(), effects.mutated.len()), (0, N + 1));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_contains_publish() -> anyhow::Result<()> {
+    // Test that a batch transaction containing publish will fail.
+    let (sender, sender_key) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let authority_state = init_state_with_ids([(sender, gas_object_id)]).await;
+    let module = file_format::empty_module();
+    let mut module_bytes = Vec::new();
+    module.serialize(&mut module_bytes).unwrap();
+    let module_bytes = vec![module_bytes];
+    let transactions = vec![SingleTransactionKind::Publish(MoveModulePublish {
+        modules: module_bytes,
+        gas_budget: 10000,
+    })];
+    let data = TransactionData::new(
+        TransactionKind::Batch(transactions),
+        sender,
+        authority_state
+            .get_object(&gas_object_id)
+            .await?
+            .unwrap()
+            .compute_object_reference(),
+    );
+    let signature = Signature::new(&data, &sender_key);
+    let tx = Transaction::new(data, signature);
+    let response = send_and_confirm_transaction(&authority_state, tx).await;
+    assert!(matches!(
+        response.unwrap_err(),
+        SuiError::InvalidBatchTransaction { .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
+    // This test creates 100 Move call transactions batch, each with a budget of 5000.
+    // However we provide a gas coin with only 49999 balance.
+    let (sender, sender_key) = get_key_pair();
+    let authority_state = init_state_with_ids([]).await;
+    let gas_object_id = ObjectID::random();
+    let gas_object = Object::with_id_owner_gas_for_testing(
+        gas_object_id,
+        SequenceNumber::new(),
+        sender,
+        49999, // We need 50000
+    );
+    authority_state.insert_object(gas_object.clone()).await;
+
+    let genesis_package_objects = genesis::clone_genesis_packages();
+    let package_object_ref =
+        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+    const N: usize = 100;
+    let mut transactions = vec![];
+    for _ in 0..N {
+        transactions.push(SingleTransactionKind::Call(MoveCall {
+            package: package_object_ref,
+            module: ident_str!("ObjectBasics").to_owned(),
+            function: ident_str!("create").to_owned(),
+            type_arguments: vec![],
+            object_arguments: vec![],
+            shared_object_arguments: vec![],
+            pure_arguments: vec![
+                16u64.to_le_bytes().to_vec(),
+                bcs::to_bytes(&AccountAddress::from(sender)).unwrap(),
+            ],
+            gas_budget: 500,
+        }));
+    }
+    let data = TransactionData::new(
+        TransactionKind::Batch(transactions),
+        sender,
+        gas_object.compute_object_reference(),
+    );
+    let signature = Signature::new(&data, &sender_key);
+    let tx = Transaction::new(data, signature);
+    let response = send_and_confirm_transaction(&authority_state, tx).await;
+    assert!(matches!(
+        response.unwrap_err(),
+        SuiError::InsufficientGas { .. }
+    ));
+
+    Ok(())
+}

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -394,6 +394,20 @@ SignedTransactionEffects:
         TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: AuthoritySignature
+SingleTransactionKind:
+  ENUM:
+    0:
+      Transfer:
+        NEWTYPE:
+          TYPENAME: Transfer
+    1:
+      Publish:
+        NEWTYPE:
+          TYPENAME: MoveModulePublish
+    2:
+      Call:
+        NEWTYPE:
+          TYPENAME: MoveCall
 StructTag:
   STRUCT:
     - address:
@@ -435,18 +449,22 @@ SuiError:
     8:
       SharedObjectLockNotSetObject: UNIT
     9:
-      InvalidSignature:
+      InvalidBatchTransaction:
         STRUCT:
           - error: STR
     10:
-      IncorrectSigner:
+      InvalidSignature:
         STRUCT:
           - error: STR
     11:
-      UnknownSigner: UNIT
+      IncorrectSigner:
+        STRUCT:
+          - error: STR
     12:
-      CertificateRequiresQuorum: UNIT
+      UnknownSigner: UNIT
     13:
+      CertificateRequiresQuorum: UNIT
+    14:
       UnexpectedSequenceNumber:
         STRUCT:
           - object_id:
@@ -455,190 +473,190 @@ SuiError:
               TYPENAME: SequenceNumber
           - given_sequence:
               TYPENAME: SequenceNumber
-    14:
+    15:
       ConflictingTransaction:
         STRUCT:
           - pending_transaction:
               TYPENAME: TransactionDigest
-    15:
-      ErrorWhileProcessingTransaction: UNIT
     16:
+      ErrorWhileProcessingTransaction: UNIT
+    17:
       ErrorWhileProcessingTransactionTransaction:
         STRUCT:
           - err: STR
-    17:
+    18:
       ErrorWhileProcessingConfirmationTransaction:
         STRUCT:
           - err: STR
-    18:
-      ErrorWhileRequestingCertificate: UNIT
     19:
+      ErrorWhileRequestingCertificate: UNIT
+    20:
       ErrorWhileProcessingPublish:
         STRUCT:
           - err: STR
-    20:
+    21:
       ErrorWhileProcessingMoveCall:
         STRUCT:
           - err: STR
-    21:
-      ErrorWhileRequestingInformation: UNIT
     22:
+      ErrorWhileRequestingInformation: UNIT
+    23:
       ObjectFetchFailed:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - err: STR
-    23:
+    24:
       MissingEarlierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    24:
-      UnexpectedTransactionIndex: UNIT
     25:
+      UnexpectedTransactionIndex: UNIT
+    26:
       CertificateNotfound:
         STRUCT:
           - certificate_digest:
               TYPENAME: TransactionDigest
-    26:
+    27:
       ParentNotfound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - sequence:
               TYPENAME: SequenceNumber
-    27:
-      UnknownSenderAccount: UNIT
     28:
-      CertificateAuthorityReuse: UNIT
+      UnknownSenderAccount: UNIT
     29:
-      InvalidSequenceNumber: UNIT
+      CertificateAuthorityReuse: UNIT
     30:
-      SequenceOverflow: UNIT
+      InvalidSequenceNumber: UNIT
     31:
-      SequenceUnderflow: UNIT
+      SequenceOverflow: UNIT
     32:
-      WrongShard: UNIT
+      SequenceUnderflow: UNIT
     33:
-      InvalidCrossShardUpdate: UNIT
+      WrongShard: UNIT
     34:
-      InvalidAuthenticator: UNIT
+      InvalidCrossShardUpdate: UNIT
     35:
-      InvalidAddress: UNIT
+      InvalidAuthenticator: UNIT
     36:
-      InvalidTransactionDigest: UNIT
+      InvalidAddress: UNIT
     37:
+      InvalidTransactionDigest: UNIT
+    38:
       InvalidObjectDigest:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_digest:
               TYPENAME: ObjectDigest
-    38:
-      InvalidDecoding: UNIT
     39:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     40:
-      DuplicateObjectRefInput: UNIT
+      UnexpectedMessage: UNIT
     41:
+      DuplicateObjectRefInput: UNIT
+    42:
       ClientIoError:
         STRUCT:
           - error: STR
-    42:
-      TransferImmutableError: UNIT
     43:
+      TransferImmutableError: UNIT
+    44:
       TooManyItemsError:
         NEWTYPE: U64
-    44:
-      InvalidSequenceRangeError: UNIT
     45:
-      NoBatchesFoundError: UNIT
+      InvalidSequenceRangeError: UNIT
     46:
-      CannotSendClientMessageError: UNIT
+      NoBatchesFoundError: UNIT
     47:
+      CannotSendClientMessageError: UNIT
+    48:
       SubscriptionItemsDroppedError:
         NEWTYPE: U64
-    48:
-      SubscriptionServiceClosed: UNIT
     49:
+      SubscriptionServiceClosed: UNIT
+    50:
       ModuleLoadFailure:
         STRUCT:
           - error: STR
-    50:
+    51:
       ModuleVerificationFailure:
         STRUCT:
           - error: STR
-    51:
+    52:
       ModuleDeserializationFailure:
         STRUCT:
           - error: STR
-    52:
+    53:
       ModulePublishFailure:
         STRUCT:
           - error: STR
-    53:
+    54:
       ModuleBuildFailure:
         STRUCT:
           - error: STR
-    54:
+    55:
       DependentPackageNotFound:
         STRUCT:
           - package_id:
               TYPENAME: ObjectID
-    55:
+    56:
       MoveUnitTestFailure:
         STRUCT:
           - error: STR
-    56:
+    57:
       FunctionNotFound:
         STRUCT:
           - error: STR
-    57:
+    58:
       ModuleNotFound:
         STRUCT:
           - module_name: STR
-    58:
+    59:
       InvalidFunctionSignature:
         STRUCT:
           - error: STR
-    59:
+    60:
       TypeError:
         STRUCT:
           - error: STR
-    60:
+    61:
       AbortedExecution:
         STRUCT:
           - error: STR
-    61:
+    62:
       InvalidMoveEvent:
         STRUCT:
           - error: STR
-    62:
-      CircularObjectOwnership: UNIT
     63:
+      CircularObjectOwnership: UNIT
+    64:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    64:
+    65:
       InsufficientGas:
         STRUCT:
           - error: STR
-    65:
-      InvalidTxUpdate: UNIT
     66:
-      TransactionLockExists: UNIT
+      InvalidTxUpdate: UNIT
     67:
-      TransactionLockDoesNotExist: UNIT
+      TransactionLockExists: UNIT
     68:
-      TransactionLockReset: UNIT
+      TransactionLockDoesNotExist: UNIT
     69:
+      TransactionLockReset: UNIT
+    70:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    70:
+    71:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -646,26 +664,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    71:
+    72:
       BadObjectType:
         STRUCT:
           - error: STR
-    72:
-      MoveExecutionFailure: UNIT
     73:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     74:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     75:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     76:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     77:
+      AuthorityUpdateFailure: UNIT
+    78:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    78:
+    79:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -676,31 +694,31 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    79:
+    80:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    80:
-      BatchErrorSender: UNIT
     81:
+      BatchErrorSender: UNIT
+    82:
       GenericAuthorityError:
         STRUCT:
           - error: STR
-    82:
+    83:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    83:
-      ObjectSerializationError: UNIT
     84:
-      ConcurrentTransactionError: UNIT
+      ObjectSerializationError: UNIT
     85:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     86:
-      TooManyIncorrectAuthorities: UNIT
+      IncorrectRecipientError: UNIT
     87:
+      TooManyIncorrectAuthorities: UNIT
+    88:
       InconsistentGatewayResult:
         STRUCT:
           - error: STR
@@ -796,17 +814,14 @@ TransactionInfoResponse:
 TransactionKind:
   ENUM:
     0:
-      Transfer:
+      Single:
         NEWTYPE:
-          TYPENAME: Transfer
+          TYPENAME: SingleTransactionKind
     1:
-      Publish:
+      Batch:
         NEWTYPE:
-          TYPENAME: MoveModulePublish
-    2:
-      Call:
-        NEWTYPE:
-          TYPENAME: MoveCall
+          SEQ:
+            TYPENAME: SingleTransactionKind
 Transfer:
   STRUCT:
     - recipient:

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -187,7 +187,6 @@ fn call(
     native_functions: &NativeFunctionTable,
     module_name: &str,
     fun_name: &str,
-    gas_object: Object,
     gas_budget: u64,
     type_args: Vec<TypeTag>,
     object_args: Vec<Object>,
@@ -207,7 +206,6 @@ fn call(
         object_args,
         pure_args,
         gas_budget,
-        gas_object,
         &mut TxContext::random_for_testing_only(),
     )
 }
@@ -226,7 +224,7 @@ fn test_object_basics() {
     // 0. Create a gas object for gas payment.
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // 1. Create obj1 owned by addr1
@@ -240,7 +238,6 @@ fn test_object_basics() {
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -250,7 +247,7 @@ fn test_object_basics() {
     .unwrap();
 
     assert_eq!(storage.created().len(), 1);
-    assert_eq!(storage.updated().len(), 1); // The gas object
+    assert!(storage.updated().is_empty());
     assert!(storage.deleted().is_empty());
     let id1 = storage.get_created_keys().pop().unwrap();
     storage.flush();
@@ -266,7 +263,6 @@ fn test_object_basics() {
         &native_functions,
         "ObjectBasics",
         "transfer",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         vec![obj1.clone()],
@@ -275,7 +271,7 @@ fn test_object_basics() {
     .unwrap()
     .unwrap();
 
-    assert_eq!(storage.updated().len(), 2);
+    assert_eq!(storage.updated().len(), 1);
     assert!(storage.created().is_empty());
     assert!(storage.deleted().is_empty());
     storage.flush();
@@ -304,7 +300,6 @@ fn test_object_basics() {
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -326,7 +321,6 @@ fn test_object_basics() {
         &native_functions,
         "ObjectBasics",
         "update",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         vec![obj1.clone(), obj2],
@@ -334,7 +328,7 @@ fn test_object_basics() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(storage.updated().len(), 2);
+    assert_eq!(storage.updated().len(), 1);
     assert!(storage.created().is_empty());
     assert!(storage.deleted().is_empty());
     // test than an event was emitted as expected
@@ -364,7 +358,6 @@ fn test_object_basics() {
         &native_functions,
         "ObjectBasics",
         "delete",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         vec![obj1],
@@ -374,7 +367,7 @@ fn test_object_basics() {
     .unwrap();
     assert_eq!(storage.deleted().len(), 1);
     assert!(storage.created().is_empty());
-    assert_eq!(storage.updated().len(), 1);
+    assert!(storage.updated().is_empty());
     storage.flush();
     assert!(storage.read_object(&id1).is_none())
 }
@@ -392,7 +385,7 @@ fn test_wrap_unwrap() {
 
     // 0. Create a gas object for gas payment. Note that we won't really use it because we won't be providing a gas budget.
     let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), addr);
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // 1. Create obj1 owned by addr
@@ -405,7 +398,6 @@ fn test_wrap_unwrap() {
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -431,7 +423,6 @@ fn test_wrap_unwrap() {
         &native_functions,
         "ObjectBasics",
         "wrap",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         vec![obj1],
@@ -454,7 +445,6 @@ fn test_wrap_unwrap() {
         &native_functions,
         "ObjectBasics",
         "unwrap",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         vec![obj2],
@@ -495,7 +485,7 @@ fn test_move_call_insufficient_gas() {
     let gas_object_id = ObjectID::random();
     let gas_object =
         Object::with_id_owner_for_testing(gas_object_id, base_types::SuiAddress::default());
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // 1. Create obj1 owned by addr1
@@ -510,7 +500,6 @@ fn test_move_call_insufficient_gas() {
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object,
         15, // This budget is not enough to execute all bytecode.
         Vec::new(),
         Vec::new(),
@@ -522,13 +511,11 @@ fn test_move_call_insufficient_gas() {
     assert_eq!(err.0, 15);
 
     // Trying again with a different gas budget.
-    let gas_object = storage.read_object(&gas_object_id).unwrap();
     let response = call(
         &mut storage,
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object,
         50, // This budget is enough to execute bytecode, but not enough for processing transfer events.
         Vec::new(),
         Vec::new(),
@@ -538,45 +525,6 @@ fn test_move_call_insufficient_gas() {
     assert!(matches!(err.1, SuiError::InsufficientGas { .. }));
     // Provided gas_budget will be deducted as gas.
     assert_eq!(err.0, 50);
-}
-
-#[test]
-fn test_publish_module_insufficient_gas() {
-    let native_functions =
-        sui_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS);
-    let genesis_objects = genesis::clone_genesis_packages();
-    let mut storage = InMemoryStorage::new(genesis_objects);
-
-    // 0. Create a gas object for gas payment.
-    let gas_object = Object::with_id_owner_gas_for_testing(
-        ObjectID::random(),
-        SequenceNumber::from(1),
-        base_types::SuiAddress::default(),
-        30,
-    );
-    storage.write_object(gas_object.clone());
-    storage.flush();
-
-    // 1. Create a module.
-    let module = file_format::empty_module();
-    let mut module_bytes = Vec::new();
-    module.serialize(&mut module_bytes).unwrap();
-    let module_bytes = vec![module_bytes];
-
-    let mut tx_context = TxContext::random_for_testing_only();
-    let response = adapter::publish(
-        &mut storage,
-        native_functions,
-        module_bytes,
-        &mut tx_context,
-        GAS_BUDGET,
-        gas_object,
-    );
-    let err = response.unwrap().unwrap_err();
-    assert!(err
-        .1
-        .to_string()
-        .contains("Gas balance is 30, not enough to pay"));
 }
 
 #[test]
@@ -591,7 +539,7 @@ fn test_freeze() {
     // 0. Create a gas object for gas payment.
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // 1. Create obj1 owned by addr1
@@ -605,7 +553,6 @@ fn test_freeze() {
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -625,7 +572,6 @@ fn test_freeze() {
         &native_functions,
         "ObjectBasics",
         "freeze_object",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         vec![obj1],
@@ -633,7 +579,7 @@ fn test_freeze() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(storage.updated().len(), 2);
+    assert_eq!(storage.updated().len(), 1);
     storage.flush();
     let obj1 = storage.read_object(&id1).unwrap();
     assert!(obj1.is_read_only());
@@ -646,7 +592,6 @@ fn test_freeze() {
         &native_functions,
         "ObjectBasics",
         "transfer",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         vec![obj1],
@@ -669,7 +614,6 @@ fn test_freeze() {
         &native_functions,
         "ObjectBasics",
         "set_value",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         vec![obj1],
@@ -695,7 +639,7 @@ fn test_move_call_args_type_mismatch() {
     // 0. Create a gas object for gas payment.
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // ObjectBasics::create expects 2 args: integer value and recipient address
@@ -706,7 +650,6 @@ fn test_move_call_args_type_mismatch() {
         &native_functions,
         "ObjectBasics",
         "create",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -763,14 +706,13 @@ fn test_move_call_incorrect_function() {
         &vm,
         &mut storage,
         native_functions.clone(),
-        gas_object.clone(),
+        gas_object,
         &Identifier::new("ObjectBasics").unwrap(),
         &Identifier::new("create").unwrap(),
         vec![],
         vec![],
         vec![],
         GAS_BUDGET,
-        gas_object.clone(),
         &mut TxContext::random_for_testing_only(),
     )
     .unwrap();
@@ -787,7 +729,6 @@ fn test_move_call_incorrect_function() {
         &native_functions,
         "ObjectBasics",
         "foo",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -823,7 +764,7 @@ fn test_publish_module_linker_error() {
     // 0. Create a gas object for gas payment.
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // 1. Create a module that depends on a genesis module that exists, but via an invalid handle
@@ -861,7 +802,6 @@ fn test_publish_module_linker_error() {
         module_bytes,
         &mut tx_context,
         GAS_BUDGET,
-        gas_object,
     );
     let err = response.unwrap().unwrap_err();
     assert_eq!(err.0, gas::MIN_MOVE);
@@ -883,7 +823,7 @@ fn test_publish_module_non_zero_address() {
     // 0. Create a gas object for gas payment.
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // 1. Create an empty module.
@@ -903,7 +843,6 @@ fn test_publish_module_non_zero_address() {
         module_bytes,
         &mut tx_context,
         GAS_BUDGET,
-        gas_object,
     );
     let err = response.unwrap().unwrap_err();
     assert_eq!(err.0, gas::MIN_MOVE);
@@ -926,7 +865,7 @@ fn test_coin_transfer() {
     // 1. Create an object to transfer
     let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), addr);
     let to_transfer = Object::with_id_owner_for_testing(ObjectID::random(), addr);
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.write_object(to_transfer.clone());
     storage.flush();
 
@@ -937,7 +876,6 @@ fn test_coin_transfer() {
         &native_functions,
         "Coin",
         "transfer_",
-        gas_object,
         GAS_BUDGET,
         vec![GAS::type_tag()],
         vec![to_transfer],
@@ -949,8 +887,8 @@ fn test_coin_transfer() {
     .unwrap()
     .unwrap();
 
-    // should update gas object and input coin
-    assert_eq!(storage.updated().len(), 2);
+    // should update input coin
+    assert_eq!(storage.updated().len(), 1);
     // should create one new coin
     assert_eq!(storage.created().len(), 1);
 }
@@ -963,7 +901,7 @@ fn publish_from_src(
     gas_object: Object,
     gas_budget: u64,
 ) {
-    storage.write_object(gas_object.clone());
+    storage.write_object(gas_object);
     storage.flush();
 
     // build modules to be published
@@ -988,7 +926,6 @@ fn publish_from_src(
         all_module_bytes,
         &mut tx_context,
         gas_budget,
-        gas_object,
     );
     assert!(matches!(response.unwrap(), ExecutionStatus::Success { .. }));
 }
@@ -1009,7 +946,7 @@ fn test_simple_call() {
         &mut storage,
         &native_functions,
         "src/unit_tests/data/simple_call",
-        gas_object.clone(),
+        gas_object,
         GAS_BUDGET,
     );
     storage.flush();
@@ -1028,7 +965,6 @@ fn test_simple_call() {
         &native_functions,
         "M1",
         "create",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -1183,7 +1119,7 @@ fn test_call_ret() {
         &mut storage,
         &native_functions,
         "src/unit_tests/data/call_ret",
-        gas_object.clone(),
+        gas_object,
         GAS_BUDGET,
     );
     storage.flush();
@@ -1194,7 +1130,6 @@ fn test_call_ret() {
         &native_functions,
         "M1",
         "get_u64",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -1219,7 +1154,6 @@ fn test_call_ret() {
         &native_functions,
         "M1",
         "get_addr",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -1245,7 +1179,6 @@ fn test_call_ret() {
         &native_functions,
         "M1",
         "get_tuple",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -1272,7 +1205,6 @@ fn test_call_ret() {
         &native_functions,
         "M1",
         "get_vec",
-        gas_object.clone(),
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),
@@ -1297,7 +1229,6 @@ fn test_call_ret() {
         &native_functions,
         "M1",
         "get_vec_vec",
-        gas_object,
         GAS_BUDGET,
         Vec::new(),
         Vec::new(),

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.55"
 base64 = "0.13.0"
 bcs = "0.1.3"
 bincode = "1.3.3"
+itertools = "0.10.3"
 once_cell = "1.9.0"
 rand = "0.7.3"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -50,6 +50,8 @@ pub enum SuiError {
     DeleteObjectOwnedObject,
     #[error("The shared locks for this transaction have not yet been set.")]
     SharedObjectLockNotSetObject,
+    #[error("Invalid Batch Transaction: {}", error)]
+    InvalidBatchTransaction { error: String },
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]

--- a/sui_types/src/gas.rs
+++ b/sui_types/src/gas.rs
@@ -34,7 +34,7 @@ pub fn check_transfer_gas_requirement(gas_object: &Object, transfer_object: &Obj
     )
 }
 
-pub fn check_move_gas_requirement(gas_object: &Object, gas_budget: u64) -> SuiResult {
+pub fn check_move_gas_requirement(gas_budget: u64) -> SuiResult {
     ok_or_gas_error!(
         gas_budget >= MIN_MOVE,
         format!(
@@ -42,14 +42,7 @@ pub fn check_move_gas_requirement(gas_object: &Object, gas_budget: u64) -> SuiRe
             gas_budget, MIN_MOVE
         )
     )?;
-    let balance = get_gas_balance(gas_object)?;
-    ok_or_gas_error!(
-        balance >= gas_budget,
-        format!(
-            "Gas balance is {}, smaller than the budget {} for move operation.",
-            balance, gas_budget
-        )
-    )
+    Ok(())
 }
 
 /// Try subtract the gas balance of \p gas_object by \p amount.

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -13,6 +13,7 @@ use super::{base_types::*, batch::*, committee::Committee, error::*, event::Even
 #[path = "unit_tests/messages_tests.rs"]
 mod messages_tests;
 
+use itertools::Either;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::TypeTag,
@@ -59,8 +60,8 @@ pub struct MoveModulePublish {
     pub gas_budget: u64,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, NamedVariant)]
-pub enum TransactionKind {
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub enum SingleTransactionKind {
     /// Initiate an object transfer between addresses
     Transfer(Transfer),
     /// Publish a new Move module
@@ -68,6 +69,157 @@ pub enum TransactionKind {
     /// Call a function in a published Move module
     Call(MoveCall),
     // .. more transaction types go here
+}
+
+impl SingleTransactionKind {
+    pub fn contains_shared_object(&self) -> bool {
+        match &self {
+            Self::Transfer(..) => false,
+            Self::Call(c) => !c.shared_object_arguments.is_empty(),
+            Self::Publish(..) => false,
+        }
+    }
+
+    pub fn shared_input_objects(&self) -> &[ObjectID] {
+        match &self {
+            Self::Call(c) => &c.shared_object_arguments,
+            _ => &[],
+        }
+    }
+
+    pub fn input_object_count(&self) -> usize {
+        match &self {
+            Self::Transfer(_) => 1,
+            Self::Call(c) => 1 + c.object_arguments.len() + c.shared_object_arguments.len(),
+            // We always special handle Publish, hence the result doesn't matter.
+            Self::Publish(_) => 0,
+        }
+    }
+
+    /// Return the metadata of each of the input objects for the transaction.
+    /// For a Move object, we attach the object reference;
+    /// for a Move package, we provide the object id only since they never change on chain.
+    /// TODO: use an iterator over references here instead of a Vec to avoid allocations.
+    pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
+        let input_objects = match &self {
+            Self::Transfer(t) => {
+                vec![InputObjectKind::OwnedMoveObject(t.object_ref)]
+            }
+            Self::Call(c) => {
+                let mut call_inputs = Vec::with_capacity(
+                    1 + c.object_arguments.len() + c.shared_object_arguments.len(),
+                );
+                call_inputs.extend(
+                    c.object_arguments
+                        .clone()
+                        .into_iter()
+                        .map(InputObjectKind::OwnedMoveObject)
+                        .collect::<Vec<_>>(),
+                );
+                call_inputs.extend(
+                    c.shared_object_arguments
+                        .iter()
+                        .cloned()
+                        .map(InputObjectKind::SharedMoveObject)
+                        .collect::<Vec<_>>(),
+                );
+                call_inputs.push(InputObjectKind::MovePackage(c.package.0));
+                call_inputs
+            }
+            Self::Publish(m) => {
+                // For module publishing, all the dependent packages are implicit input objects
+                // because they must all be on-chain in order for the package to publish.
+                // All authorities must have the same view of those dependencies in order
+                // to achieve consistent publish results.
+                let compiled_modules = m
+                    .modules
+                    .iter()
+                    .filter_map(|bytes| match CompiledModule::deserialize(bytes) {
+                        Ok(m) => Some(m),
+                        // We will ignore this error here and simply let latter execution
+                        // to discover this error again and fail the transaction.
+                        // It's preferable to let transaction fail and charge gas when
+                        // malformed package is provided.
+                        Err(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                Transaction::input_objects_in_compiled_modules(&compiled_modules)
+            }
+        };
+        // Ensure that there are no duplicate inputs. This cannot be removed because:
+        // In [`AuthorityState::check_locks`], we check that there are no duplicate mutable
+        // input objects, which would have made this check here unnecessary. However we
+        // do plan to allow mutable shared objects show up more than once in multiple single
+        // transactions down the line. Once we have that, we need check here to make sure
+        // the same mutable shared object doesn't show up more than once in the same single
+        // transaction.
+        let mut used = HashSet::new();
+        if !input_objects.iter().all(|o| used.insert(o.object_id())) {
+            return Err(SuiError::DuplicateObjectRefInput);
+        }
+        Ok(input_objects)
+    }
+}
+
+impl Display for SingleTransactionKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut writer = String::new();
+        match &self {
+            Self::Transfer(t) => {
+                writeln!(writer, "Transaction Kind : Transfer")?;
+                writeln!(writer, "Recipient : {}", t.recipient)?;
+                let (object_id, seq, digest) = t.object_ref;
+                writeln!(writer, "Object ID : {}", &object_id)?;
+                writeln!(writer, "Sequence Number : {:?}", seq)?;
+                writeln!(writer, "Object Digest : {}", encode_bytes_hex(&digest.0))?;
+            }
+            Self::Publish(p) => {
+                writeln!(writer, "Transaction Kind : Publish")?;
+                writeln!(writer, "Gas Budget : {}", p.gas_budget)?;
+            }
+            Self::Call(c) => {
+                writeln!(writer, "Transaction Kind : Call")?;
+                writeln!(writer, "Gas Budget : {}", c.gas_budget)?;
+                writeln!(writer, "Package ID : {}", c.package.0.to_hex_literal())?;
+                writeln!(writer, "Module : {}", c.module)?;
+                writeln!(writer, "Function : {}", c.function)?;
+                writeln!(writer, "Object Arguments : {:?}", c.object_arguments)?;
+                writeln!(writer, "Pure Arguments : {:?}", c.pure_arguments)?;
+                writeln!(writer, "Type Arguments : {:?}", c.type_arguments)?;
+            }
+        }
+        write!(f, "{}", writer)
+    }
+}
+
+// TODO: Make SingleTransactionKind a Box
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, NamedVariant)]
+pub enum TransactionKind {
+    /// A single transaction.
+    Single(SingleTransactionKind),
+    /// A batch of single transactions.
+    Batch(Vec<SingleTransactionKind>),
+    // .. more transaction types go here
+}
+
+impl Display for TransactionKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut writer = String::new();
+        match &self {
+            Self::Single(s) => {
+                writeln!(writer, "{}", s)?;
+            }
+            Self::Batch(b) => {
+                writeln!(writer, "Transaction Kind : Batch")?;
+                writeln!(writer, "List of transactions in the batch:")?;
+                for kind in b {
+                    writeln!(writer, "{}", kind)?;
+                }
+            }
+        }
+        write!(f, "{}", writer)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -98,7 +250,7 @@ impl TransactionData {
         pure_arguments: Vec<Vec<u8>>,
         gas_budget: u64,
     ) -> Self {
-        let kind = TransactionKind::Call(MoveCall {
+        let kind = TransactionKind::Single(SingleTransactionKind::Call(MoveCall {
             package,
             module,
             function,
@@ -107,7 +259,7 @@ impl TransactionData {
             shared_object_arguments,
             pure_arguments,
             gas_budget,
-        });
+        }));
         Self::new(kind, sender, gas_payment)
     }
 
@@ -117,10 +269,10 @@ impl TransactionData {
         sender: SuiAddress,
         gas_payment: ObjectRef,
     ) -> Self {
-        let kind = TransactionKind::Transfer(Transfer {
+        let kind = TransactionKind::Single(SingleTransactionKind::Transfer(Transfer {
             recipient,
             object_ref,
-        });
+        }));
         Self::new(kind, sender, gas_payment)
     }
 
@@ -130,10 +282,10 @@ impl TransactionData {
         modules: Vec<Vec<u8>>,
         gas_budget: u64,
     ) -> Self {
-        let kind = TransactionKind::Publish(MoveModulePublish {
+        let kind = TransactionKind::Single(SingleTransactionKind::Publish(MoveModulePublish {
             modules,
             gas_budget,
-        });
+        }));
         Self::new(kind, sender, gas_payment)
     }
 
@@ -196,11 +348,11 @@ pub struct CertifiedTransaction {
 }
 
 // Note: if you meet an error due to this line it may be because you need an Eq implementation for `CertifiedTransaction`,
-// or one of the structs that include it, i.e. `ConfirmationTransaction`, `TransactionInforResponse` or `ObjectInforResponse`.
+// or one of the structs that include it, i.e. `ConfirmationTransaction`, `TransactionInfoResponse` or `ObjectInfoResponse`.
 //
 // Please note that any such implementation must be agnostic to the exact set of signatures in the certificate, as
 // clients are allowed to equivocate on the exact nature of valid certificates they send to the system. This assertion
-// is a simple tool to make sure certifcates are accounted for correctly - should you remove it, you're on your own to
+// is a simple tool to make sure certificates are accounted for correctly - should you remove it, you're on your own to
 // maintain the invariant that valid certificates with distinct signatures are equivalent, but yet-unchecked
 // certificates that differ on signers aren't.
 //
@@ -642,71 +794,58 @@ impl Transaction {
 
     pub fn contains_shared_object(&self) -> bool {
         match &self.data.kind {
-            TransactionKind::Transfer(..) => false,
-            TransactionKind::Call(c) => !c.shared_object_arguments.is_empty(),
-            TransactionKind::Publish(..) => false,
+            TransactionKind::Single(s) => s.contains_shared_object(),
+            TransactionKind::Batch(b) => b.iter().any(|kind| kind.contains_shared_object()),
         }
     }
 
-    pub fn shared_input_objects(&self) -> &[ObjectID] {
+    pub fn shared_input_objects(&self) -> impl Iterator<Item = &ObjectID> {
         match &self.data.kind {
-            TransactionKind::Call(c) => &c.shared_object_arguments,
-            _ => &[],
+            TransactionKind::Single(s) => Either::Left(s.shared_input_objects().iter()),
+            TransactionKind::Batch(b) => {
+                Either::Right(b.iter().flat_map(|kind| kind.shared_input_objects()))
+            }
         }
     }
 
-    /// Return the metadata of each of the input objects for the transaction.
-    /// For a Move object, we attach the object reference;
-    /// for a Move package, we provide the object id only since they never change on chain.
-    /// TODO: use an iterator over references here instead of a Vec to avoid allocations.
-    pub fn input_objects(&self) -> Vec<InputObjectKind> {
+    pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
         let mut inputs = match &self.data.kind {
-            TransactionKind::Transfer(t) => {
-                vec![InputObjectKind::OwnedMoveObject(t.object_ref)]
-            }
-            TransactionKind::Call(c) => {
-                let mut call_inputs = Vec::with_capacity(2 + c.object_arguments.len());
-                call_inputs.extend(
-                    c.object_arguments
-                        .clone()
-                        .into_iter()
-                        .map(InputObjectKind::OwnedMoveObject)
-                        .collect::<Vec<_>>(),
-                );
-                call_inputs.extend(
-                    c.shared_object_arguments
-                        .iter()
-                        .cloned()
-                        .map(InputObjectKind::SharedMoveObject)
-                        .collect::<Vec<_>>(),
-                );
-                call_inputs.push(InputObjectKind::MovePackage(c.package.0));
-                call_inputs
-            }
-            TransactionKind::Publish(m) => {
-                // For module publishing, all the dependent packages are implicit input objects
-                // because they must all be on-chain in order for the package to publish.
-                // All authorities must have the same view of those dependencies in order
-                // to achieve consistent publish results.
-                let compiled_modules = m
-                    .modules
-                    .iter()
-                    .filter_map(|bytes| match CompiledModule::deserialize(bytes) {
-                        Ok(m) => Some(m),
-                        // We will ignore this error here and simply let latter execution
-                        // to discover this error again and fail the transaction.
-                        // It's preferrable to let transaction fail and charge gas when
-                        // malformed package is provided.
-                        Err(_) => None,
-                    })
-                    .collect::<Vec<_>>();
-                Transaction::input_objects_in_compiled_modules(&compiled_modules)
+            TransactionKind::Single(s) => s.input_objects()?,
+            TransactionKind::Batch(b) => {
+                let mut result = vec![];
+                for kind in b {
+                    fp_ensure!(
+                        !matches!(kind, &SingleTransactionKind::Publish(..)),
+                        SuiError::InvalidBatchTransaction {
+                            error: "Publish transaction is now allowed in Batch Transaction"
+                                .to_owned(),
+                        }
+                    );
+                    let sub = kind.input_objects()?;
+                    debug_assert_eq!(sub.len(), kind.input_object_count());
+                    result.extend(sub);
+                }
+                result
             }
         };
         inputs.push(InputObjectKind::OwnedMoveObject(
             *self.gas_payment_object_ref(),
         ));
-        inputs
+        Ok(inputs)
+    }
+
+    pub fn single_transactions(&self) -> impl Iterator<Item = &SingleTransactionKind> {
+        match &self.data.kind {
+            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
+            TransactionKind::Batch(b) => Either::Right(b.iter()),
+        }
+    }
+
+    pub fn into_single_transactions(self) -> impl Iterator<Item = SingleTransactionKind> {
+        match self.data.kind {
+            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
+            TransactionKind::Batch(b) => Either::Right(b.into_iter()),
+        }
     }
 
     // Derive a cryptographic hash of the transaction.
@@ -932,30 +1071,7 @@ impl Display for CertifiedTransaction {
                 .map(|(name, _)| name)
                 .collect::<Vec<_>>()
         )?;
-        match &self.transaction.data.kind {
-            TransactionKind::Transfer(t) => {
-                writeln!(writer, "Transaction Kind : Transfer")?;
-                writeln!(writer, "Recipient : {}", t.recipient)?;
-                let (object_id, seq, digest) = t.object_ref;
-                writeln!(writer, "Object ID : {}", &object_id)?;
-                writeln!(writer, "Sequence Number : {:?}", seq)?;
-                writeln!(writer, "Object Digest : {}", encode_bytes_hex(&digest.0))?;
-            }
-            TransactionKind::Publish(p) => {
-                writeln!(writer, "Transaction Kind : Publish")?;
-                writeln!(writer, "Gas Budget : {}", p.gas_budget)?;
-            }
-            TransactionKind::Call(c) => {
-                writeln!(writer, "Transaction Kind : Call")?;
-                writeln!(writer, "Gas Budget : {}", c.gas_budget)?;
-                writeln!(writer, "Package ID : {}", c.package.0.to_hex_literal())?;
-                writeln!(writer, "Module : {}", c.module)?;
-                writeln!(writer, "Function : {}", c.function)?;
-                writeln!(writer, "Object Arguments : {:?}", c.object_arguments)?;
-                writeln!(writer, "Pure Arguments : {:?}", c.pure_arguments)?;
-                writeln!(writer, "Type Arguments : {:?}", c.type_arguments)?;
-            }
-        }
+        write!(writer, "{}", &self.transaction.data.kind)?;
         write!(f, "{}", writer)
     }
 }


### PR DESCRIPTION
This PR aims to solve #876, supporting batch transaction in order to improve throughput.
To review this change, please start from message.rs. It introduced a few major changes in message.rs:
1. Previously a TransactionKind can be Transfer, Call and Publish. Now TransactionKind can be either a Single and Batch, where Single is a SingleTransactionKind enum, and Batch is a vector of SingleTransactionKind. SingleTransactionKind contains the 3 variants we are familiar with: Transfer, Call and Publish.
2. Many of the functions implemented on TransactionKind now are implemented both on SingleTransactionKind, and also on TransactionKind to deal with the Batch.
3. In order to mix all input objects from each single transaction to one vector, we need to know exactly which objects belong to which single transaction. Publish transaction doesn't have deterministic input object count, hence we do not allow publish to show up in a batch transaction. This allows us to walk through the input object list for each single transaction.
4. When executing the transactions in a batch, we keep using the same temporary store and the same TxContext. If any of them returns an ExecutionStatus::Failure, we roll back the entire transaction, only charge gas and increment version, return Failure. If all single transactions succeed, we commit the actual changes to the store.
5. Added dedicated unit test file
6. One nice optimization in initializing TemporaryAuthorityStore: we no longer need to recompute the object reference for each object. The input kind already has it for all owned objects.