### PR TITLE
Use a different client_db path for rest server

### DIFF
--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -133,6 +133,19 @@ As the name suggests, embedded gateway embeds the gateway logic into the applica
 all data will be stored locally and the application will make direct
 connection to the authorities.
 
+#### Rest Gateway
+You can also connect the wallet to the Sui network via a [Rest Gateway](rest-api.md#start-local-rest-server);
+To use the rest gateway, update `wallet.conf`'s `gateway` section to:
+```json
+{ 
+  ...
+  "gateway": {
+    "rest":"http://127.0.0.1:5001"
+  },
+  ...
+}
+```
+
 ### Key management
 
 The key pairs are stored in `wallet.key`. However, this is not secure


### PR DESCRIPTION
* Changed genesis code to produce gateway.conf with a different client_db path for rest server - sharing the same client_db path will prevent running the wallet and rest_server at the same time.
* Update wallet doc with descriptions of how to connect to the rest server