### PR TITLE
[sui-framework] Adds Balance module

### DIFF
--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -1,46 +1,104 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// A storable handler for `Coin` balances.
+/// Allows separation of the transferable `Coin` type and the storable
+/// `Balance` eliminating the need to create new IDs for each application
+/// that needs to hold coins.
 module Sui::Balance {
-    // use Std::Errors; // TODO: error handling
+    use Std::Errors;
+
     friend Sui::Coin;
 
+    const ENONZERO: u64 = 0;
+    const EVALUE: u64 = 0;
+
+    /// Storable balance - an inner struct of a Coin type.
+    /// Can be used to store coins which don't need to have the
+    /// key ability.
     struct Balance<phantom T> has store {
         value: u64
     }
 
+    /// Get the amount stored in a `Balance`.
     public fun value<T>(self: &Balance<T>): u64 {
         self.value
     }
 
+    /// Create an empty `Balance` for type `T`.
     public fun empty<T>(): Balance<T> {
         Balance { value: 0 }
     }
 
+    /// Join two balances together.
     public fun join<T>(self: &mut Balance<T>, balance: Balance<T>) {
         let Balance { value } = balance;
         self.value = self.value + value;
     }
 
+    /// Split a `Balance` and take a sub balance from it.
     public fun split<T>(self: &mut Balance<T>, value: u64): Balance<T> {
-        assert!(self.value >= value, 0);
+        assert!(self.value >= value, Errors::limit_exceeded(EVALUE));
         self.value = self.value - value;
         Balance { value }
     }
 
+    /// Destroy an empty `Balance`.
     public fun destroy_empty<T>(balance: Balance<T>) {
-        assert!(balance.value == 0, 0);
+        assert!(balance.value == 0, Errors::invalid_argument(ENONZERO));
         let Balance { value: _ } = balance;
     }
 
     /// Can only be called by Sui::Coin.
+    /// Create a `Balance` with a predefined value; required for minting new `Coin`s.
     public(friend) fun create<T>(value: u64): Balance<T> {
         Balance { value }
     }
 
     /// Can only be called by Sui::Coin.
+    /// Destroy a `Balance` returning its value. Required for burning `Coin`s
     public(friend) fun destroy<T>(self: Balance<T>): u64 {
         let Balance { value } = self;
         value
+    }
+
+    #[test_only]
+    public fun create_for_testing<T>(value: u64): Balance<T> {
+        create(value)
+    }
+
+    #[test_only]
+    public fun destroy_for_testing<T>(self: Balance<T>): u64 {
+        destroy(self)
+    }
+}
+
+#[test_only]
+module Sui::BalanceTests {
+    use Sui::Balance;
+    use Sui::SUI::SUI;
+
+    #[test]
+    fun test_balance() {
+        let balance = Balance::empty<SUI>();
+        let another = Balance::create_for_testing(1000);
+
+        Balance::join(&mut balance, another);
+
+        assert!(Balance::value(&balance) == 1000, 0);
+
+        let balance1 = Balance::split(&mut balance, 333);
+        let balance2 = Balance::split(&mut balance, 333);
+        let balance3 = Balance::split(&mut balance, 334);
+
+        Balance::destroy_empty(balance);
+
+        assert!(Balance::value(&balance1) == 333, 1);
+        assert!(Balance::value(&balance2) == 333, 2);
+        assert!(Balance::value(&balance3) == 334, 3);
+
+        Balance::destroy_for_testing(balance1);
+        Balance::destroy_for_testing(balance2);
+        Balance::destroy_for_testing(balance3);
     }
 }

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -1,0 +1,48 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module Sui::Balance {
+    // use Std::Errors; // TODO: error handling
+    friend Sui::Coin;
+
+    struct Balance<phantom T> has store {
+        value: u64
+    }
+
+    public fun value<T>(self: &Balance<T>): u64 {
+        self.value
+    }
+
+    public fun empty<T>(): Balance<T> {
+        Balance { value: 0 }
+    }
+
+
+
+    public fun join<T>(self: &mut Balance<T>, balance: Balance<T>) {
+        let Balance { value } = balance;
+        self.value = self.value + value;
+    }
+
+    public fun split<T>(self: &mut Balance<T>, value: u64): Balance<T> {
+        assert!(self.value >= value, 0);
+        self.value = self.value - value;
+        Balance { value }
+    }
+
+    public fun destroy_empty<T>(balance: Balance<T>) {
+        assert!(balance.value == 0, 0);
+        let Balance { value: _ } = balance;
+    }
+
+    /// Can only be called by Sui::Coin.
+    public(friend) fun create<T>(value: u64): Balance<T> {
+        Balance { value }
+    }
+
+    /// Can only be called by Sui::Coin.
+    public(friend) fun destroy<T>(self: Balance<T>): u64 {
+        let Balance { value } = self;
+        value
+    }
+}

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -51,7 +51,7 @@ module Sui::Balance {
 
     /// Can only be called by Sui::Coin.
     /// Create a `Balance` with a predefined value; required for minting new `Coin`s.
-    public(friend) fun create<T>(value: u64): Balance<T> {
+    public(friend) fun create_with_value<T>(value: u64): Balance<T> {
         Balance { value }
     }
 
@@ -63,11 +63,13 @@ module Sui::Balance {
     }
 
     #[test_only]
+    /// Create a `Balance` of any coin for testing purposes.
     public fun create_for_testing<T>(value: u64): Balance<T> {
         create(value)
     }
 
     #[test_only]
+    /// Destroy a `Balance` with any value in it for testing purposes.
     public fun destroy_for_testing<T>(self: Balance<T>): u64 {
         destroy(self)
     }

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -6,8 +6,6 @@
 /// `Balance` eliminating the need to create new IDs for each application
 /// that needs to hold coins.
 module Sui::Balance {
-    use Std::Errors;
-
     friend Sui::Coin;
 
     const ENONZERO: u64 = 0;
@@ -38,14 +36,14 @@ module Sui::Balance {
 
     /// Split a `Balance` and take a sub balance from it.
     public fun split<T>(self: &mut Balance<T>, value: u64): Balance<T> {
-        assert!(self.value >= value, Errors::limit_exceeded(EVALUE));
+        assert!(self.value >= value, EVALUE);
         self.value = self.value - value;
         Balance { value }
     }
 
     /// Destroy an empty `Balance`.
     public fun destroy_empty<T>(balance: Balance<T>) {
-        assert!(balance.value == 0, Errors::invalid_argument(ENONZERO));
+        assert!(balance.value == 0, ENONZERO);
         let Balance { value: _ } = balance;
     }
 

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -63,7 +63,7 @@ module Sui::Balance {
     #[test_only]
     /// Create a `Balance` of any coin for testing purposes.
     public fun create_for_testing<T>(value: u64): Balance<T> {
-        create(value)
+        create_with_value(value)
     }
 
     #[test_only]

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -17,8 +17,6 @@ module Sui::Balance {
         Balance { value: 0 }
     }
 
-
-
     public fun join<T>(self: &mut Balance<T>, balance: Balance<T>) {
         let Balance { value } = balance;
         self.value = self.value + value;

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -8,7 +8,9 @@
 module Sui::Balance {
     friend Sui::Coin;
 
+    /// For when trying to destroy a non-zero balance.
     const ENONZERO: u64 = 0;
+    /// For when trying to withdraw more than there is.
     const EVALUE: u64 = 0;
 
     /// Storable balance - an inner struct of a Coin type.
@@ -23,8 +25,8 @@ module Sui::Balance {
         self.value
     }
 
-    /// Create an empty `Balance` for type `T`.
-    public fun empty<T>(): Balance<T> {
+    /// Create a zero `Balance` for type `T`.
+    public fun zero<T>(): Balance<T> {
         Balance { value: 0 }
     }
 
@@ -41,8 +43,8 @@ module Sui::Balance {
         Balance { value }
     }
 
-    /// Destroy an empty `Balance`.
-    public fun destroy_empty<T>(balance: Balance<T>) {
+    /// Destroy a zero `Balance`.
+    public fun destroy_zero<T>(balance: Balance<T>) {
         assert!(balance.value == 0, ENONZERO);
         let Balance { value: _ } = balance;
     }
@@ -80,7 +82,7 @@ module Sui::BalanceTests {
 
     #[test]
     fun test_balance() {
-        let balance = Balance::empty<SUI>();
+        let balance = Balance::zero<SUI>();
         let another = Balance::create_for_testing(1000);
 
         Balance::join(&mut balance, another);
@@ -91,7 +93,7 @@ module Sui::BalanceTests {
         let balance2 = Balance::split(&mut balance, 333);
         let balance3 = Balance::split(&mut balance, 334);
 
-        Balance::destroy_empty(balance);
+        Balance::destroy_zero(balance);
 
         assert!(Balance::value(&balance1) == 333, 1);
         assert!(Balance::value(&balance2) == 333, 2);

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -39,7 +39,7 @@ module Sui::Coin {
     }
 
     /// Destruct a Coin wrapper and keep the balance.
-    public fun to_balance<T>(coin: Coin<T>): Balance<T> {
+    public fun into_balance<T>(coin: Coin<T>): Balance<T> {
         let Coin { id, balance } = coin;
         ID::delete(id);
         balance

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -28,18 +28,22 @@ module Sui::Coin {
 
     // === Balance accessors and type morphing methods ===
 
+    /// Get immutable reference to the balance of a coin.
     public fun balance<T>(coin: &Coin<T>): &Balance<T> {
         &coin.balance
     }
 
+    /// Get a mutable reference to the balance of a coin.
     public fun balance_mut<T>(coin: &mut Coin<T>): &mut Balance<T> {
         &mut coin.balance
     }
 
+    /// Wrap a balance into a Coin to make it transferable.
     public fun from_balance<T>(balance: Balance<T>, ctx: &mut TxContext): Coin<T> {
         Coin { id: TxContext::new_id(ctx), balance }
     }
 
+    /// Destruct a Coin wrapper and keep the balance.
     public fun to_balance<T>(coin: Coin<T>): Balance<T> {
         let Coin { id, balance } = coin;
         ID::delete(id);

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -36,11 +36,11 @@ module Sui::Coin {
         &mut coin.balance
     }
 
-    public fun wrap<T>(balance: Balance<T>, ctx: &mut TxContext): Coin<T> {
+    public fun from_balance<T>(balance: Balance<T>, ctx: &mut TxContext): Coin<T> {
         Coin { id: TxContext::new_id(ctx), balance }
     }
 
-    public fun unwrap<T>(coin: Coin<T>): Balance<T> {
+    public fun to_balance<T>(coin: Coin<T>): Balance<T> {
         let Coin { id, balance } = coin;
         ID::delete(id);
         balance
@@ -194,39 +194,5 @@ module Sui::Coin {
     /// Mint coins of any type for (obviously!) testing purposes only
     public fun mint_for_testing<T>(value: u64, ctx: &mut TxContext): Coin<T> {
         Coin { id: TxContext::new_id(ctx), balance: Balance::create(value) }
-    }
-}
-
-#[test_only]
-module Sui::TestCoin {
-    use Sui::TestScenario::{Self, ctx};
-    use Sui::Coin;
-    use Sui::Balance;
-    use Sui::SUI::SUI;
-
-    #[test]
-    fun type_morphing() {
-        let test = &mut TestScenario::begin(&@0x1);
-
-        let balance = Balance::empty<SUI>();
-        let coin = Coin::wrap(balance, ctx(test));
-        let balance = Coin::unwrap(coin);
-
-        Balance::destroy_empty(balance);
-
-        let coin = Coin::mint_for_testing<SUI>(100, ctx(test));
-        let balance_mut = Coin::balance_mut(&mut coin);
-        let sub_balance = Balance::split(balance_mut, 50);
-
-        assert!(Balance::value(&sub_balance) == 50, 0);
-        assert!(Coin::value(&coin) == 50, 0);
-
-        let balance = Coin::unwrap(coin);
-        Balance::join(&mut balance, sub_balance);
-
-        assert!(Balance::value(&balance) == 100, 0);
-
-        let coin = Coin::wrap(balance, ctx(test));
-        Coin::keep(coin, ctx(test));
     }
 }

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -128,7 +128,10 @@ module Sui::Coin {
         value: u64, cap: &mut TreasuryCap<T>, ctx: &mut TxContext,
     ): Coin<T> {
         cap.total_supply = cap.total_supply + value;
-        Coin { id: TxContext::new_id(ctx), balance: Balance::create(value) }
+        Coin {
+            id: TxContext::new_id(ctx),
+            balance: Balance::create_with_value(value)
+        }
     }
 
     /// Destroy the coin `c` and decrease the total supply in `cap`
@@ -192,6 +195,6 @@ module Sui::Coin {
     #[test_only]
     /// Mint coins of any type for (obviously!) testing purposes only
     public fun mint_for_testing<T>(value: u64, ctx: &mut TxContext): Coin<T> {
-        Coin { id: TxContext::new_id(ctx), balance: Balance::create(value) }
+        Coin { id: TxContext::new_id(ctx), balance: Balance::create_with_value(value) }
     }
 }

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -21,11 +21,6 @@ module Sui::Coin {
         total_supply: u64
     }
 
-    /// Trying to withdraw N from a coin with value < N
-    const EVALUE: u64 = 0;
-    /// Trying to destroy a coin with a nonzero value
-    const ENONZERO: u64 = 0;
-
     // === Balance accessors and type morphing methods ===
 
     /// Get immutable reference to the balance of a coin.

--- a/sui_programmability/framework/sources/Coin.move
+++ b/sui_programmability/framework/sources/Coin.move
@@ -97,7 +97,7 @@ module Sui::Coin {
     public fun destroy_zero<T>(c: Coin<T>) {
         let Coin { id, balance } = c;
         ID::delete(id);
-        Balance::destroy_empty(balance);
+        Balance::destroy_zero(balance);
     }
 
     // === Registering new coin types and managing the coin supply ===
@@ -105,7 +105,7 @@ module Sui::Coin {
     /// Make any Coin with a zero value. Useful for placeholding
     /// bids/payments or preemptively making empty balances.
     public fun zero<T>(ctx: &mut TxContext): Coin<T> {
-        Coin { id: TxContext::new_id(ctx), balance: Balance::empty() }
+        Coin { id: TxContext::new_id(ctx), balance: Balance::zero() }
     }
 
     /// Create a new currency type `T` as and return the `TreasuryCap`

--- a/sui_programmability/framework/tests/CoinBalanceTests.move
+++ b/sui_programmability/framework/tests/CoinBalanceTests.move
@@ -14,7 +14,7 @@ module Sui::TestCoin {
 
         let balance = Balance::empty<SUI>();
         let coin = Coin::from_balance(balance, ctx(test));
-        let balance = Coin::to_balance(coin);
+        let balance = Coin::into_balance(coin);
 
         Balance::destroy_empty(balance);
 
@@ -25,7 +25,7 @@ module Sui::TestCoin {
         assert!(Balance::value(&sub_balance) == 50, 0);
         assert!(Coin::value(&coin) == 50, 0);
 
-        let balance = Coin::to_balance(coin);
+        let balance = Coin::into_balance(coin);
         Balance::join(&mut balance, sub_balance);
 
         assert!(Balance::value(&balance) == 100, 0);

--- a/sui_programmability/framework/tests/CoinBalanceTests.move
+++ b/sui_programmability/framework/tests/CoinBalanceTests.move
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
 module Sui::TestCoin {
     use Sui::TestScenario::{Self, ctx};

--- a/sui_programmability/framework/tests/CoinBalanceTests.move
+++ b/sui_programmability/framework/tests/CoinBalanceTests.move
@@ -1,0 +1,33 @@
+#[test_only]
+module Sui::TestCoin {
+    use Sui::TestScenario::{Self, ctx};
+    use Sui::Coin;
+    use Sui::Balance;
+    use Sui::SUI::SUI;
+
+    #[test]
+    fun type_morphing() {
+        let test = &mut TestScenario::begin(&@0x1);
+
+        let balance = Balance::empty<SUI>();
+        let coin = Coin::from_balance(balance, ctx(test));
+        let balance = Coin::to_balance(coin);
+
+        Balance::destroy_empty(balance);
+
+        let coin = Coin::mint_for_testing<SUI>(100, ctx(test));
+        let balance_mut = Coin::balance_mut(&mut coin);
+        let sub_balance = Balance::split(balance_mut, 50);
+
+        assert!(Balance::value(&sub_balance) == 50, 0);
+        assert!(Coin::value(&coin) == 50, 0);
+
+        let balance = Coin::to_balance(coin);
+        Balance::join(&mut balance, sub_balance);
+
+        assert!(Balance::value(&balance) == 100, 0);
+
+        let coin = Coin::from_balance(balance, ctx(test));
+        Coin::keep(coin, ctx(test));
+    }
+}

--- a/sui_programmability/framework/tests/CoinBalanceTests.move
+++ b/sui_programmability/framework/tests/CoinBalanceTests.move
@@ -12,11 +12,11 @@ module Sui::TestCoin {
     fun type_morphing() {
         let test = &mut TestScenario::begin(&@0x1);
 
-        let balance = Balance::empty<SUI>();
+        let balance = Balance::zero<SUI>();
         let coin = Coin::from_balance(balance, ctx(test));
         let balance = Coin::into_balance(coin);
 
-        Balance::destroy_empty(balance);
+        Balance::destroy_zero(balance);
 
         let coin = Coin::mint_for_testing<SUI>(100, ctx(test));
         let balance_mut = Coin::balance_mut(&mut coin);


### PR DESCRIPTION
Covers #1233.

> This PR has a draft status and used for demonstration purposes.  
> UPD: converted to normal PR as it seems complete.

### Pros

1. Balance is a small and nice module with zero dependencies; 
2. It is possible to implement custom wrappers on a Balance type;
3. Coin is transferable wrapper around Balance; possibly not needed in some applications;
4. Separation of modules resolves name collisions and helps readability (Coin is for minting and handling accounts, balance is its internals);
5. Balance doesn't use `TxContext` at all and has no IDs - which is great!

### Cons

1. Multi-layer solutions complicate things;
2. We'll need to have a guide/tutorial on how to use them (def!); and when to use Coin or Balance;
3. Since `Coin` handles minting, Balance is always bound to it and cannot be used freely for custom implementations of finances;
4. To take a Coin from a balance, few calls needed: 
```rs
let balance = Balance { value: 100 }; // roughly
let coin = Coin::from_balance(Balance::split(&mut balance, 50), ctx);
``` 
