### PR TITLE
Added key tool and docker file

### DIFF
--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -33,6 +33,7 @@ serde-name = "0.2.0"
 dirs = "4.0.0"
 clap = { version = "3.1.8", features = ["derive"] }
 telemetry_subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a45af6dc28aa12c8cc13521d118c24aadd4c6adf" }
+base64ct = { version = "1.5.0", features = ["alloc"] }
 
 bcs = "0.1.3"
 sui_core = { path = "../sui_core" }
@@ -89,3 +90,7 @@ path = "src/rest_server.rs"
 [[bin]]
 name = "validator"
 path = "src/validator.rs"
+
+[[bin]]
+name = "key_tool"
+path = "src/key_tool.rs"

--- a/sui/src/Dockerfile
+++ b/sui/src/Dockerfile
@@ -1,0 +1,37 @@
+# Get Ubuntu
+FROM ubuntu:focal
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+
+# Prep for Sui build
+RUN apt-get install -y git curl build-essential
+
+RUN apt-get install -y libssl-dev
+RUN apt-get install -y pkg-config
+RUN apt-get install -y libclang-dev
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Build Sui
+WORKDIR build
+
+RUN git clone https://github.com/MystenLabs/sui.git
+WORKDIR sui
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN cargo build --release 
+
+# Set the default values for args. These wont work but are needed for Dockerfile
+ENV GENESIS_CFG_PATH=genesis.json
+ENV ADDRESS=0
+
+# Copy the config
+COPY ${GENESIS_CFG_PATH} target/release/genesis.json
+WORKDIR target/release
+
+# Run the validator with the given address
+# Eample: sudo docker run -e GENESIS_CFG_PATH=gen.json -e ADDRESS=6380E5D87A38BF2CC3945D6A3276BDD5CD91A22A -it validator
+
+CMD ./validator --genesis-config-path genesis.json --address ${ADDRESS}

--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -45,6 +45,7 @@ pub struct AuthorityInfo {
 
 #[derive(Serialize, Debug)]
 pub struct AuthorityPrivateInfo {
+    pub address: SuiAddress,
     pub key_pair: KeyPair,
     pub host: String,
     pub port: u16,
@@ -94,6 +95,7 @@ impl<'de> Deserialize<'de> for AuthorityPrivateInfo {
         };
 
         Ok(AuthorityPrivateInfo {
+            address: SuiAddress::from(key_pair.public_key_bytes()),
             key_pair,
             host,
             port,

--- a/sui/src/key_tool.rs
+++ b/sui/src/key_tool.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::*;
+use sui_types::{
+    base_types::SuiAddress,
+    crypto::{get_key_pair, KeyPair},
+};
+#[allow(clippy::large_enum_variant)]
+#[derive(Parser)]
+#[clap(
+    name = "Sui Key Tool",
+    about = "Utility For Generating Keys and Addresses Encoded as Base64 Bytes",
+    rename_all = "kebab-case"
+)]
+enum KeyToolOpt {
+    /// Generate a keypair
+    Generate {},
+
+    /// Extract components
+    Unpack { keypair: KeyPair },
+}
+
+fn main() {
+    let config = telemetry_subscribers::TelemetryConfig {
+        service_name: "sui".into(),
+        enable_tracing: std::env::var("SUI_TRACING_ENABLE").is_ok(),
+        json_log_output: std::env::var("SUI_JSON_SPAN_LOGS").is_ok(),
+        ..Default::default()
+    };
+    let _guard = telemetry_subscribers::init(config);
+
+    let res = match KeyToolOpt::parse() {
+        KeyToolOpt::Generate {} => get_key_pair(),
+        KeyToolOpt::Unpack { keypair } => (SuiAddress::from(keypair.public_key_bytes()), keypair),
+    };
+
+    println!("Address: {} \nKeyPair: {:?}", res.0, res.1);
+}

--- a/sui/src/validator.rs
+++ b/sui/src/validator.rs
@@ -35,8 +35,8 @@ async fn main() -> Result<(), anyhow::Error> {
         json_log_output: std::env::var("SUI_JSON_SPAN_LOGS").is_ok(),
         ..Default::default()
     };
-    #[allow(unused)]
-    let guard = telemetry_subscribers::init(config);
+
+    let _guard = telemetry_subscribers::init(config);
 
     let cfg = ValidatorOpt::parse();
     let genesis_conf: GenesisConfig = PersistedConfig::read(&cfg.genesis_config_path)?;

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use anyhow::anyhow;
 use anyhow::Error;
 use base64ct::{Base64, Encoding};
 use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use crate::base_types::{AuthorityName, SuiAddress};
 use crate::error::{SuiError, SuiResult};
@@ -16,7 +18,6 @@ use serde::{Deserialize, Serialize};
 use sha3::Sha3_256;
 
 // TODO: Make sure secrets are not copyable and movable to control where they are in memory
-#[derive(Debug)]
 pub struct KeyPair {
     key_pair: dalek::Keypair,
     public_key_cell: OnceCell<PublicKeyBytes>,
@@ -67,6 +68,27 @@ impl<'de> Deserialize<'de> for KeyPair {
             key_pair: key,
             public_key_cell: OnceCell::new(),
         })
+    }
+}
+
+impl FromStr for KeyPair {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = Base64::decode_vec(s).map_err(|e| anyhow!("{}", e.to_string()))?;
+        let key = dalek::Keypair::from_bytes(&value).map_err(|e| anyhow!("{}", e.to_string()))?;
+        Ok(KeyPair {
+            key_pair: key,
+            public_key_cell: OnceCell::new(),
+        })
+    }
+}
+
+impl std::fmt::Debug for KeyPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        let s = Base64::encode_string(&self.key_pair.to_bytes());
+        write!(f, "{}", s)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Added:
1. Initial docker file for validators which takes arguments
2. Key tool for extracting addresses from keypairs, and for generating keypairs

```
mbp> ./key_tool 
Sui Key Tool 
Utility For Generating Keys and Addresses Encoded as Base64 Bytes

USAGE:
    key_tool <SUBCOMMAND>

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    generate    Generate a keypair
    help        Print this message or the help of the given subcommand(s)
    unpack      Extract components
mbp> ./key_tool generate
Address: CBFE5EFAE4CDFDD2F74C7E75CF9BB9E50B3FEB4E 
KeyPair: 4l7AY9bjtL64oXpGj6jiKPUoMhE8xHaLHBHqvP+K+IcDVLdnO8gO1+HONREzDzxWzgjeUT7V8jiSFs6lie630w==
mbp> ./key_tool unpack 4l7AY9bjtL64oXpGj6jiKPUoMhE8xHaLHBHqvP+K+IcDVLdnO8gO1+HONREzDzxWzgjeUT7V8jiSFs6lie630w==
Address: CBFE5EFAE4CDFDD2F74C7E75CF9BB9E50B3FEB4E 
KeyPair: 4l7AY9bjtL64oXpGj6jiKPUoMhE8xHaLHBHqvP+K+IcDVLdnO8gO1+HONREzDzxWzgjeUT7V8jiSFs6lie630w==
```