### PR TITLE
[cli] Added default Sui configuration directory

### DIFF
--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -11,21 +11,10 @@ interface, *Wallet CLI*.
 
 ## Set up
 
-1. Follow the instructions to [install Sui binaries](install.md).
-
-1. Create a `sui_instance` subdirectory in your desired Sui-specific
-directory. Assuming you followed recommended setup, run:
-   ```shell
-   cd "$SUI_ROOT"
-   mkdir sui_instance
-   ```
+Follow the instructions to [install Sui binaries](install.md).
 
 ## Genesis
 
-1. Navigate to that new directory:
-   ```shell
-   cd "$SUI_ROOT"/sui_instance
-   ```
 1. Optionally, set `RUST_LOG=debug` for verbose logging.
 1. Initiate `genesis`:
    ```shell
@@ -41,10 +30,21 @@ arbitrarily; the process of generating the genesis state can be
 customized with additional accounts, objects, code, etc. as described
 in [Genesis customization](#customize-genesis).
 
-The network configuration is stored in `network.conf` and
-can be used subsequently to start the network. The `wallet.conf` and `wallet.key` are
-also created to be used by the Sui wallet to manage the
-newly created accounts.
+The network configuration is stored in `network.conf` and can be used
+subsequently to start the network. The `wallet.conf` and `wallet.key`
+are also created to be used by the Sui wallet to manage the newly
+created accounts. By default, these files will be stored in the
+o`~/.sui/sui_config` directory, but you can override this location by
+providing an alternative path:
+
+```shell
+sui genesis --working-dir /path/to/sui/config/files
+```
+### Recreating Genesis
+
+To recreate Sui genesis state in the same location, which will remove
+existing configuration files, use the `--force` option to the `sui
+genesis` command.
 
 ## Wallet configuration
 The genesis process creates a configuration file `wallet.conf`, and a keystore file `wallet.key` for the
@@ -123,15 +123,16 @@ implement more secure key management and support hardware signing in a future re
 Run the following command to start the local Sui network:
 
 ```shell
-cd "$SUI_ROOT"/sui_instance
 sui start
 ```
 
-You can also run this command in any directory if you provide a path
-to the directory where Sui configuration files are stored:
+This command will by default look for Sui network coinfiguration file
+(`network.conf`) in the `~/.sui/sui_config` directory, but you can
+override this setting by providing a path to the directory where this
+file are stored:
 
 ```shell
-sui start --config "$SUI_ROOT"/sui_instance
+sui start --config /path/to/sui/network/config/file
 ```
 
 Executing any of these two commands in a terminal window will result
@@ -140,15 +141,9 @@ instance (it will not return the command prompt).
 
 NOTE: For logs, set `RUST_LOG=debug` before invoking `sui start`.
 
-The network config file path defaults to `./network.conf` if not
-specified.
-
-If you see errors when trying to start Sui network, particularly if
-you did not start with a fresh `"$SUI_ROOT"/sui_instance` (e.g, did
-[custom wallet configuration](#wallet-configuration) or
-started/restarted Sui instance multiple time), you should remove
-`"$SUI_ROOT"/sui_instance` directory containing configuration files
-and recreate [Sui genesis state](#genesis).
+If you see errors when trying to start Sui network, particularly if you made some custom changes
+ (e.g, 
+[customized wallet configuration](#wallet-configuration)), you should [recreate Sui genesis state](#recreating-genesis).
 
 ## Using the wallet
 The following commands are supported by the wallet:
@@ -174,19 +169,17 @@ The wallet can be started in two modes: interactive shell or command line interf
 To start the interactive shell, execute the following (in a different terminal window than one used to execute `sui start`):
 
 ```shell
-cd "$SUI_ROOT"/sui_instance
 wallet
 ```
 
-You can also run this command in any directory if you provide a path
-to the directory where Sui configuration files are stored:
+This command will by default look for wallet coinfiguration file
+(`wallet.conf`) in the `~/.sui/sui_config` directory, but you can
+override this setting by providing a path to the directory where this
+file are stored:
 
 ```shell
