### PR TITLE
Revert serde changes to SuiAddress, TransactionDigest and ObjectDigest

### DIFF
--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -274,7 +274,7 @@ Object:
     - previous_transaction:
         TYPENAME: TransactionDigest
 ObjectDigest:
-  NEWTYPESTRUCT: STR
+  NEWTYPESTRUCT: BYTES
 ObjectFormatOptions:
   STRUCT:
     - include_types: BOOL
@@ -434,7 +434,7 @@ StructTag:
         SEQ:
           TYPENAME: TypeTag
 SuiAddress:
-  NEWTYPESTRUCT: STR
+  NEWTYPESTRUCT: BYTES
 SuiError:
   ENUM:
     0:
@@ -768,7 +768,7 @@ TransactionData:
           - TYPENAME: ObjectDigest
     - gas_budget: U64
 TransactionDigest:
-  NEWTYPESTRUCT: STR
+  NEWTYPESTRUCT: BYTES
 TransactionEffects:
   STRUCT:
     - status:

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -13,9 +13,8 @@ use move_core_types::identifier::IdentStr;
 use opentelemetry::{global, Context};
 use rand::Rng;
 use serde::{de::Error as _, Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::hex::Hex;
 use serde_with::serde_as;
+use serde_with::Bytes;
 use sha3::Sha3_256;
 
 use crate::crypto::PublicKeyBytes;
@@ -45,7 +44,7 @@ pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 pub const SUI_ADDRESS_LENGTH: usize = ObjectID::LENGTH;
 #[serde_as]
 #[derive(Eq, Default, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct SuiAddress(#[serde_as(as = "Hex")] [u8; SUI_ADDRESS_LENGTH]);
+pub struct SuiAddress(#[serde_as(as = "Bytes")] [u8; SUI_ADDRESS_LENGTH]);
 
 impl SuiAddress {
     pub fn to_vec(&self) -> Vec<u8> {
@@ -136,11 +135,11 @@ pub const OBJECT_DIGEST_LENGTH: usize = 32;
 /// A transaction will have a (unique) digest.
 #[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct TransactionDigest(#[serde_as(as = "Base64")] [u8; TRANSACTION_DIGEST_LENGTH]);
+pub struct TransactionDigest(#[serde_as(as = "Bytes")] [u8; TRANSACTION_DIGEST_LENGTH]);
 // Each object has a unique digest
 #[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct ObjectDigest(#[serde_as(as = "Base64")] pub [u8; OBJECT_DIGEST_LENGTH]);
+pub struct ObjectDigest(#[serde_as(as = "Bytes")] pub [u8; 32]); // We use SHA3-256 hence 32 bytes here
 
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("TxContext");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = TX_CONTEXT_MODULE_NAME;


### PR DESCRIPTION
The serde changes to these object is causing unexpected issues in DB and network.

Reverting the changes for now, we will look for different solution for human readable json responses.