### PR TITLE
[wallet CLI] use --no-shell by default

### DIFF
--- a/doc/src/build/programming-with-objects/ch1-object-basics.md
+++ b/doc/src/build/programming-with-objects/ch1-object-basics.md
@@ -78,13 +78,13 @@ Now let's try to call the `create` in transactions and see what happens. To do t
 
 Before starting, let's take a look at the default wallet address (this will be the address that will eventually own the object latter):
 ```
-wallet --no-shell active-address
+wallet active-address
 ```
 It will tell you the current wallet address.
 
 First of all, we need to publish the code onchain. Assuming the path to the root of the repository is $ROOT:
 ```
-wallet --no-shell publish --path $ROOT/doc/move_code/objects_tutorial --gas-budget 10000
+wallet publish --path $ROOT/doc/move_code/objects_tutorial --gas-budget 10000
 ```
 You can find the published package object ID in the **Publish Results**, like this:
 ```
@@ -94,7 +94,7 @@ The newly published package object: (57258F32746FD1443F2A077C0C6EC03282087C19, S
 Note that the exact data you see will be different. The first hex string in that triple is the package object ID (57258F32746FD1443F2A077C0C6EC03282087C19 in this case).
 Next we can call the function to create a color object:
 ```
-wallet --no-shell call --gas-budget 1000 --package "57258F32746FD1443F2A077C0C6EC03282087C19" --module "Ch1" --function "create" --args 0 255 0
+wallet call --gas-budget 1000 --package "57258F32746FD1443F2A077C0C6EC03282087C19" --module "Ch1" --function "create" --args 0 255 0
 ```
 In the **Transaction Effects**, you will see an object showing up in the list of **Created Objects**, like this:
 ```
@@ -103,7 +103,7 @@ Created Objects:
 ```
 We can inspect this object and see what kind of object it is:
 ```
-wallet --no-shell object --id 5EB2C3E55693282FAA7F5B07CE1C4803E6FDC1BB
+wallet object --id 5EB2C3E55693282FAA7F5B07CE1C4803E6FDC1BB
 ```
 It will show you the meta data of this object with its type:
 ```
@@ -117,7 +117,7 @@ As we can see, it's owned by the current default wallet address that we have see
 
 You can also look at the data content of the object by adding the `--json` parameter:
 ```
-wallet --no-shell object --id 5EB2C3E55693282FAA7F5B07CE1C4803E6FDC1BB --json
+wallet object --id 5EB2C3E55693282FAA7F5B07CE1C4803E6FDC1BB --json
 ```
 It will print all the value of all the fields in the Move object, such as the value of `red`, `green`, and `blue`.
 

--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -225,7 +225,7 @@ terminal window than one used to execute `sui start`). Assuming you
 accepted the default location for configuration:
 
 ```shell
-$ wallet
+$ wallet -i
 ```
 
 This command will look for the wallet configuration file
@@ -234,7 +234,7 @@ override this setting by providing a path to the directory where this
 file is stored:
 
 ```shell
-$ wallet --config /path/to/wallet/config/file
+$ wallet -i --config /path/to/wallet/config/file
 ```
 
 The Sui interactive wallet supports the following shell functionality:
@@ -258,14 +258,14 @@ commands using scripts.
 
 ```shell
 USAGE:
-    wallet --no-shell [SUBCOMMAND]
+    wallet [SUBCOMMAND]
 ```
 
 For example, we can use the following command to see the list of
 accounts available on the platform:
 
 ```shell
-$ wallet --no-shell addresses
+$ wallet addresses
 ```
 
 The result of running this command should resemble the following output:
@@ -300,7 +300,7 @@ at the start, but this can be changed later.
 In order to see what the current active address is, use the command `active-address`
 
 ```
-wallet --no-shell active-address
+wallet active-address
 562F07CF6369E8D22DBF226A5BFEDC6300014837
 ```
 
