### PR TITLE
[RFC] Use `Bag` in `Marketplace` and remove `owner`

### DIFF
--- a/sui_programmability/examples/nfts/sources/Marketplace.move
+++ b/sui_programmability/examples/nfts/sources/Marketplace.move
@@ -24,7 +24,6 @@ module NFTs::Marketplace {
     struct Marketplace has key {
         id: VersionedID,
         objects: vector<ID>,
-        owner: address,
     }
 
     /// A single listing which contains the listed item and its price in [`Coin<C>`].
@@ -40,7 +39,6 @@ module NFTs::Marketplace {
         Transfer::share_object(Marketplace {
             id: TxContext::new_id(ctx),
             objects: Vector::empty(),
-            owner: TxContext::sender(ctx),
         });
     }
 
@@ -198,7 +196,7 @@ module NFTs::MarketplaceTests {
         TestScenario::next_tx(scenario, &SELLER);
         let mkp = TestScenario::remove_object<Marketplace>(scenario);
         let nft = TestScenario::remove_object<NFT<KITTY>>(scenario);
-            
+
         Marketplace::list<NFT<KITTY>, SUI>(&mut mkp, nft, 100, TestScenario::ctx(scenario));
         TestScenario::return_object(scenario, mkp);
     }
@@ -241,7 +239,7 @@ module NFTs::MarketplaceTests {
         {
             let mkp = TestScenario::remove_object<Marketplace>(scenario);
             let listing = TestScenario::remove_nested_object<Marketplace, Listing<NFT<KITTY>, SUI>>(scenario, &mkp);
-            
+
             // Do the delist operation on a Marketplace.
             let nft = Marketplace::delist<NFT<KITTY>, SUI>(&mut mkp, listing, TestScenario::ctx(scenario));
             let _ = NFT::burn<KITTY>(nft);

--- a/sui_programmability/examples/nfts/sources/Marketplace.move
+++ b/sui_programmability/examples/nfts/sources/Marketplace.move
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module NFTs::Marketplace {
+    use Sui::Bag::{Self, Bag};
     use Sui::TxContext::{Self, TxContext};
     use Sui::ID::{Self, ID, VersionedID};
-    use Sui::Transfer::{Self};
+    use Sui::Transfer::{Self, ChildRef};
     use Sui::Coin::{Self, Coin};
-    use Std::Option::{Self, Option};
-    use Std::Vector;
 
     // For when amount paid does not match the expected.
     const EAMOUNT_INCORRECT: u64 = 0;
@@ -23,7 +22,7 @@ module NFTs::Marketplace {
 
     struct Marketplace has key {
         id: VersionedID,
-        objects: vector<ID>,
+        objects: ChildRef<Bag>,
     }
 
     /// A single listing which contains the listed item and its price in [`Coin<C>`].
@@ -36,34 +35,41 @@ module NFTs::Marketplace {
 
     /// Create a new shared Marketplace.
     public fun create(ctx: &mut TxContext) {
-        Transfer::share_object(Marketplace {
-            id: TxContext::new_id(ctx),
-            objects: Vector::empty(),
-        });
+        let id = TxContext::new_id(ctx);
+        let objects = Bag::new(ctx);
+        let (id, objects) = Transfer::transfer_to_object_id(objects, id);
+        let market_place = Marketplace {
+            id,
+            objects,
+        };
+        Transfer::share_object(market_place);
     }
 
     /// List an item at the Marketplace.
     public fun list<T: key + store, C>(
-        marketplace: &mut Marketplace,
+        _marketplace: &mut Marketplace,
+        objects: &mut Bag,
         item: T,
         ask: u64,
         ctx: &mut TxContext
     ) {
-        internal_add(marketplace, Listing<T, C> {
+        let listing = Listing<T, C> {
             item,
             ask,
             id: TxContext::new_id(ctx),
             owner: TxContext::sender(ctx),
-        })
+        };
+        Bag::add(objects, listing)
     }
 
     /// Remove listing and get an item back. Only owner can do that.
     public fun delist<T: key + store, C>(
-        marketplace: &mut Marketplace,
+        _marketplace: &mut Marketplace,
+        objects: &mut Bag,
         listing: Listing<T, C>,
         ctx: &mut TxContext
     ): T {
-        let listing = internal_remove(marketplace, listing);
+        let listing = Bag::remove(objects, listing);
         let Listing { id, item, ask: _, owner } = listing;
 
         assert!(TxContext::sender(ctx) == owner, ENOT_OWNER);
@@ -74,22 +80,24 @@ module NFTs::Marketplace {
 
     /// Call [`delist`] and transfer item to the sender.
     public fun delist_and_take<T: key + store, C>(
-        market: &mut Marketplace,
+        _marketplace: &mut Marketplace,
+        objects: &mut Bag,
         listing: Listing<T, C>,
         ctx: &mut TxContext
     ) {
-        Transfer::transfer(delist(market, listing, ctx), TxContext::sender(ctx))
+        Bag::remove_and_take(objects, listing, ctx)
     }
 
     /// Purchase an item using a known Listing. Payment is done in Coin<C>.
     /// Amount paid must match the requested amount. If conditions are met,
     /// owner of the item gets the payment and buyer receives their item.
     public fun buy<T: key + store, C>(
-        marketplace: &mut Marketplace,
+        _marketplace: &mut Marketplace,
+        objects: &mut Bag,
         listing: Listing<T, C>,
         paid: Coin<C>,
     ): T {
-        let listing = internal_remove(marketplace, listing);
+        let listing = Bag::remove(objects, listing);
         let Listing { id, item, ask, owner } = listing;
 
         assert!(ask == Coin::value(&paid), EAMOUNT_INCORRECT);
@@ -101,55 +109,23 @@ module NFTs::Marketplace {
 
     /// Call [`buy`] and transfer item to the sender.
     public fun buy_and_take<T: key + store, C>(
-        market: &mut Marketplace,
+        marketplace: &mut Marketplace,
         listing: Listing<T, C>,
+        objects: &mut Bag,
         paid: Coin<C>,
         ctx: &mut TxContext
     ) {
-        Transfer::transfer(buy(market, listing, paid), TxContext::sender(ctx))
+        Transfer::transfer(buy(marketplace, objects, listing, paid), TxContext::sender(ctx))
     }
 
     /// Check whether an object was listed on a Marketplace.
-    public fun contains(c: &Marketplace, id: &ID): bool {
-        Option::is_some(&find(c, id))
+    public fun contains(_marketplace: &Marketplace, objects: &Bag, id: &ID): bool {
+        Bag::contains(objects, id)
     }
 
     /// Returns the size of the Marketplace.
-    public fun size(c: &Marketplace): u64 {
-        Vector::length(&c.objects)
-    }
-
-    /// Rough clone of [`Sui::Bag::add`] to make Marketlace a Bag like object.
-    fun internal_add<T: key>(c: &mut Marketplace, object: T) {
-        let id = ID::id(&object);
-        if (contains(c, id)) {
-            abort EOBJECT_DOUBLE_ADD
-        };
-        Vector::push_back(&mut c.objects, *id);
-        Transfer::transfer_to_object_unsafe(object, c);
-    }
-
-    /// Rough clone of [`Sui::Bag::remove`].
-    fun internal_remove<T: key>(c: &mut Marketplace, object: T): T {
-        let idx = find(c, ID::id(&object));
-        if (Option::is_none(&idx)) {
-            abort EOBJECT_NOT_FOUND
-        };
-        Vector::remove(&mut c.objects, *Option::borrow(&idx));
-        object
-    }
-
-    /// Rough clone of [`Sui::Bag::find`].
-    fun find(c: &Marketplace, id: &ID): Option<u64> {
-        let i = 0;
-        let len = size(c);
-        while (i < len) {
-            if (Vector::borrow(&c.objects, i) == id) {
-                return Option::some(i)
-            };
-            i = i + 1;
-        };
-        Option::none()
+    public fun size(_marketplace: &Marketplace, objects: &Bag): u64 {
+        Bag::size(objects)
     }
 }
 


### PR DESCRIPTION
Feel free to shoot this down if it doesn't make sense. This PR does two things:
1. Remove `owner` field from `Marketplace` because it's not used.
2. Instead of re-implementing `Bag` in `Marketplace`, we can just use have `Bag` a child object of `Marketplace`. Any downside with this approach?
