### PR TITLE
Save to keystore file on new address

### DIFF
--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -130,13 +130,13 @@ impl SuiCommand {
                 let gateway_db_folder_path = sui_config_dir.join("gateway_client_db");
 
                 let genesis_conf = GenesisConfig::default_genesis(sui_config_dir)?;
-                let (network_config, accounts, keystore) = genesis(genesis_conf).await?;
+                let (network_config, accounts, mut keystore) = genesis(genesis_conf).await?;
                 info!("Network genesis completed.");
                 let network_config = network_config.persisted(&network_path);
                 network_config.save()?;
                 info!("Network config file is stored in {:?}.", network_path);
-
-                keystore.save(&keystore_path)?;
+                keystore.set_path(&keystore_path);
+                keystore.save()?;
                 info!("Wallet keystore is stored in {:?}.", keystore_path);
 
                 // Use the first address if any

--- a/sui/src/unit_tests/sui_network.rs
+++ b/sui/src/unit_tests/sui_network.rs
@@ -34,7 +34,7 @@ pub async fn start_test_network(
         .collect();
     genesis_config.authorities = authorities;
 
-    let (network_config, accounts, keystore) = genesis(genesis_config).await?;
+    let (network_config, accounts, mut keystore) = genesis(genesis_config).await?;
     let network = SuiNetwork::start(&network_config).await?;
 
     let network_config = network_config.persisted(&network_path);

--- a/sui/src/unit_tests/sui_network.rs
+++ b/sui/src/unit_tests/sui_network.rs
@@ -39,7 +39,8 @@ pub async fn start_test_network(
 
     let network_config = network_config.persisted(&network_path);
     network_config.save()?;
-    keystore.save(&keystore_path)?;
+    keystore.set_path(&keystore_path);
+    keystore.save()?;
 
     let authorities = network_config.get_authority_infos();
     let authorities = authorities


### PR DESCRIPTION
New addresses were not saves to wallet.key keystore
This PR enables setting a path to save to

This unblocks devnet work and fixes
https://github.com/MystenLabs/sui/issues/1350

Initial state: no addresses
~~~
sui>-$ addresses
Showing 0 results.
~~~

Add a new address
~~~
sui>-$ new-address
Created new keypair for address : F4C507D206F3DD46F3E7F2E502D75847FD22A81F
~~~

Confirm new address is saved
~~~
mbp> cat  ~/.sui/sui_config/wallet.key
[
  "1UWczBCHtYTD3TuXa+/mM9zWHOIXkx5d1Ohhdff7CftmAMkqCENwWzQIG04RWKHd4ojB2ijWjbXj6bk7tp8Dcw=="
]%                                                                                                                                                                                                      
mbp> cat  ~/.sui/sui_config/wallet.conf 
{
  "accounts": [
    "f4c507d206f3dd46f3e7f2e502d75847fd22a81f"
  ],
  "keystore": {
    "File": "/Users/ade/.sui/sui_config/wallet.key"
  },

~~~