### PR TITLE
Changes for running validator in docker

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -68,6 +68,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     // Genesis
     SuiCommand::Genesis {
         working_dir: Some(working_dir.to_path_buf()),
+        write_config: None,
         force: false,
         from_config: None,
     }
@@ -107,6 +108,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     // Genesis 2nd time should fail
     let result = SuiCommand::Genesis {
         working_dir: Some(working_dir.to_path_buf()),
+        write_config: None,
         force: false,
         from_config: None,
     }

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -77,6 +77,13 @@ impl AuthorityServer {
 
     pub async fn spawn(self) -> Result<SpawnedServer<AuthorityServer>, io::Error> {
         let address = format!("{}:{}", self.server.base_address, self.server.base_port);
+        self.spawn_with_bind_address(&address).await
+    }
+
+    pub async fn spawn_with_bind_address(
+        self,
+        address: &str,
+    ) -> Result<SpawnedServer<AuthorityServer>, io::Error> {
         let buffer_size = self.server.buffer_size;
         let guarded_state = Arc::new(self);
 
@@ -85,7 +92,7 @@ impl AuthorityServer {
             .spawn_batch_subsystem(MIN_BATCH_SIZE, Duration::from_millis(MAX_DELAY_MILLIS))
             .await;
 
-        spawn_server(&address, guarded_state, buffer_size).await
+        spawn_server(address, guarded_state, buffer_size).await
     }
 
     async fn handle_batch_streaming<'a, 'b, A>(


### PR DESCRIPTION
- Option to write genesis config without actually doing genesis
- Command for dumping addresses of validators in network (will be used by deploy script to extract addresses from network config)
- Add --listen-address to control the address we bind to, which will not be the same as the public IP