### PR TITLE
Consolidate `Transaction` and `SignedTransaction`

### DIFF
--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -6,6 +6,7 @@ use rocksdb::{ColumnFamilyDescriptor, Options};
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::path::Path;
+use sui_types::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, EmptyAuthoritySignInfo};
 
 use rocksdb::MultiThreaded;
 
@@ -16,9 +17,9 @@ use typed_store::rocks::{DBBatch, DBMap, TypedStoreError};
 
 use typed_store::{reopen, traits::Map};
 
-pub type AuthorityStore = SuiDataStore<false>;
+pub type AuthorityStore = SuiDataStore<false, AuthoritySignInfo>;
 #[allow(dead_code)]
-pub type ReplicaStore = SuiDataStore<true>;
+pub type ReplicaStore = SuiDataStore<true, EmptyAuthoritySignInfo>;
 
 const NUM_SHARDS: usize = 4096;
 
@@ -29,7 +30,13 @@ const LAST_CONSENSUS_INDEX_ADDR: u64 = 0;
 /// ALL_OBJ_VER determines whether we want to store all past
 /// versions of every object in the store. Authority doesn't store
 /// them, but other entities such as replicas will.
-pub struct SuiDataStore<const ALL_OBJ_VER: bool> {
+/// S is a template on Authority signature state. This allows SuiDataStore to be used on either
+/// authorities or non-authorities. Specifically, when storing transactions and effects,
+/// S allows SuiDataStore to either store the authority signed version or unsigned version.
+pub struct SuiDataStore<const ALL_OBJ_VER: bool, S>
+where
+    TransactionEnvelope<S>: PartialEq,
+{
     /// This is a map between the object ID and the latest state of the object, namely the
     /// state that is needed to process new transactions. If an object is deleted its entry is
     /// removed from this map.
@@ -54,11 +61,11 @@ pub struct SuiDataStore<const ALL_OBJ_VER: bool> {
     /// by a specific user, and their object reference.
     owner_index: DBMap<(SuiAddress, ObjectID), ObjectRef>,
 
-    /// This is map between the transaction digest and signed transactions found in the `transaction_lock`.
+    /// This is map between the transaction digest and transactions found in the `transaction_lock`.
     /// NOTE: after a lock is deleted the corresponding entry here could be deleted, but right
-    /// now this is not done. If a certificate is processed (see `certificates`) the signed
+    /// now this is not done. If a certificate is processed (see `certificates`) the
     /// transaction can also be deleted from this structure.
-    signed_transactions: DBMap<TransactionDigest, SignedTransaction>,
+    transactions: DBMap<TransactionDigest, TransactionEnvelope<S>>,
 
     /// This is a map between the transaction digest and the corresponding certificate for all
     /// certificates that have been successfully processed by this authority. This set of certificates
@@ -142,9 +149,12 @@ pub fn open_cf_opts<P: AsRef<Path>>(
     Ok(rocksdb)
 }
 
-impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
+impl<const ALL_OBJ_VER: bool, S: AuthoritySignInfoTrait> SuiDataStore<ALL_OBJ_VER, S>
+where
+    TransactionEnvelope<S>: PartialEq,
+{
     /// Open an authority store by directory path
-    pub fn open<P: AsRef<Path>>(path: P, db_options: Option<Options>) -> AuthorityStore {
+    pub fn open<P: AsRef<Path>>(path: P, db_options: Option<Options>) -> Self {
         let mut options = db_options.unwrap_or_default();
 
         /* The table cache is locked for updates and this determines the number
@@ -171,7 +181,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
                 ("all_object_versions", &options),
                 ("owner_index", &options),
                 ("transaction_lock", &point_lookup),
-                ("signed_transactions", &point_lookup),
+                ("transactions", &point_lookup),
                 ("certificates", &point_lookup),
                 ("parent_sync", &options),
                 ("signed_effects", &point_lookup),
@@ -192,7 +202,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             all_object_versions,
             owner_index,
             transaction_lock,
-            signed_transactions,
+            transactions,
             certificates,
             parent_sync,
             signed_effects,
@@ -206,7 +216,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             "all_object_versions";<(ObjectID, SequenceNumber), Object>,
             "owner_index";<(SuiAddress, ObjectID), ObjectRef>,
             "transaction_lock";<ObjectRef, Option<TransactionDigest>>,
-            "signed_transactions";<TransactionDigest, SignedTransaction>,
+            "transactions";<TransactionDigest, TransactionEnvelope<S>>,
             "certificates";<TransactionDigest, CertifiedTransaction>,
             "parent_sync";<ObjectRef, TransactionDigest>,
             "signed_effects";<TransactionDigest, SignedTransactionEffects>,
@@ -215,12 +225,12 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             "batches";<TxSequenceNumber, SignedBatch>,
             "last_consensus_index";<u64, SequenceNumber>
         );
-        AuthorityStore {
+        Self {
             objects,
             all_object_versions,
             owner_index,
             transaction_lock,
-            signed_transactions,
+            transactions,
             certificates,
             parent_sync,
             signed_effects,
@@ -244,11 +254,8 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     }
 
     /// Returns true if we have a signed_effects structure for this transaction digest
-    pub fn signed_transaction_exists(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> SuiResult<bool> {
-        self.signed_transactions
+    pub fn transaction_exists(&self, transaction_digest: &TransactionDigest) -> SuiResult<bool> {
+        self.transactions
             .contains_key(transaction_digest)
             .map_err(|e| e.into())
     }
@@ -309,17 +316,6 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             .collect())
     }
 
-    pub fn get_transaction_info(
-        &self,
-        transaction_digest: &TransactionDigest,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        Ok(TransactionInfoResponse {
-            signed_transaction: self.signed_transactions.get(transaction_digest)?,
-            certified_transaction: self.certificates.get(transaction_digest)?,
-            signed_effects: self.signed_effects.get(transaction_digest)?,
-        })
-    }
-
     /// Read an object and return it, or Err(ObjectNotFound) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.objects.get(object_id).map_err(|e| e.into())
@@ -334,7 +330,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     pub fn get_transaction_lock(
         &self,
         object_ref: &ObjectRef,
-    ) -> Result<Option<SignedTransaction>, SuiError> {
+    ) -> Result<Option<TransactionEnvelope<S>>, SuiError> {
         let transaction_option = self
             .transaction_lock
             .get(object_ref)?
@@ -342,7 +338,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
 
         match transaction_option {
             Some(tx_digest) => Ok(Some(
-                self.signed_transactions
+                self.transactions
                     .get(&tx_digest)?
                     .expect("Stored a lock without storing transaction?"),
             )),
@@ -499,7 +495,7 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
         &self,
         owned_input_objects: &[ObjectRef],
         tx_digest: TransactionDigest,
-        signed_transaction: SignedTransaction,
+        transaction: TransactionEnvelope<S>,
     ) -> Result<(), SuiError> {
         let lock_batch = self
             .transaction_lock
@@ -511,8 +507,8 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
                     .map(|obj_ref| (obj_ref, Some(tx_digest))),
             )?
             .insert_batch(
-                &self.signed_transactions,
-                std::iter::once((tx_digest, signed_transaction)),
+                &self.transactions,
+                std::iter::once((tx_digest, transaction)),
             )?;
 
         // This is the critical region: testing the locks and writing the
@@ -558,13 +554,13 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     ///
     /// Internally it checks that all locks for active inputs are at the correct
     /// version, and then writes locks, objects, certificates, parents atomically.
-    pub fn update_state<S>(
+    pub fn update_state<BackingPackageStore>(
         &self,
-        temporary_store: AuthorityTemporaryStore<S>,
-        certificate: CertifiedTransaction,
-        signed_effects: SignedTransactionEffects,
+        temporary_store: AuthorityTemporaryStore<BackingPackageStore>,
+        certificate: &CertifiedTransaction,
+        signed_effects: &SignedTransactionEffects,
         sequence_number: Option<TxSequenceNumber>,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> SuiResult {
         // Extract the new state from the execution
         // TODO: events are already stored in the TxDigest -> TransactionEffects store. Is that enough?
         let mut write_batch = self.transaction_lock.batch();
@@ -573,13 +569,13 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
         let transaction_digest: &TransactionDigest = certificate.digest();
         write_batch = write_batch.insert_batch(
             &self.certificates,
-            std::iter::once((transaction_digest, &certificate)),
+            std::iter::once((transaction_digest, certificate)),
         )?;
 
         // Store the signed effects of the transaction
         write_batch = write_batch.insert_batch(
             &self.signed_effects,
-            std::iter::once((transaction_digest, &signed_effects)),
+            std::iter::once((transaction_digest, signed_effects)),
         )?;
 
         // Cleanup the lock of the shared objects.
@@ -595,19 +591,13 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             temporary_store,
             *transaction_digest,
             sequence_number,
-        )?;
-
-        Ok(TransactionInfoResponse {
-            signed_transaction: self.signed_transactions.get(transaction_digest)?,
-            certified_transaction: Some(certificate),
-            signed_effects: Some(signed_effects),
-        })
+        )
     }
 
     /// Persist temporary storage to DB for genesis modules
-    pub fn update_objects_state_for_genesis<S>(
+    pub fn update_objects_state_for_genesis<BackingPackageStore>(
         &self,
-        temporary_store: AuthorityTemporaryStore<S>,
+        temporary_store: AuthorityTemporaryStore<BackingPackageStore>,
         transaction_digest: TransactionDigest,
     ) -> Result<(), SuiError> {
         debug_assert_eq!(transaction_digest, TransactionDigest::genesis());
@@ -616,10 +606,10 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     }
 
     /// Helper function for updating the objects in the state
-    fn batch_update_objects<S>(
+    fn batch_update_objects<BackingPackageStore>(
         &self,
         mut write_batch: DBBatch,
-        temporary_store: AuthorityTemporaryStore<S>,
+        temporary_store: AuthorityTemporaryStore<BackingPackageStore>,
         transaction_digest: TransactionDigest,
         seq_opt: Option<TxSequenceNumber>,
     ) -> Result<(), SuiError> {
@@ -968,6 +958,14 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
             .map_err(SuiError::from)
     }
 
+    pub fn get_transaction(
+        &self,
+        transaction_digest: &TransactionDigest,
+    ) -> SuiResult<Option<TransactionEnvelope<S>>> {
+        let transaction = self.transactions.get(transaction_digest)?;
+        Ok(transaction)
+    }
+
     #[cfg(test)]
     /// Provide read access to the `schedule` table (useful for testing).
     pub fn get_schedule(&self, object_id: &ObjectID) -> SuiResult<Option<SequenceNumber>> {
@@ -975,7 +973,23 @@ impl<const ALL_OBJ_VER: bool> SuiDataStore<ALL_OBJ_VER> {
     }
 }
 
-impl<const ALL_OBJ_VER: bool> BackingPackageStore for SuiDataStore<ALL_OBJ_VER> {
+impl<const A: bool> SuiDataStore<A, AuthoritySignInfo> {
+    pub fn get_signed_transaction_info(
+        &self,
+        transaction_digest: &TransactionDigest,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: self.transactions.get(transaction_digest)?,
+            certified_transaction: self.certificates.get(transaction_digest)?,
+            signed_effects: self.signed_effects.get(transaction_digest)?,
+        })
+    }
+}
+
+impl<const A: bool, S: AuthoritySignInfoTrait> BackingPackageStore for SuiDataStore<A, S>
+where
+    TransactionEnvelope<S>: PartialEq,
+{
     fn get_package(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         let package = self.get_object(package_id)?;
         if let Some(obj) = &package {
@@ -990,7 +1004,10 @@ impl<const ALL_OBJ_VER: bool> BackingPackageStore for SuiDataStore<ALL_OBJ_VER> 
     }
 }
 
-impl<const ALL_OBJ_VER: bool> ModuleResolver for SuiDataStore<ALL_OBJ_VER> {
+impl<const A: bool, S: AuthoritySignInfoTrait> ModuleResolver for SuiDataStore<A, S>
+where
+    TransactionEnvelope<S>: PartialEq,
+{
     type Error = SuiError;
 
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::path::Path;
-use sui_types::crypto::{AuthoritySignInfo, EmptyAuthoritySignInfo};
+use sui_types::crypto::{AuthoritySignInfo, EmptySignInfo};
 
 use rocksdb::MultiThreaded;
 
@@ -20,7 +20,7 @@ use typed_store::{reopen, traits::Map};
 
 pub type AuthorityStore = SuiDataStore<false, AuthoritySignInfo>;
 #[allow(dead_code)]
-pub type ReplicaStore = SuiDataStore<true, EmptyAuthoritySignInfo>;
+pub type ReplicaStore = SuiDataStore<true, EmptySignInfo>;
 
 const NUM_SHARDS: usize = 4096;
 

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -827,9 +827,10 @@ where
                                 signed_transaction: Some(inner_signed_transaction),
                                 ..
                             }) => {
-                                state
-                                    .signatures
-                                    .push((name, inner_signed_transaction.signature));
+                                state.signatures.push((
+                                    name,
+                                    inner_signed_transaction.auth_signature.signature,
+                                ));
                                 state.good_stake += weight;
                                 if state.good_stake >= threshold {
                                     state.certificate =

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -41,14 +41,14 @@ impl<C> SafeClient<C> {
             signed_transaction.check(&self.committee)?;
             // Check it has the right signer
             fp_ensure!(
-                signed_transaction.authority == self.address,
+                signed_transaction.auth_signature.authority == self.address,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
             );
             // Check it's the right transaction
             fp_ensure!(
-                signed_transaction.transaction.digest() == digest,
+                signed_transaction.digest() == digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -157,7 +157,7 @@ impl<C> SafeClient<C> {
                 signed_transaction.check(&self.committee)?;
                 // Check it has the right signer
                 fp_ensure!(
-                    signed_transaction.authority == self.address,
+                    signed_transaction.auth_signature.authority == self.address,
                     SuiError::ByzantineAuthoritySuspicion {
                         authority: self.address
                     }

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -84,7 +84,7 @@ async fn test_handle_transfer_transaction_bad_signature() {
     );
     let (_unknown_address, unknown_key) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone();
-    bad_signature_transfer_transaction.signature =
+    bad_signature_transfer_transaction.tx_signature =
         Signature::new(&transfer_transaction.data, &unknown_key);
     assert!(authority_state
         .handle_transaction(bad_signature_transfer_transaction)
@@ -264,7 +264,6 @@ async fn test_handle_transfer_transaction_ok() {
             .unwrap()
             .as_ref()
             .unwrap()
-            .transaction
             .data,
         transfer_transaction.data
     );
@@ -344,7 +343,7 @@ pub async fn send_and_confirm_transaction(
     // Collect signatures from a quorum of authorities
     let mut builder = SignatureAggregator::try_new(transaction, &authority.committee).unwrap();
     let certificate = builder
-        .append(vote.authority, vote.signature)
+        .append(vote.auth_signature.authority, vote.auth_signature.signature)
         .unwrap()
         .unwrap();
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
@@ -1446,7 +1445,7 @@ fn init_certified_transfer_transaction(
     let mut builder =
         SignatureAggregator::try_new(transfer_transaction, &authority_state.committee).unwrap();
     builder
-        .append(vote.authority, vote.signature)
+        .append(vote.auth_signature.authority, vote.auth_signature.signature)
         .unwrap()
         .unwrap()
 }
@@ -1630,7 +1629,7 @@ async fn shared_object() {
     let vote = response.signed_transaction.unwrap();
     let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
         .unwrap()
-        .append(vote.authority, vote.signature)
+        .append(vote.auth_signature.authority, vote.auth_signature.signature)
         .unwrap()
         .unwrap();
     let confirmation_transaction = ConfirmationTransaction::new(certificate.clone());

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -98,7 +98,7 @@ async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTransacti
         let vote = response.signed_transaction.unwrap();
         let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
             .unwrap()
-            .append(vote.authority, vote.signature)
+            .append(vote.auth_signature.authority, vote.auth_signature.signature)
             .unwrap()
             .unwrap();
         certificates.push(certificate);

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -117,7 +117,7 @@ CallResult:
 CertifiedTransaction:
   STRUCT:
     - transaction:
-        TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptyAuthoritySignInfo>"
+        TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptySignInfo>"
     - signatures:
         SEQ:
           TUPLE:
@@ -142,7 +142,7 @@ Data:
       Package:
         NEWTYPE:
           TYPENAME: MovePackage
-EmptyAuthoritySignInfo:
+EmptySignInfo:
   STRUCT: []
 Event:
   STRUCT:
@@ -340,7 +340,7 @@ SerializedMessage:
     0:
       Transaction:
         NEWTYPE:
-          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptyAuthoritySignInfo>"
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptySignInfo>"
     1:
       Vote:
         NEWTYPE:
@@ -909,12 +909,12 @@ UpdateItem:
         TYPENAME: Signature
     - auth_signature:
         TYPENAME: AuthoritySignInfo
-"sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptyAuthoritySignInfo>":
+"sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptySignInfo>":
   STRUCT:
     - data:
         TYPENAME: TransactionData
     - tx_signature:
         TYPENAME: Signature
     - auth_signature:
-        TYPENAME: EmptyAuthoritySignInfo
+        TYPENAME: EmptySignInfo
 

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -32,6 +32,12 @@ AuthorityBatch:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 32
+AuthoritySignInfo:
+  STRUCT:
+    - authority:
+        TYPENAME: PublicKeyBytes
+    - signature:
+        TYPENAME: AuthoritySignature
 AuthoritySignature:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -111,7 +117,7 @@ CallResult:
 CertifiedTransaction:
   STRUCT:
     - transaction:
-        TYPENAME: Transaction
+        TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptyAuthoritySignInfo>"
     - signatures:
         SEQ:
           TUPLE:
@@ -136,6 +142,8 @@ Data:
       Package:
         NEWTYPE:
           TYPENAME: MovePackage
+EmptyAuthoritySignInfo:
+  STRUCT: []
 Event:
   STRUCT:
     - type_:
@@ -305,7 +313,7 @@ ObjectResponse:
         TYPENAME: Object
     - lock:
         OPTION:
-          TYPENAME: SignedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>"
     - layout:
         OPTION:
           TYPENAME: MoveStructLayout
@@ -332,11 +340,11 @@ SerializedMessage:
     0:
       Transaction:
         NEWTYPE:
-          TYPENAME: Transaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptyAuthoritySignInfo>"
     1:
       Vote:
         NEWTYPE:
-          TYPENAME: SignedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>"
     2:
       Cert:
         NEWTYPE:
@@ -391,14 +399,6 @@ SignedBatch:
   STRUCT:
     - batch:
         TYPENAME: AuthorityBatch
-    - authority:
-        TYPENAME: PublicKeyBytes
-    - signature:
-        TYPENAME: AuthoritySignature
-SignedTransaction:
-  STRUCT:
-    - transaction:
-        TYPENAME: Transaction
     - authority:
         TYPENAME: PublicKeyBytes
     - signature:
@@ -751,12 +751,6 @@ SuiError:
           - error: STR
     91:
       OnlyOneConsensusClientPermitted: UNIT
-Transaction:
-  STRUCT:
-    - data:
-        TYPENAME: TransactionData
-    - signature:
-        TYPENAME: Signature
 TransactionData:
   STRUCT:
     - kind:
@@ -833,7 +827,7 @@ TransactionInfoResponse:
   STRUCT:
     - signed_transaction:
         OPTION:
-          TYPENAME: SignedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>"
     - certified_transaction:
         OPTION:
           TYPENAME: CertifiedTransaction
@@ -907,4 +901,20 @@ UpdateItem:
       Batch:
         NEWTYPE:
           TYPENAME: SignedBatch
+"sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>":
+  STRUCT:
+    - data:
+        TYPENAME: TransactionData
+    - tx_signature:
+        TYPENAME: Signature
+    - auth_signature:
+        TYPENAME: AuthoritySignInfo
+"sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptyAuthoritySignInfo>":
+  STRUCT:
+    - data:
+        TYPENAME: TransactionData
+    - tx_signature:
+        TYPENAME: Signature
+    - auth_signature:
+        TYPENAME: EmptyAuthoritySignInfo
 

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -393,13 +393,28 @@ impl AuthoritySignature {
     }
 }
 
+/// AuthoritySignInfoTrait is a trait used specifically for a few structs in messages.rs
+/// to template on whether the struct is signed by an authority. We want to limit how
+/// those structs can be instanted on, hence the sealed trait.
+/// TODO: We could also add the aggregated signature as another impl of the trait.
+///       This will make CertifiedTransaction also an instance of the same struct.
+pub trait AuthoritySignInfoTrait: private::SealedAuthoritySignInfoTrait {}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct EmptyAuthoritySignInfo {}
+pub struct EmptySignInfo {}
+impl AuthoritySignInfoTrait for EmptySignInfo {}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AuthoritySignInfo {
     pub authority: AuthorityName,
     pub signature: AuthoritySignature,
+}
+impl AuthoritySignInfoTrait for AuthoritySignInfo {}
+
+mod private {
+    pub trait SealedAuthoritySignInfoTrait {}
+    impl SealedAuthoritySignInfoTrait for super::EmptySignInfo {}
+    impl SealedAuthoritySignInfoTrait for super::AuthoritySignInfo {}
 }
 
 /// Something that we know how to hash and sign.

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -393,18 +393,14 @@ impl AuthoritySignature {
     }
 }
 
-pub trait AuthoritySignInfoTrait: Eq + Serialize + serde::de::DeserializeOwned {}
-
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EmptyAuthoritySignInfo {}
-impl AuthoritySignInfoTrait for EmptyAuthoritySignInfo {}
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AuthoritySignInfo {
     pub authority: AuthorityName,
     pub signature: AuthoritySignature,
 }
-impl AuthoritySignInfoTrait for AuthoritySignInfo {}
 
 /// Something that we know how to hash and sign.
 pub trait Signable<W> {

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 use sha3::Sha3_256;
 
-use crate::base_types::SuiAddress;
+use crate::base_types::{AuthorityName, SuiAddress};
 use crate::error::{SuiError, SuiResult};
 
 // TODO: Make sure secrets are not copyable and movable to control where they are in memory
@@ -392,6 +392,17 @@ impl AuthoritySignature {
         })
     }
 }
+
+pub trait AuthoritySignInfoTrait {}
+
+pub struct EmptyAuthoritySignInfo {}
+impl AuthoritySignInfoTrait for EmptyAuthoritySignInfo {}
+
+pub struct AuthoritySignInfo {
+    pub authority: AuthorityName,
+    pub signature: AuthoritySignature,
+}
+impl AuthoritySignInfoTrait for AuthoritySignInfo {}
 
 /// Something that we know how to hash and sign.
 pub trait Signable<W> {

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -393,11 +393,13 @@ impl AuthoritySignature {
     }
 }
 
-pub trait AuthoritySignInfoTrait {}
+pub trait AuthoritySignInfoTrait: Eq + Serialize + serde::de::DeserializeOwned {}
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EmptyAuthoritySignInfo {}
 impl AuthoritySignInfoTrait for EmptyAuthoritySignInfo {}
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AuthoritySignInfo {
     pub authority: AuthorityName,
     pub signature: AuthoritySignature,

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -334,12 +334,199 @@ const_assert_eq!(
 
 */
 
+impl Transaction {
+    #[cfg(test)]
+    pub fn from_data(data: TransactionData, signer: &dyn signature::Signer<Signature>) -> Self {
+        let signature = Signature::new(&data, signer);
+        Self::new(data, signature)
+    }
+
+    pub fn new(data: TransactionData, signature: Signature) -> Self {
+        Transaction {
+            is_checked: false,
+            data,
+            signature,
+        }
+    }
+
+    pub fn check_signature(&self) -> Result<(), SuiError> {
+        // We use this flag to see if someone has checked this before
+        // and therefore we can skip the check. Note that the flag has
+        // to be set to true manually, and is not set by calling this
+        // "check" function.
+        if self.is_checked {
+            return Ok(());
+        }
+
+        let mut obligation = VerificationObligation::default();
+        self.add_to_verification_obligation(&mut obligation)?;
+        obligation.verify_all().map(|_| ())
+    }
+
+    pub fn add_to_verification_obligation(
+        &self,
+        obligation: &mut VerificationObligation,
+    ) -> SuiResult<()> {
+        let (message, signature, public_key) = self
+            .signature
+            .get_verification_inputs(&self.data, self.data.sender)?;
+        let idx = obligation.messages.len();
+        obligation.messages.push(message);
+        let key = obligation.lookup_public_key(&public_key)?;
+        obligation.public_keys.push(key);
+        obligation.signatures.push(signature);
+        obligation.message_index.push(idx);
+        Ok(())
+    }
+
+    pub fn sender_address(&self) -> SuiAddress {
+        self.data.sender
+    }
+
+    pub fn gas_payment_object_ref(&self) -> &ObjectRef {
+        &self.data.gas_payment
+    }
+
+    pub fn contains_shared_object(&self) -> bool {
+        match &self.data.kind {
+            TransactionKind::Single(s) => s.contains_shared_object(),
+            TransactionKind::Batch(b) => b.iter().any(|kind| kind.contains_shared_object()),
+        }
+    }
+
+    pub fn shared_input_objects(&self) -> impl Iterator<Item = &ObjectID> {
+        match &self.data.kind {
+            TransactionKind::Single(s) => Either::Left(s.shared_input_objects().iter()),
+            TransactionKind::Batch(b) => {
+                Either::Right(b.iter().flat_map(|kind| kind.shared_input_objects()))
+            }
+        }
+    }
+
+    pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
+        let mut inputs = match &self.data.kind {
+            TransactionKind::Single(s) => s.input_objects()?,
+            TransactionKind::Batch(b) => {
+                let mut result = vec![];
+                for kind in b {
+                    fp_ensure!(
+                        !matches!(kind, &SingleTransactionKind::Publish(..)),
+                        SuiError::InvalidBatchTransaction {
+                            error: "Publish transaction is now allowed in Batch Transaction"
+                                .to_owned(),
+                        }
+                    );
+                    let sub = kind.input_objects()?;
+                    debug_assert_eq!(sub.len(), kind.input_object_count());
+                    result.extend(sub);
+                }
+                result
+            }
+        };
+        inputs.push(InputObjectKind::OwnedMoveObject(
+            *self.gas_payment_object_ref(),
+        ));
+        Ok(inputs)
+    }
+
+    pub fn single_transactions(&self) -> impl Iterator<Item = &SingleTransactionKind> {
+        match &self.data.kind {
+            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
+            TransactionKind::Batch(b) => Either::Right(b.iter()),
+        }
+    }
+
+    pub fn into_single_transactions(self) -> impl Iterator<Item = SingleTransactionKind> {
+        match self.data.kind {
+            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
+            TransactionKind::Batch(b) => Either::Right(b.into_iter()),
+        }
+    }
+
+    // Derive a cryptographic hash of the transaction.
+    pub fn digest(&self) -> TransactionDigest {
+        TransactionDigest::new(sha3_hash(&self.data))
+    }
+
+    pub fn input_objects_in_compiled_modules(
+        compiled_modules: &[CompiledModule],
+    ) -> Vec<InputObjectKind> {
+        let mut dependent_packages = BTreeSet::new();
+        for module in compiled_modules.iter() {
+            for handle in module.module_handles.iter() {
+                let address = ObjectID::from(*module.address_identifier_at(handle.address));
+                if address != ObjectID::ZERO {
+                    dependent_packages.insert(address);
+                }
+            }
+        }
+
+        // We don't care about the digest of the dependent packages.
+        // They are all read-only on-chain and their digest never changes.
+        dependent_packages
+            .into_iter()
+            .map(InputObjectKind::MovePackage)
+            .collect::<Vec<_>>()
+    }
+}
+
+impl Hash for Transaction {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.data.hash(state);
+    }
+}
+
+impl PartialEq for Transaction {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
 /// An transaction signed by a single authority
 #[derive(Debug, Eq, Clone, Serialize, Deserialize)]
 pub struct SignedTransaction {
     pub transaction: Transaction,
     pub authority: AuthorityName,
     pub signature: AuthoritySignature,
+}
+
+impl SignedTransaction {
+    /// Use signing key to create a signed object.
+    pub fn new(
+        transaction: Transaction,
+        authority: AuthorityName,
+        secret: &dyn signature::Signer<AuthoritySignature>,
+    ) -> Self {
+        let signature = AuthoritySignature::new(&transaction.data, secret);
+        Self {
+            transaction,
+            authority,
+            signature,
+        }
+    }
+
+    /// Verify the signature and return the non-zero voting right of the authority.
+    pub fn check(&self, committee: &Committee) -> Result<usize, SuiError> {
+        self.transaction.check_signature()?;
+        let weight = committee.weight(&self.authority);
+        fp_ensure!(weight > 0, SuiError::UnknownSigner);
+        self.signature
+            .check(&self.transaction.data, self.authority)?;
+        Ok(weight)
+    }
+}
+
+impl Hash for SignedTransaction {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.transaction.hash(state);
+        self.authority.hash(state);
+    }
+}
+
+impl PartialEq for SignedTransaction {
+    fn eq(&self, other: &Self) -> bool {
+        self.transaction == other.transaction && self.authority == other.authority
+    }
 }
 
 /// An transaction signed by a quorum of authorities
@@ -697,31 +884,6 @@ pub struct SignedTransactionEffects {
     pub signature: AuthoritySignature,
 }
 
-impl Hash for Transaction {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.data.hash(state);
-    }
-}
-
-impl PartialEq for Transaction {
-    fn eq(&self, other: &Self) -> bool {
-        self.data == other.data
-    }
-}
-
-impl Hash for SignedTransaction {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.transaction.hash(state);
-        self.authority.hash(state);
-    }
-}
-
-impl PartialEq for SignedTransaction {
-    fn eq(&self, other: &Self) -> bool {
-        self.transaction == other.transaction && self.authority == other.authority
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum InputObjectKind {
     MovePackage(ObjectID),
@@ -752,168 +914,6 @@ impl InputObjectKind {
             Self::OwnedMoveObject((object_id, _, _)) => SuiError::ObjectNotFound { object_id },
             Self::SharedMoveObject(object_id) => SuiError::ObjectNotFound { object_id },
         }
-    }
-}
-
-impl Transaction {
-    #[cfg(test)]
-    pub fn from_data(data: TransactionData, signer: &dyn signature::Signer<Signature>) -> Self {
-        let signature = Signature::new(&data, signer);
-        Self::new(data, signature)
-    }
-
-    pub fn new(data: TransactionData, signature: Signature) -> Self {
-        Transaction {
-            is_checked: false,
-            data,
-            signature,
-        }
-    }
-
-    pub fn check_signature(&self) -> Result<(), SuiError> {
-        // We use this flag to see if someone has checked this before
-        // and therefore we can skip the check. Note that the flag has
-        // to be set to true manually, and is not set by calling this
-        // "check" function.
-        if self.is_checked {
-            return Ok(());
-        }
-
-        let mut obligation = VerificationObligation::default();
-        self.add_to_verification_obligation(&mut obligation)?;
-        obligation.verify_all().map(|_| ())
-    }
-
-    pub fn add_to_verification_obligation(
-        &self,
-        obligation: &mut VerificationObligation,
-    ) -> SuiResult<()> {
-        let (message, signature, public_key) = self
-            .signature
-            .get_verification_inputs(&self.data, self.data.sender)?;
-        let idx = obligation.messages.len();
-        obligation.messages.push(message);
-        let key = obligation.lookup_public_key(&public_key)?;
-        obligation.public_keys.push(key);
-        obligation.signatures.push(signature);
-        obligation.message_index.push(idx);
-        Ok(())
-    }
-
-    pub fn sender_address(&self) -> SuiAddress {
-        self.data.sender
-    }
-
-    pub fn gas_payment_object_ref(&self) -> &ObjectRef {
-        &self.data.gas_payment
-    }
-
-    pub fn contains_shared_object(&self) -> bool {
-        match &self.data.kind {
-            TransactionKind::Single(s) => s.contains_shared_object(),
-            TransactionKind::Batch(b) => b.iter().any(|kind| kind.contains_shared_object()),
-        }
-    }
-
-    pub fn shared_input_objects(&self) -> impl Iterator<Item = &ObjectID> {
-        match &self.data.kind {
-            TransactionKind::Single(s) => Either::Left(s.shared_input_objects().iter()),
-            TransactionKind::Batch(b) => {
-                Either::Right(b.iter().flat_map(|kind| kind.shared_input_objects()))
-            }
-        }
-    }
-
-    pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
-        let mut inputs = match &self.data.kind {
-            TransactionKind::Single(s) => s.input_objects()?,
-            TransactionKind::Batch(b) => {
-                let mut result = vec![];
-                for kind in b {
-                    fp_ensure!(
-                        !matches!(kind, &SingleTransactionKind::Publish(..)),
-                        SuiError::InvalidBatchTransaction {
-                            error: "Publish transaction is now allowed in Batch Transaction"
-                                .to_owned(),
-                        }
-                    );
-                    let sub = kind.input_objects()?;
-                    debug_assert_eq!(sub.len(), kind.input_object_count());
-                    result.extend(sub);
-                }
-                result
-            }
-        };
-        inputs.push(InputObjectKind::OwnedMoveObject(
-            *self.gas_payment_object_ref(),
-        ));
-        Ok(inputs)
-    }
-
-    pub fn single_transactions(&self) -> impl Iterator<Item = &SingleTransactionKind> {
-        match &self.data.kind {
-            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
-            TransactionKind::Batch(b) => Either::Right(b.iter()),
-        }
-    }
-
-    pub fn into_single_transactions(self) -> impl Iterator<Item = SingleTransactionKind> {
-        match self.data.kind {
-            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
-            TransactionKind::Batch(b) => Either::Right(b.into_iter()),
-        }
-    }
-
-    // Derive a cryptographic hash of the transaction.
-    pub fn digest(&self) -> TransactionDigest {
-        TransactionDigest::new(sha3_hash(&self.data))
-    }
-
-    pub fn input_objects_in_compiled_modules(
-        compiled_modules: &[CompiledModule],
-    ) -> Vec<InputObjectKind> {
-        let mut dependent_packages = BTreeSet::new();
-        for module in compiled_modules.iter() {
-            for handle in module.module_handles.iter() {
-                let address = ObjectID::from(*module.address_identifier_at(handle.address));
-                if address != ObjectID::ZERO {
-                    dependent_packages.insert(address);
-                }
-            }
-        }
-
-        // We don't care about the digest of the dependent packages.
-        // They are all read-only on-chain and their digest never changes.
-        dependent_packages
-            .into_iter()
-            .map(InputObjectKind::MovePackage)
-            .collect::<Vec<_>>()
-    }
-}
-
-impl SignedTransaction {
-    /// Use signing key to create a signed object.
-    pub fn new(
-        transaction: Transaction,
-        authority: AuthorityName,
-        secret: &dyn signature::Signer<AuthoritySignature>,
-    ) -> Self {
-        let signature = AuthoritySignature::new(&transaction.data, secret);
-        Self {
-            transaction,
-            authority,
-            signature,
-        }
-    }
-
-    /// Verify the signature and return the non-zero voting right of the authority.
-    pub fn check(&self, committee: &Committee) -> Result<usize, SuiError> {
-        self.transaction.check_signature()?;
-        let weight = committee.weight(&self.authority);
-        fp_ensure!(weight > 0, SuiError::UnknownSigner);
-        self.signature
-            .check(&self.transaction.data, self.authority)?;
-        Ok(weight)
     }
 }
 

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -88,20 +88,25 @@ fn test_certificates() {
 
     let mut builder = SignatureAggregator::try_new(transaction.clone(), &committee).unwrap();
     assert!(builder
-        .append(v1.authority, v1.signature)
+        .append(v1.auth_signature.authority, v1.auth_signature.signature)
         .unwrap()
         .is_none());
-    let mut c = builder.append(v2.authority, v2.signature).unwrap().unwrap();
+    let mut c = builder
+        .append(v2.auth_signature.authority, v2.auth_signature.signature)
+        .unwrap()
+        .unwrap();
     assert!(c.check(&committee).is_ok());
     c.signatures.pop();
     assert!(c.check(&committee).is_err());
 
     let mut builder = SignatureAggregator::try_new(transaction, &committee).unwrap();
     assert!(builder
-        .append(v1.authority, v1.signature)
+        .append(v1.auth_signature.authority, v1.auth_signature.signature)
         .unwrap()
         .is_none());
-    assert!(builder.append(v3.authority, v3.signature).is_err());
+    assert!(builder
+        .append(v3.auth_signature.authority, v3.auth_signature.signature)
+        .is_err());
 
     assert!(SignatureAggregator::try_new(bad_transaction, &committee).is_err());
 }

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -312,8 +312,9 @@ fn test_time_vote() {
     let now = Instant::now();
     for _ in 0..100 {
         if let SerializedMessage::Vote(vote) = deserialize_message(&mut buf2).unwrap() {
-            vote.signature
-                .check(&vote.transaction.data, vote.authority)
+            vote.auth_signature
+                .signature
+                .check(&vote.data, vote.auth_signature.authority)
                 .unwrap();
         }
     }


### PR DESCRIPTION
Another attempt of https://github.com/MystenLabs/sui/pull/1055

`SuiDataStore` stores data that's signed by the authorities since it was initially meant to be only used by authorities.
For example, it only stores signed transactions.
This no longer works if we want to reuse `SuiDataStore` in a Gateway, where transactions are not signed by any authorities.
To make it sharable, we want to make `SuiDataStore` template on the authority signature state.
This PR does it for `Transaction`:
1. Instead of having `SignedTransaction` wrapping `Transaction`, we now have `TransactionEnvelope` which is a struct that can be used either as a transaction or a signed transaction. The authority signature is embedded. However it also templates on a trait to indicate its signing status.
2. We have two instantiations of the trait, an empty one, and an authority signature pair. Transaction and SignedTransaction will be instantiating `TransactionEnvelope` on these two.
3. The rest are mechanical changes.

In a follow up PR I will do the same for `TransactionEffects`.