### PR TITLE
Laura/refactor stream client without info

### DIFF
--- a/sui/src/benchmark.rs
+++ b/sui/src/benchmark.rs
@@ -7,7 +7,7 @@ use futures::{join, StreamExt};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::thread;
 use std::{thread::sleep, time::Duration};
-use sui_core::authority_client::AuthorityClient;
+use sui_core::authority_client::{AuthorityAPI, AuthorityClient};
 use sui_network::network::{NetworkClient, NetworkServer};
 use sui_types::batch::UpdateItem;
 use sui_types::messages::{BatchInfoRequest, BatchInfoResponseItem};
@@ -223,7 +223,7 @@ async fn run_follower(network_client: NetworkClient) {
 
         loop {
             let receiver = authority_client
-                .handle_batch_streaming_as_stream(BatchInfoRequest {
+                .handle_batch_stream(BatchInfoRequest {
                     start,
                     end: start + FOLLOWER_BATCH_SIZE,
                 })

--- a/sui_core/src/authority_batch.rs
+++ b/sui_core/src/authority_batch.rs
@@ -79,8 +79,7 @@ impl crate::authority::AuthorityState {
         if !transactions.is_empty() {
             // Make a new batch, to put the old transactions not in a batch in.
             let last_signed_batch = SignedBatch::new(
-                // Unwrap safe due to check not empty
-                AuthorityBatch::make_next(&last_batch, &transactions[..])?,
+                AuthorityBatch::make_next(&last_batch, &transactions[..]),
                 &*self.secret,
                 self.name,
             );
@@ -156,15 +155,13 @@ impl crate::authority::AuthorityState {
 
             // Logic to make a batch
             if make_batch {
-                // Test it is not empty.
                 if current_batch.is_empty() {
                     continue;
                 }
 
                 // Make and store a new batch.
                 let new_batch = SignedBatch::new(
-                    // Unwrap safe since we tested above it is not empty
-                    AuthorityBatch::make_next(&prev_batch, &current_batch).unwrap(),
+                    AuthorityBatch::make_next(&prev_batch, &current_batch),
                     &*self.secret,
                     self.name,
                 );

--- a/sui_core/src/authority_batch.rs
+++ b/sui_core/src/authority_batch.rs
@@ -79,7 +79,8 @@ impl crate::authority::AuthorityState {
         if !transactions.is_empty() {
             // Make a new batch, to put the old transactions not in a batch in.
             let last_signed_batch = SignedBatch::new(
-                AuthorityBatch::make_next(&last_batch, &transactions[..]),
+                // Unwrap safe due to check not empty
+                AuthorityBatch::make_next(&last_batch, &transactions[..])?,
                 &*self.secret,
                 self.name,
             );
@@ -155,13 +156,15 @@ impl crate::authority::AuthorityState {
 
             // Logic to make a batch
             if make_batch {
+                // Test it is not empty.
                 if current_batch.is_empty() {
                     continue;
                 }
 
                 // Make and store a new batch.
                 let new_batch = SignedBatch::new(
-                    AuthorityBatch::make_next(&prev_batch, &current_batch),
+                    // Unwrap safe since we tested above it is not empty
+                    AuthorityBatch::make_next(&prev_batch, &current_batch).unwrap(),
                     &*self.secret,
                     self.name,
                 );

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -322,7 +322,7 @@ where
                 let client = client.clone();
 
                 // We check if we have exceeded the batch boundary for this request.
-                if !(*seq < request.end) {
+                if *seq >= request.end {
                     // If we exceed it return None to end stream
                     return futures::future::ready(None);
                 }
@@ -331,8 +331,8 @@ where
                     Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
                         if let Err(err) = client.check_update_item_batch_response(
                             req_clone,
-                            &signed_batch,
-                            &txs_and_last_batch,
+                            signed_batch,
+                            txs_and_last_batch,
                         ) {
                             client.report_client_error(err.clone());
                             Some(Err(err))

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -178,7 +178,7 @@ impl<C> SafeClient<C> {
         // check the signature of the batch
         signed_batch
             .signature
-            .check(signed_batch, signed_batch.authority)?;
+            .check(&signed_batch.batch, signed_batch.authority)?;
 
         // ensure transactions enclosed match requested range
         fp_ensure!(
@@ -197,7 +197,7 @@ impl<C> SafeClient<C> {
             Some(provided_digest),
             &signed_batch.batch.transaction_batch.0,
         );
-        let computed_digest = reconstructed_batch.digest();
+        let computed_digest = reconstructed_batch.transactions_digest;
 
         fp_ensure!(
             provided_digest == computed_digest,

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -9,7 +9,7 @@ use std::io;
 use sui_types::crypto::PublicKeyBytes;
 use sui_types::{base_types::*, committee::*, fp_ensure};
 
-use sui_types::batch::{AuthorityBatch, SignedBatch, UpdateItem};
+use sui_types::batch::{AuthorityBatch, SignedBatch, TxSequenceNumber, UpdateItem};
 use sui_types::{
     error::{SuiError, SuiResult},
     messages::*,
@@ -174,6 +174,10 @@ impl<C> SafeClient<C> {
         &self,
         request: BatchInfoRequest,
         signed_batch: &SignedBatch,
+        transactions_and_last_batch: &Option<(
+            Vec<(TxSequenceNumber, TransactionDigest)>,
+            AuthorityBatch,
+        )>,
     ) -> SuiResult {
         // check the signature of the batch
         signed_batch
@@ -190,21 +194,20 @@ impl<C> SafeClient<C> {
             }
         );
 
-        // reconstruct the batch and make sure the constructed digest matches the provided one
-        let provided_digest = signed_batch.batch.transactions_digest;
+        // If we have seen a previous batch, use it to make sure the next batch
+        // is constructed correctly:
 
-        let reconstructed_batch = AuthorityBatch::make_next_with_previous_digest(
-            Some(provided_digest),
-            &signed_batch.batch.transaction_batch.0,
-        );
-        let computed_digest = reconstructed_batch.transactions_digest;
+        if let Some((transactions, prev_batch)) = transactions_and_last_batch {
+            let reconstructed_batch = AuthorityBatch::make_next(prev_batch, transactions)?;
 
-        fp_ensure!(
-            provided_digest == computed_digest,
-            SuiError::ByzantineAuthoritySuspicion {
-                authority: self.address
-            }
-        );
+            fp_ensure!(
+                reconstructed_batch == signed_batch.batch,
+                SuiError::ByzantineAuthoritySuspicion {
+                    authority: self.address
+                }
+            );
+        }
+
         Ok(())
     }
 
@@ -310,39 +313,59 @@ where
             .handle_batch_stream(request.clone())
             .await?;
 
-        let seq_requested = request.end - request.start;
-        let mut seq_to_be_returned = seq_requested as usize;
-        // check for overflow
-        if seq_requested > usize::MAX as u64 {
-            seq_to_be_returned = usize::MAX;
-        }
-
         let client = self.clone();
-        let stream = Box::pin(
-            batch_info_items
-                .then(move |batch_info_item| {
-                    let req_clone = request.clone();
-                    let client = client.clone();
-                    async move {
-                        match &batch_info_item {
-                            Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
-                                if let Err(err) =
-                                    client.check_update_item_batch_response(req_clone, signed_batch)
-                                {
-                                    client.report_client_error(err.clone());
-                                    return Err(err);
-                                }
-                                batch_info_item
-                            }
-                            Ok(BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest)))) => {
-                                batch_info_item
-                            }
-                            Err(e) => Err(e.clone()),
+        let address = self.address;
+        let stream = Box::pin(batch_info_items.scan(
+            (0u64, None),
+            move |(seq, txs_and_last_batch), batch_info_item| {
+                let req_clone = request.clone();
+                let client = client.clone();
+
+                // We check if we have exceeded the batch boundary for this request.
+                if !(*seq < request.end) {
+                    // If we exceed it return None to end stream
+                    return futures::future::ready(None);
+                }
+
+                let x = match &batch_info_item {
+                    Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
+                        if let Err(err) = client.check_update_item_batch_response(
+                            req_clone,
+                            &signed_batch,
+                            &txs_and_last_batch,
+                        ) {
+                            client.report_client_error(err.clone());
+                            Some(Err(err))
+                        } else {
+                            // Save the seqeunce number of this batch
+                            *seq = signed_batch.batch.next_sequence_number;
+                            // Insert a fresh vector for the new batch of transactions
+                            let _ =
+                                txs_and_last_batch.insert((Vec::new(), signed_batch.batch.clone()));
+                            Some(batch_info_item)
                         }
                     }
-                })
-                .take(seq_to_be_returned),
-        );
+                    Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digest)))) => {
+                        // A stream always starts with a batch, so the previous should have initialized it.
+                        // And here we insert the tuple into the batch.
+                        if txs_and_last_batch
+                            .as_mut()
+                            .map(|txs| txs.0.push((*seq, *digest)))
+                            .is_none()
+                        {
+                            let err = SuiError::ByzantineAuthoritySuspicion { authority: address };
+                            client.report_client_error(err.clone());
+                            Some(Err(err))
+                        } else {
+                            Some(batch_info_item)
+                        }
+                    }
+                    Err(e) => Some(Err(e.clone())),
+                };
+
+                futures::future::ready(x)
+            },
+        ));
         Ok(Box::pin(stream))
     }
 }

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -497,11 +497,7 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         items.reverse();
 
         let stream = stream::unfold(items, |mut items| async move {
-            if let Some(item) = items.pop() {
-                Some((Ok(item), items))
-            } else {
-                None
-            }
+            items.pop().map(|item| (Ok(item), items))
         });
         Ok(Box::pin(stream))
     }
@@ -616,11 +612,7 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         items.reverse();
 
         let stream = stream::unfold(items, |mut items| async move {
-            if let Some(item) = items.pop() {
-                Some((Ok(item), items))
-            } else {
-                None
-            }
+            items.pop().map(|item| (Ok(item), items))
         });
         Ok(Box::pin(stream))
     }

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -380,7 +380,6 @@ async fn test_batch_store_retrieval() {
         .batches_and_transactions(94, 120)
         .expect("Retrieval failed!");
 
-    println!("{:?}", batches);
     assert_eq!(3, batches.len());
     assert_eq!(90, batches.first().unwrap().batch.next_sequence_number);
     assert_eq!(115, batches.last().unwrap().batch.next_sequence_number);
@@ -471,30 +470,39 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         let name = self.0.lock().await.name;
         let batch_size = 3;
 
-        let stream = stream::unfold(
-            (request.start, AuthorityBatch::initial()),
-            move |(seq, last_batch)| {
-                let auth_secret = secret.clone();
-                async move {
-                    if seq <= request.end {
-                        let mut transactions = Vec::new();
-                        for i in 0..batch_size {
-                            transactions.push((seq + i, TransactionDigest::random()));
-                        }
-                        let next = AuthorityBatch::make_next_with_previous_digest(
-                            Some(last_batch.digest()),
-                            &transactions,
-                        );
+        let mut items = Vec::new();
+        let mut last_batch = AuthorityBatch::initial();
+        items.push({
+            let item = SignedBatch::new(last_batch.clone(), &*secret, name);
+            BatchInfoResponseItem(UpdateItem::Batch(item))
+        });
+        let mut seq = 0;
+        while last_batch.next_sequence_number < request.end {
+            let mut transactions = Vec::new();
+            for _i in 0..batch_size {
+                let rnd = TransactionDigest::random();
+                transactions.push((seq, rnd));
+                items.push(BatchInfoResponseItem(UpdateItem::Transaction((seq, rnd))));
+                seq += 1;
+            }
 
-                        let item = SignedBatch::new(next.clone(), &*auth_secret, name);
-                        let response = BatchInfoResponseItem(UpdateItem::Batch(item));
-                        Some((Ok(response), (seq + batch_size, next)))
-                    } else {
-                        None
-                    }
-                }
-            },
-        );
+            let new_batch = AuthorityBatch::make_next(&last_batch, &transactions).unwrap();
+            last_batch = new_batch;
+            items.push({
+                let item = SignedBatch::new(last_batch.clone(), &*secret, name);
+                BatchInfoResponseItem(UpdateItem::Batch(item))
+            });
+        }
+
+        items.reverse();
+
+        let stream = stream::unfold(items, |mut items| async move {
+            if let Some(item) = items.pop() {
+                Some((Ok(item), items))
+            } else {
+                None
+            }
+        });
         Ok(Box::pin(stream))
     }
 }
@@ -575,57 +583,45 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         let name = self.0.lock().await.name;
         let batch_size = 3;
 
-        let stream = stream::unfold(
-            (request.start, AuthorityBatch::initial()),
-            move |(seq, last_batch)| {
-                let auth_secret = secret.clone();
-                async move {
-                    if request.end % 2 == 0 {
-                        if seq <= request.end {
-                            let mut transactions = Vec::new();
-                            for i in 0..batch_size {
-                                transactions.push((seq + i, TransactionDigest::random()));
-                            }
-                            let next = AuthorityBatch::make_next_with_previous_digest(
-                                Some(last_batch.digest()),
-                                &transactions,
-                            );
+        let mut items = Vec::new();
+        let mut last_batch = AuthorityBatch::initial();
+        items.push({
+            let item = SignedBatch::new(last_batch.clone(), &*secret, name);
+            BatchInfoResponseItem(UpdateItem::Batch(item))
+        });
+        let mut seq = 0;
+        while last_batch.next_sequence_number < request.end {
+            let mut transactions = Vec::new();
+            for _i in 0..batch_size {
+                let rnd = TransactionDigest::random();
+                transactions.push((seq, rnd));
+                items.push(BatchInfoResponseItem(UpdateItem::Transaction((seq, rnd))));
+                seq += 1;
+            }
 
-                            let mut item = SignedBatch::new(next.clone(), &*auth_secret, name);
-                            // Remove a transaction after creating the batch
-                            item.batch.transaction_batch.0.pop();
-                            // And then add in a fake transaction
-                            item.batch
-                                .transaction_batch
-                                .0
-                                .push((seq + batch_size, TransactionDigest::random()));
-                            let response = BatchInfoResponseItem(UpdateItem::Batch(item));
-                            Some((Ok(response), (seq + batch_size, next)))
-                        } else {
-                            None
-                        }
-                    } else {
-                        // Byzantine authority sends you too much, not what you asked for.
-                        if seq <= request.end * 100 {
-                            let mut transactions = Vec::new();
-                            for i in 0..batch_size {
-                                transactions.push((seq + i, TransactionDigest::random()));
-                            }
-                            let next = AuthorityBatch::make_next_with_previous_digest(
-                                Some(last_batch.digest()),
-                                &transactions,
-                            );
+            // Introduce byzantine behaviour:
+            // Pop last transaction
+            let (seq, _) = transactions.pop().unwrap();
+            // Insert a different one
+            transactions.push((seq, TransactionDigest::random()));
 
-                            let item = SignedBatch::new(next.clone(), &*auth_secret, name);
-                            let response = BatchInfoResponseItem(UpdateItem::Batch(item));
-                            Some((Ok(response), (seq + batch_size, next)))
-                        } else {
-                            None
-                        }
-                    }
-                }
-            },
-        );
+            let new_batch = AuthorityBatch::make_next(&last_batch, &transactions).unwrap();
+            last_batch = new_batch;
+            items.push({
+                let item = SignedBatch::new(last_batch.clone(), &*secret, name);
+                BatchInfoResponseItem(UpdateItem::Batch(item))
+            });
+        }
+
+        items.reverse();
+
+        let stream = stream::unfold(items, |mut items| async move {
+            if let Some(item) = items.pop() {
+                Some((Ok(item), items))
+            } else {
+                None
+            }
+        });
         Ok(Box::pin(stream))
     }
 }
@@ -678,8 +674,9 @@ async fn test_safe_batch_stream() {
         .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
         .await;
 
-    // Length should be within sequenced range
-    assert!(items.len() <= (request.end - request.start) as usize && !items.is_empty());
+    // Check length
+    assert!(!items.is_empty());
+    assert_eq!(items.len(), 15 + 6); // 15 items, and 6 batches (enclosing them)
 
     let mut error_found = false;
     for item in items {
@@ -722,8 +719,9 @@ async fn test_safe_batch_stream() {
         .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
         .await;
 
-    // Length should be within sequenced range, despite authority that never stop sending
-    assert!(items.len() <= (request.end - request.start) as usize && !items.is_empty());
+    // Check length
+    assert!(!items.is_empty());
+    assert_eq!(items.len(), 15 + 6); // 15 items, and 6 batches (enclosing them)
 
     let request_b = BatchInfoRequest { start: 0, end: 10 };
     batch_stream = safe_client_from_byzantine

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -380,6 +380,7 @@ async fn test_batch_store_retrieval() {
         .batches_and_transactions(94, 120)
         .expect("Retrieval failed!");
 
+    println!("{:?}", batches);
     assert_eq!(3, batches.len());
     assert_eq!(90, batches.first().unwrap().batch.next_sequence_number);
     assert_eq!(115, batches.last().unwrap().batch.next_sequence_number);
@@ -470,39 +471,30 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         let name = self.0.lock().await.name;
         let batch_size = 3;
 
-        let mut items = Vec::new();
-        let mut last_batch = AuthorityBatch::initial();
-        items.push({
-            let item = SignedBatch::new(last_batch.clone(), &*secret, name);
-            BatchInfoResponseItem(UpdateItem::Batch(item))
-        });
-        let mut seq = 0;
-        while last_batch.next_sequence_number < request.end {
-            let mut transactions = Vec::new();
-            for _i in 0..batch_size {
-                let rnd = TransactionDigest::random();
-                transactions.push((seq, rnd));
-                items.push(BatchInfoResponseItem(UpdateItem::Transaction((seq, rnd))));
-                seq += 1;
-            }
+        let stream = stream::unfold(
+            (request.start, AuthorityBatch::initial()),
+            move |(seq, last_batch)| {
+                let auth_secret = secret.clone();
+                async move {
+                    if seq <= request.end {
+                        let mut transactions = Vec::new();
+                        for i in 0..batch_size {
+                            transactions.push((seq + i, TransactionDigest::random()));
+                        }
+                        let next = AuthorityBatch::make_next_with_previous_digest(
+                            Some(last_batch.digest()),
+                            &transactions,
+                        );
 
-            let new_batch = AuthorityBatch::make_next(&last_batch, &transactions).unwrap();
-            last_batch = new_batch;
-            items.push({
-                let item = SignedBatch::new(last_batch.clone(), &*secret, name);
-                BatchInfoResponseItem(UpdateItem::Batch(item))
-            });
-        }
-
-        items.reverse();
-
-        let stream = stream::unfold(items, |mut items| async move {
-            if let Some(item) = items.pop() {
-                Some((Ok(item), items))
-            } else {
-                None
-            }
-        });
+                        let item = SignedBatch::new(next.clone(), &*auth_secret, name);
+                        let response = BatchInfoResponseItem(UpdateItem::Batch(item));
+                        Some((Ok(response), (seq + batch_size, next)))
+                    } else {
+                        None
+                    }
+                }
+            },
+        );
         Ok(Box::pin(stream))
     }
 }
@@ -583,45 +575,57 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         let name = self.0.lock().await.name;
         let batch_size = 3;
 
-        let mut items = Vec::new();
-        let mut last_batch = AuthorityBatch::initial();
-        items.push({
-            let item = SignedBatch::new(last_batch.clone(), &*secret, name);
-            BatchInfoResponseItem(UpdateItem::Batch(item))
-        });
-        let mut seq = 0;
-        while last_batch.next_sequence_number < request.end {
-            let mut transactions = Vec::new();
-            for _i in 0..batch_size {
-                let rnd = TransactionDigest::random();
-                transactions.push((seq, rnd));
-                items.push(BatchInfoResponseItem(UpdateItem::Transaction((seq, rnd))));
-                seq += 1;
-            }
+        let stream = stream::unfold(
+            (request.start, AuthorityBatch::initial()),
+            move |(seq, last_batch)| {
+                let auth_secret = secret.clone();
+                async move {
+                    if request.end % 2 == 0 {
+                        if seq <= request.end {
+                            let mut transactions = Vec::new();
+                            for i in 0..batch_size {
+                                transactions.push((seq + i, TransactionDigest::random()));
+                            }
+                            let next = AuthorityBatch::make_next_with_previous_digest(
+                                Some(last_batch.digest()),
+                                &transactions,
+                            );
 
-            // Introduce byzantine behaviour:
-            // Pop last transaction
-            let (seq, _) = transactions.pop().unwrap();
-            // Insert a different one
-            transactions.push((seq, TransactionDigest::random()));
+                            let mut item = SignedBatch::new(next.clone(), &*auth_secret, name);
+                            // Remove a transaction after creating the batch
+                            item.batch.transaction_batch.0.pop();
+                            // And then add in a fake transaction
+                            item.batch
+                                .transaction_batch
+                                .0
+                                .push((seq + batch_size, TransactionDigest::random()));
+                            let response = BatchInfoResponseItem(UpdateItem::Batch(item));
+                            Some((Ok(response), (seq + batch_size, next)))
+                        } else {
+                            None
+                        }
+                    } else {
+                        // Byzantine authority sends you too much, not what you asked for.
+                        if seq <= request.end * 100 {
+                            let mut transactions = Vec::new();
+                            for i in 0..batch_size {
+                                transactions.push((seq + i, TransactionDigest::random()));
+                            }
+                            let next = AuthorityBatch::make_next_with_previous_digest(
+                                Some(last_batch.digest()),
+                                &transactions,
+                            );
 
-            let new_batch = AuthorityBatch::make_next(&last_batch, &transactions).unwrap();
-            last_batch = new_batch;
-            items.push({
-                let item = SignedBatch::new(last_batch.clone(), &*secret, name);
-                BatchInfoResponseItem(UpdateItem::Batch(item))
-            });
-        }
-
-        items.reverse();
-
-        let stream = stream::unfold(items, |mut items| async move {
-            if let Some(item) = items.pop() {
-                Some((Ok(item), items))
-            } else {
-                None
-            }
-        });
+                            let item = SignedBatch::new(next.clone(), &*auth_secret, name);
+                            let response = BatchInfoResponseItem(UpdateItem::Batch(item));
+                            Some((Ok(response), (seq + batch_size, next)))
+                        } else {
+                            None
+                        }
+                    }
+                }
+            },
+        );
         Ok(Box::pin(stream))
     }
 }
@@ -674,9 +678,8 @@ async fn test_safe_batch_stream() {
         .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
         .await;
 
-    // Check length
-    assert!(!items.is_empty());
-    assert_eq!(items.len(), 15 + 6); // 15 items, and 6 batches (enclosing them)
+    // Length should be within sequenced range
+    assert!(items.len() <= (request.end - request.start) as usize && !items.is_empty());
 
     let mut error_found = false;
     for item in items {
@@ -719,9 +722,8 @@ async fn test_safe_batch_stream() {
         .collect::<Vec<Result<BatchInfoResponseItem, SuiError>>>()
         .await;
 
-    // Check length
-    assert!(!items.is_empty());
-    assert_eq!(items.len(), 15 + 6); // 15 items, and 6 batches (enclosing them)
+    // Length should be within sequenced range, despite authority that never stop sending
+    assert!(items.len() <= (request.end - request.start) as usize && !items.is_empty());
 
     let request_b = BatchInfoRequest { start: 0, end: 10 };
     batch_stream = safe_client_from_byzantine

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -32,6 +32,8 @@ AuthorityBatch:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 32
+    - transaction_batch:
+        TYPENAME: TransactionBatch
 AuthoritySignInfo:
   STRUCT:
     - authority:
@@ -760,6 +762,12 @@ SuiError:
           - error: STR
     93:
       OnlyOneConsensusClientPermitted: UNIT
+TransactionBatch:
+  NEWTYPESTRUCT:
+    SEQ:
+      TUPLE:
+        - U64
+        - TYPENAME: TransactionDigest
 TransactionData:
   STRUCT:
     - kind:

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -32,8 +32,6 @@ AuthorityBatch:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 32
-    - transaction_batch:
-        TYPENAME: TransactionBatch
 AuthoritySignInfo:
   STRUCT:
     - authority:
@@ -762,12 +760,6 @@ SuiError:
           - error: STR
     93:
       OnlyOneConsensusClientPermitted: UNIT
-TransactionBatch:
-  NEWTYPESTRUCT:
-    SEQ:
-      TUPLE:
-        - U64
-        - TYPENAME: TransactionDigest
 TransactionData:
   STRUCT:
     - kind:

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -70,7 +70,9 @@ impl AuthorityBatch {
     ) -> Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
         if transaction_vec.is_empty() {
-            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
+            return Err(SuiError::GenericAuthorityError {
+                error: "Transaction number must be positive.".to_string(),
+            });
         };
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
@@ -93,10 +95,12 @@ impl AuthorityBatch {
     pub fn make_next_with_previous_digest(
         previous_batch_digest: Option<BatchDigest>,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) ->  Result<AuthorityBatch, SuiError> {
+    ) -> Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
         if transaction_vec.is_empty() {
-            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
+            return Err(SuiError::GenericAuthorityError {
+                error: "Transaction number must be positive.".to_string(),
+            });
         };
 
         let initial_sequence_number = transaction_vec[0].0 as u64;

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -138,8 +138,6 @@ impl SignedBatch {
     }
 }
 
-impl BcsSignable for SignedBatch {}
-
 impl PartialEq for SignedBatch {
     fn eq(&self, other: &Self) -> bool {
         self.batch == other.batch && self.authority == other.authority

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -3,7 +3,6 @@
 
 use crate::base_types::{AuthorityName, TransactionDigest};
 use crate::crypto::{sha3_hash, AuthoritySignature, BcsSignable};
-use crate::error::SuiError;
 use serde::{Deserialize, Serialize};
 
 pub type TxSequenceNumber = u64;
@@ -38,6 +37,9 @@ pub struct AuthorityBatch {
 
     /// The digest of all transactions digests in this batch
     pub transactions_digest: [u8; 32],
+
+    /// The set of transactions in this batch
+    pub transaction_batch: TransactionBatch,
 }
 
 impl BcsSignable for AuthorityBatch {}
@@ -59,6 +61,7 @@ impl AuthorityBatch {
             size: 0,
             previous_digest: None,
             transactions_digest,
+            transaction_batch,
         }
     }
 
@@ -67,11 +70,9 @@ impl AuthorityBatch {
     pub fn make_next(
         previous_batch: &AuthorityBatch,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) -> Result<AuthorityBatch, SuiError> {
+    ) -> AuthorityBatch {
         let transaction_vec = transactions.to_vec();
-        if transaction_vec.is_empty() {
-            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
-        };
+        debug_assert!(!transaction_vec.is_empty());
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
         let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
@@ -79,13 +80,14 @@ impl AuthorityBatch {
         let transaction_batch = TransactionBatch(transaction_vec);
         let transactions_digest = sha3_hash(&transaction_batch);
 
-        Ok(AuthorityBatch {
+        AuthorityBatch {
             next_sequence_number,
             initial_sequence_number,
             size: transactions.len() as u64,
             previous_digest: Some(previous_batch.digest()),
             transactions_digest,
-        })
+            transaction_batch,
+        }
     }
 
     /// Make a batch, containing some transactions, and following the previous
@@ -93,11 +95,9 @@ impl AuthorityBatch {
     pub fn make_next_with_previous_digest(
         previous_batch_digest: Option<BatchDigest>,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) ->  Result<AuthorityBatch, SuiError> {
+    ) -> AuthorityBatch {
         let transaction_vec = transactions.to_vec();
-        if transaction_vec.is_empty() {
-            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
-        };
+        debug_assert!(!transaction_vec.is_empty());
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
         let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
@@ -105,13 +105,14 @@ impl AuthorityBatch {
         let transaction_batch = TransactionBatch(transaction_vec);
         let transactions_digest = sha3_hash(&transaction_batch);
 
-        Ok(AuthorityBatch {
+        AuthorityBatch {
             next_sequence_number,
             initial_sequence_number,
             size: transactions.len() as u64,
             previous_digest: previous_batch_digest,
             transactions_digest,
-        })
+            transaction_batch,
+        }
     }
 }
 

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -89,34 +89,6 @@ impl AuthorityBatch {
             transactions_digest,
         })
     }
-
-    /// Make a batch, containing some transactions, and following the previous
-    /// batch, using the digest of the previous batch.
-    pub fn make_next_with_previous_digest(
-        previous_batch_digest: Option<BatchDigest>,
-        transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) -> Result<AuthorityBatch, SuiError> {
-        let transaction_vec = transactions.to_vec();
-        if transaction_vec.is_empty() {
-            return Err(SuiError::GenericAuthorityError {
-                error: "Transaction number must be positive.".to_string(),
-            });
-        };
-
-        let initial_sequence_number = transaction_vec[0].0 as u64;
-        let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
-
-        let transaction_batch = TransactionBatch(transaction_vec);
-        let transactions_digest = sha3_hash(&transaction_batch);
-
-        Ok(AuthorityBatch {
-            next_sequence_number,
-            initial_sequence_number,
-            size: transactions.len() as u64,
-            previous_digest: previous_batch_digest,
-            transactions_digest,
-        })
-    }
 }
 
 /// An transaction signed by a single authority

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -3,6 +3,7 @@
 
 use crate::base_types::{AuthorityName, TransactionDigest};
 use crate::crypto::{sha3_hash, AuthoritySignature, BcsSignable};
+use crate::error::SuiError;
 use serde::{Deserialize, Serialize};
 
 pub type TxSequenceNumber = u64;
@@ -37,9 +38,6 @@ pub struct AuthorityBatch {
 
     /// The digest of all transactions digests in this batch
     pub transactions_digest: [u8; 32],
-
-    /// The set of transactions in this batch
-    pub transaction_batch: TransactionBatch,
 }
 
 impl BcsSignable for AuthorityBatch {}
@@ -61,7 +59,6 @@ impl AuthorityBatch {
             size: 0,
             previous_digest: None,
             transactions_digest,
-            transaction_batch,
         }
     }
 
@@ -70,9 +67,11 @@ impl AuthorityBatch {
     pub fn make_next(
         previous_batch: &AuthorityBatch,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) -> AuthorityBatch {
+    ) -> Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
-        debug_assert!(!transaction_vec.is_empty());
+        if transaction_vec.is_empty() {
+            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
+        };
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
         let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
@@ -80,14 +79,13 @@ impl AuthorityBatch {
         let transaction_batch = TransactionBatch(transaction_vec);
         let transactions_digest = sha3_hash(&transaction_batch);
 
-        AuthorityBatch {
+        Ok(AuthorityBatch {
             next_sequence_number,
             initial_sequence_number,
             size: transactions.len() as u64,
             previous_digest: Some(previous_batch.digest()),
             transactions_digest,
-            transaction_batch,
-        }
+        })
     }
 
     /// Make a batch, containing some transactions, and following the previous
@@ -95,9 +93,11 @@ impl AuthorityBatch {
     pub fn make_next_with_previous_digest(
         previous_batch_digest: Option<BatchDigest>,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) -> AuthorityBatch {
+    ) ->  Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
-        debug_assert!(!transaction_vec.is_empty());
+        if transaction_vec.is_empty() {
+            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
+        };
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
         let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
@@ -105,14 +105,13 @@ impl AuthorityBatch {
         let transaction_batch = TransactionBatch(transaction_vec);
         let transactions_digest = sha3_hash(&transaction_batch);
 
-        AuthorityBatch {
+        Ok(AuthorityBatch {
             next_sequence_number,
             initial_sequence_number,
             size: transactions.len() as u64,
             previous_digest: previous_batch_digest,
             transactions_digest,
-            transaction_batch,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/MystenLabs/sui/issues/729

• Converts the handle_batch_stream functions for the AuthorityAPI trait to process and return streams.
• Updates the Batch version of UpdateItem to include the transaction digests of each transaction in the batch
• Reconstructs the batch in the safe client and compares provided digest with digest of reconstructed batch
• ensures the processing stops after (requested sequence end - requested sequence start) number of iterations
• ensures the returned sequences are in the requested range