@@ -308,7 +308,7 @@ Changing the default address is as easy as calling the `switch` command
 
 ```
 
-wallet --no-shell switch --address 913CF36F370613ED131868AC6F9DA2420166062E
+wallet switch --address 913CF36F370613ED131868AC6F9DA2420166062E
 Active address switched to 913CF36F370613ED131868AC6F9DA2420166062E
 ```
 
@@ -348,7 +348,7 @@ To see how much gas is in an account, use the `gas` command. Note that this comm
 `active-address`, unless otherwise specified.
 
 ```
-wallet --no-shell gas
+wallet gas
                 Object ID                 |  Version   |  Gas Value
 ----------------------------------------------------------------------
  0B8A4620426E526FA42995CF26EB610BFE6BF063 |     0      |   100000
@@ -361,7 +361,7 @@ wallet --no-shell gas
 If one does not want to use the active address, the addresses can be specified:
 
 ```
-/wallet --no-shell gas --address 562F07CF6369E8D22DBF226A5BFEDC6300014837
+/wallet gas --address 562F07CF6369E8D22DBF226A5BFEDC6300014837
                 Object ID                 |  Version   |  Gas Value
 ----------------------------------------------------------------------
  A8DDC2661A19010E5F85CBF6D905DDFBE4DD0320 |     0      |   100000
@@ -382,7 +382,7 @@ not enough, there are two ways to add accounts to the Sui wallet if needed.
 To create a new account, execute the `new-address` command:
 
 ```shell
-$ wallet --no-shell new-address
+$ wallet new-address
 ```
 
 The output shows a confirmation after the account has been created:
@@ -421,7 +421,7 @@ OPTIONS:
 To view the objects owned by the accounts created in genesis, run the following command (substitute the address with one of the genesis addresses in your wallet):
 
 ```shell
-$ wallet --no-shell objects --address 66AF3898E7558B79E115AB61184A958497D1905A
+$ wallet objects --address 66AF3898E7558B79E115AB61184A958497D1905A
 ```
 
 The result should resemble the following, which shows the object in the format of (`object_id`, `sequence_number`, `object_hash`).
@@ -455,7 +455,7 @@ OPTIONS:
 To view the object, use the following command:
 
 ```bash
-$ wallet --no-shell object --id EEA4167BE074537F4A2879C7781D8EF4FFD651CC
+$ wallet object --id EEA4167BE074537F4A2879C7781D8EF4FFD651CC
 ```
 
 This should give you output similar to the following:
