### PR TITLE
fix: make cargo-udeps run on rust only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,6 +114,8 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   cargo-udeps:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #1471 .
This is on auto-merge.