### PR TITLE
Refactored readable serde and fix SuiAddress serialization 

### DIFF
--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -1057,7 +1057,6 @@ impl<const A: bool, S: Eq + Serialize + for<'de> Deserialize<'de>> ModuleResolve
                     .serialized_module_map()
                     .get(module_id.name().as_str())
                     .cloned()
-                    .map(|m| m.into_vec())
             }))
     }
 }

--- a/sui_core/src/authority/temporary_store.rs
+++ b/sui_core/src/authority/temporary_store.rs
@@ -358,8 +358,7 @@ impl<S: BackingPackageStore> ModuleResolver for AuthorityTemporaryStore<S> {
             Data::Package(c) => Ok(c
                 .serialized_module_map()
                 .get(module_id.name().as_str())
-                .cloned()
-                .map(|m| m.into_vec())),
+                .cloned()),
             _ => Err(SuiError::BadObjectType {
                 error: "Expected module object".to_string(),
             }),

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -208,13 +208,12 @@ MoveFieldLayout:
 MoveModulePublish:
   STRUCT:
     - modules:
-        SEQ:
-          SEQ: U8
+        SEQ: BYTES
 MoveObject:
   STRUCT:
     - type_:
         TYPENAME: StructTag
-    - contents: STR
+    - contents: BYTES
 MovePackage:
   STRUCT:
     - id:
@@ -435,7 +434,10 @@ StructTag:
         SEQ:
           TYPENAME: TypeTag
 SuiAddress:
-  NEWTYPESTRUCT: BYTES
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 20
 SuiError:
   ENUM:
     0:

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -160,11 +160,9 @@ impl ModuleResolver for InMemoryStorage {
         Ok(self
             .read_object(&ObjectID::from(*module_id.address()))
             .and_then(|o| match &o.data {
-                Data::Package(m) => Some(
-                    m.serialized_module_map()[module_id.name().as_str()]
-                        .clone()
-                        .into_vec(),
-                ),
+                Data::Package(m) => {
+                    Some(m.serialized_module_map()[module_id.name().as_str()].clone())
+                }
                 Data::Move(_) => None,
             }))
     }

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -1,13 +1,16 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use base64ct::{Base64, Encoding};
+use base64ct::Encoding;
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
-use crate::readable_serde::BytesOrBase64;
-use crate::readable_serde::BytesOrHex;
+use crate::crypto::PublicKeyBytes;
+use crate::error::SuiError;
+use crate::readable_serde::encoding::Base64;
+use crate::readable_serde::encoding::Hex;
+use crate::readable_serde::Readable;
 use ed25519_dalek::Digest;
 use hex::FromHex;
 use move_core_types::account_address::AccountAddress;
@@ -15,13 +18,10 @@ use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use opentelemetry::{global, Context};
 use rand::Rng;
-use serde::de::Error;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use serde_with::Bytes;
 use sha3::Sha3_256;
-
-use crate::crypto::PublicKeyBytes;
-use crate::error::SuiError;
-
 #[cfg(test)]
 #[path = "unit_tests/base_types_tests.rs"]
 mod base_types_tests;
@@ -38,14 +38,16 @@ pub struct UserData(pub Option<[u8; 32]>);
 
 pub type AuthorityName = PublicKeyBytes;
 
-#[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash)]
-pub struct ObjectID(AccountAddress);
+#[serde_as]
+#[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ObjectID(#[serde_as(as = "Readable<Hex, _>")] AccountAddress);
 
 pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 
 pub const SUI_ADDRESS_LENGTH: usize = ObjectID::LENGTH;
+#[serde_as]
 #[derive(Eq, Default, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct SuiAddress(#[serde(with = "BytesOrHex")] [u8; SUI_ADDRESS_LENGTH]);
