### PR TITLE
Bump Move version

### DIFF
--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -33,6 +33,7 @@ serde-value = "0.7.0"
 serde-name = "0.2.0"
 log = "0.4.14"
 dirs = "4.0.0"
+clap = { version = "3", features = ["derive"] }
 telemetry_subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a45af6dc28aa12c8cc13521d118c24aadd4c6adf" }
 
 bcs = "0.1.3"
@@ -53,12 +54,12 @@ http = "0.2.6"
 hyper = "0.14.17"
 schemars = "0.8.8"
 
-move-package = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-core-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a", features = ["address20"] }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-unit-test = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-package = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-core-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090", features = ["address20"] }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-unit-test = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
 
 once_cell = "1.9.0"
 reqwest = { version = "0.11.10", features=["json","serde_json", "blocking"]}

--- a/sui/src/sui-move.rs
+++ b/sui/src/sui-move.rs
@@ -1,25 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::*;
 use colored::Colorize;
 use move_unit_test::UnitTestingConfig;
 use std::path::Path;
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case")]
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
 pub enum MoveCommands {
     /// Build and verify Move project
-    #[structopt(name = "build")]
+    #[clap(name = "build")]
     Build {
         /// Whether we are printing in hex.
-        #[structopt(long)]
+        #[clap(long)]
         dump_bytecode_as_hex: bool,
     },
 
     /// Run all Move unit tests
-    #[structopt(name = "test")]
+    #[clap(name = "test")]
     Test(UnitTestingConfig),
 }
 
@@ -57,27 +56,26 @@ impl MoveCommands {
     }
 }
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     name = "Sui Move Development Tool",
     about = "Tool to build and test Move applications",
     rename_all = "kebab-case"
 )]
 struct MoveOpt {
     /// Path to the Move project root.
-    #[structopt(long, default_value = "./")]
+    #[clap(long, default_value = "./")]
     path: String,
     /// Whether we are building/testing the std/framework code.
-    #[structopt(long)]
+    #[clap(long)]
     std: bool,
     /// Subcommands.
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: MoveCommands,
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    let app: App = MoveOpt::clap();
-    let options = MoveOpt::from_clap(&app.get_matches());
+    let options = MoveOpt::parse();
     let path = options.path;
     options.cmd.execute(path.as_ref(), options.std)
 }

--- a/sui/src/unit_tests/data/custom_genesis_package_1/Move.toml
+++ b/sui/src/unit_tests/data/custom_genesis_package_1/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../../../../sui_programmability/framework" }
 
 [addresses]
 Examples = "0x0"
-
-[dev-addresses]
-Examples = "0x0"

--- a/sui/src/unit_tests/data/dummy_modules_publish/Move.toml
+++ b/sui/src/unit_tests/data/dummy_modules_publish/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../../../../sui_programmability/framework" }
 
 [addresses]
 Examples = "0x0"
-
-[dev-addresses]
-Examples = "0x0"

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -31,12 +31,12 @@ sui-framework = { path = "../sui_programmability/framework" }
 sui-network = { path = "../network_utils" }
 sui-types = { path = "../sui_types" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-core-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a", features = ["address20"] }
-move-package = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-core-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090", features = ["address20"] }
+move-package = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "e44bca4513a6ff6c97399cd79e82e4bc00571ac3"}
 

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -53,3 +53,6 @@ test_utils = { path = "../test_utils" }
 name = "generate-format"
 path = "src/generate_format.rs"
 test = false
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["structopt"]

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -42,8 +42,6 @@ typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "e44bc
 
 [dev-dependencies]
 fdlimit = "0.2.1"
-naughty-strings = "0.2.4"
-similar-asserts = "1.2.0"
 serde-reflection = "0.3.5"
 serde_yaml = "0.8.23"
 pretty_assertions = "1.2.0"

--- a/sui_core/src/unit_tests/data/hero/Move.toml
+++ b/sui_core/src/unit_tests/data/hero/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../../../../sui_programmability/framework" }
 
 [addresses]
 Examples = "0x0"
-
-[dev-addresses]
-Examples = "0x0"

