### PR TITLE
[Gas Metering] Add `storage_rebate` to `Object` and introduce gas price

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -127,7 +127,8 @@ impl AuthorityState {
             object_id: gas_payment_id,
         })?;
         gas::check_gas_balance(&gas_object, gas_budget)?;
-        let gas_status = gas::start_gas_metering(gas_budget)?;
+        // TODO: Pass in real computation gas unit price and storage gas unit price.
+        let gas_status = gas::start_gas_metering(gas_budget, 1, 1)?;
         Ok((gas_object, gas_status))
     }
 

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -222,7 +222,8 @@ where
     ) -> SuiResult<(Object, SuiGasStatus<'_>)> {
         let gas_object = self.get_object(&gas_payment_id).await?;
         gas::check_gas_balance(&gas_object, gas_budget)?;
-        let gas_status = gas::start_gas_metering(gas_budget)?;
+        // TODO: Pass in real computation gas unit price and storage gas unit price.
+        let gas_status = gas::start_gas_metering(gas_budget, 1, 1)?;
         Ok((gas_object, gas_status))
     }
 

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -1416,15 +1416,8 @@ async fn shared_object() {
         use sui_types::object::MoveObject;
 
         let content = GasCoin::new(shared_object_id, SequenceNumber::new(), 10);
-        let data = Data::Move(MoveObject::new(
-            /* type */ GasCoin::type_(),
-            content.to_bcs_bytes(),
-        ));
-        Object {
-            data,
-            owner: Owner::SharedMutable,
-            previous_transaction: TransactionDigest::genesis(),
-        }
+        let obj = MoveObject::new(/* type */ GasCoin::type_(), content.to_bcs_bytes());
+        Object::new_move(obj, Owner::SharedMutable, TransactionDigest::genesis())
     };
 
     let authority = init_state_with_objects(vec![gas_object, shared_object]).await;

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -17,7 +17,7 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
     CertifiedTransaction, SignatureAggregator, Transaction, TransactionData,
 };
-use sui_types::object::{Data, MoveObject, Object, Owner};
+use sui_types::object::{MoveObject, Object, Owner};
 use sui_types::serialize::serialize_cert;
 use test_utils::sequencer::Sequencer;
 
@@ -47,15 +47,8 @@ fn test_shared_object() -> Object {
     let seed = "0x6666666666666660";
     let shared_object_id = ObjectID::from_hex_literal(seed).unwrap();
     let content = GasCoin::new(shared_object_id, SequenceNumber::new(), 10);
-    let data = Data::Move(MoveObject::new(
-        /* type */ GasCoin::type_(),
-        content.to_bcs_bytes(),
-    ));
-    Object {
-        data,
-        owner: Owner::SharedMutable,
-        previous_transaction: TransactionDigest::genesis(),
-    }
+    let obj = MoveObject::new(/* type */ GasCoin::type_(), content.to_bcs_bytes());
+    Object::new_move(obj, Owner::SharedMutable, TransactionDigest::genesis())
 }
 
 /// Fixture: a few test certificates containing a shared object.

--- a/sui_core/src/unit_tests/gas_tests.rs
+++ b/sui_core/src/unit_tests/gas_tests.rs
@@ -82,7 +82,8 @@ async fn test_native_transfer_sufficient_gas() -> SuiResult {
     let effects = result.response.unwrap().signed_effects.unwrap().effects;
     let gas_cost = effects.status.gas_cost_summary();
     assert!(gas_cost.computation_cost > *MIN_GAS_BUDGET);
-    assert_eq!(gas_cost.storage_cost, 0);
+    assert!(gas_cost.storage_cost > 0);
+    // Removing genesis object does not have rebate.
     assert_eq!(gas_cost.storage_rebate, 0);
 
     let object = result
@@ -103,22 +104,14 @@ async fn test_native_transfer_sufficient_gas() -> SuiResult {
 
     // Mimic the process of gas charging, to check that we are charging
     // exactly what we should be charging.
-    let mut gas_status = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET);
+    let mut gas_status = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET, 1, 1);
     gas_status.charge_min_tx_gas()?;
+    let obj_size = object.object_size_for_gas_metering();
+    let gas_size = gas_object.object_size_for_gas_metering();
 
