### PR TITLE
[RFC] Add `AuthoritySignedData` type

### DIFF
--- a/sui/src/bench.rs
+++ b/sui/src/bench.rs
@@ -408,8 +408,8 @@ impl ClientServerBenchmark {
                 match reply_message {
                     Ok(SerializedMessage::TransactionResp(res)) => {
                         if let Some(e) = res.signed_effects {
-                            if matches!(e.effects.status, ExecutionStatus::Failure { .. }) {
-                                info!("Execution Error {:?}", e.effects.status);
+                            if matches!(e.data.status, ExecutionStatus::Failure { .. }) {
+                                info!("Execution Error {:?}", e.data.status);
                             }
                         }
                     }

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -172,7 +172,7 @@ impl<S> AuthorityTemporaryStore<S> {
         let signature = AuthoritySignature::new(&effects, secret);
 
         SignedTransactionEffects {
-            effects,
+            data: effects,
             authority: *authority_name,
             signature,
         }

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -1005,6 +1005,7 @@ where
                             // Note: here we aggregate votes by the hash of the effects structure
                             let entry = state
                                 .effects_map
+                                // TODO: We should probably not call the sha3_hash directly here but someghing like .digest() on the effects.
                                 .entry(sha3_hash(&inner_effects.data))
                                 .or_insert((0usize, inner_effects.data));
                             entry.0 += weight;

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -151,7 +151,7 @@ where
                 .signed_effects
                 .ok_or(SuiError::AuthorityInformationUnavailable)?;
 
-            for returned_digest in &signed_effects.effects.dependencies {
+            for returned_digest in &signed_effects.data.dependencies {
                 // We check that we are not processing twice the same certificate, as
                 // it would be common if two objects used by one transaction, were also both
                 // mutated by the same preceding transaction.
@@ -1005,8 +1005,8 @@ where
                             // Note: here we aggregate votes by the hash of the effects structure
                             let entry = state
                                 .effects_map
-                                .entry(sha3_hash(&inner_effects.effects))
-                                .or_insert((0usize, inner_effects.effects));
+                                .entry(sha3_hash(&inner_effects.data))
+                                .or_insert((0usize, inner_effects.data));
                             entry.0 += weight;
 
                             if entry.0 >= threshold {

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -46,7 +46,7 @@ impl<C> SafeClient<C> {
             );
             // Check it's the right transaction
             fp_ensure!(
-                signed_transaction.transaction.digest() == digest,
+                signed_transaction.data.digest() == digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -69,10 +69,10 @@ impl<C> SafeClient<C> {
             // Check signature
             signed_effects
                 .signature
-                .check(&signed_effects.effects, self.address)?;
+                .check(&signed_effects.data, self.address)?;
             // Checks it concerns the right tx
             fp_ensure!(
-                signed_effects.effects.transaction_digest == digest,
+                signed_effects.data.transaction_digest == digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -169,7 +169,7 @@ impl<C> SafeClient<C> {
     /// This function is used by the higher level authority logic to report an
     /// error that could be due to this authority.
     pub fn report_client_error(&self, _error: SuiError) {
-        // TODO: At a minumum we log this error along the authority name, and potentially
+        // TODO: At a minimum we log this error along the authority name, and potentially
         // in case of strong evidence of byzantine behaviour we could share this error
         // with the rest of the network, or de-prioritize requests to this authority given
         // weaker evidence.

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -264,7 +264,7 @@ async fn test_handle_transfer_transaction_ok() {
             .unwrap()
             .as_ref()
             .unwrap()
-            .transaction
+            .data
             .data,
         transfer_transaction.data
     );
@@ -425,7 +425,7 @@ async fn test_publish_dependent_module_ok() {
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap();
-    response.signed_effects.unwrap().effects.status.unwrap();
+    response.signed_effects.unwrap().data.status.unwrap();
 
     // check that the dependent module got published
     assert!(authority.get_object(&dependent_module_id).await.is_ok());
@@ -455,7 +455,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap();
-    response.signed_effects.unwrap().effects.status.unwrap();
+    response.signed_effects.unwrap().data.status.unwrap();
 
     // check that the module actually got published
     assert!(response.certified_transaction.is_some());
@@ -835,7 +835,7 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         ))
         .await
         .unwrap();
-    response.signed_effects.unwrap().effects.status.unwrap();
+    response.signed_effects.unwrap().data.status.unwrap();
     let account = authority_state
         .get_object(&object_id)
         .await
@@ -941,7 +941,7 @@ async fn test_handle_confirmation_transaction_ok() {
         ))
         .await
         .unwrap();
-    info.signed_effects.unwrap().effects.status.unwrap();
+    info.signed_effects.unwrap().data.status.unwrap();
     // Key check: the ownership has changed
 
     let new_account = authority_state
@@ -1022,7 +1022,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
         ))
         .await
         .unwrap();
-    assert!(info.signed_effects.as_ref().unwrap().effects.status.is_ok());
+    assert!(info.signed_effects.as_ref().unwrap().data.status.is_ok());
 
     let info2 = authority_state
         .handle_confirmation_transaction(ConfirmationTransaction::new(
@@ -1030,13 +1030,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
         ))
         .await
         .unwrap();
-    assert!(info2
-        .signed_effects
-        .as_ref()
-        .unwrap()
-        .effects
-        .status
-        .is_ok());
+    assert!(info2.signed_effects.as_ref().unwrap().data.status.is_ok());
 
     // this is valid because we're checking the authority state does not change the certificate
     compare_transaction_info_responses(&info, &info2);
@@ -1510,7 +1504,7 @@ pub async fn call_move(
     let transaction = Transaction::new(data, signature);
 
     let response = send_and_confirm_transaction(authority, transaction).await?;
-    Ok(response.signed_effects.unwrap().effects)
+    Ok(response.signed_effects.unwrap().data)
 }
 
 async fn call_framework_code(

--- a/sui_core/src/unit_tests/batch_transaction_tests.rs
+++ b/sui_core/src/unit_tests/batch_transaction_tests.rs
@@ -68,7 +68,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
     let signature = Signature::new(&data, &sender_key);
     let tx = Transaction::new(data, signature);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().data;
     assert!(effects.status.is_ok());
     assert_eq!((effects.created.len(), effects.mutated.len()), (N, N + 1),);
     assert!(effects
@@ -135,7 +135,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
     let signature = Signature::new(&data, &sender_key);
     let tx = Transaction::new(data, signature);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().data;
     assert!(effects.status.is_err());
     assert_eq!((effects.created.len(), effects.mutated.len()), (0, N + 1));
 

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -138,9 +138,9 @@ async fn extract_cert(
         {
             votes.push((signed.authority, signed.signature));
             if let Some(inner_transaction) = transaction {
-                assert!(inner_transaction == signed.transaction);
+                assert!(inner_transaction == signed.data);
             }
-            transaction = Some(signed.transaction);
+            transaction = Some(signed.data);
         }
     }
 
@@ -283,7 +283,7 @@ async fn do_cert(
         .unwrap()
         .signed_effects
         .unwrap()
-        .effects
+        .data
 }
 
 async fn init_local_authorities(

--- a/sui_core/src/unit_tests/move_integration_tests.rs
+++ b/sui_core/src/unit_tests/move_integration_tests.rs
@@ -518,7 +518,7 @@ async fn build_and_publish_test_package(
         .unwrap()
         .signed_effects
         .unwrap()
-        .effects;
+        .data;
 
     assert!(
         matches!(effects.status, ExecutionStatus::Success { .. }),

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -305,7 +305,7 @@ ObjectResponse:
         TYPENAME: Object
     - lock:
         OPTION:
-          TYPENAME: SignedTransaction
+          TYPENAME: "sui_types::messages::AuthoritySignedData<sui_types::messages::Transaction>"
     - layout:
         OPTION:
           TYPENAME: MoveStructLayout
@@ -336,7 +336,7 @@ SerializedMessage:
     1:
       Vote:
         NEWTYPE:
-          TYPENAME: SignedTransaction
+          TYPENAME: "sui_types::messages::AuthoritySignedData<sui_types::messages::Transaction>"
     2:
       Cert:
         NEWTYPE:
@@ -391,22 +391,6 @@ SignedBatch:
   STRUCT:
     - batch:
         TYPENAME: AuthorityBatch
-    - authority:
-        TYPENAME: PublicKeyBytes
-    - signature:
-        TYPENAME: AuthoritySignature
-SignedTransaction:
-  STRUCT:
-    - transaction:
-        TYPENAME: Transaction
-    - authority:
-        TYPENAME: PublicKeyBytes
-    - signature:
-        TYPENAME: AuthoritySignature
-SignedTransactionEffects:
-  STRUCT:
-    - effects:
-        TYPENAME: TransactionEffects
     - authority:
         TYPENAME: PublicKeyBytes
     - signature:
@@ -833,13 +817,13 @@ TransactionInfoResponse:
   STRUCT:
     - signed_transaction:
         OPTION:
-          TYPENAME: SignedTransaction
+          TYPENAME: "sui_types::messages::AuthoritySignedData<sui_types::messages::Transaction>"
     - certified_transaction:
         OPTION:
           TYPENAME: CertifiedTransaction
     - signed_effects:
         OPTION:
-          TYPENAME: SignedTransactionEffects
+          TYPENAME: "sui_types::messages::AuthoritySignedData<sui_types::messages::TransactionEffects>"
 TransactionKind:
   ENUM:
     0:
@@ -907,4 +891,20 @@ UpdateItem:
       Batch:
         NEWTYPE:
           TYPENAME: SignedBatch
+"sui_types::messages::AuthoritySignedData<sui_types::messages::Transaction>":
+  STRUCT:
+    - data:
+        TYPENAME: Transaction
+    - authority:
+        TYPENAME: PublicKeyBytes
+    - signature:
+        TYPENAME: AuthoritySignature
+"sui_types::messages::AuthoritySignedData<sui_types::messages::TransactionEffects>":
+  STRUCT:
+    - data:
+        TYPENAME: TransactionEffects
+    - authority:
+        TYPENAME: PublicKeyBytes
+    - signature:
+        TYPENAME: AuthoritySignature
 

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -335,6 +335,9 @@ const_assert_eq!(
 
 */
 
+// TODO: Should we have a uniform way to convert AuthoritySignedData to certificates?
+// Should we have a uniform authority certificate type too?
+
 // Generic types instantiated multiple times in the same Serde tracing session
 // requires a walk-around: https://crates.io/crates/serde-name
 #[derive(Debug, Eq, Clone, Serialize, Deserialize)]

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -313,7 +313,7 @@ fn test_time_vote() {
     for _ in 0..100 {
         if let SerializedMessage::Vote(vote) = deserialize_message(&mut buf2).unwrap() {
             vote.signature
-                .check(&vote.transaction.data, vote.authority)
+                .check(&vote.data.data, vote.authority)
                 .unwrap();
         }
     }


### PR DESCRIPTION
`SuiDataStore` currently contains these two tables:
1. `signed_transactions` which maps from transaction digest to `SignedTransaction`.
2. `signed_effects` which maps from transaction digest to `SignedTransactionEffects`.

If we want to reuse `SuiDataStore` in Gateway or other non-authority nodes, we will want to use the above two tables to store non-signed transaction and effects.
This PR attempts to do that:
1. Added a generic type `AuthoritySignedData` which wraps an authority signed data. This type derives `SignedTransaction` and `SignedTransactionEffects` as two instantiations of `AuthoritySignedData`. One nice thing about this is that if we ever want to add more common code on authority signed types, this will come in handy.
2. In `SuiDataStore`, introduce a new enum called `RawOrSignedData`, which wraps the data type as well as a const generic type indicating whether this is used by authority. Added conversions between `RawOrSignedData` and `AuthoritySignedData`. Since there is no use of the non-authority case yet, I didn't add the `false` case for now, but you can see where it's going.
3. Both `signed_transactions` table and `signed_effects` table will be converted to store `RawOrSignedData`.

Review tips: Start from message.rs to review `AuthoritySignedData`,  and then go to `authority_store` to review RawOrSignedData. The rest are mechanical changes.