### PR TITLE
[Gateway] Fix get_owned_objects bug

### DIFF
--- a/sui/src/rest_gateway.rs
+++ b/sui/src/rest_gateway.rs
@@ -194,13 +194,13 @@ impl GatewayAPI for RestGatewayClient {
             .await?)
     }
 
-    fn get_owned_objects(
+    async fn get_owned_objects(
         &mut self,
         account_addr: SuiAddress,
     ) -> Result<Vec<ObjectRef>, anyhow::Error> {
         let url = format!("{}/api/objects?address={}", self.url, account_addr);
-        let response = reqwest::blocking::get(url)?;
-        let response: ObjectResponse = response.json()?;
+        let response = reqwest::get(url).await?;
+        let response: ObjectResponse = response.json().await?;
         let objects = response
             .objects
             .into_iter()

--- a/sui/src/rest_server.rs
+++ b/sui/src/rest_server.rs
@@ -190,6 +190,7 @@ async fn get_objects(
 
     let objects = gateway
         .get_owned_objects(*address)
+        .await
         .unwrap()
         .into_iter()
         .map(NamedObjectRef::from)

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -294,7 +294,7 @@ async fn test_objects_command() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     for (object_id, _, _) in object_refs {
@@ -418,7 +418,7 @@ async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     let object_id = object_refs.first().unwrap().0;
@@ -457,7 +457,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     .execute(&mut context)
     .await?;
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     let object_id = object_refs.first().unwrap().0;
     let object_to_send = object_refs.get(1).unwrap().0;
@@ -664,7 +664,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     .print(true);
     tokio::time::sleep(Duration::from_millis(2000)).await;
 
-    let object_refs = context.gateway.get_owned_objects(address1)?;
+    let object_refs = context.gateway.get_owned_objects(address1).await?;
 
     // Check log output contains all object ids.
     for (object_id, _, _) in &object_refs {
@@ -833,7 +833,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     let gas_obj_id = object_refs.first().unwrap().0;
@@ -915,7 +915,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     let gas_obj_id = object_refs.first().unwrap().0;
@@ -1010,7 +1010,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     let obj_id = object_refs.get(1).unwrap().0;
@@ -1086,7 +1086,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     .execute(&mut context)
     .await?;
 
-    // Run a command with address ommited
+    // Run a command with address omitted
     let os = WalletCommands::Objects { address: None }
         .execute(&mut context)
         .await?;
@@ -1098,7 +1098,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     };
 
     // Check that we indeed fetched for addr1
-    let mut actual_objs = context.gateway.get_owned_objects(addr1).unwrap();
+    let mut actual_objs = context.gateway.get_owned_objects(addr1).await.unwrap();
     cmd_objs.sort();
     actual_objs.sort();
     assert_eq!(cmd_objs, actual_objs);
@@ -1169,7 +1169,7 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
     .execute(&mut context)
     .await?;
 
-    // Run a command with address ommited
+    // Run a command with address omitted
     let os = WalletCommands::ActiveAddress {}
         .execute(&mut context)
         .await?;
@@ -1231,7 +1231,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     let gas = object_refs.first().unwrap().0;
@@ -1269,7 +1269,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
     }
     .execute(&mut context)
     .await?;
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     let primary_coin = object_refs.get(1).unwrap().0;
     let coin_to_merge = object_refs.get(2).unwrap().0;
@@ -1324,7 +1324,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Check log output contains all object ids.
     let gas = object_refs.first().unwrap().0;
@@ -1360,7 +1360,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     .await?
     .print(true);
 
-    let object_refs = context.gateway.get_owned_objects(address)?;
+    let object_refs = context.gateway.get_owned_objects(address).await?;
 
     // Get another coin
     for c in object_refs {

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -409,7 +409,7 @@ impl WalletCommands {
                     Some(a) => *a,
                     None => context.active_address()?,
                 };
-                WalletCommandResult::Objects(context.gateway.get_owned_objects(address)?)
+                WalletCommandResult::Objects(context.gateway.get_owned_objects(address).await?)
             }
 
             WalletCommands::SyncClientState { address } => {
@@ -586,7 +586,7 @@ impl WalletContext {
         &mut self,
         address: SuiAddress,
     ) -> Result<Vec<(u64, Object)>, anyhow::Error> {
-        let object_refs = self.gateway.get_owned_objects(address)?;
+        let object_refs = self.gateway.get_owned_objects(address).await?;
 
         // TODO: We should ideally fetch the objects from local cache
         let mut values_objects = Vec::new();

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -176,7 +176,7 @@ pub trait GatewayAPI {
     async fn get_object_info(&self, object_id: ObjectID) -> Result<ObjectRead, anyhow::Error>;
 
     /// Get refs of all objects we own from local cache.
-    fn get_owned_objects(
+    async fn get_owned_objects(
         &mut self,
         account_addr: SuiAddress,
     ) -> Result<Vec<ObjectRef>, anyhow::Error>;
@@ -733,7 +733,7 @@ where
         Ok(result)
     }
 
-    fn get_owned_objects(
+    async fn get_owned_objects(
         &mut self,
         account_addr: SuiAddress,
     ) -> Result<Vec<ObjectRef>, anyhow::Error> {

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -773,7 +773,7 @@ async fn test_client_state_sync_with_transferred_object() {
     );
 
     // Confirm client 2 received the new object id
-    assert_eq!(1, client.get_owned_objects(addr2).unwrap().len());
+    assert_eq!(1, client.get_owned_objects(addr2).await.unwrap().len());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem
I encountered a weird bug where if I set the gateway in `wallet.conf` to 

```
"gateway": {
    "rest":"http://127.0.0.1:5001"
  },
```

the command `wallet objects --address <address>` will always return empty result. After adding some print statement, I found that the program will abruptly exit on this line

https://github.com/MystenLabs/sui/blob/72dbf0bf4fd280b3bafed371aee7c6d3dad63828/sui/src/rest_gateway.rs#L202, indicating that there's a panic(but it does not print anything)


## Cause
According to the [documentation](https://docs.rs/reqwest/0.11.10/reqwest/blocking/index.html#:~:text=Module%20reqwest%3A%3Ablocking&text=The%20blocking%20Client%20will%20block,panic%20when%20attempting%20to%20block.), we are not supposed to use `reqwest::blocking` directly in a [synchronous function](https://github.com/MystenLabs/sui/blob/72dbf0bf4fd280b3bafed371aee7c6d3dad63828/sui/src/rest_gateway.rs#L202) that's called from an [Asynchronous function
](https://github.com/MystenLabs/sui/blob/72dbf0bf4fd280b3bafed371aee7c6d3dad63828/sui/src/wallet_commands.rs#L210)

> Conversely, the functionality in reqwest::blocking must not be executed within an async runtime, or it will panic when attempting to block. If calling directly from an async function, consider using an async reqwest::Client instead. If the immediate context is only synchronous, but a transitive caller is async, consider changing that caller to use tokio::task::spawn_blocking around the calls that need to block.

## Fix
I converted the function into `async`. After the fix, I am able to see the output
```
➜ wallet objects --address 836F28FCE574A84E4135725FDCB549679B09E62D
Showing 5 results.
(024F81362EFE7404119B931BD5DAA66E35D4E704, SequenceNumber(0), o#9ed130456f5433f50d35092402eba74edbeb6a727edc6e718d2eea0e1cfc03bd)
(52E1B9AB5DE880AEF1B22FEED9ECACF982FBC6AF, SequenceNumber(0), o#2383756327910c8390768ec5f5a288664bd54158cce98f0ef0fd910b9e4926d7)
(AD8F02E7A5EA6C2909C646AFC9509580C1EF58C9, SequenceNumber(0), o#eac8bdcc1ceb6b31e6e7bd518fbf392c06ef7ed44f55f0358c3a6d801a74f402)
(E6CD60439030B5CEF2E8FC192EC6ED9B6CCBA069, SequenceNumber(0), o#d1de3b3b8ffda9d2f7e08c95e4d3f735324e3f0cb0b7c57842a79e544a3656ae)
(E80C18F5D971AE6B1C4490BD16D164FA0369D819, SequenceNumber(0), o#51d541ec4ce8dc6d626265362ba8eb0e04101724192e0f671a2a57702cce6569)
```