-    // Both the object to be transferred and the gas object will be read
-    // from the store. Hence we need to charge for 2 reads.
-    gas_status.charge_storage_read(
-        object.object_size_for_gas_metering() + gas_object.object_size_for_gas_metering(),
-    )?;
-    gas_status.charge_storage_mutation(
-        object.object_size_for_gas_metering(),
-        object.object_size_for_gas_metering(),
-    )?;
-    gas_status.charge_storage_mutation(
-        gas_object.object_size_for_gas_metering(),
-        gas_object.object_size_for_gas_metering(),
-    )?;
+    gas_status.charge_storage_read(obj_size + gas_size)?;
+    gas_status.charge_storage_mutation(obj_size, obj_size, 0)?;
+    gas_status.charge_storage_mutation(gas_size, gas_size, 0)?;
     assert_eq!(gas_cost, &gas_status.summary(true));
     Ok(())
 }
@@ -158,8 +151,8 @@ async fn test_native_transfer_insufficient_gas_execution() {
     let budget = total_gas - 1;
     let result = execute_transfer(budget, budget, true).await;
     let effects = result.response.unwrap().signed_effects.unwrap().effects;
-    // The gas balance should be drained.
-    assert_eq!(effects.status.gas_cost_summary().gas_used(), budget);
+    // We won't drain the entire budget because we don't charge for storage if tx failed.
+    assert!(effects.status.gas_cost_summary().gas_used() < budget);
     let gas_object = result
         .authority_state
         .get_object(&result.gas_object_id)
@@ -167,11 +160,14 @@ async fn test_native_transfer_insufficient_gas_execution() {
         .unwrap()
         .unwrap();
     let gas_coin = GasCoin::try_from(&gas_object).unwrap();
-    assert_eq!(gas_coin.value(), 0);
+    assert_eq!(
+        gas_coin.value(),
+        budget - effects.status.gas_cost_summary().gas_used()
+    );
     assert_eq!(
         effects.status.unwrap_err().1,
         SuiError::InsufficientGas {
-            error: "Ran out of gas while deducting computation cost".to_owned()
+            error: "Ran out of gas while deducting storage cost".to_owned()
         }
     );
 }
@@ -221,7 +217,7 @@ async fn test_publish_gas() -> SuiResult {
     };
 
     // Mimic the gas charge behavior and cross check the result with above.
-    let mut gas_status = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET);
+    let mut gas_status = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET, 1, 1);
     gas_status.charge_min_tx_gas()?;
     gas_status.charge_storage_read(
         genesis_objects
@@ -231,12 +227,13 @@ async fn test_publish_gas() -> SuiResult {
     )?;
     gas_status.charge_storage_read(gas_object.object_size_for_gas_metering())?;
     gas_status.charge_publish_package(publish_bytes.iter().map(|v| v.len()).sum())?;
-    gas_status.charge_storage_mutation(0, package.object_size_for_gas_metering())?;
+    gas_status.charge_storage_mutation(0, package.object_size_for_gas_metering(), 0)?;
     // Remember the gas used so far. We will use this to create another failure case latter.
     let gas_used_after_package_creation = gas_status.summary(true).gas_used();
     gas_status.charge_storage_mutation(
         gas_object.object_size_for_gas_metering(),
         gas_object.object_size_for_gas_metering(),
+        0,
     )?;
     assert_eq!(gas_cost, &gas_status.summary(true));
 
@@ -261,16 +258,14 @@ async fn test_publish_gas() -> SuiResult {
     assert_eq!(
         err,
         SuiError::InsufficientGas {
-            error: "Ran out of gas while deducting computation cost".to_owned()
+            error: "Ran out of gas while deducting storage cost".to_owned()
         }
     );
 
     // Make sure that we are not charging storage cost at failure.
     assert_eq!(gas_cost.storage_cost, 0);
     // Upon failure, we should only be charging the expected computation cost.
-    // Since we failed when trying to charge the last piece of computation cost,
-    // the total cost will be DELTA less since it's not enough.
-    assert_eq!(gas_cost.gas_used(), computation_cost - DELTA);
+    assert_eq!(gas_cost.gas_used(), computation_cost);
 
     let gas_object = authority_state.get_object(&gas_object_id).await?.unwrap();
     let expected_gas_balance = expected_gas_balance - gas_cost.gas_used();
@@ -352,7 +347,7 @@ async fn test_move_call_gas() -> SuiResult {
     );
 
     // Mimic the gas charge behavior and cross check the result with above.
-    let mut gas_status = SuiGasStatus::new_with_budget(GAS_VALUE_FOR_TESTING);
+    let mut gas_status = SuiGasStatus::new_with_budget(GAS_VALUE_FOR_TESTING, 1, 1);
     gas_status.charge_min_tx_gas()?;
     let package_object = authority_state
         .get_object(&package_object_ref.0)
@@ -370,22 +365,53 @@ async fn test_move_call_gas() -> SuiResult {
         .get_object(&effects.created[0].0 .0)
         .await?
         .unwrap();
-    gas_status.charge_storage_mutation(0, created_object.object_size_for_gas_metering())?;
+    gas_status.charge_storage_mutation(0, created_object.object_size_for_gas_metering(), 0)?;
     gas_status.charge_storage_mutation(
         gas_object.object_size_for_gas_metering(),
         gas_object.object_size_for_gas_metering(),
+        0,
     )?;
 
     let new_cost = gas_status.summary(true);
     assert_eq!(gas_cost.computation_cost, new_cost.computation_cost,);
     assert_eq!(gas_cost.storage_cost, new_cost.storage_cost);
+    // This is the total amount of storage cost paid. We will use this
+    // to check if we get back the same amount of rebate latter.
+    let prev_storage_cost = gas_cost.storage_cost;
 
-    // Create a transaction with gas budget that should run out during Move VM execution.
-    let budget = gas_used_before_vm_exec + 1;
+    // Execute object deletion, and make sure we have storage rebate.
     let data = TransactionData::new_move_call(
         sender,
         package_object_ref,
         module.clone(),
+        ident_str!("delete").to_owned(),
+        vec![],
+        gas_object.compute_object_reference(),
+        vec![created_object_ref],
+        vec![],
+        vec![],
+        expected_gas_balance,
+    );
+    let signature = Signature::new(&data, &sender_key);
+    let transaction = Transaction::new(data, signature);
+    let response = send_and_confirm_transaction(&authority_state, transaction).await?;
+    let effects = response.signed_effects.unwrap().effects;
+    assert!(effects.status.is_ok());
+    let gas_cost = effects.status.gas_cost_summary();
+    // storage_cost should be less than rebate because for object deletion, we only
+    // rebate without charging.
+    assert!(gas_cost.storage_cost > 0 && gas_cost.storage_cost < gas_cost.storage_rebate);
+    // Check that we have storage rebate that's the same as previous cost.
+    assert_eq!(gas_cost.storage_rebate, prev_storage_cost);
+    let expected_gas_balance = expected_gas_balance - gas_cost.gas_used() + gas_cost.storage_rebate;
+
+    // Create a transaction with gas budget that should run out during Move VM execution.
+    let gas_object = authority_state.get_object(&gas_object_id).await?.unwrap();
+    let budget = gas_used_before_vm_exec + 1;
+    let data = TransactionData::new_move_call(
+        sender,
+        package_object_ref,
+        module,
         function,
         Vec::new(),
         gas_object.compute_object_reference(),
@@ -409,34 +435,28 @@ async fn test_move_call_gas() -> SuiResult {
         }
     );
     let gas_object = authority_state.get_object(&gas_object_id).await?.unwrap();
-    let expected_gas_balance = expected_gas_balance - gas_cost.gas_used();
+    let expected_gas_balance = expected_gas_balance - gas_cost.gas_used() + gas_cost.storage_rebate;
     assert_eq!(
         GasCoin::try_from(&gas_object)?.value(),
         expected_gas_balance,
     );
+    Ok(())
+}
 
-    // Execute object deletion, and make sure we have storage rebate.
-    let data = TransactionData::new_move_call(
-        sender,
-        package_object_ref,
-        module,
-        ident_str!("delete").to_owned(),
-        vec![],
-        gas_object.compute_object_reference(),
-        vec![created_object_ref],
-        vec![],
-        vec![],
-        expected_gas_balance,
-    );
-    let signature = Signature::new(&data, &sender_key);
-    let transaction = Transaction::new(data, signature);
-    let response = send_and_confirm_transaction(&authority_state, transaction).await?;
-    let effects = response.signed_effects.unwrap().effects;
-    assert!(effects.status.is_ok());
-    let gas_cost = effects.status.gas_cost_summary();
-    assert_eq!(gas_cost.storage_cost, 0);
-    // Check that we have storage rebate after deletion.
-    assert!(gas_cost.storage_rebate > 0);
+#[tokio::test]
+async fn test_storage_gas_unit_price() -> SuiResult {
+    let mut gas_status1 = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET, 1, 1);
+    gas_status1.charge_storage_mutation(100, 200, 5)?;
+    let gas_cost1 = gas_status1.summary(true);
+    let mut gas_status2 = SuiGasStatus::new_with_budget(*MAX_GAS_BUDGET, 1, 3);
+    gas_status2.charge_storage_mutation(100, 200, 5)?;
+    let gas_cost2 = gas_status2.summary(true);
+    // Computation unit price is the same, hence computation cost should be the same.
+    assert_eq!(gas_cost1.computation_cost, gas_cost2.computation_cost);
+    // Storage unit prices is 3X, so will be the storage cost.
+    assert_eq!(gas_cost1.storage_cost * 3, gas_cost2.storage_cost);
+    // Storage rebate should not be affected by the price.
+    assert_eq!(gas_cost1.storage_rebate, gas_cost2.storage_rebate);
     Ok(())
 }
 

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -273,6 +273,7 @@ Object:
         TYPENAME: Owner
     - previous_transaction:
         TYPENAME: TransactionDigest
+    - storage_rebate: U64
 ObjectDigest:
   NEWTYPESTRUCT: BYTES
 ObjectFormatOptions:

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -204,7 +204,7 @@ fn call(
         type_args,
         object_args,
         pure_args,
-        &mut SuiGasStatus::new_with_budget(gas_budget),
+        &mut SuiGasStatus::new_with_budget(gas_budget, 1, 1),
         &mut TxContext::random_for_testing_only(),
     )
 }

