### PR TITLE
[cleanup] Extract `LocalAuthorityClient` from `gateway_tests`

### DIFF
--- a/sui/src/benchmark.rs
+++ b/sui/src/benchmark.rs
@@ -7,7 +7,7 @@ use futures::{join, StreamExt};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::thread;
 use std::{thread::sleep, time::Duration};
-use sui_core::authority_client::{AuthorityAPI, AuthorityClient};
+use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use sui_network::network::{NetworkClient, NetworkServer};
 use sui_types::batch::UpdateItem;
 use sui_types::messages::{BatchInfoRequest, BatchInfoResponseItem};
@@ -217,7 +217,7 @@ fn run_latency_microbench(
 async fn run_follower(network_client: NetworkClient) {
     // We spawn a second client that listens to the batch interface
     let _batch_client_handle = tokio::task::spawn(async move {
-        let authority_client = AuthorityClient::new(network_client);
+        let authority_client = NetworkAuthorityClient::new(network_client);
 
         let mut start = 0;
 

--- a/sui/src/gateway_config.rs
+++ b/sui/src/gateway_config.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde::Serialize;
 
-use sui_core::authority_client::AuthorityClient;
+use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::gateway_state::{GatewayClient, GatewayState};
 use sui_network::network::NetworkClient;
 use sui_network::transport;
@@ -100,10 +100,10 @@ impl GatewayConfig {
         Committee::new(voting_rights)
     }
 
-    pub fn make_authority_clients(&self) -> BTreeMap<AuthorityName, AuthorityClient> {
+    pub fn make_authority_clients(&self) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
         let mut authority_clients = BTreeMap::new();
         for authority in &self.authorities {
-            let client = AuthorityClient::new(NetworkClient::new(
+            let client = NetworkAuthorityClient::new(NetworkClient::new(
                 authority.host.clone(),
                 authority.base_port,
                 self.buffer_size,


### PR DESCRIPTION
First step towards https://github.com/MystenLabs/sui/issues/1279
This PR does the following things:
1. Rename `AuthorityClient` to `NetworkAuthorityClient` to avoid confusions
2. Move `LocalAuthorityClient` to authority_client.rs for clarity
3. Reuse some common code in there