### PR TITLE
Make the sequencer more solid

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -46,6 +46,7 @@ similar-asserts = "1.2.0"
 serde-reflection = "0.3.5"
 serde_yaml = "0.8.23"
 pretty_assertions = "1.2.0"
+temp_testdir = "0.2"
 
 test_utils = { path = "../test_utils" }
 

--- a/sui_core/src/consensus_client.rs
+++ b/sui_core/src/consensus_client.rs
@@ -85,7 +85,7 @@ impl ConsensusClient {
     /// and right order.
     async fn synchronize(&mut self, connection: &mut TcpDataStream) -> SuiResult<()> {
         let request = ConsensusSync {
-            sequencer_number: self.last_consensus_index,
+            sequence_number: self.last_consensus_index,
         };
         let bytes = Bytes::from(serialize_consensus_sync(&request));
         connection
@@ -106,9 +106,9 @@ impl ConsensusClient {
             Ok(SerializedMessage::ConsensusOutput(value)) => {
                 let ConsensusOutput {
                     message,
-                    sequencer_number,
+                    sequence_number,
                 } = *value;
-                (message, sequencer_number)
+                (message, sequence_number)
             }
             Ok(_) => {
                 log::error!("{}", SuiError::UnexpectedMessage);

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -127,7 +127,9 @@ async fn handle_consensus_output() {
         buffer_size: NETWORK_BUFFER_SIZE,
         consensus_delay: Duration::from_millis(0),
     };
-    Sequencer::spawn(sequencer).await;
+    let store_path = "test_storage_handle_consensus_output";
+    let _ = std::fs::remove_dir_all(store_path);
+    Sequencer::spawn(sequencer, store_path).await.unwrap();
 
     // Spawn a consensus client.
     let state = Arc::new(authority);
@@ -154,6 +156,9 @@ async fn handle_consensus_output() {
         state.db().last_consensus_index().unwrap(),
         SequenceNumber::from(1)
     );
+
+    // Cleanup the storage.
+    let _ = std::fs::remove_dir_all(store_path);
 }
 
 #[tokio::test]
@@ -170,7 +175,7 @@ async fn test_guardrail() {
 }
 
 #[tokio::test]
-async fn test_sync() {
+async fn sync_with_consensus() {
     // Initialize an authority with a (owned) gas object and a shared object.
     let mut objects = test_gas_objects();
     objects.push(test_shared_object());
@@ -192,7 +197,9 @@ async fn test_sync() {
         buffer_size: NETWORK_BUFFER_SIZE,
         consensus_delay: Duration::from_millis(0),
     };
-    Sequencer::spawn(sequencer).await;
+    let store_path = "test_storage_sync_with_consensus";
+    let _ = std::fs::remove_dir_all(store_path);
+    Sequencer::spawn(sequencer, store_path).await.unwrap();
 
     // Submit a certificate to the sequencer.
     tokio::task::yield_now().await;
@@ -252,4 +259,7 @@ async fn test_sync() {
         .unwrap()
         .unwrap();
     assert_eq!(certificate_1_sequence, SequenceNumber::from(1));
+
+    // Cleanup the storage.
+    let _ = std::fs::remove_dir_all(store_path);
 }

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -127,9 +127,10 @@ async fn handle_consensus_output() {
         buffer_size: NETWORK_BUFFER_SIZE,
         consensus_delay: Duration::from_millis(0),
     };
-    let store_path = "test_storage_handle_consensus_output";
-    let _ = std::fs::remove_dir_all(store_path);
-    Sequencer::spawn(sequencer, store_path).await.unwrap();
+    let store_path = temp_testdir::TempDir::default();
+    Sequencer::spawn(sequencer, store_path.as_ref())
+        .await
+        .unwrap();
 
     // Spawn a consensus client.
     let state = Arc::new(authority);
@@ -197,9 +198,10 @@ async fn sync_with_consensus() {
         buffer_size: NETWORK_BUFFER_SIZE,
         consensus_delay: Duration::from_millis(0),
     };
-    let store_path = "test_storage_sync_with_consensus";
-    let _ = std::fs::remove_dir_all(store_path);
-    Sequencer::spawn(sequencer, store_path).await.unwrap();
+    let store_path = temp_testdir::TempDir::default();
+    Sequencer::spawn(sequencer, store_path.as_ref())
+        .await
+        .unwrap();
 
     // Submit a certificate to the sequencer.
     tokio::task::yield_now().await;

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -120,11 +120,11 @@ CertifiedTransaction:
 ConsensusOutput:
   STRUCT:
     - message: BYTES
-    - sequencer_number:
+    - sequence_number:
         TYPENAME: SequenceNumber
 ConsensusSync:
   STRUCT:
-    - sequencer_number:
+    - sequence_number:
         TYPENAME: SequenceNumber
 Data:
   ENUM:

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -1102,10 +1102,10 @@ impl BcsSignable for TransactionData {}
 pub struct ConsensusOutput {
     #[serde(with = "serde_bytes")]
     pub message: Vec<u8>,
-    pub sequencer_number: SequenceNumber,
+    pub sequence_number: SequenceNumber,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ConsensusSync {
-    pub sequencer_number: SequenceNumber,
+    pub sequence_number: SequenceNumber,
 }

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -15,5 +15,7 @@ log = "0.4.14"
 rand = "0.7.3"
 rocksdb = "0.18.0"
 
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="e44bca4513a6ff6c97399cd79e82e4bc00571ac3"}
+
 sui-types = { path = "../sui_types" }
 sui-network = { path = "../network_utils" }

--- a/test_utils/src/sequencer.rs
+++ b/test_utils/src/sequencer.rs
@@ -40,7 +40,7 @@ pub struct Sequencer {
 impl Sequencer {
     /// Spawn a new sequencer. The sequencer is made of a number of component each running
     /// in their own tokio task.
-    pub async fn spawn(sequencer: Self, store_path: &str) -> SuiResult<()> {
+    pub async fn spawn(sequencer: Self, store_path: &Path) -> SuiResult<()> {
         let (tx_input, rx_input) = channel(100);
         let (tx_subscriber, rx_subscriber) = channel(100);
 

--- a/test_utils/src/sequencer.rs
+++ b/test_utils/src/sequencer.rs
@@ -6,17 +6,22 @@ use bytes::Bytes;
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::stream::StreamExt;
 use futures::SinkExt;
+use rocksdb::{ColumnFamilyDescriptor, DBCompressionType, DBWithThreadMode, MultiThreaded};
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use sui_network::transport::{MessageHandler, RwChannel};
 use sui_types::base_types::SequenceNumber;
-use sui_types::error::SuiError;
+use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::ConsensusOutput;
 use sui_types::serialize::{deserialize_message, serialize_consensus_output, SerializedMessage};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::sleep;
+use typed_store::rocks::{DBMap, TypedStoreError};
+use typed_store::traits::Map;
 
 /// A mock single-process sequencer. It is not crash-safe (it has no storage) and should
 /// only be used for testing.
@@ -35,15 +40,17 @@ pub struct Sequencer {
 impl Sequencer {
     /// Spawn a new sequencer. The sequencer is made of a number of component each running
     /// in their own tokio task.
-    pub async fn spawn(sequencer: Self) {
+    pub async fn spawn(sequencer: Self, store_path: &str) -> SuiResult<()> {
         let (tx_input, rx_input) = channel(100);
         let (tx_subscriber, rx_subscriber) = channel(100);
 
+        // Load the persistent storage.
+        let store = Arc::new(SequencerStore::open(store_path, None));
+
         // Spawn the sequencer core.
+        let mut sequencer_core = SequencerCore::new(rx_input, rx_subscriber, store.clone())?;
         tokio::spawn(async move {
-            SequencerCore::new(rx_input, rx_subscriber)
-                .run(sequencer.consensus_delay)
-                .await;
+            sequencer_core.run(sequencer.consensus_delay).await;
         });
 
         // Spawn the server receiving input messages to order.
@@ -63,7 +70,7 @@ impl Sequencer {
 
         // Spawn the server receiving subscribers to the output of the sequencer.
         tokio::spawn(async move {
-            let subscriber_server = SubscriberServer::new(tx_subscriber);
+            let subscriber_server = SubscriberServer::new(tx_subscriber, store);
             sui_network::transport::spawn_server(
                 &sequencer.subscriber_address.to_string(),
                 subscriber_server,
@@ -75,6 +82,8 @@ impl Sequencer {
             .await
             .unwrap();
         });
+
+        Ok(())
     }
 }
 
@@ -84,21 +93,26 @@ pub struct SequencerCore {
     rx_input: Receiver<Bytes>,
     /// Communicate with subscribers to update with the output of the sequence.
     rx_subscriber: Receiver<SubscriberMessage>,
+    /// Persistent storage to hold all consensus outputs.
+    store: Arc<SequencerStore>,
     /// The global consensus index.
     consensus_index: SequenceNumber,
-    /// Holds all consensus outputs.
-    all_outputs: Vec<ConsensusOutput>,
 }
 
 impl SequencerCore {
     /// Create a new sequencer core instance.
-    pub fn new(rx_input: Receiver<Bytes>, rx_subscriber: Receiver<SubscriberMessage>) -> Self {
-        Self {
+    pub fn new(
+        rx_input: Receiver<Bytes>,
+        rx_subscriber: Receiver<SubscriberMessage>,
+        store: Arc<SequencerStore>,
+    ) -> SuiResult<Self> {
+        let consensus_index = store.get_last_consensus_index()?;
+        Ok(Self {
             rx_input,
             rx_subscriber,
-            consensus_index: SequenceNumber::new(),
-            all_outputs: Vec::new(),
-        }
+            store,
+            consensus_index,
+        })
     }
 
     /// Simply wait for a fixed delay and then returns the input.
@@ -119,32 +133,27 @@ impl SequencerCore {
                 },
 
                 // Receive subscribers to update with the sequencer's output.
-                Some(message) = self.rx_subscriber.recv() => match message {
-                    SubscriberMessage::Init(sender, id) => {
-                        subscribers.insert(id, sender);
-                    },
-                    SubscriberMessage::Sync(index, id) if index < self.consensus_index => {
-                        if let Some(sender) = subscribers.get(&id) {
-                            for output in &self.all_outputs[usize::from(index)..] {
-                                sender
-                                    .send(output.clone())
-                                    .await
-                                    .expect("Failed to send output to subscriber");
-                            }
-                        }
-                    },
-                    _ => ()
+                Some(message) = self.rx_subscriber.recv() => {
+                    let SubscriberMessage(sender, id) = message;
+                    subscribers.insert(id, sender);
                 },
 
                 // Bytes are ready to be delivered, notify the subscribers.
                 Some(message) = waiting.next() => {
                     let output = ConsensusOutput {
                         message: message.to_vec(),
-                        sequencer_number: self.consensus_index,
+                        sequence_number: self.consensus_index,
                     };
 
-                    // Store the sequenced message.
-                    self.all_outputs.push(output.clone());
+                    // Store the sequenced message. If this fails, we do not notify and subscribers
+                    // and effectively throw away the message. Liveness may be lost.
+                    if let Err(e) = self.store.store_output(&output) {
+                        log::error!("Failed to store consensus output: {}", e);
+                        continue;
+                    }
+
+                    // Increment the consensus index.
+                    self.consensus_index = self.consensus_index.increment();
 
                     // Notify the subscribers of the new output.
                     let mut to_drop = Vec::new();
@@ -153,9 +162,6 @@ impl SequencerCore {
                             to_drop.push(*id);
                         }
                     }
-
-                    // Increment the consensus index.
-                    self.consensus_index = self.consensus_index.increment();
 
                     // Cleanup the list subscribers that dropped connection.
                     for id in to_drop {
@@ -212,14 +218,10 @@ where
 /// Represents the subscriber's unique id.
 pub type SubscriberId = usize;
 
-/// The messages sent by the subscriber server to the sequencer core.
+/// The messages sent by the subscriber server to the sequencer core to notify
+/// the core of a new subscriber.
 #[derive(Debug)]
-pub enum SubscriberMessage {
-    /// Notify the core of a new subscriber.
-    Init(Sender<ConsensusOutput>, SubscriberId),
-    /// Request missed consensus outputs.
-    Sync(SequenceNumber, SubscriberId),
-}
+pub struct SubscriberMessage(Sender<ConsensusOutput>, SubscriberId);
 
 /// Define how the network server should handle incoming authorities sync requests.
 /// The authorities are basically light clients of the sequencer. A real consensus
@@ -230,14 +232,48 @@ struct SubscriberServer {
     pub tx_subscriber: Sender<SubscriberMessage>,
     /// Count the number of subscribers.
     counter: AtomicUsize,
+    /// The persistent storage. It is only used to help subscribers to sync, this
+    /// task never writes to the store.
+    store: Arc<SequencerStore>,
 }
 
 impl SubscriberServer {
-    pub fn new(tx_subscriber: Sender<SubscriberMessage>) -> Self {
+    /// Create a new subscriber server.
+    pub fn new(tx_subscriber: Sender<SubscriberMessage>, store: Arc<SequencerStore>) -> Self {
         Self {
             tx_subscriber,
             counter: AtomicUsize::new(0),
+            store,
         }
+    }
+
+    /// Helper function loading from store the outputs missed by the subscriber (in the right order).
+    async fn synchronize<'a, Stream>(
+        &self,
+        sequence_number: SequenceNumber,
+        stream: &mut Stream,
+    ) -> SuiResult<()>
+    where
+        Stream: 'static + RwChannel<'a> + Unpin + Send,
+    {
+        // TODO: Loading the missed outputs one by one may not be the most efficient. But we can't
+        // load them all in memory at once (there may be a lot of missed outputs). We could do
+        // this in chunks.
+        let consensus_index = self.store.get_last_consensus_index()?;
+        if sequence_number < consensus_index {
+            let start: u64 = sequence_number.into();
+            let stop: u64 = consensus_index.into();
+            for i in start..=stop {
+                let index = SequenceNumber::from(i);
+                let message = self.store.get_output(&index)?.unwrap();
+                let serialized = serialize_consensus_output(&message);
+                if stream.sink().send(Bytes::from(serialized)).await.is_err() {
+                    log::debug!("Connection dropped by subscriber");
+                    break;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -252,7 +288,7 @@ where
 
         // Notify the core of a new subscriber.
         self.tx_subscriber
-            .send(SubscriberMessage::Init(tx_output, subscriber_id))
+            .send(SubscriberMessage(tx_output, subscriber_id))
             .await
             .expect("Failed to send new subscriber to core");
 
@@ -271,11 +307,12 @@ where
                 // Receive sync requests form the subscriber.
                 Some(buffer) = stream.stream().next() => match buffer {
                     Ok(buffer) => match deserialize_message(&*buffer) {
-                        Ok(SerializedMessage::ConsensusSync(sync)) => self
-                            .tx_subscriber
-                            .send(SubscriberMessage::Sync(sync.sequencer_number, subscriber_id))
-                            .await
-                            .expect("Failed to send sync request to core"),
+                        Ok(SerializedMessage::ConsensusSync(sync)) => {
+                            if let Err(e) = self.synchronize(sync.sequence_number, &mut stream).await {
+                                log::error!("{}", e);
+                                break;
+                            }
+                        }
                         Ok(_) => {
                             log::warn!("{}", SuiError::UnexpectedMessage);
                             break;
@@ -292,5 +329,88 @@ where
                 }
             }
         }
+    }
+}
+
+/// The persistent storage of the sequencer.
+pub struct SequencerStore {
+    /// All sequenced messages indexed by sequence number.
+    outputs: DBMap<SequenceNumber, ConsensusOutput>,
+}
+
+impl SequencerStore {
+    /// Open the consensus store.
+    pub fn open<P: AsRef<Path>>(path: P, db_options: Option<rocksdb::Options>) -> Self {
+        let row_cache = rocksdb::Cache::new_lru_cache(1_000_000).expect("Cache is ok");
+        let mut options = db_options.unwrap_or_default();
+        options.set_row_cache(&row_cache);
+        options.set_table_cache_num_shard_bits(10);
+        options.set_compression_type(DBCompressionType::None);
+
+        let db = Self::open_cf_opts(
+            &path,
+            Some(options.clone()),
+            &[("last_consensus_index", &options), ("outputs", &options)],
+        )
+        .expect("Cannot open DB.");
+
+        Self {
+            outputs: DBMap::reopen(&db, Some("outputs")).expect("Cannot open CF."),
+        }
+    }
+
+    /// Helper function to open the store.
+    fn open_cf_opts<P: AsRef<Path>>(
+        path: P,
+        db_options: Option<rocksdb::Options>,
+        opt_cfs: &[(&str, &rocksdb::Options)],
+    ) -> Result<Arc<DBWithThreadMode<MultiThreaded>>, TypedStoreError> {
+        let mut options = db_options.unwrap_or_default();
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+
+        let mut cfs = DBWithThreadMode::<MultiThreaded>::list_cf(&options, &path)
+            .ok()
+            .unwrap_or_default();
+        for cf_key in opt_cfs.iter().map(|(name, _)| name) {
+            let key = (*cf_key).to_owned();
+            if !cfs.contains(&key) {
+                cfs.push(key);
+            }
+        }
+
+        Ok(Arc::new(
+            DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+                &options,
+                /* primary */ &path.as_ref(),
+                opt_cfs
+                    .iter()
+                    .map(|(name, opts)| ColumnFamilyDescriptor::new(*name, (*opts).clone())),
+            )?,
+        ))
+    }
+
+    /// Read the last consensus index from the store.
+    pub fn get_last_consensus_index(&self) -> SuiResult<SequenceNumber> {
+        self.outputs
+            .iter()
+            .skip_prior_to(&SequenceNumber::MAX)?
+            .next()
+            .map_or_else(|| Ok(SequenceNumber::default()), |(s, _)| Ok(s.increment()))
+    }
+
+    /// Stores a new consensus output.
+    pub fn store_output(&self, output: &ConsensusOutput) -> SuiResult<()> {
+        let mut write_batch = self.outputs.batch();
+        write_batch = write_batch.insert_batch(
+            &self.outputs,
+            std::iter::once((output.sequence_number, output)),
+        )?;
+        write_batch.write().map_err(SuiError::from)
+    }
+
+    /// Load a specific output from storage.
+    pub fn get_output(&self, index: &SequenceNumber) -> SuiResult<Option<ConsensusOutput>> {
+        self.outputs.get(index).map_err(SuiError::from)
     }
 }


### PR DESCRIPTION
This PR makes the sequencer more robust so that we can use it for dev net. It remains a testing facility, but it should not make our life miserable when deploying/re-deploying networks of authorities.

Particularly:
* The sequencer is now crash-safe
* The core sequencer does not get stuck if one of the subscribers is (unnaturally) slow
* The core sequencer is memory-bound.

Note that the sequencer cannot re-use the store of the authority since we have a single sequencer for all authorities (thus running on a single machine). 