--- a/sui_types/src/gas.rs
+++ b/sui_types/src/gas.rs
@@ -187,6 +187,13 @@ impl<'a> SuiGasStatus<'a> {
         }
     }
 
+    /// This function is only called during testing, where we need to mock
+    /// Move VM charging gas.
+    pub fn charge_vm_exec_test_only(&mut self, cost: u64) -> SuiResult {
+        self.gas_status.deduct_gas(InternalGasUnits::new(cost))?;
+        Ok(())
+    }
+
     /// Returns the final (computation cost, storage cost, storage rebate) of the gas meter.
     /// We use initial budget, combined with remaining gas and storage cost to derive
     /// computation cost.

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -336,6 +336,10 @@ pub struct Object {
     pub owner: Owner,
     /// The digest of the transaction that created or last mutated this object
     pub previous_transaction: TransactionDigest,
+    /// The amount of SUI we would rebate if this object gets deleted.
+    /// This number is re-calculated each time the object is mutated based on
+    /// the present storage gas price.
+    pub storage_rebate: u64,
 }
 
 impl BcsSignable for Object {}
@@ -347,6 +351,7 @@ impl Object {
             data: Data::Move(o),
             owner,
             previous_transaction,
+            storage_rebate: 0,
         }
     }
 
@@ -358,6 +363,7 @@ impl Object {
             data: Data::Package(MovePackage::from(&modules)),
             owner: Owner::SharedImmutable,
             previous_transaction,
+            storage_rebate: 0,
         }
     }
 
