### PR TITLE
chore: use a caching crate install

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,10 +54,10 @@ jobs:
         toolchain: stable
         override: true
     - uses: Swatinem/rust-cache@v1
-    - uses: actions-rs/install@v0.1
+    - name: Install huniq, and cache the binary
+      uses: baptiste0928/cargo-install@v1
       with:
         crate: huniq
-        version: latest
     - name: prepare artifact directory
       run: |
         mkdir -p artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,9 +158,9 @@ jobs:
           toolchain: nightly
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/install@v0.1
+      - name: Install cargo-udeps, and cache the binary
+        uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-udeps
-          version: latest
       - name: run cargo-udeps
         run: cargo +nightly udeps


### PR DESCRIPTION
https://github.com/baptiste0928/cargo-install caches the binary after compilation, for speed of repeated execution