### PR TITLE
[JSON-RPC] - RPC Gateway server using paritytech/jsonrpsee

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -85,6 +85,7 @@ allow = [
     "CC0-1.0",
     # "LicenseRef-ring",
     "BSL-1.0",
+    "OpenSSL",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explictly disallowed licenses
@@ -139,18 +140,19 @@ exceptions = [
     # Each entry is a crate relative path, and the (opaque) hash of its contents
     #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
-# [[licenses.clarify]]
-# name = "ring"
-# expression = "LicenseRef-ring"
-# license-files = [
-#     { path = "LICENSE", hash = 0xbd0eed23 },
-# ]
 [[licenses.clarify]]
 name = "encoding_rs"
 version = "*"
 expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
 license-files = [
     { path = "COPYRIGHT", hash = 0x39f8ad31 }
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
 [licenses.private]

--- a/deny.toml
+++ b/deny.toml
@@ -83,9 +83,8 @@ allow = [
     "MPL-2.0",
     "ISC",
     "CC0-1.0",
-    # "LicenseRef-ring",
+    "LicenseRef-ring",
     "BSL-1.0",
-    "OpenSSL",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explictly disallowed licenses
@@ -141,18 +140,17 @@ exceptions = [
     #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 [[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+[[licenses.clarify]]
 name = "encoding_rs"
 version = "*"
 expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
 license-files = [
     { path = "COPYRIGHT", hash = 0x39f8ad31 }
-]
-
-[[licenses.clarify]]
-name = "ring"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
 [licenses.private]

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -91,7 +91,7 @@ name = "rest_server"
 path = "src/rest_server.rs"
 
 [[bin]]
-name = "rpc_server"
+name = "rpc-server"
 path = "src/rpc_server.rs"
 
 [[bin]]

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -61,11 +61,11 @@ move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "2e
 move-unit-test = { git = "https://github.com/move-language/move", rev = "2e7c37edada44436805e047dd26724a26c07635a" }
 
 once_cell = "1.9.0"
-reqwest = { version = "0.11.10", features=["json","serde_json", "blocking"]}
-jsonrpc-core = "18.0.0"
-jsonrpc-derive = "18.0.0"
-jsonrpc-core-client = "18.0.0"
-jsonrpc-http-server = "18.0.0"
+reqwest = { version = "0.11.10", features = ["json", "serde_json", "blocking"] }
+
+jsonrpsee = { version = "0.10.1", features = ["full"] }
+
+jsonrpsee-proc-macros = "0.10.1"
 
 [dev-dependencies]
 tracing-test = "0.2.1"

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -91,8 +91,8 @@ name = "rest_server"
 path = "src/rest_server.rs"
 
 [[bin]]
-name = "rpc_gateway"
-path = "src/rpc_gateway.rs"
+name = "rpc_server"
+path = "src/rpc_server.rs"
 
 [[bin]]
 name = "validator"

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -62,6 +62,10 @@ move-unit-test = { git = "https://github.com/move-language/move", rev = "2e7c37e
 
 once_cell = "1.9.0"
 reqwest = { version = "0.11.10", features=["json","serde_json", "blocking"]}
+jsonrpc-core = "18.0.0"
+jsonrpc-derive = "18.0.0"
+jsonrpc-core-client = "18.0.0"
+jsonrpc-http-server = "18.0.0"
 
 [dev-dependencies]
 tracing-test = "0.2.1"
@@ -85,6 +89,10 @@ path = "src/sui-move.rs"
 [[bin]]
 name = "rest_server"
 path = "src/rest_server.rs"
+
+[[bin]]
+name = "rpc_gateway"
+path = "src/rpc_gateway.rs"
 
 [[bin]]
 name = "validator"

--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_STARTING_PORT: u16 = 10000;
 static PORT_ALLOCATOR: Lazy<Mutex<PortAllocator>> =
     Lazy::new(|| Mutex::new(PortAllocator::new(DEFAULT_STARTING_PORT)));
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AuthorityInfo {
     #[serde(serialize_with = "bytes_as_hex", deserialize_with = "bytes_from_hex")]
     pub name: AuthorityName,

--- a/sui/src/lib.rs
+++ b/sui/src/lib.rs
@@ -14,6 +14,7 @@ pub mod gateway;
 pub mod keystore;
 pub mod rest_gateway;
 pub mod rpc_gateway;
+pub mod rpc_gateway_client;
 pub mod shell;
 pub mod sui_commands;
 pub mod sui_json;

--- a/sui/src/lib.rs
+++ b/sui/src/lib.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod gateway;
 pub mod keystore;
 pub mod rest_gateway;
+pub mod rpc_gateway;
 pub mod shell;
 pub mod sui_commands;
 pub mod sui_json;

--- a/sui/src/rest_gateway.rs
+++ b/sui/src/rest_gateway.rs
@@ -34,7 +34,7 @@ pub struct RestGatewayClient {
 #[allow(unused_variables)]
 impl GatewayAPI for RestGatewayClient {
     async fn execute_transaction(
-        &mut self,
+        &self,
         tx: Transaction,
     ) -> Result<TransactionResponse, anyhow::Error> {
         let url = format!("{}/api/", self.url);
@@ -54,7 +54,7 @@ impl GatewayAPI for RestGatewayClient {
     }
 
     async fn transfer_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         object_id: ObjectID,
         gas_payment: ObjectID,
@@ -87,7 +87,7 @@ impl GatewayAPI for RestGatewayClient {
     }
 
     async fn move_call(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_object_ref: ObjectRef,
         module: Identifier,
@@ -133,7 +133,7 @@ impl GatewayAPI for RestGatewayClient {
     }
 
     async fn publish(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
         gas_object_ref: ObjectRef,
@@ -151,7 +151,7 @@ impl GatewayAPI for RestGatewayClient {
     }
 
     async fn split_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
@@ -170,7 +170,7 @@ impl GatewayAPI for RestGatewayClient {
     }
 
     async fn merge_coins(
-        &mut self,
+        &self,
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
@@ -195,7 +195,7 @@ impl GatewayAPI for RestGatewayClient {
     }
 
     async fn get_owned_objects(
-        &mut self,
+        &self,
         account_addr: SuiAddress,
     ) -> Result<Vec<ObjectRef>, anyhow::Error> {
         let url = format!("{}/api/objects?address={}", self.url, account_addr);

--- a/sui/src/rest_gateway/responses.rs
+++ b/sui/src/rest_gateway/responses.rs
@@ -89,7 +89,7 @@ impl TransactionBytes {
     }
 
     pub fn to_data(self) -> Result<TransactionData, anyhow::Error> {
-        TransactionData::from_signable_bytes(base64::decode(self.tx_bytes)?)
+        TransactionData::from_signable_bytes(&base64::decode(self.tx_bytes)?)
     }
 }
 

--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -178,7 +178,7 @@ async fn get_objects(
     ctx: Arc<RequestContext<ServerContext>>,
     query: Query<GetObjectsRequest>,
 ) -> Result<HttpResponseOk<ObjectResponse>, HttpError> {
-    let mut gateway = ctx.context().gateway.lock().await;
+    let gateway = ctx.context().gateway.lock().await;
     let get_objects_params = query.into_inner();
     let address = get_objects_params.address;
     let address = &decode_bytes_hex(address.as_str()).map_err(|error| {
@@ -301,7 +301,7 @@ async fn new_transfer(
     ctx: Arc<RequestContext<ServerContext>>,
     request: TypedBody<TransferTransactionRequest>,
 ) -> Result<HttpResponseOk<TransactionBytes>, HttpError> {
-    let mut gateway = ctx.context().gateway.lock().await;
+    let gateway = ctx.context().gateway.lock().await;
     let request = request.into_inner();
 
     let tx_data = async {
@@ -334,7 +334,7 @@ async fn split_coin(
     ctx: Arc<RequestContext<ServerContext>>,
     request: TypedBody<SplitCoinRequest>,
 ) -> Result<HttpResponseOk<TransactionBytes>, HttpError> {
-    let mut gateway = ctx.context().gateway.lock().await;
+    let gateway = ctx.context().gateway.lock().await;
     let request = request.into_inner();
 
     let tx_data = async {
@@ -365,7 +365,7 @@ async fn merge_coin(
     ctx: Arc<RequestContext<ServerContext>>,
     request: TypedBody<MergeCoinRequest>,
 ) -> Result<HttpResponseOk<TransactionBytes>, HttpError> {
-    let mut gateway = ctx.context().gateway.lock().await;
+    let gateway = ctx.context().gateway.lock().await;
     let request = request.into_inner();
 
     let tx_data = async {
@@ -489,7 +489,7 @@ async fn execute_transaction(
     response: TypedBody<SignedTransaction>,
 ) -> Result<HttpResponseOk<JsonResponse<TransactionResponse>>, HttpError> {
     let response = response.into_inner();
-    let mut gateway = ctx.context().gateway.lock().await;
+    let gateway = ctx.context().gateway.lock().await;
 
     let response: Result<_, anyhow::Error> = async {
         let data = base64::decode(response.tx_bytes)?;

--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -493,7 +493,7 @@ async fn execute_transaction(
 
     let response: Result<_, anyhow::Error> = async {
         let data = base64::decode(response.tx_bytes)?;
-        let data = TransactionData::from_signable_bytes(data)?;
+        let data = TransactionData::from_signable_bytes(&data)?;
 
         let mut signature_bytes = base64::decode(response.signature)?;
         let mut pub_key_bytes = base64::decode(response.pub_key)?;

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -1,21 +1,33 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
 use std::path::Path;
 use std::result;
 use std::sync::Arc;
 
+use ed25519_dalek::ed25519::signature::Signature;
 use jsonrpc_core::{BoxFuture, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::ServerBuilder;
+use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::TypeTag;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_with::serde_as;
 use tokio::sync::Mutex;
 
 use sui::config::PersistedConfig;
 use sui::gateway::GatewayConfig;
 use sui::rest_gateway::responses::{NamedObjectRef, ObjectResponse, TransactionBytes};
 use sui::sui_config_dir;
+use sui_core::gateway_state::gateway_responses::TransactionResponse;
 use sui_core::gateway_state::{GatewayClient, GatewayState};
 use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::crypto;
+use sui_types::crypto::SignableBytes;
+use sui_types::messages::{Transaction, TransactionData};
+use sui_types::object::ObjectRead;
 
 #[rpc]
 pub trait RPCGateway {
@@ -31,6 +43,32 @@ pub trait RPCGateway {
 
     #[rpc(name = "objects")]
     fn objects(&self, owner: SuiAddress) -> BoxFuture<Result<ObjectResponse>>;
+
+    #[rpc(name = "object_info")]
+    fn object_info(&self, object_id: ObjectID) -> BoxFuture<Result<ObjectRead>>;
+
+    #[rpc(name = "execute_transaction")]
+    fn execute_transaction(
+        &self,
+        tx_bytes: Base64EncodedBytes,
+        signature: Base64EncodedBytes,
+        pub_key: Base64EncodedBytes,
+    ) -> BoxFuture<Result<TransactionResponse>>;
+
+    #[rpc(name = "move_call")]
+    fn move_call(
+        &self,
+        signer: SuiAddress,
+        package_object_id: ObjectID,
+        module: Identifier,
+        function: Identifier,
+        type_arguments: Vec<TypeTag>,
+        pure_arguments: Vec<Base64EncodedBytes>,
+        gas_object_id: ObjectID,
+        gas_budget: u64,
+        object_arguments: Vec<ObjectID>,
+        shared_object_arguments: Vec<ObjectID>,
+    ) -> BoxFuture<Result<TransactionBytes>>;
 }
 
 pub struct RPCGatewayImpl {
@@ -95,6 +133,120 @@ impl RPCGateway for RPCGatewayImpl {
                 .collect();
             Ok(ObjectResponse { objects })
         })
+    }
+
+    fn object_info(&self, object_id: ObjectID) -> BoxFuture<Result<ObjectRead>> {
+        let gateway = self.gateway.clone();
+        Box::pin(async move {
+            let object_read = gateway
+                .lock()
+                .await
+                .get_object_info(object_id)
+                .await
+                .map_err(to_internal_error)?;
+            Ok(object_read)
+        })
+    }
+
+    fn execute_transaction(
+        &self,
+        tx_bytes: Base64EncodedBytes,
+        signature: Base64EncodedBytes,
+        pub_key: Base64EncodedBytes,
+    ) -> BoxFuture<Result<TransactionResponse>> {
+        let gateway = self.gateway.clone();
+        Box::pin(async move {
+            async {
+                let data = TransactionData::from_signable_bytes(&tx_bytes)?;
+                let signature = crypto::Signature::from_bytes(&[&*signature, &*pub_key].concat())?;
+                gateway
+                    .lock()
+                    .await
+                    .execute_transaction(Transaction::new(data, signature))
+                    .await
+            }
+            .await
+            .map_err(to_internal_error)
+        })
+    }
+
+    fn move_call(
+        &self,
+        signer: SuiAddress,
+        package_object_id: ObjectID,
+        module: Identifier,
+        function: Identifier,
+        type_arguments: Vec<TypeTag>,
+        pure_arguments: Vec<Base64EncodedBytes>,
+        gas_object_id: ObjectID,
+        gas_budget: u64,
+        object_arguments: Vec<ObjectID>,
+        shared_object_arguments: Vec<ObjectID>,
+    ) -> BoxFuture<Result<TransactionBytes>> {
+        let gateway = self.gateway.clone();
+
+        Box::pin(async move {
+            let mut gateway = gateway.lock().await;
+
+            let data = async {
+                let package_object_ref = gateway
+                    .get_object_info(package_object_id)
+                    .await?
+                    .reference()?;
+                // Fetch the object info for the gas obj
+                let gas_obj_ref = gateway.get_object_info(gas_object_id).await?.reference()?;
+
+                // Fetch the objects for the object args
+                let mut object_args_refs = Vec::new();
+                for obj_id in object_arguments {
+                    let object_ref = gateway.get_object_info(obj_id).await?.reference()?;
+                    object_args_refs.push(object_ref);
+                }
+                let pure_arguments = pure_arguments
+                    .iter()
+                    .map(|arg| arg.to_vec())
+                    .collect::<Vec<_>>();
+
+                gateway
+                    .move_call(
+                        signer,
+                        package_object_ref,
+                        module,
+                        function,
+                        type_arguments,
+                        gas_obj_ref,
+                        object_args_refs,
+                        shared_object_arguments,
+                        pure_arguments,
+                        gas_budget,
+                    )
+                    .await
+            }
+            .await
+            .map_err(to_internal_error)?;
+
+            Ok(TransactionBytes::new(data))
+        })
+    }
+}
+
+fn to_internal_error(e: anyhow::Error) -> jsonrpc_core::Error {
+    jsonrpc_core::Error {
+        code: ErrorCode::InternalError,
+        message: e.to_string(),
+        data: None,
+    }
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct Base64EncodedBytes(#[serde_as(as = "serde_with::base64::Base64")] Vec<u8>);
+
+impl Deref for Base64EncodedBytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -356,11 +356,10 @@ pub struct SignedTransaction {
 
 impl SignedTransaction {
     pub fn new(tx_bytes: Vec<u8>, signature: crypto::Signature) -> Self {
-        let signature_bytes = signature.as_bytes();
         Self {
             tx_bytes,
-            signature: signature_bytes[..32].to_vec(),
-            pub_key: signature_bytes[32..].to_vec(),
+            signature: signature.signature_bytes().to_vec(),
+            pub_key: signature.public_key_bytes().to_vec(),
         }
     }
 }

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+use std::result;
+use std::sync::Arc;
+
+use jsonrpc_core::{BoxFuture, ErrorCode, Result};
+use jsonrpc_derive::rpc;
+use jsonrpc_http_server::ServerBuilder;
+use tokio::sync::Mutex;
+
+use sui::config::PersistedConfig;
+use sui::gateway::GatewayConfig;
+use sui::rest_gateway::responses::{NamedObjectRef, ObjectResponse, TransactionBytes};
+use sui::sui_config_dir;
+use sui_core::gateway_state::{GatewayClient, GatewayState};
+use sui_types::base_types::{ObjectID, SuiAddress};
+
+#[rpc]
+pub trait RPCGateway {
+    #[rpc(name = "new_transfer")]
+    fn new_transfer(
+        &self,
+        signer: SuiAddress,
+        object_id: ObjectID,
+        gas_payment: ObjectID,
+        gas_budget: u64,
+        recipient: SuiAddress,
+    ) -> BoxFuture<Result<TransactionBytes>>;
+
+    #[rpc(name = "objects")]
+    fn objects(&self, owner: SuiAddress) -> BoxFuture<Result<ObjectResponse>>;
+}
+
+pub struct RPCGatewayImpl {
+    gateway: Arc<Mutex<GatewayClient>>,
+}
+
+impl RPCGatewayImpl {
+    fn new(config_path: &Path) -> result::Result<Self, anyhow::Error> {
+        let config: GatewayConfig = PersistedConfig::read(config_path)?;
+        let committee = config.make_committee();
+        let authority_clients = config.make_authority_clients();
+        let gateway = Box::new(GatewayState::new(
+            config.db_folder_path,
+            committee,
+            authority_clients,
+        ));
+        Ok(Self {
+            gateway: Arc::new(Mutex::new(gateway)),
+        })
+    }
+}
+
+impl RPCGateway for RPCGatewayImpl {
+    fn new_transfer(
+        &self,
+        signer: SuiAddress,
+        object_id: ObjectID,
+        gas_payment: ObjectID,
+        gas_budget: u64,
+        recipient: SuiAddress,
+    ) -> BoxFuture<Result<TransactionBytes>> {
+        let gateway = self.gateway.clone();
+        Box::pin(async move {
+            let mut gateway = gateway.lock().await;
+            Ok(TransactionBytes::new(
+                gateway
+                    .transfer_coin(signer, object_id, gas_payment, gas_budget, recipient)
+                    .await
+                    .map_err(|e| jsonrpc_core::Error {
+                        code: ErrorCode::InternalError,
+                        message: e.to_string(),
+                        data: None,
+                    })?,
+            ))
+        })
+    }
+
+    fn objects(&self, owner: SuiAddress) -> BoxFuture<Result<ObjectResponse>> {
+        let gateway = self.gateway.clone();
+        Box::pin(async move {
+            let objects = gateway
+                .lock()
+                .await
+                .get_owned_objects(owner)
+                .map_err(|e| jsonrpc_core::Error {
+                    code: ErrorCode::InternalError,
+                    message: e.to_string(),
+                    data: None,
+                })?
+                .into_iter()
+                .map(NamedObjectRef::from)
+                .collect();
+            Ok(ObjectResponse { objects })
+        })
+    }
+}
+
+fn main() -> result::Result<(), anyhow::Error> {
+    let mut io = jsonrpc_core::IoHandler::new();
+
+    let config_path = sui_config_dir()?.join("gateway.conf");
+    io.extend_with(RPCGatewayImpl::new(&config_path)?.to_delegate());
+
+    let server = ServerBuilder::new(io)
+        .threads(3)
+        .start_http(&"127.0.0.1:3030".parse().unwrap())?;
+
+    server.wait();
+    Ok(())
+}

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -233,7 +233,8 @@ impl RpcGatewayServer for RpcGatewayImpl {
         debug!("get_objects : {}", owner);
         let objects = self
             .gateway
-            .get_owned_objects(owner)?
+            .get_owned_objects(owner)
+            .await?
             .into_iter()
             .map(NamedObjectRef::from)
             .collect();

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -31,12 +31,12 @@ use crate::config::PersistedConfig;
 use crate::gateway::GatewayConfig;
 use crate::rest_gateway::responses::{NamedObjectRef, ObjectResponse};
 
-#[rpc(server, client, namespace = "gateway")]
+#[rpc(server, client, namespace = "sui")]
 pub trait RpcGateway {
-    #[method(name = "get_object_info")]
+    #[method(name = "getObjectInfo")]
     async fn get_object_info(&self, object_id: ObjectID) -> RpcResult<ObjectRead>;
 
-    #[method(name = "transfer_coin")]
+    #[method(name = "transferCoin")]
     async fn transfer_coin(
         &self,
         signer: SuiAddress,
@@ -46,7 +46,7 @@ pub trait RpcGateway {
         recipient: SuiAddress,
     ) -> RpcResult<TransactionBytes>;
 
-    #[method(name = "move_call")]
+    #[method(name = "moveCall")]
     async fn move_call(
         &self,
         signer: SuiAddress,
@@ -70,7 +70,7 @@ pub trait RpcGateway {
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
 
-    #[method(name = "split_coin")]
+    #[method(name = "splitCoin")]
     async fn split_coin(
         &self,
         signer: SuiAddress,
@@ -80,7 +80,7 @@ pub trait RpcGateway {
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
 
-    #[method(name = "merge_coins")]
+    #[method(name = "mergeCoins")]
     async fn merge_coin(
         &self,
         signer: SuiAddress,
@@ -90,29 +90,29 @@ pub trait RpcGateway {
         gas_budget: u64,
     ) -> RpcResult<TransactionBytes>;
 
-    #[method(name = "execute_transaction")]
+    #[method(name = "executeTransaction")]
     async fn execute_transaction(
         &self,
         signed_transaction: SignedTransaction,
     ) -> RpcResult<TransactionResponse>;
 
-    #[method(name = "sync_account_state")]
+    #[method(name = "syncAccountState")]
     async fn sync_account_state(&self, address: SuiAddress) -> RpcResult<()>;
 
-    #[method(name = "get_owned_objects")]
+    #[method(name = "getOwnedObjects")]
     async fn get_owned_objects(&self, owner: SuiAddress) -> RpcResult<ObjectResponse>;
 
-    #[method(name = "get_total_transaction_number")]
+    #[method(name = "getTotalTransactionNumber")]
     async fn get_total_transaction_number(&self) -> RpcResult<u64>;
 
-    #[method(name = "get_transactions_in_range")]
+    #[method(name = "getTransactionsInRange")]
     async fn get_transactions_in_range(
         &self,
         start: GatewayTxSeqNumber,
         end: GatewayTxSeqNumber,
     ) -> RpcResult<Vec<(GatewayTxSeqNumber, TransactionDigest)>>;
 
-    #[method(name = "get_recent_transactions")]
+    #[method(name = "getRecentTransactions")]
     async fn get_recent_transactions(
         &self,
         count: u64,

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -55,7 +55,7 @@ impl GatewayAPI for RpcGatewayClient {
     ) -> Result<TransactionData, Error> {
         let bytes: TransactionBytes = self
             .client
-            .create_coin_transfer(signer, object_id, gas_payment, gas_budget, recipient)
+            .transfer_coin(signer, object_id, gas_payment, gas_budget, recipient)
             .await?;
         bytes.to_data()
     }
@@ -86,7 +86,7 @@ impl GatewayAPI for RpcGatewayClient {
 
         let bytes: TransactionBytes = self
             .client
-            .create_move_call(
+            .move_call(
                 signer,
                 package_object_ref.0,
                 module,
@@ -161,7 +161,7 @@ impl GatewayAPI for RpcGatewayClient {
         let handle = Handle::current();
         let _ = handle.enter();
         let object_response: ObjectResponse =
-            futures::executor::block_on(self.client.get_objects(account_addr))?;
+            futures::executor::block_on(self.client.get_owned_objects(account_addr))?;
 
         let object_refs = object_response
             .objects

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -7,7 +7,6 @@ use crate::rpc_gateway::{
 };
 use anyhow::Error;
 use async_trait::async_trait;
-use ed25519_dalek::ed25519::signature::Signature;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
@@ -32,14 +31,11 @@ impl RpcGatewayClient {
 #[async_trait]
 impl GatewayAPI for RpcGatewayClient {
     async fn execute_transaction(&self, tx: Transaction) -> Result<TransactionResponse, Error> {
-        let signature = tx.tx_signature.as_bytes();
-        let pub_key = &signature[32..];
-        let signature = &signature[..32];
-
+        let signature = tx.tx_signature;
         let signed_tx = SignedTransaction {
             tx_bytes: tx.data.to_bytes(),
-            signature: signature.to_vec(),
-            pub_key: pub_key.to_vec(),
+            signature: signature.signature_bytes().to_vec(),
+            pub_key: signature.public_key_bytes().to_vec(),
         };
 
         Ok(self.client.execute_transaction(signed_tx).await?)

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -31,7 +31,7 @@ impl RpcGatewayClient {
 
 #[async_trait]
 impl GatewayAPI for RpcGatewayClient {
-    async fn execute_transaction(&mut self, tx: Transaction) -> Result<TransactionResponse, Error> {
+    async fn execute_transaction(&self, tx: Transaction) -> Result<TransactionResponse, Error> {
         let signature = tx.tx_signature.as_bytes();
         let pub_key = &signature[32..];
         let signature = &signature[..32];
@@ -46,7 +46,7 @@ impl GatewayAPI for RpcGatewayClient {
     }
 
     async fn transfer_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         object_id: ObjectID,
         gas_payment: ObjectID,
@@ -66,7 +66,7 @@ impl GatewayAPI for RpcGatewayClient {
     }
 
     async fn move_call(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_object_ref: ObjectRef,
         module: Identifier,
@@ -103,7 +103,7 @@ impl GatewayAPI for RpcGatewayClient {
     }
 
     async fn publish(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
         gas_object_ref: ObjectRef,
@@ -118,7 +118,7 @@ impl GatewayAPI for RpcGatewayClient {
     }
 
     async fn split_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
@@ -139,7 +139,7 @@ impl GatewayAPI for RpcGatewayClient {
     }
 
     async fn merge_coins(
-        &mut self,
+        &self,
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
@@ -157,7 +157,7 @@ impl GatewayAPI for RpcGatewayClient {
         Ok(self.client.get_object_info(object_id).await?)
     }
 
-    fn get_owned_objects(&mut self, account_addr: SuiAddress) -> Result<Vec<ObjectRef>, Error> {
+    fn get_owned_objects(&self, account_addr: SuiAddress) -> Result<Vec<ObjectRef>, Error> {
         let handle = Handle::current();
         let _ = handle.enter();
         let object_response: ObjectResponse =

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -157,12 +157,8 @@ impl GatewayAPI for RpcGatewayClient {
         Ok(self.client.get_object_info(object_id).await?)
     }
 
-    fn get_owned_objects(&self, account_addr: SuiAddress) -> Result<Vec<ObjectRef>, Error> {
-        let handle = Handle::current();
-        let _ = handle.enter();
-        let object_response: ObjectResponse =
-            futures::executor::block_on(self.client.get_owned_objects(account_addr))?;
-
+    async fn get_owned_objects(&self, account_addr: SuiAddress) -> Result<Vec<ObjectRef>, Error> {
+        let object_response: ObjectResponse = self.client.get_owned_objects(account_addr).await?;
         let object_refs = object_response
             .objects
             .into_iter()

--- a/sui/src/rpc_server.rs
+++ b/sui/src/rpc_server.rs
@@ -1,0 +1,63 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+
+use jsonrpsee::http_server::HttpServerBuilder;
+use jsonrpsee::RpcModule;
+use structopt::StructOpt;
+use tracing::info;
+
+use sui::rpc_gateway::RPCGatewayImpl;
+use sui::rpc_gateway::RPCGatewayServer;
+use sui::sui_config_dir;
+
+const DEFAULT_REST_SERVER_PORT: &str = "5001";
+const DEFAULT_REST_SERVER_ADDR_IPV4: &str = "127.0.0.1";
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "Sui RPC Gateway",
+    about = "A Byzantine fault tolerant chain with low-latency finality and high throughput",
+    rename_all = "kebab-case"
+)]
+struct RpcGatewayOpt {
+    #[structopt(long)]
+    config: Option<PathBuf>,
+
+    #[structopt(long, default_value = DEFAULT_REST_SERVER_PORT)]
+    port: u16,
+
+    #[structopt(long, default_value = DEFAULT_REST_SERVER_ADDR_IPV4)]
+    host: Ipv4Addr,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = telemetry_subscribers::TelemetryConfig {
+        service_name: "rpc_gateway".into(),
+        enable_tracing: std::env::var("SUI_TRACING_ENABLE").is_ok(),
+        json_log_output: std::env::var("SUI_JSON_SPAN_LOGS").is_ok(),
+        ..Default::default()
+    };
+    #[allow(unused)]
+    let guard = telemetry_subscribers::init(config);
+
+    let options: RpcGatewayOpt = RpcGatewayOpt::from_args();
+
+    let config_path = options
+        .config
+        .unwrap_or(sui_config_dir()?.join("gateway.conf"));
+
+    let server = HttpServerBuilder::default()
+        .build(SocketAddr::new(IpAddr::V4(options.host), options.port))
+        .await?;
+
+    let mut module = RpcModule::new(());
+    module.merge(RPCGatewayImpl::new(&config_path)?.into_rpc())?;
+
+    let addr = server.local_addr()?;
+    let server_handle = server.start(module)?;
+    info!("Sui RPC Gateway listening on local_addr:{}", addr);
+
+    server_handle.await;
+    Ok(())
+}

--- a/sui/src/rpc_server.rs
+++ b/sui/src/rpc_server.rs
@@ -1,32 +1,34 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use jsonrpsee::http_server::HttpServerBuilder;
 use jsonrpsee::RpcModule;
-use structopt::StructOpt;
 use tracing::info;
 
-use sui::rpc_gateway::RPCGatewayImpl;
-use sui::rpc_gateway::RPCGatewayServer;
+use clap::Parser;
+use sui::rpc_gateway::RpcGatewayImpl;
+use sui::rpc_gateway::RpcGatewayServer;
 use sui::sui_config_dir;
-
 const DEFAULT_REST_SERVER_PORT: &str = "5001";
 const DEFAULT_REST_SERVER_ADDR_IPV4: &str = "127.0.0.1";
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     name = "Sui RPC Gateway",
     about = "A Byzantine fault tolerant chain with low-latency finality and high throughput",
     rename_all = "kebab-case"
 )]
 struct RpcGatewayOpt {
-    #[structopt(long)]
+    #[clap(long)]
     config: Option<PathBuf>,
 
-    #[structopt(long, default_value = DEFAULT_REST_SERVER_PORT)]
+    #[clap(long, default_value = DEFAULT_REST_SERVER_PORT)]
     port: u16,
 
-    #[structopt(long, default_value = DEFAULT_REST_SERVER_ADDR_IPV4)]
+    #[clap(long, default_value = DEFAULT_REST_SERVER_ADDR_IPV4)]
     host: Ipv4Addr,
 }
 
@@ -41,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
     #[allow(unused)]
     let guard = telemetry_subscribers::init(config);
 
-    let options: RpcGatewayOpt = RpcGatewayOpt::from_args();
+    let options: RpcGatewayOpt = RpcGatewayOpt::parse();
 
     let config_path = options
         .config
@@ -52,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     let mut module = RpcModule::new(());
-    module.merge(RPCGatewayImpl::new(&config_path)?.into_rpc())?;
+    module.merge(RpcGatewayImpl::new(&config_path)?.into_rpc())?;
 
     let addr = server.local_addr()?;
     let server_handle = server.start(module)?;

--- a/sui/src/rpc_server.rs
+++ b/sui/src/rpc_server.rs
@@ -15,6 +15,10 @@ use sui::sui_config_dir;
 const DEFAULT_REST_SERVER_PORT: &str = "5001";
 const DEFAULT_REST_SERVER_ADDR_IPV4: &str = "127.0.0.1";
 
+#[cfg(test)]
+#[path = "unit_tests/rpc_server_tests.rs"]
+mod rpc_server_tests;
+
 #[derive(Parser)]
 #[clap(
     name = "Sui RPC Gateway",

--- a/sui/src/rpc_server.rs
+++ b/sui/src/rpc_server.rs
@@ -14,8 +14,8 @@ use sui::rpc_gateway::RpcGatewayImpl;
 use sui::rpc_gateway::RpcGatewayServer;
 use sui::sui_config_dir;
 
-const DEFAULT_REST_SERVER_PORT: &str = "5001";
-const DEFAULT_REST_SERVER_ADDR_IPV4: &str = "127.0.0.1";
+const DEFAULT_RPC_SERVER_PORT: &str = "5001";
+const DEFAULT_RPC_SERVER_ADDR_IPV4: &str = "127.0.0.1";
 
 #[cfg(test)]
 #[path = "unit_tests/rpc_server_tests.rs"]
@@ -31,10 +31,10 @@ struct RpcGatewayOpt {
     #[clap(long)]
     config: Option<PathBuf>,
 
-    #[clap(long, default_value = DEFAULT_REST_SERVER_PORT)]
+    #[clap(long, default_value = DEFAULT_RPC_SERVER_PORT)]
     port: u16,
 
-    #[clap(long, default_value = DEFAULT_REST_SERVER_ADDR_IPV4)]
+    #[clap(long, default_value = DEFAULT_RPC_SERVER_ADDR_IPV4)]
     host: Ipv4Addr,
 }
 

--- a/sui/src/unit_tests/rpc_server_tests.rs
+++ b/sui/src/unit_tests/rpc_server_tests.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::str::FromStr;
+
+use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
+use move_core_types::identifier::Identifier;
+
+use sui::config::{PersistedConfig, WalletConfig};
+use sui::keystore::{Keystore, SuiKeystore};
+use sui::rest_gateway::responses::ObjectResponse;
+use sui::rpc_gateway::RpcGatewayServer;
+use sui::rpc_gateway::TransactionBytes;
+use sui::rpc_gateway::{Base64EncodedBytes, RpcGatewayClient};
+use sui::rpc_gateway::{RpcGatewayImpl, SignedTransaction};
+use sui::sui_json::{resolve_move_function_args, SuiJsonValue};
+use sui::{SUI_GATEWAY_CONFIG, SUI_WALLET_CONFIG};
+use sui_core::gateway_state::gateway_responses::TransactionResponse;
+use sui_framework::build_move_package_to_bytes;
+use sui_types::base_types::ObjectID;
+use sui_types::object::ObjectRead;
+use sui_types::SUI_FRAMEWORK_ADDRESS;
+
+use crate::rpc_server_tests::sui_network::start_test_network;
+
+mod sui_network;
+
+#[tokio::test]
+async fn test_get_objects() -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let working_dir = temp_dir.path();
+    let _network = start_test_network(working_dir, None).await?;
+    let (server_addr, _handle) = start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG)).await?;
+    let wallet_conf: WalletConfig = PersistedConfig::read(&working_dir.join(SUI_WALLET_CONFIG))?;
+    let address = wallet_conf.accounts.first().unwrap();
+
+    let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
+
+    http_client.sync_account_state(*address).await?;
+    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let result = result
+        .objects
+        .into_iter()
+        .map(|o| o.to_object_ref())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(5, result.len());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transfer_coin() -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let working_dir = temp_dir.path();
+    let _network = start_test_network(working_dir, None).await?;
+    let (server_addr, _handle) = start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG)).await?;
+    let wallet_conf: WalletConfig = PersistedConfig::read(&working_dir.join(SUI_WALLET_CONFIG))?;
+    let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
+    let address = wallet_conf.accounts.first().unwrap();
+    http_client.sync_account_state(*address).await?;
+    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let objects = result
+        .objects
+        .into_iter()
+        .map(|o| o.to_object_ref())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let tx_data: TransactionBytes = http_client
+        .create_coin_transfer(
+            *address,
+            objects.first().unwrap().0,
+            objects.last().unwrap().0,
+            1000,
+            *address,
+        )
+        .await?;
+
+    let keystore = SuiKeystore::load_or_create(&working_dir.join("wallet.key"))?;
+    let signature = keystore.sign(address, &tx_data.tx_bytes)?;
+
+    let tx_response: TransactionResponse = http_client
+        .execute_transaction(SignedTransaction::new(tx_data.tx_bytes, signature))
+        .await?;
+
+    let (_cert, effect) = tx_response.to_effect_response()?;
+    assert_eq!(2, effect.mutated.len());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_publish() -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let working_dir = temp_dir.path();
+    let _network = start_test_network(working_dir, None).await?;
+    let (server_addr, _handle) = start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG)).await?;
+    let wallet_conf: WalletConfig = PersistedConfig::read(&working_dir.join(SUI_WALLET_CONFIG))?;
+    let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
+    let address = wallet_conf.accounts.first().unwrap();
+    http_client.sync_account_state(*address).await?;
+    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let objects = result
+        .objects
+        .into_iter()
+        .map(|o| o.to_object_ref())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let gas = objects.first().unwrap();
+
+    let compiled_modules = build_move_package_to_bytes(
+        Path::new("../sui_programmability/examples/fungible_tokens"),
+        false,
+    )?
+    .into_iter()
+    .map(Base64EncodedBytes)
+    .collect::<Vec<_>>();
+
+    let tx_data: TransactionBytes = http_client
+        .publish(*address, compiled_modules, gas.0, 10000)
+        .await?;
+
+    let keystore = SuiKeystore::load_or_create(&working_dir.join("wallet.key"))?;
+    let signature = keystore.sign(address, &tx_data.tx_bytes)?;
+
+    let tx_response: TransactionResponse = http_client
+        .execute_transaction(SignedTransaction::new(tx_data.tx_bytes, signature))
+        .await?;
+
+    let response = tx_response.to_publish_response()?;
+    assert_eq!(2, response.created_objects.len());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_move_call() -> Result<(), anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    let working_dir = temp_dir.path();
+    let _network = start_test_network(working_dir, None).await?;
+    let (server_addr, _handle) = start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG)).await?;
+    let wallet_conf: WalletConfig = PersistedConfig::read(&working_dir.join(SUI_WALLET_CONFIG))?;
+    let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
+    let address = wallet_conf.accounts.first().unwrap();
+    http_client.sync_account_state(*address).await?;
+    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let objects = result
+        .objects
+        .into_iter()
+        .map(|o| o.to_object_ref())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let gas = objects.first().unwrap();
+
+    let package_id = ObjectID::new(SUI_FRAMEWORK_ADDRESS.into_bytes());
+    let package: ObjectRead = http_client.get_object_info(package_id).await?;
+    let package = package.into_object()?;
+    let module = Identifier::new("ObjectBasics")?;
+    let function = Identifier::new("create")?;
+
+    let (object_ids, pure_args) = resolve_move_function_args(
+        &package,
+        module.clone(),
+        function.clone(),
+        vec![
+            SuiJsonValue::from_str("10000")?,
+            SuiJsonValue::from_str(&format!("\"0x{}\"", address))?,
+        ],
+    )?;
+
+    let pure_args = pure_args
+        .into_iter()
+        .map(Base64EncodedBytes)
+        .collect::<Vec<_>>();
+
+    let tx_data: TransactionBytes = http_client
+        .create_move_call(
+            *address,
+            package_id,
+            module,
+            function,
+            Vec::new(),
+            pure_args,
+            gas.0,
+            1000,
+            object_ids,
+            Vec::new(),
+        )
+        .await?;
+
+    let keystore = SuiKeystore::load_or_create(&working_dir.join("wallet.key"))?;
+    let signature = keystore.sign(address, &tx_data.tx_bytes)?;
+
+    let tx_response: TransactionResponse = http_client
+        .execute_transaction(SignedTransaction::new(tx_data.tx_bytes, signature))
+        .await?;
+
+    let (_cert, effect) = tx_response.to_effect_response()?;
+    assert_eq!(1, effect.created.len());
+    Ok(())
+}
+
+pub async fn start_rpc_gateway(
+    config_path: &Path,
+) -> Result<(SocketAddr, HttpServerHandle), anyhow::Error> {
+    let server = HttpServerBuilder::default().build("127.0.0.1:0").await?;
+    let addr = server.local_addr()?;
+    let handle = server.start(RpcGatewayImpl::new(config_path)?.into_rpc())?;
+    Ok((addr, handle))
+}

--- a/sui/src/unit_tests/rpc_server_tests.rs
+++ b/sui/src/unit_tests/rpc_server_tests.rs
@@ -40,7 +40,7 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
     let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
 
     http_client.sync_account_state(*address).await?;
-    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let result: ObjectResponse = http_client.get_owned_objects(*address).await?;
     let result = result
         .objects
         .into_iter()
@@ -61,7 +61,7 @@ async fn test_transfer_coin() -> Result<(), anyhow::Error> {
     let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
     let address = wallet_conf.accounts.first().unwrap();
     http_client.sync_account_state(*address).await?;
-    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let result: ObjectResponse = http_client.get_owned_objects(*address).await?;
     let objects = result
         .objects
         .into_iter()
@@ -69,7 +69,7 @@ async fn test_transfer_coin() -> Result<(), anyhow::Error> {
         .collect::<Result<Vec<_>, _>>()?;
 
     let tx_data: TransactionBytes = http_client
-        .create_coin_transfer(
+        .transfer_coin(
             *address,
             objects.first().unwrap().0,
             objects.last().unwrap().0,
@@ -101,7 +101,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
     let address = wallet_conf.accounts.first().unwrap();
     http_client.sync_account_state(*address).await?;
-    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let result: ObjectResponse = http_client.get_owned_objects(*address).await?;
     let objects = result
         .objects
         .into_iter()
@@ -144,7 +144,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let http_client = HttpClientBuilder::default().build(format!("http://{}", server_addr))?;
     let address = wallet_conf.accounts.first().unwrap();
     http_client.sync_account_state(*address).await?;
-    let result: ObjectResponse = http_client.get_objects(*address).await?;
+    let result: ObjectResponse = http_client.get_owned_objects(*address).await?;
     let objects = result
         .objects
         .into_iter()
@@ -175,7 +175,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
         .collect::<Vec<_>>();
 
     let tx_data: TransactionBytes = http_client
-        .create_move_call(
+        .move_call(
             *address,
             package_id,
             module,

--- a/sui/src/unit_tests/sui_network.rs
+++ b/sui/src/unit_tests/sui_network.rs
@@ -7,7 +7,7 @@ use sui::config::{AuthorityPrivateInfo, Config, GenesisConfig, WalletConfig};
 use sui::gateway::{GatewayConfig, GatewayType};
 use sui::keystore::KeystoreType;
 use sui::sui_commands::{genesis, SuiNetwork};
-use sui::{SUI_NETWORK_CONFIG, SUI_WALLET_CONFIG};
+use sui::{SUI_GATEWAY_CONFIG, SUI_NETWORK_CONFIG, SUI_WALLET_CONFIG};
 
 pub async fn start_test_network(
     working_dir: &Path,
@@ -50,8 +50,17 @@ pub async fn start_test_network(
             info.base_port = server.get_port();
             info
         })
-        .collect();
+        .collect::<Vec<_>>();
     let active_address = accounts.get(0).copied();
+
+    GatewayConfig {
+        db_folder_path: db_folder_path.clone(),
+        authorities: authorities.clone(),
+        ..Default::default()
+    }
+    .persisted(&working_dir.join(SUI_GATEWAY_CONFIG))
+    .save()?;
+
     // Create wallet config with stated authorities port
     WalletConfig {
         accounts,

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -97,13 +97,13 @@ impl<A> GatewayState<A> {
 #[async_trait]
 pub trait GatewayAPI {
     async fn execute_transaction(
-        &mut self,
+        &self,
         tx: Transaction,
     ) -> Result<TransactionResponse, anyhow::Error>;
 
     /// Send coin object to a Sui address.
     async fn transfer_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         object_id: ObjectID,
         gas_payment: ObjectID,
@@ -118,7 +118,7 @@ pub trait GatewayAPI {
 
     /// Call move functions in the module in the given package, with args supplied
     async fn move_call(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_object_ref: ObjectRef,
         module: Identifier,
@@ -133,7 +133,7 @@ pub trait GatewayAPI {
 
     /// Publish Move modules
     async fn publish(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
         gas_object_ref: ObjectRef,
@@ -147,7 +147,7 @@ pub trait GatewayAPI {
     /// Note that the order of the new coins in SplitCoinResponse will
     /// not be the same as the order of `split_amounts`.
     async fn split_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
@@ -164,7 +164,7 @@ pub trait GatewayAPI {
     ///
     /// TODO: Support merging a vector of coins.
     async fn merge_coins(
-        &mut self,
+        &self,
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
@@ -177,7 +177,7 @@ pub trait GatewayAPI {
 
     /// Get refs of all objects we own from local cache.
     async fn get_owned_objects(
-        &mut self,
+        &self,
         account_addr: SuiAddress,
     ) -> Result<Vec<ObjectRef>, anyhow::Error>;
 
@@ -206,7 +206,7 @@ where
     // TODO: This is expensive and unnecessary.
     // We should make sure that the framework package exists in the gateway store and read it.
     // Or even better, we should cache the reference in GatewayState struct.
-    pub async fn get_framework_object_ref(&mut self) -> Result<ObjectRef, anyhow::Error> {
+    pub async fn get_framework_object_ref(&self) -> Result<ObjectRef, anyhow::Error> {
         let info = self
             .get_object_info(ObjectID::from(SUI_FRAMEWORK_ADDRESS))
             .await?;
@@ -555,7 +555,7 @@ where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
     async fn execute_transaction(
-        &mut self,
+        &self,
         tx: Transaction,
     ) -> Result<TransactionResponse, anyhow::Error> {
         let tx_kind = tx.data.kind.clone();
@@ -586,7 +586,7 @@ where
     }
 
     async fn transfer_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         object_id: ObjectID,
         gas_payment: ObjectID,
@@ -627,7 +627,7 @@ where
     }
 
     async fn move_call(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_object_ref: ObjectRef,
         module: Identifier,
@@ -655,7 +655,7 @@ where
     }
 
     async fn publish(
-        &mut self,
+        &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
         gas_object_ref: ObjectRef,
@@ -666,7 +666,7 @@ where
     }
 
     async fn split_coin(
-        &mut self,
+        &self,
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
@@ -696,7 +696,7 @@ where
     }
 
     async fn merge_coins(
-        &mut self,
+        &self,
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
@@ -734,7 +734,7 @@ where
     }
 
     async fn get_owned_objects(
-        &mut self,
+        &self,
         account_addr: SuiAddress,
     ) -> Result<Vec<ObjectRef>, anyhow::Error> {
         Ok(self.store.get_account_objects(account_addr)?)

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -489,7 +489,7 @@ async fn test_initiating_valid_transfer() {
     ];
 
     let (sender, sender_key) = get_key_pair();
-    let mut client = init_local_client_and_fund_account(sender, authority_objects).await;
+    let client = init_local_client_and_fund_account(sender, authority_objects).await;
     assert_eq!(
         client.get_authorities().get_latest_owner(object_id_1).await,
         (sender, SequenceNumber::from(0))
@@ -546,7 +546,7 @@ async fn test_initiating_valid_transfer_despite_bad_authority() {
         vec![object_id, gas_object],
     ];
     let (sender, sender_key) = get_key_pair();
-    let mut client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
+    let client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
     let data = client
         .transfer_coin(sender, object_id, gas_object, 50000, recipient)
         .await
@@ -593,7 +593,7 @@ async fn test_initiating_transfer_low_funds() {
         vec![object_id_1, object_id_2, gas_object],
     ];
     let (sender, sender_key) = get_key_pair();
-    let mut client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
+    let client = init_local_client_and_fund_account_bad(sender, authority_objects).await;
 
     let transfer = async {
         let data = client
@@ -1333,7 +1333,7 @@ async fn test_transfer_object_error() {
         .collect();
 
     let (sender, sender_key) = get_key_pair();
-    let mut client = init_local_client_and_fund_account(sender, authority_objects).await;
+    let client = init_local_client_and_fund_account(sender, authority_objects).await;
 
     let mut objects = objects.iter();
 
@@ -1944,7 +1944,7 @@ async fn test_transfer_pending_transactions() {
         .collect();
 
     let (sender, sender_key) = get_key_pair();
-    let mut client = init_local_client_and_fund_account(sender, authority_objects).await;
+    let client = init_local_client_and_fund_account(sender, authority_objects).await;
     let (recipient, _) = get_key_pair();
 
     let mut objects = objects.iter();

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -201,11 +201,11 @@ impl Signature {
         secret.sign(&message)
     }
 
-    fn signature_bytes(&self) -> &[u8] {
+    pub fn signature_bytes(&self) -> &[u8] {
         &self.0[..ed25519_dalek::SIGNATURE_LENGTH]
     }
 
-    fn public_key_bytes(&self) -> &[u8] {
+    pub fn public_key_bytes(&self) -> &[u8] {
         &self.0[ed25519_dalek::SIGNATURE_LENGTH..]
     }
 

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -423,7 +423,7 @@ pub trait SignableBytes
 where
     Self: Sized,
 {
-    fn from_signable_bytes(bytes: Vec<u8>) -> Result<Self, anyhow::Error>;
+    fn from_signable_bytes(bytes: &[u8]) -> Result<Self, anyhow::Error>;
 }
 /// Activate the blanket implementation of `Signable` based on serde and BCS.
 /// * We use `serde_name` to extract a seed from the name of structs and enums.
@@ -447,7 +447,7 @@ impl<T> SignableBytes for T
 where
     T: BcsSignable,
 {
-    fn from_signable_bytes(bytes: Vec<u8>) -> Result<Self, Error> {
+    fn from_signable_bytes(bytes: &[u8]) -> Result<Self, Error> {
         // Remove name tag before deserialization using BCS
         let name = serde_name::trace_name::<Self>().expect("Self must be a struct or an enum");
         let name_byte_len = format!("{}::", name).bytes().len();

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -2,14 +2,14 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use base64ct::{Base64, Encoding};
-use std::fmt::Write;
-use std::fmt::{Display, Formatter};
-use std::{
-    collections::{BTreeSet, HashSet},
-    hash::{Hash, Hasher},
+use crate::crypto::{
+    sha3_hash, AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature, BcsSignable,
+    EmptySignInfo, Signable, Signature, VerificationObligation,
 };
-
+use crate::gas::GasCostSummary;
+use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
+use crate::readable_serde::VecOrBase64;
+use base64ct::{Base64, Encoding};
 use itertools::Either;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
 use move_core_types::{
@@ -20,13 +20,13 @@ use name_variant::NamedVariant;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
-
-use crate::crypto::{
-    sha3_hash, AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature, BcsSignable,
-    EmptySignInfo, Signable, Signature, VerificationObligation,
+use serde_with::serde_as;
+use std::fmt::Write;
+use std::fmt::{Display, Formatter};
+use std::{
+    collections::{BTreeSet, HashSet},
+    hash::{Hash, Hasher},
 };
-use crate::gas::GasCostSummary;
-use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
 
 use super::{base_types::*, batch::*, committee::Committee, error::*, event::Event};
 
@@ -56,8 +56,10 @@ pub struct MoveCall {
     pub pure_arguments: Vec<Vec<u8>>,
 }
 
+#[serde_as]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveModulePublish {
+    #[serde_as(as = "Vec<VecOrBase64>")]
     pub modules: Vec<Vec<u8>>,
 }
 

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -8,7 +8,7 @@ use crate::crypto::{
 };
 use crate::gas::GasCostSummary;
 use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
-use crate::readable_serde::VecOrBase64;
+use crate::readable_serde::Base64OrDefault;
 use base64ct::{Base64, Encoding};
 use itertools::Either;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
@@ -59,7 +59,7 @@ pub struct MoveCall {
 #[serde_as]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveModulePublish {
-    #[serde_as(as = "Vec<VecOrBase64>")]
+    #[serde_as(as = "Vec<Base64OrDefault>")]
     pub modules: Vec<Vec<u8>>,
 }
 

--- a/sui_types/src/move_package.rs
+++ b/sui_types/src/move_package.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::readable_serde::Base64OrDefault;
 use crate::{
     base_types::ObjectID,
     error::{SuiError, SuiResult},
@@ -9,17 +10,19 @@ use move_binary_format::file_format::CompiledModule;
 use move_core_types::identifier::Identifier;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
+use serde_with::serde_as;
 use std::collections::BTreeMap;
-
 // TODO: robust MovePackage tests
 // #[cfg(test)]
 // #[path = "unit_tests/move_package.rs"]
 // mod base_types_tests;
 
 // serde_bytes::ByteBuf is an analog of Vec<u8> with built-in fast serialization.
+#[serde_as]
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MovePackage {
     id: ObjectID,
+    #[serde_as(as = "BTreeMap<_, Base64OrDefault>")]
     // TODO use session cache
     module_map: BTreeMap<String, ByteBuf>,
 }

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -404,7 +404,7 @@ fn test_signable_serde() -> Result<(), anyhow::Error> {
     // Serialize
     let bytes = data.to_bytes();
     // Deserialize
-    let deserialized_data = TransactionData::from_signable_bytes(bytes)?;
+    let deserialized_data = TransactionData::from_signable_bytes(&bytes)?;
     assert_eq!(data, deserialized_data);
     Ok(())
 }


### PR DESCRIPTION
JSON-RPC gateway server implementation to replace the Rest Gateway server

* using JSON-RPC lib from paritytech/jsonrpsee
* ported all endpoints from rest server,  endpoints mirroring `GatewayAPI`
* endpoint methods are prefixed with namespace `sui`
* list of methods : `sui_getObjectInfo`, `sui_moveCall`, `sui_syncAccountState`, `sui_getTransactionsInRange`, `sui_getTotalTransactionNumber`, `sui_getOwnedObjects`, `sui_transferCoin`, `sui_splitCoin`, `sui_executeTransaction`, `sui_mergeCoins`, `sui_publish`, `sui_getRecentTransactions`
* New RPCGatewayClient implementation for the wallet cli

**Running the server** (*you will need to do a fresh genesis first)
`./rpc_server`

**Running the server with CORS**
`ACCESS_CONTROL_ALLOW_ORIGIN=* ./rpc_server `

**Invoke method with curl**
```
curl -X POST \
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","id":1,"method":"sui_getOwnedObjects","params":["<< address >>"]}' \
     http://127.0.0.1:5001
```
Replace << address >> with one of the addresses in `wallet.conf`

**You can also use the wallet cli with the RPC server, to do this modify `wallet.conf`'s gateway section to** 
```
  "gateway": {
    "rpc": "http://127.0.0.1:5001"
  }
```

**Todos:**
* OpenRPC doc
* Add getTransaction endpoint from @stella3d 's branch https://github.com/MystenLabs/sui/tree/get-tx-route
* Refactor/simplify GatewayAPI response objects
* Documentation, tutorial etc
* Remove rest gateway server