### PR TITLE
[Wallet CLI] Add command to create example NFT

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -307,12 +307,12 @@ async fn test_create_example_nft_command() -> Result<(), anyhow::Error> {
     .execute(&mut context)
     .await?;
 
-    let obj = match result {
+    match result {
         WalletCommandResult::CreateExampleNFT(ObjectRead::Exists(_, obj, layout)) => {
             assert_eq!(obj.owner, address);
             assert_eq!(
                 obj.type_().unwrap().to_string(),
-                "0x2::ExampleNFT::ExampleNFT"
+                "0x2::DevNetNFT::DevNetNFT"
             );
             Ok(obj.to_json(&layout).unwrap_or_else(|_| json!("")))
         }

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -14,6 +14,7 @@ use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
 use move_core_types::parser::parse_type_tag;
 use serde::Serialize;
+use serde_json::json;
 use tracing::info;
 
 use sui_adapter::adapter::resolve_and_type_check;
@@ -31,6 +32,10 @@ use sui_types::object::{Object, ObjectRead};
 use crate::config::{Config, PersistedConfig, WalletConfig};
 use crate::keystore::Keystore;
 use crate::sui_json::{resolve_move_function_args, SuiJsonValue};
+
+const EXAMPLE_NFT_NAME: &str = "Example NFT";
+const EXAMPLE_NFT_DESCRIPTION: &str = "An NFT created by the wallet Command Line Tool";
+const EXAMPLE_NFT_URL: &str = "ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty";
 
 #[derive(Parser)]
 #[clap(name = "", rename_all = "kebab-case", no_binary_name = true)]
@@ -200,6 +205,31 @@ pub enum WalletCommands {
         #[clap(long)]
         gas_budget: u64,
     },
+
+    /// Create an example NFT
+    #[clap(name = "create-example-nft")]
+    CreateExampleNFT {
+        /// Name of the NFT
+        #[clap(long)]
+        name: Option<String>,
+
+        /// Description of the NFT
+        #[clap(long)]
+        description: Option<String>,
+
+        /// Display url(e.g., an image url) of the NFT
+        #[clap(long)]
+        url: Option<String>,
+
+        /// ID of the gas object for gas payment, in 20 bytes Hex string
+        /// If not provided, a gas object with at least gas_budget value will be selected
+        #[clap(long)]
+        gas: Option<ObjectID>,
+
+        /// Gas budget for this transfer
+        #[clap(long)]
+        gas_budget: Option<u64>,
+    },
 }
 
 pub struct SimpleTransactionSigner {
@@ -256,89 +286,10 @@ impl WalletCommands {
                 gas_budget,
                 args,
             } => {
-                let package_obj_info = context.gateway.get_object_info(*package).await?;
-                let package_obj = package_obj_info.object().clone()?;
-                let package_obj_ref = package_obj_info.reference().unwrap();
-
-                // These steps can potentially be condensed and moved into the client/manager level
-                // Extract the input args
-                let (object_ids, pure_args) = resolve_move_function_args(
-                    package_obj,
-                    module.clone(),
-                    function.clone(),
-                    args.clone(),
-                )?;
-
-                // Fetch all the objects needed for this call
-                let mut input_objs = vec![];
-                for obj_id in object_ids.clone() {
-                    input_objs.push(
-                        context
-                            .gateway
-                            .get_object_info(obj_id)
-                            .await?
-                            .into_object()?,
-                    );
-                }
-                let forbidden_gas_objects = BTreeSet::from_iter(object_ids.clone().into_iter());
-                let gas_object = context
-                    .choose_gas_for_wallet(*gas, *gas_budget, forbidden_gas_objects)
-                    .await?;
-                let sender = gas_object.owner.get_owner_address()?;
-
-                // Pass in the objects for a deeper check
-                let compiled_module = package_obj
-                    .data
-                    .try_as_package()
-                    .ok_or_else(|| anyhow!("Cannot get package from object"))?
-                    .deserialize_module(module)?;
-                resolve_and_type_check(
-                    &compiled_module,
-                    function,
-                    type_args,
-                    input_objs,
-                    pure_args.clone(),
-                )?;
-
-                // Fetch the object info for the gas obj
-                let gas_obj_ref = gas_object.compute_object_reference();
-
-                // Fetch the objects for the object args
-                let mut object_args_refs = Vec::new();
-                for obj_id in object_ids {
-                    let obj_info = context.gateway.get_object_info(obj_id).await?;
-                    object_args_refs.push(obj_info.object()?.compute_object_reference());
-                }
-
-                let data = context
-                    .gateway
-                    .move_call(
-                        sender,
-                        package_obj_ref,
-                        module.to_owned(),
-                        function.to_owned(),
-                        type_args.clone(),
-                        gas_obj_ref,
-                        object_args_refs,
-                        vec![],
-                        pure_args,
-                        *gas_budget,
-                    )
-                    .await?;
-                let signature = context
-                    .keystore
-                    .read()
-                    .unwrap()
-                    .sign(&sender, &data.to_bytes())?;
-                let (cert, effects) = context
-                    .gateway
-                    .execute_transaction(Transaction::new(data, signature))
-                    .await?
-                    .to_effect_response()?;
-
-                if matches!(effects.status, ExecutionStatus::Failure { .. }) {
-                    return Err(anyhow!("Error calling module: {:#?}", effects.status));
-                }
+                let (cert, effects) = call_move(
+                    package, module, function, type_args, gas, gas_budget, args, context,
+                )
+                .await?;
                 WalletCommandResult::Call(cert, effects)
             }
 
@@ -518,6 +469,42 @@ impl WalletCommands {
             }
             WalletCommands::ActiveAddress {} => {
                 WalletCommandResult::ActiveAddress(context.active_address().ok())
+            }
+            WalletCommands::CreateExampleNFT {
+                name,
+                description,
+                url,
+                gas,
+                gas_budget,
+            } => {
+                let args_json = json!([
+                    unwrap_or(name, EXAMPLE_NFT_NAME),
+                    unwrap_or(description, EXAMPLE_NFT_DESCRIPTION),
+                    unwrap_or(url, EXAMPLE_NFT_URL)
+                ]);
+                let mut args = vec![];
+                for a in args_json.as_array().unwrap() {
+                    args.push(SuiJsonValue::new(a.clone()).unwrap());
+                }
+                let (_, effects) = call_move(
+                    &ObjectID::from_hex_literal("0x2").unwrap(),
+                    &Identifier::new("ExampleNFT").unwrap(),
+                    &Identifier::new("mint").unwrap(),
+                    &[],
+                    gas,
+                    &gas_budget.unwrap_or(1000),
+                    &args,
+                    context,
+                )
+                .await?;
+                let nft_id = effects
+                    .created
+                    .first()
+                    .ok_or_else(|| anyhow!("Failed to create NFT"))?
+                    .0
+                     .0;
+                let object_read = context.gateway.get_object_info(nft_id).await?;
+                WalletCommandResult::CreateExampleNFT(object_read)
             }
         });
         // Sync all managed addresses
@@ -728,8 +715,113 @@ impl Display for WalletCommandResult {
                     None => write!(writer, "None")?,
                 };
             }
