### PR TITLE
Add Gateway API to query transaction history

### DIFF
--- a/sui/src/rest_gateway.rs
+++ b/sui/src/rest_gateway.rs
@@ -13,8 +13,8 @@ use serde::Serialize;
 use serde_json::json;
 
 use sui_core::gateway_state::gateway_responses::TransactionResponse;
-use sui_core::gateway_state::GatewayAPI;
-use sui_types::base_types::{encode_bytes_hex, ObjectID, ObjectRef, SuiAddress};
+use sui_core::gateway_state::{GatewayAPI, GatewayTxSeqNumber};
+use sui_types::base_types::{encode_bytes_hex, ObjectID, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::messages::{Transaction, TransactionData};
 use sui_types::object::ObjectRead;
 
@@ -212,6 +212,23 @@ impl GatewayAPI for RestGatewayClient {
     fn get_total_transaction_number(&self) -> Result<u64, anyhow::Error> {
         // TODO: Implement this.
         Ok(0)
+    }
+
+    fn get_transactions_in_range(
+        &self,
+        start: GatewayTxSeqNumber,
+        end: GatewayTxSeqNumber,
+    ) -> Result<Vec<(GatewayTxSeqNumber, TransactionDigest)>, anyhow::Error> {
+        // TODO: Implement this.
+        Ok(vec![])
+    }
+
+    fn get_recent_transactions(
+        &self,
+        count: u64,
+    ) -> Result<Vec<(GatewayTxSeqNumber, TransactionDigest)>, anyhow::Error> {
+        // TODO: Implement this.
+        Ok(vec![])
     }
 }
 

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -750,10 +750,10 @@ where
         end: GatewayTxSeqNumber,
     ) -> Result<Vec<(GatewayTxSeqNumber, TransactionDigest)>, anyhow::Error> {
         fp_ensure!(
-            start < end,
+            start <= end,
             SuiError::GatewayInvalidTxRangeQuery {
                 error: format!(
-                    "start must be smaller than end, (start={}, end={}) given",
+                    "start must not exceed end, (start={}, end={}) given",
                     start, end
                 ),
             }

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -2138,8 +2138,9 @@ async fn test_recent_transactions() -> Result<(), anyhow::Error> {
         cnt += 1;
         assert_eq!(client.get_total_transaction_number()?, cnt);
     }
-    // start must < end.
-    assert!(client.get_transactions_in_range(1, 1).is_err());
+    // start must <= end.
+    assert!(client.get_transactions_in_range(2, 1).is_err());
+    assert!(client.get_transactions_in_range(1, 1).unwrap().is_empty());
     // Extends max range allowed.
     assert!(client.get_transactions_in_range(1, 100000).is_err());
     let txs = client.get_recent_transactions(10)?;

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -755,6 +755,10 @@ SuiError:
         STRUCT:
           - error: STR
     92:
+      GatewayInvalidTxRangeQuery:
+        STRUCT:
+          - error: STR
+    93:
       OnlyOneConsensusClientPermitted: UNIT
 TransactionData:
   STRUCT:

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -272,6 +272,8 @@ pub enum SuiError {
     },
     #[error("Inconsistent results observed in the Gateway. This should not happen and typically means there is a bug in the Sui implementation. Details: {error:?}")]
     InconsistentGatewayResult { error: String },
+    #[error("Invalid transactiojn range query to the gateway: {:?}", error)]
+    GatewayInvalidTxRangeQuery { error: String },
 
     // Errors related to the authority-consensus interface.
     #[error("Authority state can be modified by a single consensus client at the time")]


### PR DESCRIPTION
This PR adds two APIs:
1. Get most recent N transactions from the gateway.
2. Get transactions with sequence number in range (start, end).

These two APIs should be sufficient to support explorer for now.

Need someone to help finish the REST API impl.