### PR TITLE
[REST Server] Show clear error message

### DIFF
--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -89,7 +89,14 @@ async fn main() -> Result<(), anyhow::Error> {
     let config_path = options
         .config
         .unwrap_or(sui_config_dir()?.join(SUI_GATEWAY_CONFIG));
-    let config: GatewayConfig = PersistedConfig::read(&config_path)?;
+
+    let config: GatewayConfig = PersistedConfig::read(&config_path).map_err(|e| {
+        anyhow!(
+            "Failed to read config file at {:?}: {}. Have you run `sui genesis` first?",
+            config_path,
+            e
+        )
+    })?;
     let committee = config.make_committee();
     let authority_clients = config.make_authority_clients();
     let gateway = Box::new(GatewayState::new(


### PR DESCRIPTION
The user will get a vague message if they forget to run `sui genesis` before `./rest_sever`:
```
➜ ./rest_server
Error: No such file or directory (os error 2)
```

After this PR:
```
➜ ./rest_server
Error: Failed to read config file at "/Users/cl/.sui/sui_config/gateway.conf": No such file or directory (os error 2). 
Have you run `sui genesis` first?
```