### PR TITLE
[Move][RFC] Add take_immutable_object and take_shared_object in TestScenario

### DIFF
--- a/sui_programmability/examples/basics/sources/Counter.move
+++ b/sui_programmability/examples/basics/sources/Counter.move
@@ -71,41 +71,44 @@ module Basics::CounterTest {
 
         TestScenario::next_tx(scenario, &user1);
         {
-            let counter = TestScenario::take_object<Counter::Counter>(scenario);
+            let counter_wrapper = TestScenario::take_shared_object<Counter::Counter>(scenario);
+            let counter = TestScenario::borrow_mut(&mut counter_wrapper);
 
-            assert!(Counter::owner(&counter) == owner, 0);
-            assert!(Counter::value(&counter) == 0, 1);
+            assert!(Counter::owner(counter) == owner, 0);
+            assert!(Counter::value(counter) == 0, 1);
 
-            Counter::increment(&mut counter, TestScenario::ctx(scenario));
-            Counter::increment(&mut counter, TestScenario::ctx(scenario));
-            Counter::increment(&mut counter, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, counter);
+            Counter::increment(counter, TestScenario::ctx(scenario));
+            Counter::increment(counter, TestScenario::ctx(scenario));
+            Counter::increment(counter, TestScenario::ctx(scenario));
+            TestScenario::return_shared_object(scenario, counter_wrapper);
         };
 
         TestScenario::next_tx(scenario, &owner);
         {
-            let counter = TestScenario::take_object<Counter::Counter>(scenario);
+            let counter_wrapper = TestScenario::take_shared_object<Counter::Counter>(scenario);
+            let counter = TestScenario::borrow_mut(&mut counter_wrapper);
 
-            assert!(Counter::owner(&counter) == owner, 0);
-            assert!(Counter::value(&counter) == 3, 1);
+            assert!(Counter::owner(counter) == owner, 0);
+            assert!(Counter::value(counter) == 3, 1);
 
-            Counter::set_value(&mut counter, 100, TestScenario::ctx(scenario));
+            Counter::set_value(counter, 100, TestScenario::ctx(scenario));
 
-            TestScenario::return_object(scenario, counter);
+            TestScenario::return_shared_object(scenario, counter_wrapper);
         };
 
         TestScenario::next_tx(scenario, &user1);
         {
-            let counter = TestScenario::take_object<Counter::Counter>(scenario);
+            let counter_wrapper = TestScenario::take_shared_object<Counter::Counter>(scenario);
+            let counter = TestScenario::borrow_mut(&mut counter_wrapper);
 
-            assert!(Counter::owner(&counter) == owner, 0);
-            assert!(Counter::value(&counter) == 100, 1);
+            assert!(Counter::owner(counter) == owner, 0);
+            assert!(Counter::value(counter) == 100, 1);
 
-            Counter::increment(&mut counter, TestScenario::ctx(scenario));
+            Counter::increment(counter, TestScenario::ctx(scenario));
 
-            assert!(Counter::value(&counter) == 101, 2);
+            assert!(Counter::value(counter) == 101, 2);
 
-            TestScenario::return_object(scenario, counter);
+            TestScenario::return_shared_object(scenario, counter_wrapper);
         };
     }
 }

--- a/sui_programmability/examples/basics/sources/Lock.move
+++ b/sui_programmability/examples/basics/sources/Lock.move
@@ -135,14 +135,15 @@ module Basics::LockTest {
         // User2 is impatient and he decides to take the treasure.
         TestScenario::next_tx(scenario, &user2);
         {
-            let lock = TestScenario::take_object<Lock<Treasure>>(scenario);
+            let lock_wrapper = TestScenario::take_shared_object<Lock<Treasure>>(scenario);
+            let lock = TestScenario::borrow_mut(&mut lock_wrapper);
             let key = TestScenario::take_object<Key<Treasure>>(scenario);
             let ctx = TestScenario::ctx(scenario);
 
-            Lock::take<Treasure>(&mut lock, &key, ctx);
+            Lock::take<Treasure>(lock, &key, ctx);
 
-            TestScenario::return_object<Lock<Treasure>>(scenario, lock);
-            TestScenario::return_object<Key<Treasure>>(scenario, key);
+            TestScenario::return_shared_object(scenario, lock_wrapper);
+            TestScenario::return_object(scenario, key);
         };
     }
 }

