### PR TITLE
Build out Contribute index with download instructions and descriptions of primary directories

### DIFF
--- a/doc/src/contribute/index.md
+++ b/doc/src/contribute/index.md
@@ -26,7 +26,7 @@ In order to obtain the Sui source code, clone the Sui repository:
 git clone https://github.com/MystenLabs/sui.git
 ```
 
-The primary directories are:
+You can start exploring Sui's source code by looking into the following primary directories:
 
 * [sui](https://github.com/MystenLabs/sui/tree/main/sui) - the Sui binaries (`wallet`, `sui-move`, and more)
 * [sui_programmability](https://github.com/MystenLabs/sui/tree/main/sui_programmability) - Sui's Move language integration also including games and other Move code examples for testing and reuse


### PR DESCRIPTION
Move `git clone` command to Contribute in prep for removal from tutorial
Add link to Install docs for getting binaries