### PR TITLE
[move][adapter] Static init rules

### DIFF
--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -816,7 +816,7 @@ fn publish_from_src(
     src_path: &str,
     gas_object: Object,
     _gas_budget: u64,
-) {
+) -> SuiResult {
     storage.write_object(gas_object);
     storage.flush();
 
@@ -843,7 +843,6 @@ fn publish_from_src(
         &mut tx_context,
         &mut SuiGasStatus::new_unmetered(),
     )
-    .unwrap();
 }
 
 #[test]
@@ -864,7 +863,8 @@ fn test_simple_call() {
         "src/unit_tests/data/simple_call",
         gas_object,
         GAS_BUDGET,
-    );
+    )
+    .unwrap();
     storage.flush();
 
     // call published module function
@@ -921,7 +921,8 @@ fn test_publish_init() {
         "src/unit_tests/data/publish_init",
         gas_object,
         GAS_BUDGET,
-    );
+    )
+    .unwrap();
 
     // a package object and a fresh object in the constructor should
     // have been crated
@@ -954,16 +955,17 @@ fn test_publish_init_public() {
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
 
     // publish modules at a given path
-    publish_from_src(
+    assert!(publish_from_src(
         &mut storage,
         &native_functions,
         "src/unit_tests/data/publish_init_public",
         gas_object,
         GAS_BUDGET,
-    );
+    )
+    .is_err());
 
-    // only a package object should have been crated
-    assert_eq!(storage.created().len(), 1);
+    // nothing should have been crated
+    assert_eq!(storage.created().len(), 0);
 }
 
 #[test]
@@ -980,16 +982,17 @@ fn test_publish_init_ret() {
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
 
     // publish modules at a given path
-    publish_from_src(
+    assert!(publish_from_src(
         &mut storage,
         &native_functions,
         "src/unit_tests/data/publish_init_ret",
         gas_object,
         GAS_BUDGET,
-    );
+    )
+    .is_err());
 
-    // only a package object should have been crated
-    assert_eq!(storage.created().len(), 1);
+    // nothing should have been crated
+    assert_eq!(storage.created().len(), 0);
 }
 
 #[test]
@@ -1006,14 +1009,15 @@ fn test_publish_init_param() {
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
 
     // publish modules at a given path
-    publish_from_src(
+    assert!(publish_from_src(
         &mut storage,
         &native_functions,
         "src/unit_tests/data/publish_init_param",
         gas_object,
         GAS_BUDGET,
-    );
+    )
+    .is_err());
 
-    // only a package object should have been crated
-    assert_eq!(storage.created().len(), 1);
+    // nothing should have been crated
+    assert_eq!(storage.created().len(), 0);
 }

--- a/sui_programmability/examples/nfts/sources/Num.move
+++ b/sui_programmability/examples/nfts/sources/Num.move
@@ -29,7 +29,7 @@ module NFTs::Num {
     const ETOO_MANY_NUMS: u64 = 0;
 
     /// Create a unique issuer cap and give it to the transaction sender
-    public fun init(ctx: &mut TxContext) {
+    fun init(ctx: &mut TxContext) {
         let issuer_cap = NumIssuerCap {
             id: TxContext::new_id(ctx),
             supply: 0,


### PR DESCRIPTION
- Made init rules static
- The existence of the function is optional
- The function must be named 'init'
- The function must be private
- The function can have a single parameter, &mut TxContext
- Alternatively, the function can have zero parameters