### PR TITLE
refactor: remove code duplication with typed_store

### DIFF
--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, RwLock};
 
 use dropshot::{endpoint, Query, TypedBody, CONTENT_TYPE_JSON};
 use dropshot::{
-    ApiDescription, ConfigDropshot, ConfigLogging, ConfigLoggingLevel, HttpError, HttpResponseOk,
+    ApiDescription, ConfigDropshot, ConfigLogging, ConfigLoggingLevel, HttpError,
     HttpResponseUpdatedNoContent, HttpServerStarter, RequestContext,
 };
 use futures::lock::Mutex;


### PR DESCRIPTION
See https://github.com/MystenLabs/mysten-infra/blob/a45af6dc28aa12c8cc13521d118c24aadd4c6adf/typed-store/src/rocks/mod.rs#L409-L457

(which is also a tad more correct re: preserving existing columns)