+pub struct SuiAddress(#[serde_as(as = "Readable<Hex, _>")] [u8; SUI_ADDRESS_LENGTH]);
 
 impl SuiAddress {
     pub fn to_vec(&self) -> Vec<u8> {
@@ -134,11 +136,15 @@ pub const TRANSACTION_DIGEST_LENGTH: usize = 32;
 pub const OBJECT_DIGEST_LENGTH: usize = 32;
 
 /// A transaction will have a (unique) digest.
+#[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct TransactionDigest(#[serde(with = "BytesOrBase64")] [u8; TRANSACTION_DIGEST_LENGTH]);
+pub struct TransactionDigest(
+    #[serde_as(as = "Readable<Base64, Bytes>")] [u8; TRANSACTION_DIGEST_LENGTH],
+);
 // Each object has a unique digest
+#[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
-pub struct ObjectDigest(#[serde(with = "BytesOrBase64")] pub [u8; 32]); // We use SHA3-256 hence 32 bytes here
+pub struct ObjectDigest(#[serde_as(as = "Readable<Base64, Bytes>")] pub [u8; 32]); // We use SHA3-256 hence 32 bytes here
 
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("TxContext");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = TX_CONTEXT_MODULE_NAME;
@@ -394,7 +400,7 @@ impl TryFrom<&[u8]> for ObjectDigest {
 
 impl std::fmt::Debug for TransactionDigest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let s = Base64::encode_string(&self.0);
+        let s = base64ct::Base64::encode_string(&self.0);
         write!(f, "{}", s)?;
         Ok(())
     }
@@ -638,41 +644,5 @@ impl std::str::FromStr for ObjectID {
     fn from_str(s: &str) -> Result<Self, ObjectIDParseError> {
         // Try to match both the literal (0xABC..) and the normal (ABC)
         Self::from_hex(s).or_else(|_| Self::from_hex_literal(s))
-    }
-}
-
-impl<'de> Deserialize<'de> for ObjectID {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = <String>::deserialize(deserializer)?;
-            ObjectID::from_hex(s).map_err(D::Error::custom)
-        } else {
-            // In order to preserve the Serde data model and help analysis tools,
-            // make sure to wrap our value in a container with the same name
-            // as the original type.
-            #[derive(::serde::Deserialize)]
-            #[serde(rename = "ObjectID")]
-            struct Value([u8; ObjectID::LENGTH]);
-
-            let value = Value::deserialize(deserializer)?;
-            Ok(ObjectID::new(value.0))
-        }
-    }
-}
-
-impl Serialize for ObjectID {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if serializer.is_human_readable() {
-            self.to_hex().serialize(serializer)
-        } else {
-            // See comment in deserialize.
-            serializer.serialize_newtype_struct("ObjectID", &self.0)
-        }
     }
 }

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -2,14 +2,16 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{base_types::*, batch::*, committee::Committee, error::*, event::Event};
 use crate::crypto::{
     sha3_hash, AuthoritySignInfo, AuthoritySignInfoTrait, AuthoritySignature, BcsSignable,
     EmptySignInfo, Signable, Signature, VerificationObligation,
 };
 use crate::gas::GasCostSummary;
 use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
-use crate::readable_serde::Base64OrDefault;
-use base64ct::{Base64, Encoding};
+use crate::readable_serde::encoding::Base64;
+use crate::readable_serde::Readable;
+use base64ct::Encoding;
 use itertools::Either;
 use move_binary_format::{access::ModuleAccess, CompiledModule};
 use move_core_types::{
@@ -21,15 +23,13 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
 use serde_with::serde_as;
+use serde_with::Bytes;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 use std::{
     collections::{BTreeSet, HashSet},
     hash::{Hash, Hasher},
 };
-
-use super::{base_types::*, batch::*, committee::Committee, error::*, event::Event};
-
 #[cfg(test)]
 #[path = "unit_tests/messages_tests.rs"]
 mod messages_tests;
@@ -59,7 +59,7 @@ pub struct MoveCall {
 #[serde_as]
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct MoveModulePublish {
-    #[serde_as(as = "Vec<Base64OrDefault>")]
+    #[serde_as(as = "Vec<Readable<Base64, Bytes>>")]
     pub modules: Vec<Vec<u8>>,
 }
 
@@ -319,7 +319,7 @@ where
     }
 
     pub fn to_base64(&self) -> String {
-        Base64::encode_string(&self.to_bytes())
+        base64ct::Base64::encode_string(&self.to_bytes())
     }
 }
 

--- a/sui_types/src/object.rs
+++ b/sui_types/src/object.rs
@@ -16,13 +16,15 @@ use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use serde_with::base64::Base64;
 use serde_with::serde_as;
+use serde_with::Bytes;
 
 use crate::coin::Coin;
 use crate::crypto::{sha3_hash, BcsSignable};
 use crate::error::{SuiError, SuiResult};
 use crate::move_package::MovePackage;
+use crate::readable_serde::encoding::Base64;
+use crate::readable_serde::Readable;
 use crate::{
     base_types::{
         ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
@@ -37,7 +39,7 @@ pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MoveObject {
     pub type_: StructTag,
-    #[serde_as(as = "Base64")]
+    #[serde_as(as = "Readable<Base64, Bytes>")]
     contents: Vec<u8>,
 }
 

--- a/sui_types/src/readable_serde.rs
+++ b/sui_types/src/readable_serde.rs
@@ -26,11 +26,11 @@ where
 /// R : serde_as SerializeAs/DeserializeAs delegation
 ///
 /// # Example:
-/// ```
+///
 /// #[serde_as]
 /// #[derive(Deserialize, Serialize)]
 /// struct Example(#[serde_as(as = "Readable(Hex, _)")] [u8; 20]);
-/// ```
+///
 /// The above example will encode the byte array to Hex string for human-readable serializer
 /// and array tuple (default) for non-human-readable serializer.
 ///

--- a/sui_types/src/readable_serde.rs
+++ b/sui_types/src/readable_serde.rs
@@ -21,7 +21,19 @@ where
     D::Error::custom(format!("byte deserialization failed, cause by: {:?}", e))
 }
 
-/// Encode/Decode bytes to/from Base64/Hex for human-readable serializer and deserializer,
+/// Use with serde_as to encode/decode bytes to/from Base64/Hex for human-readable serializer and deserializer
+/// E : Encoding of the human readable output
+/// R : serde_as SerializeAs/DeserializeAs delegation
+///
+/// # Example:
+/// ```
+/// #[serde_as]
+/// #[derive(Deserialize, Serialize)]
+/// struct Example(#[serde_as(as = "Readable(Hex, _)")] [u8; 20]);
+/// ```
+/// The above example will encode the byte array to Hex string for human-readable serializer
+/// and array tuple (default) for non-human-readable serializer.
+///
 pub struct Readable<E, R> {
     element: PhantomData<R>,
     encoding: PhantomData<E>,

--- a/sui_types/src/readable_serde.rs
+++ b/sui_types/src/readable_serde.rs
@@ -1,206 +1,155 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
-use std::fmt::Display;
+use move_core_types::account_address::AccountAddress;
+use std::fmt::Debug;
+use std::marker::PhantomData;
 
-use base64ct::{Base64, Encoding as _};
 use serde;
 use serde::de::{Deserialize, Deserializer, Error};
 use serde::ser::Serializer;
 use serde::Serialize;
-use serde_bytes::ByteBuf;
-use serde_with::{Bytes, DeserializeAs, SerializeAs};
+use serde_with::{DeserializeAs, SerializeAs};
 
-/// Encode bytes to hex for human-readable serializer and deserializer,
-/// serde to bytes for non-human-readable serializer and deserializer.
-pub trait BytesOrHex<'de>: Sized {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        Self: AsRef<[u8]>,
-    {
-        serialize_to_bytes_or_encode(serializer, self.as_ref(), Encoding::Hex)
-    }
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>;
-}
-
-/// Encode bytes to Base64 for human-readable serializer and deserializer,
-/// serde to array tuple for non-human-readable serializer and deserializer.
-pub trait BytesOrBase64<'de>: Sized {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        Self: AsRef<[u8]>,
-    {
-        serialize_to_bytes_or_encode(serializer, self.as_ref(), Encoding::Base64)
-    }
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>;
-}
-
-fn deserialize_from_bytes_or_decode<'de, D>(
-    deserializer: D,
-    encoding: Encoding,
-) -> Result<Vec<u8>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    if deserializer.is_human_readable() {
-        let s = String::deserialize(deserializer)?;
-        encoding.decode(s).map_err(to_custom_error::<'de, D, _>)
-    } else {
-        Bytes::deserialize_as(deserializer)
-    }
-}
-
-fn serialize_to_bytes_or_encode<S>(
-    serializer: S,
-    data: &[u8],
-    encoding: Encoding,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    if serializer.is_human_readable() {
-        encoding.encode(data).serialize(serializer)
-    } else {
-        Bytes::serialize_as(&data, serializer)
-    }
-}
-
-impl<'de> BytesOrBase64<'de> for ed25519_dalek::Signature {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        Self: AsRef<[u8]>,
-    {
-        if serializer.is_human_readable() {
-            Encoding::Base64.encode(self.as_ref()).serialize(serializer)
-        } else {
-            <Self as Serialize>::serialize(self, serializer)
-        }
-    }
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            let value = Encoding::Base64
-                .decode(s)
-                .map_err(to_custom_error::<'de, D, _>)?;
-            Self::try_from(value.as_slice()).map_err(to_custom_error::<'de, D, _>)
-        } else {
-            <Self as Deserialize>::deserialize(deserializer)
-        }
-    }
-}
+use crate::readable_serde::encoding::Encoding;
 
 fn to_custom_error<'de, D, E>(e: E) -> D::Error
 where
-    E: Display,
+    E: Debug,
     D: Deserializer<'de>,
 {
-    D::Error::custom(format!("byte deserialization failed, cause by: {}", e))
+    D::Error::custom(format!("byte deserialization failed, cause by: {:?}", e))
 }
 
-impl<'de, const N: usize> BytesOrHex<'de> for [u8; N] {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = deserialize_from_bytes_or_decode(deserializer, Encoding::Hex)?;
-        let mut array = [0u8; N];
-        array.copy_from_slice(&value[..N]);
-        Ok(array)
-    }
+/// Encode/Decode bytes to/from Base64/Hex for human-readable serializer and deserializer,
+pub struct Readable<E, R> {
+    element: PhantomData<R>,
+    encoding: PhantomData<E>,
 }
 
-impl<'de, const N: usize> BytesOrBase64<'de> for [u8; N] {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = deserialize_from_bytes_or_decode(deserializer, Encoding::Base64)?;
-        let mut array = [0u8; N];
-        array.copy_from_slice(&value[..N]);
-        Ok(array)
-    }
-}
-
-enum Encoding {
-    Base64,
-    Hex,
-}
-
-impl Encoding {
-    fn decode(&self, s: String) -> Result<Vec<u8>, anyhow::Error> {
-        Ok(match self {
-            Encoding::Base64 => Base64::decode_vec(&s).map_err(|e| anyhow!(e))?,
-            Encoding::Hex => hex::decode(s)?,
-        })
-    }
-
-    fn encode<T: AsRef<[u8]>>(&self, data: T) -> String {
-        match self {
-            Encoding::Base64 => Base64::encode_string(data.as_ref()),
-            Encoding::Hex => hex::encode(data),
-        }
-    }
-}
-
-pub struct Base64OrDefault;
-
-impl<T> SerializeAs<T> for Base64OrDefault
+impl<T, R, E> SerializeAs<T> for Readable<E, R>
 where
