### PR TITLE
Derive narwhal ports from sui

### DIFF
--- a/sui/src/validator.rs
+++ b/sui/src/validator.rs
@@ -5,7 +5,6 @@ use anyhow::anyhow;
 use clap::*;
 use narwhal_config::Parameters as ConsensusParameters;
 use std::path::PathBuf;
-use sui::config::make_default_narwhal_committee;
 use sui::{
     config::{GenesisConfig, NetworkConfig, PersistedConfig, CONSENSUS_DB_NAME},
     sui_commands::{genesis, make_server},
@@ -100,7 +99,7 @@ async fn main() -> Result<(), anyhow::Error> {
         net_cfg.port
     );
 
-    let consensus_committee = make_default_narwhal_committee(&network_config.authorities)?;
+    let consensus_committee = network_config.make_narwhal_committee();
     let consensus_parameters = ConsensusParameters::default();
     let consensus_store_path = sui_config_dir()?
         .join(CONSENSUS_DB_NAME)


### PR DESCRIPTION
The narwhal node need a committee file, it is now derived from the Sui committee file. The narwhal primary and workers already bind to 0.0.0.0:  https://github.com/MystenLabs/narwhal/blob/6788cf3da00b94b72a9dcc16e9da199e18ba6e37/primary/src/primary.rs#L142