### PR TITLE
Rename `remove_object` to `take_object` in TestScenario

### DIFF
--- a/doc/move_code/objects_tutorial/sources/Ch1_2/ColorObject.move
+++ b/doc/move_code/objects_tutorial/sources/Ch1_2/ColorObject.move
@@ -65,13 +65,13 @@ module Tutorial::ColorObjectTests {
         let not_owner = @0x2;
         TestScenario::next_tx(scenario, &not_owner);
         {
-            assert!(!TestScenario::can_remove_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
         };
         // Check that @owner indeed owns the just-created ColorObject.
         // Also checks the value fields of the object.
         TestScenario::next_tx(scenario, &owner);
         {
-            let object = TestScenario::remove_object<ColorObject>(scenario);
+            let object = TestScenario::take_object<ColorObject>(scenario);
             let (red, green, blue) = ColorObject::get_color(&object);
             assert!(red == 255 && green == 0 && blue == 255, 0);
             TestScenario::return_object(scenario, object);
@@ -92,14 +92,14 @@ module Tutorial::ColorObjectTests {
         // Delete the ColorObject we just created.
         TestScenario::next_tx(scenario, &owner);
         {
-            let object = TestScenario::remove_object<ColorObject>(scenario);
+            let object = TestScenario::take_object<ColorObject>(scenario);
             let ctx = TestScenario::ctx(scenario);
             ColorObject::delete(object, ctx);
         };
         // Verify that the object was indeed deleted.
         TestScenario::next_tx(scenario, &owner);
         {
-            assert!(!TestScenario::can_remove_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
         }
     }
 
@@ -116,19 +116,19 @@ module Tutorial::ColorObjectTests {
         let recipient = @0x2;
         TestScenario::next_tx(scenario, &owner);
         {
-            let object = TestScenario::remove_object<ColorObject>(scenario);
+            let object = TestScenario::take_object<ColorObject>(scenario);
             let ctx = TestScenario::ctx(scenario);
             ColorObject::transfer(object, recipient, ctx);
         };
         // Check that owner no longer owns the object.
         TestScenario::next_tx(scenario, &owner);
         {
-            assert!(!TestScenario::can_remove_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
         };
         // Check that recipient now owns the object.
         TestScenario::next_tx(scenario, &recipient);
         {
-            assert!(TestScenario::can_remove_object<ColorObject>(scenario), 0);
+            assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
         };
     }
 }

--- a/doc/src/build/move.md
+++ b/doc/src/build/move.md
@@ -688,7 +688,7 @@ function:
         TestScenario::next_tx(scenario, &initial_owner);
         {
             // extract the sword owned by the initial owner
-            let sword = TestScenario::remove_object<Sword>(scenario);
+            let sword = TestScenario::take_object<Sword>(scenario);
             // transfer the sword to the final owner
             sword_transfer(sword, final_owner, TestScenario::ctx(scenario));
         };
@@ -696,7 +696,7 @@ function:
         TestScenario::next_tx(scenario, &final_owner);
         {
             // extract the sword owned by the final owner
-            let sword = TestScenario::remove_object<Sword>(scenario);
+            let sword = TestScenario::take_object<Sword>(scenario);
             // verify that the sword has expected properties
             assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
             // return the sword to the object pool (it cannot be simply "dropped")
@@ -719,7 +719,7 @@ the sword it now owns to its final owner. Please note that in *pure
 Move* we do not have the notion of Sui storage and, consequently, no
 easy way for the emulated Sui transaction to retrieve it from
 storage. This is where the `TestScenario` module comes to help - its
-`remove_object` function makes an object of a given type (in this case
+`take_object` function makes an object of a given type (in this case
 of type `Sword`) owned by an address executing the current transaction
 available for manipulation by the Move code. (For now, we assume that
 there is only one such object.) In this case, the object retrieved
@@ -878,7 +878,7 @@ We can now create a function to test the module initialization:
         TestScenario::next_tx(scenario, &admin);
         {
             // extract the Forge object
-            let forge = TestScenario::remove_object<Forge>(scenario);
+            let forge = TestScenario::take_object<Forge>(scenario);
             // verify number of created swords
             assert!(swords_created(&forge) == 0, 1);
             // return the Forge object to the object pool

--- a/doc/src/build/programming-with-objects/ch1-object-basics.md
+++ b/doc/src/build/programming-with-objects/ch1-object-basics.md
@@ -113,26 +113,26 @@ let not_owner = @0x2;
 // Check that @not_owner does not own the just-created ColorObject.
 TestScenario::next_tx(scenario, &not_owner);
 {
-    assert!(!TestScenario::can_remove_object<ColorObject>(scenario), 0);
+    assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
 };
 ```
 `TestScenario::next_tx` switches the transaction sender to `@0x2`, which is a new address than the previous one.
-`TestScenario::can_remove_object` checks whether an object with the given type actually exists in the global storage owned by the current sender of the transaction. In this code, we assert that we should not be able to remove such an object, because `@0x2` does not own any object.
+`TestScenario::can_take_object` checks whether an object with the given type actually exists in the global storage owned by the current sender of the transaction. In this code, we assert that we should not be able to remove such an object, because `@0x2` does not own any object.
 > :bulb: The second parameter of `assert!` is the error code. In non-test code, we usually define a list of dedicated error code constants for each type of error that could happen in production. For unit tests though, it's usually unnecessary because there will be way too many assetions and the stacktrace upon error is sufficient to tell where the error happened. Hence we recommend just putting `0` there in unit tests for assertions.
 
 Finally we check that `@0x1` owns the object and the object value is consistent:
 ```rust
 TestScenario::next_tx(scenario, &owner);
 {
-    let object = TestScenario::remove_object<ColorObject>(scenario);
+    let object = TestScenario::take_object<ColorObject>(scenario);
     let (red, green, blue) = ColorObject::get_color(&object);
     assert!(red == 255 && green == 0 && blue == 255, 0);
     TestScenario::return_object(scenario, object);
 };
 ```
-`TestScenario::remove_object` removes the object of given type from global storage that's owned by the current transaction sender (it also implicitly checks `can_remove_object`). If this line of code succeeds, it means that `owner` indeed owns an object of type `ColorObject`.
+`TestScenario::take_object` removes the object of given type from global storage that's owned by the current transaction sender (it also implicitly checks `can_take_object`). If this line of code succeeds, it means that `owner` indeed owns an object of type `ColorObject`.
 We also check that the field values of the object match with what we set in creation. At the end, we must return the object back to the global storage by calling `TestScenario::return_object` so that it's back to the global storage. This also ensures that if any mutations happened to the object during the test, the global storage is aware of the changes.
-You may have noticed that `remove_object` picks the object only based on the type parameter. What if there are multiple objects of the same type owned by the account? How do we retrieve each of them? In fact, if you call `remove_object` when there are more than one object of the same type in the same account, an assertion failure will be triggered. We are working on adding an API just for this. Update coming soon.
+You may have noticed that `take_object` picks the object only based on the type parameter. What if there are multiple objects of the same type owned by the account? How do we retrieve each of them? In fact, if you call `take_object` when there are more than one object of the same type in the same account, an assertion failure will be triggered. We are working on adding an API just for this. Update coming soon.
 
 Again, you can find the full code [here](../../../move_code/objects_tutorial/sources/Ch1_2/ColorObject.move).
 

--- a/doc/src/build/programming-with-objects/ch2-using-objects.md
+++ b/doc/src/build/programming-with-objects/ch2-using-objects.md
@@ -62,14 +62,14 @@ let scenario = &mut TestScenario::begin(&owner);
 // Delete the ColorObject we just created.
 TestScenario::next_tx(scenario, &owner);
 {
-    let object = TestScenario::remove_object<ColorObject>(scenario);
+    let object = TestScenario::take_object<ColorObject>(scenario);
     let ctx = TestScenario::ctx(scenario);
     ColorObject::delete(object, ctx);
 };
 // Verify that the object was indeed deleted.
 TestScenario::next_tx(scenario, &owner);
 {
-    assert!(!TestScenario::can_remove_object<ColorObject>(scenario), 0);
+    assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
 }
 ```
 The first part is the same as what we have seen in [Chapter 1](./ch1-object-basics.md#writing-unit-tests), which creates a new `ColorObject` and put it to the owner's account. The second transaction is what we are testing: retrieve the object from the storage, and then delete it. Since the object is deleted, there is no need (in fact, impossible) to return it to the storage. The last part checks that the object is indeed no longer in the global storage, and hence cannot be retrieved from there.
@@ -96,7 +96,7 @@ let scenario = &mut TestScenario::begin(&owner);
 let recipient = @0x2;
 TestScenario::next_tx(scenario, &owner);
 {
-    let object = TestScenario::remove_object<ColorObject>(scenario);
+    let object = TestScenario::take_object<ColorObject>(scenario);
     let ctx = TestScenario::ctx(scenario);
     ColorObject::transfer(object, recipient, ctx);
 };
@@ -106,12 +106,12 @@ Note that in the second transaction, the sender of the transaction should still 
 // Check that owner no longer owns the object.
 TestScenario::next_tx(scenario, &owner);
 {
-    assert!(!TestScenario::can_remove_object<ColorObject>(scenario), 0);
+    assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
 };
 // Check that recipient now owns the object.
 TestScenario::next_tx(scenario, &recipient);
 {
-    assert!(TestScenario::can_remove_object<ColorObject>(scenario), 0);
+    assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
 };
 ```
 

--- a/sui_core/src/unit_tests/data/hero/sources/Hero.move
+++ b/sui_core/src/unit_tests/data/hero/sources/Hero.move
@@ -313,7 +313,7 @@ module Examples::Hero {
         // Admin mints 500 coins and sends them to the Player so they can buy game items
         TestScenario::next_tx(scenario, &admin);
         {
-            let treasury_cap = TestScenario::remove_object<TreasuryCap<EXAMPLE>>(scenario);
+            let treasury_cap = TestScenario::take_object<TreasuryCap<EXAMPLE>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             let coins = Coin::mint(500, &mut treasury_cap, ctx);
             Coin::transfer(coins, copy player);
@@ -322,21 +322,21 @@ module Examples::Hero {
         // Player purchases a hero with the coins
         TestScenario::next_tx(scenario, &player);
         {
-            let coin = TestScenario::remove_object<Coin<EXAMPLE>>(scenario);
+            let coin = TestScenario::take_object<Coin<EXAMPLE>>(scenario);
             acquire_hero(coin, TestScenario::ctx(scenario));
         };
         // Admin sends a boar to the Player
         TestScenario::next_tx(scenario, &admin);
         {
-            let admin_cap = TestScenario::remove_object<GameAdmin>(scenario);
+            let admin_cap = TestScenario::take_object<GameAdmin>(scenario);
             send_boar(&mut admin_cap, 10, 10, player, TestScenario::ctx(scenario));
             TestScenario::return_object(scenario, admin_cap)
         };
         // Player slays the boar!
         TestScenario::next_tx(scenario, &player);
         {
-            let hero = TestScenario::remove_object<Hero>(scenario);
-            let boar = TestScenario::remove_object<Boar>(scenario);
+            let hero = TestScenario::take_object<Hero>(scenario);
+            let boar = TestScenario::take_object<Boar>(scenario);
             slay(&mut hero, boar, TestScenario::ctx(scenario));
             TestScenario::return_object(scenario, hero)
         };

--- a/sui_programmability/examples/basics/sources/Lock.move
+++ b/sui_programmability/examples/basics/sources/Lock.move
@@ -127,7 +127,7 @@ module Basics::LockTest {
         // key to User2, so that he can have access to the stored treasure.
         TestScenario::next_tx(scenario, &user1);
         {
-            let key = TestScenario::remove_object<Key<Treasure>>(scenario);
+            let key = TestScenario::take_object<Key<Treasure>>(scenario);
 
             Transfer::transfer(key, user2);
         };
@@ -135,8 +135,8 @@ module Basics::LockTest {
         // User2 is impatient and he decides to take the treasure.
         TestScenario::next_tx(scenario, &user2);
         {
-            let lock = TestScenario::remove_object<Lock<Treasure>>(scenario);
-            let key = TestScenario::remove_object<Key<Treasure>>(scenario);
+            let lock = TestScenario::take_object<Lock<Treasure>>(scenario);
+            let key = TestScenario::take_object<Key<Treasure>>(scenario);
             let ctx = TestScenario::ctx(scenario);
 
             Lock::take<Treasure>(&mut lock, &key, ctx);

--- a/sui_programmability/examples/defi/tests/EscrowTests.move
+++ b/sui_programmability/examples/defi/tests/EscrowTests.move
@@ -47,11 +47,11 @@ module DeFi::EscrowTests {
         // The third party returns item A to Alice, item B to Bob
         TestScenario::next_tx(scenario, &THIRD_PARTY_ADDRESS);
         {
-            let item_a = TestScenario::remove_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let item_a = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             Escrow::return_to_sender<ItemA, ItemB>(item_a, ctx);
 
-            let item_b = TestScenario::remove_object<EscrowedObj<ItemB, ItemA>>(scenario);
+            let item_b = TestScenario::take_object<EscrowedObj<ItemB, ItemA>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             Escrow::return_to_sender<ItemB, ItemA>(item_b, ctx);
         };
@@ -82,8 +82,8 @@ module DeFi::EscrowTests {
     fun swap(scenario: &mut Scenario, third_party: &address) {
         TestScenario::next_tx(scenario, third_party);
         {
-            let item_a = TestScenario::remove_object<EscrowedObj<ItemA, ItemB>>(scenario);
-            let item_b = TestScenario::remove_object<EscrowedObj<ItemB, ItemA>>(scenario);
+            let item_a = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let item_b = TestScenario::take_object<EscrowedObj<ItemB, ItemA>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             Escrow::swap(item_a, item_b, ctx);
         };
@@ -157,6 +157,6 @@ module DeFi::EscrowTests {
 
     fun owns_object<T: key + store>(scenario: &mut Scenario, owner: &address): bool{
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_remove_object<T>(scenario)
+        TestScenario::can_take_object<T>(scenario)
     }
 }

--- a/sui_programmability/examples/defi/tests/FlashLenderTests.move
+++ b/sui_programmability/examples/defi/tests/FlashLenderTests.move
@@ -23,7 +23,7 @@ module DeFi::FlashLenderTests {
         // borrower requests and repays a loan of 10 coins + the fee
         TestScenario::next_tx(scenario, &borrower);
         {
-            let lender = TestScenario::remove_object<FlashLender<SUI>>(scenario);
+            let lender = TestScenario::take_object<FlashLender<SUI>>(scenario);
             let ctx = TestScenario::ctx(scenario);
 
             let (loan, receipt) = FlashLender::loan(&mut lender, 10, ctx);
@@ -40,8 +40,8 @@ module DeFi::FlashLenderTests {
         // admin withdraws the 1 coin profit from lending
         TestScenario::next_tx(scenario, &admin);
         {
-            let lender = TestScenario::remove_object<FlashLender<SUI>>(scenario);
-            let admin_cap = TestScenario::remove_object<AdminCap>(scenario);
+            let lender = TestScenario::take_object<FlashLender<SUI>>(scenario);
+            let admin_cap = TestScenario::take_object<AdminCap>(scenario);
             let ctx = TestScenario::ctx(scenario);
 
             // max loan size should have increased because of the fee payment

--- a/sui_programmability/examples/defi/tests/SharedEscrowTest.move
+++ b/sui_programmability/examples/defi/tests/SharedEscrowTest.move
@@ -118,7 +118,7 @@ module DeFi::SharedEscrowTests {
     fun cancel(scenario: &mut Scenario, initiator: &address) {
         TestScenario::next_tx(scenario, initiator);
         {
-            let escrow = TestScenario::remove_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             SharedEscrow::cancel(&mut escrow, ctx);
             TestScenario::return_object(scenario, escrow);
@@ -128,7 +128,7 @@ module DeFi::SharedEscrowTests {
     fun exchange(scenario: &mut Scenario, bob: &address, item_b_verioned_id: VersionedID) {
         TestScenario::next_tx(scenario, bob);
         {
-            let escrow = TestScenario::remove_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
             let item_b = ItemB {
                 id: item_b_verioned_id
             };
@@ -171,6 +171,6 @@ module DeFi::SharedEscrowTests {
 
     fun owns_object<T: key + store>(scenario: &mut Scenario, owner: &address): bool{
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_remove_object<T>(scenario)
+        TestScenario::can_take_object<T>(scenario)
     }
 }

--- a/sui_programmability/examples/fungible_tokens/tests/BASKETTests.move
+++ b/sui_programmability/examples/fungible_tokens/tests/BASKETTests.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module FungibleTokens::BASKETTests {    
+module FungibleTokens::BASKETTests {
     use FungibleTokens::BASKET::{Self, Reserve};
     use FungibleTokens::MANAGED::MANAGED;
     use Sui::Coin;
@@ -20,7 +20,7 @@ module FungibleTokens::BASKETTests {
         };
         TestScenario::next_tx(scenario, &user);
         {
-            let reserve = TestScenario::remove_object<Reserve>(scenario);
+            let reserve = TestScenario::take_object<Reserve>(scenario);
             let ctx = TestScenario::ctx(scenario);
             assert!(BASKET::total_supply(&reserve) == 0, 0);
 
@@ -29,7 +29,7 @@ module FungibleTokens::BASKETTests {
             let managed = Coin::mint_for_testing<MANAGED>(num_coins, ctx);
             let basket = BASKET::mint(&mut reserve, sui, managed, ctx);
             assert!(Coin::value(&basket) == num_coins, 1);
-            assert!(BASKET::total_supply(&reserve) == num_coins, 2);            
+            assert!(BASKET::total_supply(&reserve) == num_coins, 2);
 
             let (sui, managed) = BASKET::burn(&mut reserve, basket, ctx);
             assert!(Coin::value(&sui) == num_coins, 3);

--- a/sui_programmability/examples/games/hero/sources/Hero.move
+++ b/sui_programmability/examples/games/hero/sources/Hero.move
@@ -316,15 +316,15 @@ module HeroGame::Hero {
         // Admin sends a boar to the Player
         TestScenario::next_tx(scenario, &admin);
         {
-            let admin_cap = TestScenario::remove_object<GameAdmin>(scenario);
+            let admin_cap = TestScenario::take_object<GameAdmin>(scenario);
             send_boar(&mut admin_cap, 10, 10, player, TestScenario::ctx(scenario));
             TestScenario::return_object(scenario, admin_cap)
         };
         // Player slays the boar!
         TestScenario::next_tx(scenario, &player);
         {
-            let hero = TestScenario::remove_object<Hero>(scenario);
-            let boar = TestScenario::remove_object<Boar>(scenario);
+            let hero = TestScenario::take_object<Hero>(scenario);
+            let boar = TestScenario::take_object<Boar>(scenario);
             slay(&mut hero, boar, TestScenario::ctx(scenario));
             TestScenario::return_object(scenario, hero)
         };

--- a/sui_programmability/examples/games/tests/RockPaperScissorsTests.move
+++ b/sui_programmability/examples/games/tests/RockPaperScissorsTests.move
@@ -31,8 +31,8 @@ module Games::RockPaperScissorsTests {
         // Now it's time for The Main Guy to accept his turn.
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::remove_object<Game>(scenario);
-            let cap = TestScenario::remove_object<PlayerTurn>(scenario);
+            let game = TestScenario::take_object<Game>(scenario);
+            let cap = TestScenario::take_object<PlayerTurn>(scenario);
 
             assert!(Game::status(&game) == 0, 0); // STATUS_READY
 
@@ -52,8 +52,8 @@ module Games::RockPaperScissorsTests {
 
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::remove_object<Game>(scenario);
-            let cap = TestScenario::remove_object<PlayerTurn>(scenario);
+            let game = TestScenario::take_object<Game>(scenario);
+            let cap = TestScenario::take_object<PlayerTurn>(scenario);
             Game::add_hash(&mut game, cap, TestScenario::ctx(scenario));
 
             assert!(Game::status(&game) == 2, 0); // STATUS_HASHES_SUBMITTED
@@ -69,8 +69,8 @@ module Games::RockPaperScissorsTests {
 
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::remove_object<Game>(scenario);
-            let secret = TestScenario::remove_object<Secret>(scenario);
+            let game = TestScenario::take_object<Game>(scenario);
+            let secret = TestScenario::take_object<Secret>(scenario);
             Game::match_secret(&mut game, secret, TestScenario::ctx(scenario));
 
             assert!(Game::status(&game) == 3, 0); // STATUS_REVEALING
@@ -85,8 +85,8 @@ module Games::RockPaperScissorsTests {
         // calls the [`select_winner`] function to release The Prize.
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::remove_object<Game>(scenario);
-            let secret = TestScenario::remove_object<Secret>(scenario);
+            let game = TestScenario::take_object<Game>(scenario);
+            let secret = TestScenario::take_object<Secret>(scenario);
             Game::match_secret(&mut game, secret, TestScenario::ctx(scenario));
 
             assert!(Game::status(&game) == 4, 0); // STATUS_REVEALED
@@ -96,7 +96,7 @@ module Games::RockPaperScissorsTests {
 
         TestScenario::next_tx(scenario, &mr_spock);
         // If it works, then MrSpock is in possession of the prize;
-        let prize = TestScenario::remove_object<ThePrize>(scenario);
+        let prize = TestScenario::take_object<ThePrize>(scenario);
         // Don't forget to give it back!
         TestScenario::return_object(scenario, prize);
     }

--- a/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
@@ -72,11 +72,11 @@ module Games::SharedTicTacToeTests {
 
         // X has the Trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(TestScenario::can_take_object<Trophy>(scenario), 1);
 
         TestScenario::next_tx(scenario, &player_o);
         // O has no Trophy
-        assert!(!TestScenario::can_remove_object<Trophy>(scenario), 2);
+        assert!(!TestScenario::can_take_object<Trophy>(scenario), 2);
     }
 
 
@@ -182,9 +182,9 @@ module Games::SharedTicTacToeTests {
 
         // No one has the trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(!TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
         TestScenario::next_tx(scenario, &player_o);
-        assert!(!TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
     }
 
 
@@ -199,7 +199,7 @@ module Games::SharedTicTacToeTests {
         TestScenario::next_tx(scenario, player);
         let status;
         {
-            let game = TestScenario::remove_object<TicTacToe>(scenario);
+            let game = TestScenario::take_object<TicTacToe>(scenario);
             SharedTicTacToe::place_mark(&mut game, row, col, TestScenario::ctx(scenario));
             status = SharedTicTacToe::get_status(&game);
             TestScenario::return_object(scenario, game);

--- a/sui_programmability/examples/games/tests/TicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/TicTacToeTests.move
@@ -75,11 +75,11 @@ module Games::TicTacToeTests {
 
         // X has the trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(TestScenario::can_take_object<Trophy>(scenario), 1);
 
         TestScenario::next_tx(scenario, &player_o);
         // O has no Trophy
-        assert!(!TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
     }
 
 
@@ -186,9 +186,9 @@ module Games::TicTacToeTests {
 
         // No one has the trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(!TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
         TestScenario::next_tx(scenario, &player_o);
-        assert!(!TestScenario::can_remove_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
     }
 
     fun place_mark(
@@ -201,7 +201,7 @@ module Games::TicTacToeTests {
         // Step 1: player creates a mark and sends it to the game.
         TestScenario::next_tx(scenario, player);
         {
-            let cap = TestScenario::remove_object<MarkMintCap>(scenario);
+            let cap = TestScenario::take_object<MarkMintCap>(scenario);
             TicTacToe::send_mark_to_game(&mut cap, *admin, row, col, TestScenario::ctx(scenario));
             TestScenario::return_object(scenario, cap);
         };
@@ -209,8 +209,8 @@ module Games::TicTacToeTests {
         TestScenario::next_tx(scenario, admin);
         let status;
         {
-            let game = TestScenario::remove_object<TicTacToe>(scenario);
-            let mark = TestScenario::remove_object<Mark>(scenario);
+            let game = TestScenario::take_object<TicTacToe>(scenario);
+            let mark = TestScenario::take_object<Mark>(scenario);
             assert!(TicTacToe::mark_player(&mark) == player, 0);
             assert!(TicTacToe::mark_row(&mark) == row, 1);
             assert!(TicTacToe::mark_col(&mark) == col, 2);

--- a/sui_programmability/examples/nfts/sources/Marketplace.move
+++ b/sui_programmability/examples/nfts/sources/Marketplace.move
@@ -170,9 +170,9 @@ module NFTs::MarketplaceTests {
     // SELLER lists KITTY at the Marketplace for 100 SUI.
     fun list_kitty(scenario: &mut Scenario) {
         TestScenario::next_tx(scenario, &SELLER);
-        let mkp = TestScenario::remove_object<Marketplace>(scenario);
-        let bag = TestScenario::remove_nested_object<Marketplace, Bag>(scenario, &mkp);
-        let nft = TestScenario::remove_object<NFT<KITTY>>(scenario);
+        let mkp = TestScenario::take_object<Marketplace>(scenario);
+        let bag = TestScenario::take_nested_object<Marketplace, Bag>(scenario, &mkp);
+        let nft = TestScenario::take_object<NFT<KITTY>>(scenario);
 
         Marketplace::list<NFT<KITTY>, SUI>(&mkp, &mut bag, nft, 100, TestScenario::ctx(scenario));
         TestScenario::return_object(scenario, mkp);
@@ -189,9 +189,9 @@ module NFTs::MarketplaceTests {
 
         TestScenario::next_tx(scenario, &SELLER);
         {
-            let mkp = TestScenario::remove_object<Marketplace>(scenario);
-            let bag = TestScenario::remove_nested_object<Marketplace, Bag>(scenario, &mkp);
-            let listing = TestScenario::remove_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
+            let mkp = TestScenario::take_object<Marketplace>(scenario);
+            let bag = TestScenario::take_nested_object<Marketplace, Bag>(scenario, &mkp);
+            let listing = TestScenario::take_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
 
             // Do the delist operation on a Marketplace.
             let nft = Marketplace::delist<NFT<KITTY>, SUI>(&mkp, &mut bag, listing, TestScenario::ctx(scenario));
@@ -217,9 +217,9 @@ module NFTs::MarketplaceTests {
         // BUYER attempts to delist KITTY and he has no right to do so. :(
         TestScenario::next_tx(scenario, &BUYER);
         {
-            let mkp = TestScenario::remove_object<Marketplace>(scenario);
-            let bag = TestScenario::remove_nested_object<Marketplace, Bag>(scenario, &mkp);
-            let listing = TestScenario::remove_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
+            let mkp = TestScenario::take_object<Marketplace>(scenario);
+            let bag = TestScenario::take_nested_object<Marketplace, Bag>(scenario, &mkp);
+            let listing = TestScenario::take_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
 
             // Do the delist operation on a Marketplace.
             let nft = Marketplace::delist<NFT<KITTY>, SUI>(&mkp, &mut bag, listing, TestScenario::ctx(scenario));
@@ -242,10 +242,10 @@ module NFTs::MarketplaceTests {
         // BUYER takes 100 SUI from his wallet and purchases KITTY.
         TestScenario::next_tx(scenario, &BUYER);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
-            let mkp = TestScenario::remove_object<Marketplace>(scenario);
-            let bag = TestScenario::remove_nested_object<Marketplace, Bag>(scenario, &mkp);
-            let listing = TestScenario::remove_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let mkp = TestScenario::take_object<Marketplace>(scenario);
+            let bag = TestScenario::take_nested_object<Marketplace, Bag>(scenario, &mkp);
+            let listing = TestScenario::take_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
             let payment = Coin::withdraw(&mut coin, 100, TestScenario::ctx(scenario));
 
             // Do the buy call and expect successful purchase.
@@ -273,10 +273,10 @@ module NFTs::MarketplaceTests {
         // BUYER takes 100 SUI from his wallet and purchases KITTY.
         TestScenario::next_tx(scenario, &BUYER);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
-            let mkp = TestScenario::remove_object<Marketplace>(scenario);
-            let bag = TestScenario::remove_nested_object<Marketplace, Bag>(scenario, &mkp);
-            let listing = TestScenario::remove_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let mkp = TestScenario::take_object<Marketplace>(scenario);
+            let bag = TestScenario::take_nested_object<Marketplace, Bag>(scenario, &mkp);
+            let listing = TestScenario::take_nested_object<Bag, Listing<NFT<KITTY>, SUI>>(scenario, &bag);
 
             // AMOUNT here is 10 while expected is 100.
             let payment = Coin::withdraw(&mut coin, 10, TestScenario::ctx(scenario));

--- a/sui_programmability/examples/nfts/tests/AuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/AuctionTests.move
@@ -71,7 +71,7 @@ module NFTs::AuctionTests {
         // a transaction by the first bidder to create and put a bid
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
 
             Auction::bid(coin, auction_id, auctioneer, TestScenario::ctx(scenario));
         };
@@ -79,9 +79,9 @@ module NFTs::AuctionTests {
         // a transaction by the auctioneer to update state of the auction
         TestScenario::next_tx(scenario, &auctioneer);
         {
-            let auction = TestScenario::remove_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
 
-            let bid = TestScenario::remove_object<Bid>(scenario);
+            let bid = TestScenario::take_object<Bid>(scenario);
             Auction::update_auction(&mut auction, bid, TestScenario::ctx(scenario));
 
             TestScenario::return_object(scenario, auction);
@@ -91,7 +91,7 @@ module NFTs::AuctionTests {
         // bidder's)
         TestScenario::next_tx(scenario, &bidder2);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
 
             Auction::bid(coin, auction_id, auctioneer, TestScenario::ctx(scenario));
         };
@@ -99,9 +99,9 @@ module NFTs::AuctionTests {
         // a transaction by the auctioneer to update state of the auction
         TestScenario::next_tx(scenario, &auctioneer);
         {
-            let auction = TestScenario::remove_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
 
-            let bid = TestScenario::remove_object<Bid>(scenario);
+            let bid = TestScenario::take_object<Bid>(scenario);
             Auction::update_auction(&mut auction, bid, TestScenario::ctx(scenario));
 
             TestScenario::return_object(scenario, auction);
@@ -110,7 +110,7 @@ module NFTs::AuctionTests {
         // a transaction by the auctioneer to end auction
         TestScenario::next_tx(scenario, &auctioneer);
         {
-            let auction = TestScenario::remove_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
 
             Auction::end_auction(auction, TestScenario::ctx(scenario));
         };
@@ -119,7 +119,7 @@ module NFTs::AuctionTests {
         // second bidder's bid was the same as that of the first one)
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let acquired_item = TestScenario::remove_object<SomeItemToSell>(scenario);
+            let acquired_item = TestScenario::take_object<SomeItemToSell>(scenario);
 
             assert!(acquired_item.value == 42, EWRONG_ITEM_VALUE);
 

--- a/sui_programmability/examples/nfts/tests/DiscountCouponTests.move
+++ b/sui_programmability/examples/nfts/tests/DiscountCouponTests.move
@@ -34,16 +34,16 @@ module NFTs::DiscountCouponTests {
 
         // Mint and transfer NFT + top up recipient's address.
         TestScenario::next_tx(scenario, &ISSUER_ADDRESS);
-        {           
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
+        {
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
             DiscountCoupon::mint_and_topup(coin, 10, 1648820870, USER1_ADDRESS, TestScenario::ctx(scenario));
         };
 
         TestScenario::next_tx(scenario, &USER1_ADDRESS);
         {
-            assert!(TestScenario::can_remove_object<NFT<DiscountCoupon>>(scenario), 0);
-            let nft_coupon = TestScenario::remove_object<NFT<DiscountCoupon>>(scenario); // if can remove, object exists
-            assert!(DiscountCoupon::issuer(NFT::data(&nft_coupon)) == ISSUER_ADDRESS, 0); 
+            assert!(TestScenario::can_take_object<NFT<DiscountCoupon>>(scenario), 0);
+            let nft_coupon = TestScenario::take_object<NFT<DiscountCoupon>>(scenario); // if can remove, object exists
+            assert!(DiscountCoupon::issuer(NFT::data(&nft_coupon)) == ISSUER_ADDRESS, 0);
             TestScenario::return_object(scenario, nft_coupon);
         }
     }

--- a/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
@@ -68,8 +68,8 @@ module NFTs::SharedAuctionTests {
         // a transaction by the first bidder to put a bid
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
-            let auction = TestScenario::remove_object<Auction<SomeItemToSell>>(scenario);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
 
             SharedAuction::bid(coin, &mut auction, TestScenario::ctx(scenario));
 
@@ -81,8 +81,8 @@ module NFTs::SharedAuctionTests {
         // bidder's)
         TestScenario::next_tx(scenario, &bidder2);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
-            let auction = TestScenario::remove_object<Auction<SomeItemToSell>>(scenario);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
 
             SharedAuction::bid(coin, &mut auction, TestScenario::ctx(scenario));
 
@@ -93,7 +93,7 @@ module NFTs::SharedAuctionTests {
         // have been returned (as a result of the failed bid).
         TestScenario::next_tx(scenario, &bidder2);
         {
-            let coin = TestScenario::remove_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
 
             assert!(Coin::value(&coin) == COIN_VALUE, EWRONG_COIN_VALUE);
 
@@ -103,7 +103,7 @@ module NFTs::SharedAuctionTests {
         // a transaction by the owner to end auction
         TestScenario::next_tx(scenario, &owner);
         {
-            let auction = TestScenario::remove_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
 
             // pass auction as mutable reference as its a shared
             // object that cannot be deleted
@@ -116,7 +116,7 @@ module NFTs::SharedAuctionTests {
         // second bidder's bid was the same as that of the first one)
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let acquired_item = TestScenario::remove_object<SomeItemToSell>(scenario);
+            let acquired_item = TestScenario::take_object<SomeItemToSell>(scenario);
 
             assert!(acquired_item.value == 42, EWRONG_ITEM_VALUE);
 

--- a/sui_programmability/framework/tests/BagTests.move
+++ b/sui_programmability/framework/tests/BagTests.move
@@ -33,7 +33,7 @@ module Sui::BagTests {
         // Add two objects of different types into the bag.
         TestScenario::next_tx(scenario, &sender);
         {
-            let bag = TestScenario::remove_object<Bag>(scenario);
+            let bag = TestScenario::take_object<Bag>(scenario);
             assert!(Bag::size(&bag) == 0, EBAG_SIZE_MISMATCH);
 
             let obj1 = Object1 { id: TxContext::new_id(TestScenario::ctx(scenario)) };

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -27,7 +27,7 @@ module Sui::CollectionTests {
         // Add two objects of different types into the collection.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::remove_object<Collection<Object>>(scenario);
+            let collection = TestScenario::take_object<Collection<Object>>(scenario);
             assert!(Collection::size(&collection) == 0, 0);
 
             let obj1 = Object { id: TxContext::new_id(TestScenario::ctx(scenario)) };
@@ -61,7 +61,7 @@ module Sui::CollectionTests {
         // Add a new object to the Collection.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::remove_object<Collection<Object>>(scenario);
+            let collection = TestScenario::take_object<Collection<Object>>(scenario);
             let obj = Object { id: TxContext::new_id(TestScenario::ctx(scenario)) };
             Collection::add(&mut collection, obj);
             TestScenario::return_object(scenario, collection);
@@ -70,9 +70,9 @@ module Sui::CollectionTests {
         // Remove the object from the collection and add it to the bag.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::remove_object<Collection<Object>>(scenario);
-            let bag = TestScenario::remove_object<Bag>(scenario);
-            let obj = TestScenario::remove_nested_object<Collection<Object>, Object>(scenario, &collection);
+            let collection = TestScenario::take_object<Collection<Object>>(scenario);
+            let bag = TestScenario::take_object<Bag>(scenario);
+            let obj = TestScenario::take_nested_object<Collection<Object>, Object>(scenario, &collection);
             let id = *ID::id(&obj);
 
             let (obj, child_ref) = Collection::remove(&mut collection, obj);
@@ -89,9 +89,9 @@ module Sui::CollectionTests {
         // Remove the object from the bag and add it back to the collection.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::remove_object<Collection<Object>>(scenario);
-            let bag = TestScenario::remove_object<Bag>(scenario);
-            let obj = TestScenario::remove_nested_object<Bag, Object>(scenario, &bag);
+            let collection = TestScenario::take_object<Collection<Object>>(scenario);
+            let bag = TestScenario::take_object<Bag>(scenario);
+            let obj = TestScenario::take_nested_object<Bag, Object>(scenario, &bag);
             let id = *ID::id(&obj);
 
             let obj = Bag::remove(&mut bag, obj);

--- a/sui_programmability/framework/tests/CrossChainAirdropTests.move
+++ b/sui_programmability/framework/tests/CrossChainAirdropTests.move
@@ -31,13 +31,13 @@ module Sui::CrossChainAirdropTests {
 
         // claim a token
         claim_token(&mut scenario, &oracle_address, SOURCE_TOKEN_ID);
-        
+
         // verify that the recipient has received the nft
         assert!(owns_object(&mut scenario, &RECIPIENT_ADDRESS), EOBJECT_NOT_FOUND);
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)] 
+    #[expected_failure(abort_code = 0)]
     fun test_double_claim() {
         let (scenario, oracle_address) = init();
 
@@ -60,7 +60,7 @@ module Sui::CrossChainAirdropTests {
     fun claim_token(scenario: &mut Scenario, oracle_address: &address, token_id: u64) {
         TestScenario::next_tx(scenario, oracle_address);
         {
-            let oracle = TestScenario::remove_object<CrossChainAirdropOracle>(scenario);
+            let oracle = TestScenario::take_object<CrossChainAirdropOracle>(scenario);
             let ctx = TestScenario::ctx(scenario);
             CrossChainAirdrop::claim(
                 &mut oracle,
@@ -78,6 +78,6 @@ module Sui::CrossChainAirdropTests {
     fun owns_object(scenario: &mut Scenario, owner: &address): bool{
         // Verify the token has been transfer to the recipient
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_remove_object<NFT<ERC721>>(scenario)
+        TestScenario::can_take_object<NFT<ERC721>>(scenario)
     }
 }

--- a/sui_programmability/framework/tests/TestScenarioTests.move
+++ b/sui_programmability/framework/tests/TestScenarioTests.move
@@ -34,15 +34,15 @@ module Sui::TestScenarioTests {
         TestScenario::next_tx(&mut scenario, &sender);
         {
             let id = TestScenario::new_id(&mut scenario);
-            let child = TestScenario::remove_object<Object>(&mut scenario);
+            let child = TestScenario::take_object<Object>(&mut scenario);
             let wrapper = Wrapper { id, child };
             Transfer::transfer(wrapper, copy sender);
         };
         // wrapped object should no longer be removable, but wrapper should be
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 0);
-            assert!(TestScenario::can_remove_object<Wrapper>(&scenario), 1);
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(TestScenario::can_take_object<Wrapper>(&scenario), 1);
         }
     }
 
@@ -58,13 +58,13 @@ module Sui::TestScenarioTests {
         // object gets removed, then returned
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let object = TestScenario::remove_object<Object>(&mut scenario);
+            let object = TestScenario::take_object<Object>(&mut scenario);
             TestScenario::return_object(&mut scenario, object);
         };
         // Object should remain accessible
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            assert!(TestScenario::can_remove_object<Object>(&scenario), 0);
+            assert!(TestScenario::can_take_object<Object>(&scenario), 0);
         }
     }
 
@@ -79,14 +79,14 @@ module Sui::TestScenarioTests {
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             assert!(obj.value == 10, 0);
             obj.value = 100;
             TestScenario::return_object(&mut scenario, obj);
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             assert!(obj.value == 100, 1);
             TestScenario::return_object(&mut scenario, obj);
         }
@@ -101,7 +101,7 @@ module Sui::TestScenarioTests {
             let obj = Object { id, value: 10 };
             Transfer::transfer(obj, copy sender);
             // an object transferred during the tx shouldn't be available in that tx
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 0)
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 0)
         };
     }
 
@@ -117,8 +117,8 @@ module Sui::TestScenarioTests {
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj1 = TestScenario::remove_object<Object>(&mut scenario);
-            let obj2 = TestScenario::remove_object<Object>(&mut scenario);
+            let obj1 = TestScenario::take_object<Object>(&mut scenario);
+            let obj2 = TestScenario::take_object<Object>(&mut scenario);
             TestScenario::return_object(&mut scenario, obj1);
             TestScenario::return_object(&mut scenario, obj2);
         }
@@ -141,34 +141,34 @@ module Sui::TestScenarioTests {
         // addr1 -> addr2
         TestScenario::next_tx(&mut scenario, &addr1);
         {
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             Transfer::transfer(obj, copy addr2)
         };
         // addr1 cannot access
         TestScenario::next_tx(&mut scenario, &addr1);
         {
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
         };
         // addr2 -> addr3
         TestScenario::next_tx(&mut scenario, &addr2);
         {
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             Transfer::transfer(obj, copy addr3)
         };
         // addr1 cannot access
         TestScenario::next_tx(&mut scenario, &addr1);
         {
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
         };
         // addr2 cannot access
         TestScenario::next_tx(&mut scenario, &addr2);
         {
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
         };
         // addr3 *can* access
         TestScenario::next_tx(&mut scenario, &addr3);
         {
-            assert!(TestScenario::can_remove_object<Object>(&scenario), 0);
+            assert!(TestScenario::can_take_object<Object>(&scenario), 0);
         }
     }
 
@@ -185,13 +185,13 @@ module Sui::TestScenarioTests {
             let obj = Object { id, value: 100 };
             Transfer::transfer(obj, copy tx2_sender);
             // sender cannot access the object
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
         };
         // check that tx2_sender can get the object, and it's the same one
         TestScenario::next_tx(&mut scenario, &tx2_sender);
         {
-            assert!(TestScenario::can_remove_object<Object>(&scenario), 1);
-            let received_obj = TestScenario::remove_object<Object>(&mut scenario);
+            assert!(TestScenario::can_take_object<Object>(&scenario), 1);
+            let received_obj = TestScenario::take_object<Object>(&mut scenario);
             let Object { id: received_id, value } = received_obj;
             assert!(ID::inner(&received_id) == &id_bytes, ID_BYTES_MISMATCH);
             assert!(value == 100, VALUE_MISMATCH);
@@ -200,12 +200,12 @@ module Sui::TestScenarioTests {
         // check that the object is no longer accessible after deletion
         TestScenario::next_tx(&mut scenario, &tx2_sender);
         {
-            assert!(!TestScenario::can_remove_object<Object>(&scenario), 2);
+            assert!(!TestScenario::can_take_object<Object>(&scenario), 2);
         }
     }
 
     #[test]
-    fun test_remove_object_by_id() {
+    fun test_take_object_by_id() {
         let sender = @0x0;
         let scenario = TestScenario::begin(&sender);
         let versioned_id1 = TestScenario::new_id(&mut scenario);
@@ -225,20 +225,20 @@ module Sui::TestScenarioTests {
         TestScenario::next_tx(&mut scenario, &sender);
         {
             assert!(
-                TestScenario::can_remove_object_by_id<Object>(&mut scenario, id1),
+                TestScenario::can_take_object_by_id<Object>(&mut scenario, id1),
                 OBJECT_ID_NOT_FOUND
             );
             assert!(
-                TestScenario::can_remove_object_by_id<Object>(&mut scenario, id2),
+                TestScenario::can_take_object_by_id<Object>(&mut scenario, id2),
                 OBJECT_ID_NOT_FOUND
             );
             assert!(
-                TestScenario::can_remove_object_by_id<Object>(&mut scenario, id3),
+                TestScenario::can_take_object_by_id<Object>(&mut scenario, id3),
                 OBJECT_ID_NOT_FOUND
             );
-            let obj1 = TestScenario::remove_object_by_id<Object>(&mut scenario, id1);
-            let obj3 = TestScenario::remove_object_by_id<Object>(&mut scenario, id3);
-            let obj2 = TestScenario::remove_object_by_id<Object>(&mut scenario, id2);
+            let obj1 = TestScenario::take_object_by_id<Object>(&mut scenario, id1);
+            let obj3 = TestScenario::take_object_by_id<Object>(&mut scenario, id3);
+            let obj2 = TestScenario::take_object_by_id<Object>(&mut scenario, id2);
             assert!(obj1.value == 10, VALUE_MISMATCH);
             assert!(obj2.value == 20, VALUE_MISMATCH);
             assert!(obj3.value == 30, VALUE_MISMATCH);
@@ -259,7 +259,7 @@ module Sui::TestScenarioTests {
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             // Transfer an immutable object, this won't fail right away.
             Transfer::transfer(obj, copy sender);
         };
@@ -267,7 +267,7 @@ module Sui::TestScenarioTests {
         {
             // while removing the object, test scenario will read the inventory,
             // and discover that we transferred an immutable object.
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             TestScenario::return_object(&mut scenario, obj);
         };
     }
@@ -283,7 +283,7 @@ module Sui::TestScenarioTests {
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj = TestScenario::remove_object<Object>(&mut scenario);
+            let obj = TestScenario::take_object<Object>(&mut scenario);
             obj.value = 200;
             TestScenario::return_object(&mut scenario, obj);
         };

--- a/sui_programmability/tutorial/sources/M1.move
+++ b/sui_programmability/tutorial/sources/M1.move
@@ -78,7 +78,7 @@ module MyFirstPackage::M1 {
         TestScenario::next_tx(scenario, &admin);
         {
             // extract the Forge object
-            let forge = TestScenario::remove_object<Forge>(scenario);
+            let forge = TestScenario::take_object<Forge>(scenario);
             // verify number of created swords
             assert!(swords_created(&forge) == 0, 1);
             // return the Forge object to the object pool
@@ -103,7 +103,7 @@ module MyFirstPackage::M1 {
         // second transaction executed by admin to create the sword
         TestScenario::next_tx(scenario, &admin);
         {
-            let forge = TestScenario::remove_object<Forge>(scenario);
+            let forge = TestScenario::take_object<Forge>(scenario);
             // create the sword and transfer it to the initial owner
             sword_create(&mut forge, 42, 7, initial_owner, TestScenario::ctx(scenario));
             TestScenario::return_object(scenario, forge)
@@ -112,7 +112,7 @@ module MyFirstPackage::M1 {
         TestScenario::next_tx(scenario, &initial_owner);
         {
             // extract the sword owned by the initial owner
-            let sword = TestScenario::remove_object<Sword>(scenario);
+            let sword = TestScenario::take_object<Sword>(scenario);
             // transfer the sword to the final owner
             sword_transfer(sword, final_owner, TestScenario::ctx(scenario));
         };
@@ -121,7 +121,7 @@ module MyFirstPackage::M1 {
         {
 
             // extract the sword owned by the final owner
-            let sword = TestScenario::remove_object<Sword>(scenario);
+            let sword = TestScenario::take_object<Sword>(scenario);
             // verify that the sword has expected properties
             assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
             // return the sword to the object pool (it cannot be simply "dropped")


### PR DESCRIPTION
As title, from API point of view, it's easier to understand for developers.