### PR TITLE
[docs] Update recommended cargo version

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -5,7 +5,7 @@ title: Install Sui
 Sui is written in Rust, and we are using Cargo to build and manage the
 dependencies.  As a prerequisite, you will need to [install
 Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-version 1.59.0 or higher in order to build and install Sui on your machine.
+version 1.60.0 or higher in order to build and install Sui on your machine.
 
 ## Binaries
 


### PR DESCRIPTION
Currently, the recommended `cargo` version for `sui` is `1.59.0`. However, this is no longer applicable since PR #1541, which breaks compatibility with `1.59.0` because of the use of `output.stderr.escape_ascii()` in `sui/build.rs`. 

This change simply updates the docs to suggest `1.60.0` instead.

This issue affects other users as well. See https://github.com/MystenLabs/sui/issues/1605