### PR TITLE
Move package deps commitments

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -633,6 +633,7 @@ impl AuthorityState {
             modules,
             ctx,
             MAX_GAS_BUDGET,
+            package_id,
         ) {
             return Err(*error);
         };

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -6,6 +6,7 @@ use rocksdb::{ColumnFamilyDescriptor, Options};
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::path::Path;
+use sui_types::object::OBJECT_START_VERSION;
 
 use rocksdb::MultiThreaded;
 use std::sync::atomic::AtomicU64;
@@ -852,9 +853,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             .zip(versions.iter())
             .map(|(id, v)| {
                 let version = v.unwrap_or_else(SequenceNumber::new);
-                let next_version = v
-                    .map(|v| v.increment())
-                    .unwrap_or_else(|| SequenceNumber::from(1));
+                let next_version = v.map(|v| v.increment()).unwrap_or(OBJECT_START_VERSION);
 
                 let sequenced = ((transaction_digest, *id), version);
                 let scheduled = (id, next_version);

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -1676,5 +1676,5 @@ async fn shared_object() {
         .unwrap()
         .unwrap()
         .version();
-    assert_eq!(shared_object_version, SequenceNumber::from(1));
+    assert_eq!(shared_object_version, OBJECT_START_VERSION);
 }

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -17,7 +17,7 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     CertifiedTransaction, SignatureAggregator, Transaction, TransactionData,
 };
-use sui_types::object::{Data, MoveObject, Object, Owner};
+use sui_types::object::{Data, MoveObject, Object, Owner, OBJECT_START_VERSION};
 use sui_types::serialize::serialize_cert;
 use test_utils::sequencer::Sequencer;
 
@@ -152,7 +152,7 @@ async fn handle_consensus_output() {
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     assert_eq!(
         state.db().last_consensus_index().unwrap(),
-        SequenceNumber::from(1)
+        OBJECT_START_VERSION
     );
 }
 
@@ -251,5 +251,5 @@ async fn test_sync() {
         .pop()
         .unwrap()
         .unwrap();
-    assert_eq!(certificate_1_sequence, SequenceNumber::from(1));
+    assert_eq!(certificate_1_sequence, OBJECT_START_VERSION);
 }

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -206,6 +206,11 @@ MovePackage:
   STRUCT:
     - id:
         TYPENAME: ObjectID
+    - deps:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: ObjectDigest
     - module_map:
         MAP:
           KEY: STR

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -370,7 +370,7 @@ pub fn publish<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
         modules,
         ctx,
         gas_budget - gas_used_for_publish,
-        package_id
+        package_id,
     ) {
         ExecutionStatus::Success { gas_used, .. } => gas_used,
         ExecutionStatus::Failure { gas_used, error } => {

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -14,7 +14,7 @@ use sui_types::{
     crypto::get_key_pair,
     error::SuiResult,
     gas_coin::GAS,
-    object::{Data, Owner},
+    object::{Data, Owner, OBJECT_START_VERSION},
     storage::{BackingPackageStore, Storage},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
@@ -252,7 +252,7 @@ fn test_object_basics() {
     let id1 = storage.get_created_keys().pop().unwrap();
     storage.flush();
     let mut obj1 = storage.read_object(&id1).unwrap();
-    let mut obj1_seq = SequenceNumber::from(1);
+    let mut obj1_seq = OBJECT_START_VERSION;
     assert!(obj1.owner == addr1);
     assert_eq!(obj1.version(), obj1_seq);
 
@@ -415,7 +415,7 @@ fn test_wrap_unwrap() {
         .unwrap()
         .type_specific_contents()
         .to_vec();
-    assert_eq!(obj1.version(), SequenceNumber::from(1));
+    assert_eq!(obj1.version(), OBJECT_START_VERSION);
 
     // 2. wrap addr
     call(
@@ -977,7 +977,7 @@ fn test_simple_call() {
     storage.flush();
     let obj = storage.read_object(&id).unwrap();
     assert!(obj.owner == addr);
-    assert_eq!(obj.version(), SequenceNumber::from(1));
+    assert_eq!(obj.version(), OBJECT_START_VERSION);
     let move_obj = obj.data.try_as_move().unwrap();
     assert_eq!(
         u64::from_le_bytes(move_obj.type_specific_contents().try_into().unwrap()),

--- a/sui_types/src/move_package.rs
+++ b/sui_types/src/move_package.rs
@@ -19,10 +19,7 @@ use move_core_types::{
 };
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use std::{
-    collections::{BTreeMap},
-    u32,
-};
+use std::{collections::BTreeMap, u32};
 
 // TODO: robust MovePackage tests
 // #[cfg(test)]

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -4,7 +4,7 @@
 use crate::coin::Coin;
 use crate::crypto::{sha3_hash, BcsSignable};
 use crate::error::{SuiError, SuiResult};
-use crate::move_package::MovePackage;
+use crate::move_package::{MovePackage, PackageObjectRef};
 use crate::{
     base_types::{
         ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
@@ -324,10 +324,11 @@ impl Object {
 
     pub fn new_package(
         modules: Vec<CompiledModule>,
+        deps: Vec<PackageObjectRef>,
         previous_transaction: TransactionDigest,
     ) -> Self {
         Object {
-            data: Data::Package(MovePackage::from(&modules)),
+            data: Data::Package(MovePackage::from((&modules, &deps))),
             owner: Owner::SharedImmutable,
             previous_transaction,
         }
@@ -374,7 +375,7 @@ impl Object {
 
         match &self.data {
             Move(v) => v.version(),
-            Package(_) => SequenceNumber::from(1), // modules are immutable, version is always 1
+            Package(_) => OBJECT_START_VERSION, // modules are immutable, version is constant
         }
     }
 


### PR DESCRIPTION
This allows us to fetch a package from an untrusted source and verify the dependencies.

Once this merges, I will push my changes to enable safe local execution.

PR addresses https://github.com/MystenLabs/sui/issues/530 

**Note:**
Computing the deps commitments in the adapter is more computationally expensive. We can instead cache package digests as part of the package or move the commitment logic somewhere else.