--- a/sui_programmability/examples/defi/tests/SharedEscrowTest.move
+++ b/sui_programmability/examples/defi/tests/SharedEscrowTest.move
@@ -118,23 +118,25 @@ module DeFi::SharedEscrowTests {
     public(script) fun cancel(scenario: &mut Scenario, initiator: &address) {
         TestScenario::next_tx(scenario, initiator);
         {
-            let escrow = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow_wrapper = TestScenario::take_shared_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow = TestScenario::borrow_mut(&mut escrow_wrapper);
             let ctx = TestScenario::ctx(scenario);
-            SharedEscrow::cancel(&mut escrow, ctx);
-            TestScenario::return_object(scenario, escrow);
+            SharedEscrow::cancel(escrow, ctx);
+            TestScenario::return_shared_object(scenario, escrow_wrapper);
         };
     }
 
     public(script) fun exchange(scenario: &mut Scenario, bob: &address, item_b_verioned_id: VersionedID) {
         TestScenario::next_tx(scenario, bob);
         {
-            let escrow = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow_wrapper = TestScenario::take_shared_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow = TestScenario::borrow_mut(&mut escrow_wrapper);
             let item_b = ItemB {
                 id: item_b_verioned_id
             };
             let ctx = TestScenario::ctx(scenario);
-            SharedEscrow::exchange(item_b, &mut escrow, ctx);
-            TestScenario::return_object(scenario, escrow);
+            SharedEscrow::exchange(item_b, escrow, ctx);
+            TestScenario::return_shared_object(scenario, escrow_wrapper);
         };
     }
 

--- a/sui_programmability/examples/fungible_tokens/tests/BASKETTests.move
+++ b/sui_programmability/examples/fungible_tokens/tests/BASKETTests.move
@@ -20,24 +20,25 @@ module FungibleTokens::BASKETTests {
         };
         TestScenario::next_tx(scenario, &user);
         {
-            let reserve = TestScenario::take_object<Reserve>(scenario);
+            let reserve_wrapper = TestScenario::take_shared_object<Reserve>(scenario);
+            let reserve = TestScenario::borrow_mut(&mut reserve_wrapper);
             let ctx = TestScenario::ctx(scenario);
-            assert!(BASKET::total_supply(&reserve) == 0, 0);
+            assert!(BASKET::total_supply(reserve) == 0, 0);
 
             let num_coins = 10;
             let sui = Coin::mint_for_testing<SUI>(num_coins, ctx);
             let managed = Coin::mint_for_testing<MANAGED>(num_coins, ctx);
-            let basket = BASKET::mint(&mut reserve, sui, managed, ctx);
+            let basket = BASKET::mint(reserve, sui, managed, ctx);
             assert!(Coin::value(&basket) == num_coins, 1);
-            assert!(BASKET::total_supply(&reserve) == num_coins, 2);
+            assert!(BASKET::total_supply(reserve) == num_coins, 2);
 
-            let (sui, managed) = BASKET::burn(&mut reserve, basket, ctx);
+            let (sui, managed) = BASKET::burn(reserve, basket, ctx);
             assert!(Coin::value(&sui) == num_coins, 3);
             assert!(Coin::value(&managed) == num_coins, 4);
 
             Coin::keep(sui, ctx);
             Coin::keep(managed, ctx);
-            TestScenario::return_object(scenario, reserve);
+            TestScenario::return_shared_object(scenario, reserve_wrapper);
         }
     }
 

--- a/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
@@ -199,10 +199,11 @@ module Games::SharedTicTacToeTests {
         TestScenario::next_tx(scenario, player);
         let status;
         {
-            let game = TestScenario::take_object<TicTacToe>(scenario);
-            SharedTicTacToe::place_mark(&mut game, row, col, TestScenario::ctx(scenario));
-            status = SharedTicTacToe::get_status(&game);
-            TestScenario::return_object(scenario, game);
+            let game_wrapper = TestScenario::take_shared_object<TicTacToe>(scenario);
+            let game = TestScenario::borrow_mut(&mut game_wrapper);
+            SharedTicTacToe::place_mark(game, row, col, TestScenario::ctx(scenario));
+            status = SharedTicTacToe::get_status(game);
+            TestScenario::return_shared_object(scenario, game_wrapper);
         };
         status
     }