+            WalletCommandResult::CreateExampleNFT(object_read) => {
+                // TODO: display the content of the object
+                let object = unwrap_err_to_string(|| Ok(object_read.object()?));
+                writeln!(writer, "{}\n", "Successfully created an ExampleNFT:".bold())?;
+                writeln!(writer, "{}", object)?;
+            }
         }
         write!(f, "{}", writer)
+    }
+}
+
+async fn call_move(
+    package: &ObjectID,
+    module: &Identifier,
+    function: &Identifier,
+    type_args: &[TypeTag],
+    gas: &Option<ObjectID>,
+    gas_budget: &u64,
+    args: &[SuiJsonValue],
+    context: &mut WalletContext,
+) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
+    let package_obj_info = context.gateway.get_object_info(*package).await?;
+    let package_obj = package_obj_info.object().clone()?;
+    let package_obj_ref = package_obj_info.reference().unwrap();
+
+    // These steps can potentially be condensed and moved into the client/manager level
+    // Extract the input args
+    let (object_ids, pure_args) =
+        resolve_move_function_args(package_obj, module.clone(), function.clone(), args.to_vec())?;
+
+    // Fetch all the objects needed for this call
+    let mut input_objs = vec![];
+    for obj_id in object_ids.clone() {
+        input_objs.push(
+            context
+                .gateway
+                .get_object_info(obj_id)
+                .await?
+                .into_object()?,
+        );
+    }
+    let forbidden_gas_objects = BTreeSet::from_iter(object_ids.clone().into_iter());
+    let gas_object = context
+        .choose_gas_for_wallet(*gas, *gas_budget, forbidden_gas_objects)
+        .await?;
+    let sender = gas_object.owner.get_owner_address()?;
+
+    // Pass in the objects for a deeper check
+    let compiled_module = package_obj
+        .data
+        .try_as_package()
+        .ok_or_else(|| anyhow!("Cannot get package from object"))?
+        .deserialize_module(module)?;
+    resolve_and_type_check(
+        &compiled_module,
+        function,
+        type_args,
+        input_objs,
+        pure_args.clone(),
+    )?;
+
+    // Fetch the object info for the gas obj
+    let gas_obj_ref = gas_object.compute_object_reference();
+
+    // Fetch the objects for the object args
+    let mut object_args_refs = Vec::new();
+    for obj_id in object_ids {
+        let obj_info = context.gateway.get_object_info(obj_id).await?;
+        object_args_refs.push(obj_info.object()?.compute_object_reference());
+    }
+
+    let data = context
+        .gateway
+        .move_call(
+            sender,
+            package_obj_ref,
+            module.to_owned(),
+            function.to_owned(),
+            type_args.to_vec(),
+            gas_obj_ref,
+            object_args_refs,
+            vec![],
+            pure_args,
+            *gas_budget,
+        )
+        .await?;
+    let signature = context
+        .keystore
+        .read()
+        .unwrap()
+        .sign(&sender, &data.to_bytes())?;
+    let (cert, effects) = context
+        .gateway
+        .execute_transaction(Transaction::new(data, signature))
+        .await?
+        .to_effect_response()?;
+
+    if matches!(effects.status, ExecutionStatus::Failure { .. }) {
+        return Err(anyhow!("Error calling module: {:#?}", effects.status));
+    }
+    Ok((cert, effects))
+}
+
+fn unwrap_or<'a>(val: &'a mut Option<String>, default: &'a str) -> &'a str {
+    match val {
+        Some(v) => v,
+        None => default,
     }
 }
 
