### PR TITLE
[RPC server] - add get transaction endpoint

### DIFF
--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -20,7 +20,7 @@ toml = "0.5.8"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 num_cpus = "1.13.1"
-base64 = "0.13.0"
+base64ct = { version = "1.5.0", features = ["alloc"] }
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 rocksdb = "0.18.0"
 hex = "0.4.3"

--- a/sui/src/rest_gateway.rs
+++ b/sui/src/rest_gateway.rs
@@ -15,7 +15,8 @@ use serde_json::json;
 use sui_core::gateway_state::gateway_responses::TransactionResponse;
 use sui_core::gateway_state::{GatewayAPI, GatewayTxSeqNumber};
 use sui_types::base_types::{encode_bytes_hex, ObjectID, ObjectRef, SuiAddress, TransactionDigest};
-use sui_types::messages::{Transaction, TransactionData};
+use sui_types::crypto::EmptySignInfo;
+use sui_types::messages::{Transaction, TransactionData, TransactionEnvelope};
 use sui_types::object::ObjectRead;
 
 use crate::rest_gateway::requests::{
@@ -229,6 +230,17 @@ impl GatewayAPI for RestGatewayClient {
     ) -> Result<Vec<(GatewayTxSeqNumber, TransactionDigest)>, anyhow::Error> {
         // TODO: Implement this.
         Ok(vec![])
+    }
+
+    async fn get_transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<TransactionEnvelope<EmptySignInfo>, anyhow::Error> {
+        // TODO: Implement this.
+        let hex_digest = encode_bytes_hex(&digest);
+        let url = format!("{}/api/tx?digest={}", self.url, hex_digest);
+        let response = reqwest::blocking::get(url)?;
+        Ok(response.json()?)
     }
 }
 

--- a/sui/src/rest_gateway.rs
+++ b/sui/src/rest_gateway.rs
@@ -3,6 +3,7 @@
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use base64ct::{Base64, Encoding};
 use dropshot::HttpErrorResponseBody;
 use http::StatusCode;
 use move_core_types::identifier::Identifier;
@@ -15,8 +16,7 @@ use serde_json::json;
 use sui_core::gateway_state::gateway_responses::TransactionResponse;
 use sui_core::gateway_state::{GatewayAPI, GatewayTxSeqNumber};
 use sui_types::base_types::{encode_bytes_hex, ObjectID, ObjectRef, SuiAddress, TransactionDigest};