-wallet --config "$SUI_ROOT"/sui_instance
+wallet --config /path/to/wallet/config/file
 ```
-
-The wallet config file path defaults to `./wallet.conf` if not
-specified.
 
 The Sui interactive wallet supports the following shell functionality:
 * Command History
@@ -205,10 +198,6 @@ The Sui interactive wallet supports the following shell functionality:
 The wallet can also be used without the interactive shell, which can be useful if 
 you want to pipe the output of the wallet to another application or invoke wallet 
 commands using scripts.
-
-**For the remainder of this tutorial we will assume that you are
-executing the `wallet` command in a directory where the Sui
-configuration files are stored (`"$SUI_ROOT"/sui_instance`).**
 
 ```shell
 USAGE:

--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -34,7 +34,7 @@ The network configuration is stored in `network.conf` and can be used
 subsequently to start the network. The `wallet.conf` and `wallet.key`
 are also created to be used by the Sui wallet to manage the newly
 created accounts. By default, these files will be stored in the
-o`~/.sui/sui_config` directory, but you can override this location by
+`~/.sui/sui_config` directory, but you can override this location by
 providing an alternative path:
 
 ```shell

--- a/doc/src/explore/tutorials.md
+++ b/doc/src/explore/tutorials.md
@@ -21,26 +21,9 @@ the `wallet` command used in the remainder of this tutorial in your path.
 Simply leave the terminal with Sui running and start a new terminal for the
 remainder of this tutorial.
 
-We will follow the same convention as the one described in the [Sui
-setup instructions](../build/wallet.md#setup) and assume that Sui
-configuration files generated during Sui genesis state creation are
-stored in the `"$SUI_ROOT"/sui_instance` directory.
-
-*IMPORTANT*: For the remainder of this tutorial, we will assume that you are
-executing the `wallet` command in the `"$SUI_ROOT"/sui_instance` directory as well.
-Adjust your paths accordingly.
-
 ## Gather accounts and gas objects
 
-After completing the [Setup section](#setup) you should have a Sui instance running in a terminal window. Now switch to a new terminal window and keep the first terminal running.
-Make sure that you run the `wallet` command in the directory
-where wallet configuration is located or by passing wallet's
-configuration file as a parameter, as described in the `wallet`
-[command description](../build/wallet.md#using-the-wallet).
-This will be the same directory where you ran `sui genesis`,
-so return to $SUI_ROOT/sui_instance.
-
-There take a look at the account addresses we own in our wallet:
+Let us take a look at the account addresses we own in our wallet:
 ```
 $ wallet --no-shell addresses
 Showing 5 results.