@@ -419,7 +425,7 @@ impl Object {
     /// we also don't want to serialize the object just to get the size.
     /// This approximation should be good enough for gas metering.
     pub fn object_size_for_gas_metering(&self) -> usize {
-        let meta_data_size = size_of::<Owner>() + size_of::<TransactionDigest>();
+        let meta_data_size = size_of::<Owner>() + size_of::<TransactionDigest>() + size_of::<u64>();
         let data_size = match &self.data {
             Data::Move(m) => m.object_size_for_gas_metering(),
             Data::Package(p) => p
@@ -450,6 +456,7 @@ impl Object {
             owner: Owner::SharedImmutable,
             data,
             previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
         }
     }
 
@@ -467,6 +474,7 @@ impl Object {
             owner: Owner::AddressOwner(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
         }
     }
 
@@ -492,6 +500,7 @@ impl Object {
             owner: Owner::AddressOwner(owner),
             data,
             previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
         }
     }
 


### PR DESCRIPTION
This PR does two things together, since they are tightly coupled.
What we are trying to do here is to properly implement Alonso's storage rebate design:
Whenever an object is being mutated, what we do is to first think that this original object is being deleted, and hence we are giving back a storage rebate, and then the new version of the object is being inserted, which will charge a new storage cost.
Because we want to make sure that the storage fund never gets depleted, the storage rebate on the same object can never be bigger (in SUI) than the storage cost when the object was added. To achieve this, we need to track the amount of SUI the previous mutation paid for the storage, and this amount will be used as the rebate next time this same object is being mutated.
This PR achieves this by adding these two things:
1. We are initializing the gas status with a computation gas unit price and a storage gas unit price. This will eventually come from epoch metadata but I haven't added that part.
2. We are adding a `storage_rebate` field to `Object`. This value represents the amount of rebate (in SUI) someone will get if they ever delete this object from storage. It's set by the previous transaction that mutated this object. In this implementation, what we do is that every time when an object is being mutated (not just deleted), we first "delete" the old object and provide the storage rebate, and then charge the storage cost based on the current storage gas unit price.