### PR TITLE
Allow shared objects in adapter events

### DIFF
--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -498,7 +498,8 @@ fn process_successful_execution<
         match event_type {
             EventType::TransferToAddress
             | EventType::FreezeObject
-            | EventType::TransferToObject => {
+            | EventType::TransferToObject
+            | EventType::ShareObject => {
                 let new_owner = match event_type {
                     EventType::TransferToAddress => {
                         Owner::AddressOwner(SuiAddress::try_from(recipient.as_slice()).unwrap())
@@ -507,6 +508,7 @@ fn process_successful_execution<
                     EventType::TransferToObject => {
                         Owner::ObjectOwner(ObjectID::try_from(recipient.borrow()).unwrap().into())
                     }
+                    EventType::ShareObject => Owner::SharedMutable,
                     _ => unreachable!(),
                 };
                 handle_transfer(
@@ -520,7 +522,6 @@ fn process_successful_execution<
                     &newly_generated_ids,
                 )
             }
-            EventType::ShareObject => Err(SuiError::UnsupportedSharedObjectError),
             EventType::DeleteObjectID => {
                 // unwrap safe because this event can only be emitted from processing
                 // native call delete_id, which guarantees the type of the id.


### PR DESCRIPTION
Although we don't support using shared objects in transactions, there is no harm to allow generating shared objects in Move code.
This is particularly important since some of our module initializers generate them (e.g. BASKET in fungible tokens), and we want to be able to at least publish the package.