### PR TITLE
Expose allocation error

### DIFF
--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -25,6 +25,7 @@ ed25519-dalek = "1.0.1"
 scopeguard = "1.1.0"
 clap = { version = "3.1.8", features = ["derive"] }
 fdlimit = "0.2.1"
+bincode = "1.3.3"
 
 sui-adapter = { path = "../sui_programmability/adapter" }
 sui-framework = { path = "../sui_programmability/framework" }

--- a/sui_core/src/consensus_adapter.rs
+++ b/sui_core/src/consensus_adapter.rs
@@ -146,7 +146,8 @@ impl ConsensusSubmitter {
         certificate.check(&self.committee)?;
 
         // Send certificate to consensus
-        let serialized = serialize_consensus_transaction(certificate);
+        //let serialized = serialize_consensus_transaction(certificate);
+        let serialized = bincode::serialize(certificate).unwrap();
         let bytes = Bytes::from(serialized.clone());
         // TODO [issue #1452]: We are re-creating a connection every time. This is wasteful but does not
         // require to take self as a mutable reference.


### PR DESCRIPTION
**Do not Merge!**

Minimal changes to reproduce the following error when running `cargo test -p sui_core`:
```
memory allocation of 11111879338867120743 bytes failed
error: test failed, to rerun pass '-p sui_core --lib'
```

I didn't manage to get the stack trace, below is the complete output:
```
alberto@Albertos-MacBook-Pro-14 sui % cargo test -p sui_core
warning: unused import: `sui_types::serialize::serialize_consensus_transaction`
  --> sui_core/src/consensus_adapter.rs:15:5
   |
15 | use sui_types::serialize::serialize_consensus_transaction;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `sui_core` (lib) generated 1 warning
warning: `sui_core` (lib test) generated 1 warning (1 duplicate)
    Finished test [unoptimized + debuginfo] target(s) in 0.18s
     Running unittests (target/debug/deps/sui_core-fed5ccc3cda8a245)

running 60 tests
test authority::authority_tests::test_handle_confirmation_transaction_bad_sequence_number ... ignored
test authority::authority_notifier::tests::test_notifier ... ok
test authority::authority_tests::test_handle_confirmation_transaction_ok ... ok
test authority::authority_tests::test_handle_confirmation_transaction_receiver_equal_sender ... ok
test authority::authority_tests::test_handle_confirmation_transaction_idempotent ... ok
test authority::authority_tests::test_account_state_unknown_account ... ok
test authority::authority_tests::test_account_state_ok ... ok
test authority::authority_tests::test_handle_confirmation_transaction_unknown_sender ... ok
test authority::authority_tests::test_get_latest_parent_entry ... ok
test authority::authority_tests::shared_object ... ok
test authority::authority_tests::test_authority_persist ... ok
test authority::authority_tests::test_handle_move_transaction ... ok
test authority::authority_tests::test_handle_transfer_transaction_double_spend ... ok
test authority::authority_tests::test_handle_transfer_transaction_ok ... ok
test authority::authority_tests::test_immutable_gas ... ok
test authority::authority_tests::test_handle_transfer_transaction_bad_signature ... ok
test authority::authority_tests::test_handle_transfer_transaction_unknown_sender ... ok
test authority::authority_tests::test_publish_dependent_module_ok ... ok
test authority::authority_tests::test_move_call_delete ... ok
test authority::authority_tests::test_move_call_mutable_object_not_mutated ... ok
test authority::authority_tests::test_publish_module_no_dependencies_ok ... ok
test authority::authority_tests::test_publish_non_existing_dependent_module ... ok
test authority::authority_tests::test_transfer_package ... ok
test authority::gas_tests::test_storage_gas_unit_price ... ok
test authority::batch_transaction_tests::test_batch_contains_publish ... ok
test authority::batch_transaction_tests::test_batch_insufficient_gas_balance ... ok
test authority::gas_tests::test_native_transfer_sufficient_gas ... ok
test authority::gas_tests::test_native_transfer_insufficient_gas_reading_objects ... ok
test authority::gas_tests::test_move_call_gas ... ok
test authority::batch_transaction_tests::test_batch_transaction_last_one_fail ... ok
test authority::gas_tests::test_tx_gas_balance_less_than_budget ... ok
test authority::gas_tests::test_tx_less_than_minimum_gas_budget ... ok
test authority::batch_transaction_tests::test_batch_transaction_ok ... ok
test authority::gas_tests::test_tx_more_than_maximum_gas_budget ... ok
test authority::gas_tests::test_native_transfer_insufficient_gas_execution ... ok
test authority::gas_tests::test_publish_gas ... ok
test authority::move_integration_tests::test_object_owning_another_object ... ok
test authority_batch::batch_tests::test_batch_manager_happy_path ... ok
test authority::move_integration_tests::test_object_wrapping_unwrapping ... ok
test authority_batch::batch_tests::test_batch_manager_out_of_order ... ok
test authority_batch::batch_tests::test_batch_store_retrieval ... ok
test authority_batch::batch_tests::test_handle_move_order_with_batch ... ok
test authority_batch::batch_tests::test_safe_batch_stream ... ok
test consensus_adapter::consensus_tests::listen_to_sequenced_transaction ... ok
test authority_server::server_tests::test_channel_infra ... ok
test authority_batch::batch_tests::test_open_manager ... ok
test authority_server::server_tests::test_start_stop_batch_subsystem ... ok
memory allocation of 11111879338867120743 bytes failed
error: test failed, to rerun pass '-p sui_core --lib'

Caused by:
  process didn't exit successfully: `/Users/alberto/GitHub/sui/target/debug/deps/sui_core-fed5ccc3cda8a245` (signal: 6, SIGABRT: process abort signal)
alberto@Albertos-MacBook-Pro-14 sui % 
```