### PR TITLE
[follower] Remove transaction from batch, and verify the digests received.

### DIFF
--- a/sui_core/src/authority_batch.rs
+++ b/sui_core/src/authority_batch.rs
@@ -79,7 +79,8 @@ impl crate::authority::AuthorityState {
         if !transactions.is_empty() {
             // Make a new batch, to put the old transactions not in a batch in.
             let last_signed_batch = SignedBatch::new(
-                AuthorityBatch::make_next(&last_batch, &transactions[..]),
+                // Unwrap safe due to check not empty
+                AuthorityBatch::make_next(&last_batch, &transactions[..])?,
                 &*self.secret,
                 self.name,
             );
@@ -155,13 +156,15 @@ impl crate::authority::AuthorityState {
 
             // Logic to make a batch
             if make_batch {
+                // Test it is not empty.
                 if current_batch.is_empty() {
                     continue;
                 }
 
                 // Make and store a new batch.
                 let new_batch = SignedBatch::new(
-                    AuthorityBatch::make_next(&prev_batch, &current_batch),
+                    // Unwrap safe since we tested above it is not empty
+                    AuthorityBatch::make_next(&prev_batch, &current_batch).unwrap(),
                     &*self.secret,
                     self.name,
                 );

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -329,7 +329,6 @@ where
 
                 let x = match &batch_info_item {
                     Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
-                        println!("batch {:?}", signed_batch.batch);
                         if let Err(err) = client.check_update_item_batch_response(
                             req_clone,
                             &signed_batch,
@@ -358,7 +357,6 @@ where
                             client.report_client_error(err.clone());
                             Some(Err(err))
                         } else {
-                            println!("Add transactions");
                             Some(batch_info_item)
                         }
                     }

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -9,7 +9,7 @@ use std::io;
 use sui_types::crypto::PublicKeyBytes;
 use sui_types::{base_types::*, committee::*, fp_ensure};
 
-use sui_types::batch::{AuthorityBatch, SignedBatch, UpdateItem};
+use sui_types::batch::{AuthorityBatch, SignedBatch, TxSequenceNumber, UpdateItem};
 use sui_types::{
     error::{SuiError, SuiResult},
     messages::*,
@@ -174,6 +174,10 @@ impl<C> SafeClient<C> {
         &self,
         request: BatchInfoRequest,
         signed_batch: &SignedBatch,
+        transactions_and_last_batch: &Option<(
+            Vec<(TxSequenceNumber, TransactionDigest)>,
+            AuthorityBatch,
+        )>,
     ) -> SuiResult {
         // check the signature of the batch
         signed_batch
@@ -190,21 +194,20 @@ impl<C> SafeClient<C> {
             }
         );
 
-        // reconstruct the batch and make sure the constructed digest matches the provided one
-        let provided_digest = signed_batch.batch.transactions_digest;
+        // If we have seen a previous batch, use it to make sure the next batch
+        // is constructed correctly:
 
-        let reconstructed_batch = AuthorityBatch::make_next_with_previous_digest(
-            Some(provided_digest),
-            &signed_batch.batch.transaction_batch.0,
-        );
-        let computed_digest = reconstructed_batch.transactions_digest;
+        if let Some((transactions, prev_batch)) = transactions_and_last_batch {
+            let reconstructed_batch = AuthorityBatch::make_next(prev_batch, transactions)?;
 
-        fp_ensure!(
-            provided_digest == computed_digest,
-            SuiError::ByzantineAuthoritySuspicion {
-                authority: self.address
-            }
-        );
+            fp_ensure!(
+                reconstructed_batch == signed_batch.batch,
+                SuiError::ByzantineAuthoritySuspicion {
+                    authority: self.address
+                }
+            );
+        }
+
         Ok(())
     }
 
@@ -310,39 +313,61 @@ where
             .handle_batch_stream(request.clone())
             .await?;
 
-        let seq_requested = request.end - request.start;
-        let mut seq_to_be_returned = seq_requested as usize;
-        // check for overflow
-        if seq_requested > usize::MAX as u64 {
-            seq_to_be_returned = usize::MAX;
-        }
-
         let client = self.clone();
-        let stream = Box::pin(
-            batch_info_items
-                .then(move |batch_info_item| {
-                    let req_clone = request.clone();
-                    let client = client.clone();
-                    async move {
-                        match &batch_info_item {
-                            Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
-                                if let Err(err) =
-                                    client.check_update_item_batch_response(req_clone, signed_batch)
-                                {
-                                    client.report_client_error(err.clone());
-                                    return Err(err);
-                                }
-                                batch_info_item
-                            }
-                            Ok(BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest)))) => {
-                                batch_info_item
-                            }
-                            Err(e) => Err(e.clone()),
+        let address = self.address;
+        let stream = Box::pin(batch_info_items.scan(
+            (0u64, None),
+            move |(seq, txs_and_last_batch), batch_info_item| {
+                let req_clone = request.clone();
+                let client = client.clone();
+
+                // We check if we have exceeded the batch boundary for this request.
+                if !(*seq < request.end) {
+                    // If we exceed it return None to end stream
+                    return futures::future::ready(None);
+                }
+
+                let x = match &batch_info_item {
+                    Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
+                        println!("batch {:?}", signed_batch.batch);
+                        if let Err(err) = client.check_update_item_batch_response(
+                            req_clone,
+                            &signed_batch,
+                            &txs_and_last_batch,
+                        ) {
+                            client.report_client_error(err.clone());
+                            Some(Err(err))
+                        } else {
+                            // Save the seqeunce number of this batch
+                            *seq = signed_batch.batch.next_sequence_number;
+                            // Insert a fresh vector for the new batch of transactions
+                            let _ =
+                                txs_and_last_batch.insert((Vec::new(), signed_batch.batch.clone()));
+                            Some(batch_info_item)
                         }
                     }
-                })
-                .take(seq_to_be_returned),
-        );
+                    Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digest)))) => {
+                        // A stream always starts with a batch, so the previous should have initialized it.
+                        // And here we insert the tuple into the batch.
+                        if txs_and_last_batch
+                            .as_mut()
+                            .map(|txs| txs.0.push((*seq, *digest)))
+                            .is_none()
+                        {
+                            let err = SuiError::ByzantineAuthoritySuspicion { authority: address };
+                            client.report_client_error(err.clone());
+                            Some(Err(err))
+                        } else {
+                            println!("Add transactions");
+                            Some(batch_info_item)
+                        }
+                    }
+                    Err(e) => Some(Err(e.clone())),
+                };
+
+                futures::future::ready(x)
+            },
+        ));
         Ok(Box::pin(stream))
     }
 }

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -380,7 +380,6 @@ async fn test_batch_store_retrieval() {
         .batches_and_transactions(94, 120)
         .expect("Retrieval failed!");
 
-    println!("{:?}", batches);
     assert_eq!(3, batches.len());
     assert_eq!(90, batches.first().unwrap().batch.next_sequence_number);
     assert_eq!(115, batches.last().unwrap().batch.next_sequence_number);
@@ -740,7 +739,6 @@ async fn test_safe_batch_stream() {
     let mut error_found = false;
     for item in items {
         if item.is_err() {
-            println!("!!!!!!!!!!!!!!!!!! {:?}", item);
             error_found = true;
         }
     }

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -32,8 +32,6 @@ AuthorityBatch:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 32
-    - transaction_batch:
-        TYPENAME: TransactionBatch
 AuthoritySignInfo:
   STRUCT:
     - authority:
@@ -762,12 +760,6 @@ SuiError:
           - error: STR
     93:
       OnlyOneConsensusClientPermitted: UNIT
-TransactionBatch:
-  NEWTYPESTRUCT:
-    SEQ:
-      TUPLE:
-        - U64
-        - TYPENAME: TransactionDigest
 TransactionData:
   STRUCT:
     - kind:

--- a/sui_types/src/batch.rs
+++ b/sui_types/src/batch.rs
@@ -3,6 +3,7 @@
 
 use crate::base_types::{AuthorityName, TransactionDigest};
 use crate::crypto::{sha3_hash, AuthoritySignature, BcsSignable};
+use crate::error::SuiError;
 use serde::{Deserialize, Serialize};
 
 pub type TxSequenceNumber = u64;
@@ -37,9 +38,6 @@ pub struct AuthorityBatch {
 
     /// The digest of all transactions digests in this batch
     pub transactions_digest: [u8; 32],
-
-    /// The set of transactions in this batch
-    pub transaction_batch: TransactionBatch,
 }
 
 impl BcsSignable for AuthorityBatch {}
@@ -61,7 +59,6 @@ impl AuthorityBatch {
             size: 0,
             previous_digest: None,
             transactions_digest,
-            transaction_batch,
         }
     }
 
@@ -70,9 +67,11 @@ impl AuthorityBatch {
     pub fn make_next(
         previous_batch: &AuthorityBatch,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) -> AuthorityBatch {
+    ) -> Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
-        debug_assert!(!transaction_vec.is_empty());
+        if transaction_vec.is_empty() {
+            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
+        };
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
         let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
@@ -80,14 +79,13 @@ impl AuthorityBatch {
         let transaction_batch = TransactionBatch(transaction_vec);
         let transactions_digest = sha3_hash(&transaction_batch);
 
-        AuthorityBatch {
+        Ok(AuthorityBatch {
             next_sequence_number,
             initial_sequence_number,
             size: transactions.len() as u64,
             previous_digest: Some(previous_batch.digest()),
             transactions_digest,
-            transaction_batch,
-        }
+        })
     }
 
     /// Make a batch, containing some transactions, and following the previous
@@ -95,9 +93,11 @@ impl AuthorityBatch {
     pub fn make_next_with_previous_digest(
         previous_batch_digest: Option<BatchDigest>,
         transactions: &[(TxSequenceNumber, TransactionDigest)],
-    ) -> AuthorityBatch {
+    ) ->  Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
-        debug_assert!(!transaction_vec.is_empty());
+        if transaction_vec.is_empty() {
+            return Err(SuiError::GenericAuthorityError{ error: "Transaction number must be positive.".to_string()});
+        };
 
         let initial_sequence_number = transaction_vec[0].0 as u64;
         let next_sequence_number = (transaction_vec[transaction_vec.len() - 1].0 + 1) as u64;
@@ -105,14 +105,13 @@ impl AuthorityBatch {
         let transaction_batch = TransactionBatch(transaction_vec);
         let transactions_digest = sha3_hash(&transaction_batch);
 
-        AuthorityBatch {
+        Ok(AuthorityBatch {
             next_sequence_number,
             initial_sequence_number,
             size: transactions.len() as u64,
             previous_digest: previous_batch_digest,
             transactions_digest,
-            transaction_batch,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
This is a patch to `refactor_stream_client` that removes the list of transactions from the batch, and uses the transactions received to verify the batches and ensure they are signed.