### PR TITLE
[server + bench] Now start the batch maker, and integrate into bench

### DIFF
--- a/network_utils/src/unit_tests/transport_tests.rs
+++ b/network_utils/src/unit_tests/transport_tests.rs
@@ -66,7 +66,7 @@ async fn test_server() -> Result<(usize, usize), std::io::Error> {
     let counter = Arc::new(AtomicUsize::new(0));
     let mut received = 0;
 
-    let server = spawn_server(&address, TestService::new(counter.clone()), 100).await?;
+    let server = spawn_server(&address, Arc::new(TestService::new(counter.clone())), 100).await?;
 
     let mut client = connect(address.clone(), 1000).await?;
     client.write_data(b"abcdef").await?;

--- a/sui/src/microbench.rs
+++ b/sui/src/microbench.rs
@@ -260,7 +260,10 @@ impl ClientServerBenchmark {
         (state, transactions)
     }
 
-    async fn spawn_server(&self, state: AuthorityState) -> transport::SpawnedServer {
+    async fn spawn_server(
+        &self,
+        state: AuthorityState,
+    ) -> transport::SpawnedServer<AuthorityServer> {
         let server = AuthorityServer::new(self.host.clone(), self.port, self.buffer_size, state);
         server.spawn().await.unwrap()
     }
@@ -354,7 +357,7 @@ fn make_transfer_transaction(
 
         SingleTransactionKind::Call(MoveCall {
             package: framework_obj_ref,
-            module: ident_str!("GAS").to_owned(),
+            module: ident_str!("SUI").to_owned(),
             function: ident_str!("transfer").to_owned(),
             type_arguments: Vec::new(),
             object_arguments: vec![object_ref],

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -158,7 +158,7 @@ impl SuiCommand {
 }
 
 pub struct SuiNetwork {
-    pub spawned_authorities: Vec<SpawnedServer>,
+    pub spawned_authorities: Vec<SpawnedServer<AuthorityServer>>,
 }
 
 impl SuiNetwork {

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -54,7 +54,7 @@ pub use authority_store::{AuthorityStore, GatewayStore};
 
 pub mod authority_notifier;
 
-const MAX_ITEMS_LIMIT: u64 = 10_000;
+const MAX_ITEMS_LIMIT: u64 = 100_000;
 const BROADCAST_CAPACITY: usize = 10_000;
 
 /// a Trait object for `signature::Signer` that is:

--- a/sui_types/src/serialize.rs
+++ b/sui_types/src/serialize.rs
@@ -200,14 +200,11 @@ pub fn deserialize_transaction_info(
 }
 
 pub fn deserialize_batch_info(
-    message: Result<SerializedMessage, SuiError>,
+    message: SerializedMessage,
 ) -> Result<BatchInfoResponseItem, SuiError> {
     match message {
-        Ok(message) => match message {
-            SerializedMessage::BatchInfoResp(resp) => Ok(*resp),
-            SerializedMessage::Error(error) => Err(*error),
-            _ => Err(SuiError::UnexpectedMessage),
-        },
-        Err(e) => Err(e),
+        SerializedMessage::BatchInfoResp(resp) => Ok(*resp),
+        SerializedMessage::Error(error) => Err(*error),
+        _ => Err(SuiError::UnexpectedMessage),
     }
 }

--- a/test_utils/src/sequencer.rs
+++ b/test_utils/src/sequencer.rs
@@ -58,7 +58,7 @@ impl Sequencer {
             let input_server = InputServer { tx_input };
             sui_network::transport::spawn_server(
                 &sequencer.input_address.to_string(),
-                input_server,
+                Arc::new(input_server),
                 sequencer.buffer_size,
             )
             .await
@@ -73,7 +73,7 @@ impl Sequencer {
             let subscriber_server = SubscriberServer::new(tx_subscriber, store);
             sui_network::transport::spawn_server(
                 &sequencer.subscriber_address.to_string(),
-                subscriber_server,
+                Arc::new(subscriber_server),
                 sequencer.buffer_size,
             )
             .await


### PR DESCRIPTION
This PR does three things:
1. Starts the batch maker task when the server starts. This necessitated a little bit of reworking of function params in `authority_server` to pass around `Arc`s, but nothing drastic.
2. Adapts the micro benchmark to listen to update items from the authority, to ensure these facilities do not lead to performance regressions, and also return results correctly.
3. Provides a client facility to get update items as a stream rather than a channel, to avoid launching a separate task.