### PR TITLE
[Gas Metering] More accurate object size calculation

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -148,7 +148,7 @@ impl AuthorityState {
         // fetching only unique objects.
         let total_size = all_objects
             .iter()
-            .map(|(_, obj)| obj.object_data_size())
+            .map(|(_, obj)| obj.object_size_for_gas_metering())
             .sum();
         gas_status.charge_storage_read(total_size)?;
 

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -125,9 +125,9 @@ impl<S> AuthorityTemporaryStore<S> {
         for (object_id, (_object_ref, object)) in &self.written {
             // Objects in written can be either mutation or creation.
             // We figure it out by looking them up in `self.objects`.
-            let object_size = object.object_data_size();
+            let object_size = object.object_size_for_gas_metering();
             let old_object_size = if let Some(old_obj) = self.objects.get(object_id) {
-                old_obj.object_data_size()
+                old_obj.object_size_for_gas_metering()
             } else {
                 0
             };
@@ -139,7 +139,7 @@ impl<S> AuthorityTemporaryStore<S> {
             // object was unwrapped and then deleted. The rebate would have been provided already when
             // mutating the object that wrapped this object.
             if let Some(old_obj) = self.objects.get(object_id) {
-                gas_status.charge_storage_mutation(old_obj.object_data_size(), 0)?;
+                gas_status.charge_storage_mutation(old_obj.object_size_for_gas_metering(), 0)?;
             }
         }
         // Also charge gas for mutating the gas object in advance.

--- a/sui_core/src/execution_engine.rs
+++ b/sui_core/src/execution_engine.rs
@@ -133,7 +133,7 @@ fn execute_transaction<S: BackingPackageStore>(
     }
     temporary_store.ensure_active_inputs_mutated();
     if let Err(err) = temporary_store
-        .charge_gas_for_storage_changes(&mut gas_status, gas_object.object_data_size())
+        .charge_gas_for_storage_changes(&mut gas_status, gas_object.object_size_for_gas_metering())
     {
         result = Err(err);
     }

--- a/sui_core/src/unit_tests/gas_tests.rs
+++ b/sui_core/src/unit_tests/gas_tests.rs
@@ -106,6 +106,8 @@ async fn test_native_transfer_sufficient_gas() -> SuiResult {
     let mut gas_status = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET);
     gas_status.charge_min_tx_gas()?;
 
+    // Both the object to be transferred and the gas object will be read
+    // from the store. Hence we need to charge for 2 reads.
     gas_status.charge_storage_read(
         object.object_size_for_gas_metering() + gas_object.object_size_for_gas_metering(),
     )?;

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -167,7 +167,7 @@ impl MoveObject {
     /// Approximate size of the object in bytes. This is used for gas metering.
     /// For the type tag field, we serialize it on the spot to get the accurate size.
     /// This should not be very expensive since the type tag is usually simple, and
-    /// we only do this once perf object being mutated.
+    /// we only do this once per object being mutated.
     pub fn object_size_for_gas_metering(&self) -> usize {
         let seriealized_type_tag =
             bcs::to_bytes(&self.type_).expect("Serializing type tag should not fail");


### PR DESCRIPTION
We need object size to properly calculate both of the computation cost and storage cost.
We could try to serialize the object to bytes and look at the serialized size, but that's too costly and we don't need to be that accurate. We should focus on what brings most of the size and that should be sufficient.
This PR looks at the size of all metadata and vectors and strings in the objects.