### PR TITLE
fix: make the format test print a diff of what's gone wrong

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -44,7 +44,7 @@ naughty-strings = "0.2.4"
 similar-asserts = "1.2.0"
 serde-reflection = "0.3.5"
 serde_yaml = "0.8.23"
-assert-str = "0.1.0"
+pretty_assertions = "1.2.0"
 
 [[example]]
 name = "generate-format"

--- a/sui_core/src/generate_format.rs
+++ b/sui_core/src/generate_format.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 use move_core_types::{
     language_storage::TypeTag,
     value::{MoveStructLayout, MoveTypeLayout},
 };
+use pretty_assertions::assert_str_eq;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use signature::Signer;
 use std::{fs::File, io::Write};
@@ -113,7 +113,7 @@ fn main() {
         Action::Test => {
             let reference = std::fs::read_to_string(FILE_PATH).unwrap();
             let content = serde_yaml::to_string(&registry).unwrap() + "\n";
-            assert_str::assert_str_eq!(&reference, &content);
+            assert_str_eq!(&reference, &content);
         }
     }
 }


### PR DESCRIPTION
When the format test fails, the output now looks better (it even has color):

```
huitseeker@Garillots-MBP.tmp/fastnft/sui_core(better_format_ cargo test -- format                                                                   [9:57:40]
   Compiling sui_core v0.1.0 (/Users/huitseeker/tmp/fastnft/sui_core)
    Finished test [unoptimized + debuginfo] target(s) in 5.01s
     Running unittests (/Users/huitseeker/tmp/fastnft/target/debug/deps/sui_core-bf6615b943a3725a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 64 filtered out; finished in 0.00s

     Running tests/format.rs (/Users/huitseeker/tmp/fastnft/target/debug/deps/format-5ad2723ef95f03e7)

running 1 test
   Compiling sui_core v0.1.0 (/Users/huitseeker/tmp/fastnft/sui_core)
    Finished dev [unoptimized + debuginfo] target(s) in 3.43s
     Running `target/debug/examples/generate-format test`
thread 'main' panicked at 'assertion failed: `(left == right)`

Diff < left / right > :
 ---
 AccountAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 20
 AccountInfoRequest:
   STRUCT:
     - account:
         TYPENAME: SuiAddress
 AccountInfoResponse:
   STRUCT:
     - object_ids:
         SEQ:
           TUPLE:
<            - TYPENAME: SuiAddress
>            - TYPENAME: ObjectID
             - TYPENAME: SequenceNumber
             - TYPENAME: ObjectDigest
```