### PR TITLE
[doc] improvements to install and contributing pages

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -7,52 +7,21 @@ dependencies.  As a prerequisite, you will need to [install
 Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)
 version 1.59.0 or higher in order to build and install Sui on your machine.
 
-## Set up
+### CLIs
 
-Although you may create whatever directory structure you desire, both our
-[Wallet Quick Start](wallet.md) and [end-to-end tutorial](../explore/tutorials.md)
-assume Sui is installed in a directory found by a `$SUI_ROOT` environment variable.
-
-To set this up, run the following commands and substitute in your path and
-desired directory name:
-
-```shell
-mkdir some-dir
-export SUI_ROOT=/path/to/some-dir
-```
-
-## Download
-
-Navigate to your desired install location, for example:
-
-```shell
-cd "$SUI_ROOT"
-```
-
-### Binaries only
-
-If you'd like to install only Sui binaries (`sui`, `wallet`,
-`sui-move`, and `rest_server`), use the following command:
+After installing `cargo`, run:
 
 ```shell
 cargo install --git https://github.com/MystenLabs/sui.git
 ```
 
-### Whole repository
+This will put three binaries in your `PATH`:
+* [`sui-move`](move.md): Build and test Move packages.
+* [`wallet`](wallet.md): Run a local Sui network and gateway service accessible via the wallet CLI. The wallet CLI manage keypairs to sign/send transactions.
+* [`rest_server`](rest-api.md): Run a local Sui network and gateway service accessible via a REST interface.
 
-Alternatively, clone the [Sui
-GitHub](https://github.com/MystenLabs/sui) repository and then `cargo
-install` with the repository clone:
-
-```shell
-git clone https://github.com/MystenLabs/sui.git
-cargo install --path sui/sui
-```
-
-## Use
-
-Either method will install `sui`, `wallet`, `sui-move`, and `rest_server`
-binaries in a `~/.cargo/bin` directory that can be executed directly.
+### IDE
+For Move development, the best IDE is vscode with [this](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer) plugin. Some alternative IDE options are [here]( https://github.com/MystenLabs/awesome-move#ide).
 
 ## Next steps
 

--- a/doc/src/contribute/index.md
+++ b/doc/src/contribute/index.md
@@ -2,30 +2,6 @@
 title: Contributing to Sui
 ---
 
-Now that you understand Sui, consider helping the project. To contribute to Sui, ensure you have the latest version of the codebase.
-
-To clone the repository, run the following:
-```bash
-git clone https://github.com/mystenlabs/sui.git
-cd sui
-cargo build --all --all-targets
-cargo test
-```
-
-See [Install Sui](../build/install.md) for installation instructions and our [end-to-end tutorial](../explore/tutorials.md) to work with Sui immediately.
-
-## Pull requests
-
-To submit your pull request:
-
-1. Fork the `sui` repository and create your branch from `main`.
-2. If you have added code that should be tested, add unit tests.
-3. If you have made changes to APIs, update the relevant documentation, and build and test the developer site.
-4. Verify and ensure that the test suite passes.
-5. Make sure your code passes both linters.
-6. Complete the Contributor License Agreement (CLA), if you haven't already done so.
-7. Submit your pull request.
-
 ## File issues
 
 Report bugs and make feature requests in the [Sui GitHub](https://github.com/MystenLabs/sui/issues) repository
@@ -39,6 +15,26 @@ doc@mystenlabs.com
 You may also suggest changes to the docs directly in GitHub right here using the **Source Code** link below.
 
 Simply edit the file in question and generate a pull request. We will get back to you shortly.
+
+## Send pull requests
+
+Start by creating your own fork of the repo:
+```bash
+gh fork https://github.com/mystenlabs/sui.git # or alternatively, clone your fork
+cargo install --path sui/sui # put Sui CLI's in your PATH
+cd sui
+cargo build --all --all-targets # check that build works
+cargo test # check that tests pass
+```
+
+To submit your pull request:
+
+1. Make your changes in a descriptively named branch.
+2. If you have added code that should be tested, add unit tests.
+3. Ensure your code builds and passes the tests: `cargo test`
+4. Make sure your code passes the linters and autoformatter: `cargo clippy --all --all-targets && cargo fmt --all`
+5. If you have made changes to APIs, update the relevant documentation, and build and test the developer site.
+6. Run `git push -f origin <branch_name>`, then open a pull request from the Sui GitHub site.
 
 ## Further reading
 


### PR DESCRIPTION
* Explain what each CLI does
* Recommend vscode + move-analyzer plugin for IDE
* Move Sui Core contributor-specific content to from install to contributing
* Adjust structure of contributing to put most frequent contribution types (issues, docs) first