### PR TITLE
add license for .ts files missing it

### DIFF
--- a/explorer/client/src/setupTests.ts
+++ b/explorer/client/src/setupTests.ts
@@ -1,1 +1,4 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import '@testing-library/jest-dom';

--- a/explorer/client/src/utils/reportWebVitals.ts
+++ b/explorer/client/src/utils/reportWebVitals.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ReportHandler } from 'web-vitals';
 
 enum ReportMethod {


### PR DESCRIPTION
checked that as many files have the license as exist in the explorer dir, using these commands from the `./explorer/client/` directory

```sh
# count .ts/.tsx files
find ./src/ -name "*.ts*" | wc -l                                 
# output:   30

# count .ts/.tsx files containing the copyright
find ./src/ -name "*.ts*" | xargs grep "2022, Mysten Labs" | wc -l        
# output:   30  
```