### PR TITLE
Remove unnecessary sync in wallet 

### DIFF
--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -508,21 +508,6 @@ impl WalletCommands {
                 WalletCommandResult::CreateExampleNFT(object_read)
             }
         });
-        // Sync all managed addresses
-        // This is wasteful because not all addresses might be modified
-        // but will be removed as part of https://github.com/MystenLabs/sui/issues/1045
-        match self {
-            WalletCommands::Publish { .. }
-            | WalletCommands::Call { .. }
-            | WalletCommands::Transfer { .. }
-            | WalletCommands::SplitCoin { .. }
-            | WalletCommands::MergeCoin { .. } => {
-                for address in context.config.accounts.clone() {
-                    context.gateway.sync_account_state(address).await?;
-                }
-            }
-            _ => {}
-        }
         ret
     }
 }


### PR DESCRIPTION
We still need the sync when the wallet first connected to the gateway, because the gateway still have no way to get the genesis objects.