@@ -803,4 +895,5 @@ pub enum WalletCommandResult {
     MergeCoin(MergeCoinResponse),
     Switch(SwitchResponse),
     ActiveAddress(Option<SuiAddress>),
+    CreateExampleNFT(ObjectRead),
 }

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -28,6 +28,7 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{CertifiedTransaction, ExecutionStatus, Transaction, TransactionEffects};
 use sui_types::object::ObjectRead::Exists;
 use sui_types::object::{Object, ObjectRead};
+use sui_types::SUI_FRAMEWORK_ADDRESS;
 
 use crate::config::{Config, PersistedConfig, WalletConfig};
 use crate::keystore::Keystore;
@@ -487,8 +488,8 @@ impl WalletCommands {
                     args.push(SuiJsonValue::new(a.clone()).unwrap());
                 }
                 let (_, effects) = call_move(
-                    &ObjectID::from_hex_literal("0x2").unwrap(),
-                    &Identifier::new("ExampleNFT").unwrap(),
+                    &ObjectID::from(SUI_FRAMEWORK_ADDRESS),
+                    &Identifier::new("DevNetNFT").unwrap(),
                     &Identifier::new("mint").unwrap(),
                     &[],
                     gas,
@@ -497,13 +498,11 @@ impl WalletCommands {
                     context,
                 )
                 .await?;
-                let nft_id = effects
+                let ((nft_id, _, _), _) = effects
                     .created
                     .first()
-                    .ok_or_else(|| anyhow!("Failed to create NFT"))?
-                    .0
-                     .0;
-                let object_read = context.gateway.get_object_info(nft_id).await?;
+                    .ok_or_else(|| anyhow!("Failed to create NFT"))?;
+                let object_read = context.gateway.get_object_info(*nft_id).await?;
                 WalletCommandResult::CreateExampleNFT(object_read)
             }
         });


### PR DESCRIPTION
Wallet CLI will be the primary interface for users to perform "writes" on Sui at the Devnet launch, therefore we want to provide an easy way for the users to create a NFT-like rich object with image and attributes.

```
➜ wallet create-example-nft
Successfully created an ExampleNFT:

Owner: AddressOwner(k#c40322c9fa0edcf020cadd83896835549c5370cd)
Version: 1
ID: 34E70AAC60985889963565FE2EA767A892F91276
Readonly: false
Type: 0x2::ExampleNFT::ExampleNFT


➜ wallet create-example-nft --name "My NFT" --description "Great" --url "ipfs://fasdfasdfeuuDASJD"
Successfully created an ExampleNFT:

Owner: AddressOwner(k#c40322c9fa0edcf020cadd83896835549c5370cd)
Version: 1
ID: 21B836F0AE0DFAEB71D0FA3A1E9DCD5B24ACB903
Readonly: false
Type: 0x2::ExampleNFT::ExampleNFT
```


TODO
- will add documentation after this PR is approved


Closes https://github.com/MystenLabs/sui/issues/1400

