### PR TITLE
[Bench] Fix a few issues in benchmark

### DIFF
--- a/network_utils/src/network.rs
+++ b/network_utils/src/network.rs
@@ -99,7 +99,7 @@ impl NetworkClient {
                 if received % 5000 == 0 && received > 0 {
                     debug!("Received {}", received);
                 }
-                let xcontinue = received < total;
+                let xcontinue = received <= total;
                 futures::future::ready(xcontinue)
             })
             .collect()

--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -105,6 +105,7 @@ fn main() {
         benchmark.committee_size,
         MIN_COMMITTEE_SIZE
     );
+
     let (state, transactions) = benchmark.make_structures();
 
     // Make multi-threaded runtime for the authority
@@ -114,6 +115,12 @@ fn main() {
     } else {
         num_cpus::get()
     };
+    if benchmark.benchmark_type == BenchmarkType::TransactionsAndCerts {
+        assert!(
+            (benchmark.num_accounts * 2 / connections) % 2 == 0,
+            "Each tx and their cert must be sent in order. Multiple TCP connections will break requests into chunks, and chunk size must be an even number so it doesn't break each tx and cert pair"
+        );
+    }
 
     thread::spawn(move || {
         let runtime = Builder::new_multi_thread()


### PR DESCRIPTION
This PR fixes two issues:
1. When we are benchmarking sending both transaction and cert, each tx and their cert pair must be sent in order.
When we use multiple TCP connections, requests are broken into chunks and each chunk will be sent in parallel. We need to make sure that when we break them into chunks, we don't break any tx/cert pair, which would end up cert sending earlier before tx, causing tx failures. Added an assertion for this to make sure correct config is provided.
2. The take_while condition in `batch_send_one_chunk` is incorrect. It would always miss the last response. Fix it.
