### PR TITLE
[wallet] Infer gas and allow for default address

### DIFF
--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -156,7 +156,7 @@ If you see errors when trying to start Sui network, particularly if you made som
 
 The following commands are supported by the wallet:
 
-    active-address    Default address used for commands when none specified
+    active-address    Use this default address for commands when none is specified
     addresses         Obtain the Addresses managed by the wallet
     call              Call Move function
     clear             Clear screen
@@ -164,11 +164,11 @@ The following commands are supported by the wallet:
     env               Print environment
     exit              Exit the interactive shell
     gas               Obtain all gas objects owned by the address
-    help              Prints this message or the help of the given subcommand(s)
+    help              Print this message or the help of the given subcommand(s)
     history           Print history
     merge-coin        Merge two coin objects into one coin
     new-address       Generate new address and keypair
-    object            Get obj info
+    object            Get object information
     objects           Obtain all objects owned by the address
     publish           Publish Move modules
     split-coin        Split a coin object into multiple coins
@@ -247,12 +247,14 @@ and object IDs will be assigned randomly. Consequently, you cannot rely
 on copy-pasting commands that include these values, as they will be different
 between different users/configs.
 
-### Active Address
+### Active address
 
-Since a wallet manages multiple disjoint addresses, one might need to specify which address they want to call a command on.
+Since a wallet manages multiple disjointed addresses, one might need to specify
+which address they want to call a command on.
 
-For convenience, one can chose to set a default address which will be used for commands that require an address to operate on.
-A default address is picked at the start but this can be changed later.
+For convenience, one can choose to set a default, or active address that will be
+used for commands that require an address to operate on. A default address is picked
+at the start, but this can be changed later.
 
 In order to see what the current active address is, use the command `active-address`
 
@@ -269,8 +271,8 @@ wallet --no-shell switch --address 913CF36F370613ED131868AC6F9DA2420166062E
 Active address switched to 913CF36F370613ED131868AC6F9DA2420166062E
 ```
 
-One can call for example the `objects` command with or without an address specified.
-When not specified, the active address is used
+One can call, for example, the `objects` command with or without an address specified.
+When not specified, the active address is used.
 
 ```
 sui>-$ objects
@@ -282,19 +284,27 @@ Showing 5 results.
 (0B8A4620426E526FA42995CF26EB610BFE6BF063, SequenceNumber(0), o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221)
 ```
 
-All commands where `address` is omitted will now use the newly specified active address 913CF36F370613ED131868AC6F9DA2420166062E
+All commands where `address` is omitted will now use the newly specified active address:
+913CF36F370613ED131868AC6F9DA2420166062E
 
+Note that if one calls a command that uses a gas object not owned by the active address,
+the address owned by the gas object is temporarily used for the transaction.
 
+### Paying For transactions with gas objects
 
-Note that if one calls a command that uses a gas object not owned by the active address, the address owned by the gas object is temporarily used for the transaction.
+All Sui transactions require a gas object for payment, as well as a budget. However, specifying
+the gas object can be cumbersome; so in the CLI, one is allowed to omit the gas object and leave
+the wallet to pick an object that meets the specified budget. This gas selection logic is currently
+rudimentary as it does not combine/split gas as needed but currently picks the first object it finds
+that meets the budget. Note that one can always specify their own gas if they want to manage the gas
+themselves.
 
-### Paying For Transactions With Gas Objects
+:warning: A gas object cannot be part of the transaction while also being used to
+pay for the transaction. For example, one cannot try to transfer gas object X while paying for the
+transaction with gas object X. The gas selection logic checks for this and rejects such cases.
 
-All Sui transactions require a gas object for payment as well as a budget. Specifying the gas object however can be cumbersome, so in the CLI one is allowed to omit the gas object and leave the wallet to pick an object that meets the specified budget. This gas selection logic is currently rudimentary as it does not combine/split gas as needed but currently picks the first object it finds which meets the budget. Note that one can always specify their own gas if they want to manage the gas themselves.
-
-One important thing to note is that a gas object cannot be part of the transation while also being used to pay for the transaction. For example one cannot try to transfer a gas object X while paying for the transaction with gas object X. The gas selection logic checks for this and rejects such cases.
-
-To check how much gas one has, use the `gas` command. Note that this command uses the `active-address`, unless otherwise specified.
+To see how much gas is in an account, use the `gas` command. Note that this command uses the
+`active-address`, unless otherwise specified.
 
 ```
 wallet --no-shell gas
