### PR TITLE
fix: ignore flaky test call_shared_object_contract

### DIFF
--- a/sui/tests/shared_objects_tests.rs
+++ b/sui/tests/shared_objects_tests.rs
@@ -101,6 +101,7 @@ async fn shared_object_transaction() {
 }
 
 #[tokio::test]
+#[ignore = "Flaky, see #1624"]
 async fn call_shared_object_contract() {
     let mut gas_objects = test_gas_objects();
 


### PR DESCRIPTION
See #1624 