### PR TITLE
[Authority] Remove standalone next sequence from store struct

### DIFF
--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -8,7 +8,6 @@ use std::convert::TryInto;
 use std::path::Path;
 
 use rocksdb::MultiThreaded;
-use std::sync::atomic::AtomicU64;
 
 use sui_types::base_types::SequenceNumber;
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
@@ -102,9 +101,6 @@ pub struct SuiDataStore<const ALL_OBJ_VER: bool> {
     /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
     /// every message output by consensus (and in the right order).
     last_consensus_index: DBMap<u64, SequenceNumber>,
-
-    /// The next available sequence number to use in the `executed sequence` table.
-    pub next_sequence_number: AtomicU64,
 }
 
 /// Opens a database with options, and a number of column families that are created if they do not exist.
@@ -191,18 +187,6 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
         let executed_sequence =
             DBMap::reopen(&db, Some("executed_sequence")).expect("Cannot open CF.");
 
-        // Read the index of the last entry in the sequence of commands
-        // to extract the next sequence number or it is zero.
-        let next_sequence_number = AtomicU64::new(
-            executed_sequence
-                .iter()
-                .skip_prior_to(&TxSequenceNumber::MAX)
-                .expect("Error reading table.")
-                .next()
-                .map(|(v, _)| v + 1u64)
-                .unwrap_or(0),
-        );
-
         let (
             objects,
             all_object_versions,
@@ -249,7 +233,6 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             executed_sequence,
             batches,
             last_consensus_index,
-            next_sequence_number,
         }
     }
 


### PR DESCRIPTION
Given the latest logic for maintaining batches and a local sequence of commands, we do not need the atomic `next_sequence_number` in the store any more. So this PR removes it, and its initialisation.