### PR TITLE
[documentation] update cargo install instructions

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -12,7 +12,7 @@ version 1.59.0 or higher in order to build and install Sui on your machine.
 To develop in Sui, you will need the Sui binaries. After installing `cargo`, run:
 
 ```shell
-$ cargo install --git https://github.com/MystenLabs/sui.git
+$ cargo install --git https://github.com/MystenLabs/sui.git sui
 ```
 
 This will put three binaries in your `PATH` (ex. under `~/.cargo/bin`) that provide these command line interfaces (CLIs):


### PR DESCRIPTION
Fixed the error 

```
➜ cargo install --git https://github.com/MystenLabs/sui.git
    Updating git repository `https://github.com/MystenLabs/sui.git`
error: multiple packages with binaries found: sui, sui-faucet. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify which to install.
```