@@ -93,9 +76,19 @@ export O_GAS=2110ADFB7BAF889A05EA6F5889AF7724299F9BED
 ```
 
 ## Publish the TicTacToe game on Sui
-We implemented a TicTacToe game in [TicTacToe.move](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples/games/sources/TicTacToe.move). To publish the game, we run the publish command and specify the path to the game package. As described in the earlier [setup section](#setup), we assume that Sui repository was cloned locally - *let us further assume that it was cloned into `"$SUI_ROOT"/sui` directory* **Adjust the `--path` to match your own environment if you used different paths**.
+We implemented a TicTacToe game in [TicTacToe.move](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples/games/sources/TicTacToe.move).
+
+In order to obtain source code for the game, let us clone the Sui
+repository to the current directory:
+
+```shell
+git clone https://github.com/MystenLabs/sui.git
 ```
-$ wallet --no-shell publish --path "$SUI_ROOT"/sui/sui_programmability/examples/games --gas $ADMIN_GAS --gas-budget 30000
+
+To publish the game, we run the publish command and specify the path to the source code of the game package:
+
+```
+$ wallet --no-shell publish --path ./sui/sui_programmability/examples/games --gas $ADMIN_GAS --gas-budget 30000
 ----- Certificate ----
 Signed Authorities : ...
 Transaction Kind : Publish

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = { version = "0.3.9", features = ["time", "registry", "env-f
 tracing-bunyan-formatter = "0.3"
 serde-value = "0.7.0"
 log = "0.4.14"
+dirs = "4.0.0"
 
 bcs = "0.1.3"
 sui_core = { path = "../sui_core" }

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -54,11 +54,16 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     let config = working_dir.join("network.conf");
 
     // Start network without authorities
-    let start = SuiCommand::Start { config }.execute().await;
+    let start = SuiCommand::Start {
+        config: Some(config),
+    }
+    .execute()
+    .await;
     assert!(matches!(start, Err(..)));
     // Genesis
     SuiCommand::Genesis {
-        working_dir: working_dir.to_path_buf(),
+        working_dir: Some(working_dir.to_path_buf()),
+        force: false,
     }
     .execute()
     .await?;
@@ -93,7 +98,8 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 
     // Genesis 2nd time should fail
     let result = SuiCommand::Genesis {
-        working_dir: working_dir.to_path_buf(),
+        working_dir: Some(working_dir.to_path_buf()),
+        force: false,
     }
     .execute()
     .await;

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -59,7 +59,6 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     // Genesis
     SuiCommand::Genesis {
         working_dir: working_dir.to_path_buf(),
-        config: None,
     }
     .execute()
     .await?;
@@ -95,7 +94,6 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     // Genesis 2nd time should fail
     let result = SuiCommand::Genesis {
         working_dir: working_dir.to_path_buf(),
-        config: None,
     }
     .execute()
     .await;

--- a/sui/src/wallet.rs
+++ b/sui/src/wallet.rs
@@ -19,8 +19,6 @@ use sui::shell::{
 use sui::sui_commands;
 use sui::wallet_commands::*;
 
-const SUI_WALLET_CONFIG: &str = "wallet.conf";
-
 const SUI: &str = "   _____       _    _       __      ____     __
   / ___/__  __(_)  | |     / /___ _/ / /__  / /_
   \\__ \\/ / / / /   | | /| / / __ `/ / / _ \\/ __/
@@ -67,14 +65,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut app: App = ClientOpt::clap();
     app = app.unset_setting(AppSettings::NoBinaryName);
     let options: ClientOpt = ClientOpt::from_clap(&app.get_matches());
-    let wallet_conf_path = match options.config {
-        Some(v) => v.clone(),
-        None => {
-            let mut p = sui_commands::sui_config_dir()?;
-            p.push(SUI_WALLET_CONFIG);
-            p
-        }
-    };
+    let wallet_conf_path = options
+        .config
+        .clone()
+        .unwrap_or(sui_commands::sui_config_dir()?.join(sui_commands::SUI_WALLET_CONFIG));
 
     let mut context = WalletContext::new(&wallet_conf_path)?;
 

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -452,8 +452,8 @@ impl WalletContext {
     pub fn new(config_path: &Path) -> Result<Self, anyhow::Error> {
         let config: WalletConfig = PersistedConfig::read(config_path).map_err(|err| {
             err.context(format!(
-                "Cannot open wallet config file at {}",
-                config_path.to_str().unwrap()
+                "Cannot open wallet config file at {:?}",
+                config_path
             ))
         })?;
         let config = config.persisted(config_path);

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -450,7 +450,12 @@ pub struct WalletContext {
 
 impl WalletContext {
     pub fn new(config_path: &Path) -> Result<Self, anyhow::Error> {
-        let config: WalletConfig = PersistedConfig::read(config_path)?;
+        let config: WalletConfig = PersistedConfig::read(config_path).map_err(|err| {
+            err.context(format!(
+                "Cannot open wallet config file at {}",
+                config_path.to_str().unwrap()
+            ))
+        })?;
         let config = config.persisted(config_path);
         let keystore = Arc::new(RwLock::new(config.keystore.init()?));
         let gateway = config.gateway.init();


### PR DESCRIPTION
The idea here is to default Wallet CLI and Sui CLI to by default use the ~/.sui directory for storing required data (e.g., config files).

I am putting this out for the review before I change the required docs so that I don't have to repeat the docs change work in case this PR needs modifications that could affect doc content. However, IT WILL NOT LAND BEFORE DOCUMENTATION CHANGES ARE IN AS WELL.