### PR TITLE
Add gas budget to TransactionData

### DIFF
--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -142,7 +142,7 @@ instance (it will not return the command prompt).
 NOTE: For logs, set `RUST_LOG=debug` before invoking `sui start`.
 
 If you see errors when trying to start Sui network, particularly if you made some custom changes
- (e.g, 
+ (e.g,
 [customized wallet configuration](#wallet-configuration)), you should [recreate Sui genesis state](#recreating-genesis).
 
 ## Using the wallet
@@ -183,20 +183,20 @@ wallet --config /path/to/wallet/config/file
 
 The Sui interactive wallet supports the following shell functionality:
 * Command History
-  The `history` command can be used to print the interactive shell's command history; 
-  you can also use Up, Down or Ctrl-P, Ctrl-N to navigate previous or next matches from history. 
+  The `history` command can be used to print the interactive shell's command history;
+  you can also use Up, Down or Ctrl-P, Ctrl-N to navigate previous or next matches from history.
   History search is also supported using Ctrl-R.
 * Tab completion
   Tab completion is supported for all commands using Tab and Ctrl-I keys.
 * Environment variable substitution
-  The wallet shell will substitute inputs prefixed with `$` with environment variables, 
-  you can use the `env` command to print out the entire list of variables and 
-  use `echo` to preview the substitution without invoking any commands.  
+  The wallet shell will substitute inputs prefixed with `$` with environment variables,
+  you can use the `env` command to print out the entire list of variables and
+  use `echo` to preview the substitution without invoking any commands.
 
 ### Command line mode
 
-The wallet can also be used without the interactive shell, which can be useful if 
-you want to pipe the output of the wallet to another application or invoke wallet 
+The wallet can also be used without the interactive shell, which can be useful if
+you want to pipe the output of the wallet to another application or invoke wallet
 commands using scripts.
 
 ```shell
@@ -351,7 +351,7 @@ We will explore how to transfer objects using the wallet in this section.
 `transfer` command usage:
 ```shell
 USAGE:
-    transfer [FLAGS] --gas <gas> --object-id <object-id> --to <to>
+    transfer [FLAGS] --gas <gas> --gas-budget <gas-budget> --object-id <object-id> --to <to>
 
 FLAGS:
     -h, --help       Prints help information
@@ -360,16 +360,18 @@ FLAGS:
 
 OPTIONS:
         --gas <gas>                ID of the gas object for gas payment, in 20 bytes Hex string
+        --gas-budget <gas-budget>    Gas budget for this transfer
         --object-id <object-id>    Object to transfer, in 20 bytes Hex string
         --to <to>                  Recipient address
 ```
 To transfer an object to a recipient, you will need the recipient's address,
 the object ID of the object that you want to transfer,
-and the gas object ID for the transaction fee payment.
+and the gas object ID for the transaction fee payment. Gas budget sets a cap for how much gas you want to spend.
+We are still finalizing our gas metering mechanisms. For now, just set something large enough.
 
 Here is an example transfer of an object to account `F456EBEF195E4A231488DF56B762AC90695BE2DD`.
 ```shell
-$ wallet --no-shell transfer --to C72CF3ADCC4D11C03079CEF2C8992AEA5268677A --object-id DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1 --gas 00A0A5211F6EDCF4BA09D23B8A7250072BE1EDB6
+$ wallet --no-shell transfer --to C72CF3ADCC4D11C03079CEF2C8992AEA5268677A --object-id DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1 --gas 00A0A5211F6EDCF4BA09D23B8A7250072BE1EDB6 --gas-budget 100
 Transfer confirmed after 4412 us
 ----- Certificate ----
 Signed Authorities : [k#21d89c3a12409b7aeadf36a9753417ead5fa9ea607ccb666e83b739b8a73c5e8, k#8d86bef2f8ae835d4763c9a697ad5c458130907996d59adc4ea5be37f2e0fab2, k#f9664056f3cc46b03e86beeb3febf99af1c9ec3f6aa709a1dbd101c9e9a79c3a]

--- a/sui/src/microbench.rs
+++ b/sui/src/microbench.rs
@@ -360,7 +360,6 @@ fn make_transfer_transaction(
             object_arguments: vec![object_ref],
             shared_object_arguments: vec![],
             pure_arguments: vec![bcs::to_bytes(&AccountAddress::from(recipient)).unwrap()],
-            gas_budget: 1000,
         })
     } else {
         SingleTransactionKind::Transfer(Transfer {
@@ -506,6 +505,7 @@ fn make_serialized_transactions(
                     TransactionKind::Single(single_kinds.into_iter().next().unwrap()),
                     address,
                     gas_object_ref,
+                    10000,
                 )
             } else {
                 assert!(single_kinds.len() == batch_size, "Inconsistent batch size");
@@ -513,6 +513,7 @@ fn make_serialized_transactions(
                     TransactionKind::Batch(single_kinds),
                     address,
                     gas_object_ref,
+                    2000000,
                 )
             };
 

--- a/sui/src/microbench_latency.rs
+++ b/sui/src/microbench_latency.rs
@@ -334,7 +334,6 @@ fn make_transfer_transaction(
             object_arguments: vec![object_ref],
             shared_object_arguments: vec![],
             pure_arguments: vec![bcs::to_bytes(&AccountAddress::from(recipient)).unwrap()],
-            gas_budget: 1000,
         })
     } else {
         SingleTransactionKind::Transfer(Transfer {
@@ -479,6 +478,7 @@ fn make_serialized_transactions(
                     TransactionKind::Single(single_kinds.into_iter().next().unwrap()),
                     address,
                     gas_object_ref,
+                    1000,
                 )
             } else {
                 assert!(single_kinds.len() == batch_size, "Inconsistent batch size");
@@ -486,6 +486,7 @@ fn make_serialized_transactions(
                     TransactionKind::Batch(single_kinds),
                     address,
                     gas_object_ref,
+                    2000000,
                 )
             };
 

--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -702,6 +702,8 @@ struct TransferTransactionRequest {
     to_address: String,
     /** Required; Hex code as string representing the gas object id to be used as payment */
     gas_object_id: String,
+    /** Required; Gas budget required as a cap for gas usage */
+    gas_budget: u64,
 }
 
 /**
@@ -765,11 +767,12 @@ async fn transfer_object(
             format!("Could not decode address from hex {error}"),
         )
     })?;
+    let gas_budget = transfer_order_params.gas_budget;
 
     let response: Result<_, anyhow::Error> = async {
         let data = state
             .gateway
-            .transfer_coin(owner, object_id, gas_object_id, to_address)
+            .transfer_coin(owner, object_id, gas_object_id, gas_budget, to_address)
             .await?;
         let signature = state
             .keystore

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -490,6 +490,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
         to: recipient,
         object_id: object_to_send,
         gas: object_id,
+        gas_budget: 50000,
     }
     .execute(&mut context)
     .await?;
@@ -953,6 +954,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         gas: gas_obj_id,
         to: recipient,
         object_id: obj_id,
+        gas_budget: 50000,
     }
     .execute(&mut context)
     .await?;

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -112,6 +112,10 @@ pub enum WalletCommands {
         /// ID of the gas object for gas payment, in 20 bytes Hex string
         #[structopt(long)]
         gas: ObjectID,
+
+        /// Gas budget for this transfer
+        #[structopt(long)]
+        gas_budget: u64,
     },
     /// Synchronize client state with authorities.
     #[structopt(name = "sync")]
@@ -317,7 +321,12 @@ impl WalletCommands {
                 WalletCommandResult::Call(cert, effects)
             }
 
-            WalletCommands::Transfer { to, object_id, gas } => {
+            WalletCommands::Transfer {
+                to,
+                object_id,
+                gas,
+                gas_budget,
+            } => {
                 let gas_object_info = context.gateway.get_object_info(*gas).await?;
                 let gas_object = gas_object_info.object()?;
                 let from = gas_object.owner.get_owner_address()?;
@@ -326,7 +335,7 @@ impl WalletCommands {
 
                 let data = context
                     .gateway
-                    .transfer_coin(from, *object_id, *gas, *to)
+                    .transfer_coin(from, *object_id, *gas, *gas_budget, *to)
                     .await?;
                 let signature = context
                     .keystore

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -92,6 +92,7 @@ pub trait GatewayAPI {
         signer: SuiAddress,
         object_id: ObjectID,
         gas_payment: ObjectID,
+        gas_budget: u64,
         recipient: SuiAddress,
     ) -> Result<TransactionData, anyhow::Error>;
 
@@ -534,6 +535,7 @@ where
         signer: SuiAddress,
         object_id: ObjectID,
         gas_payment: ObjectID,
+        gas_budget: u64,
         recipient: SuiAddress,
     ) -> Result<TransactionData, anyhow::Error> {
         // TODO: We should be passing in object_ref directly instead of object_id.
@@ -542,7 +544,13 @@ where
         let gas_payment = self.get_object(&gas_payment).await?;
         let gas_payment_ref = gas_payment.compute_object_reference();
 
-        let data = TransactionData::new_transfer(recipient, object_ref, signer, gas_payment_ref);
+        let data = TransactionData::new_transfer(
+            recipient,
+            object_ref,
+            signer,
+            gas_payment_ref,
+            gas_budget,
+        );
 
         Ok(data)
     }

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -679,9 +679,7 @@ async fn test_handle_move_transaction_insufficient_budget() {
         .handle_transaction(transaction.clone())
         .await
         .unwrap_err();
-    assert!(response
-        .to_string()
-        .contains("Gas budget is 9, smaller than minimum requirement of 10 for move operation"));
+    assert!(matches!(response, SuiError::InsufficientGas { .. }));
 }
 
 #[tokio::test]
@@ -922,13 +920,13 @@ async fn test_handle_confirmation_transaction_gas() {
             ))
             .await
     };
-    let result = run_test_with_gas(10).await;
+    let result = run_test_with_gas(1000).await;
     assert!(matches!(
         result.unwrap_err(),
         SuiError::InsufficientGas { .. }
     ));
     // This will execute sufccessfully.
-    let result = run_test_with_gas(20).await;
+    let result = run_test_with_gas(10000).await;
     result.unwrap();
 }
 
@@ -1455,7 +1453,7 @@ fn init_transfer_transaction(
     object_ref: ObjectRef,
     gas_object_ref: ObjectRef,
 ) -> Transaction {
-    let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object_ref);
+    let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object_ref, 10000);
     let signature = Signature::new(&data, secret);
     Transaction::new(data, signature)
 }

--- a/sui_core/src/unit_tests/batch_transaction_tests.rs
+++ b/sui_core/src/unit_tests/batch_transaction_tests.rs
@@ -53,7 +53,6 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
                 16u64.to_le_bytes().to_vec(),
                 bcs::to_bytes(&AccountAddress::from(sender)).unwrap(),
             ],
-            gas_budget: 500,
         }));
     }
     let data = TransactionData::new(
@@ -64,6 +63,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
             .await?
             .unwrap()
             .compute_object_reference(),
+        100000,
     );
     let signature = Signature::new(&data, &sender_key);
     let tx = Transaction::new(data, signature);
@@ -121,7 +121,6 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         object_arguments: vec![],
         shared_object_arguments: vec![],
         pure_arguments: vec![],
-        gas_budget: 500,
     }));
     let data = TransactionData::new(
         TransactionKind::Batch(transactions),
@@ -131,6 +130,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
             .await?
             .unwrap()
             .compute_object_reference(),
+        100000,
     );
     let signature = Signature::new(&data, &sender_key);
     let tx = Transaction::new(data, signature);
@@ -154,7 +154,6 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
     let module_bytes = vec![module_bytes];
     let transactions = vec![SingleTransactionKind::Publish(MoveModulePublish {
         modules: module_bytes,
-        gas_budget: 10000,
     })];
     let data = TransactionData::new(
         TransactionKind::Batch(transactions),
@@ -164,6 +163,7 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
             .await?
             .unwrap()
             .compute_object_reference(),
+        100000,
     );
     let signature = Signature::new(&data, &sender_key);
     let tx = Transaction::new(data, signature);
@@ -209,13 +209,13 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
                 16u64.to_le_bytes().to_vec(),
                 bcs::to_bytes(&AccountAddress::from(sender)).unwrap(),
             ],
-            gas_budget: 500,
         }));
     }
     let data = TransactionData::new(
         TransactionKind::Batch(transactions),
         sender,
         gas_object.compute_object_reference(),
+        100000,
     );
     let signature = Signature::new(&data, &sender_key);
     let tx = Transaction::new(data, signature);

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -505,7 +505,7 @@ async fn test_initiating_valid_transfer() {
         (sender, SequenceNumber::from(0))
     );
     let data = client
-        .transfer_coin(sender, object_id_1, gas_object, recipient)
+        .transfer_coin(sender, object_id_1, gas_object, 50000, recipient)
         .await
         .unwrap();
     let signature = sender_key.sign(&data.to_bytes());
@@ -554,7 +554,7 @@ async fn test_initiating_valid_transfer_despite_bad_authority() {
     let (sender, sender_key) = get_key_pair();
     let mut client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
     let data = client
-        .transfer_coin(sender, object_id, gas_object, recipient)
+        .transfer_coin(sender, object_id, gas_object, 50000, recipient)
         .await
         .unwrap();
 
@@ -603,7 +603,7 @@ async fn test_initiating_transfer_low_funds() {
 
     let transfer = async {
         let data = client
-            .transfer_coin(sender, object_id_2, gas_object, recipient)
+            .transfer_coin(sender, object_id_2, gas_object, 50000, recipient)
             .await?;
         let signature = sender_key.sign(&data.to_bytes());
         client
@@ -659,7 +659,7 @@ async fn test_bidirectional_transfer() {
     );
     // Transfer object to client.
     let data = client
-        .transfer_coin(addr1, object_id, gas_object1, addr2)
+        .transfer_coin(addr1, object_id, gas_object1, 50000, addr2)
         .await
         .unwrap();
 
@@ -705,7 +705,7 @@ async fn test_bidirectional_transfer() {
 
     // Transfer the object back to Client1
     let data = client
-        .transfer_coin(addr2, object_id, gas_object2, addr1)
+        .transfer_coin(addr2, object_id, gas_object2, 50000, addr1)
         .await
         .unwrap();
     let signature = key2.sign(&data.to_bytes());
@@ -736,7 +736,7 @@ async fn test_bidirectional_transfer() {
 
     // Should fail if Client 2 double spend the object
     let data = client
-        .transfer_coin(addr2, object_id, gas_object2, addr1)
+        .transfer_coin(addr2, object_id, gas_object2, 50000, addr1)
         .await
         .unwrap();
 
@@ -762,7 +762,7 @@ async fn test_client_state_sync_with_transferred_object() {
 
     // Transfer object to client.
     let data = client
-        .transfer_coin(addr1, object_id, gas_object_id, addr2)
+        .transfer_coin(addr1, object_id, gas_object_id, 50000, addr2)
         .await
         .unwrap();
 
@@ -1346,7 +1346,7 @@ async fn test_transfer_object_error() {
     // Test 1: Double spend
     let object_id = *objects.next().unwrap();
     let data = client
-        .transfer_coin(sender, object_id, gas_object, recipient)
+        .transfer_coin(sender, object_id, gas_object, 50000, recipient)
         .await
         .unwrap();
 
@@ -1357,7 +1357,7 @@ async fn test_transfer_object_error() {
         .unwrap();
 
     let data = client
-        .transfer_coin(sender, object_id, gas_object, recipient)
+        .transfer_coin(sender, object_id, gas_object, 50000, recipient)
         .await
         .unwrap();
 
@@ -1376,7 +1376,7 @@ async fn test_transfer_object_error() {
     let obj = Object::with_id_owner_for_testing(ObjectID::random(), sender);
 
     let result = client
-        .transfer_coin(sender, obj.id(), gas_object, recipient)
+        .transfer_coin(sender, obj.id(), gas_object, 50000, recipient)
         .await;
     assert!(result.is_err());
 }
@@ -1958,7 +1958,7 @@ async fn test_transfer_pending_transactions() {
     // Test 1: Normal transfer
     let object_id = *objects.next().unwrap();
     let data = client
-        .transfer_coin(sender, object_id, gas_object, recipient)
+        .transfer_coin(sender, object_id, gas_object, 50000, recipient)
         .await
         .unwrap();
 
@@ -1975,7 +1975,7 @@ async fn test_transfer_pending_transactions() {
     let obj = Object::with_id_owner_for_testing(ObjectID::random(), sender);
 
     let result = client
-        .transfer_coin(sender, obj.id(), gas_object, recipient)
+        .transfer_coin(sender, obj.id(), gas_object, 50000, recipient)
         .await;
     assert!(result.is_err());
     // assert!(matches!(result.unwrap_err().downcast_ref(),

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -192,7 +192,6 @@ MoveCall:
     - pure_arguments:
         SEQ:
           SEQ: U8
-    - gas_budget: U64
 MoveFieldLayout:
   STRUCT:
     - name:
@@ -204,7 +203,6 @@ MoveModulePublish:
     - modules:
         SEQ:
           SEQ: U8
-    - gas_budget: U64
 MoveObject:
   STRUCT:
     - type_:
@@ -761,6 +759,7 @@ TransactionData:
           - TYPENAME: ObjectID
           - TYPENAME: SequenceNumber
           - TYPENAME: ObjectDigest
+    - gas_budget: U64
 TransactionDigest:
   NEWTYPESTRUCT: BYTES
 TransactionEffects:

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -52,13 +52,11 @@ pub struct MoveCall {
     pub object_arguments: Vec<ObjectRef>,
     pub shared_object_arguments: Vec<ObjectID>,
     pub pure_arguments: Vec<Vec<u8>>,
-    pub gas_budget: u64,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveModulePublish {
     pub modules: Vec<Vec<u8>>,
-    pub gas_budget: u64,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
@@ -174,13 +172,11 @@ impl Display for SingleTransactionKind {
                 writeln!(writer, "Sequence Number : {:?}", seq)?;
                 writeln!(writer, "Object Digest : {}", encode_bytes_hex(&digest.0))?;
             }
-            Self::Publish(p) => {
+            Self::Publish(_p) => {
                 writeln!(writer, "Transaction Kind : Publish")?;
-                writeln!(writer, "Gas Budget : {}", p.gas_budget)?;
             }
             Self::Call(c) => {
                 writeln!(writer, "Transaction Kind : Call")?;
-                writeln!(writer, "Gas Budget : {}", c.gas_budget)?;
                 writeln!(writer, "Package ID : {}", c.package.0.to_hex_literal())?;
                 writeln!(writer, "Module : {}", c.module)?;
                 writeln!(writer, "Function : {}", c.function)?;
@@ -228,17 +224,24 @@ pub struct TransactionData {
     pub kind: TransactionKind,
     sender: SuiAddress,
     gas_payment: ObjectRef,
+    pub gas_budget: u64,
 }
 
 impl TransactionData
 where
     Self: BcsSignable,
 {
-    pub fn new(kind: TransactionKind, sender: SuiAddress, gas_payment: ObjectRef) -> Self {
+    pub fn new(
+        kind: TransactionKind,
+        sender: SuiAddress,
+        gas_payment: ObjectRef,
+        gas_budget: u64,
+    ) -> Self {
         TransactionData {
             kind,
             sender,
             gas_payment,
+            gas_budget,
         }
     }
 
@@ -262,9 +265,8 @@ where
             object_arguments,
             shared_object_arguments,
             pure_arguments,
-            gas_budget,
         }));
-        Self::new(kind, sender, gas_payment)
+        Self::new(kind, sender, gas_payment, gas_budget)
     }
 
     pub fn new_transfer(
@@ -272,12 +274,13 @@ where
         object_ref: ObjectRef,
         sender: SuiAddress,
         gas_payment: ObjectRef,
+        gas_budget: u64,
     ) -> Self {
         let kind = TransactionKind::Single(SingleTransactionKind::Transfer(Transfer {
             recipient,
             object_ref,
         }));
-        Self::new(kind, sender, gas_payment)
+        Self::new(kind, sender, gas_payment, gas_budget)
     }
 
     pub fn new_module(
@@ -288,9 +291,8 @@ where
     ) -> Self {
         let kind = TransactionKind::Single(SingleTransactionKind::Publish(MoveModulePublish {
             modules,
-            gas_budget,
         }));
-        Self::new(kind, sender, gas_payment)
+        Self::new(kind, sender, gas_payment, gas_budget)
     }
 
     /// Returns the transaction kind as a &str (variant name, no fields)

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -35,11 +35,11 @@ fn test_signed_values() {
     let committee = Committee::new(authorities);
 
     let transaction = Transaction::from_data(
-        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref()),
+        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref(), 10000),
         &sec1,
     );
     let bad_transaction = Transaction::from_data(
-        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref()),
+        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref(), 10000),
         &sec2,
     );
 
@@ -74,11 +74,11 @@ fn test_certificates() {
     let committee = Committee::new(authorities);
 
     let transaction = Transaction::from_data(
-        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref()),
+        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref(), 10000),
         &sec1,
     );
     let bad_transaction = Transaction::from_data(
-        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref()),
+        TransactionData::new_transfer(a2, random_object_ref(), a1, random_object_ref(), 10000),
         &sec2,
     );
 

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -95,6 +95,7 @@ fn test_transaction() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            10000,
         ),
         &sender_key,
     );
@@ -115,6 +116,7 @@ fn test_transaction() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            10000,
         ),
         &sender_key,
     );
@@ -138,6 +140,7 @@ fn test_vote() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            50000,
         ),
         &sender_key,
     );
@@ -168,6 +171,7 @@ fn test_cert() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            10000,
         ),
         &sender_key,
     );
@@ -200,6 +204,7 @@ fn test_info_response() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            10000,
         ),
         &sender_key,
     );
@@ -256,6 +261,7 @@ fn test_time_transaction() {
                 random_object_ref(),
                 sender_name,
                 random_object_ref(),
+                50000,
             ),
             &sender_key,
         );
@@ -290,6 +296,7 @@ fn test_time_vote() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            10000,
         ),
         &sender_key,
     );
@@ -335,6 +342,7 @@ fn test_time_cert() {
             random_object_ref(),
             sender_name,
             random_object_ref(),
+            10000,
         ),
         &sender_key,
     );


### PR DESCRIPTION
First step towards https://github.com/MystenLabs/sui/issues/1122.
This PR moves the `gas_budget` from each single tx kind to the top level, so that every transaction universally requires a single gas_budget. This also means that a Transfer tx also requires a gas budget.

Feel free to ignore most of the changes in gas around constants and etc. These will all go away soon.