-    T: AsRef<[u8]> + Serialize,
+    T: AsRef<[u8]>,
+    R: SerializeAs<T>,
+    E: Encoding,
 {
     fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if serializer.is_human_readable() {
-            Encoding::Base64.encode(value).serialize(serializer)
+            E::encode(value).serialize(serializer)
         } else {
-            <T as Serialize>::serialize(value, serializer)
+            R::serialize_as(value, serializer)
         }
     }
 }
-
-impl<'de> DeserializeAs<'de, Vec<u8>> for Base64OrDefault {
+/// DeserializeAs support for Arrays
+impl<'de, R, E, const N: usize> DeserializeAs<'de, [u8; N]> for Readable<E, R>
+where
+    R: DeserializeAs<'de, [u8; N]>,
+    E: Encoding,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<[u8; N], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let value = E::decode(s).map_err(to_custom_error::<'de, D, _>)?;
+            let mut array = [0u8; N];
+            array.copy_from_slice(&value[..N]);
+            Ok(array)
+        } else {
+            R::deserialize_as(deserializer)
+        }
+    }
+}
+/// DeserializeAs support for Vec
+impl<'de, R, E> DeserializeAs<'de, Vec<u8>> for Readable<E, R>
+where
+    R: DeserializeAs<'de, Vec<u8>>,
+    E: Encoding,
+{
     fn deserialize_as<D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where
         D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            Encoding::Base64
-                .decode(s)
-                .map_err(to_custom_error::<'de, D, _>)
+            E::decode(s).map_err(to_custom_error::<'de, D, _>)
         } else {
-            <Vec<u8> as Deserialize>::deserialize(deserializer)
+            R::deserialize_as(deserializer)
         }
     }
 }
