### PR TITLE
Changes for devnet deployment

### DIFF
--- a/sui/src/lib.rs
+++ b/sui/src/lib.rs
@@ -27,8 +27,11 @@ pub const SUI_WALLET_CONFIG: &str = "wallet.conf";
 pub const SUI_GATEWAY_CONFIG: &str = "gateway.conf";
 
 pub fn sui_config_dir() -> Result<PathBuf, anyhow::Error> {
-    match dirs::home_dir() {
-        Some(v) => Ok(v.join(SUI_DIR).join(SUI_CONFIG_DIR)),
-        None => bail!("Cannot obtain home directory path"),
+    match std::env::var_os("SUI_CONFIG_DIR") {
+        Some(config_env) => Ok(config_env.into()),
+        None => match dirs::home_dir() {
+            Some(v) => Ok(v.join(SUI_DIR).join(SUI_CONFIG_DIR)),
+            None => bail!("Cannot obtain home directory path"),
+        }
     }
 }

--- a/sui/src/lib.rs
+++ b/sui/src/lib.rs
@@ -32,6 +32,6 @@ pub fn sui_config_dir() -> Result<PathBuf, anyhow::Error> {
         None => match dirs::home_dir() {
             Some(v) => Ok(v.join(SUI_DIR).join(SUI_CONFIG_DIR)),
             None => bail!("Cannot obtain home directory path"),
-        }
+        },
     }
 }

--- a/sui/src/validator.rs
+++ b/sui/src/validator.rs
@@ -5,10 +5,9 @@ use anyhow::anyhow;
 use clap::*;
 use std::path::PathBuf;
 use sui::{
-    sui_config_dir,
-    SUI_NETWORK_CONFIG,
     config::{GenesisConfig, NetworkConfig, PersistedConfig},
     sui_commands::{genesis, make_server},
+    sui_config_dir, SUI_NETWORK_CONFIG,
 };
 use sui_types::base_types::{decode_bytes_hex, SuiAddress};
 use sui_types::committee::Committee;
@@ -29,9 +28,15 @@ struct ValidatorOpt {
 
     #[clap(long)]
     pub network_config_path: Option<PathBuf>,
+
     /// Public key/address of the validator to start
     #[clap(long, parse(try_from_str = decode_bytes_hex))]
-    address: SuiAddress,
+    address: Option<SuiAddress>,
+
+    /// Index in validator array of validator to start
+    #[clap(long)]
+    validator_idx: Option<usize>,
+
     #[clap(long, help = "Specify host:port to listen on")]
     listen_address: Option<String>,
 }
@@ -62,27 +67,31 @@ async fn main() -> Result<(), anyhow::Error> {
         }
     };
 
-    let address = cfg.address;
-
-    // Find the network config for this validator
-    let net_cfg = network_config
-        .authorities
-        .iter()
-        .find(|x| SuiAddress::from(x.key_pair.public_key_bytes()) == address)
-        .ok_or_else(|| {
-            anyhow!(
-                "Network configs must include config for address {}",
-                address
-            )
-        })?;
+    let net_cfg = if let Some(address) = cfg.address {
+        // Find the network config for this validator
+        network_config
+            .authorities
+            .iter()
+            .find(|x| SuiAddress::from(x.key_pair.public_key_bytes()) == address)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Network configs must include config for address {}",
+                    address
+                )
+            })?
+    } else if let Some(index) = cfg.validator_idx {
+        &network_config.authorities[index]
+    } else {
+        return Err(anyhow!("Must supply either --address of --validator-idx"));
+    };
 
     let listen_address = cfg
         .listen_address
         .unwrap_or(format!("{}:{}", net_cfg.host, net_cfg.port));
 
     info!(
-        "authority {} listening on {} (public addr: {}:{})",
-        address, listen_address, net_cfg.host, net_cfg.port
+        "authority {:?} listening on {} (public addr: {}:{})",
+        net_cfg.key_pair.public_key_bytes(), listen_address, net_cfg.host, net_cfg.port
     );
 
     if let Err(e) = make_server(

--- a/sui/src/validator.rs
+++ b/sui/src/validator.rs
@@ -91,7 +91,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!(
         "authority {:?} listening on {} (public addr: {}:{})",
-        net_cfg.key_pair.public_key_bytes(), listen_address, net_cfg.host, net_cfg.port
+        net_cfg.key_pair.public_key_bytes(),
+        listen_address,
+        net_cfg.host,
+        net_cfg.port
     );
 
     if let Err(e) = make_server(


### PR DESCRIPTION
* Allow config dir to be overridden with `SUI_CONFIG_DIR` env var.
* validator binary assumes that genesis is already complete, and reads `network.conf`