### PR TITLE
[shared-object] Synchroniser for consensus client

### DIFF
--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -986,6 +986,12 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             .map(|x| x.unwrap_or_default())
             .map_err(SuiError::from)
     }
+
+    #[cfg(test)]
+    /// Provide read access to the `schedule` table (useful for testing).
+    pub fn get_schedule(&self, object_id: &ObjectID) -> SuiResult<Option<SequenceNumber>> {
+        self.schedule.get(object_id).map_err(SuiError::from)
+    }
 }
 
 impl<const ALL_OBJ_VER: bool> BackingPackageStore for SuiDataStore<ALL_OBJ_VER> {

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -11,82 +11,111 @@ use rand::SeedableRng;
 use std::time::Duration;
 use sui_adapter::genesis;
 use sui_network::transport;
-use sui_types::base_types::{ObjectID, TransactionDigest};
-use sui_types::crypto::{get_key_pair_from_rng, Signature};
-use sui_types::messages::{SignatureAggregator, Transaction, TransactionData};
-use sui_types::object::{Data, Object, Owner};
+use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
+use sui_types::crypto::{get_key_pair_from_rng, KeyPair, Signature};
+use sui_types::gas_coin::GasCoin;
+use sui_types::messages::{
+    CertifiedTransaction, SignatureAggregator, Transaction, TransactionData,
+};
+use sui_types::object::{Data, MoveObject, Object, Owner};
 use sui_types::serialize::serialize_cert;
 use test_utils::sequencer::Sequencer;
 
 /// Default network buffer size.
 const NETWORK_BUFFER_SIZE: usize = 65_000;
 
+/// Fixture: a test keypair.
+fn test_keypair() -> (SuiAddress, KeyPair) {
+    let mut rng = StdRng::from_seed([0; 32]);
+    get_key_pair_from_rng(&mut rng)
+}
+
+/// Fixture: a few test gas objects.
+fn test_gas_objects() -> Vec<Object> {
+    (0..4)
+        .map(|i| {
+            let seed = format!("0x555555555555555{}", i);
+            let gas_object_id = ObjectID::from_hex_literal(&seed).unwrap();
+            let (sender, _) = test_keypair();
+            Object::with_id_owner_for_testing(gas_object_id, sender)
+        })
+        .collect()
+}
+
+/// Fixture: a a test shared object.
+fn test_shared_object() -> Object {
+    let seed = "0x6666666666666660";
+    let shared_object_id = ObjectID::from_hex_literal(seed).unwrap();
+    let content = GasCoin::new(shared_object_id, SequenceNumber::new(), 10);
+    let data = Data::Move(MoveObject::new(
+        /* type */ GasCoin::type_(),
+        content.to_bcs_bytes(),
+    ));
+    Object {
+        data,
+        owner: Owner::SharedMutable,
+        previous_transaction: TransactionDigest::genesis(),
+    }
+}
+
+/// Fixture: a few test certificates containing a shared object.
+async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTransaction> {
+    let (sender, keypair) = test_keypair();
+
+    let mut certificates = Vec::new();
+    let shared_object_id = test_shared_object().id();
+    for gas_object in test_gas_objects() {
+        // Make a sample transaction.
+        let module = "ObjectBasics";
+        let function = "create";
+        let genesis_package_objects = genesis::clone_genesis_packages();
+        let package_object_ref = get_genesis_package_by_module(&genesis_package_objects, module);
+
+        let data = TransactionData::new_move_call(
+            sender,
+            package_object_ref,
+            ident_str!(module).to_owned(),
+            ident_str!(function).to_owned(),
+            /* type_args */ vec![],
+            gas_object.compute_object_reference(),
+            /* object_args */ vec![],
+            vec![shared_object_id],
+            /* pure_args */
+            vec![
+                16u64.to_le_bytes().to_vec(),
+                bcs::to_bytes(&AccountAddress::from(sender)).unwrap(),
+            ],
+            /* max_gas */ 10_000,
+        );
+        let signature = Signature::new(&data, &keypair);
+        let transaction = Transaction::new(data, signature);
+
+        // Submit the transaction and assemble a certificate.
+        let response = authority
+            .handle_transaction(transaction.clone())
+            .await
+            .unwrap();
+        let vote = response.signed_transaction.unwrap();
+        let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
+            .unwrap()
+            .append(vote.authority, vote.signature)
+            .unwrap()
+            .unwrap();
+        certificates.push(certificate);
+    }
+    certificates
+}
+
 #[tokio::test]
 async fn handle_consensus_output() {
-    let mut rng = StdRng::from_seed([0; 32]);
-    let (sender, keypair) = get_key_pair_from_rng(&mut rng);
-
     // Initialize an authority with a (owned) gas object and a shared object.
-    let gas_object_id = ObjectID::random();
-    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
-    let gas_object_ref = gas_object.compute_object_reference();
+    let mut objects = test_gas_objects();
+    objects.push(test_shared_object());
+    let authority = init_state_with_objects(objects).await;
 
-    let shared_object_id = ObjectID::random();
-    let shared_object = {
-        use sui_types::gas_coin::GasCoin;
-        use sui_types::object::MoveObject;
-
-        let content = GasCoin::new(shared_object_id, SequenceNumber::new(), 10);
-        let data = Data::Move(MoveObject::new(
-            /* type */ GasCoin::type_(),
-            content.to_bcs_bytes(),
-        ));
-        Object {
-            data,
-            owner: Owner::SharedMutable,
-            previous_transaction: TransactionDigest::genesis(),
-        }
-    };
-
-    let authority = init_state_with_objects(vec![gas_object, shared_object]).await;
-
-    // Make a sample transaction.
-    let module = "ObjectBasics";
-    let function = "create";
-    let genesis_package_objects = genesis::clone_genesis_packages();
-    let package_object_ref = get_genesis_package_by_module(&genesis_package_objects, module);
-
-    let data = TransactionData::new_move_call(
-        sender,
-        package_object_ref,
-        ident_str!(module).to_owned(),
-        ident_str!(function).to_owned(),
-        /* type_args */ vec![],
-        gas_object_ref,
-        /* object_args */ vec![],
-        vec![shared_object_id],
-        /* pure_args */
-        vec![
-            16u64.to_le_bytes().to_vec(),
-            bcs::to_bytes(&AccountAddress::from(sender)).unwrap(),
-        ],
-        /* max_gas */ 10_000,
-    );
-    let signature = Signature::new(&data, &keypair);
-    let transaction = Transaction::new(data, signature);
-
-    // Submit the transaction and assemble a certificate.
-    let response = authority
-        .handle_transaction(transaction.clone())
-        .await
-        .unwrap();
-    let vote = response.signed_transaction.unwrap();
-    let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
-        .unwrap()
-        .append(vote.authority, vote.signature)
-        .unwrap()
-        .unwrap();
-    let serialized_certificate = serialize_cert(&certificate);
+    // Make a sample certificate.
+    let certificate = &test_certificates(&authority).await[0];
+    let serialized_certificate = serialize_cert(certificate);
 
     // Spawn a sequencer.
     // TODO [issue #932]: Use a port allocator to avoid port conflicts.
@@ -138,4 +167,89 @@ async fn test_guardrail() {
     // Create a second consensus client from the same state.
     let result = ConsensusClient::new(state);
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_sync() {
+    // Initialize an authority with a (owned) gas object and a shared object.
+    let mut objects = test_gas_objects();
+    objects.push(test_shared_object());
+    let authority = init_state_with_objects(objects).await;
+
+    // Make two certificates.
+    let certificate_0 = &test_certificates(&authority).await[0];
+    let serialized_certificate_0 = serialize_cert(certificate_0);
+    let certificate_1 = &test_certificates(&authority).await[1];
+    let serialized_certificate_1 = serialize_cert(certificate_1);
+
+    // Spawn a sequencer.
+    // TODO [issue #932]: Use a port allocator to avoid port conflicts.
+    let consensus_input_address = "127.0.0.1:13011".parse().unwrap();
+    let consensus_subscriber_address = "127.0.0.1:1312".parse().unwrap();
+    let sequencer = Sequencer {
+        input_address: consensus_input_address,
+        subscriber_address: consensus_subscriber_address,
+        buffer_size: NETWORK_BUFFER_SIZE,
+        consensus_delay: Duration::from_millis(0),
+    };
+    Sequencer::spawn(sequencer).await;
+
+    // Submit a certificate to the sequencer.
+    tokio::task::yield_now().await;
+    transport::connect(consensus_input_address.to_string(), NETWORK_BUFFER_SIZE)
+        .await
+        .unwrap()
+        .write_data(&serialized_certificate_0)
+        .await
+        .unwrap();
+
+    // Spawn a consensus client.
+    let state = Arc::new(authority);
+    let consensus_client = ConsensusClient::new(state.clone()).unwrap();
+    ConsensusClient::spawn(
+        consensus_client,
+        consensus_subscriber_address,
+        NETWORK_BUFFER_SIZE,
+    );
+
+    // Submit a second certificate to the sequencer. This will force the consensus client to sync.
+    transport::connect(consensus_input_address.to_string(), NETWORK_BUFFER_SIZE)
+        .await
+        .unwrap()
+        .write_data(&serialized_certificate_1)
+        .await
+        .unwrap();
+
+    // Wait for the certificate to be processed.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Ensure the last consensus index is correctly updated.
+    assert_eq!(
+        state.db().last_consensus_index().unwrap(),
+        SequenceNumber::from(2)
+    );
+
+    // Ensure the version number of the shared object is correctly updated.
+    let shared_object_id = test_shared_object().id();
+    let version = state.db().get_schedule(&shared_object_id).unwrap().unwrap();
+    assert_eq!(version, SequenceNumber::from(2));
+
+    // Ensure the certificates are locked in the right order.
+    let certificate_0_sequence = state
+        .db()
+        .sequenced(certificate_0.digest(), vec![shared_object_id].iter())
+        .unwrap()
+        .pop()
+        .unwrap()
+        .unwrap();
+    assert_eq!(certificate_0_sequence, SequenceNumber::default());
+
+    let certificate_1_sequence = state
+        .db()
+        .sequenced(certificate_1.digest(), vec![shared_object_id].iter())
+        .unwrap()
+        .pop()
+        .unwrap()
+        .unwrap();
+    assert_eq!(certificate_1_sequence, SequenceNumber::from(1));
 }

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -751,8 +751,6 @@ SuiError:
           - error: STR
     91:
       OnlyOneConsensusClientPermitted: UNIT
-    92:
-      RequireSyncWithConsensus: UNIT
 Transaction:
   STRUCT:
     - data:

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -122,6 +122,10 @@ ConsensusOutput:
     - message: BYTES
     - sequencer_number:
         TYPENAME: SequenceNumber
+ConsensusSync:
+  STRUCT:
+    - sequencer_number:
+        TYPENAME: SequenceNumber
 Data:
   ENUM:
     0:
@@ -377,6 +381,10 @@ SerializedMessage:
       ConsensusOutput:
         NEWTYPE:
           TYPENAME: ConsensusOutput
+    13:
+      ConsensusSync:
+        NEWTYPE:
+          TYPENAME: ConsensusSync
 Signature:
   NEWTYPESTRUCT: BYTES
 SignedBatch:
@@ -743,6 +751,8 @@ SuiError:
           - error: STR
     91:
       OnlyOneConsensusClientPermitted: UNIT
+    92:
+      RequireSyncWithConsensus: UNIT
 Transaction:
   STRUCT:
     - data:

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -274,8 +274,6 @@ pub enum SuiError {
     // Errors related to the authority-consensus interface.
     #[error("Authority state can be modified by a single consensus client at the time")]
     OnlyOneConsensusClientPermitted,
-    #[error("Authority needs to sync with the consensus node")]
-    RequireSyncWithConsensus,
 }
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -271,8 +271,11 @@ pub enum SuiError {
     #[error("Inconsistent results observed in the Gateway. This should not happen and typically means there is a bug in the Sui implementation. Details: {error:?}")]
     InconsistentGatewayResult { error: String },
 
+    // Errors related to the authority-consensus interface.
     #[error("Authority state can be modified by a single consensus client at the time")]
     OnlyOneConsensusClientPermitted,
+    #[error("Authority needs to sync with the consensus node")]
+    RequireSyncWithConsensus,
 }
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -1084,9 +1084,14 @@ impl ConfirmationTransaction {
 
 impl BcsSignable for TransactionData {}
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ConsensusOutput {
     #[serde(with = "serde_bytes")]
     pub message: Vec<u8>,
+    pub sequencer_number: SequenceNumber,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConsensusSync {
     pub sequencer_number: SequenceNumber,
 }

--- a/sui_types/src/serialize.rs
+++ b/sui_types/src/serialize.rs
@@ -27,6 +27,7 @@ pub enum SerializedMessage {
     BatchInfoReq(Box<BatchInfoRequest>),
     BatchInfoResp(Box<BatchInfoResponseItem>),
     ConsensusOutput(Box<ConsensusOutput>),
+    ConsensusSync(Box<ConsensusSync>),
 }
 
 // This helper structure is only here to avoid cloning while serializing commands.
@@ -48,6 +49,7 @@ enum ShallowSerializedMessage<'a> {
     BatchInfoReq(&'a BatchInfoRequest),
     BatchInfoResp(&'a BatchInfoResponseItem),
     ConsensusOutput(&'a ConsensusOutput),
+    ConsensusSync(&'a ConsensusSync),
 }
 
 fn serialize_into<T, W>(writer: W, msg: &T) -> Result<(), anyhow::Error>
@@ -156,6 +158,10 @@ where
 
 pub fn serialize_consensus_output(value: &ConsensusOutput) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::ConsensusOutput(value))
+}
+
+pub fn serialize_consensus_sync(value: &ConsensusSync) -> Vec<u8> {
+    serialize(&ShallowSerializedMessage::ConsensusSync(value))
 }
 
 pub fn deserialize_message<R>(reader: R) -> Result<SerializedMessage, anyhow::Error>


### PR DESCRIPTION
Implement a synchroniser for the consensus client. Please carefully read the file `consensus_client.rs` (safety and liveness critical). Every file in the crate `test_utils` (thus also `sequencer.rs) is only there for testing and has been written to optimise readability instead of anything else.