@@ -307,7 +317,7 @@ wallet --no-shell gas
  F2961464AC6860A05D21B48C020B7E121399965C |     0      |   100000   
 ```
 
-If one does not want to use the active address, thr addresses can be specified
+If one does not want to use the active address, the addresses can be specified:
 
 ```
 /wallet --no-shell gas --address 562F07CF6369E8D22DBF226A5BFEDC6300014837
@@ -463,10 +473,12 @@ OPTIONS:
 
 To transfer an object to a recipient, you will need the recipient's address,
 the object ID of the object that you want to transfer,
-and optionally the gas object ID for the transaction fee payment. If a gas object is not specified, one which meets the budget is picked. Gas budget sets a cap for how much gas you want to spend.
-We are still finalizing our gas metering mechanisms. For now, just set something large enough.
+and optionally the gas object ID for the transaction fee payment. If a gas
+object is not specified, one that meets the budget is picked. Gas budget sets a
+cap for how much gas you want to spend. We are still finalizing our gas metering
+mechanisms. For now, just set something large enough.
 
-Here is an example transfer of an object to account `F456EBEF195E4A231488DF56B762AC90695BE2DD`.
+Here is an example transfer of an object to account `F456EBEF195E4A231488DF56B762AC90695BE2DD`:
 
 ```shell
 $ wallet --no-shell transfer --to C72CF3ADCC4D11C03079CEF2C8992AEA5268677A --object-id DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1 --gas-budget 100

--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -269,6 +269,23 @@ wallet --no-shell switch --address 913CF36F370613ED131868AC6F9DA2420166062E
 Active address switched to 913CF36F370613ED131868AC6F9DA2420166062E
 ```
 
+One can call for example the `objects` command with or without an address specified.
+When not specified, the active address is used
+
+```
+sui>-$ objects
+Showing 5 results.
+(0B8A4620426E526FA42995CF26EB610BFE6BF063, SequenceNumber(0), o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221)
+
+sui>-$ objects --address 913CF36F370613ED131868AC6F9DA2420166062E
+Showing 5 results.
+(0B8A4620426E526FA42995CF26EB610BFE6BF063, SequenceNumber(0), o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221)
+```
+
+All commands where `address` is omitted will now use the newly specified active address 913CF36F370613ED131868AC6F9DA2420166062E
+
+
+
 Note that if one calls a command that uses a gas object not owned by the active address, the address owned by the gas object is temporarily used for the transaction.
 
 ### Paying For Transactions With Gas Objects

--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -109,6 +109,7 @@ pub struct WalletConfig {
     pub accounts: Vec<SuiAddress>,
     pub keystore: KeystoreType,
     pub gateway: GatewayType,
+    pub active_address: Option<SuiAddress>,
 }
 
 impl Config for WalletConfig {}
