### PR TITLE
[docs] Fixes to the Move tutorial related to GAS->SUI renaming

### DIFF
--- a/doc/src/build/move.md
+++ b/doc/src/build/move.md
@@ -182,13 +182,13 @@ and also about the optional
 at your leisure.
 
 In particular, one type of custom coin already defined in Sui is
-`Coin<GAS>`, which represents a token used to pay for gas used in Sui
-computations - in this case, the concrete type used to parameterize the
-`Coin` struct is the `GAS` struct in the
+`Coin<SUI>`, which represents a token used to pay for Sui
+computations (more generally known as _gas_) - in this case, the concrete type used to parameterize the
+`Coin` struct is the `SUI` struct in the
 [Coin module](https://github.com/MystenLabs/sui/tree/main/sui_programmability/framework/sources/Coin.move):
 
 ``` rust
-struct GAS has drop {}
+struct SUI has drop {}
 ```
 
 We will show how to define and instantiate custom structs in the
@@ -241,12 +241,12 @@ must satisfy a certain set of properties.
 One of the basic operations in Sui is transfer of gas objects between
 [addresses](https://github.com/diem/move/blob/main/language/documentation/book/src/address.md)
 representing individual users. And one of the
-simplest entry functions is defined in the GAS
-[module](https://github.com/MystenLabs/sui/tree/main/sui_programmability/framework/sources/GAS.move) to
+simplest entry functions is defined in the SUI
+[module](https://github.com/MystenLabs/sui/tree/main/sui_programmability/framework/sources/SUI.move) to
 implement gas object transfer:
 
 ```rust
-public fun transfer(c: Coin::Coin<GAS>, recipient: address, _ctx: &mut TxContext) {
+public fun transfer(c: Coin::Coin<SUI>, recipient: address, _ctx: &mut TxContext) {
     ...
 }
 ```


### PR DESCRIPTION
I left most of references to "gas" intact (there were not that many) and focused on fixing parts that refer to the gas code.