### PR TITLE
Some cleanups around input object checking

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -201,7 +201,7 @@ impl AuthorityState {
             let shared_ids: HashSet<_> = inputs
                 .iter()
                 .filter_map(|(kind, obj)| match kind {
-                    InputObjectKind::SharedMoveObject(..) if obj.owner.is_shared_mutable() => {
+                    InputObjectKind::MutSharedMoveObject(..) if obj.owner.is_shared_mutable() => {
                         Some((obj.id(), obj.version()))
                     }
                     _ => None,

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -50,14 +50,16 @@ impl<S> AuthorityTemporaryStore<S> {
                 .iter()
                 .filter_map(|(kind, object)| match kind {
                     InputObjectKind::MovePackage(_) => None,
-                    InputObjectKind::OwnedMoveObject(object_ref) => {
+                    InputObjectKind::ImmOrOwnedMoveObject(object_ref) => {
                         if object.is_read_only() {
                             None
                         } else {
                             Some(*object_ref)
                         }
                     }
-                    InputObjectKind::SharedMoveObject(_) => Some(object.compute_object_reference()),
+                    InputObjectKind::MutSharedMoveObject(_) => {
+                        Some(object.compute_object_reference())
+                    }
                 })
                 .collect(),
             written: BTreeMap::new(),

--- a/sui_core/src/transaction_input_checker.rs
+++ b/sui_core/src/transaction_input_checker.rs
@@ -75,7 +75,7 @@ pub fn check_locks(
         return Err(SuiError::LockErrors { errors });
     }
     fp_ensure!(!all_objects.is_empty(), SuiError::ObjectInputArityViolation);
-    check_gas_requirement(transaction, &all_objects)?;
+    check_tx_requirement(transaction, &all_objects)?;
     Ok(all_objects)
 }
 
@@ -84,14 +84,14 @@ pub fn filter_owned_objects(all_objects: Vec<(InputObjectKind, Object)>) -> Vec<
         .into_iter()
         .filter_map(|(object_kind, object)| match object_kind {
             InputObjectKind::MovePackage(_) => None,
-            InputObjectKind::OwnedMoveObject(object_ref) => {
+            InputObjectKind::ImmOrOwnedMoveObject(object_ref) => {
                 if object.is_read_only() {
                     None
                 } else {
                     Some(object_ref)
                 }
             }
-            InputObjectKind::SharedMoveObject(..) => None,
+            InputObjectKind::MutSharedMoveObject(..) => None,
         })
         .collect();
 
@@ -120,7 +120,11 @@ fn check_one_lock(
                 }
             );
         }
-        InputObjectKind::OwnedMoveObject((object_id, sequence_number, object_digest)) => {
+        InputObjectKind::ImmOrOwnedMoveObject((object_id, sequence_number, object_digest)) => {
+            fp_ensure!(
+                !object.is_package(),
+                SuiError::MovePackageAsObject { object_id }
+            );
             fp_ensure!(
                 sequence_number <= SequenceNumber::MAX,
                 SuiError::InvalidSequenceNumber
@@ -154,7 +158,7 @@ fn check_one_lock(
                     fp_ensure!(
                         transaction.sender_address() == owner,
                         SuiError::IncorrectSigner {
-                            error: format!("Object {:?} is owned by account address {:?}, but signer address is {:?}", object.id(), owner, transaction.sender_address()),
+                            error: format!("Object {:?} is owned by account address {:?}, but signer address is {:?}", object_id, owner, transaction.sender_address()),
                         }
                     );
                 }
@@ -178,7 +182,7 @@ fn check_one_lock(
                 }
             };
         }
-        InputObjectKind::SharedMoveObject(..) => {
+        InputObjectKind::MutSharedMoveObject(..) => {
             // When someone locks an object as shared it must be shared already.
             fp_ensure!(object.is_shared(), SuiError::NotSharedObjectError);
         }
@@ -196,7 +200,7 @@ fn check_one_lock(
 ///   This can help reduce DDos attacks.
 /// 3. Check that the objects used in transfers are mutable. We put the check here
 ///   because this is the most convenient spot to check.
-fn check_gas_requirement(
+fn check_tx_requirement(
     transaction: &Transaction,
     input_objects: &[(InputObjectKind, Object)],
 ) -> SuiResult {
@@ -207,10 +211,7 @@ fn check_gas_requirement(
             SingleTransactionKind::Transfer(_) => {
                 // Index access safe because the inputs were constructed in order.
                 let transfer_object = &input_objects[idx].1;
-                fp_ensure!(
-                    !transfer_object.is_read_only(),
-                    SuiError::TransferImmutableError
-                );
+                transfer_object.is_transfer_eligible()?;
                 // TODO: Make Transfer transaction to also contain gas_budget.
                 // By @gdanezis: Now his is the only part of this function that requires
                 // an input object besides the gas object. It would be a major win if we
@@ -237,5 +238,11 @@ fn check_gas_requirement(
     }
     // The last element in the inputs is always gas object.
     let gas_object = &input_objects.last().unwrap().1;
+    fp_ensure!(
+        !gas_object.is_shared(),
+        SuiError::InsufficientGas {
+            error: format!("Gas object cannot be shared: {:?}", gas_object.id())
+        }
+    );
     gas::check_gas_balance(gas_object, total_cost)
 }

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -448,32 +448,37 @@ SuiError:
           - object_id:
               TYPENAME: ObjectID
     4:
-      UnexpectedOwnerType: UNIT
+      MovePackageAsObject:
+        STRUCT:
+          - object_id:
+              TYPENAME: ObjectID
     5:
-      UnsupportedSharedObjectError: UNIT
+      UnexpectedOwnerType: UNIT
     6:
-      NotSharedObjectError: UNIT
+      UnsupportedSharedObjectError: UNIT
     7:
-      DeleteObjectOwnedObject: UNIT
+      NotSharedObjectError: UNIT
     8:
-      SharedObjectLockNotSetObject: UNIT
+      DeleteObjectOwnedObject: UNIT
     9:
+      SharedObjectLockNotSetObject: UNIT
+    10:
       InvalidBatchTransaction:
         STRUCT:
           - error: STR
-    10:
+    11:
       InvalidSignature:
         STRUCT:
           - error: STR
-    11:
+    12:
       IncorrectSigner:
         STRUCT:
           - error: STR
-    12:
-      UnknownSigner: UNIT
     13:
-      CertificateRequiresQuorum: UNIT
+      UnknownSigner: UNIT
     14:
+      CertificateRequiresQuorum: UNIT
+    15:
       UnexpectedSequenceNumber:
         STRUCT:
           - object_id:
@@ -482,194 +487,194 @@ SuiError:
               TYPENAME: SequenceNumber
           - given_sequence:
               TYPENAME: SequenceNumber
-    15:
+    16:
       ConflictingTransaction:
         STRUCT:
           - pending_transaction:
               TYPENAME: TransactionDigest
-    16:
-      ErrorWhileProcessingTransaction: UNIT
     17:
+      ErrorWhileProcessingTransaction: UNIT
+    18:
       ErrorWhileProcessingTransactionTransaction:
         STRUCT:
           - err: STR
-    18:
+    19:
       ErrorWhileProcessingConfirmationTransaction:
         STRUCT:
           - err: STR
-    19:
-      ErrorWhileRequestingCertificate: UNIT
     20:
+      ErrorWhileRequestingCertificate: UNIT
+    21:
       ErrorWhileProcessingPublish:
         STRUCT:
           - err: STR
-    21:
+    22:
       ErrorWhileProcessingMoveCall:
         STRUCT:
           - err: STR
-    22:
-      ErrorWhileRequestingInformation: UNIT
     23:
+      ErrorWhileRequestingInformation: UNIT
+    24:
       ObjectFetchFailed:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - err: STR
-    24:
+    25:
       MissingEarlierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    25:
-      UnexpectedTransactionIndex: UNIT
     26:
-      ConcurrentIteratorError: UNIT
+      UnexpectedTransactionIndex: UNIT
     27:
-      ClosedNotifierError: UNIT
+      ConcurrentIteratorError: UNIT
     28:
+      ClosedNotifierError: UNIT
+    29:
       CertificateNotfound:
         STRUCT:
           - certificate_digest:
               TYPENAME: TransactionDigest
-    29:
+    30:
       ParentNotfound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - sequence:
               TYPENAME: SequenceNumber
-    30:
-      UnknownSenderAccount: UNIT
     31:
-      CertificateAuthorityReuse: UNIT
+      UnknownSenderAccount: UNIT
     32:
-      InvalidSequenceNumber: UNIT
+      CertificateAuthorityReuse: UNIT
     33:
-      SequenceOverflow: UNIT
+      InvalidSequenceNumber: UNIT
     34:
-      SequenceUnderflow: UNIT
+      SequenceOverflow: UNIT
     35:
-      WrongShard: UNIT
+      SequenceUnderflow: UNIT
     36:
-      InvalidCrossShardUpdate: UNIT
+      WrongShard: UNIT
     37:
-      InvalidAuthenticator: UNIT
+      InvalidCrossShardUpdate: UNIT
     38:
-      InvalidAddress: UNIT
+      InvalidAuthenticator: UNIT
     39:
-      InvalidTransactionDigest: UNIT
+      InvalidAddress: UNIT
     40:
+      InvalidTransactionDigest: UNIT
+    41:
       InvalidObjectDigest:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_digest:
               TYPENAME: ObjectDigest
-    41:
-      InvalidDecoding: UNIT
     42:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     43:
-      DuplicateObjectRefInput: UNIT
+      UnexpectedMessage: UNIT
     44:
+      DuplicateObjectRefInput: UNIT
+    45:
       ClientIoError:
         STRUCT:
           - error: STR
-    45:
-      TransferImmutableError: UNIT
     46:
+      TransferImmutableError: UNIT
+    47:
       TooManyItemsError:
         NEWTYPE: U64
-    47:
-      InvalidSequenceRangeError: UNIT
     48:
-      NoBatchesFoundError: UNIT
+      InvalidSequenceRangeError: UNIT
     49:
-      CannotSendClientMessageError: UNIT
+      NoBatchesFoundError: UNIT
     50:
+      CannotSendClientMessageError: UNIT
+    51:
       SubscriptionItemsDroppedError:
         NEWTYPE: U64
-    51:
-      SubscriptionServiceClosed: UNIT
     52:
+      SubscriptionServiceClosed: UNIT
+    53:
       ModuleLoadFailure:
         STRUCT:
           - error: STR
-    53:
+    54:
       ModuleVerificationFailure:
         STRUCT:
           - error: STR
-    54:
+    55:
       ModuleDeserializationFailure:
         STRUCT:
           - error: STR
-    55:
+    56:
       ModulePublishFailure:
         STRUCT:
           - error: STR
-    56:
+    57:
       ModuleBuildFailure:
         STRUCT:
           - error: STR
-    57:
+    58:
       DependentPackageNotFound:
         STRUCT:
           - package_id:
               TYPENAME: ObjectID
-    58:
+    59:
       MoveUnitTestFailure:
         STRUCT:
           - error: STR
-    59:
+    60:
       FunctionNotFound:
         STRUCT:
           - error: STR
-    60:
+    61:
       ModuleNotFound:
         STRUCT:
           - module_name: STR
-    61:
+    62:
       InvalidFunctionSignature:
         STRUCT:
           - error: STR
-    62:
+    63:
       TypeError:
         STRUCT:
           - error: STR
-    63:
+    64:
       AbortedExecution:
         STRUCT:
           - error: STR
-    64:
+    65:
       InvalidMoveEvent:
         STRUCT:
           - error: STR
-    65:
-      CircularObjectOwnership: UNIT
     66:
+      CircularObjectOwnership: UNIT
+    67:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    67:
+    68:
       InsufficientGas:
         STRUCT:
           - error: STR
-    68:
-      InvalidTxUpdate: UNIT
     69:
-      TransactionLockExists: UNIT
+      InvalidTxUpdate: UNIT
     70:
-      TransactionLockDoesNotExist: UNIT
+      TransactionLockExists: UNIT
     71:
-      TransactionLockReset: UNIT
+      TransactionLockDoesNotExist: UNIT
     72:
+      TransactionLockReset: UNIT
+    73:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    73:
+    74:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -677,26 +682,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    74:
+    75:
       BadObjectType:
         STRUCT:
           - error: STR
-    75:
-      MoveExecutionFailure: UNIT
     76:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     77:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     78:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     79:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     80:
+      AuthorityUpdateFailure: UNIT
+    81:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    81:
+    82:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -707,29 +712,29 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    82:
+    83:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    83:
-      BatchErrorSender: UNIT
     84:
+      BatchErrorSender: UNIT
+    85:
       GenericAuthorityError:
         STRUCT:
           - error: STR
-    85:
+    86:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    86:
-      ObjectSerializationError: UNIT
     87:
-      ConcurrentTransactionError: UNIT
+      ObjectSerializationError: UNIT
     88:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     89:
+      IncorrectRecipientError: UNIT
+    90:
       TooManyIncorrectAuthorities:
         STRUCT:
           - errors:
@@ -737,11 +742,11 @@ SuiError:
                 TUPLE:
                   - TYPENAME: PublicKeyBytes
                   - TYPENAME: SuiError
-    90:
+    91:
       InconsistentGatewayResult:
         STRUCT:
           - error: STR
-    91:
+    92:
       OnlyOneConsensusClientPermitted: UNIT
 TransactionData:
   STRUCT:

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -40,6 +40,8 @@ pub enum SuiError {
     TransferNonCoinError,
     #[error("A move package is expected, instead a move object is passed: {object_id}")]
     MoveObjectAsPackage { object_id: ObjectID },
+    #[error("A move object is expected, instead a move package is passed: {object_id}")]
+    MovePackageAsObject { object_id: ObjectID },
     #[error("Expecting a singler owner, shared ownership found")]
     UnexpectedOwnerType,
     #[error("Shared mutable object not yet supported")]

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -396,6 +396,18 @@ impl Object {
         Ok(())
     }
 
+    pub fn immutable_with_id_for_testing(id: ObjectID) -> Self {
+        let data = Data::Move(MoveObject {
+            type_: GasCoin::type_(),
+            contents: GasCoin::new(id, SequenceNumber::new(), GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
+        });
+        Self {
+            owner: Owner::SharedImmutable,
+            data,
+            previous_transaction: TransactionDigest::genesis(),
+        }
+    }
+
     pub fn with_id_owner_gas_for_testing(
         id: ObjectID,
         version: SequenceNumber,


### PR DESCRIPTION
This PR cleans up some logic when checking input objects:
1. Check gas object immutability early, instead of waiting till transaction execution phase to find out.
2. Use full transfer eligibility on the transfer object, which would check a bunch of different things
3. Make sure we don't use move package as object
4. Rename `SharedMoveObject` and `OwnedMoveObject` in input object kind to make them more accurate.