### PR TITLE
[crypto] SuiAddress derivation via sha3

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -45,6 +45,7 @@ serde-reflection = "0.3.5"
 serde_yaml = "0.8.23"
 pretty_assertions = "1.2.0"
 temp_testdir = "0.2"
+hex = "0.4.3"
 
 test_utils = { path = "../test_utils" }
 

--- a/sui_core/src/unit_tests/data/hero/sources/Hero.move
+++ b/sui_core/src/unit_tests/data/hero/sources/Hero.move
@@ -70,7 +70,7 @@ module Examples::Hero {
     }
 
     /// Address of the admin account that receives payment for swords
-    const ADMIN: address = @0xa5e6dbcf33730ace6ec8b400ff4788c1f150ff7e;
+    const ADMIN: address = @0xee0437cf625b77af4d12bff98af1a88332b00638;
     /// Upper bound on player's HP
     const MAX_HP: u64 = 1000;
     /// Upper bound on how magical a sword can be

--- a/sui_core/src/unit_tests/gateway_tests.rs
+++ b/sui_core/src/unit_tests/gateway_tests.rs
@@ -475,6 +475,21 @@ async fn init_local_client_and_fund_account_bad(
     client
 }
 
+#[cfg(test)]
+const ADMIN_SENTINEL: &str = "ee0437cf625b77af4d12bff98af1a88332b00638";
+
+// Required to capture address creation algorithm updates that break some tests.
+#[test]
+fn test_admin_address_consistency() {
+    use hex;
+    let (admin_address, _) = make_admin_account();
+    assert_eq!(admin_address.to_vec(), hex::decode(ADMIN_SENTINEL).expect("Decoding failed"),
+               "If this test broke, then the algorithm for deriving addresses from public keys has \
+               changed. Please compute the new admin address in hex format from `make_admin_account`\
+               and update both the ADMIN_SENTINEL const above, but also the ADMIN address to \
+               Hero.move with the new admin account hex value.");
+}
+
 #[tokio::test]
 async fn test_initiating_valid_transfer() {
     let recipient = get_new_address();

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.7.3"
 serde = { version = "1.0.136", features = ["derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 serde-name = "0.2.0"
-sha3 = "0.9"
+sha3 = "0.9.1"
 thiserror = "1.0.30"
 hex = "0.4.3"
 serde_bytes = "0.11.5"
@@ -37,5 +37,3 @@ move-core-types = { git = "https://github.com/move-language/move", rev = "2e7c37
 move-disassembler = { git = "https://github.com/move-language/move", rev = "2e7c37edada44436805e047dd26724a26c07635a" }
 move-ir-types = { git = "https://github.com/move-language/move", rev = "2e7c37edada44436805e047dd26724a26c07635a" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "2e7c37edada44436805e047dd26724a26c07635a" }
-
-sha2 = "0.10.2"

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -102,10 +102,9 @@ impl TryFrom<Vec<u8>> for SuiAddress {
 
 impl From<&PublicKeyBytes> for SuiAddress {
     fn from(key: &PublicKeyBytes) -> SuiAddress {
-        use sha2::Digest;
-        let mut sha2 = sha2::Sha256::new();
-        sha2.update(key.as_ref());
-        let g_arr = sha2.finalize();
+        let mut hasher = Sha3_256::default();
+        hasher.update(key.as_ref());
+        let g_arr = hasher.finalize();
 
         let mut res = [0u8; SUI_ADDRESS_LENGTH];
         res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);


### PR DESCRIPTION
We currently mix sha2 (pubKey->address) and sha3 (objects/transaction) and this is an attempt to unify our hash-digest functionality into a single behavior and scheme.
This is very important for a) auditing purposes b) consistency c) less dependencies (-sha2)