### PR TITLE
ci: more small tweaks

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,10 @@
+[alias]
+# Collection of project wide clippy lints. This is done via an alias because
+# clippy doesn't currently allow for specifiying project-wide lints in a
+# configuration file. This is a similar workaround to the ones presented here:
+# <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+xclippy = [
+    "clippy", "--all-targets", "--",
+    "-Wclippy::all",
+    "-Wclippy::disallowed_methods",
+]

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,17 +47,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install minimal rust stable
-      uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@v1
+    # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+    # 'librocksdb-sys' src directory which is managed by cargo
+    - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v1
+        path: ~/.cargo/registry/src/**/librocksdb-sys-*
     - name: Install huniq, and cache the binary
       uses: baptiste0928/cargo-install@v1
       with:
         crate: huniq
+        locked: true
     - name: prepare artifact directory
       run: |
         mkdir -p artifacts

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,7 +24,6 @@ jobs:
             - '!(explorer|doc|.github)/**'
             - '.github/workflows/bench.yml'
 
-
   codecov-grcov:
     name: Generate code coverage
     needs: diff
@@ -33,20 +32,23 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - name: install toolchain according to rust-toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: beta # temporarily use beta till 'instrument-coverage' stabilizes in 1.60
           profile: default
           override: true
           components: llvm-tools-preview
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - uses: Swatinem/rust-cache@v1
+      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+      # 'librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/librocksdb-sys-*
       - name: Install grcov, and cache the binary
         uses: baptiste0928/cargo-install@v1
         with:
           crate: grcov
+          locked: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -59,8 +61,7 @@ jobs:
           RUSTFLAGS: '-Cinstrument-coverage'
           RUSTDOCFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: 'codecov-instrumentation-%p-%m.profraw'
-        run: |
-          cargo test 
+        run: cargo test
       - name: Run grcov
         run: grcov . --binary-path target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov
       - name: Upload to codecov.io

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,11 +38,9 @@ jobs:
           toolchain: beta
           components: clippy
           override: true
+      # See '.cargo/config' for list of enabled/disappled clippy lints
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D clippy::all -D warnings -D clippy::disallowed_methods
+        run: cargo xclippy -D warnings
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,11 +85,9 @@ jobs:
       - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
         with:
           path: ~/.cargo/registry/src/**/librocksdb-sys-*
+      # See '.cargo/config' for list of enabled/disappled clippy lints
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- -D clippy::all -D warnings -D clippy::disallowed_methods
+        run: cargo xclippy -D warnings
 
   rustfmt:
     needs: diff


### PR DESCRIPTION
ci: properly cache deps for benchmark workflow

ci: improve the codecov workflow

    * proper caching of the librocksdb-sys crate
    * use the beta compiler which has -Cinstrument-coverage stabilized.
      We can move to stable once 1.60.0 is released

rust: introduce xclippy project alias
    
    Introduce 'cargo xclippy' alias for better control of enabling and
    disabling clippy lints project-wide.