### PR TITLE
Enable Running Validator As Process & Container

### DIFF
--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -85,3 +85,7 @@ path = "src/sui-move.rs"
 [[bin]]
 name = "rest_server"
 path = "src/rest_server.rs"
+
+[[bin]]
+name = "validator"
+path = "src/validator.rs"

--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::hex::Hex;
 use serde_with::serde_as;
+use sui_types::committee::Committee;
 use tracing::log::trace;
 
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
@@ -42,7 +43,7 @@ pub struct AuthorityInfo {
     pub base_port: u16,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct AuthorityPrivateInfo {
     pub key_pair: KeyPair,
     pub host: String,
@@ -150,6 +151,17 @@ impl NetworkConfig {
                 base_port: info.port,
             })
             .collect()
+    }
+}
+
+impl From<&NetworkConfig> for Committee {
+    fn from(network_config: &NetworkConfig) -> Committee {
+        let voting_rights = network_config
+            .authorities
+            .iter()
+            .map(|authority| (*authority.key_pair.public_key_bytes(), authority.stake))
+            .collect();
+        Committee::new(voting_rights)
     }
 }
 

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -43,6 +43,8 @@ pub enum SuiCommand {
     },
     #[clap(name = "genesis")]
     Genesis {
+        #[clap(long, help = "Start genesis with a given config file")]
+        from_config: Option<PathBuf>,
         #[clap(long)]
         working_dir: Option<PathBuf>,
         #[clap(short, long, help = "Forces overwriting existing configuration")]
@@ -77,7 +79,7 @@ impl SuiCommand {
                     .wait_for_completion()
                     .await
             }
-            SuiCommand::Genesis { working_dir, force } => {
+            SuiCommand::Genesis { working_dir, force, from_config } => {
                 let sui_config_dir = &match working_dir {
                     // if a directory is specified, it must exist (it
                     // will not be created)
@@ -129,7 +131,11 @@ impl SuiCommand {
                 let db_folder_path = sui_config_dir.join("client_db");
                 let gateway_db_folder_path = sui_config_dir.join("gateway_client_db");
 
-                let genesis_conf = GenesisConfig::default_genesis(sui_config_dir)?;
+                let genesis_conf = match from_config {
+                    Some(q) =>  PersistedConfig::read(q)?,
+                    None => GenesisConfig::default_genesis(sui_config_dir)?,
+                };
+
                 let (network_config, accounts, keystore) = genesis(genesis_conf).await?;
                 info!("Network genesis completed.");
                 let network_config = network_config.persisted(&network_path);

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -79,7 +79,11 @@ impl SuiCommand {
                     .wait_for_completion()
                     .await
             }
-            SuiCommand::Genesis { working_dir, force, from_config } => {
+            SuiCommand::Genesis {
+                working_dir,
+                force,
+                from_config,
+            } => {
                 let sui_config_dir = &match working_dir {
                     // if a directory is specified, it must exist (it
                     // will not be created)
@@ -132,7 +136,7 @@ impl SuiCommand {
                 let gateway_db_folder_path = sui_config_dir.join("gateway_client_db");
 
                 let genesis_conf = match from_config {
-                    Some(q) =>  PersistedConfig::read(q)?,
+                    Some(q) => PersistedConfig::read(q)?,
                     None => GenesisConfig::default_genesis(sui_config_dir)?,
                 };
 

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -66,10 +66,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     .await;
     assert!(matches!(start, Err(..)));
     // Genesis
-    SuiCommand::Genesis {
-        working_dir: Some(working_dir.to_path_buf()),
-        force: false,
-    }
+    SuiCommand::Genesis {working_dir:Some(working_dir.to_path_buf()),force:false, from_config: None }
     .execute()
     .await?;
     assert!(logs_contain("Network genesis completed."));
@@ -104,10 +101,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     assert_eq!(5, wallet_conf.accounts.len());
 
     // Genesis 2nd time should fail
-    let result = SuiCommand::Genesis {
-        working_dir: Some(working_dir.to_path_buf()),
-        force: false,
-    }
+    let result = SuiCommand::Genesis {working_dir:Some(working_dir.to_path_buf()),force:false, from_config: None }
     .execute()
     .await;
     assert!(matches!(result, Err(..)));

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -66,7 +66,11 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     .await;
     assert!(matches!(start, Err(..)));
     // Genesis
-    SuiCommand::Genesis {working_dir:Some(working_dir.to_path_buf()),force:false, from_config: None }
+    SuiCommand::Genesis {
+        working_dir: Some(working_dir.to_path_buf()),
+        force: false,
+        from_config: None,
+    }
     .execute()
     .await?;
     assert!(logs_contain("Network genesis completed."));
@@ -101,7 +105,11 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     assert_eq!(5, wallet_conf.accounts.len());
 
     // Genesis 2nd time should fail
-    let result = SuiCommand::Genesis {working_dir:Some(working_dir.to_path_buf()),force:false, from_config: None }
+    let result = SuiCommand::Genesis {
+        working_dir: Some(working_dir.to_path_buf()),
+        force: false,
+        from_config: None,
+    }
     .execute()
     .await;
     assert!(matches!(result, Err(..)));

--- a/sui/src/validator.rs
+++ b/sui/src/validator.rs
@@ -56,7 +56,10 @@ async fn main() -> Result<(), anyhow::Error> {
             )
         })?;
 
-    info!("Started {:?} authority", net_cfg);
+    info!(
+        "Started {} authority on {}:{}",
+        address, net_cfg.host, net_cfg.port
+    );
 
     if let Err(e) = make_server(
         net_cfg,

--- a/sui/src/validator.rs
+++ b/sui/src/validator.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use clap::*;
+use std::path::PathBuf;
+use sui::{
+    config::{GenesisConfig, PersistedConfig},
+    sui_commands::{genesis, make_server},
+};
+use sui_types::base_types::{decode_bytes_hex, SuiAddress};
+use sui_types::committee::Committee;
+use tracing::{error, info};
+
+#[derive(Parser)]
+#[clap(
+    name = "Sui Validator",
+    about = "Validator for Sui Network",
+    rename_all = "kebab-case"
+)]
+struct ValidatorOpt {
+    /// The genesis config file location
+    #[clap(long)]
+    pub genesis_config_path: PathBuf,
+    /// Public key/address of the validator to start
+    #[clap(long, parse(try_from_str = decode_bytes_hex))]
+    address: SuiAddress,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let config = telemetry_subscribers::TelemetryConfig {
+        service_name: "sui".into(),
+        enable_tracing: std::env::var("SUI_TRACING_ENABLE").is_ok(),
+        json_log_output: std::env::var("SUI_JSON_SPAN_LOGS").is_ok(),
+        ..Default::default()
+    };
+    #[allow(unused)]
+    let guard = telemetry_subscribers::init(config);
+
+    let cfg = ValidatorOpt::parse();
+    let genesis_conf: GenesisConfig = PersistedConfig::read(&cfg.genesis_config_path)?;
+    let address = cfg.address;
+
+    let (network_config, _, _) = genesis(genesis_conf).await?;
+
+    // Find the network config for this validator
+    let net_cfg = network_config
+        .authorities
+        .iter()
+        .find(|x| SuiAddress::from(x.key_pair.public_key_bytes()) == address)
+        .ok_or_else(|| {
+            anyhow!(
+                "Network configs must include config for address {}",
+                address
+            )
+        })?;
+
+    info!("Started {:?} authority", net_cfg);
+
+    if let Err(e) = make_server(
+        net_cfg,
+        &Committee::from(&network_config),
+        network_config.buffer_size,
+    )
+    .await
+    .unwrap()
+    .spawn()
+    .await
+    .unwrap()
+    .join()
+    .await
+    {
+        error!("Validator server ended with an error: {e}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Allows one to start a validator with a genesis config.
This allows running validators in containers as long as we provide:
1. Genesis config file
2. `sui_programmability` dir for genesis objects
3. The address of the validator to run

We simply need to provide these with the docker file.

Note:
1. For now we don't care about sharing the authority keys because it's all internal for devnet.
2. Once this PR merges, I'll add the Dockerfile

Example below:

```
mbp> ./validator --genesis-config-path ../../genesis.json --address 672CE5B4B59F378ADB393B435D04B816C99C0CB8
2022-04-19T03:13:01.552052Z  INFO sui::sui_commands: Creating 2 new authorities...
2022-04-19T03:13:01.552111Z  INFO sui::sui_commands: Creating accounts and gas objects...
2022-04-19T03:13:01.552154Z  INFO sui::sui_commands: Loading Move framework lib from "/Users/ade/Documents/work/val/fastx/sui_programmability/framework/deps/move-stdlib"
2022-04-19T03:13:01.559264Z  INFO sui::sui_commands: Loading Sui framework lib from "/Users/ade/Documents/work/val/fastx/sui_programmability/framework"
2022-04-19T03:13:01.605967Z  INFO validator: Started 672CE5B4B59F378ADB393B435D04B816C99C0CB8 authority on 127.0.0.1:5000
2022-04-19T03:13:01.616715Z  INFO sui_network::transport: Listening to TCP traffic on 127.0.0.1:5000

```




With the following config file: `genesis.json`
~~~
{
  "authorities": [
    {
      "key_pair": "gpQYaPZzWoi0tLUuu6CC3XO291OAUIzkwQVJ0XAhvWQ06QN5OysR6AZvmebhnKTD0wIAAKXfJjlUOaKZFIiMgA==",
      "host": "127.0.0.1",
      "port": 5000,
      "db_path": "DB_PATH1",
      "stake": 3
    },
    {
      "key_pair": "WwFNQ+z4cKJ3vV4XkQx9v9pSLhTBQ6LeknR6MwfXo2OWwXXe4YF3ED6b8cByM1OZCl9BQjW9aNe7A7qHsedKGw==",
      "host": "127.0.0.1",
      "port": 5001,
      "db_path": "DB_PATH2",
      "stake": 6
    }
  ],
  "sui_framework_lib_path": "../../sui_programmability/framework",
  "move_framework_lib_path": "../../sui_programmability/framework/deps/move-stdlib",
  "accounts": [
    {
      "address": "09818AAC3EDF9CF9B006B70C36E7241768B26386",
      "gas_objects": [
        {
          "object_id": "0000000000000000000000000070000000000127",
          "gas_value": 1000000000
        },
        {
          "object_id": "0000000000000000000000000070000000000128",
          "gas_value": 1000000
        }
      ]
    }
  ]
}

~~~

Sample `Dockerfile`

~~~
FROM ubuntu:focal

RUN apt-get update
RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata

RUN apt-get install -y git curl build-essential

RUN apt-get install -y libssl-dev
RUN apt-get install -y pkg-config
RUN apt-get install -y libclang-dev

RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

WORKDIR build

RUN git clone https://github.com/MystenLabs/sui.git
WORKDIR sui
RUN git checkout validator_as_process

ENV PATH="/root/.cargo/bin:${PATH}"

RUN cargo build --release 

# Copy the config
COPY genesis.json target/release/
WORKDIR target/release

CMD ./validator --genesis-config-path genesis.json --address {VALIDATOR_ADDRESS}
~~~
Thanks @mystenmark for initial dockerfile