--- a/sui_core/src/unit_tests/data/object_owner/Move.toml
+++ b/sui_core/src/unit_tests/data/object_owner/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../../../../sui_programmability/framework" }
 
 [addresses]
 ObjectOwner = "0x0"
-
-[dev-addresses]
-ObjectOwner = "0x0"

--- a/sui_core/src/unit_tests/data/object_wrapping/Move.toml
+++ b/sui_core/src/unit_tests/data/object_wrapping/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../../../../sui_programmability/framework" }
 
 [addresses]
 ObjectWrapping = "0x0"
-
-[dev-addresses]
-ObjectWrapping = "0x0"

--- a/sui_programmability/adapter/Cargo.toml
+++ b/sui_programmability/adapter/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 anyhow = "1.0.55"
 bcs = "0.1.3"
 once_cell = "1.9.0"
-structopt = "0.3.26"
 parking_lot = "0.12.0"
 
 move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }

--- a/sui_programmability/adapter/Cargo.toml
+++ b/sui_programmability/adapter/Cargo.toml
@@ -14,17 +14,17 @@ once_cell = "1.9.0"
 structopt = "0.3.26"
 parking_lot = "0.12.0"
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-core-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a", features = ["address20"] }
-move-cli = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-core-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090", features = ["address20"] }
+move-cli = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
 
 sui-framework = { path = "../framework" }
 sui-verifier = { path = "../verifier" }
 sui-types = { path = "../../sui_types" }
 
 [dev-dependencies]
-move-package = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-package = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use crate::bytecode_rewriter::ModuleHandleRewriter;
 use move_binary_format::{
-    access::ModuleAccess, errors::PartialVMResult, file_format::CompiledModule, normalized::Type,
+    access::ModuleAccess, errors::PartialVMResult, file_format::CompiledModule,
 };
 use sui_framework::EventType;
 use sui_types::{
@@ -27,8 +27,9 @@ use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     resolver::{ModuleResolver, ResourceResolver},
+    value::MoveTypeLayout,
 };
-use move_vm_runtime::{native_functions::NativeFunctionTable, session::ExecutionResult};
+use move_vm_runtime::{native_functions::NativeFunctionTable, session::SerializedReturnValues};
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, HashMap, HashSet},
@@ -125,7 +126,7 @@ pub fn execute<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
         args,
         mutable_ref_objects,
         by_value_objects,
-        return_types,
+        return_types: _,
     } = resolve_and_type_check(
         &cached_package,
         module,
@@ -149,7 +150,6 @@ pub fn execute<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
         object_owner_map,
         gas_status,
         ctx,
-        return_types,
     )
 }
 
@@ -171,27 +171,31 @@ fn execute_internal<
     object_owner_map: HashMap<SuiAddress, SuiAddress>,
     gas_status: &mut SuiGasStatus, // gas status for the current call operation
     ctx: &mut TxContext,
