### PR TITLE
[move] Implement trustless escrow using Shared Object

### DIFF
--- a/sui_programmability/examples/defi/sources/SharedEscrow.move
+++ b/sui_programmability/examples/defi/sources/SharedEscrow.move
@@ -1,0 +1,76 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// An escrow for atomic swap of objects without a trusted third party
+module DeFi::SharedEscrow {
+    use Std::Option::{Self, Option};
+
+    use Sui::ID::{Self, ID, VersionedID};
+    use Sui::Transfer;
+    use Sui::TxContext::{Self, TxContext};
+
+    /// An object held in escrow
+    struct EscrowedObj<T: key + store, phantom ExchangeForT: key + store> has key, store {
+        id: VersionedID,
+        /// owner of the escrowed object
+        creator: address,
+        /// intended recipient of the escrowed object
+        recipient: address,
+        /// ID of the object `creator` wants in exchange
+        exchange_for: ID,
+        /// the escrowed object
+        escrowed: Option<T>,
+    }
+
+    // Error codes
+    /// An attempt to cancel escrow by a different user than the owner
+    const EWRONG_OWNER: u64 = 0;
+    /// Exchange by a different user than the `recipient` of the escrowed object
+    const EWRONG_RECIPIENT: u64 = 1;
+    /// Exchange with a different item than the `exchange_for` field
+    const EWRONG_EXCHANGE_OBJECT: u64 = 2;
+    /// The escrow has already been exchanged or cancelled
+    const EALREADY_EXCHANGED_OR_CANCELLED: u64 = 3;
+
+    /// Create an escrow for exchanging goods with counterparty
+    public fun create<T: key + store, ExchangeForT: key + store>(
+        recipient: address,
+        exchange_for: ID,
+        escrowed_item: T,
+        ctx: &mut TxContext
+    ) {
+        let creator = TxContext::sender(ctx);
+        let id = TxContext::new_id(ctx);
+        let escrowed = Option::some(escrowed_item);
+        Transfer::share_object(
+            EscrowedObj<T,ExchangeForT> {
+                id, creator, recipient, exchange_for, escrowed
+            }
+        );
+    }
+
+    /// The `recipient` of the escrow can exchange `obj` with the escrowed item
+    public fun exchange<T: key + store, ExchangeForT: key + store>(
+        obj: ExchangeForT,
+        escrow: &mut EscrowedObj<T, ExchangeForT>,
+        ctx: &mut TxContext
+    ) {
+        assert!(Option::is_some(&escrow.escrowed), EALREADY_EXCHANGED_OR_CANCELLED);
+        let escrowed_item = Option::extract<T>(&mut escrow.escrowed);
+        assert!(&TxContext::sender(ctx) == &escrow.recipient, EWRONG_RECIPIENT);
+        assert!(ID::id(&obj) == &escrow.exchange_for, EWRONG_EXCHANGE_OBJECT);
+        // everything matches. do the swap!
+        Transfer::transfer(escrowed_item, TxContext::sender(ctx));
+        Transfer::transfer(obj, escrow.creator);
+    }
+
+    /// The `creator` can cancel the escrow and get back the escrowed item
+    public fun cancel<T: key + store, ExchangeForT: key + store>(
+        escrow: &mut EscrowedObj<T, ExchangeForT>,
+        ctx: &mut TxContext
+    ) {
+        assert!(&TxContext::sender(ctx) == &escrow.creator, EWRONG_OWNER);
+        assert!(Option::is_some(&escrow.escrowed), EALREADY_EXCHANGED_OR_CANCELLED);
+        Transfer::transfer(Option::extract<T>(&mut escrow.escrowed), escrow.creator);
+    }
+}

