### PR TITLE
ci: cleanup ci

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,7 +1,7 @@
 too-many-arguments-threshold = 20
 disallowed-methods = [
     # unbounded channels are for expert use only
-    { path = "tokio::sync::mpsc::unbounded", reason = "use a bounded channel instead" },
+    { path = "tokio::sync::mpsc::unbounded_channel", reason = "use a bounded channel instead" },
     { path = "futures::channel::mpsc::unbounded", reason = "use a bounded channel instead" },
     { path = "futures_channel::mpsc::unbounded", reason = "use a bounded channel instead" },
 ]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
-name: Rust
+name: nightly
 
 on:
   schedule:
-      - cron: '0 0 * * *'  # every day at midnight
+    - cron: '0 0 * * *'  # every day at midnight
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,26 +27,36 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
-  
-  test:
-    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
-        os: [ubuntu]
+  beta:
+    name: Run test on the beta channel
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install rust
+      - name: Install beta toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{matrix.toolchain}}
-          profile: minimal
+          toolchain: beta
+          components: clippy
           override: true
-      - uses: Swatinem/rust-cache@v1
-      - name: Test
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets -- -D clippy::all -D warnings -D clippy::disallowed_methods
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --release --profile=release
+          args: --all-features
+
+  release:
+    name: build release binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-targets --all-features --release --profile=release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,95 +43,6 @@ jobs:
           isRust:
             - '!(explorer|doc|.github)/**'
             - '.github/workflows/rust.yml'
-  release-check:
-    name: Rust release-mode compilation nightly on ubuntu
-    needs: diff
-    if: needs.diff.outputs.isRust == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all --tests -Z unstable-options --profile=release
-
-  test:
-    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
-    needs: diff
-    runs-on: ${{matrix.os}}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
-        os: [ubuntu]
-    steps:
-      - uses: actions/checkout@v2
-        if: needs.diff.outputs.isRust == 'true'
-      - name: Install rust
-        if: needs.diff.outputs.isRust == 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
-          profile: minimal
-          override: true
-      - uses: Swatinem/rust-cache@v1
-        if: needs.diff.outputs.isRust == 'true'
-      - name: Test
-        if: needs.diff.outputs.isRust == 'true'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-
-  clippy:
-    name: Clippy
-    needs: diff
-    if: needs.diff.outputs.isRust == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install minimal nightly with clippy
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: clippy
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --tests -- -D clippy::all -D warnings -D clippy::disallowed_methods
-
-  rustfmt:
-    name: rustfmt
-    needs: diff
-    if: needs.diff.outputs.isRust == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install minimal nightly with rustfmt
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          components: rustfmt
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
 
   license-check:
     name: license-check
@@ -139,6 +50,53 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: scripts/license_check.sh
+
+  test:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - uses: Swatinem/rust-cache@v1
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
+  clippy:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v1
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets -- -D clippy::all -D warnings -D clippy::disallowed_methods
+
+  rustfmt:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: rustfmt
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check
 
   cargo-deny:
     name: cargo-deny (advisories, licenses, bans, ...)
@@ -150,22 +108,20 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   cargo-udeps:
-    name: cargo-udeps
-    needs: diff
-    if: needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install minimal nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-udeps, and cache the binary
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-udeps
+          locked: true
+      # Normally running cargo-udeps requires use of a nightly compiler
+      # In order to have a more stable and less noisy experience, lets instead
+      # opt to use the stable toolchain specified via the 'rust-toolchain' file
+      # and instead enable nightly features via 'RUSTC_BOOTSTRAP'
       - name: run cargo-udeps
-        run: cargo +nightly udeps
+        run: RUSTC_BOOTSTRAP=1 cargo udeps
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-      - uses: Swatinem/rust-cache@v1
+      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+      # 'librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/librocksdb-sys-*
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:
@@ -76,7 +80,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v1
+      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+      # 'librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/librocksdb-sys-*
       - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -112,7 +120,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-      - uses: Swatinem/rust-cache@v1
+      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+      # 'librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/librocksdb-sys-*
       - name: Install cargo-udeps, and cache the binary
         uses: baptiste0928/cargo-install@v1
         with:


### PR DESCRIPTION
This PR includes the following commits:

### ci: various cleanups
This patch does some various cleanups to our rust ci pipeline. In
particular it runs linting (clippy, rustfmt) as well as tests using the
compiler toolchain specified inside of the `rust-toolchain` file instead
of overriding it with either `stable` or `nightly` either of which could
cause CI to break when a new toolchain is released to the stable or
nightly channels.

It also moves canarying of a new compiler toolchain from the workflow
that runs on every PR to a 'nightly' Github Action workflow. It also
prefers using the 'beta' channel instead of 'nightly' channel in order
to reduce noise.

### clippy: correctly disallow tokio unbounded channel

### ci: enable 'librocksdb-sys' to be able to be properly cached
Today we leverage the 'Swatinem/rust-cache' github action in order to
cache rust third-party dependencies and avoid needing to rebuild them
every time CI is run. Unfortunately it was identified that despite a
cache hit the 'librocksdb-sys' crate was always retriggering a very
costly build.

The crux of the issue is mostly highlighted by this issue
(https://github.com/rust-rocksdb/rust-rocksdb/issues/574) on the
rust-rocksdb repository. The 'librocksdb-sys' crate uses a build script
to be able to build the c++ rocksdb project (tracked via a submodule in
the rust-rocksdb repo) and makes use of of the cargo directive
"cargo:rerun-if-changed=rocksdb/" to ensure that anytime the submodule
is updated that the c++ code should be recompiled. In particular this
cargo directive only uses the filesystem last-modified "mtime" timestamp
to determine if the file has changed
(https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath).

The 'Swatinem/rust-cache' action explicitly avoids caching the
'.cargo/registry/src' directory since its faster for cargo to repopulate
the unpacked crate src from their archives in '.cargo/registry/cache'
(which is cached by the github action). This leads to the unintended
consiquency that when cargo goes to unpack the 'librocksdb-sys' crate
src, the mtime of the "rocksdb/" directory no longer matches the cached
mtime that was restored from a previous build of the 'librocksdb-sys'
dependency resulting in 'librocksdb-sys' being rebuilt.

In order to fix this issue we can additionally cache the
'.cargo/registry/src/*/librocksdb-sys-*' directory (since the github
caching infrastructure preserves mtimes of cached files) and ensure that
the mtime matches what cargo expects, avoiding a rebuild. In order to do
this I've forked the 'Swatinem/rust-cache' action to 'bmwill/rust-cache'
add added the ability to additionally specify other paths that should be
cached and specified the '.cargo/registry/src/*/lib-rocksdb-sys-*'
directory.

## Results
Due to the proper caching of the 'librocksdb-sys' crate CI times have improved:

| job | cache-miss | cache-hit pre-patch | cache-hit post-patch | speed up |
| - | - | - | - | - |
| cargo-test | 29m | 18m | 12m 15s | 1.5x |
| cargo-clippy | 13m | 8m 14s | 1m 17s | 6.6x |
