### PR TITLE
[Faucet] Increase default gas budget

### DIFF
--- a/faucet/src/main.rs
+++ b/faucet/src/main.rs
@@ -40,7 +40,7 @@ struct FaucetConfig {
     #[clap(long, default_value = "127.0.0.1")]
     host_ip: Ipv4Addr,
 
-    #[clap(long, default_value_t = 2000)]
+    #[clap(long, default_value_t = 50000)]
     amount: u64,
 
     #[clap(long, default_value_t = 5)]


### PR DESCRIPTION
A typical publish can cost 10000 gas. 1000 is likely not enough to do anything meaningful.
Let me know if this is too big.