### PR TITLE
Consolidate `TransactionEffects` and `SignedTransactionEffects`

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -173,7 +173,7 @@ impl AuthorityState {
         let transaction_digest = *confirmation_transaction.certificate.digest();
 
         // Ensure an idempotent answer.
-        if self._database.signed_effects_exists(&transaction_digest)? {
+        if self._database.effects_exists(&transaction_digest)? {
             let transaction_info = self.make_transaction_info(&transaction_digest).await?;
             return Ok(transaction_info);
         }
@@ -302,14 +302,13 @@ impl AuthorityState {
         // Remove from dependencies the generic hash
         transaction_dependencies.remove(&TransactionDigest::genesis());
 
-        let signed_effects = temporary_store.to_signed_effects(
-            &self.name,
-            &*self.secret,
+        let effects = temporary_store.to_effects(
             &transaction_digest,
             transaction_dependencies.into_iter().collect(),
             status,
             &gas_object_id,
         );
+        let signed_effects = effects.sign(&self.name, &*self.secret);
         // Update the database in an atomic manner
 
         self.update_state(temporary_store, &certificate, &signed_effects)

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -110,17 +110,15 @@ impl<S> AuthorityTemporaryStore<S> {
         }
     }
 
-    pub fn to_signed_effects(
+    pub fn to_effects(
         &self,
-        authority_name: &AuthorityName,
-        secret: &dyn signature::Signer<AuthoritySignature>,
         transaction_digest: &TransactionDigest,
         transaction_dependencies: Vec<TransactionDigest>,
         status: ExecutionStatus,
         gas_object_id: &ObjectID,
-    ) -> SignedTransactionEffects {
+    ) -> TransactionEffects {
         let (gas_reference, gas_object) = &self.written[gas_object_id];
-        let effects = TransactionEffects {
+        TransactionEffects {
             status,
             transaction_digest: *transaction_digest,
             created: self
@@ -168,13 +166,6 @@ impl<S> AuthorityTemporaryStore<S> {
             gas_object: (*gas_reference, gas_object.owner),
             events: self.events.clone(),
             dependencies: transaction_dependencies,
-        };
-        let signature = AuthoritySignature::new(&effects, secret);
-
-        SignedTransactionEffects {
-            effects,
-            authority: *authority_name,
-            signature,
         }
     }
 

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -7,7 +7,7 @@ use crate::safe_client::SafeClient;
 
 use futures::{future, StreamExt};
 use move_core_types::value::MoveStructLayout;
-use sui_types::crypto::{sha3_hash, AuthoritySignature, PublicKeyBytes};
+use sui_types::crypto::{AuthoritySignature, PublicKeyBytes};
 use sui_types::object::{Object, ObjectFormatOptions, ObjectRead};
 use sui_types::{
     base_types::*,
@@ -1006,7 +1006,7 @@ where
                             // Note: here we aggregate votes by the hash of the effects structure
                             let entry = state
                                 .effects_map
-                                .entry(sha3_hash(&inner_effects.effects))
+                                .entry(inner_effects.digest())
                                 .or_insert((0usize, inner_effects.effects));
                             entry.0 += weight;
 

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -70,6 +70,7 @@ impl<C> SafeClient<C> {
         if let Some(signed_effects) = &response.signed_effects {
             // Check signature
             signed_effects
+                .auth_signature
                 .signature
                 .check(&signed_effects.effects, self.address)?;
             // Checks it concerns the right tx
@@ -81,7 +82,7 @@ impl<C> SafeClient<C> {
             );
             // Check it has the right signer
             fp_ensure!(
-                signed_effects.authority == self.address,
+                signed_effects.auth_signature.authority == self.address,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -171,7 +172,7 @@ impl<C> SafeClient<C> {
     /// This function is used by the higher level authority logic to report an
     /// error that could be due to this authority.
     pub fn report_client_error(&self, _error: SuiError) {
-        // TODO: At a minumum we log this error along the authority name, and potentially
+        // TODO: At a minimum we log this error along the authority name, and potentially
         // in case of strong evidence of byzantine behaviour we could share this error
         // with the rest of the network, or de-prioritize requests to this authority given
         // weaker evidence.

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -403,14 +403,6 @@ SignedBatch:
         TYPENAME: PublicKeyBytes
     - signature:
         TYPENAME: AuthoritySignature
-SignedTransactionEffects:
-  STRUCT:
-    - effects:
-        TYPENAME: TransactionEffects
-    - authority:
-        TYPENAME: PublicKeyBytes
-    - signature:
-        TYPENAME: AuthoritySignature
 SingleTransactionKind:
   ENUM:
     0:
@@ -819,6 +811,12 @@ TransactionEffects:
     - dependencies:
         SEQ:
           TYPENAME: TransactionDigest
+TransactionEffectsEnvelope:
+  STRUCT:
+    - effects:
+        TYPENAME: TransactionEffects
+    - auth_signature:
+        TYPENAME: AuthoritySignInfo
 TransactionInfoRequest:
   STRUCT:
     - transaction_digest:
@@ -833,7 +831,7 @@ TransactionInfoResponse:
           TYPENAME: CertifiedTransaction
     - signed_effects:
         OPTION:
-          TYPENAME: SignedTransactionEffects
+          TYPENAME: TransactionEffectsEnvelope
 TransactionKind:
   ENUM:
     0:


### PR DESCRIPTION
Similar to https://github.com/MystenLabs/sui/pull/1071, we consolidate `TransactionEffects` and `SignedTransactionEffects`:
1. Introduce `TransactionEffectsEnvelope` which templates on the authority signature state.
2. `TransactionEffects` now is the "data" part of the `TransactionEffectsEnvelope`.
3. We could define a type alias called UnsignedTransactionEffects but it's not needed anywhere so I didn't define it.