-use sui_types::crypto::EmptySignInfo;
-use sui_types::messages::{Transaction, TransactionData, TransactionEnvelope};
+use sui_types::messages::{CertifiedTransaction, Transaction, TransactionData};
 use sui_types::object::ObjectRead;
 
 use crate::rest_gateway::requests::{
@@ -115,7 +115,10 @@ impl GatewayAPI for RestGatewayClient {
             .map(|object_id| object_id.to_hex())
             .collect();
 
-        let pure_arguments = pure_arguments.iter().map(base64::encode).collect();
+        let pure_arguments = pure_arguments
+            .iter()
+            .map(|s| Base64::encode_string(s))
+            .collect();
 
         let request = CallRequest {
             signer: encode_bytes_hex(&signer),
@@ -140,7 +143,10 @@ impl GatewayAPI for RestGatewayClient {
         gas_object_ref: ObjectRef,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error> {
-        let package_bytes = package_bytes.iter().map(base64::encode).collect::<Vec<_>>();
+        let package_bytes = package_bytes
+            .iter()
+            .map(|s| Base64::encode_string(s))
+            .collect::<Vec<_>>();
         let request = PublishRequest {
             sender: encode_bytes_hex(&signer),
             compiled_modules: package_bytes,
@@ -235,8 +241,7 @@ impl GatewayAPI for RestGatewayClient {
     async fn get_transaction(
         &self,
         digest: TransactionDigest,
-    ) -> Result<TransactionEnvelope<EmptySignInfo>, anyhow::Error> {
-        // TODO: Implement this.
+    ) -> Result<CertifiedTransaction, anyhow::Error> {
         let hex_digest = encode_bytes_hex(&digest);
         let url = format!("{}/api/tx?digest={}", self.url, hex_digest);
         let response = reqwest::blocking::get(url)?;

--- a/sui/src/rest_gateway/requests.rs
+++ b/sui/src/rest_gateway/requests.rs
@@ -143,3 +143,10 @@ pub struct SyncRequest {
     /// Required; Hex code as string representing the address
     pub address: String,
 }
+
+/// Query string containing the digest of the transaction to be retrieved.
+#[derive(Deserialize, Serialize, JsonSchema)]
+pub struct GetTransactionDetailsRequest {
+    /// Required; hex string encoding a 32 byte transaction digest
+    pub digest: String,
+}

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -346,7 +346,7 @@ impl RpcGatewayServer for RpcGatewayImpl {
     }
 
     async fn get_transaction(&self, digest: TransactionDigest) -> RpcResult<CertifiedTransaction> {
-        Ok(self.gateway.lock().await.get_transaction(digest).await?)
+        Ok(self.gateway.get_transaction(digest).await?)
     }
 }
 

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -22,7 +22,7 @@ use sui_core::gateway_state::{GatewayClient, GatewayState, GatewayTxSeqNumber};
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::crypto;
 use sui_types::crypto::SignableBytes;
-use sui_types::messages::{Transaction, TransactionData};
+use sui_types::messages::{CertifiedTransaction, Transaction, TransactionData};
 use sui_types::object::ObjectRead;
 
 use crate::config::PersistedConfig;
@@ -115,6 +115,9 @@ pub trait RpcGateway {
         &self,
         count: u64,
     ) -> RpcResult<Vec<(GatewayTxSeqNumber, TransactionDigest)>>;
+
+    #[method(name = "getTransaction")]
+    async fn get_transaction(&self, digest: TransactionDigest) -> RpcResult<CertifiedTransaction>;
 }
 
 pub struct RpcGatewayImpl {
@@ -340,6 +343,10 @@ impl RpcGatewayServer for RpcGatewayImpl {
         count: u64,
     ) -> RpcResult<Vec<(GatewayTxSeqNumber, TransactionDigest)>> {
         Ok(self.gateway.get_recent_transactions(count)?)
+    }
+
+    async fn get_transaction(&self, digest: TransactionDigest) -> RpcResult<CertifiedTransaction> {
+        Ok(self.gateway.lock().await.get_transaction(digest).await?)
     }
 }
 

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -13,7 +13,7 @@ use move_core_types::language_storage::TypeTag;
 use sui_core::gateway_state::gateway_responses::TransactionResponse;
 use sui_core::gateway_state::{GatewayAPI, GatewayTxSeqNumber};
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
-use sui_types::messages::{Transaction, TransactionData};
+use sui_types::messages::{CertifiedTransaction, Transaction, TransactionData};
 use sui_types::object::ObjectRead;
 use tokio::runtime::Handle;
 
@@ -192,5 +192,12 @@ impl GatewayAPI for RpcGatewayClient {
         Ok(futures::executor::block_on(
             self.client.get_recent_transactions(count),
         )?)
+    }
+
+    async fn get_transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<CertifiedTransaction, Error> {
+        Ok(self.client.get_transaction(digest).await?)
     }
 }

--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
+use base64ct::{Base64, Encoding};
 use clap::*;
 use futures::future::join_all;
 use move_binary_format::CompiledModule;
@@ -192,7 +193,8 @@ impl SuiCommand {
                 let keystore = SuiKeystore::load_or_create(&keystore_path)?;
                 info!("Data to sign : {}", data);
                 info!("Address : {}", address);
-                let signature = keystore.sign(address, &base64::decode(data)?)?;
+                let message = Base64::decode_vec(data).map_err(|e| anyhow!(e))?;
+                let signature = keystore.sign(address, &message)?;
                 // Separate pub key and signature string, signature and pub key are concatenated with an '@' symbol.
                 let signature_string = format!("{:?}", signature);
                 let sig_split = signature_string.split('@').collect::<Vec<_>>();

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -986,6 +986,14 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
         Ok(transaction)
     }
 
+    pub fn get_certified_transaction(
+        &self,
+        transaction_digest: &TransactionDigest,
+    ) -> SuiResult<Option<CertifiedTransaction>> {
+        let transaction = self.certificates.get(transaction_digest)?;
+        Ok(transaction)
+    }
+
     #[cfg(test)]
     /// Provide read access to the `schedule` table (useful for testing).
     pub fn get_schedule(&self, object_id: &ObjectID) -> SuiResult<Option<SequenceNumber>> {

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -676,11 +676,16 @@ SuiError:
     72:
       TransactionLockReset: UNIT
     73:
+      TransactionNotFound:
+        STRUCT:
+          - digest:
+              TYPENAME: TransactionDigest
+    74:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    74:
+    75:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -688,26 +693,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    75:
+    76:
       BadObjectType:
         STRUCT:
           - error: STR
-    76:
-      MoveExecutionFailure: UNIT
     77:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     78:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     79:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     80:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     81:
+      AuthorityUpdateFailure: UNIT
+    82:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    82:
+    83:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -718,31 +723,31 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    83:
+    84:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    84:
-      BatchErrorSender: UNIT
     85:
+      BatchErrorSender: UNIT
+    86:
       GenericAuthorityError:
         STRUCT:
           - error: STR
-    86:
+    87:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    87:
+    88:
       ObjectSerializationError:
         STRUCT:
           - error: STR
-    88:
-      ConcurrentTransactionError: UNIT
     89:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     90:
+      IncorrectRecipientError: UNIT
+    91:
       TooManyIncorrectAuthorities:
         STRUCT:
           - errors:
@@ -750,15 +755,15 @@ SuiError:
                 TUPLE:
                   - TYPENAME: PublicKeyBytes
                   - TYPENAME: SuiError
-    91:
+    92:
       InconsistentGatewayResult:
         STRUCT:
           - error: STR
-    92:
+    93:
       GatewayInvalidTxRangeQuery:
         STRUCT:
           - error: STR
-    93:
+    94:
       OnlyOneConsensusClientPermitted: UNIT
 TransactionData:
   STRUCT:

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -243,6 +243,12 @@ impl TransactionDigest {
     }
 }
 
+impl AsRef<[u8]> for TransactionDigest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// Returns a Context for OpenTelemetry tracing from a TransactionDigest
 // NOTE: See https://github.com/MystenLabs/sui/issues/852
 // The current code doesn't really work.  Maybe the traceparent needs to be a specific format,

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use base64ct::{Base64, Encoding};
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -393,8 +394,8 @@ impl TryFrom<&[u8]> for ObjectDigest {
 
 impl std::fmt::Debug for TransactionDigest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let s = hex::encode(&self.0);
-        write!(f, "t#{}", s)?;
+        let s = Base64::encode_string(&self.0);
+        write!(f, "{}", s)?;
         Ok(())
     }
 }

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -215,6 +215,8 @@ pub enum SuiError {
     TransactionLockDoesNotExist,
     #[error("Attempt to reset a set transaction lock to a different value.")]
     TransactionLockReset,
+    #[error("Could not find the referenced transaction {:?}.", digest)]
+    TransactionNotFound { digest: TransactionDigest },
     #[error("Could not find the referenced object {:?}.", object_id)]
     ObjectNotFound { object_id: ObjectID },
     #[error("Object deleted at reference {:?}.", object_ref)]

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -215,7 +215,7 @@ pub enum SuiError {
     TransactionLockDoesNotExist,
     #[error("Attempt to reset a set transaction lock to a different value.")]
     TransactionLockReset,
-    #[error("Could not find the referenced transaction {:?}.", digest)]
+    #[error("Could not find the referenced transaction [{:?}].", digest)]
     TransactionNotFound { digest: TransactionDigest },
     #[error("Could not find the referenced object {:?}.", object_id)]
     ObjectNotFound { object_id: ObjectID },


### PR DESCRIPTION
This PR add get_transaction to the GatewayAPI, RestAPI and JSON-RPC

Currently it return CertifiedTransactions, we can extend it to return SignedTransaction(signed unconfirmed) as well if needed.

*also replaced base64 with base64ct