--- a/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
@@ -69,11 +69,12 @@ module NFTs::SharedAuctionTests {
         TestScenario::next_tx(scenario, &bidder1);
         {
             let coin = TestScenario::take_object<Coin<SUI>>(scenario);
-            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
+            let auction_wrapper = TestScenario::take_shared_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::borrow_mut(&mut auction_wrapper);
 
-            SharedAuction::bid(coin, &mut auction, TestScenario::ctx(scenario));
+            SharedAuction::bid(coin, auction, TestScenario::ctx(scenario));
 
-            TestScenario::return_object(scenario, auction);
+            TestScenario::return_shared_object(scenario, auction_wrapper);
         };
 
         // a transaction by the second bidder to put a bid (a bid will
@@ -82,11 +83,12 @@ module NFTs::SharedAuctionTests {
         TestScenario::next_tx(scenario, &bidder2);
         {
             let coin = TestScenario::take_object<Coin<SUI>>(scenario);
-            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
+            let auction_wrapper = TestScenario::take_shared_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::borrow_mut(&mut auction_wrapper);
 
-            SharedAuction::bid(coin, &mut auction, TestScenario::ctx(scenario));
+            SharedAuction::bid(coin, auction, TestScenario::ctx(scenario));
 
-            TestScenario::return_object(scenario, auction);
+            TestScenario::return_shared_object(scenario, auction_wrapper);
         };
 
         // a transaction by the second bidder to verify that the funds
@@ -103,13 +105,14 @@ module NFTs::SharedAuctionTests {
         // a transaction by the owner to end auction
         TestScenario::next_tx(scenario, &owner);
         {
-            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
+            let auction_wrapper = TestScenario::take_shared_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::borrow_mut(&mut auction_wrapper);
 
             // pass auction as mutable reference as its a shared
             // object that cannot be deleted
-            SharedAuction::end_auction(&mut auction, TestScenario::ctx(scenario));
+            SharedAuction::end_auction(auction, TestScenario::ctx(scenario));
 
-            TestScenario::return_object(scenario, auction);
+            TestScenario::return_shared_object(scenario, auction_wrapper);
         };
 
         // a transaction to check if the first bidder won (as the

--- a/sui_programmability/examples/objects_tutorial/sources/ColorObject.move
+++ b/sui_programmability/examples/objects_tutorial/sources/ColorObject.move
@@ -207,30 +207,16 @@ module Tutorial::ColorObjectTests {
         };
         TestScenario::next_tx(scenario, &sender1);
         {
-            assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
         };
         let sender2 = @0x2;
         TestScenario::next_tx(scenario, &sender2);
         {
-            assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
-        };
-    }
-
-    #[test]
-    #[expected_failure(abort_code = 101)]
-    public(script) fun test_mutate_immutable() {
-        let sender1 = @0x1;
-        let scenario = &mut TestScenario::begin(&sender1);
-        {
-            let ctx = TestScenario::ctx(scenario);
-            ColorObject::create_immutable(255, 0, 255, ctx);
-        };
-        TestScenario::next_tx(scenario, &sender1);
-        {
-            let object = TestScenario::take_object<ColorObject>(scenario);
-            let ctx = TestScenario::ctx(scenario);
-            ColorObject::update(&mut object, 0, 0, 0, ctx);
-            TestScenario::return_object(scenario, object);
+            let object_wrapper = TestScenario::take_immutable_object<ColorObject>(scenario);
+            let object = TestScenario::borrow(&object_wrapper);
+            let (red, green, blue) = ColorObject::get_color(object);
+            assert!(red == 255 && green == 0 && blue == 255, 0);
+            TestScenario::return_immutable_object(scenario, object_wrapper);
         };
     }
 }

--- a/sui_programmability/framework/src/natives/mod.rs
+++ b/sui_programmability/framework/src/natives/mod.rs
@@ -33,8 +33,18 @@ pub fn all_natives(
         ),
         (
             "TestScenario",
-            "get_inventory",
-            test_scenario::get_inventory,
+            "get_account_owned_inventory",
+            test_scenario::get_account_owned_inventory,
+        ),
+        (
+            "TestScenario",
+            "get_object_owned_inventory",
+            test_scenario::get_object_owned_inventory,
+        ),
+        (
+            "TestScenario",
+            "get_unowned_inventory",
+            test_scenario::get_unowned_inventory,
         ),
         ("TestScenario", "num_events", test_scenario::num_events),
         (

--- a/sui_programmability/framework/src/natives/test_scenario.rs
+++ b/sui_programmability/framework/src/natives/test_scenario.rs
@@ -28,21 +28,23 @@ type Event = (Vec<u8>, u64, Type, MoveTypeLayout, Value);
 const WRAPPED_OBJECT_EVENT: u64 = 255;
 const UPDATE_OBJECT_EVENT: u64 = 254;
 
-/// Trying to transfer an unowned object, which is not allowed.
-/// This won't be detected right away when a transfer is happening.
-/// Instead, it's detected when processing the inventory events.
-const ETRANSFER_UNOWNED_OBJECT: u64 = 100;
-
-/// Trying to mutating an immutable object.
-/// This is detected when returning an immutable object back to
-/// the inventory.
-const EMUTATING_IMMUTABLE_OBJECT: u64 = 101;
+/// When transfer an object to a parent object, the parent object
+/// is not found in the inventory.
+const EPARENT_OBJECT_NOT_FOUND: u64 = 100;
 
 #[derive(Debug)]
 struct OwnedObj {
     value: Value,
     type_: Type,
+    /// Owner is the direct owner of the object.
     owner: Owner,
+    /// Signer is the ultimate owner of the object potentially through
+    /// chains of object ownership.
+    /// e.g. If account A ownd object O1, O1 owns O2. Then
+    /// O2's owner is O1, and signer is A.
+    /// signer will always be set eventually, but it needs to be optional first
+    /// since we may not know its signer initially.
+    signer: Option<Owner>,
 }
 
 /// Set of all live objects in the current test scenario
@@ -74,10 +76,22 @@ fn get_object_id_from_event(event_type_byte: u64, val: &Value) -> Option<ObjectI
     Some(ObjectID::try_from(address.value_as::<AccountAddress>().unwrap().as_slice()).unwrap())
 }
 
+fn account_to_sui_address(address: AccountAddress) -> SuiAddress {
+    SuiAddress::try_from(address.as_slice()).unwrap()
+}
+
 /// Process the event log to determine the global set of live objects
 /// Returns the abort_code if an error is encountered.
 fn get_global_inventory(events: &[Event]) -> Result<Inventory, u64> {
     let mut inventory = Inventory::new();
+    // Since we allow transfer object to ID, it's possible that when we transfer
+    // an object to a parenet object, the parent object does not yet exist in the event log.
+    // And without the parent object we cannot know the ultimate signer.
+    // To handle this, for child objects whose parent is not yet known, we add them
+    // to the unresolved_signer_parents map, which maps from parent object ID
+    // to the list of child objects it has. Whenever a new object is seen, we check the map
+    // and resolve if the object is an unresolved parent.
+    let mut unresolved_signer_parents: BTreeMap<ObjectID, BTreeSet<ObjectID>> = BTreeMap::new();
     for (recipient, event_type_byte, type_, _layout, val) in events {
         let obj_id = if let Some(obj_id) = get_object_id_from_event(*event_type_byte, val) {
             obj_id
@@ -93,9 +107,6 @@ fn get_global_inventory(events: &[Event]) -> Result<Inventory, u64> {
         if *event_type_byte == UPDATE_OBJECT_EVENT {
             if let Some(cur) = inventory.get_mut(&obj_id) {
                 let new_value = val.copy_value().unwrap();
-                if cur.owner == Owner::Immutable && !cur.value.equals(&new_value).unwrap() {
-                    return Err(EMUTATING_IMMUTABLE_OBJECT);
-                }
                 // Update the object content since it may have been mutated.
                 cur.value = new_value;
             }
@@ -108,7 +119,28 @@ fn get_global_inventory(events: &[Event]) -> Result<Inventory, u64> {
             | EventType::TransferToObject
             | EventType::FreezeObject
             | EventType::ShareObject => {
-                let owner = get_new_owner(&inventory, &obj_id, event_type, recipient.clone())?;
+                let owner = get_new_owner(&event_type, recipient.clone());
+                let signer = if event_type == EventType::TransferToObject {
+                    let parent_id = ObjectID::try_from(recipient.as_slice()).unwrap();
+                    if let Some(parent_obj) = inventory.get(&parent_id) {
+                        parent_obj.signer
+                    } else {
+                        unresolved_signer_parents
+                            .entry(parent_id)
+                            .or_default()
+                            .insert(obj_id);
+                        None
+                    }
+                } else {
+                    Some(owner)
+                };
+                if signer.is_some() {
+                    if let Some(children) = unresolved_signer_parents.remove(&obj_id) {
+                        for child in children {
+                            inventory.get_mut(&child).unwrap().signer = signer;
+                        }
+                    }
+                }
                 // note; may overwrite older values of the object, which is intended
                 inventory.insert(
                     obj_id,
@@ -116,6 +148,7 @@ fn get_global_inventory(events: &[Event]) -> Result<Inventory, u64> {
                         value: Value::copy_value(val).unwrap(),
                         type_: type_.clone(),
                         owner,
+                        signer,
                     },
                 );
             }
@@ -126,22 +159,16 @@ fn get_global_inventory(events: &[Event]) -> Result<Inventory, u64> {
             EventType::User => (),
         }
     }
-    Ok(inventory)
+    if unresolved_signer_parents.is_empty() {
+        Ok(inventory)
+    } else {
+        Err(EPARENT_OBJECT_NOT_FOUND)
+    }
 }
 
-fn get_new_owner(
-    inventory: &Inventory,
-    obj_id: &ObjectID,
-    event_type: EventType,
-    recipient: Vec<u8>,
-) -> Result<Owner, u64> {
-    if let Some(existing) = inventory.get(obj_id) {
-        if !existing.owner.is_owned() {
-            // Unowned objects are not allowed to be transferred.
-            return Err(ETRANSFER_UNOWNED_OBJECT);
-        }
-    }
-    Ok(match event_type {
+/// Return the new owner of the object after the transfer event.
+fn get_new_owner(event_type: &EventType, recipient: Vec<u8>) -> Owner {
+    match event_type {
         EventType::FreezeObject => Owner::Immutable,
         EventType::ShareObject => Owner::Shared,
         EventType::TransferToAddress => {
@@ -149,35 +176,33 @@ fn get_new_owner(
         }
         EventType::TransferToObject => Owner::ObjectOwner(SuiAddress::try_from(recipient).unwrap()),
         _ => panic!("Unrecognized event_type"),
-    })
+    }
 }
 
 /// Get the objects of type `type_` that can be spent by `addr`
 /// Returns the abort_code if an error is encountered.
 fn get_inventory_for(
-    addr: &AccountAddress,
+    signer: Owner,
+    parent_object: Option<AccountAddress>,
     type_: &Type,
     tx_end_index: usize,
     events: &[Event],
 ) -> Result<Vec<Value>, u64> {
     let inventory = get_global_inventory(&events[..tx_end_index])?;
-    let sui_addr = SuiAddress::try_from(addr.to_vec()).unwrap();
     Ok(inventory
         .into_iter()
-        .filter_map(|(_, obj)| {
-            // TODO: We should also be able to include objects indirectly owned by the
-            // requested address through owning other objects.
-            // https://github.com/MystenLabs/sui/issues/673
-            if (obj.owner == Owner::AddressOwner(sui_addr)
-                || obj.owner == Owner::ObjectOwner(sui_addr)
-                || !obj.owner.is_owned())
-                && &obj.type_ == type_
-            {
-                Some(obj.value)
-            } else {
-                None
-            }
+        .filter(|(_, obj)| {
+            &obj.type_ == type_
+                && if let Some(parent) = parent_object {
+                    let obj_signer = obj.signer.unwrap();
+                    obj.owner
+                        == Owner::ObjectOwner(SuiAddress::try_from(parent.as_slice()).unwrap())
+                        && (!obj_signer.is_owned() || obj_signer == signer)
+                } else {
+                    obj.owner == signer
+                }
         })
+        .map(|(_, obj)| obj.value)
         .collect())
 }
 
@@ -241,7 +266,7 @@ pub fn num_events(
 }
 
 /// Return all the values of type `T` in the inventory of `owner_address`
-pub fn get_inventory(
+pub fn get_account_owned_inventory(
     context: &mut NativeContext,
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
@@ -253,7 +278,67 @@ pub fn get_inventory(
     let owner_address = pop_arg!(args, AccountAddress);
 
     let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 0);
-    match get_inventory_for(&owner_address, &ty_args[0], tx_end_index, context.events()) {
+    match get_inventory_for(
+        Owner::AddressOwner(account_to_sui_address(owner_address)),
+        None,
+        &ty_args[0],
+        tx_end_index,
+        context.events(),
+    ) {
+        Ok(inventory) => Ok(NativeResult::ok(
+            cost,
+            smallvec![Value::vector_for_testing_only(inventory)],
+        )),
+        Err(abort_code) => Ok(NativeResult::err(cost, abort_code)),
+    }
+}
+
+pub fn get_unowned_inventory(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert_eq!(ty_args.len(), 1);
+    debug_assert_eq!(args.len(), 2);
+
+    let tx_end_index = pop_arg!(args, u64) as usize;
+    let immutable = pop_arg!(args, bool);
+    let owner = if immutable {
+        Owner::Immutable
+    } else {
+        Owner::Shared
+    };
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 0);
+    match get_inventory_for(owner, None, &ty_args[0], tx_end_index, context.events()) {
+        Ok(inventory) => Ok(NativeResult::ok(
+            cost,
+            smallvec![Value::vector_for_testing_only(inventory)],
+        )),
+        Err(abort_code) => Ok(NativeResult::err(cost, abort_code)),
+    }
+}
+
+pub fn get_object_owned_inventory(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert_eq!(ty_args.len(), 1);
+    debug_assert_eq!(args.len(), 3);
+
+    let tx_end_index = pop_arg!(args, u64) as usize;
+    let parent_object = pop_arg!(args, AccountAddress);
+    let signer_address = pop_arg!(args, AccountAddress);
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 0);
+    match get_inventory_for(
+        Owner::AddressOwner(account_to_sui_address(signer_address)),
+        Some(parent_object),
+        &ty_args[0],
+        tx_end_index,
+        context.events(),
+    ) {
         Ok(inventory) => Ok(NativeResult::ok(
             cost,
             smallvec![Value::vector_for_testing_only(inventory)],

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -72,7 +72,7 @@ module Sui::CollectionTests {
         {
             let collection = TestScenario::take_object<Collection<Object>>(scenario);
             let bag = TestScenario::take_object<Bag>(scenario);
-            let obj = TestScenario::take_nested_object<Collection<Object>, Object>(scenario, &collection);
+            let obj = TestScenario::take_child_object<Collection<Object>, Object>(scenario, &collection);
             let id = *ID::id(&obj);
 
             let (obj, child_ref) = Collection::remove(&mut collection, obj);
@@ -91,7 +91,7 @@ module Sui::CollectionTests {
         {
             let collection = TestScenario::take_object<Collection<Object>>(scenario);
             let bag = TestScenario::take_object<Bag>(scenario);
-            let obj = TestScenario::take_nested_object<Bag, Object>(scenario, &bag);
+            let obj = TestScenario::take_child_object<Bag, Object>(scenario, &bag);
             let id = *ID::id(&obj);
 
             let obj = Bag::remove(&mut bag, obj);


### PR DESCRIPTION
This PR adds two primary changes:
1. `take_obect` API now only takes account owned objects. To take immutable or shared objects, it's now required to call `take_immutable_object` or `take_shared_object`. These functions return a wrapper that requires an extra borrow call to get the underlying reference.

2. `take_child_object` now authenticates both the parent object and the signer, i.e. not only the parent object matches, the ultimate signer of the parent object must also match the current context (or the ultimate signer is shared).