### PR TITLE
[wallet bug fix] Interactive shell crashes when trying to query an account address with 'object' command

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -11,6 +11,7 @@ use move_core_types::identifier::Identifier;
 use serde_json::{json, Value};
 use tracing_test::traced_test;
 
+use std::fmt::Write;
 use sui::config::{
     AccountConfig, AuthorityPrivateInfo, Config, GenesisConfig, NetworkConfig, ObjectConfig,
     PersistedConfig, WalletConfig, AUTHORITIES_DB_NAME,
@@ -1026,4 +1027,14 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
 
     network.kill().await?;
     Ok(())
+}
+
+#[test]
+// Test for issue https://github.com/MystenLabs/sui/issues/1078
+fn test_bug_1078() {
+    let read = WalletCommandResult::Object(ObjectRead::NotExists(ObjectID::random()));
+    let mut writer = String::new();
+    // fmt ObjectRead should not fail.
+    write!(writer, "{}", read).unwrap();
+    write!(writer, "{:?}", read).unwrap();
 }


### PR DESCRIPTION
This fixes issue #1078 

The panic is caused by display formatter, we mistakenly returned Error in formatter expecting it to print out the error message, however the formatter will panic if it receive an Error.


Thanks @chinesco for summiting the bug report.