### PR TITLE
Add test (and fix) to ensure idempotent response when confirm after tx

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -190,7 +190,9 @@ impl AuthorityState {
         let transaction_digest = transaction.digest();
 
         // Ensure an idempotent answer.
-        if self._database.transaction_exists(&transaction_digest)? {
+        if self._database.transaction_exists(&transaction_digest)?
+            || self._database.effects_exists(&transaction_digest)?
+        {
             let transaction_info = self.make_transaction_info(&transaction_digest).await?;
             return Ok(transaction_info);
         }


### PR DESCRIPTION
@oxade discovered an interesting issue in the distributed benchmarking where we are seeing lock errors when confirmation tx arrived out of order after the tx.
If an authority processes a certificate before seeing the transaction, it shouldn't error out but should be able to return the response that contains the known effect.
This PR adds a test to exercise it, and also a fix?