### PR TITLE
Add handle_consensus_transaction to AuthorityAPI and call it from gateway

### DIFF
--- a/sui/src/config.rs
+++ b/sui/src/config.rs
@@ -114,7 +114,7 @@ impl<'de> Deserialize<'de> for AuthorityPrivateInfo {
                 .map_err(serde::de::Error::custom)?
                 .next_port()
                 .ok_or_else(|| serde::de::Error::custom("No available port."))?;
-            socket_addr_from_hostport("localhost", port)
+            socket_addr_from_hostport("127.0.0.1", port)
         };
 
         Ok(AuthorityPrivateInfo {

--- a/sui/tests/shared_objects_tests.rs
+++ b/sui/tests/shared_objects_tests.rs
@@ -108,7 +108,7 @@ async fn call_shared_object_contract() {
     let configs = test_authority_configs();
     let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
 
-    // Publish the move package to all authorities and get the new pacakge ref.
+    // Publish the move package to all authorities and get the new package ref.
     tokio::task::yield_now().await;
     let transaction = publish_move_package_transaction(gas_objects.pop().unwrap());
     let replies = submit_single_owner_transaction(transaction, &configs).await;

--- a/sui_core/src/authority_client.rs
+++ b/sui_core/src/authority_client.rs
@@ -39,6 +39,12 @@ pub trait AuthorityAPI {
         transaction: ConfirmationTransaction,
     ) -> Result<TransactionInfoResponse, SuiError>;
 
+    /// Processes consensus request.
+    async fn handle_consensus_transaction(
+        &self,
+        transaction: ConsensusTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError>;
+
     /// Handle Account information requests for this account.
     async fn handle_account_info_request(
         &self,
@@ -96,6 +102,17 @@ impl AuthorityAPI for NetworkAuthorityClient {
         let response = self
             .0
             .send_recv_bytes(serialize_cert(&transaction.certificate))
+            .await?;
+        deserialize_transaction_info(response)
+    }
+
+    async fn handle_consensus_transaction(
+        &self,
+        transaction: ConsensusTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        let response = self
+            .0
+            .send_recv_bytes(serialize_consensus_transaction(&transaction))
             .await?;
         deserialize_transaction_info(response)
     }
@@ -211,6 +228,13 @@ impl AuthorityAPI for LocalAuthorityClient {
             .handle_confirmation_transaction(transaction)
             .await;
         result
+    }
+
+    async fn handle_consensus_transaction(
+        &self,
+        _transaction: ConsensusTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        unimplemented!("LocalAuthorityClient does not support consensus transaction");
     }
 
     async fn handle_account_info_request(

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -302,6 +302,16 @@ where
         Ok(transaction_info)
     }
 
+    async fn handle_consensus_transaction(
+        &self,
+        transaction: ConsensusTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        // TODO: Add safety checks on the response.
+        self.authority_client
+            .handle_consensus_transaction(transaction)
+            .await
+    }
+
     async fn handle_account_info_request(
         &self,
         request: AccountInfoRequest,

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use std::{env, io};
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    ConfirmationTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
-    TransactionInfoRequest, TransactionInfoResponse,
+    ConfirmationTransaction, ConsensusTransaction, ObjectInfoRequest, ObjectInfoResponse,
+    Transaction, TransactionInfoRequest, TransactionInfoResponse,
 };
 use sui_types::object::Object;
 
@@ -443,6 +443,17 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         })
     }
 
+    async fn handle_consensus_transaction(
+        &self,
+        _transaction: ConsensusTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
     async fn handle_account_info_request(
         &self,
         _request: AccountInfoRequest,
@@ -543,6 +554,17 @@ impl AuthorityAPI for ByzantineAuthorityClient {
     async fn handle_confirmation_transaction(
         &self,
         _transaction: ConfirmationTransaction,
+    ) -> Result<TransactionInfoResponse, SuiError> {
+        Ok(TransactionInfoResponse {
+            signed_transaction: None,
+            certified_transaction: None,
+            signed_effects: None,
+        })
+    }
+
+    async fn handle_consensus_transaction(
+        &self,
+        _transaction: ConsensusTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         Ok(TransactionInfoResponse {
             signed_transaction: None,


### PR DESCRIPTION
This PR adds two things:
1. A new API in AuthorityAPI that takes in ConsensusTransaction.
2. Send ConsensusTransaction from gateway when there are shared objects in the transaction.

Unfortunately we cannot test this in gateway_state_tests yet. We will need to be able to connect to the consensus engine in LocalAuthorityClient.