--- a/sui_programmability/examples/defi/tests/SharedEscrowTest.move
+++ b/sui_programmability/examples/defi/tests/SharedEscrowTest.move
@@ -1,0 +1,176 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module DeFi::SharedEscrowTests {
+    use Sui::ID::{Self, VersionedID};
+    use Sui::TestScenario::{Self, Scenario};
+    use Sui::TxContext::{Self};
+
+    use DeFi::SharedEscrow::{Self, EscrowedObj};
+
+    const ALICE_ADDRESS: address = @0xACE;
+    const BOB_ADDRESS: address = @0xACEB;
+    const THIRD_PARTY_ADDRESS: address = @0xFACE;
+    const RANDOM_ADDRESS: address = @123;
+
+    // Error codes.
+    const ESWAP_TRANSFER_FAILED: u64 = 0;
+    const ERETURN_TRANSFER_FAILED: u64 = 0;
+
+    // Example of an object type used for exchange
+    struct ItemA has key, store {
+        id: VersionedID
+    }
+
+    // Example of the other object type used for exchange
+    struct ItemB has key, store {
+        id: VersionedID
+    }
+
+    #[test]
+    public fun test_escrow_flow() {
+        // Alice creates the escrow
+        let (scenario, item_b_versioned_id) = create_escrow(ALICE_ADDRESS, BOB_ADDRESS);
+
+        // Bob exchanges item B for the escrowed item A
+        exchange(&mut scenario, &BOB_ADDRESS, item_b_versioned_id);
+
+        // Alice now owns item B, and Bob now owns item A
+        assert!(owns_object<ItemB>(&mut scenario, &ALICE_ADDRESS), ESWAP_TRANSFER_FAILED);
+        assert!(owns_object<ItemA>(&mut scenario, &BOB_ADDRESS), ESWAP_TRANSFER_FAILED);
+    }
+
+    #[test]
+    public fun test_cancel() {
+        // Alice creates the escrow
+        let (scenario, id) = create_escrow(ALICE_ADDRESS, BOB_ADDRESS);
+        ID::delete(id);
+        let scenario = &mut scenario;
+        // Alice does not own item A
+        assert!(!owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+
+        // Alice cancels the escrow
+        cancel(scenario, &ALICE_ADDRESS);
+
+        // Alice now owns item A
+        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0)]
+    public fun test_cancel_with_wrong_owner() {
+        // Alice creates the escrow
+        let (scenario, id) = create_escrow(ALICE_ADDRESS, BOB_ADDRESS);
+        ID::delete(id);
+        let scenario = &mut scenario;
+
+        // Bob tries to cancel the escrow that Alice owns and expects failure
+        cancel(scenario, &BOB_ADDRESS);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 2)]
+    public fun test_swap_wrong_objects() {
+        // Alice creates the escrow in exchange for item b
+        let (scenario, item_b_versioned_id) = create_escrow(ALICE_ADDRESS, BOB_ADDRESS);
+        ID::delete(item_b_versioned_id);
+        let scenario = &mut scenario;
+
+        // Bob tries to exchange item C for the escrowed item A and expects failure
+        TestScenario::next_tx(scenario, &BOB_ADDRESS);
+        let ctx = TestScenario::ctx(scenario);
+        let item_c_versioned_id = TxContext::new_id(ctx);
+        exchange(scenario, &BOB_ADDRESS, item_c_versioned_id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 1)]
+    public fun test_swap_wrong_recipient() {
+         // Alice creates the escrow in exchange for item b
+        let (scenario, item_b_versioned_id) = create_escrow(ALICE_ADDRESS, BOB_ADDRESS);
+        let scenario = &mut scenario;
+
+        // Random address tries to exchange item B for the escrowed item A and expects failure
+        exchange(scenario, &RANDOM_ADDRESS, item_b_versioned_id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 3)]
+    public fun test_cancel_twice() {
+        // Alice creates the escrow
+        let (scenario, id) = create_escrow(ALICE_ADDRESS, BOB_ADDRESS);
+        ID::delete(id);
+        let scenario = &mut scenario;
+        // Alice does not own item A
+        assert!(!owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+
+        // Alice cancels the escrow
+        cancel(scenario, &ALICE_ADDRESS);
+
+        // Alice now owns item A
+        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+
+        // Alice tries to cancel the escrow again
+        cancel(scenario, &ALICE_ADDRESS);
+    }
+
+    fun cancel(scenario: &mut Scenario, initiator: &address) {
+        TestScenario::next_tx(scenario, initiator);
+        {
+            let escrow = TestScenario::remove_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let ctx = TestScenario::ctx(scenario);
+            SharedEscrow::cancel(&mut escrow, ctx);
+            TestScenario::return_object(scenario, escrow);
+        };
+    }
+
+    fun exchange(scenario: &mut Scenario, bob: &address, item_b_verioned_id: VersionedID) {
+        TestScenario::next_tx(scenario, bob);
+        {
+            let escrow = TestScenario::remove_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let item_b = ItemB {
+                id: item_b_verioned_id
+            };
+            let ctx = TestScenario::ctx(scenario);
+            SharedEscrow::exchange(item_b, &mut escrow, ctx);
+            TestScenario::return_object(scenario, escrow);
+        };
+    }
+
+    fun create_escrow(
+        alice: address,
+        bob: address,
+    ): (Scenario, VersionedID) {
+        let new_scenario = TestScenario::begin(&alice);
+        let scenario = &mut new_scenario;
+        let ctx = TestScenario::ctx(scenario);
+        let item_a_versioned_id = TxContext::new_id(ctx);
+
+        TestScenario::next_tx(scenario, &bob);
+        let ctx = TestScenario::ctx(scenario);
+        let item_b_versioned_id = TxContext::new_id(ctx);
+        let item_b_id = *ID::inner(&item_b_versioned_id);
+
+        // Alice creates the escrow
+        TestScenario::next_tx(scenario, &alice);
+        {
+            let ctx = TestScenario::ctx(scenario);
+            let escrowed = ItemA {
+                id: item_a_versioned_id
+            };
+            SharedEscrow::create<ItemA, ItemB>(
+                bob,
+                item_b_id,
+                escrowed,
+                ctx
+            );
+        };
+        (new_scenario, item_b_versioned_id)
+    }
+
+    fun owns_object<T: key + store>(scenario: &mut Scenario, owner: &address): bool{
+        TestScenario::next_tx(scenario, owner);
+        TestScenario::can_remove_object<T>(scenario)
+    }
+}

--- a/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
@@ -19,7 +19,7 @@ module NFTs::SharedAuctionTests {
 
     // Error codes.
     const EWRONG_ITEM_VALUE: u64 = 1;
-    const EWRONG_COIN_VALUE: u64 = 1;
+    const EWRONG_COIN_VALUE: u64 = 2;
 
     // Example of an object type that could be sold at an auction.
     struct SomeItemToSell has key, store {


### PR DESCRIPTION
Follow up for https://github.com/MystenLabs/sui/pull/937

Considerations:
- I intentionally decided not to share code between the `SharedEscrow` and `Escrow` because I want to make `SharedEscrow` self-contained, so that I can compare it with the [verbose Solana implementation](https://github.com/paul-schaaf/solana-escrow/tree/master/program/src) in a tutorial.