-
-impl<'de> DeserializeAs<'de, ByteBuf> for Base64OrDefault {
-    fn deserialize_as<D>(deserializer: D) -> Result<ByteBuf, D::Error>
+/// DeserializeAs support for Signature
+impl<'de, R, E> DeserializeAs<'de, ed25519_dalek::Signature> for Readable<E, R>
+where
+    R: DeserializeAs<'de, ed25519_dalek::Signature>,
+    E: Encoding,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<ed25519_dalek::Signature, D::Error>
     where
         D: Deserializer<'de>,
     {
         if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            Ok(ByteBuf::from(
-                Encoding::Base64
-                    .decode(s)
-                    .map_err(to_custom_error::<'de, D, _>)?,
-            ))
+            let value = E::decode(s).map_err(to_custom_error::<'de, D, _>)?;
+            ed25519_dalek::Signature::from_bytes(&value).map_err(to_custom_error::<'de, D, _>)
         } else {
-            <ByteBuf as Deserialize>::deserialize(deserializer)
+            R::deserialize_as(deserializer)
+        }
+    }
+}
+
+/// DeserializeAs support for AccountAddress
+impl<'de, R, E> DeserializeAs<'de, AccountAddress> for Readable<E, R>
+where
+    R: DeserializeAs<'de, AccountAddress>,
+    E: Encoding,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<AccountAddress, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            let value = E::decode(s).map_err(to_custom_error::<'de, D, _>)?;
+            AccountAddress::from_bytes(&value).map_err(to_custom_error::<'de, D, _>)
+        } else {
+            R::deserialize_as(deserializer)
+        }
+    }
+}
+
+pub mod encoding {
+    use anyhow::anyhow;
+    use base64ct::Encoding as _;
+
+    pub trait Encoding {
+        fn decode(s: String) -> Result<Vec<u8>, anyhow::Error>;
+        fn encode<T: AsRef<[u8]>>(data: T) -> String;
+    }
+    pub struct Hex;
+    pub struct Base64;
+
+    impl Encoding for Hex {
+        fn decode(s: String) -> Result<Vec<u8>, anyhow::Error> {
+            Ok(hex::decode(s)?)
+        }
+
+        fn encode<T: AsRef<[u8]>>(data: T) -> String {
+            hex::encode(data)
+        }
+    }
+    impl Encoding for Base64 {
+        fn decode(s: String) -> Result<Vec<u8>, anyhow::Error> {
+            base64ct::Base64::decode_vec(&s).map_err(|e| anyhow!(e))
+        }
+
+        fn encode<T: AsRef<[u8]>>(data: T) -> String {
+            base64ct::Base64::encode_string(data.as_ref())
         }
     }
 }

--- a/sui_types/src/unit_tests/base_types_tests.rs
+++ b/sui_types/src/unit_tests/base_types_tests.rs
@@ -185,8 +185,8 @@ fn test_address_serde_not_human_readable() {
     let serialized = bincode::serialize(&address).unwrap();
     let bcs_serialized = bcs::to_bytes(&address).unwrap();
     // bincode use 8 bytes for BYTES len and bcs use 1 byte
-    assert_eq!(serialized[8..], bcs_serialized[1..]);
-    assert_eq!(address.0, serialized[8..]);
+    assert_eq!(serialized, bcs_serialized);
+    assert_eq!(address.0, serialized[..]);
     let deserialized: SuiAddress = bincode::deserialize(&serialized).unwrap();
     assert_eq!(deserialized, address);
 }
@@ -268,7 +268,7 @@ fn test_move_object_size_for_gas_metering() {
     // all the metadata data needed for serializing various types.
     // If the following assertion breaks, it's likely you have changed MoveObject's fields.
     // Make sure to adjust `object_size_for_gas_metering()` to include those changes.
-    assert_eq!(size + 16, serialized.len());
+    assert_eq!(size + 3, serialized.len());
 }
 
 #[test]

--- a/sui_types/src/unit_tests/base_types_tests.rs
+++ b/sui_types/src/unit_tests/base_types_tests.rs
@@ -180,6 +180,20 @@ fn test_object_id_serde_not_human_readable() {
 }
 
 #[test]
+fn test_object_id_serde_with_expected_value() {
+    let object_id_vec = vec![
+        71, 183, 32, 230, 10, 187, 253, 56, 195, 142, 30, 23, 38, 201, 102, 0, 130, 240, 199, 52,
+    ];
+    let object_id = ObjectID::try_from(object_id_vec.clone()).unwrap();
+    let json_serialized = serde_json::to_string(&object_id).unwrap();
+    let bcs_serialized = bcs::to_bytes(&object_id).unwrap();
+
+    let expected_json_address = "\"47b720e60abbfd38c38e1e1726c9660082f0c734\"";
+    assert_eq!(expected_json_address, json_serialized);
+    assert_eq!(object_id_vec, bcs_serialized);
+}
+
+#[test]
 fn test_address_serde_not_human_readable() {
     let address = SuiAddress::random_for_testing_only();
     let serialized = bincode::serialize(&address).unwrap();
@@ -198,6 +212,20 @@ fn test_address_serde_human_readable() {
     assert_eq!(format!("\"{}\"", hex::encode(address)), serialized);
     let deserialized: SuiAddress = serde_json::from_str(&serialized).unwrap();
     assert_eq!(deserialized, address);
+}
+
+#[test]
+fn test_address_serde_with_expected_value() {
+    let address_vec = vec![
+        42, 202, 201, 60, 233, 75, 103, 251, 224, 56, 148, 252, 58, 57, 61, 244, 92, 124, 211, 191,
+    ];
+    let address = SuiAddress::try_from(address_vec.clone()).unwrap();
+    let json_serialized = serde_json::to_string(&address).unwrap();
+    let bcs_serialized = bcs::to_bytes(&address).unwrap();
+
+    let expected_json_address = "\"2acac93ce94b67fbe03894fc3a393df45c7cd3bf\"";
+    assert_eq!(expected_json_address, json_serialized);
+    assert_eq!(address_vec, bcs_serialized);
 }
 
 #[test]


### PR DESCRIPTION
* Refactored readable serde to use serde_as instead, greatly simplified the code and removed a lot of duplicated logics
* Changed SuiAddress serde to tuple array instead of Bytes
* Refactored ObjectID serde to reuse readable_serde, without changing the output
* Fixed/Improved serde for MoveObject and MovePackage