### PR TITLE
Removing dev-addresses from Move.toml

### DIFF
--- a/doc/src/build/move.md
+++ b/doc/src/build/move.md
@@ -407,9 +407,6 @@ Sui = { local = "../sui/sui_programmability/framework/" }
 
 [addresses]
 MyFirstPackage = "0x0"
-
-[dev-addresses]
-MyFirstPackage = "0x0"
 ```
 
 Ensure you are in the `my_move_package` directory containing your package and build it:


### PR DESCRIPTION
There is no undefined address in the [addresses] section (e.g. AddressToBeFilledIn = "_") so having a [dev-addresses] section is not necessary.