### PR TITLE
Gateway logic improvements (RFC)

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -22,6 +22,7 @@ tempfile = "3.3.0"
 tracing = { version = "0.1.31", features = ["log"] }
 signature = "1.5.0"
 ed25519-dalek = "1.0.1"
+scopeguard = "1.1.0"
 structopt = "0.3.26"
 log = "0.4.14"
 

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -384,11 +384,9 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
         transaction_digest: &TransactionDigest,
         object_ids: impl Iterator<Item = &'a ObjectID>,
     ) -> Result<Vec<Option<SequenceNumber>>, SuiError> {
-        let keys: Vec<_> = object_ids
-            .map(|objid| (*transaction_digest, *objid))
-            .collect();
+        let keys = object_ids.map(|objid| (*transaction_digest, *objid));
 
-        self.sequenced.multi_get(&keys[..]).map_err(SuiError::from)
+        self.sequenced.multi_get(keys).map_err(SuiError::from)
     }
 
     /// Read a lock for a specific (transaction, shared object) pair.

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -5,7 +5,7 @@
 use crate::{authority_aggregator::AuthorityAggregator, authority_client::AuthorityAPI};
 use async_trait::async_trait;
 use futures::future;
-use itertools::Itertools;
+
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::value::MoveStructLayout;
@@ -410,13 +410,10 @@ impl AccountState {
     /// The caller has to explicitly find which objects are locked
     /// TODO: always return true for immutable objects https://github.com/MystenLabs/sui/issues/305
     fn can_lock_or_unlock(&self, transaction: &Transaction) -> Result<bool, SuiError> {
-        let iter_matches = self.store.pending_transactions.multi_get(
-            &transaction
-                .input_objects()?
-                .iter()
-                .map(|q| q.object_id())
-                .collect_vec(),
-        )?;
+        let iter_matches = self
+            .store
+            .pending_transactions
+            .multi_get(transaction.input_objects()?.iter().map(|q| q.object_id()))?;
         if iter_matches.into_iter().any(|match_for_transaction| {
             matches!(match_for_transaction,
                 // If we find any transaction that isn't the given transaction, we cannot proceed


### PR DESCRIPTION
This is a conversation starter around #346 rather than a fix.

We currently fail to unlock client-side on all failures in the execution of a transaction. This is sometimes good (if the TX legitimately did not get to all authorities in `authorities.execute_transaction`) and mostly bad (network transport errors). This catches the unwinding of the execution and triggers the unlocking logic then.

On the good side, this will not lock everything on network transport failures,
One the bad side, this will unlock on failure-to-submit-to-authorities, whereas it should not.

There are many variants of this code that could be better, e.g. using a `futures_lock::Mutex`, etc ...