### PR TITLE
Added Clay as the default reviewer for all .md files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 sui_core/src/crypto.rs @huitseeker
 sui/src/keystore.rs @huitseeker @patrickkuo
+*.md @Clay-Mysten


### PR DESCRIPTION
It would be good to have @Clay-Mysten to be able to track all changes to our docs so per his request this should add him as the default reviewer for all changes to .md files (tagging @huitseeker on this for a quick check if I got the syntax in the `CODEOWNERS` file right).