### PR TITLE
[docs] Updates to the REST API tutorial

### DIFF
--- a/doc/src/build/rest-api.md
+++ b/doc/src/build/rest-api.md
@@ -259,7 +259,7 @@ curl --location --request POST $SUI_GATEWAY_HOST/sync \
 ```
 
 You should replace `{{address}}` in the command above with an actual
-address values, for example one obtained from [`GET
+address value, for example one obtained from [`GET
 /addresses`](#get-addresses) (without quotes).
 
 This will fetch the latest information on all objects owned by each


### PR DESCRIPTION
I did a pass over the REST API tutorial and changed things a bit (hopefully @arun-koshy is not going to kill me :-) ). I also ran through the examples just to make sure that all substitutions for arguments work as I described them.

In terms of changes, I extended description of some "base" commands to include some examples (at least for some of them) to make it more explicit what the arguments should be for the subsequent commands are.

The biggest structural changes include:
- moving the Postman section to the end as I think the document flows better this way (otherwise, at least to me, the Postman section was a bit out of place and was breaking the natural flow).
- I replaced the `BasicObject` Move call example with the one to transfer gas - it is more consistent with the rest of the docs (wallet tutorial uses the same example) and I think `BasicObject` module is likely to move out of framework (this way we don't have to worry about updating docs when/if this happens).