### PR TITLE
fix: make self-hosted actions able to run on generic ubuntu (rather than latest)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,7 @@ jobs:
   bench:
     needs: diff
     if: github.event.pull_request.draft == false && needs.diff.outputs.isRust == 'true'
-    runs-on: [self-hosted, ubuntu-latest]
+    runs-on: [self-hosted, ubuntu]
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,7 +23,7 @@ jobs:
     name: Generate code coverage
     needs: diff
     if: github.event.pull_request.draft == false && needs.diff.outputs.isRust == 'true'
-    runs-on: [self-hosted, ubuntu-latest]
+    runs-on: [self-hosted, ubuntu]
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   beta:
     name: Run test on the beta channel
-    runs-on: [self-hosted, ubuntu-latest]
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v3
       - name: Install beta toolchain
@@ -49,7 +49,7 @@ jobs:
 
   release:
     name: build release binaries
-    runs-on: [self-hosted, ubuntu-latest]
+    runs-on: [self-hosted, ubuntu]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
   test:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [self-hosted, ubuntu-latest]
+    runs-on: [self-hosted, ubuntu]
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
Solves starvation on lack of self-hosted runners @Ubuntu 22