-    return_types: Vec<Type>,
 ) -> SuiResult<Vec<CallResult>> {
-    let session = vm.movevm.new_session(state_view);
-    match session.execute_function_for_effects(
-        module_id,
-        function,
-        type_args,
-        args,
-        gas_status.get_move_gas_status(),
-    ) {
-        ExecutionResult::Success {
-            change_set,
-            events,
-            return_values,
-            mut mutable_ref_values,
-            gas_used: _,
-        } => {
+    let mut session = vm.movevm.new_session(state_view);
+    let mut move_gas_status = gas_status.get_move_gas_status();
+    let result = session
+        .execute_function_bypass_visibility(
+            module_id,
+            function,
+            type_args,
+            args,
+            &mut move_gas_status,
+        )
+        .and_then(|ret| Ok((ret, session.finish()?)));
+
+    match result {
+        Ok((
+            SerializedReturnValues {
+                mut mutable_reference_outputs,
+                return_values,
+            },
+            (change_set, events),
+        )) => {
             // Sui Move programs should never touch global state, so ChangeSet should be empty
             debug_assert!(change_set.accounts().is_empty());
             // Input ref parameters we put in should be the same number we get out, plus one for the &mut TxContext
-            debug_assert!(mutable_ref_objects.len() + 1 == mutable_ref_values.len());
+            debug_assert!(mutable_ref_objects.len() + 1 == mutable_reference_outputs.len());
 
             // When this function is used during publishing, it
             // may be executed several times, with objects being
@@ -200,13 +204,15 @@ fn execute_internal<
             // reflects what happened each time we call into the
             // Move VM (e.g. to account for the number of created
             // objects).
-            let ctx_bytes = mutable_ref_values.pop().unwrap();
-            let updated_ctx: TxContext = bcs::from_bytes(ctx_bytes.as_slice()).unwrap();
+            let (_, ctx_bytes, _) = mutable_reference_outputs.pop().unwrap();
+            let updated_ctx: TxContext = bcs::from_bytes(&ctx_bytes).unwrap();
             ctx.update_state(updated_ctx)?;
 
-            let mutable_refs = mutable_ref_objects
-                .into_iter()
-                .zip(mutable_ref_values.into_iter());
+            let mutable_refs = mutable_ref_objects.into_iter().zip(
+                mutable_reference_outputs
+                    .into_iter()
+                    .map(|(_local_idx, bytes, _layout)| bytes),
+            );
             process_successful_execution(
                 state_view,
                 by_value_objects,
@@ -215,84 +221,69 @@ fn execute_internal<
                 ctx,
                 object_owner_map,
             )?;
-            Ok(process_return_values(&return_values, &return_types))
+            Ok(process_return_values(&return_values))
         }
         // charge for all computations so far
-        ExecutionResult::Fail { error, gas_used: _ } => Err(SuiError::AbortedExecution {
+        Err(error) => Err(SuiError::AbortedExecution {
             error: error.to_string(),
         }),
     }
 }
 
-fn process_return_values(values: &[Vec<u8>], return_types: &[Type]) -> Vec<CallResult> {
-    let mut results = vec![];
-    debug_assert!(values.len() == return_types.len());
+fn process_return_values(return_values: &[(Vec<u8>, MoveTypeLayout)]) -> Vec<CallResult> {
+    return_values
+        .iter()
+        .filter_map(|(bytes, ty_layout)| {
+            Some(match ty_layout {
+                // debug_assert-s for missing arms should be OK here as we
+                // already checked in
+                // MovePackage::check_and_get_entry_function that no other
+                // types can exist in the signature
 
-    for (idx, r) in return_types.iter().enumerate() {
-        match r {
-            // debug_assert-s for missing arms should be OK here as we
-            // already checked in
-            // MovePackage::check_and_get_entry_function that no other
-            // types can exist in the signature
-
-            // see CallResults struct comments for why this is
-            // implemented the way it is
-            Type::Bool => results.push(CallResult::Bool(
-                bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-            )),
-            Type::U8 => results.push(CallResult::U8(
-                bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-            )),
-            Type::U64 => results.push(CallResult::U64(
-                bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-            )),
-            Type::U128 => results.push(CallResult::U128(
-                bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-            )),
-            Type::Address => results.push(CallResult::Address(
-                bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-            )),
-            Type::Vector(t) => match &**t {
-                Type::Bool => results.push(CallResult::BoolVec(
-                    bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                )),
-                Type::U8 => results.push(CallResult::U8Vec(
-                    bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                )),
-                Type::U64 => results.push(CallResult::U64Vec(
-                    bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                )),
-                Type::U128 => results.push(CallResult::U128Vec(
-                    bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                )),
-                Type::Address => results.push(CallResult::AddrVec(
-                    bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                )),
-                Type::Vector(inner_t) => match &**inner_t {
-                    Type::Bool => results.push(CallResult::BoolVecVec(
-                        bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                    )),
-                    Type::U8 => results.push(CallResult::U8VecVec(
-                        bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                    )),
-                    Type::U64 => results.push(CallResult::U64VecVec(
-                        bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                    )),
-                    Type::U128 => results.push(CallResult::U128VecVec(
-                        bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                    )),
-                    Type::Address => results.push(CallResult::AddrVecVec(
-                        bcs::from_bytes(values.get(idx).unwrap()).unwrap(),
-                    )),
-                    _ => debug_assert!(false),
+                // see CallResults struct comments for why this is
+                // implemented the way it is
+                MoveTypeLayout::Bool => CallResult::Bool(bcs::from_bytes(bytes).unwrap()),
+                MoveTypeLayout::U8 => CallResult::U8(bcs::from_bytes(bytes).unwrap()),
+                MoveTypeLayout::U64 => CallResult::U64(bcs::from_bytes(bytes).unwrap()),
+                MoveTypeLayout::U128 => CallResult::U128(bcs::from_bytes(bytes).unwrap()),
+                MoveTypeLayout::Address => CallResult::Address(bcs::from_bytes(bytes).unwrap()),
+                MoveTypeLayout::Vector(t) => match &**t {
+                    MoveTypeLayout::Bool => CallResult::BoolVec(bcs::from_bytes(bytes).unwrap()),
+                    MoveTypeLayout::U8 => CallResult::U8Vec(bcs::from_bytes(bytes).unwrap()),
+                    MoveTypeLayout::U64 => CallResult::U64Vec(bcs::from_bytes(bytes).unwrap()),
+                    MoveTypeLayout::U128 => CallResult::U128Vec(bcs::from_bytes(bytes).unwrap()),
+                    MoveTypeLayout::Address => CallResult::AddrVec(bcs::from_bytes(bytes).unwrap()),
+                    MoveTypeLayout::Vector(inner_t) => match &**inner_t {
+                        MoveTypeLayout::Bool => {
+                            CallResult::BoolVecVec(bcs::from_bytes(bytes).unwrap())
+                        }
+                        MoveTypeLayout::U8 => CallResult::U8VecVec(bcs::from_bytes(bytes).unwrap()),
+                        MoveTypeLayout::U64 => {
+                            CallResult::U64VecVec(bcs::from_bytes(bytes).unwrap())
+                        }
+                        MoveTypeLayout::U128 => {
+                            CallResult::U128VecVec(bcs::from_bytes(bytes).unwrap())
+                        }
+                        MoveTypeLayout::Address => {
+                            CallResult::AddrVecVec(bcs::from_bytes(bytes).unwrap())
+                        }
+                        _ => {
+                            debug_assert!(false);
+                            return None;
+                        }
+                    },
+                    _ => {
+                        debug_assert!(false);
+                        return None;
+                    }
                 },
-                _ => debug_assert!(false),
-            },
-            _ => debug_assert!(false),
-        }
-    }
-
-    results
+                _ => {
+                    debug_assert!(false);
+                    return None;
+                }
+            })
+        })
+        .collect()
 }
 
 pub fn publish<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error = E> + Storage>(
@@ -375,7 +366,6 @@ fn init_modules<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error 
             HashMap::new(),
             gas_status,
             ctx,
-            vec![], // no return types for module initializers
         )?;
     }
     Ok(())

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -173,14 +173,13 @@ fn execute_internal<
     ctx: &mut TxContext,
 ) -> SuiResult<Vec<CallResult>> {
     let mut session = vm.movevm.new_session(state_view);
-    let mut move_gas_status = gas_status.get_move_gas_status();
     let result = session
         .execute_function_bypass_visibility(
             module_id,
             function,
             type_args,
             args,
-            &mut move_gas_status,
+            gas_status.get_move_gas_status(),
         )
         .and_then(|ret| Ok((ret, session.finish()?)));
 

--- a/sui_programmability/examples/basics/Move.toml
+++ b/sui_programmability/examples/basics/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../framework" }
 
 [addresses]
 Basics = "0x0"
-
-[dev-addresses]
-Basics = "0x0"

--- a/sui_programmability/examples/defi/Move.toml
+++ b/sui_programmability/examples/defi/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../framework" }
 
 [addresses]
 DeFi = "0x0"
-
-[dev-addresses]
-DeFi = "0x0"

--- a/sui_programmability/examples/fungible_tokens/Move.toml
+++ b/sui_programmability/examples/fungible_tokens/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../framework" }
 
 [addresses]
 FungibleTokens = "0x0"
-
-[dev-addresses]
-FungibleTokens = "0x0"

--- a/sui_programmability/examples/games/Move.toml
+++ b/sui_programmability/examples/games/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../framework" }
 
 [addresses]
 Games = "0x0"
-
-[dev-addresses]
-Games = "0x0"

--- a/sui_programmability/examples/games/hero/Move.toml
+++ b/sui_programmability/examples/games/hero/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../../framework" }
 
 [addresses]
 HeroGame = "0x0"
-
-[dev-addresses]
-HeroGame = "0x0"

--- a/sui_programmability/examples/nfts/Move.toml
+++ b/sui_programmability/examples/nfts/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../../framework" }
 
 [addresses]
 NFTs = "0x0"
-
-[dev-addresses]
-NFTs = "0x0"

--- a/sui_programmability/framework/Cargo.toml
+++ b/sui_programmability/framework/Cargo.toml
@@ -15,15 +15,15 @@ num_enum = "0.5.6"
 sui-types = { path = "../../sui_types" }
 sui-verifier = { path = "../verifier" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-cli = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-core-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a", features = ["address20"] }
-move-package = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-stdlib = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-unit-test = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-cli = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-core-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090", features = ["address20"] }
+move-package = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-stdlib = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-unit-test = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
 
 
 [package.metadata.cargo-udeps.ignore]

--- a/sui_programmability/framework/Move.toml
+++ b/sui_programmability/framework/Move.toml
@@ -10,6 +10,3 @@ MoveStdlib = { local = "deps/move-stdlib" }
 
 [addresses]
 Sui = "0x2"
-
-[dev-addresses]
-Sui = "0x2"

--- a/sui_programmability/framework/deps/move-stdlib/Move.toml
+++ b/sui_programmability/framework/deps/move-stdlib/Move.toml
@@ -4,6 +4,3 @@ version = "1.5.0"
 
 [addresses]
 Std = "0x1"
-
-[dev-addresses]
-Std = "0x1"

--- a/sui_programmability/framework/src/lib.rs
+++ b/sui_programmability/framework/src/lib.rs
@@ -6,10 +6,11 @@ use move_core_types::{account_address::AccountAddress, ident_str, language_stora
 use move_package::BuildConfig;
 use move_unit_test::UnitTestingConfig;
 use num_enum::TryFromPrimitive;
-use std::collections::HashSet;
-use std::path::Path;
-use sui_types::base_types::encode_bytes_hex;
-use sui_types::error::{SuiError, SuiResult};
+use std::{collections::HashSet, path::Path};
+use sui_types::{
+    base_types::encode_bytes_hex,
+    error::{SuiError, SuiResult},
+};
 use sui_verifier::verifier as sui_bytecode_verifier;
 
 #[cfg(test)]
@@ -214,7 +215,7 @@ pub fn run_move_unit_tests(path: &Path, config: Option<UnitTestingConfig>) -> Su
         /* compute_coverage */ false,
     )
     .map_err(|err| SuiError::MoveUnitTestFailure {
-        error: err.to_string(),
+        error: format!("{:?}", err),
     })?;
     if result == UnitTestResult::Failure {
         Err(SuiError::MoveUnitTestFailure {

--- a/sui_programmability/tutorial/Move.toml
+++ b/sui_programmability/tutorial/Move.toml
@@ -7,6 +7,3 @@ Sui = { local = "../framework" }
 
 [addresses]
 MyFirstPackage = "0x0"
-
-[dev-addresses]
-MyFirstPackage = "0x0"

--- a/sui_programmability/verifier/Cargo.toml
+++ b/sui_programmability/verifier/Cargo.toml
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-core-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a", features = ["address20"] }
-move-disassembler = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-ir-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-core-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090", features = ["address20"] }
+move-disassembler = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-ir-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
 
 sui-types = { path = "../../sui_types" }

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -31,11 +31,11 @@ parking_lot = "0.12.0"
 name_variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "97a056f85555fa2afe497d6abb7cf6bf8faa63cf" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "e44bca4513a6ff6c97399cd79e82e4bc00571ac3" }
 
-move-binary-format = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-core-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a", features = ["address20"] }
-move-disassembler = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-ir-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "2ef516919d5bbc728a57a2c0073b85c46d9fcf5a" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-core-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090", features = ["address20"] }
+move-disassembler = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-ir-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "63bd52e0f5b02711d29a678e6f946b3d429f2090" }
 
 sha2 = "0.10.2"


### PR DESCRIPTION
- Brings in adapter changes and fileformat V5 (WIP)
- Various Move packages  now use clap instead of structopt