### PR TITLE
Gateway should deserialize object contents

### DIFF
--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -39,8 +39,8 @@ use sui_types::base_types::*;
 use sui_types::crypto;
 use sui_types::crypto::SignableBytes;
 use sui_types::messages::{Transaction, TransactionData};
-use sui_types::object::Object as SuiObject;
 use sui_types::object::ObjectRead;
+use sui_types::object::{Object as SuiObject, ObjectInfo};
 
 const DEFAULT_REST_SERVER_PORT: &str = "5001";
 const DEFAULT_REST_SERVER_ADDR_IPV4: &str = "127.0.0.1";
@@ -222,7 +222,7 @@ async fn object_schema(
     };
 
     let layout = match gateway.get_object_info(object_id).await {
-        Ok(ObjectRead::Exists(_, _, layout)) => layout,
+        Ok(ObjectRead::Exists(ObjectInfo(_, _, layout))) => layout,
         Ok(ObjectRead::Deleted(_)) => {
             return Err(custom_http_error(
                 StatusCode::NOT_FOUND,
@@ -513,7 +513,9 @@ async fn get_object_info(
     object_id: ObjectID,
 ) -> Result<(ObjectRef, SuiObject, Option<MoveStructLayout>), HttpError> {
     let (object_ref, object, layout) = match gateway.get_object_info(object_id).await {
-        Ok(ObjectRead::Exists(object_ref, object, layout)) => (object_ref, object, layout),
+        Ok(ObjectRead::Exists(ObjectInfo(object_ref, object, layout))) => {
+            (object_ref, object, layout)
+        }
         Ok(ObjectRead::Deleted(_)) => {
             return Err(custom_http_error(
                 StatusCode::NOT_FOUND,

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -26,7 +26,7 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{CertifiedTransaction, ExecutionStatus, Transaction, TransactionEffects};
 use sui_types::move_package::resolve_and_type_check;
 use sui_types::object::ObjectRead::Exists;
-use sui_types::object::{Object, ObjectRead};
+use sui_types::object::{Object, ObjectInfo, ObjectRead};
 
 use crate::config::{Config, PersistedConfig, WalletConfig};
 use crate::keystore::Keystore;
@@ -589,7 +589,7 @@ impl WalletContext {
         let mut values_objects = Vec::new();
         for (id, _, _) in object_refs {
             match self.gateway.get_object_info(id).await? {
-                Exists(_, o, _) => {
+                Exists(ObjectInfo(_, o, _)) => {
                     if matches!( o.type_(), Some(v)  if *v == GasCoin::type_()) {
                         // Okay to unwrap() since we already checked type
                         let gas_coin = GasCoin::try_from(o.data.try_as_move().unwrap())?;

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -1049,7 +1049,6 @@ impl<const A: bool, S: Eq + Serialize + for<'de> Deserialize<'de>> ModuleResolve
                     .serialized_module_map()
                     .get(module_id.name().as_str())
                     .cloned()
-                    .map(|m| m.into_vec())
             }))
     }
 }

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -360,8 +360,7 @@ impl<S: BackingPackageStore> ModuleResolver for AuthorityTemporaryStore<S> {
             Data::Package(c) => Ok(c
                 .serialized_module_map()
                 .get(module_id.name().as_str())
-                .cloned()
-                .map(|m| m.into_vec())),
+                .cloned()),
             _ => Err(SuiError::BadObjectType {
                 error: "Expected module object".to_string(),
             }),

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -8,7 +8,7 @@ use crate::safe_client::SafeClient;
 use futures::{future, StreamExt};
 use move_core_types::value::MoveStructLayout;
 use sui_types::crypto::{AuthoritySignature, PublicKeyBytes};
-use sui_types::object::{Object, ObjectFormatOptions, ObjectRead};
+use sui_types::object::{Object, ObjectFormatOptions, ObjectInfo, ObjectRead};
 use sui_types::{
     base_types::*,
     committee::Committee,
@@ -1158,7 +1158,7 @@ where
             if is_ok {
                 match obj_option {
                     Some(obj) => {
-                        return Ok(ObjectRead::Exists(obj_ref, obj, layout_option));
+                        return Ok(ObjectRead::Exists(ObjectInfo(obj_ref, obj, layout_option)));
                     }
                     None => {
                         // TODO: Figure out how to find out object being wrapped instead of deleted.

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -31,6 +31,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_types::object::ObjectInfo;
 
 use self::gateway_responses::*;
 
@@ -265,7 +266,7 @@ where
             // If any object does not exist in the store, give it a chance
             // to download from authorities.
             if object_opt.is_none() {
-                if let ObjectRead::Exists(_, object, _) =
+                if let ObjectRead::Exists(ObjectInfo(_, object, _)) =
                     self.get_object_info(kind.object_id()).await?
                 {
                     *object_opt = Some(object);
@@ -328,7 +329,7 @@ where
 
     async fn download_object_from_authorities(&self, object_id: ObjectID) -> SuiResult<ObjectRead> {
         let result = self.authorities.get_object_info_execute(object_id).await?;
-        if let ObjectRead::Exists(obj_ref, object, _) = &result {
+        if let ObjectRead::Exists(ObjectInfo(obj_ref, object, _)) = &result {
             let local_object = self.store.get_object(&object_id)?;
             if local_object.is_none()
                 || &local_object.unwrap().compute_object_reference() != obj_ref

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -214,7 +214,7 @@ MoveObject:
   STRUCT:
     - type_:
         TYPENAME: StructTag
-    - contents: STR
+    - contents: BYTES
 MovePackage:
   STRUCT:
     - id:

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -160,9 +160,7 @@ impl ModuleResolver for InMemoryStorage {
         Ok(self
             .read_object(&ObjectID::from(*module_id.address()))
             .map(|o| match &o.data {
-                Data::Package(m) => m.serialized_module_map()[module_id.name().as_str()]
-                    .clone()
-                    .into_vec(),
+                Data::Package(m) => m.serialized_module_map()[module_id.name().as_str()].clone(),
                 Data::Move(_) => panic!("Type error"),
             }))
     }

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -5,8 +5,10 @@ use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
-use crate::readable_serde::BytesOrBase64;
-use crate::readable_serde::BytesOrHex;
+use crate::crypto::PublicKeyBytes;
+use crate::error::SuiError;
+use crate::readable_serde::Base64OrBytes;
+use crate::readable_serde::HexOrBytes;
 use ed25519_dalek::Digest;
 use hex::FromHex;
 use move_core_types::account_address::AccountAddress;
@@ -16,10 +18,8 @@ use opentelemetry::{global, Context};
 use rand::Rng;
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use sha3::Sha3_256;
-
-use crate::crypto::PublicKeyBytes;
-use crate::error::SuiError;
 
 #[cfg(test)]
 #[path = "unit_tests/base_types_tests.rs"]
@@ -43,8 +43,9 @@ pub struct ObjectID(AccountAddress);
 pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 
 pub const SUI_ADDRESS_LENGTH: usize = ObjectID::LENGTH;
+#[serde_as]
 #[derive(Eq, Default, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct SuiAddress(#[serde(with = "BytesOrHex")] [u8; SUI_ADDRESS_LENGTH]);
+pub struct SuiAddress(#[serde_as(as = "HexOrBytes")] [u8; SUI_ADDRESS_LENGTH]);
 
 impl SuiAddress {
     pub fn to_vec(&self) -> Vec<u8> {
@@ -133,11 +134,13 @@ pub const TRANSACTION_DIGEST_LENGTH: usize = 32;
 pub const OBJECT_DIGEST_LENGTH: usize = 32;
 
 /// A transaction will have a (unique) digest.
+#[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct TransactionDigest(#[serde(with = "BytesOrBase64")] [u8; TRANSACTION_DIGEST_LENGTH]);
+pub struct TransactionDigest(#[serde_as(as = "Base64OrBytes")] [u8; TRANSACTION_DIGEST_LENGTH]);
 // Each object has a unique digest
+#[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct ObjectDigest(#[serde(with = "BytesOrBase64")] pub [u8; 32]); // We use SHA3-256 hence 32 bytes here
+pub struct ObjectDigest(#[serde_as(as = "Base64OrBytes")] pub [u8; 32]); // We use SHA3-256 hence 32 bytes here
 
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("TxContext");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = TX_CONTEXT_MODULE_NAME;

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -575,6 +575,9 @@ pub enum ObjectRead {
 #[derive(Deserialize)]
 pub struct ObjectInfo(pub ObjectRef, pub Object, pub Option<MoveStructLayout>);
 
+/// Custom serializer for ObjectInfo
+/// This serializer inject an extra field `json_data` to Object, the data is created using `Data::to_json` and `MoveStructLayout`
+/// The `json_data` is not deserializable and will be ignored by the deserializer
 impl Serialize for ObjectInfo {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/sui_types/src/unit_tests/base_types_tests.rs
+++ b/sui_types/src/unit_tests/base_types_tests.rs
@@ -268,7 +268,7 @@ fn test_move_object_size_for_gas_metering() {
     // all the metadata data needed for serializing various types.
     // If the following assertion breaks, it's likely you have changed MoveObject's fields.
     // Make sure to adjust `object_size_for_gas_metering()` to include those changes.
-    assert_eq!(size + 16, serialized.len());
+    assert_eq!(size + 4, serialized.len());
 }
 
 #[test]


### PR DESCRIPTION
### **Changes**
* refactored human-readable serde to serde_as, make it easier to reuse with Vec, BTreeMap etc
* changed ByteBuf to Vec<u8> in MovePackage::module_map, use serde to define bytes type instead.
* add json_data to object for human-readable serialisation

I am adding an extra field `json_data` to the JSON output together with the base64 encoded data, the raw data is needed for deserialisation because value created by `Data::to_json` (MoveStruct/CompiledModule) are not deserializable. The `json_data` field will be ignored by the deserialiser.

I think this solution is not ideal because it increase the size of the json payload, I can think of a few alternatives but I am not sure if they are any better...

1, we can provide a utility endpoint to convert the data to json -- the explorer will need to make extra calls to the gateway
2, Implement deserialisations for `MoveStruct` and `CompileModule` -- not sure if possible or not

_**Any suggestion for improvement are welcome!**_

**`ObjectRead` json after the change:**
MoveStruct:
https://gist.github.com/patrickkuo/15f8d936441471a9970385a3e312d8e0

Package:
https://gist.github.com/patrickkuo/ec7cc628c9526fabca6ed36fd234068d

