### PR TITLE
Trigger dev portal update 2

### DIFF
--- a/.github/workflows/dev-portal-update.yml
+++ b/.github/workflows/dev-portal-update.yml
@@ -3,7 +3,7 @@ name: Trigger Dev Docs Portal Update
 on:
   push:
     branches:
-      - trigger-dev-portal-update
+      - main
     paths:
       - doc/**
 

--- a/.github/workflows/dev-portal-update.yml
+++ b/.github/workflows/dev-portal-update.yml
@@ -1,0 +1,20 @@
+name: Trigger Dev Docs Portal Update
+
+on:
+  push:
+    branches:
+      - trigger-dev-portal-update
+    paths:
+      - doc/**
+
+jobs:
+  trigger-dev-portal-update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.RELEASE_HUB_SECRET }}
+          repository: MystenLabs/sui_dev_portal
+          event-type: deploy-qa
+          client-payload: "{}"


### PR DESCRIPTION
Github action to trigger dev portal dispatch action. Please, we have to add a  Personal Access Token as a GitHub secret `RELEASE_HUB_SECRET`. I do not have access to do so on this repo. 