### PR TITLE
Add license headers to all move files

### DIFF
--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/CombinableObjects.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/CombinableObjects.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example of objects that can be combined to create
 /// new objects
 module Examples::CombinableObjects {

--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/CustomObjectTemplate.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/CustomObjectTemplate.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// An example of a custom object with comments explaining the relevant bits
 module Examples::CustomObjectTemplate {
     use Sui::ID::VersionedID;

--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/TicTacToe.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/TicTacToe.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Examples::TicTacToe {
     use Std::Option::{Self, Option};
     use Std::Vector;

--- a/sui/src/unit_tests/data/custom_genesis_package_1/sources/TrustedCoin.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/sources/TrustedCoin.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module Examples::TrustedCoin {
     use Sui::Coin::{Self, TreasuryCap};

--- a/sui/src/unit_tests/data/custom_genesis_package_2/sources/M1.move
+++ b/sui/src/unit_tests/data/custom_genesis_package_2/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};

--- a/sui/src/unit_tests/data/dummy_modules_publish/sources/TrustedCoin.move
+++ b/sui/src/unit_tests/data/dummy_modules_publish/sources/TrustedCoin.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module Examples::TrustedCoin {
     use Sui::Coin::{Self, TreasuryCap};

--- a/sui_core/src/unit_tests/data/hero/sources/Hero.move
+++ b/sui_core/src/unit_tests/data/hero/sources/Hero.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example of a game character with basic attributes, inventory, and
 /// associated logic.
 module Examples::Hero {
@@ -34,7 +37,7 @@ module Examples::Hero {
     /// For healing wounded heroes
     struct Potion has key, store {
         id: VersionedID,
-        /// Effectivenss of the potion
+        /// Effectiveness of the potion
         potency: u64
     }
 
@@ -206,7 +209,7 @@ module Examples::Hero {
         let value = Coin::value(&payment);
         // ensure the user pays enough for the sword
         assert!(value >= MIN_SWORD_COST, EINSUFFICIENT_FUNDS);
-        // pay the admin for ths sword
+        // pay the admin for this sword
         Transfer::transfer(payment, admin());
 
         // magic of the sword is proportional to the amount you paid, up to
@@ -225,7 +228,7 @@ module Examples::Hero {
         Transfer::transfer(hero, TxContext::sender(ctx))
     }
 
-    /// Anyone can create a hero if they have a sword. All heros start with the
+    /// Anyone can create a hero if they have a sword. All heroes start with the
     /// same attributes.
     public fun create_hero(sword: Sword, ctx: &mut TxContext): Hero {
         Hero {

--- a/sui_core/src/unit_tests/data/hero/sources/TrustedCoin.move
+++ b/sui_core/src/unit_tests/data/hero/sources/TrustedCoin.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example coin with a trusted owner responsible for minting/burning (e.g., a stablecoin)
 module Examples::TrustedCoin {
     use Sui::Coin::{Self, TreasuryCap};

--- a/sui_core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
+++ b/sui_core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module ObjectOwner::ObjectOwner {
     use Std::Option::{Self, Option};
     use Sui::ID::{Self, VersionedID};

--- a/sui_core/src/unit_tests/data/object_wrapping/sources/ObjectWrapping.move
+++ b/sui_core/src/unit_tests/data/object_wrapping/sources/ObjectWrapping.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module ObjectWrapping::ObjectWrapping {
     use Std::Option::{Self, Option};
     use Sui::Transfer;

--- a/sui_programmability/adapter/src/unit_tests/data/call_ret/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/call_ret/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Std::Vector;
 

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init_param/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init_param/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init_public/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init_public/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};

--- a/sui_programmability/adapter/src/unit_tests/data/publish_init_ret/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/publish_init_ret/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};

--- a/sui_programmability/adapter/src/unit_tests/data/simple_call/sources/M1.move
+++ b/sui_programmability/adapter/src/unit_tests/data/simple_call/sources/M1.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Test::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::{Self, TxContext};
@@ -10,7 +13,7 @@ module Test::M1 {
     }
 
     fun foo<T: key, T2: drop>(_p1: u64, value1: T, _value2: &Coin<T2>, _p2: u64): T {
-        value1 
+        value1
     }
 
     public fun create(value: u64, recipient: address, ctx: &mut TxContext) {
@@ -18,5 +21,5 @@ module Test::M1 {
             Object { id: TxContext::new_id(ctx), value },
             recipient
         )
-    }    
+    }
 }

--- a/sui_programmability/examples/basics/sources/Lock.move
+++ b/sui_programmability/examples/basics/sources/Lock.move
@@ -1,8 +1,11 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// An example of a module that uses Shared Objects and ID linking/access.
 ///
 /// This module allows any content to be locked inside a 'virtual chest' and later
 /// be accessed by putting a 'key' into the 'lock'. Lock is shared and is visible
-/// and discoverable by the key owner. 
+/// and discoverable by the key owner.
 module Basics::Lock {
     use Sui::ID::{Self, ID, VersionedID};
     use Sui::Transfer;
@@ -18,14 +21,14 @@ module Basics::Lock {
     /// Lock already contains something.
     const ELOCK_IS_FULL: u64 = 2;
 
-    /// Lock that stores any content inside it. 
+    /// Lock that stores any content inside it.
     struct Lock<T: store + key> has key, store {
         id: VersionedID,
         locked: Option<T>
     }
 
     /// A key that is created with a Lock; is transferable
-    /// and contains all the needed information to open the Lock. 
+    /// and contains all the needed information to open the Lock.
     struct Key<phantom T: store + key> has key, store {
         id: VersionedID,
         for: ID,
@@ -36,7 +39,7 @@ module Basics::Lock {
         key.for
     }
 
-    /// Lock some content inside a shared object. A Key is created and is 
+    /// Lock some content inside a shared object. A Key is created and is
     /// sent to the transaction sender.
     public fun create<T: store + key>(obj: T, ctx: &mut TxContext) {
         let id = TxContext::new_id(ctx);
@@ -67,7 +70,7 @@ module Basics::Lock {
         Option::fill(&mut lock.locked, obj);
     }
 
-    /// Unlock the Lock with a Key and access its contents. 
+    /// Unlock the Lock with a Key and access its contents.
     /// Can only be called if both conditions are met:
     /// - key matches the lock
     /// - lock is not empty

--- a/sui_programmability/examples/basics/sources/Object.move
+++ b/sui_programmability/examples/basics/sources/Object.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// An example of a custom object with comments explaining the relevant bits
 module Basics::Object {
     use Sui::ID::VersionedID;

--- a/sui_programmability/examples/basics/sources/Sandwich.move
+++ b/sui_programmability/examples/basics/sources/Sandwich.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example of objects that can be combined to create
 /// new objects
 module Basics::Sandwich {

--- a/sui_programmability/examples/defi/sources/Escrow.move
+++ b/sui_programmability/examples/defi/sources/Escrow.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// An escrow for atomic swap of objects that trusts a third party for liveness, but not safety.
 module DeFi::Escrow {
     use Sui::ID::{Self, ID, VersionedID};

--- a/sui_programmability/examples/defi/sources/FlashLender.move
+++ b/sui_programmability/examples/defi/sources/FlashLender.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// A flash loan that works for any Coin type
 module DeFi::FlashLender {
     use Sui::Coin::{Self, Coin};
@@ -30,8 +33,8 @@ module DeFi::FlashLender {
         repay_amount: u64
     }
 
-    /// An object conveying the privilege to withdraw funds from and deposit funds to the 
-    /// `FlashLender` instance with ID `flash_lender_id`. Initially granted to the creator 
+    /// An object conveying the privilege to withdraw funds from and deposit funds to the
+    /// `FlashLender` instance with ID `flash_lender_id`. Initially granted to the creator
     /// of the `FlashLender`, and only one `AdminCap` per lender exists.
     struct AdminCap has key, store {
         id: VersionedID,
@@ -82,7 +85,7 @@ module DeFi::FlashLender {
     // === Core functionality: requesting a loan and repaying it ===
 
     /// Request a loan of `amount` from `lender`. The returned `Receipt<T>` "hot potato" ensures
-    /// that the borrower will call `repay(lender, ...)` later on in this tx. 
+    /// that the borrower will call `repay(lender, ...)` later on in this tx.
     /// Aborts if `amount` is greater that the amount that `lender` has available for lending.
     public fun loan<T>(
         self: &mut FlashLender<T>, amount: u64, ctx: &mut TxContext
@@ -91,14 +94,14 @@ module DeFi::FlashLender {
         assert!(Coin::value(to_lend) >= amount, ELOAN_TOO_LARGE);
         let loan = Coin::withdraw(to_lend, amount, ctx);
 
-        let repay_amount = amount + self.fee;        
+        let repay_amount = amount + self.fee;
         let receipt = Receipt { flash_lender_id: *ID::id(self), repay_amount };
         (loan, receipt)
     }
 
     /// Repay the loan recorded by `receipt` to `lender` with `payment`.
     /// Aborts if the repayment amount is incorrect or `lender` is not the `FlashLender`
-    /// that issued the original loan. 
+    /// that issued the original loan.
     public fun repay<T>(self: &mut FlashLender<T>, payment: Coin<T>, receipt: Receipt<T>) {
         let Receipt { flash_lender_id, repay_amount } = receipt;
         assert!(ID::id(self) == &flash_lender_id, EREPAY_TO_WRONG_LENDER);
@@ -111,9 +114,9 @@ module DeFi::FlashLender {
 
     /// Allow admin for `self` to withdraw funds.
     public fun withdraw<T>(
-        self: &mut FlashLender<T>, 
+        self: &mut FlashLender<T>,
         admin_cap: &AdminCap,
-        amount: u64, 
+        amount: u64,
         ctx: &mut TxContext
     ): Coin<T> {
         // only the holder of the `AdminCap` for `self` can withdraw funds

--- a/sui_programmability/examples/defi/tests/FlashLenderTests.move
+++ b/sui_programmability/examples/defi/tests/FlashLenderTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module DeFi::FlashLenderTests {
     use DeFi::FlashLender::{Self, AdminCap, FlashLender};

--- a/sui_programmability/examples/fungible_tokens/sources/MANAGED.move
+++ b/sui_programmability/examples/fungible_tokens/sources/MANAGED.move
@@ -1,5 +1,8 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example coin with a trusted manager responsible for minting/burning (e.g., a stablecoin)
-/// By convention, modules defining custom coin types use upper case names, in constrast to
+/// By convention, modules defining custom coin types use upper case names, in contrast to
 /// ordinary modules, which use camel case.
 module FungibleTokens::MANAGED {
     use Sui::Coin::{Self, Coin, TreasuryCap};

--- a/sui_programmability/examples/games/hero/sources/Hero.move
+++ b/sui_programmability/examples/games/hero/sources/Hero.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example of a game character with basic attributes, inventory, and
 /// associated logic.
 module HeroGame::Hero {

--- a/sui_programmability/examples/games/hero/sources/SeaHero.move
+++ b/sui_programmability/examples/games/hero/sources/SeaHero.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Example of a game mod or different game that uses objects from the Hero
 /// game.
 /// This mod introduces sea monsters that can also be slain with the hero's

--- a/sui_programmability/examples/games/hero/sources/SeaHeroHelper.move
+++ b/sui_programmability/examples/games/hero/sources/SeaHeroHelper.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Mod of the economics of the SeaHero game. In the game, a `Hero` can onAly
 /// slay a `SeaMonster` if they have sufficient strength. This mod allows a
 /// player with a weak `Hero` to ask a player with a stronger `Hero` to slay

--- a/sui_programmability/examples/games/sources/SharedTicTacToe.move
+++ b/sui_programmability/examples/games/sources/SharedTicTacToe.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // This is a rewrite of TicTacToe using a completely different approach.
 // In TicTacToe, since the game object is owned by the admin, the players was not
 // able to directly mutate the gameboard. Hence each marker placement takes

--- a/sui_programmability/examples/games/sources/TicTacToe.move
+++ b/sui_programmability/examples/games/sources/TicTacToe.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // This is an implementation of the TicTacToe game.
 // The game object (which includes gameboard) is owned by a game admin.
 // Since players don't have ownership over the game object, they cannot

--- a/sui_programmability/examples/games/tests/RockPaperScissorsTests.move
+++ b/sui_programmability/examples/games/tests/RockPaperScissorsTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Games::RockPaperScissorsTests {
     use Games::RockPaperScissors::{Self as Game, Game, PlayerTurn, Secret, ThePrize};
@@ -7,7 +10,7 @@ module Games::RockPaperScissorsTests {
 
     #[test]
     public fun play_rock_paper_scissors() {
-        // So these are our heros.
+        // So these are our heroes.
         let the_main_guy = @0xA1C05;
         let mr_lizard = @0xA55555;
         let mr_spock = @0x590C;
@@ -15,10 +18,10 @@ module Games::RockPaperScissorsTests {
         let scenario = &mut TestScenario::begin(&the_main_guy);
 
         // Let the game begin!
-        Game::new_game(mr_spock, mr_lizard, TestScenario::ctx(scenario));        
+        Game::new_game(mr_spock, mr_lizard, TestScenario::ctx(scenario));
 
         // Mr Spock makes his move. He does it secretly and hashes the gesture with a salt
-        // so that only he knows what it is. 
+        // so that only he knows what it is.
         TestScenario::next_tx(scenario, &mr_spock);
         {
             let hash = hash(Game::rock(), b"my_phaser_never_failed_me!");
@@ -30,11 +33,11 @@ module Games::RockPaperScissorsTests {
         {
             let game = TestScenario::remove_object<Game>(scenario);
             let cap = TestScenario::remove_object<PlayerTurn>(scenario);
-            
+
             assert!(Game::status(&game) == 0, 0); // STATUS_READY
-            
+
             Game::add_hash(&mut game, cap, TestScenario::ctx(scenario));
-            
+
             assert!(Game::status(&game) == 1, 0); // STATUS_HASH_SUBMISSION
 
             TestScenario::return_object(scenario, game);
@@ -92,10 +95,10 @@ module Games::RockPaperScissorsTests {
         };
 
         TestScenario::next_tx(scenario, &mr_spock);
-        // If it works, then MrSpock is in posession of the prize;
-        let prize = TestScenario::remove_object<ThePrize>(scenario); 
+        // If it works, then MrSpock is in possession of the prize;
+        let prize = TestScenario::remove_object<ThePrize>(scenario);
         // Don't forget to give it back!
-        TestScenario::return_object(scenario, prize); 
+        TestScenario::return_object(scenario, prize);
     }
 
     // Copy of the hashing function from the main module.

--- a/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Games::SharedTicTacToeTests {
     use Sui::TestScenario::{Self, Scenario};

--- a/sui_programmability/examples/games/tests/TicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/TicTacToeTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Games::TicTacToeTests {
     use Sui::TestScenario::{Self, Scenario};

--- a/sui_programmability/examples/nfts/sources/Auction.move
+++ b/sui_programmability/examples/nfts/sources/Auction.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// This is an implementation of an English auction
 /// (https://en.wikipedia.org/wiki/English_auction) using single-owner
 /// objects only. There are 3 types of parties participating in an

--- a/sui_programmability/examples/nfts/sources/AuctionLib.move
+++ b/sui_programmability/examples/nfts/sources/AuctionLib.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// This is a helper module for implementing two versions of an
 /// English auction (https://en.wikipedia.org/wiki/English_auction),
 /// one using single-owner objects only and the other using shared

--- a/sui_programmability/examples/nfts/sources/Geniteam.move
+++ b/sui_programmability/examples/nfts/sources/Geniteam.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module NFTs::Geniteam {
     use Sui::ID::{Self, ID, VersionedID};
     use Sui::TxContext::{Self, TxContext};

--- a/sui_programmability/examples/nfts/sources/Marketplace.move
+++ b/sui_programmability/examples/nfts/sources/Marketplace.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module NFTs::Marketplace {
     use Sui::TxContext::{Self, TxContext};
     use Sui::ID::{Self, ID, VersionedID};
@@ -22,7 +25,7 @@ module NFTs::Marketplace {
         id: VersionedID,
         objects: vector<ID>,
         owner: address,
-    }  
+    }
 
     /// A single listing which contains the listed item and its price in [`Coin<C>`].
     struct Listing<T: key + store, phantom C> has key, store {
@@ -91,7 +94,7 @@ module NFTs::Marketplace {
         let listing = internal_remove(marketplace, listing);
         let Listing { id, item, ask, owner } = listing;
 
-        assert!(ask == Coin::value(&paid), EAMOUNT_INCORRECT); 
+        assert!(ask == Coin::value(&paid), EAMOUNT_INCORRECT);
 
         Transfer::transfer(paid, owner);
         ID::delete(id);
@@ -192,10 +195,10 @@ module NFTs::MarketplaceTests {
 
     // SELLER lists KITTY at the Marketplace for 100 GAS.
     fun list_kitty(scenario: &mut Scenario) {
-        TestScenario::next_tx(scenario, &SELLER);  
+        TestScenario::next_tx(scenario, &SELLER);
         let mkp = TestScenario::remove_object<Marketplace>(scenario);
         let nft = TestScenario::remove_object<NFT<KITTY>>(scenario);
-            
+
         Marketplace::list<NFT<KITTY>, GAS>(&mut mkp, nft, 100, TestScenario::ctx(scenario));
         TestScenario::return_object(scenario, mkp);
     }
@@ -207,7 +210,7 @@ module NFTs::MarketplaceTests {
         create_marketplace(scenario);
         mint_kitty(scenario);
         list_kitty(scenario);
-        
+
         TestScenario::next_tx(scenario, &SELLER);
         {
             let mkp = TestScenario::remove_object<Marketplace>(scenario);
@@ -216,7 +219,7 @@ module NFTs::MarketplaceTests {
             // Do the delist operation on a Marketplace.
             let nft = Marketplace::delist<NFT<KITTY>, GAS>(&mut mkp, listing, TestScenario::ctx(scenario));
             let kitten = NFT::burn<KITTY>(nft);
-        
+
             assert!(kitten.id == 1, 0);
 
             TestScenario::return_object(scenario, mkp);
@@ -238,7 +241,7 @@ module NFTs::MarketplaceTests {
         {
             let mkp = TestScenario::remove_object<Marketplace>(scenario);
             let listing = TestScenario::remove_nested_object<Marketplace, Listing<NFT<KITTY>, GAS>>(scenario, &mkp);
-            
+
             // Do the delist operation on a Marketplace.
             let nft = Marketplace::delist<NFT<KITTY>, GAS>(&mut mkp, listing, TestScenario::ctx(scenario));
             let _ = NFT::burn<KITTY>(nft);
@@ -267,14 +270,14 @@ module NFTs::MarketplaceTests {
             // Do the buy call and expect successful purchase.
             let nft = Marketplace::buy<NFT<KITTY>, GAS>(&mut mkp, listing, payment);
             let kitten = NFT::burn<KITTY>(nft);
-            
+
             assert!(kitten.id == 1, 0);
 
             TestScenario::return_object(scenario, mkp);
             TestScenario::return_object(scenario, coin);
         };
     }
-    
+
     #[test]
     #[expected_failure(abort_code = 0)]
     fun fail_to_buy() {
@@ -291,14 +294,14 @@ module NFTs::MarketplaceTests {
             let coin = TestScenario::remove_object<Coin<GAS>>(scenario);
             let mkp = TestScenario::remove_object<Marketplace>(scenario);
             let listing = TestScenario::remove_nested_object<Marketplace, Listing<NFT<KITTY>, GAS>>(scenario, &mkp);
-            
+
             // AMOUNT here is 10 while expected is 100.
             let payment = Coin::withdraw(&mut coin, 10, TestScenario::ctx(scenario));
 
             // Attempt to buy and expect failure purchase.
             let nft = Marketplace::buy<NFT<KITTY>, GAS>(&mut mkp, listing, payment);
             let _ = NFT::burn<KITTY>(nft);
-            
+
             TestScenario::return_object(scenario, mkp);
             TestScenario::return_object(scenario, coin);
         };

--- a/sui_programmability/examples/nfts/sources/Num.move
+++ b/sui_programmability/examples/nfts/sources/Num.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module NFTs::Num {
     use Sui::ID::VersionedID;
     use Sui::NFT::{Self, NFT};

--- a/sui_programmability/examples/nfts/sources/SharedAuction.move
+++ b/sui_programmability/examples/nfts/sources/SharedAuction.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// This is an implementation of an English auction
 /// (https://en.wikipedia.org/wiki/English_auction) using shared
 /// objects. There are types of participants:

--- a/sui_programmability/examples/nfts/tests/AuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/AuctionTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module NFTs::AuctionTests {
     use Std::Vector;
@@ -20,7 +23,7 @@ module NFTs::AuctionTests {
         value: u64,
     }
 
-    // Initializes the "state of the world" that mimicks what should
+    // Initializes the "state of the world" that mimics what should
     // be available in Sui genesis state (e.g., mints and distributes
     // coins to users).
     fun init(ctx: &mut TxContext, bidders: vector<address>) {

--- a/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module NFTs::SharedAuctionTests {
     use Std::Vector;
@@ -24,7 +27,7 @@ module NFTs::SharedAuctionTests {
         value: u64,
     }
 
-    // Initializes the "state of the world" that mimicks what should
+    // Initializes the "state of the world" that mimics what should
     // be available in Sui genesis state (e.g., mints and distributes
     // coins to users).
     fun init(ctx: &mut TxContext, bidders: vector<address>) {

--- a/sui_programmability/framework/deps/move-stdlib/sources/ASCII.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/ASCII.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// The `ASCII` module defines basic string and char newtypes in Move that verify
 /// that characters are valid ASCII, and that strings consist of only valid ASCII characters.
 module Std::ASCII {

--- a/sui_programmability/framework/deps/move-stdlib/sources/BCS.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/BCS.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Utility for converting a Move value to its binary representation in BCS (Binary Canonical
 /// Serialization). BCS is the binary encoding for Move resources and other non-module values
 /// published on-chain. See https://github.com/diem/bcs#binary-canonical-serialization-bcs for more

--- a/sui_programmability/framework/deps/move-stdlib/sources/BitVector.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/BitVector.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Std::BitVector {
     use Std::Vector;
     use Std::Errors;

--- a/sui_programmability/framework/deps/move-stdlib/sources/Capability.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Capability.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// A module which defines the basic concept of
 /// [*capabilities*](https://en.wikipedia.org/wiki/Capability-based_security) for managing access control.
 ///

--- a/sui_programmability/framework/deps/move-stdlib/sources/Debug.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Debug.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Module providing debug functionality.
 module Std::Debug {
     native public fun print<T>(x: &T);

--- a/sui_programmability/framework/deps/move-stdlib/sources/Errors.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Errors.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Module defining error codes used in Move aborts throughout the framework.
 ///
 /// A `u64` error code is constructed from two values:

--- a/sui_programmability/framework/deps/move-stdlib/sources/FixedPoint32.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/FixedPoint32.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Defines a fixed-point numeric type with a 32-bit integer part and
 /// a 32-bit fractional part.
 

--- a/sui_programmability/framework/deps/move-stdlib/sources/GUID.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/GUID.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// A module for generating globally unique identifiers
 module Std::GUID {
     use Std::Signer;

--- a/sui_programmability/framework/deps/move-stdlib/sources/Hash.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Hash.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Module which defines SHA hashes for byte vectors.
 ///
 /// The functions in this module are natively declared both in the Move runtime

--- a/sui_programmability/framework/deps/move-stdlib/sources/Option.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Option.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// This module defines the Option type and its methods to represent and handle an optional value.
 module Std::Option {
     use Std::Errors;

--- a/sui_programmability/framework/deps/move-stdlib/sources/Signer.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Signer.move
@@ -1,6 +1,9 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Std::Signer {
     // Borrows the address of the signer
-    // Conceptually, you can think of the `signer` as being a struct wrapper arround an
+    // Conceptually, you can think of the `signer` as being a struct wrapper around an
     // address
     // ```
     // struct Signer has drop { addr: address }

--- a/sui_programmability/framework/deps/move-stdlib/sources/UnitTest.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/UnitTest.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 /// Module providing testing functionality. Only included for tests.
 module Std::UnitTest {

--- a/sui_programmability/framework/deps/move-stdlib/sources/Vector.move
+++ b/sui_programmability/framework/deps/move-stdlib/sources/Vector.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// A variable-sized container that can hold any type. Indexing is 0-based, and
 /// vectors are growable. This module has many native functions.
 /// Verification of modules that use this one uses model functions that are implemented

--- a/sui_programmability/framework/sources/Bag.move
+++ b/sui_programmability/framework/sources/Bag.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// A Bag is a heterogeneous collection of objects with arbitrary types, i.e.
 /// the objects in the bag don't need to be of the same type.
 /// These objects are not stored in the Bag directly, instead only a reference

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::Coin {
     use Sui::ID::{Self, VersionedID};
     use Sui::Transfer;

--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// The `Collection` type represents a collection of objects of the same type `T`.
 /// In contrast to `vector<T>` which stores the object in the vector directly,
 /// `Collection<T>` only tracks the ownership indirectly, by keeping a list of

--- a/sui_programmability/framework/sources/ERC721Metadata.move
+++ b/sui_programmability/framework/sources/ERC721Metadata.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::ERC721Metadata {
     use Std::ASCII;
     use Sui::Url::{Self, Url};
@@ -5,17 +8,17 @@ module Sui::ERC721Metadata {
 
     // TODO: add symbol()?
     /// A wrapper type for the ERC721 metadata standard https://eips.ethereum.org/EIPS/eip-721
-    struct ERC721Metadata has store {       
+    struct ERC721Metadata has store {
         /// The token id associated with the source contract on Ethereum
         token_id: TokenID,
-        /// A descriptive name for a collection of NFTs in this contract. 
+        /// A descriptive name for a collection of NFTs in this contract.
         /// This corresponds to the `name()` method in the
         /// ERC721Metadata interface in EIP-721.
-        name: UTF8::String,        
+        name: UTF8::String,
         /// A distinct Uniform Resource Identifier (URI) for a given asset.
-        /// This corresponds to the `tokenURI()` method in the ERC721Metadata 
+        /// This corresponds to the `tokenURI()` method in the ERC721Metadata
         /// interface in EIP-721.
-        token_uri: Url,    
+        token_uri: Url,
     }
 
     // TODO: replace u64 with u256 once the latter is supported
@@ -30,7 +33,7 @@ module Sui::ERC721Metadata {
     public fun new(token_id: TokenID, name: vector<u8>, token_uri: vector<u8>): ERC721Metadata {
         // Note: this will abort if `token_uri` is not valid ASCII
         let uri_str = ASCII::string(token_uri);
-        ERC721Metadata { 
+        ERC721Metadata {
             token_id,
             name: UTF8::string_unsafe(name),
             token_uri: Url::new_unsafe(uri_str),

--- a/sui_programmability/framework/sources/Event.move
+++ b/sui_programmability/framework/sources/Event.move
@@ -1,7 +1,10 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::Event {
 
     /// Add `t` to the event log of this transaction
-    // TODO(https://github.com/MystenLabs/sui/issues/19): 
+    // TODO(https://github.com/MystenLabs/sui/issues/19):
     // restrict to internal types once we can express this in the ability system
     public native fun emit<T: copy + drop>(event: T);
 }

--- a/sui_programmability/framework/sources/GAS.move
+++ b/sui_programmability/framework/sources/GAS.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Coin<Gas> is the token used to pay for gas in Sui
 module Sui::GAS {
     use Sui::Coin;

--- a/sui_programmability/framework/sources/Geniteam.move
+++ b/sui_programmability/framework/sources/Geniteam.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::Geniteam {
     use Sui::Bag::{Self, Bag};
     use Sui::Collection::{Self, Collection};

--- a/sui_programmability/framework/sources/ID.move
+++ b/sui_programmability/framework/sources/ID.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Sui object identifiers
 module Sui::ID {
     use Std::BCS;

--- a/sui_programmability/framework/sources/Math.move
+++ b/sui_programmability/framework/sources/Math.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Basic math for nicer programmability
 module Sui::Math {
 

--- a/sui_programmability/framework/sources/NFT.move
+++ b/sui_programmability/framework/sources/NFT.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::NFT {
     use Sui::ID::{Self, VersionedID};
     use Sui::Transfer;

--- a/sui_programmability/framework/sources/ObjectBasics.move
+++ b/sui_programmability/framework/sources/ObjectBasics.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Test CTURD object basics (create, transfer, update, read, delete)
 module Sui::ObjectBasics {
     use Sui::Event;
@@ -12,7 +15,7 @@ module Sui::ObjectBasics {
 
     struct Wrapper has key {
         id: VersionedID,
-        o: Object 
+        o: Object
     }
 
     struct NewValueEvent has copy, drop {

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::Transfer {
     use Sui::ID::{Self, ID, VersionedID};
 

--- a/sui_programmability/framework/sources/TxContext.move
+++ b/sui_programmability/framework/sources/TxContext.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::TxContext {
     use Std::Signer;
     use Sui::ID::{Self, VersionedID};
@@ -14,7 +17,7 @@ module Sui::TxContext {
     const EBAD_TX_HASH_LENGTH: u64 = 0;
 
     /// Information about the transaction currently being executed.
-    /// This cannot be constructed by a transaction--it is a privileged object created by 
+    /// This cannot be constructed by a transaction--it is a privileged object created by
     /// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
     struct TxContext has drop {
         /// A `signer` wrapping the address of the user that signed the current transaction
@@ -37,7 +40,7 @@ module Sui::TxContext {
         &self.signer
     }
 
-    /// Generate a new, globally unqiue object ID with version 0
+    /// Generate a new, globally unique object ID with version 0
     public fun new_id(ctx: &mut TxContext): VersionedID {
         let ids_created = ctx.ids_created;
         let id = ID::new_versioned_id(fresh_id(*&ctx.tx_hash, ids_created));

--- a/sui_programmability/framework/sources/UTF8.move
+++ b/sui_programmability/framework/sources/UTF8.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module Sui::UTF8 {
     use Std::ASCII;
     use Std::Option::Option;
@@ -24,7 +27,7 @@ module Sui::UTF8 {
         ASCII::try_string(self.bytes)
     }
 
-    /// Return the underyling bytes of `self`
+    /// Return the underlying bytes of `self`
     public fun bytes(self: &String): &vector<u8> {
         &self.bytes
     }

--- a/sui_programmability/framework/sources/Url.move
+++ b/sui_programmability/framework/sources/Url.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// URL: standard Uniform Resource Locator string
 /// Url: Sui type which wraps a URL
 /// UrlCommitment: Sui type which wraps a Url but also includes an immutable commitment

--- a/sui_programmability/framework/tests/BagTests.move
+++ b/sui_programmability/framework/tests/BagTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Sui::BagTests {
     use Sui::Bag::{Self, Bag};

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Sui::CollectionTests {
     use Sui::Collection::{Self, Collection};

--- a/sui_programmability/framework/tests/IDTests.move
+++ b/sui_programmability/framework/tests/IDTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Sui::IDTests {
     use Sui::ID;

--- a/sui_programmability/framework/tests/TxContextTests.move
+++ b/sui_programmability/framework/tests/TxContextTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Sui::TxContextTests {
     use Sui::ID;

--- a/sui_programmability/framework/tests/UrlTests.move
+++ b/sui_programmability/framework/tests/UrlTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Sui::UrlTests {
     use Sui::Url;

--- a/sui_programmability/tutorial/sources/M1.move
+++ b/sui_programmability/tutorial/sources/M1.move
@@ -1,7 +1,10 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module MyFirstPackage::M1 {
     use Sui::ID::VersionedID;
     use Sui::TxContext::TxContext;
-    
+
     struct Sword has key, store {
         id: VersionedID,
         magic: u64,
@@ -24,12 +27,12 @@ module MyFirstPackage::M1 {
         // transfer the forge object to the module/package publisher
         // (presumably the game admin)
         Transfer::transfer(admin, TxContext::sender(ctx));
-    }    
+    }
 
     public fun swords_created(self: &Forge): u64 {
         self.swords_created
     }
-    
+
     public fun magic(self: &Sword): u64 {
         self.magic
     }
@@ -45,7 +48,7 @@ module MyFirstPackage::M1 {
         let sword = Sword {
             id: TxContext::new_id(ctx),
             magic: magic,
-            strength: strength,                
+            strength: strength,
         };
         // transfer the sword
         Transfer::transfer(sword, recipient);
@@ -66,7 +69,7 @@ module MyFirstPackage::M1 {
         let admin = @0xBABE;
 
         // first transaction to emulate module initialization
-        let scenario = &mut TestScenario::begin(&admin);        
+        let scenario = &mut TestScenario::begin(&admin);
         {
             init(TestScenario::ctx(scenario));
         };
@@ -116,7 +119,7 @@ module MyFirstPackage::M1 {
         // fourth transaction executed by the final sword owner
         TestScenario::next_tx(scenario, &final_owner);
         {
-            
+
             // extract the sword owned by the final owner
             let sword = TestScenario::remove_object<Sword>(scenario);
             // verify that the sword has expected properties
@@ -125,29 +128,29 @@ module MyFirstPackage::M1 {
             TestScenario::return_object(scenario, sword)
         }
     }
-    
-    
+
+
     #[test]
     public fun test_sword_create() {
         use Sui::Transfer;
         use Sui::TxContext;
-        
+
         // create a dummy TxContext for testing
         let ctx = TxContext::dummy();
-        
+
         // create a sword
         let sword = Sword {
             id: TxContext::new_id(&mut ctx),
             magic: 42,
-            strength: 7,                
+            strength: 7,
         };
-        
+
         // check if accessor functions return correct values
         assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
 
         // create a dummy address and transfer the sword
-        let dummy_address = @0xCAFE;        
+        let dummy_address = @0xCAFE;
         Transfer::transfer(sword, dummy_address);
     }
-    
+
 }


### PR DESCRIPTION
Command used: `find ./ -name "*.move" -exec gsed -i -e '1i\/\/ Copyright (c) 2022, Mysten Labs, Inc.\n\/\/ SPDX-License-Identifier: Apache-2.0\n' '{}' \;\n` thanks to @huitseeker 

There're also some typo/formatting fix due to the pre-commit hooks setup

## Next steps
- Also add license headers to typescript files