### PR TITLE
ci: skip rust checks for sdk changes

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -1,0 +1,26 @@
+name: Detect Changes
+description: Defines variables indicating the parts of the code that changed
+outputs:
+  isRust:
+    description: True when changes happened to the rust code
+    value: "${{ steps.diff.outputs.isRust }}"
+  isExplorerClient:
+    description: True when there are changes to files related to explorer client
+    value: "${{ steps.diff.outputs.isExplorerClient }}"
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@v3
+  - name: Detect Changes
+    uses: dorny/paths-filter@v2.10.2
+    id: diff
+    with:
+      filters: |
+        isRust:
+          - '!(explorer|doc|.github)/**'
+          - '.github/workflows/bench.yml'
+          - '.github/workflows/codecov.yml'
+          - '.github/workflows/rust.yml'
+        isExplorerClient:
+          - 'explorer/client/**'
+          - '.github/workflows/explorer-client-prs.yml'

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -17,7 +17,7 @@ runs:
     with:
       filters: |
         isRust:
-          - '!(explorer|doc|.github)/**'
+          - '!(explorer|doc|.github|sdk)/**'
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
           - '.github/workflows/rust.yml'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,21 +32,17 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Detect Changes
-      uses: dorny/paths-filter@v2.10.2
+      uses: './.github/actions/diffs'
       id: diff
-      with:
-        filters: |
-          isRust:
-            - '!(explorer|doc|.github)/**'
-            - '.github/workflows/bench.yml'
+
   bench:
     needs: diff
     if: github.event.pull_request.draft == false && needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
     # Enable caching of the 'librocksdb-sys' crate by additionally caching the
     # 'librocksdb-sys' src directory which is managed by cargo

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,15 +14,10 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Detect Changes
-      uses: dorny/paths-filter@v2.10.2
+      uses: './.github/actions/diffs'
       id: diff
-      with:
-        filters: |
-          isRust:
-            - '!(explorer|doc|.github)/**'
-            - '.github/workflows/bench.yml'
 
   codecov-grcov:
     name: Generate code coverage
@@ -32,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           components: llvm-tools-preview

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -4,17 +4,12 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     outputs:
-      isClient: ${{ steps.diff.outputs.isClient }}
+      isClient: ${{ steps.diff.outputs.isExplorerClient }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Detect Changes
-      uses: dorny/paths-filter@v2.10.2
+      uses: './.github/actions/diffs'
       id: diff
-      with:
-        filters: |
-          isClient:
-            - 'explorer/client/**'
-            - '.github/workflows/explorer-client-prs.yml'
   client_checks:
     name: Lint, Test & Build
     needs: diff
@@ -22,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Nodejs
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
     name: Run test on the beta channel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install beta toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -51,7 +51,7 @@ jobs:
     name: build release binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,21 +34,16 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Detect Changes
-      uses: dorny/paths-filter@v2.10.2
+      uses: './.github/actions/diffs'
       id: diff
-      with:
-        filters: |
-          isRust:
-            - '!(explorer|doc|.github)/**'
-            - '.github/workflows/rust.yml'
 
   license-check:
     name: license-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: scripts/license_check.sh
 
   test:
@@ -58,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo
@@ -76,7 +71,7 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
@@ -94,7 +89,7 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           components: rustfmt
@@ -110,7 +105,7 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   cargo-udeps:
@@ -118,7 +113,7 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo


### PR DESCRIPTION
* use one shared action to detect changes
* update `actions/checkout` to `v3`
* skip rust workflows/checks for anything under `/sdk` directory