### PR TITLE
Refine type guards

### DIFF
--- a/sdk/typescript/src/cryptography/ed25519-keypair.ts
+++ b/sdk/typescript/src/cryptography/ed25519-keypair.ts
@@ -79,7 +79,6 @@ export class Ed25519Keypair implements Keypair {
     return new Ed25519Keypair(nacl.sign.keyPair.fromSeed(seed));
   }
 
-  //ts-auto-guard-suppress function-type
   /**
    * The public key for this keypair
    */
@@ -87,11 +86,9 @@ export class Ed25519Keypair implements Keypair {
     return new PublicKey(this.keypair.publicKey);
   }
 
-  //ts-auto-guard-suppress function-type
   /**
    * Return the signature for the provided data.
    */
-  //ts-auto-guard-suppress function-type
   signData(data: Base64DataBuffer): Base64DataBuffer {
     return new Base64DataBuffer(
       nacl.sign.detached(data.getData(), this.keypair.secretKey)

--- a/sdk/typescript/src/cryptography/ed25519-keypair.ts
+++ b/sdk/typescript/src/cryptography/ed25519-keypair.ts
@@ -79,6 +79,7 @@ export class Ed25519Keypair implements Keypair {
     return new Ed25519Keypair(nacl.sign.keyPair.fromSeed(seed));
   }
 
+  //ts-auto-guard-suppress function-type
   /**
    * The public key for this keypair
    */
@@ -86,9 +87,11 @@ export class Ed25519Keypair implements Keypair {
     return new PublicKey(this.keypair.publicKey);
   }
 
+  //ts-auto-guard-suppress function-type
   /**
    * Return the signature for the provided data.
    */
+  //ts-auto-guard-suppress function-type
   signData(data: Base64DataBuffer): Base64DataBuffer {
     return new Base64DataBuffer(
       nacl.sign.detached(data.getData(), this.keypair.secretKey)

--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -11,10 +11,12 @@ export interface Keypair {
   /**
    * The public key for this keypair
    */
+  //ts-auto-guard-suppress function-type
   getPublicKey(): PublicKey;
 
   /**
    * Return the signature for the data
    */
+  //ts-auto-guard-suppress function-type
   signData(data: Base64DataBuffer): Base64DataBuffer;
 }

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -8,7 +8,7 @@
 import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignedTransaction, TransactionResponse, TransferTransaction, TxnDataSerializer, ObjectRef, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, Transfer, RawAuthoritySignInfo, SingleTransactionKind, TransactionKind, TransactionData, Transaction, CertifiedTransaction, TransactionDigest, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, MoveTypeTag, MoveCall, EmptySignInfo, AuthorityName, AuthoritySignature } from "./index";
 import { BN } from "bn.js";
 
-export function isEd25519KeypairData(obj: any, _argumentName?: string): obj is Ed25519KeypairData {
+export function isEd25519KeypairData(obj: any): obj is Ed25519KeypairData {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -18,7 +18,7 @@ export function isEd25519KeypairData(obj: any, _argumentName?: string): obj is E
     )
 }
 
-export function isKeypair(obj: any, _argumentName?: string): obj is Keypair {
+export function isKeypair(obj: any): obj is Keypair {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -28,7 +28,7 @@ export function isKeypair(obj: any, _argumentName?: string): obj is Keypair {
     )
 }
 
-export function isPublicKeyInitData(obj: any, _argumentName?: string): obj is PublicKeyInitData {
+export function isPublicKeyInitData(obj: any): obj is PublicKeyInitData {
     return (
         (isTransactionResponse(obj) as boolean ||
             isSequenceNumber(obj) as boolean ||
@@ -42,7 +42,7 @@ export function isPublicKeyInitData(obj: any, _argumentName?: string): obj is Pu
     )
 }
 
-export function isPublicKeyData(obj: any, _argumentName?: string): obj is PublicKeyData {
+export function isPublicKeyData(obj: any): obj is PublicKeyData {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -51,7 +51,7 @@ export function isPublicKeyData(obj: any, _argumentName?: string): obj is Public
     )
 }
 
-export function isSignedTransaction(obj: any, _argumentName?: string): obj is SignedTransaction {
+export function isSignedTransaction(obj: any): obj is SignedTransaction {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -62,13 +62,13 @@ export function isSignedTransaction(obj: any, _argumentName?: string): obj is Si
     )
 }
 
-export function isTransactionResponse(obj: any, _argumentName?: string): obj is TransactionResponse {
+export function isTransactionResponse(obj: any): obj is TransactionResponse {
     return (
         typeof obj === "string"
     )
 }
 
-export function isTransferTransaction(obj: any, _argumentName?: string): obj is TransferTransaction {
+export function isTransferTransaction(obj: any): obj is TransferTransaction {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -81,7 +81,7 @@ export function isTransferTransaction(obj: any, _argumentName?: string): obj is 
     )
 }
 
-export function isTxnDataSerializer(obj: any, _argumentName?: string): obj is TxnDataSerializer {
+export function isTxnDataSerializer(obj: any): obj is TxnDataSerializer {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -90,7 +90,7 @@ export function isTxnDataSerializer(obj: any, _argumentName?: string): obj is Tx
     )
 }
 
-export function isObjectRef(obj: any, _argumentName?: string): obj is ObjectRef {
+export function isObjectRef(obj: any): obj is ObjectRef {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -101,7 +101,7 @@ export function isObjectRef(obj: any, _argumentName?: string): obj is ObjectRef 
     )
 }
 
-export function isObjectExistsInfo(obj: any, _argumentName?: string): obj is ObjectExistsInfo {
+export function isObjectExistsInfo(obj: any): obj is ObjectExistsInfo {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -110,7 +110,7 @@ export function isObjectExistsInfo(obj: any, _argumentName?: string): obj is Obj
     )
 }
 
-export function isObjectNotExistsInfo(obj: any, _argumentName?: string): obj is ObjectNotExistsInfo {
+export function isObjectNotExistsInfo(obj: any): obj is ObjectNotExistsInfo {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -118,7 +118,7 @@ export function isObjectNotExistsInfo(obj: any, _argumentName?: string): obj is 
     )
 }
 
-export function isObjectStatus(obj: any, _argumentName?: string): obj is ObjectStatus {
+export function isObjectStatus(obj: any): obj is ObjectStatus {
     return (
         (obj === "Exists" ||
             obj === "NotExists" ||
@@ -126,7 +126,7 @@ export function isObjectStatus(obj: any, _argumentName?: string): obj is ObjectS
     )
 }
 
-export function isGetOwnedObjectRefsResponse(obj: any, _argumentName?: string): obj is GetOwnedObjectRefsResponse {
+export function isGetOwnedObjectRefsResponse(obj: any): obj is GetOwnedObjectRefsResponse {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -138,7 +138,7 @@ export function isGetOwnedObjectRefsResponse(obj: any, _argumentName?: string): 
     )
 }
 
-export function isGetObjectInfoResponse(obj: any, _argumentName?: string): obj is GetObjectInfoResponse {
+export function isGetObjectInfoResponse(obj: any): obj is GetObjectInfoResponse {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -150,25 +150,25 @@ export function isGetObjectInfoResponse(obj: any, _argumentName?: string): obj i
     )
 }
 
-export function isObjectDigest(obj: any, _argumentName?: string): obj is ObjectDigest {
+export function isObjectDigest(obj: any): obj is ObjectDigest {
     return (
         typeof obj === "string"
     )
 }
 
-export function isObjectId(obj: any, _argumentName?: string): obj is ObjectId {
+export function isObjectId(obj: any): obj is ObjectId {
     return (
         typeof obj === "string"
     )
 }
 
-export function isSequenceNumber(obj: any, _argumentName?: string): obj is SequenceNumber {
+export function isSequenceNumber(obj: any): obj is SequenceNumber {
     return (
         typeof obj === "number"
     )
 }
 
-export function isRawObjectRef(obj: any, _argumentName?: string): obj is RawObjectRef {
+export function isRawObjectRef(obj: any): obj is RawObjectRef {
     return (
         Array.isArray(obj) &&
         isTransactionResponse(obj[0]) as boolean &&
@@ -177,7 +177,7 @@ export function isRawObjectRef(obj: any, _argumentName?: string): obj is RawObje
     )
 }
 
-export function isTransfer(obj: any, _argumentName?: string): obj is Transfer {
+export function isTransfer(obj: any): obj is Transfer {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -187,7 +187,7 @@ export function isTransfer(obj: any, _argumentName?: string): obj is Transfer {
     )
 }
 
-export function isRawAuthoritySignInfo(obj: any, _argumentName?: string): obj is RawAuthoritySignInfo {
+export function isRawAuthoritySignInfo(obj: any): obj is RawAuthoritySignInfo {
     return (
         Array.isArray(obj) &&
         isTransactionResponse(obj[0]) as boolean &&
@@ -195,7 +195,7 @@ export function isRawAuthoritySignInfo(obj: any, _argumentName?: string): obj is
     )
 }
 
-export function isSingleTransactionKind(obj: any, _argumentName?: string): obj is SingleTransactionKind {
+export function isSingleTransactionKind(obj: any): obj is SingleTransactionKind {
     return (
         ((obj !== null &&
             typeof obj === "object" ||
@@ -212,7 +212,7 @@ export function isSingleTransactionKind(obj: any, _argumentName?: string): obj i
     )
 }
 
-export function isTransactionKind(obj: any, _argumentName?: string): obj is TransactionKind {
+export function isTransactionKind(obj: any): obj is TransactionKind {
     return (
         ((obj !== null &&
             typeof obj === "object" ||
@@ -228,7 +228,7 @@ export function isTransactionKind(obj: any, _argumentName?: string): obj is Tran
     )
 }
 
-export function isTransactionData(obj: any, _argumentName?: string): obj is TransactionData {
+export function isTransactionData(obj: any): obj is TransactionData {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -240,7 +240,7 @@ export function isTransactionData(obj: any, _argumentName?: string): obj is Tran
     )
 }
 
-export function isTransaction(obj: any, _argumentName?: string): obj is Transaction {
+export function isTransaction(obj: any): obj is Transaction {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -251,7 +251,7 @@ export function isTransaction(obj: any, _argumentName?: string): obj is Transact
     )
 }
 
-export function isCertifiedTransaction(obj: any, _argumentName?: string): obj is CertifiedTransaction {
+export function isCertifiedTransaction(obj: any): obj is CertifiedTransaction {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -264,19 +264,19 @@ export function isCertifiedTransaction(obj: any, _argumentName?: string): obj is
     )
 }
 
-export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
+export function isTransactionDigest(obj: any): obj is TransactionDigest {
     return (
         typeof obj === "string"
     )
 }
 
-export function isGatewayTxSeqNumber(obj: any, _argumentName?: string): obj is GatewayTxSeqNumber {
+export function isGatewayTxSeqNumber(obj: any): obj is GatewayTxSeqNumber {
     return (
         typeof obj === "number"
     )
 }
 
-export function isGetTxnDigestsResponse(obj: any, _argumentName?: string): obj is GetTxnDigestsResponse {
+export function isGetTxnDigestsResponse(obj: any): obj is GetTxnDigestsResponse {
     return (
         Array.isArray(obj) &&
         obj.every((e: any) =>
@@ -287,7 +287,7 @@ export function isGetTxnDigestsResponse(obj: any, _argumentName?: string): obj i
     )
 }
 
-export function isMoveModulePublish(obj: any, _argumentName?: string): obj is MoveModulePublish {
+export function isMoveModulePublish(obj: any): obj is MoveModulePublish {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -295,7 +295,7 @@ export function isMoveModulePublish(obj: any, _argumentName?: string): obj is Mo
     )
 }
 
-export function isMoveTypeTag(obj: any, _argumentName?: string): obj is MoveTypeTag {
+export function isMoveTypeTag(obj: any): obj is MoveTypeTag {
     return (
         (obj === "bool" ||
             obj === "u8" ||
@@ -308,7 +308,7 @@ export function isMoveTypeTag(obj: any, _argumentName?: string): obj is MoveType
     )
 }
 
-export function isMoveCall(obj: any, _argumentName?: string): obj is MoveCall {
+export function isMoveCall(obj: any): obj is MoveCall {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -332,19 +332,19 @@ export function isMoveCall(obj: any, _argumentName?: string): obj is MoveCall {
     )
 }
 
-export function isEmptySignInfo(obj: any, _argumentName?: string): obj is EmptySignInfo {
+export function isEmptySignInfo(obj: any): obj is EmptySignInfo {
     return (
         typeof obj === "object"
     )
 }
 
-export function isAuthorityName(obj: any, _argumentName?: string): obj is AuthorityName {
+export function isAuthorityName(obj: any): obj is AuthorityName {
     return (
         typeof obj === "string"
     )
 }
 
-export function isAuthoritySignature(obj: any, _argumentName?: string): obj is AuthoritySignature {
+export function isAuthoritySignature(obj: any): obj is AuthoritySignature {
     return (
         typeof obj === "string"
     )

--- a/sdk/typescript/src/rpc/client.guard.ts
+++ b/sdk/typescript/src/rpc/client.guard.ts
@@ -8,7 +8,7 @@
 import { HttpHeaders, ValidResponse, ErrorResponse } from "./client";
 import { isTransactionResponse } from "../index.guard";
 
-export function isHttpHeaders(obj: any, _argumentName?: string): obj is HttpHeaders {
+export function isHttpHeaders(obj: any): obj is HttpHeaders {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -16,7 +16,7 @@ export function isHttpHeaders(obj: any, _argumentName?: string): obj is HttpHead
     )
 }
 
-export function isValidResponse(obj: any, _argumentName?: string): obj is ValidResponse {
+export function isValidResponse(obj: any): obj is ValidResponse {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -26,7 +26,7 @@ export function isValidResponse(obj: any, _argumentName?: string): obj is ValidR
     )
 }
 
-export function isErrorResponse(obj: any, _argumentName?: string): obj is ErrorResponse {
+export function isErrorResponse(obj: any): obj is ErrorResponse {
     return (
         (obj !== null &&
             typeof obj === "object" ||

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -19,6 +19,7 @@ export interface TransferTransaction {
  * Serializes a transaction to a string that can be signed by a `Signer`.
  */
 export interface TxnDataSerializer {
+  //ts-auto-guard-suppress function-type
   new_transfer(transaction: TransferTransaction): Promise<Base64DataBuffer>;
 
   // TODO: add more interface methods

--- a/sdk/typescript/type_guards.sh
+++ b/sdk/typescript/type_guards.sh
@@ -3,9 +3,19 @@
 # generate TS type guards for project
 npx ts-auto-guard --export-all src/rpc/client.ts src/**.ts
 
-# this only works on macos due to sed differences, perhaps a node script should do this?
-# fix import of BN.js types on line 6
-sed -i '' '6s/"..\/node_modules\/@types\/bn";/"bn.js";/g' src/index.guard.ts
+second_arg=", _argumentName?: string"
+if [[ `uname` == "Darwin" ]]; then
+    # fix import of BN.js types
+    sed -i '' 's/"..\/node_modules\/@types\/bn";/"bn.js";/g' src/index.guard.ts
+    # remove the unsupported second argument from generated type guards
+    sed -i '' "s/${second_arg}//g" src/index.guard.ts
+    sed -i '' "s/${second_arg}//g" src/rpc/client.guard.ts
+else
+    # linux / GNU sed versions of same thing
+    sed -i 's/"..\/node_modules\/@types\/bn";/"bn.js";/g' src/index.guard.ts
+    sed -i "s/${second_arg}//g" src/index.guard.ts
+    sed -i "s/${second_arg}//g" src/rpc/client.guard.ts
+fi
 
 LICENSE="// Copyright (c) 2022, Mysten Labs, Inc.\n// SPDX-License-Identifier: Apache-2.0\n";
 index="src/index.guard.ts"

--- a/sdk/typescript/type_guards.sh
+++ b/sdk/typescript/type_guards.sh
@@ -3,28 +3,25 @@
 # generate TS type guards for project
 npx ts-auto-guard --export-all src/rpc/client.ts src/**.ts
 
-second_arg=", _argumentName?: string"
-if [[ `uname` == "Darwin" ]]; then
-    # fix import of BN.js types
-    sed -i '' 's/"..\/node_modules\/@types\/bn";/"bn.js";/g' src/index.guard.ts
-    # remove the unsupported second argument from generated type guards
-    sed -i '' "s/${second_arg}//g" src/index.guard.ts
-    sed -i '' "s/${second_arg}//g" src/rpc/client.guard.ts
-else
-    # linux / GNU sed versions of same thing
-    sed -i 's/"..\/node_modules\/@types\/bn";/"bn.js";/g' src/index.guard.ts
-    sed -i "s/${second_arg}//g" src/index.guard.ts
-    sed -i "s/${second_arg}//g" src/rpc/client.guard.ts
-fi
-
 LICENSE="// Copyright (c) 2022, Mysten Labs, Inc.\n// SPDX-License-Identifier: Apache-2.0\n";
-index="src/index.guard.ts"
-# add license header to generated files
-echo -e ${LICENSE} | cat - ${index} > src/index.guard.temp.ts
-rm ${index}
-mv src/index.guard.temp.ts ${index}
+second_arg=", _argumentName?: string"
 
-client="src/rpc/client.guard.ts"
-echo -e ${LICENSE} | cat - ${client} > src/client.guard.temp.ts
-rm ${client}
-mv src/client.guard.temp.ts ${client}
+for FILE in src/index.guard.ts src/rpc/client.guard.ts
+do
+    if [[ `uname` == "Darwin" ]]; then
+        # fix import of BN.js types
+        sed -i '' 's/"..\/node_modules\/@types\/bn";/"bn.js";/g' ${FILE}
+        # remove the unsupported second argument from generated type guards
+        sed -i '' "s/${second_arg}//g" ${FILE}
+    else
+        # linux / GNU sed versions of same thing
+        sed -i 's/"..\/node_modules\/@types\/bn";/"bn.js";/g' ${FILE}
+        sed -i "s/${second_arg}//g" ${FILE}
+    fi
+
+    TEMP=${FILE}.temp
+    # add license header to generated file
+    echo -e ${LICENSE} | cat - ${FILE} > ${TEMP}
+    rm ${FILE}
+    mv ${TEMP} ${FILE}
+done


### PR DESCRIPTION
This fixes 3 small issues:
1) the generated guards had an extra `_argumentName?` parameter (not sure why, it didn't do anything), these are removed.
2) the `type_guards.sh` script should now work on Linux or Windows bash environments (despite `#!/bin/zsh`)
3) warnings about not being able to validate the return type of a function at runtime are suppressed