### PR TITLE
[Move] Prevent transfer/delete shared/immutable object in unit tests

### DIFF
--- a/sui_programmability/framework/sources/TestScenario.move
+++ b/sui_programmability/framework/sources/TestScenario.move
@@ -76,6 +76,7 @@ module Sui::TestScenario {
 
     /// Begin a new multi-transaction test scenario in a context where `sender` is the tx sender
     public fun begin(sender: &address): Scenario {
+        emit_test_start_event();
         Scenario {
             ctx: TxContext::new_from_address(*sender, 0),
             removed: Vector::empty(),
@@ -328,6 +329,12 @@ module Sui::TestScenario {
 
     /// Return the ID's of objects deleted since the `tx_begin_idx`th event in the global event log
     native fun deleted_object_ids(tx_begin_idx: u64): vector<vector<u8>>;
+
+    /// Emit a special, test-only event indicating that a unit test has started.
+    /// This must be the first event emitted during a test run.
+    /// In the native functions, we rely on this to quickly tell whether we are
+    /// in test mode or not.
+    native fun emit_test_start_event();
 
     /// Emit a special, test-only event recording that `object_id` was wrapped
     native fun emit_wrapped_object_event(object_id: vector<u8>);

--- a/sui_programmability/framework/src/natives/id.rs
+++ b/sui_programmability/framework/src/natives/id.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::EventType;
+use crate::{
+    abort_if_object_shared,
+    natives::{get_versioned_id_bytes, is_object_shared_in_test},
+    EventType,
+};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::native_functions::NativeContext;
@@ -65,6 +69,8 @@ pub fn delete_id(
 
     // TODO: what should the cost of this be?
     let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 0);
+
+    abort_if_object_shared!(context, cost, get_versioned_id_bytes(&versioned_id));
 
     if !context.save_event(vec![], EventType::DeleteObjectID as u64, ty, versioned_id)? {
         return Ok(NativeResult::err(cost, 0));

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -8,8 +8,30 @@ mod transfer;
 mod tx_context;
 
 use move_core_types::{account_address::AccountAddress, identifier::Identifier};
-use move_vm_runtime::native_functions::{NativeFunction, NativeFunctionTable};
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction, NativeFunctionTable};
 use move_vm_types::values::{Struct, Value};
+use num_enum::TryFromPrimitive;
+
+use crate::EventType;
+
+use self::test_scenario::TEST_START_EVENT;
+
+/// Trying to transfer or delete a shared object, which is not allowed.
+pub const ECONSUME_SHARED_OBJECT: u64 = 100;
+
+#[macro_export(local_inner_macros)]
+macro_rules! abort_if_object_shared {
+    ($context:expr, $cost:expr, $object_id:expr) => {
+        if is_object_shared_in_test($context, $object_id) {
+            // TODO: Abort like this is impossible to debug.
+            // Can we expose something more than just abort_code=0?
+            return Ok(NativeResult::err(
+                $cost,
+                crate::natives::ECONSUME_SHARED_OBJECT,
+            ));
+        }
+    };
+}
 
 pub fn all_natives(
     move_stdlib_addr: AccountAddress,
@@ -34,6 +56,11 @@ pub fn all_natives(
             "TestScenario",
             "emit_wrapped_object_event",
             test_scenario::emit_wrapped_object_event,
+        ),
+        (
+            "TestScenario",
+            "emit_test_start_event",
+            test_scenario::emit_test_start_event,
         ),
         (
             "TestScenario",
@@ -81,22 +108,76 @@ pub fn all_natives(
         .collect()
 }
 
+/// Given an object, return the most inner id bytes wrapped in `Value`.
 // Object { id: VersionedID { id: UniqueID { id: ID { bytes: address } } } .. }
 // Extract the first field of the struct 4 times to get the id bytes.
-pub fn get_object_id(object: Value) -> Value {
+pub fn get_object_id_bytes_value(object: &Value) -> Value {
     get_nested_struct_field(object, &[0, 0, 0, 0])
+}
+
+/// Given an object, return the most inner id bytes.
+/// Similar to get_object_id_bytes_value, but different return type.
+pub fn get_object_id_bytes(object: &Value) -> AccountAddress {
+    id_value_to_bytes(&get_object_id_bytes_value(object))
+}
+
+/// Given a VersionedID, return the most inner id bytes.
+/// VersionedID { id: UniqueID { id: ID { bytes: address } } }
+/// Extract the first field of the struct 3 times to get the bytes,
+/// and convert it to AccountAddress.
+pub fn get_versioned_id_bytes(id: &Value) -> AccountAddress {
+    id_value_to_bytes(&get_nested_struct_field(id, &[0, 0, 0]))
+}
+
+/// Convert a wrapped AccountAddress Value into AccountAddress.
+pub fn id_value_to_bytes(id: &Value) -> AccountAddress {
+    id.copy_value()
+        .unwrap()
+        .value_as::<AccountAddress>()
+        .unwrap()
 }
 
 // Extract a field valye that's nested inside value `v`. The offset of each nesting
 // is determined by `offsets`.
-pub fn get_nested_struct_field(mut v: Value, offsets: &[usize]) -> Value {
+pub fn get_nested_struct_field(v: &Value, offsets: &[usize]) -> Value {
+    let mut v = v.copy_value().unwrap();
     for offset in offsets {
-        v = get_nth_struct_field(v, *offset);
+        v = get_nth_struct_field(&v, *offset);
     }
     v
 }
 
-pub fn get_nth_struct_field(v: Value, n: usize) -> Value {
-    let mut itr = v.value_as::<Struct>().unwrap().unpack().unwrap();
+pub fn get_nth_struct_field(v: &Value, n: usize) -> Value {
+    let mut itr = v
+        .copy_value()
+        .unwrap()
+        .value_as::<Struct>()
+        .unwrap()
+        .unpack()
+        .unwrap();
     itr.nth(n).unwrap()
+}
+
+fn is_object_shared_in_test(context: &mut NativeContext, object_id: AccountAddress) -> bool {
+    if let Some(event) = context.events().iter().next() {
+        let (_, event_type_byte, ..) = event;
+        if *event_type_byte != TEST_START_EVENT {
+            return false;
+        }
+        for (_, event_type_byte, _, _, val) in context.events() {
+            match EventType::try_from_primitive(*event_type_byte as u8) {
+                Err(_) => {
+                    continue;
+                }
+                Ok(EventType::FreezeObject) | Ok(EventType::ShareObject) => {
+                    let id = get_object_id_bytes(val);
+                    if id == object_id {
+                        return true;
+                    }
+                }
+                Ok(_) => (),
+            }
+        }
+    }
+    false
 }


### PR DESCRIPTION
A shared object (immutable or not) cannot be transferred or deleted. This is enforced in adapter when we process the events from an execution. However we don't currently enforce this in unit tests.
This PR adds the enforcement in unit tests.
To minimize the cost of checking it at every transfer/delete, we want it to be very quick to detect whether we are running a unit test or in normal execution. For this purpose, I added a new system event called TEST_START_EVENT. This event is emitted when we begin a test scenario. During transfer/delete, we check if the first event is such event, and only so we start walking through the event history to find out whether we are dealing with a shared object.