### PR TITLE
Add ordering for transactions on Gateway

### DIFF
--- a/sui/src/gateway.rs
+++ b/sui/src/gateway.rs
@@ -16,6 +16,7 @@ use sui_network::network::NetworkClient;
 use sui_network::transport;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::Committee;
+use sui_types::error::SuiResult;
 
 use crate::config::{AuthorityInfo, Config};
 use crate::rest_gateway::RestGatewayClient;
@@ -59,16 +60,16 @@ impl Display for GatewayType {
 }
 
 impl GatewayType {
-    pub fn init(&self) -> GatewayClient {
-        match self {
+    pub fn init(&self) -> SuiResult<GatewayClient> {
+        Ok(match self {
             GatewayType::Embedded(config) => {
                 let path = config.db_folder_path.clone();
                 let committee = config.make_committee();
                 let authority_clients = config.make_authority_clients();
-                Box::new(GatewayState::new(path, committee, authority_clients))
+                Box::new(GatewayState::new(path, committee, authority_clients)?)
             }
             GatewayType::Rest(url) => Box::new(RestGatewayClient { url: url.clone() }),
-        }
+        })
     }
 }
 

--- a/sui/src/rest_gateway.rs
+++ b/sui/src/rest_gateway.rs
@@ -208,6 +208,11 @@ impl GatewayAPI for RestGatewayClient {
             .collect::<Result<Vec<_>, anyhow::Error>>()?;
         Ok(objects)
     }
+
+    fn get_total_transaction_number(&self) -> Result<u64, anyhow::Error> {
+        // TODO: Implement this.
+        Ok(0)
+    }
 }
 
 impl RestGatewayClient {

--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<(), anyhow::Error> {
         config.db_folder_path,
         committee,
         authority_clients,
-    ));
+    )?);
 
     let api_context = ServerContext::new(documentation, gateway);
     let server = HttpServerStarter::new(&config_dropshot, api, api_context, &log)?.start();

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -550,7 +550,7 @@ impl WalletContext {
         })?;
         let config = config.persisted(config_path);
         let keystore = Arc::new(RwLock::new(config.keystore.init()?));
-        let gateway = config.gateway.init();
+        let gateway = config.gateway.init()?;
         let context = Self {
             config,
             keystore,

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -439,7 +439,7 @@ async fn make_address_manager(
 ) {
     let (authority_clients, committee) = init_local_authorities(authority_count).await;
     let path = tempfile::tempdir().unwrap().into_path();
-    let client = GatewayState::new(path, committee, authority_clients.clone());
+    let client = GatewayState::new(path, committee, authority_clients.clone()).unwrap();
     (client, authority_clients.into_values().collect())
 }
 
@@ -470,7 +470,7 @@ async fn init_local_client_and_fund_account_bad(
 ) -> GatewayState<LocalAuthorityClient> {
     let (authority_clients, committee) = init_local_authorities_bad(object_ids.len()).await;
     let path = tempfile::tempdir().unwrap().into_path();
-    let mut client = GatewayState::new(path, committee, authority_clients.clone());
+    let mut client = GatewayState::new(path, committee, authority_clients.clone()).unwrap();
     fund_account(
         authority_clients.into_values().collect(),
         &mut client,
@@ -2100,6 +2100,44 @@ async fn test_coin_merge() {
     );
     let update_coin = GasCoin::try_from(response.updated_coin.data.try_as_move().unwrap()).unwrap();
     assert_eq!(update_coin.value(), GAS_VALUE_FOR_TESTING * 2);
+}
+
+#[tokio::test]
+async fn test_get_total_transaction_number() -> Result<(), anyhow::Error> {
+    let (mut client, authority_clients) = make_address_manager(4).await;
+    let (addr1, key1) = get_key_pair();
+    let (addr2, _) = get_key_pair();
+
+    let object_id1 = ObjectID::random();
+    let object_id2 = ObjectID::random();
+    let object_id3 = ObjectID::random();
+
+    let gas_object = ObjectID::random();
+
+    fund_account_with_same_objects(
+        authority_clients.clone(),
+        &mut client,
+        addr1,
+        vec![object_id1, object_id2, object_id3, gas_object],
+    )
+    .await;
+
+    let mut cnt = 0;
+    for obj_id in [object_id1, object_id2, object_id3] {
+        assert_eq!(client.get_total_transaction_number()?, cnt);
+        let data = client
+            .transfer_coin(addr1, obj_id, gas_object, 50000, addr2)
+            .await
+            .unwrap();
+        let signature = key1.sign(&data.to_bytes());
+        client
+            .execute_transaction(Transaction::new(data, signature))
+            .await?;
+        cnt += 1;
+        assert_eq!(client.get_total_transaction_number()?, cnt);
+    }
+
+    Ok(())
 }
 
 fn to_transaction(data: TransactionData, signer: &dyn Signer<Signature>) -> Transaction {


### PR DESCRIPTION
This PR adds a next tx sequence number on Gateway, which is an atomic value, incremented every time we are adding a new tx cert into the store.
This will allow us to query the total number of tx in history, as well as querying tx digests in sequence number range (to be added).