@@ -484,7 +484,7 @@ Here is an example:
 If you inspect a newly created account, you would expect the account does not own any object. Let us inspect the fresh account we create in the [Generating a new account](#generating-a-new-account) section (`C72CF3ADCC4D11C03079CEF2C8992AEA5268677A`):
 
 ```shell
-$ wallet --no-shell objects --address C72CF3ADCC4D11C03079CEF2C8992AEA5268677A
+$ wallet objects --address C72CF3ADCC4D11C03079CEF2C8992AEA5268677A
 Showing 0 results.
 
 ```
@@ -522,7 +522,7 @@ mechanisms. For now, just set something large enough.
 Here is an example transfer of an object to account `F456EBEF195E4A231488DF56B762AC90695BE2DD`:
 
 ```shell
-$ wallet --no-shell transfer --to C72CF3ADCC4D11C03079CEF2C8992AEA5268677A --object-id DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1 --gas-budget 100
+$ wallet transfer --to C72CF3ADCC4D11C03079CEF2C8992AEA5268677A --object-id DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1 --gas-budget 100
 ```
 
 With output like:
@@ -547,7 +547,7 @@ DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1 SequenceNumber(1) o#f77edd77f5c154a8500
 The account will now have one object:
 
 ```shell
-$ wallet --no-shell objects --address C72CF3ADCC4D11C03079CEF2C8992AEA5268677A
+$ wallet objects --address C72CF3ADCC4D11C03079CEF2C8992AEA5268677A
 Showing 1 results.
 (DA2237A9890BCCEBEEEAE0D23EC739F00D2CE2B1, SequenceNumber(1), o#f77edd77f5c154a850078b81b320870890bbb4f06d18f80fd512b1cc26bc3297)
 ```
@@ -588,7 +588,7 @@ Let us examine objects owned by address `EF999DBDB19CCCA504EEF5432CEC69EA8A1D4A1
 and use the first coin (gas) object as the one to be the result of the merge, the second one to be merged, and the third one to be used as payment:
 
 ```shell
-$ wallet --no-shell objects --address EF999DBDB19CCCA504EEF5432CEC69EA8A1D4A1B
+$ wallet objects --address EF999DBDB19CCCA504EEF5432CEC69EA8A1D4A1B
 ```
 
 And its output:
@@ -604,7 +604,7 @@ Showing 5 results.
 
 Then we merge:
 ```shell
-$ wallet --no-shell merge-coin --primary-coin 149A3493C97FAFC696526052FE08E77043D4BE0B  --coin-to-merge 1B19F74AD77A95D7562432F6991AC9EC1EA2C57C --gas-budget 1000
+$ wallet merge-coin --primary-coin 149A3493C97FAFC696526052FE08E77043D4BE0B  --coin-to-merge 1B19F74AD77A95D7562432F6991AC9EC1EA2C57C --gas-budget 1000
 ```
 
 With results resembling:
@@ -653,7 +653,7 @@ one coin to split, one for the gas payment.
 Let us examine objects owned by address `45CDA12E3BAFE3017B4B3CD62C493E5FBAAD7FB0`:
 
 ```shell
-$ wallet --no-shell objects --address 45CDA12E3BAFE3017B4B3CD62C493E5FBAAD7FB0
+$ wallet objects --address 45CDA12E3BAFE3017B4B3CD62C493E5FBAAD7FB0
 ```
 
 With output resembling:
@@ -672,7 +672,7 @@ with values of 1000, 5000 and 3000, respectively; note the `--amounts` argument 
 We use the second coin on the list to pay for this transaction.
 
 ```shell
-$ wallet --no-shell split-coin --coin-id 13347BD461E8A2B9EE5DE7F6131063A3050A45C4 --amounts 1000 5000 3000 --gas-budget 1000
+$ wallet split-coin --coin-id 13347BD461E8A2B9EE5DE7F6131063A3050A45C4 --amounts 1000 5000 3000 --gas-budget 1000
 ```
 
 You will see output resembling:
@@ -696,7 +696,7 @@ New Coins : Coin { id: 72129FBF3168C37A4DD8EC7EE69DA28D0D4D4636, value: 5000 },
             Coin { id: D2E65E9A3107662F7B6399BD1D82C235CFD8C874, value: 3000 }
 Updated Gas : Coin { id: B402F52BA6216A770939E6D4922AE6D6D05C2256, value: 99780 }
 
-$ wallet --no-shell objects --address 45CDA12E3BAFE3017B4B3CD62C493E5FBAAD7FB0
+$ wallet objects --address 45CDA12E3BAFE3017B4B3CD62C493E5FBAAD7FB0
 Showing 8 results.
 (13347BD461E8A2B9EE5DE7F6131063A3050A45C4, SequenceNumber(1), o#4f86a454ed9aa482adcbfece78cdd77d491d4e768aa8034af78a237d18e09f9f)
 (72129FBF3168C37A4DD8EC7EE69DA28D0D4D4636, SequenceNumber(1), o#247905d1c8eee09b4d3bd02f4229376cd7482705e28ef7ff4ca86774d09c72b8)
@@ -732,7 +732,7 @@ simplicity.
 Let us examine objects owned by address `AE6FB6036570FEC1DF71599740C132CDF5B45B9D`:
 
 ```shell
-$ wallet --no-shell objects --address AE6FB6036570FEC1DF71599740C132CDF5B45B9D
+$ wallet objects --address AE6FB6036570FEC1DF71599740C132CDF5B45B9D
 Showing 5 results.
 (5044DC15D3C71D500116EB026E8B70D0A180F3AC, SequenceNumber(0), o#748fabf1f7f92c8d00b54f5b431fd4e28d9dfd642cc0bc5c48b16dc0efdc58c1)
 (749E3EE0E0AC93BFC06ED58972EFE87717A428DA, SequenceNumber(0), o#05efb7971ec89b78fd512913fb6f9bfbd0b5ffd2e99775493f9703ff153b3998)
@@ -752,7 +752,7 @@ We will perform the transfer by calling the `transfer` function from
 the SUI module using the following Sui Wallet command:
 
 ```shell
-wallet --no-shell call --function transfer --module SUI --package 0x2 --args \"0x5044DC15D3C71D500116EB026E8B70D0A180F3AC\" \"0xF456EBEF195E4A231488DF56B762AC90695BE2DD\" --gas-budget 1000
+wallet call --function transfer --module SUI --package 0x2 --args \"0x5044DC15D3C71D500116EB026E8B70D0A180F3AC\" \"0xF456EBEF195E4A231488DF56B762AC90695BE2DD\" --gas-budget 1000
 ```
 
 This is a pretty complicated command so let's explain all of its
@@ -812,7 +812,7 @@ of the `transfer` function) by querying objects that are now owned by
 the sender:
 
 ```shell
-$ wallet --no-shell objects --address AE6FB6036570FEC1DF71599740C132CDF5B45B9D
+$ wallet objects --address AE6FB6036570FEC1DF71599740C132CDF5B45B9D
 Showing 4 results.
 (749E3EE0E0AC93BFC06ED58972EFE87717A428DA, SequenceNumber(0), o#05efb7971ec89b78fd512913fb6f9bfbd0b5ffd2e99775493f9703ff153b3998)
 (98765D1CBC66BDFC443AA60B614427470B266B28, SequenceNumber(0), o#5f1696a263b9c97ba2e50175db0af1052a70943148b697fca98f98781482eba5)
@@ -825,7 +825,7 @@ And if we inspect this object, we can see it has the new
 owner, different from the original one:
 
 ```shell
-$ wallet --no-shell object --id 5044DC15D3C71D500116EB026E8B70D0A180F3AC
+$ wallet object --id 5044DC15D3C71D500116EB026E8B70D0A180F3AC
 ```
 
 Resulting in:
@@ -858,7 +858,7 @@ an upper limit (we use 1000 as our gas budget.
 Let us use the same address for publishing that we used for calling Move code in the previous [section](#calling-move-code) (`AE6FB6036570FEC1DF71599740C132CDF5B45B9D`) which now has 4 objecst left:
 
 ```shell
-$ wallet --no-shell objects --address AE6FB6036570FEC1DF71599740C132CDF5B45B9D
+$ wallet objects --address AE6FB6036570FEC1DF71599740C132CDF5B45B9D
 ```
 
 Outputting:
@@ -877,7 +877,7 @@ that the location of the package's sources is in the `PATH_TO_PACKAGE`
 environment variable):
 
 ```shell
-wallet --no-shell publish --path $PATH_TO_PACKAGE/my_move_package --gas-budget 30000
+wallet publish --path $PATH_TO_PACKAGE/my_move_package --gas-budget 30000
 ```
 
 The result of running this command should look as follows:

--- a/doc/src/explore/tutorials.md
+++ b/doc/src/explore/tutorials.md
@@ -31,7 +31,7 @@ gas units) times the price of gas in the SUI currency (i.e. the gas price).
 In that new terminal, let us take a look at the account addresses we own in 
 our wallet:
 ```
-$ wallet --no-shell addresses
+$ wallet addresses
 Showing 5 results.
 ECF53CE22D1B2FB588573924057E9ADDAD1D8385
 7B61DA6AACED7F28C1187D998955F10464BEAE55
@@ -49,7 +49,7 @@ export PLAYER_O=251CF224B6BA3A019D04B6041357C20490F7A322
 
 For each of these addresses, let's discover their gas objects for each account address:
 ```
-$ wallet --no-shell gas --address $ADMIN
+$ wallet gas --address $ADMIN
                 Object ID                 |  Version   |  Gas Value
 ----------------------------------------------------------------------
  38B89FE9F4A4823F1406938E87A8767CBD7F0B93 |     0      |   100000
@@ -57,7 +57,7 @@ $ wallet --no-shell gas --address $ADMIN
  6AB7D15F41B28FF1EBF6D32499214BBD9035D1EB |     0      |   100000
  800F2704E22637A036C4325B539D711BB83CA6C2 |     0      |   100000
  D2F52301D5343DD2C1FA076401BC6283C3E4AA34 |     0      |   100000
-$ wallet --no-shell gas --address $PLAYER_X
+$ wallet gas --address $PLAYER_X
                 Object ID                 |  Version   |  Gas Value
 ----------------------------------------------------------------------
  6F675038CAA48184707DBBE95ACFBA2030E87CD8 |     0      |   100000
@@ -65,7 +65,7 @@ $ wallet --no-shell gas --address $PLAYER_X
  9FED1FC3D21F284DC53DE87C0E19718971D96D8C |     0      |   100000
  E293F935F015C23216867442DB4E712518E7CAB7 |     0      |   100000
  F19384C06AE538F9C3C9D9762002B4DAEA49FE3A |     0      |   100000
-$ wallet --no-shell gas --address $PLAYER_O
+$ wallet gas --address $PLAYER_O
                 Object ID                 |  Version   |  Gas Value
 ----------------------------------------------------------------------
  2110ADFB7BAF889A05EA6F5889AF7724299F9BED |     0      |   100000
@@ -97,7 +97,7 @@ git clone https://github.com/MystenLabs/sui.git
 To publish the game, we run the publish command and specify the path to the source code of the game package:
 
 ```
-$ wallet --no-shell publish --path ./sui/sui_programmability/examples/games --gas $ADMIN_GAS --gas-budget 30000
+$ wallet publish --path ./sui/sui_programmability/examples/games --gas $ADMIN_GAS --gas-budget 30000
 ----- Certificate ----
 Signed Authorities : ...
 Transaction Kind : Publish
@@ -125,7 +125,7 @@ Because the admin owns the gameboard, each individual player cannot place a mark
 Now let's begin the game!
 First of all, let's create a game:
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function create_game --args \"0x$PLAYER_X\" \"0x$PLAYER_O\" --gas $ADMIN_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function create_game --args \"0x$PLAYER_X\" \"0x$PLAYER_O\" --gas $ADMIN_GAS --gas-budget 1000
 ----- Certificate ----
 Signed Authorities : ...
 Transaction Kind : Call
@@ -147,21 +147,21 @@ Mutated Objects:
 ```
 The above call created three objects. For each object, it printed out a tuple of three values (object_id, version, object_digest). Object ID is what we care about here. Since we don't have a real application here to display things for us, we need a bit of object printing magic to figure out which object is which. Let's print out the metadata of each created object (replace the object ID with what you see on your screen):
 ```
-$ wallet --no-shell object --id 5851B7EA07B93E68696BC0CF811D2E266DFB880D
+$ wallet object --id 5851B7EA07B93E68696BC0CF811D2E266DFB880D
 Owner: AddressOwner(k#251cf224b6ba3a019d04b6041357c20490f7a322)
 Version: 1
 ID: 5851B7EA07B93E68696BC0CF811D2E266DFB880D
 Readonly: false
 Type: 0xa613a7ff8cb03e0dfc0d157e232bba50c5f19d17::TicTacToe::MarkMintCap
 
-$ wallet --no-shell object --id A6D3B507D4533822E690291166891D42694A2721
+$ wallet object --id A6D3B507D4533822E690291166891D42694A2721
 Owner: AddressOwner(k#7b61da6aaced7f28c1187d998955f10464beae55)
 Version: 1
 ID: A6D3B507D4533822E690291166891D42694A2721
 Readonly: false
 Type: 0xa613a7ff8cb03e0dfc0d157e232bba50c5f19d17::TicTacToe::MarkMintCap
 
-$ wallet --no-shell object --id F1B8161BD97D3CD6627E739AD675089C5ACFB452
+$ wallet object --id F1B8161BD97D3CD6627E739AD675089C5ACFB452
 Owner: AddressOwner(k#ecf53ce22d1b2fb588573924057e9addad1d8385)
 Version: 1
 ID: F1B8161BD97D3CD6627E739AD675089C5ACFB452
@@ -187,7 +187,7 @@ public fun send_mark_to_game(cap: &mut MarkMintCap, game_address: address, row: 
 ```
 The `cap` argument will be Player X's capability object (XCAP), and `game_address` argument will be the admin's address (ADMIN):
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$XCAP\" \"0x$ADMIN\" 1 1 --gas $X_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$XCAP\" \"0x$ADMIN\" 1 1 --gas $X_GAS --gas-budget 1000
 
 ----- Certificate ----
 Signed Authorities : ...
@@ -213,7 +213,7 @@ public fun place_mark(game: &mut TicTacToe, mark: Mark, ctx: &mut TxContext);
 ```
 The first argument is the game board, and the second argument is the mark the admin just received from the player. We will call this function (replace the second argument with the Mark object ID above):
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0xAE3CE9176F1A8C1F21D922722486DF667FA00394\" --gas $ADMIN_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0xAE3CE9176F1A8C1F21D922722486DF667FA00394\" --gas $ADMIN_GAS --gas-budget 1000
 ```
 The gameboard now looks like this (this won't be printed out, so keep it in your imagination):
 ```
@@ -224,7 +224,7 @@ _|X|_
 
 Player O now tries to put a mark at (0, 0) (note, in the second call, the second argument comes from the created objects in the first call):
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$OCAP\" \"0x$ADMIN\" 0 0 --gas $O_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$OCAP\" \"0x$ADMIN\" 0 0 --gas $O_GAS --gas-budget 1000
 ----- Certificate ----
 ...
 ----- Transaction Effects ----
@@ -233,7 +233,7 @@ Created Objects:
 7A16D266DAD41145F34649258BC1F744D147BF2F SequenceNumber(1) o#58cb018be98dd828c10f5b2045329f6ec4dab56c5a90e719ad225f0bc195908a
 ...
 
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0x7A16D266DAD41145F34649258BC1F744D147BF2F\" --gas $ADMIN_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0x7A16D266DAD41145F34649258BC1F744D147BF2F\" --gas $ADMIN_GAS --gas-budget 1000
 ----- Certificate ----
 ...
 ----- Transaction Effects ----
@@ -249,7 +249,7 @@ _|X|_
 
 Player X puts a mark at (0, 2):
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$XCAP\" \"0x$ADMIN\" 0 2 --gas $X_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$XCAP\" \"0x$ADMIN\" 0 2 --gas $X_GAS --gas-budget 1000
 
 ----- Certificate ----
 ...
@@ -259,7 +259,7 @@ Created Objects:
 2875D50BD9021ED2009A1278C7CB6D4C876FFF6A SequenceNumber(1) o#d4371b72e77bfc07bd088a9113ef7bf870198066649f6c9e9e4abf5f7a7fbd2a
 ...
 
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0x2875D50BD9021ED2009A1278C7CB6D4C876FFF6A\" --gas $ADMIN_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0x2875D50BD9021ED2009A1278C7CB6D4C876FFF6A\" --gas $ADMIN_GAS --gas-budget 1000
 
 ...
 ```
@@ -272,7 +272,7 @@ _|X|_
 
 Player O places a mark at (1, 0):
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$OCAP\" \"0x$ADMIN\" 1 0 --gas $O_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$OCAP\" \"0x$ADMIN\" 1 0 --gas $O_GAS --gas-budget 1000
 ----- Certificate ----
 ...
 ----- Transaction Effects ----
@@ -281,7 +281,7 @@ Created Objects:
 4F7391F172063D87013DD9DC95B8BD45C35FD2D9 SequenceNumber(1) o#ee7ba8ea66e574d7636e159da9f33c96d724d71f141a57a1e4929b2b928c298d
 ...
 
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0x4F7391F172063D87013DD9DC95B8BD45C35FD2D9\" --gas $ADMIN_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0x4F7391F172063D87013DD9DC95B8BD45C35FD2D9\" --gas $ADMIN_GAS --gas-budget 1000
 ...
 ```
 The gameboard now looks like:
@@ -292,7 +292,7 @@ O|X|_
 ```
 This is a chance for Player X to win! X now mints the winning mark at (2, 0):
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$XCAP\" \"0x$ADMIN\" 2 0 --gas $X_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function send_mark_to_game --args \"0x$XCAP\" \"0x$ADMIN\" 2 0 --gas $X_GAS --gas-budget 1000
 ----- Certificate ----
 ...
 ----- Transaction Effects ----
@@ -303,7 +303,7 @@ AA7A6624E16E5E447801462FF6614013FC4AD156 SequenceNumber(1) o#e5e1b15f03531db118e
 ```
 And then finally the admin places the winning mark:
 ```
-$ wallet --no-shell call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0xAA7A6624E16E5E447801462FF6614013FC4AD156\" --gas $ADMIN_GAS --gas-budget 1000
+$ wallet call --package $PACKAGE --module TicTacToe --function place_mark --args \"0x$GAME\" \"0xAA7A6624E16E5E447801462FF6614013FC4AD156\" --gas $ADMIN_GAS --gas-budget 1000
 ----- Certificate ----
 ...
 ----- Transaction Effects ----
@@ -315,7 +315,7 @@ Mutated Objects:
 ```
 Cool! The last transaction created a new object. Let's find out what object was created:
 ```
-$ wallet --no-shell object --id 54B58C0D5B14A269B1CD424B3CCAB1E315C43343
+$ wallet object --id 54B58C0D5B14A269B1CD424B3CCAB1E315C43343
 
 Owner: AddressOwner(k#7b61da6aaced7f28c1187d998955f10464beae55)
 Version: 1

--- a/sui/src/wallet.rs
+++ b/sui/src/wallet.rs
@@ -25,14 +25,14 @@ const SUI: &str = "   _____       _    _       __      ____     __
 
 #[derive(StructOpt)]
 #[structopt(
-    name = "Sui Demo Wallet",
+    name = "wallet",
     about = "A Byzantine fault tolerant chain with low-latency finality and high throughput",
     rename_all = "kebab-case"
 )]
 struct ClientOpt {
-    #[structopt(long, global = true)]
-    /// Run wallet command without interactive shell
-    no_shell: bool,
+    #[structopt(short, global = true)]
+    /// Start interactive wallet
+    interactive: bool,
     /// Sets the file storing the state of our user accounts (an empty one will be created if missing)
     #[structopt(long)]
     config: Option<PathBuf>,
@@ -77,7 +77,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let mut out = stdout();
 
-    if !options.no_shell {
+    if options.interactive {
         let app: App = WalletCommands::clap();
         writeln!(out, "{}", SUI.cyan().bold())?;
         let version = app
@@ -101,6 +101,8 @@ async fn main() -> Result<(), anyhow::Error> {
         shell.run_async(&mut out, &mut stderr()).await?;
     } else if let Some(mut cmd) = options.cmd {
         cmd.execute(&mut context).await?.print(!options.json);
+    } else {
+        ClientOpt::clap().print_long_help()?
     }
     Ok(())
 }

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -44,7 +44,7 @@ pub struct WalletOpts {
     pub json: bool,
 }
 
-#[derive(StructOpt)]
+#[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
 #[structopt(setting(AppSettings::NoBinaryName))]
 pub enum WalletCommands {


### PR DESCRIPTION
wallet cli now default to cli mode (no-shell)
added `-i` flag for interactive mode 

Also updated command snippets in docs for this changes