### PR TITLE
 use stream combinators to return streams, update safe client with security checks

### DIFF
--- a/sui/src/microbench.rs
+++ b/sui/src/microbench.rs
@@ -332,6 +332,7 @@ impl ClientServerBenchmark {
                         Ok(BatchInfoResponseItem(UpdateItem::Transaction((
                             _tx_seq,
                             _tx_digest,
+                            _tx_info,
                         )))) => {
                             start = _tx_seq + 1;
                         }

--- a/sui/src/microbench.rs
+++ b/sui/src/microbench.rs
@@ -14,7 +14,7 @@ use rayon::prelude::*;
 use std::collections::{HashSet, VecDeque};
 use std::time::{Duration, Instant};
 use sui_adapter::genesis;
-use sui_core::authority_client::AuthorityClient;
+use sui_core::authority_client::{AuthorityAPI, AuthorityClient};
 use sui_core::{authority::*, authority_server::AuthorityServer};
 use sui_network::{network::NetworkClient, transport};
 use sui_types::batch::UpdateItem;
@@ -314,7 +314,7 @@ impl ClientServerBenchmark {
 
             loop {
                 let receiver = authority_client
-                    .handle_batch_streaming_as_stream(BatchInfoRequest {
+                    .handle_batch_stream(BatchInfoRequest {
                         start,
                         end: start + 10_000,
                     })

--- a/sui/src/microbench.rs
+++ b/sui/src/microbench.rs
@@ -317,6 +317,7 @@ impl ClientServerBenchmark {
                     .handle_batch_stream(BatchInfoRequest {
                         start,
                         end: start + 10_000,
+                        include_tx_info: false,
                     })
                     .await;
 

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -565,7 +565,7 @@ impl AuthorityState {
                 }
 
                 let current_transaction = dq_transactions.pop_front().unwrap();
-                items.push_back(UpdateItem::Transaction(current_transaction)); //todo: @Laura update Transaction contents
+                items.push_back(UpdateItem::Transaction(current_transaction));
             }
 
             // Now send the batch

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -527,8 +527,7 @@ impl AuthorityState {
 
         let mut transactions_info = Vec::new();
         for (seq, digest) in transactions.iter() {
-            if true {
-                // TODO: @Laura add flag to request
+            if request.include_tx_info {
                 let tx_info = self.make_transaction_info(digest).await;
                 match tx_info {
                     Ok(info) => {

--- a/sui_core/src/authority/authority_notifier.rs
+++ b/sui_core/src/authority/authority_notifier.rs
@@ -50,7 +50,15 @@ impl TransactionNotifier {
     pub fn iter_from(
         self: &Arc<Self>,
         next_seq: u64,
-    ) -> SuiResult<impl futures::Stream<Item = (TxSequenceNumber, TransactionDigest)> + Unpin> {
+    ) -> SuiResult<
+        impl futures::Stream<
+                Item = (
+                    TxSequenceNumber,
+                    TransactionDigest,
+                    Option<Box<TransactionInfoResponse>>,
+                ),
+            > + Unpin,
+    > {
         if self
             .has_stream
             .compare_exchange(
@@ -66,7 +74,11 @@ impl TransactionNotifier {
 
         // The state we inject in the async stream
         let transaction_notifier = self.clone();
-        let temp_buffer: VecDeque<(TxSequenceNumber, TransactionDigest)> = VecDeque::new();
+        let temp_buffer: VecDeque<(
+            TxSequenceNumber,
+            TransactionDigest,
+            Option<Box<TransactionInfoResponse>>,
+        )> = VecDeque::new();
         let uniquess_guard = IterUniquenessGuard(transaction_notifier.clone());
         let initial_state = (transaction_notifier, temp_buffer, next_seq, uniquess_guard);
 
@@ -100,7 +112,7 @@ impl TransactionNotifier {
                         // ... contued here with take_while. And expand the buffer with the new items.
                         temp_buffer.extend(
                             iter.take_while(|(tx_seq, _tx_digest)| *tx_seq < last_safe)
-                                .map(|(tx_seq, _tx_digest)| (tx_seq, _tx_digest)),
+                                .map(|(tx_seq, _tx_digest)| (tx_seq, _tx_digest, None)),
                         );
 
                         // Update what the next item would be to no re-read messages in the buffer
@@ -225,9 +237,9 @@ mod tests {
             Err(SuiError::ConcurrentIteratorError)
         ));
 
-        assert!(matches!(iter.next().await, Some((0, _))));
-        assert!(matches!(iter.next().await, Some((1, _))));
-        assert!(matches!(iter.next().await, Some((2, _))));
+        assert!(matches!(iter.next().await, Some((0, _, _))));
+        assert!(matches!(iter.next().await, Some((1, _, _))));
+        assert!(matches!(iter.next().await, Some((2, _, _))));
 
         assert!(timeout(Duration::from_millis(10), iter.next())
             .await
@@ -246,7 +258,7 @@ mod tests {
         }
 
         let x = iter.next().await;
-        assert!(matches!(x, Some((4, _))));
+        assert!(matches!(x, Some((4, _, _))));
 
         assert!(timeout(Duration::from_millis(10), iter.next())
             .await
@@ -270,9 +282,9 @@ mod tests {
         store.side_sequence(t8.seq(), &TransactionDigest::random());
         drop(t8);
 
-        assert!(matches!(iter.next().await, Some((5, _))));
-        assert!(matches!(iter.next().await, Some((6, _))));
-        assert!(matches!(iter.next().await, Some((8, _))));
+        assert!(matches!(iter.next().await, Some((5, _, _))));
+        assert!(matches!(iter.next().await, Some((6, _, _))));
+        assert!(matches!(iter.next().await, Some((8, _, _))));
 
         assert!(timeout(Duration::from_millis(10), iter.next())
             .await

--- a/sui_core/src/authority_batch.rs
+++ b/sui_core/src/authority_batch.rs
@@ -137,7 +137,7 @@ impl crate::authority::AuthorityState {
             tokio::select! {
               _ = interval.tick() => {
                 // Every so often we check if we should make a batch
-                // but it should never be empty. But never empty.
+                // but it should never be empty.
                   make_batch = true;
               },
               item_option = transaction_stream.next() => {
@@ -146,10 +146,11 @@ impl crate::authority::AuthorityState {
                         make_batch = true;
                         exit = true;
                     },
-                    Some((seq, tx_digest, tx_info)) => {
+                    Some((seq, tx_digest)) => {
                         // Add to batch and broadcast
-                        current_batch.push((seq, tx_digest, tx_info.clone()));
-                        let _ = self.batch_channels.send(UpdateItem::Transaction((seq, tx_digest, tx_info)));
+                        // The Tx info gets populated at broadcast time if it was requested, so here it is set to None.
+                        current_batch.push((seq, tx_digest, None));
+                        let _ = self.batch_channels.send(UpdateItem::Transaction((seq, tx_digest, None)));
 
                         if current_batch.len() as TxSequenceNumber >= min_batch_size {
                             make_batch = true;

--- a/sui_core/src/authority_client.rs
+++ b/sui_core/src/authority_client.rs
@@ -159,9 +159,11 @@ impl AuthorityAPI for AuthorityClient {
                     Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
                         signed_batch.batch.next_sequence_number < request.end
                     }
-                    Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest)))) => {
-                        *seq < request.end
-                    }
+                    Ok(BatchInfoResponseItem(UpdateItem::Transaction((
+                        seq,
+                        _digest,
+                        _tx_info,
+                    )))) => *seq < request.end,
                     Err(_e) => {
                         // TODO: record e
                         error_count += 1;

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -106,7 +106,7 @@ impl AuthorityServer {
         let mut last_seq_sent = 0;
         while let Some(item) = items.pop_front() {
             // Remember the last transaction sequence number sent
-            if let UpdateItem::Transaction((seq, _)) = &item {
+            if let UpdateItem::Transaction((seq, _, _)) = &item {
                 last_seq_sent = *seq;
             }
 
@@ -129,7 +129,7 @@ impl AuthorityServer {
             match subscriber.recv().await {
                 Ok(item) => {
                     let seq = match &item {
-                        UpdateItem::Transaction((seq, _)) => *seq,
+                        UpdateItem::Transaction((seq, _, _)) => *seq,
                         UpdateItem::Batch(signed_batch) => signed_batch.batch.next_sequence_number,
                     };
 

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -336,9 +336,19 @@ where
                             }
                             Ok(BatchInfoResponseItem(UpdateItem::Transaction((
                                 _seq,
-                                _digest,
-                                _tx_info,
-                            )))) => batch_info_item,
+                                digest,
+                                tx_info,
+                            )))) => {
+                                if let Some(transaction_info) = tx_info {
+                                    if let Err(err) =
+                                        client.check_transaction_response(*digest, transaction_info)
+                                    {
+                                        client.report_client_error(err.clone());
+                                        return Err(err);
+                                    }
+                                }
+                                batch_info_item
+                            }
                             Err(e) => Err(e.clone()),
                         }
                     }

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -334,9 +334,11 @@ where
                                 }
                                 batch_info_item
                             }
-                            Ok(BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest)))) => {
-                                batch_info_item
-                            }
+                            Ok(BatchInfoResponseItem(UpdateItem::Transaction((
+                                _seq,
+                                _digest,
+                                _tx_info,
+                            )))) => batch_info_item,
                             Err(e) => Err(e.clone()),
                         }
                     }

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -178,7 +178,7 @@ impl<C> SafeClient<C> {
         // check the signature of the batch
         signed_batch
             .signature
-            .check(signed_batch, signed_batch.authority)?;
+            .check(&signed_batch.batch, signed_batch.authority)?;
 
         // ensure transactions enclosed match requested range
         fp_ensure!(
@@ -197,7 +197,7 @@ impl<C> SafeClient<C> {
             Some(provided_digest),
             &signed_batch.batch.transaction_batch.0,
         );
-        let computed_digest = reconstructed_batch.digest();
+        let computed_digest = reconstructed_batch.transactions_digest;
 
         fp_ensure!(
             provided_digest == computed_digest,

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -149,7 +149,7 @@ async fn test_batch_manager_happy_path() {
     let mut rx = authority_state.subscribe_batch();
     assert!(matches!(
         rx.recv().await.unwrap(),
-        UpdateItem::Transaction((0, _))
+        UpdateItem::Transaction((0, _, _))
     ));
 
     // Then we (eventually) get a batch
@@ -166,7 +166,7 @@ async fn test_batch_manager_happy_path() {
     // But the block is made, and sent as a notification.
     assert!(matches!(
         rx.recv().await.unwrap(),
-        UpdateItem::Transaction((1, _))
+        UpdateItem::Transaction((1, _, _))
     ));
     assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
 
@@ -213,20 +213,20 @@ async fn test_batch_manager_out_of_order() {
     // Get transactions in order then batch.
     assert!(matches!(
         rx.recv().await.unwrap(),
-        UpdateItem::Transaction((0, _))
+        UpdateItem::Transaction((0, _, _))
     ));
 
     assert!(matches!(
         rx.recv().await.unwrap(),
-        UpdateItem::Transaction((1, _))
+        UpdateItem::Transaction((1, _, _))
     ));
     assert!(matches!(
         rx.recv().await.unwrap(),
-        UpdateItem::Transaction((2, _))
+        UpdateItem::Transaction((2, _, _))
     ));
     assert!(matches!(
         rx.recv().await.unwrap(),
-        UpdateItem::Transaction((3, _))
+        UpdateItem::Transaction((3, _, _))
     ));
 
     // Then we (eventually) get a batch
@@ -272,7 +272,7 @@ async fn test_handle_move_order_with_batch() {
     println!("{:?}", y);
     assert!(matches!(
         y,
-        UpdateItem::Transaction((0, x)) if x == effects.transaction_digest
+        UpdateItem::Transaction((0, x, _)) if x == effects.transaction_digest
     ));
 
     assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));

--- a/sui_core/src/unit_tests/server_tests.rs
+++ b/sui_core/src/unit_tests/server_tests.rs
@@ -182,7 +182,7 @@ async fn test_subscription() {
                         break;
                     }
                 }
-                BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest))) => {
+                BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest, _))) => {
                     num_transactions += 1;
                 }
             },
@@ -240,7 +240,7 @@ async fn test_subscription() {
                         break;
                     }
                 }
-                BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest))) => {
+                BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest, _))) => {
                     println!("Received {seq}");
                     num_transactions += 1;
                 }

--- a/sui_core/src/unit_tests/server_tests.rs
+++ b/sui_core/src/unit_tests/server_tests.rs
@@ -163,7 +163,11 @@ async fn test_subscription() {
     println!("Started messahe handling.");
     // TEST 1: Get historical data
 
-    let req = BatchInfoRequest { start: 12, end: 34 };
+    let req = BatchInfoRequest {
+        start: 12,
+        end: 34,
+        include_tx_info: false,
+    };
 
     let bytes: BytesMut = BytesMut::from(&serialize_batch_request(&req)[..]);
     tx.send(Ok(bytes)).await.expect("Problem sending");
@@ -221,6 +225,7 @@ async fn test_subscription() {
     let req = BatchInfoRequest {
         start: 101,
         end: 112,
+        include_tx_info: false,
     };
 
     let bytes: BytesMut = BytesMut::from(&serialize_batch_request(&req)[..]);

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -32,6 +32,8 @@ AuthorityBatch:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 32
+    - transaction_batch:
+        TYPENAME: TransactionBatch
 AuthoritySignInfo:
   STRUCT:
     - authority:
@@ -47,6 +49,7 @@ BatchInfoRequest:
   STRUCT:
     - start: U64
     - end: U64
+    - include_tx_info: BOOL
 BatchInfoResponseItem:
   NEWTYPESTRUCT:
     TYPENAME: UpdateItem
@@ -760,6 +763,14 @@ SuiError:
           - error: STR
     93:
       OnlyOneConsensusClientPermitted: UNIT
+TransactionBatch:
+  NEWTYPESTRUCT:
+    SEQ:
+      TUPLE:
+        - U64
+        - TYPENAME: TransactionDigest
+        - OPTION:
+            TYPENAME: TransactionInfoResponse
 TransactionData:
   STRUCT:
     - kind:
@@ -913,6 +924,8 @@ UpdateItem:
           TUPLE:
             - U64
             - TYPENAME: TransactionDigest
+            - OPTION:
+                TYPENAME: TransactionInfoResponse
     1:
       Batch:
         NEWTYPE:

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -3,21 +3,34 @@
 
 use crate::base_types::{AuthorityName, TransactionDigest};
 use crate::crypto::{sha3_hash, AuthoritySignature, BcsSignable};
+use crate::messages::TransactionInfoResponse;
 use serde::{Deserialize, Serialize};
 
 pub type TxSequenceNumber = u64;
 
 /// Either a freshly sequenced transaction hash or a batch
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum UpdateItem {
-    Transaction((TxSequenceNumber, TransactionDigest)),
+    Transaction(
+        (
+            TxSequenceNumber,
+            TransactionDigest,
+            Option<Box<TransactionInfoResponse>>,
+        ),
+    ),
     Batch(SignedBatch),
 }
 
 pub type BatchDigest = [u8; 32];
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
-pub struct TransactionBatch(pub Vec<(TxSequenceNumber, TransactionDigest)>);
+pub struct TransactionBatch(
+    pub  Vec<(
+        TxSequenceNumber,
+        TransactionDigest,
+        Option<Box<TransactionInfoResponse>>,
+    )>,
+);
 impl BcsSignable for TransactionBatch {}
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Default, Debug, Serialize, Deserialize)]
@@ -69,7 +82,11 @@ impl AuthorityBatch {
     /// batch.
     pub fn make_next(
         previous_batch: &AuthorityBatch,
-        transactions: &[(TxSequenceNumber, TransactionDigest)],
+        transactions: &[(
+            TxSequenceNumber,
+            TransactionDigest,
+            Option<Box<TransactionInfoResponse>>,
+        )],
     ) -> AuthorityBatch {
         let transaction_vec = transactions.to_vec();
         debug_assert!(!transaction_vec.is_empty());
@@ -94,7 +111,11 @@ impl AuthorityBatch {
     /// batch, using the digest of the previous batch.
     pub fn make_next_with_previous_digest(
         previous_batch_digest: Option<BatchDigest>,
-        transactions: &[(TxSequenceNumber, TransactionDigest)],
+        transactions: &[(
+            TxSequenceNumber,
+            TransactionDigest,
+            Option<Box<TransactionInfoResponse>>,
+        )],
     ) -> AuthorityBatch {
         let transaction_vec = transactions.to_vec();
         debug_assert!(!transaction_vec.is_empty());

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -159,8 +159,6 @@ impl SignedBatch {
     }
 }
 
-impl BcsSignable for SignedBatch {}
-
 impl PartialEq for SignedBatch {
     fn eq(&self, other: &Self) -> bool {
         self.batch == other.batch && self.authority == other.authority

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base64ct::{Base64, Encoding};
+use std::cmp::Ordering;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 use std::{
@@ -648,7 +649,7 @@ pub struct BatchInfoRequest {
     pub end: TxSequenceNumber,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchInfoResponseItem(pub UpdateItem);
 
 impl From<SuiAddress> for AccountInfoRequest {
@@ -760,6 +761,36 @@ pub struct TransactionInfoResponse {
     // The effects resulting from a successful execution should
     // contain ObjectRef created, mutated, deleted and events.
     pub signed_effects: Option<SignedTransactionEffects>,
+}
+
+impl Eq for TransactionInfoResponse {}
+
+impl PartialEq for TransactionInfoResponse {
+    fn eq(&self, other: &Self) -> bool {
+        if self.signed_transaction == other.signed_transaction
+            //&& self.certified_transaction == other.certified_transaction
+            && self.signed_effects == other.signed_effects
+        {
+            return true;
+        }
+        false
+    }
+}
+
+impl PartialOrd for TransactionInfoResponse {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        None
+    }
+}
+
+impl Ord for TransactionInfoResponse {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        Ordering::Equal
+    }
+}
+
+impl Hash for TransactionInfoResponse {
+    fn hash<H: Hasher>(&self, _state: &mut H) {}
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -647,6 +647,7 @@ pub struct AccountInfoRequest {
 pub struct BatchInfoRequest {
     pub start: TxSequenceNumber,
     pub end: TxSequenceNumber,
+    pub include_tx_info: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Part of https://github.com/MystenLabs/sui/issues/729
* Converts the `handle_batch_stream` functions for the `AuthorityAPI` trait to process and return streams.
* Updates the Batch version of UpdateItem to include the transaction digests of each transaction in the batch
* Reconstructs the batch in the safe client and compares provided digest with digest of reconstructed batch
* ensures the processing stops after (requested sequence end - requested sequence start) number of iterations
* ensures the returned sequences are in the requested range
* extend the request object to contain flag for including transaction info, including signatures and/or certificates if available
* return the transaction info along with the UpdateInfoResponse object
* use the transaction info to verify the transactions in the safe client
* tests