@@ -118,6 +119,11 @@ impl Display for WalletConfig {
         let mut writer = String::new();
 
         writeln!(writer, "Managed addresses : {}", self.accounts.len())?;
+        write!(writer, "Active address: ")?;
+        match self.active_address {
+            Some(r) => writeln!(writer, "{}", r)?,
+            None => writeln!(writer, "None")?,
+        };
         writeln!(writer, "{}", self.keystore)?;
         write!(writer, "{}", self.gateway)?;
 

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -138,6 +138,9 @@ impl SuiCommand {
                 keystore.save(&keystore_path)?;
                 info!("Wallet keystore is stored in {:?}.", keystore_path);
 
+                // Use the first address if any
+                let active_address = accounts.get(0).copied();
+
                 let gateway_config = GatewayConfig {
                     db_folder_path,
                     authorities: network_config.get_authority_infos(),
@@ -152,6 +155,7 @@ impl SuiCommand {
                     accounts,
                     keystore: KeystoreType::File(keystore_path),
                     gateway: GatewayType::Embedded(PersistedConfig::read(&gateway_path)?),
+                    active_address,
                 };
 
                 let wallet_config = wallet_config.persisted(&wallet_path);

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-&Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeSet;
 use std::fs::read_dir;

--- a/sui/src/unit_tests/sui_network.rs
+++ b/sui/src/unit_tests/sui_network.rs
@@ -50,7 +50,7 @@ pub async fn start_test_network(
             info
         })
         .collect();
-
+    let active_address = accounts.get(0).copied();
     // Create wallet config with stated authorities port
     WalletConfig {
         accounts,
@@ -60,6 +60,7 @@ pub async fn start_test_network(
             authorities,
             ..Default::default()
         }),
+        active_address,
     }
     .persisted(&wallet_path)
     .save()?;

--- a/sui/src/wallet.rs
+++ b/sui/src/wallet.rs
@@ -68,9 +68,11 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Sync all accounts on start up.
     for address in context.config.accounts.clone() {
-        WalletCommands::SyncClientState { address }
-            .execute(&mut context)
-            .await?;
+        WalletCommands::SyncClientState {
+            address: Some(address),
+        }
+        .execute(&mut context)
+        .await?;
     }
 
     let mut out = stdout();

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use core::fmt;
+use std::collections::BTreeSet;
 use std::fmt::{Debug, Display, Formatter, Write};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -17,7 +18,7 @@ use structopt::StructOpt;
 use tracing::info;
 
 use sui_core::gateway_state::gateway_responses::{
-    MergeCoinResponse, PublishResponse, SplitCoinResponse,
+    MergeCoinResponse, PublishResponse, SplitCoinResponse, SwitchResponse,
 };
 use sui_core::gateway_state::GatewayClient;
 use sui_framework::build_move_package_to_bytes;
@@ -25,8 +26,8 @@ use sui_types::base_types::{decode_bytes_hex, ObjectID, ObjectRef, SuiAddress};
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{CertifiedTransaction, ExecutionStatus, Transaction, TransactionEffects};
 use sui_types::move_package::resolve_and_type_check;
-use sui_types::object::ObjectRead;
 use sui_types::object::ObjectRead::Exists;
+use sui_types::object::{Object, ObjectRead};
 
 use crate::config::{Config, PersistedConfig, WalletConfig};
 use crate::keystore::Keystore;
@@ -47,6 +48,18 @@ pub struct WalletOpts {
 #[structopt(rename_all = "kebab-case")]
 #[structopt(setting(AppSettings::NoBinaryName))]
 pub enum WalletCommands {
+    /// Switch active address
+    #[structopt(name = "switch")]
+    Switch {
+        /// Address to switch wallet commands to
+        #[structopt(long, parse(try_from_str = decode_bytes_hex))]
+        address: SuiAddress,
+    },
+
+    /// Default address used for commands when none specified
+    #[structopt(name = "active-address")]
+    ActiveAddress {},
+
     /// Get obj info
     #[structopt(name = "object")]
     Object {
@@ -63,8 +76,9 @@ pub enum WalletCommands {
         path: String,
 
         /// ID of the gas object for gas payment, in 20 bytes Hex string
+        /// If not provided, a gas object with at least gas_budget value will be selected
         #[structopt(long)]
-        gas: ObjectID,
+        gas: Option<ObjectID>,
 
         /// Gas budget for running module initializers
         #[structopt(long)]
@@ -92,7 +106,9 @@ pub enum WalletCommands {
         args: Vec<SuiJsonValue>,
         /// ID of the gas object for gas payment, in 20 bytes Hex string
         #[structopt(long)]
-        gas: ObjectID,
+        /// If not provided, a gas object with at least gas_budget value will be selected
+        #[structopt(long)]
+        gas: Option<ObjectID>,
         /// Gas budget for this call
         #[structopt(long)]
         gas_budget: u64,
@@ -110,8 +126,9 @@ pub enum WalletCommands {
         object_id: ObjectID,
 
         /// ID of the gas object for gas payment, in 20 bytes Hex string
+        /// If not provided, a gas object with at least gas_budget value will be selected
         #[structopt(long)]
-        gas: ObjectID,
+        gas: Option<ObjectID>,
 
         /// Gas budget for this transfer
         #[structopt(long)]
@@ -121,7 +138,7 @@ pub enum WalletCommands {
     #[structopt(name = "sync")]
     SyncClientState {
         #[structopt(long, parse(try_from_str = decode_bytes_hex))]
-        address: SuiAddress,
+        address: Option<SuiAddress>,
     },
 
     /// Obtain the Addresses managed by the wallet.
@@ -137,7 +154,7 @@ pub enum WalletCommands {
     Objects {
         /// Address owning the objects
         #[structopt(long, parse(try_from_str = decode_bytes_hex))]
-        address: SuiAddress,
+        address: Option<SuiAddress>,
     },
 
     /// Obtain all gas objects owned by the address.
@@ -145,7 +162,7 @@ pub enum WalletCommands {
     Gas {
         /// Address owning the objects
         #[structopt(long, parse(try_from_str = decode_bytes_hex))]
-        address: SuiAddress,
+        address: Option<SuiAddress>,
     },
 
     /// Split a coin object into multiple coins.
@@ -157,8 +174,9 @@ pub enum WalletCommands {
         #[structopt(long)]
         amounts: Vec<u64>,
         /// ID of the gas object for gas payment, in 20 bytes Hex string
+        /// If not provided, a gas object with at least gas_budget value will be selected
         #[structopt(long)]
-        gas: ObjectID,
+        gas: Option<ObjectID>,
         /// Gas budget for this call
         #[structopt(long)]
         gas_budget: u64,
@@ -173,8 +191,9 @@ pub enum WalletCommands {
         #[structopt(long)]
         coin_to_merge: ObjectID,
         /// ID of the gas object for gas payment, in 20 bytes Hex string
+        /// If not provided, a gas object with at least gas_budget value will be selected
         #[structopt(long)]
-        gas: ObjectID,
+        gas: Option<ObjectID>,
         /// Gas budget for this call
         #[structopt(long)]
         gas_budget: u64,
@@ -196,8 +215,9 @@ impl WalletCommands {
                 gas,
                 gas_budget,
             } => {
-                let gas_object_read = context.gateway.get_object_info(*gas).await?;
-                let gas_object = gas_object_read.object()?;
+                let gas_object = context
+                    .choose_gas_for_wallet(*gas, *gas_budget, BTreeSet::new())
+                    .await?;
                 let sender = gas_object.owner.get_owner_address()?;
                 let gas_obj_ref = gas_object.compute_object_reference();
 
@@ -234,10 +254,6 @@ impl WalletCommands {
                 gas_budget,
                 args,
             } => {
-                let gas_object_info = context.gateway.get_object_info(*gas).await?;
-                let gas_object = gas_object_info.object()?;
-                let sender = gas_object.owner.get_owner_address()?;
-
                 let package_obj_info = context.gateway.get_object_info(*package).await?;
                 let package_obj = package_obj_info.object().clone()?;
                 let package_obj_ref = package_obj_info.reference().unwrap();
@@ -262,6 +278,11 @@ impl WalletCommands {
                             .into_object()?,
                     );
                 }
+                let forbidden_gas_objects = BTreeSet::from_iter(object_ids.clone().into_iter());
+                let gas_object = context
+                    .choose_gas_for_wallet(*gas, *gas_budget, forbidden_gas_objects)
+                    .await?;
+                let sender = gas_object.owner.get_owner_address()?;
 
                 // Pass in the objects for a deeper check
                 // We can technically move this to impl MovePackage
@@ -275,12 +296,7 @@ impl WalletCommands {
                 )?;
 
                 // Fetch the object info for the gas obj
-                let gas_obj_ref = context
-                    .gateway
-                    .get_object_info(*gas)
-                    .await?
-                    .into_object()?
-                    .compute_object_reference();
+                let gas_obj_ref = gas_object.compute_object_reference();
 
                 // Fetch the objects for the object args
                 let mut object_args_refs = Vec::new();
@@ -327,15 +343,38 @@ impl WalletCommands {
                 gas,
                 gas_budget,
             } => {
-                let gas_object_info = context.gateway.get_object_info(*gas).await?;
-                let gas_object = gas_object_info.object()?;
+                let obj = context
+                    .gateway
+                    .get_object_info(*object_id)
+                    .await?
+                    .object()?
+                    .clone();
+                let forbidden_gas_objects = BTreeSet::from([*object_id]);
+
+                // If this isnt the active account, and no gas is specified, derive sender and gas from object to be sent
+                let gas_object = if context.active_address()? != obj.owner.get_owner_address()?
+                    && gas.is_none()
+                {
+                    context
+                        .gas_for_owner_budget(
+                            obj.owner.get_owner_address()?,
+                            *gas_budget,
+                            forbidden_gas_objects,
+                        )
+                        .await?
+                        .1
+                } else {
+                    context
+                        .choose_gas_for_wallet(*gas, *gas_budget, forbidden_gas_objects)
+                        .await?
+                };
                 let from = gas_object.owner.get_owner_address()?;
 
                 let time_start = Instant::now();
 
                 let data = context
                     .gateway
-                    .transfer_coin(from, *object_id, *gas, *gas_budget, *to)
+                    .transfer_coin(from, *object_id, gas_object.id(), *gas_budget, *to)
                     .await?;
                 let signature = context
                     .keystore
@@ -361,11 +400,19 @@ impl WalletCommands {
             }
 
             WalletCommands::Objects { address } => {
-                WalletCommandResult::Objects(context.gateway.get_owned_objects(*address)?)
+                let address = match address {
+                    Some(a) => *a,
+                    None => context.active_address()?,
+                };
+                WalletCommandResult::Objects(context.gateway.get_owned_objects(address)?)
             }
 
             WalletCommands::SyncClientState { address } => {
-                context.gateway.sync_account_state(*address).await?;
+                let address = match address {
+                    Some(a) => *a,
+                    None => context.active_address()?,
+                };
+                context.gateway.sync_account_state(address).await?;
                 WalletCommandResult::SyncClientState
             }
             WalletCommands::NewAddress => {
@@ -375,23 +422,17 @@ impl WalletCommands {
                 WalletCommandResult::NewAddress(address)
             }
             WalletCommands::Gas { address } => {
-                context.gateway.sync_account_state(*address).await?;
-                let object_refs = context.gateway.get_owned_objects(*address)?;
-
-                // TODO: We should ideally fetch the objects from local cache
-                let mut coins = Vec::new();
-                for (id, _, _) in object_refs {
-                    match context.gateway.get_object_info(id).await? {
-                        Exists(_, o, _) => {
-                            if matches!( o.type_(), Some(v)  if *v == GasCoin::type_()) {
-                                // Okay to unwrap() since we already checked type
-                                let gas_coin = GasCoin::try_from(o.data.try_as_move().unwrap())?;
-                                coins.push(gas_coin);
-                            }
-                        }
-                        _ => continue,
-                    }
-                }
+                let address = match address {
+                    Some(a) => *a,
+                    None => context.active_address()?,
+                };
+                let coins = context
+                    .gas_objects(address)
+                    .await?
+                    .iter()
+                    // Ok to unwrap() since `get_gas_objects` guarantees gas
+                    .map(|q| GasCoin::try_from(&q.1).unwrap())
+                    .collect();
                 WalletCommandResult::Gas(coins)
             }
             WalletCommands::SplitCoin {
@@ -400,13 +441,20 @@ impl WalletCommands {
                 gas,
                 gas_budget,
             } => {
-                let gas_object_info = context.gateway.get_object_info(*gas).await?;
-                let gas_object = gas_object_info.object()?;
+                let forbidden_gas_objects = BTreeSet::from([*coin_id]);
+                let gas_object = context
+                    .choose_gas_for_wallet(*gas, *gas_budget, forbidden_gas_objects)
+                    .await?;
                 let signer = gas_object.owner.get_owner_address()?;
-
                 let data = context
                     .gateway
-                    .split_coin(signer, *coin_id, amounts.clone(), *gas, *gas_budget)
+                    .split_coin(
+                        signer,
+                        *coin_id,
+                        amounts.clone(),
+                        gas_object.id(),
+                        *gas_budget,
+                    )
                     .await?;
                 let signature = context
                     .keystore
@@ -426,12 +474,21 @@ impl WalletCommands {
                 gas,
                 gas_budget,
             } => {
-                let gas_object_info = context.gateway.get_object_info(*gas).await?;
-                let gas_object = gas_object_info.object()?;
+                let forbidden_gas_objects = BTreeSet::from([*primary_coin, *coin_to_merge]);
+                let gas_object = context
+                    .choose_gas_for_wallet(*gas, *gas_budget, forbidden_gas_objects)
+                    .await?;
+
                 let signer = gas_object.owner.get_owner_address()?;
                 let data = context
                     .gateway
-                    .merge_coins(signer, *primary_coin, *coin_to_merge, *gas, *gas_budget)
+                    .merge_coins(
+                        signer,
+                        *primary_coin,
+                        *coin_to_merge,
+                        gas_object.id(),
+                        *gas_budget,
+                    )
                     .await?;
                 let signature = context
                     .keystore
@@ -445,6 +502,17 @@ impl WalletCommands {
                     .to_merge_coin_response()?;
 
                 WalletCommandResult::MergeCoin(response)
+            }
+            WalletCommands::Switch { address } => {
+                if !context.config.accounts.contains(address) {
+                    return Err(anyhow!("Address {} not managed by wallet", address));
+                }
+                context.config.active_address = Some(*address);
+                context.config.save()?;
+                WalletCommandResult::Switch(SwitchResponse { address: *address })
+            }
+            WalletCommands::ActiveAddress {} => {
+                WalletCommandResult::ActiveAddress(context.active_address().ok())
             }
         });
         // Sync all managed addresses
@@ -489,6 +557,97 @@ impl WalletContext {
             gateway,
         };
         Ok(context)
+    }
+    pub fn active_address(&mut self) -> Result<SuiAddress, anyhow::Error> {
+        if self.config.accounts.is_empty() {
+            return Err(anyhow!(
+                "No managed addresses. Create new address with `new-address` command."
+            ));
+        }
+
+        // Ok to unwrap because we checked that config addresses not empty
+        // Set it if not exists
+        self.config.active_address = Some(
+            self.config
+                .active_address
+                .unwrap_or(*self.config.accounts.get(0).unwrap()),
+        );
+
+        Ok(self.config.active_address.unwrap())
+    }
+
+    /// Get all the gas objects (and conveniently, gas amounts) for the address
+    pub async fn gas_objects(
+        &mut self,
+        address: SuiAddress,
+    ) -> Result<Vec<(u64, Object)>, anyhow::Error> {
+        let object_refs = self.gateway.get_owned_objects(address)?;
+
+        // TODO: We should ideally fetch the objects from local cache
+        let mut values_objects = Vec::new();
+        for (id, _, _) in object_refs {
+            match self.gateway.get_object_info(id).await? {
+                Exists(_, o, _) => {
+                    if matches!( o.type_(), Some(v)  if *v == GasCoin::type_()) {
+                        // Okay to unwrap() since we already checked type
+                        let gas_coin = GasCoin::try_from(o.data.try_as_move().unwrap())?;
+                        values_objects.push((gas_coin.value(), o));
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(values_objects)
+    }
+
+    /// Choose ideal gas object based on the budget and provided gas if any
+    async fn choose_gas_for_wallet(
+        &mut self,
+        specified_gas: Option<ObjectID>,
+        budget: u64,
+        forbidden_gas_objects: BTreeSet<ObjectID>,
+    ) -> Result<Object, anyhow::Error> {
+        Ok(match specified_gas {
+            None => {
+                let addr = self.active_address()?;
+                self.gas_for_owner_budget(addr, budget, forbidden_gas_objects)
+                    .await?
+                    .1
+            }
+            Some(g) => {
+                if forbidden_gas_objects.contains(&g) {
+                    return Err(anyhow!(
+                        "Gas {} cannot be used as payment and in transaction input",
+                        g
+                    ));
+                }
+
+                let gas_object_read = self.gateway.get_object_info(g).await?;
+                // You could technically try to pay with a gas not owned by user.
+                // Especially if one forgets to switch account
+                // Allow it still
+                gas_object_read.object()?.clone()
+            }
+        })
+    }
+
+    /// Find a gas object which fits the budget
+    pub async fn gas_for_owner_budget(
+        &mut self,
+        address: SuiAddress,
+        budget: u64,
+        forbidden_gas_objects: BTreeSet<ObjectID>,
+    ) -> Result<(u64, Object), anyhow::Error> {
+        for o in self.gas_objects(address).await.unwrap() {
+            if o.0 >= budget && !forbidden_gas_objects.contains(&o.1.id()) {
+                return Ok(o);
+            }
+        }
+        return Err(anyhow!(
+            "No non-argument gas objects found with value >= budget {}",
+            budget
+        ));
     }
 }
 
@@ -554,6 +713,15 @@ impl Display for WalletCommandResult {
             }
             WalletCommandResult::MergeCoin(response) => {
                 write!(writer, "{}", response)?;
+            }
+            WalletCommandResult::Switch(response) => {
+                write!(writer, "{}", response)?;
+            }
+            WalletCommandResult::ActiveAddress(response) => {
+                match response {
+                    Some(r) => write!(writer, "{}", r)?,
+                    None => write!(writer, "None")?,
+                };
             }
         }
         write!(f, "{}", writer)
@@ -628,4 +796,6 @@ pub enum WalletCommandResult {
     Gas(Vec<GasCoin>),
     SplitCoin(SplitCoinResponse),
     MergeCoin(MergeCoinResponse),
+    Switch(SwitchResponse),
+    ActiveAddress(Option<SuiAddress>),
 }

--- a/sui_core/src/gateway_state/gateway_responses.rs
+++ b/sui_core/src/gateway_state/gateway_responses.rs
@@ -9,7 +9,7 @@ use serde::ser::Error;
 use serde::Serialize;
 
 use serde::Deserialize;
-use sui_types::base_types::ObjectRef;
+use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::error::SuiError;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{CertifiedTransaction, TransactionEffects};
@@ -149,6 +149,20 @@ impl Display for PublishResponse {
         }
         let gas_coin = GasCoin::try_from(&self.updated_gas).map_err(fmt::Error::custom)?;
         writeln!(writer, "Updated Gas : {}", gas_coin)?;
+        write!(f, "{}", writer)
+    }
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct SwitchResponse {
+    /// Active address
+    pub address: SuiAddress,
+}
+
+impl Display for SwitchResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut writer = String::new();
+        writeln!(writer, "Active address switched to {}", self.address)?;
         write!(f, "{}", writer)
     }
 }


### PR DESCRIPTION
**Note**: Most of the code is tests due to code coverage reqs. The core logic is in `wallet_commands.rs`

This PR simplifies using the CLI by letting one omit certain fields which can be inferred or stored/re-used.


Two main changes:
## 1. Allows omitting the `address` field in most cases. 
This is because we can now set the `active-address` and `switch`addresses as needed.

This shows the active/default address
```
sui>-$ active-address
913CF36F370613ED131868AC6F9DA2420166062E
```
One can call for example the `objects` command with or without an address specified.
When not specified, the active address is used

```
sui>-$ objects
Showing 5 results.
(0B8A4620426E526FA42995CF26EB610BFE6BF063, SequenceNumber(0), o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221)

sui>-$ objects --address 913CF36F370613ED131868AC6F9DA2420166062E
Showing 5 results.
(0B8A4620426E526FA42995CF26EB610BFE6BF063, SequenceNumber(0), o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221)

```

To switch the active address, use the `switch` command
```
sui>-$ switch --address 913CF36F370613ED131868AC6F9DA2420166062E
Active address switched to 913CF36F370613ED131868AC6F9DA2420166062E
```

## 2. Allows omitting the gas object. 
This lets the wallet pick one that meets the budget

Example
```
sui>-$ transfer --to C6D75CF6AB0DCE6DDFB0B8AF560326275BD40942 --object-id 3C0763CCDEA4FF5A4557505A62AB5E1DAF91F4A2 --gas-budget 100
Transfer confirmed after 8997 us
----- Certificate ----
Signed Authorities : [k#ade0d0a5203ee66e4882e0a5b72157b301707820291f8b5ba3960b120bfbf9cc, k#fbbc43c880396e35ec94f000ccecec575ac497c24d7dbe0ffa2719f8957b53fa, k#34274bff2f6bc70ad0ee01b26330e74b8df4d0cf34855751f899fbdf20e12c1c]
Transaction Kind : Transfer
Recipient : C6D75CF6AB0DCE6DDFB0B8AF560326275BD40942
Object ID : 3C0763CCDEA4FF5A4557505A62AB5E1DAF91F4A2
Sequence Number : SequenceNumber(0)
Object Digest : 701258e1c36cbb30914965d02be1970f21c02e2c26a665eb308e2e6abbdc5494

----- Transaction Effects ----
Status : Success { gas_used: 18, results: [] }
Mutated Objects:
0B8A4620426E526FA42995CF26EB610BFE6BF063 SequenceNumber(1) o#ee948946891888e496d78305f520ef00d4443075ed1112cc6498268fe0ecf32c
3C0763CCDEA4FF5A4557505A62AB5E1DAF91F4A2 SequenceNumber(1) o#c6b05cf8e61e3d6dcf68eaadd6a1fc50a55ddb4fe4e8efc041a25fe38e090862
```

Gas selection algorithm will be fleshed out and handled in issue https://github.com/MystenLabs/sui/issues/1150