### PR TITLE
Add license headers for all typescript files

### DIFF
--- a/explorer/client/src/__tests__/App.test.tsx
+++ b/explorer/client/src/__tests__/App.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { render, screen, fireEvent } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import {

--- a/explorer/client/src/app/App.tsx
+++ b/explorer/client/src/app/App.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import Footer from '../components/footer/Footer';
 import Header from '../components/header/Header';
 import Search from '../components/search/Search';

--- a/explorer/client/src/components/external-link/ExternalLink.tsx
+++ b/explorer/client/src/components/external-link/ExternalLink.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 function ExternalLink({ href, label }: { href: string; label: string }) {
     return (
         <a href={href} target="_blank" rel="noreferrer noopener">

--- a/explorer/client/src/components/footer/Footer.tsx
+++ b/explorer/client/src/components/footer/Footer.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Link } from 'react-router-dom';
 
 import ExternalLink from '../external-link/ExternalLink';

--- a/explorer/client/src/components/header/Header.tsx
+++ b/explorer/client/src/components/header/Header.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Link } from 'react-router-dom';
 
 import styles from './Header.module.css';

--- a/explorer/client/src/components/search/Search.tsx
+++ b/explorer/client/src/components/search/Search.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import React, { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/explorer/client/src/index.tsx
+++ b/explorer/client/src/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';

--- a/explorer/client/src/pages/config/AppRoutes.tsx
+++ b/explorer/client/src/pages/config/AppRoutes.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import Home from '../home/Home';

--- a/explorer/client/src/pages/home/Home.tsx
+++ b/explorer/client/src/pages/home/Home.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 function Home() {
     return <div>Latest Transactions</div>;
 }

--- a/explorer/client/src/pages/other-details/OtherDetails.tsx
+++ b/explorer/client/src/pages/other-details/OtherDetails.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { useParams } from 'react-router-dom';
 
 import styles from './OtherDetails.module.css';

--- a/explorer/client/src/pages/transaction-result/TransactionResult.test.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionResult.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { instanceOfDataType } from './TransactionResult';
 
 describe('tests for Type Guard', () => {

--- a/explorer/client/src/pages/transaction-result/TransactionResult.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionResult.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { useParams } from 'react-router-dom';
 
 import mockTransactionData from '../../utils/transaction_mock.json';

--- a/explorer/client/src/react-app-env.d.ts
+++ b/explorer/client/src/react-app-env.d.ts
@@ -1,1 +1,4 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="react-scripts" />

--- a/explorer/client/src/setupTests.ts
+++ b/explorer/client/src/setupTests.ts
@@ -1,1 +1,4 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import '@testing-library/jest-dom';

--- a/explorer/client/src/utils/reportWebVitals.ts
+++ b/explorer/client/src/utils/reportWebVitals.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ReportHandler } from 'web-vitals';
 
 enum ReportMethod {

--- a/nft_mirror/oracle_server/src/polyfills/fetch-polyfill.ts
+++ b/nft_mirror/oracle_server/src/polyfills/fetch-polyfill.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import fetch, { Headers, Request, Response } from 'node-fetch';
 
 if (!globalThis.fetch) {

--- a/nft_mirror/oracle_server/src/sdk/gatewayServiceAPI.ts
+++ b/nft_mirror/oracle_server/src/sdk/gatewayServiceAPI.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
     paths as GatewayServicePaths,
     components,


### PR DESCRIPTION
Commands used: 

`find ./ -name "*.ts" -exec gsed -i -e '1i\/\/ Copyright (c) 2022, Mysten Labs, Inc.\n\/\/ SPDX-License-Identifier: Apache-2.0\n' '{}' \;\n`

`find ./ -name "*.tsx" -exec gsed -i -e '1i\/\/ Copyright (c) 2022, Mysten Labs, Inc.\n\/\/ SPDX-License-Identifier: Apache-2.0\n' '{}' \;\n`

thanks to @huitseeker


Similar to https://github.com/MystenLabs/sui/pull/1022