### PR TITLE
[move] ECamelCase all errors

### DIFF
--- a/sui_programmability/examples/basics/sources/Lock.move
+++ b/sui_programmability/examples/basics/sources/Lock.move
@@ -13,13 +13,13 @@ module Basics::Lock {
     use Std::Option::{Self, Option};
 
     /// Lock is empty, nothing to take.
-    const ELOCK_IS_EMPTY: u64 = 0;
+    const ELockIsEmpty: u64 = 0;
 
     /// Key does not match the Lock.
-    const EKEY_MISMATCH: u64 = 1;
+    const EKeyMismatch: u64 = 1;
 
     /// Lock already contains something.
-    const ELOCK_IS_FULL: u64 = 2;
+    const ELockIsFull: u64 = 2;
 
     /// Lock that stores any content inside it.
     struct Lock<T: store + key> has key, store {
@@ -64,8 +64,8 @@ module Basics::Lock {
         key: &Key<T>,
         _ctx: &mut TxContext,
     ) {
-        assert!(Option::is_none(&lock.locked), ELOCK_IS_FULL);
-        assert!(&key.for == ID::id(lock), EKEY_MISMATCH);
+        assert!(Option::is_none(&lock.locked), ELockIsFull);
+        assert!(&key.for == ID::id(lock), EKeyMismatch);
 
         Option::fill(&mut lock.locked, obj);
     }
@@ -78,8 +78,8 @@ module Basics::Lock {
         lock: &mut Lock<T>,
         key: &Key<T>,
     ): T {
-        assert!(Option::is_some(&lock.locked), ELOCK_IS_EMPTY);
-        assert!(&key.for == ID::id(lock), EKEY_MISMATCH);
+        assert!(Option::is_some(&lock.locked), ELockIsEmpty);
+        assert!(&key.for == ID::id(lock), EKeyMismatch);
 
         Option::extract(&mut lock.locked)
     }

--- a/sui_programmability/examples/basics/sources/Sandwich.move
+++ b/sui_programmability/examples/basics/sources/Sandwich.move
@@ -39,10 +39,9 @@ module Basics::Sandwich {
     const BREAD_PRICE: u64 = 2;
 
     /// Not enough funds to pay for the good in question
-    const EINSUFFICIENT_FUNDS: u64 = 0;
-
+    const EInsufficientFunds: u64 = 0;
     /// Nothing to withdraw
-    const ENO_PROFITS: u64 = 1;
+    const ENoProfits: u64 = 1;
 
     /// On module init, create a grocery
     fun init(ctx: &mut TxContext) {
@@ -62,7 +61,7 @@ module Basics::Sandwich {
         c: Coin<SUI>,
         ctx: &mut TxContext
     ) {
-        assert!(Coin::value(&c) == HAM_PRICE, EINSUFFICIENT_FUNDS);
+        assert!(Coin::value(&c) == HAM_PRICE, EInsufficientFunds);
         Coin::join(&mut grocery.profits, c);
         Transfer::transfer(Ham { id: TxContext::new_id(ctx) }, TxContext::sender(ctx))
     }
@@ -73,7 +72,7 @@ module Basics::Sandwich {
         c: Coin<SUI>,
         ctx: &mut TxContext
     ) {
-        assert!(Coin::value(&c) == BREAD_PRICE, EINSUFFICIENT_FUNDS);
+        assert!(Coin::value(&c) == BREAD_PRICE, EInsufficientFunds);
         Coin::join(&mut grocery.profits, c);
         Transfer::transfer(Bread { id: TxContext::new_id(ctx) }, TxContext::sender(ctx))
     }
@@ -98,7 +97,7 @@ module Basics::Sandwich {
     public(script) fun collect_profits(_cap: &GroceryOwnerCapability, grocery: &mut Grocery, ctx: &mut TxContext) {
         let amount = Coin::value(&grocery.profits);
 
-        assert!(amount > 0, ENO_PROFITS);
+        assert!(amount > 0, ENoProfits);
 
         let coin = Coin::withdraw(&mut grocery.profits, amount, ctx);
         Transfer::transfer(coin, TxContext::sender(ctx));

--- a/sui_programmability/examples/defi/sources/Escrow.move
+++ b/sui_programmability/examples/defi/sources/Escrow.move
@@ -25,9 +25,9 @@ module DeFi::Escrow {
 
     // Error codes
     /// The `sender` and `recipient` of the two escrowed objects do not match
-    const EMISMATCHED_SENDER_RECIPIENT: u64 = 0;
+    const EMismatchedSenderRecipient: u64 = 0;
     /// The `exchange_for` fields of the two escrowed objects do not match
-    const EMISMATCHED_EXCHANGE_OBJECT: u64 = 1;
+    const EMismatchedExchangeObject: u64 = 1;
 
     /// Create an escrow for exchanging goods with
     /// `counterparty`, mediated by a `third_party`
@@ -73,11 +73,11 @@ module DeFi::Escrow {
         ID::delete(id1);
         ID::delete(id2);
         // check sender/recipient compatibility
-        assert!(&sender1 == &recipient2, EMISMATCHED_SENDER_RECIPIENT);
-        assert!(&sender2 == &recipient1, EMISMATCHED_SENDER_RECIPIENT);
+        assert!(&sender1 == &recipient2, EMismatchedSenderRecipient);
+        assert!(&sender2 == &recipient1, EMismatchedSenderRecipient);
         // check object ID compatibility
-        assert!(ID::id(&escrowed1) == &exchange_for2, EMISMATCHED_EXCHANGE_OBJECT);
-        assert!(ID::id(&escrowed2) == &exchange_for1, EMISMATCHED_EXCHANGE_OBJECT);
+        assert!(ID::id(&escrowed1) == &exchange_for2, EMismatchedExchangeObject);
+        assert!(ID::id(&escrowed2) == &exchange_for1, EMismatchedExchangeObject);
         // everything matches. do the swap!
         Transfer::transfer(escrowed1, sender2);
         Transfer::transfer(escrowed2, sender1)

--- a/sui_programmability/examples/defi/sources/FlashLender.move
+++ b/sui_programmability/examples/defi/sources/FlashLender.move
@@ -43,23 +43,23 @@ module DeFi::FlashLender {
 
     /// Attempted to borrow more than the `FlashLender` has.
     /// Try borrowing a smaller amount.
-    const ELOAN_TOO_LARGE: u64 = 0;
+    const ELoanTooLarge: u64 = 0;
 
     /// Tried to repay an amount other than `repay_amount` (i.e., the amount borrowed + the fee).
     /// Try repaying the proper amount.
-    const EINVALID_REPAYMENT_AMOUNT: u64 = 1;
+    const EInvalidRepaymentAmount: u64 = 1;
 
     /// Attempted to repay a `FlashLender` that was not the source of this particular debt.
     /// Try repaying the correct lender.
-    const EREPAY_TO_WRONG_LENDER: u64 = 2;
+    const ERepayToWrongLender: u64 = 2;
 
     /// Attempted to perform an admin-only operation without valid permissions
     /// Try using the correct `AdminCap`
-    const EADMIN_ONLY: u64 = 3;
+    const EAdminOnly: u64 = 3;
 
     /// Attempted to withdraw more than the `FlashLender` has.
     /// Try withdrawing a smaller amount.
-    const EWITHDRAW_TOO_LARGE: u64 = 4;
+    const EWithdrawTooLarge: u64 = 4;
 
     // === Creating a flash lender ===
 
@@ -91,7 +91,7 @@ module DeFi::FlashLender {
         self: &mut FlashLender<T>, amount: u64, ctx: &mut TxContext
     ): (Coin<T>, Receipt<T>) {
         let to_lend = &mut self.to_lend;
-        assert!(Coin::value(to_lend) >= amount, ELOAN_TOO_LARGE);
+        assert!(Coin::value(to_lend) >= amount, ELoanTooLarge);
         let loan = Coin::withdraw(to_lend, amount, ctx);
 
         let repay_amount = amount + self.fee;
@@ -104,8 +104,8 @@ module DeFi::FlashLender {
     /// that issued the original loan.
     public fun repay<T>(self: &mut FlashLender<T>, payment: Coin<T>, receipt: Receipt<T>) {
         let Receipt { flash_lender_id, repay_amount } = receipt;
-        assert!(ID::id(self) == &flash_lender_id, EREPAY_TO_WRONG_LENDER);
-        assert!(Coin::value(&payment) == repay_amount, EINVALID_REPAYMENT_AMOUNT);
+        assert!(ID::id(self) == &flash_lender_id, ERepayToWrongLender);
+        assert!(Coin::value(&payment) == repay_amount, EInvalidRepaymentAmount);
 
         Coin::join(&mut self.to_lend, payment)
     }
@@ -123,7 +123,7 @@ module DeFi::FlashLender {
         check_admin(self, admin_cap);
 
         let to_lend = &mut self.to_lend;
-        assert!(Coin::value(to_lend) >= amount, EWITHDRAW_TOO_LARGE);
+        assert!(Coin::value(to_lend) >= amount, EWithdrawTooLarge);
         Coin::withdraw(to_lend, amount, ctx)
     }
 
@@ -148,7 +148,7 @@ module DeFi::FlashLender {
     }
 
     fun check_admin<T>(self: &FlashLender<T>, admin_cap: &AdminCap) {
-        assert!(ID::id(self) == &admin_cap.flash_lender_id, EADMIN_ONLY);
+        assert!(ID::id(self) == &admin_cap.flash_lender_id, EAdminOnly);
     }
 
     // === Reads ===

--- a/sui_programmability/examples/defi/sources/SharedEscrow.move
+++ b/sui_programmability/examples/defi/sources/SharedEscrow.move
@@ -24,13 +24,13 @@ module DeFi::SharedEscrow {
 
     // Error codes
     /// An attempt to cancel escrow by a different user than the owner
-    const EWRONG_OWNER: u64 = 0;
+    const EWrongOwner: u64 = 0;
     /// Exchange by a different user than the `recipient` of the escrowed object
-    const EWRONG_RECIPIENT: u64 = 1;
+    const EWrongRecipient: u64 = 1;
     /// Exchange with a different item than the `exchange_for` field
-    const EWRONG_EXCHANGE_OBJECT: u64 = 2;
+    const EWrongExchangeObject: u64 = 2;
     /// The escrow has already been exchanged or cancelled
-    const EALREADY_EXCHANGED_OR_CANCELLED: u64 = 3;
+    const EAlreadyExchangedOrCancelled: u64 = 3;
 
     /// Create an escrow for exchanging goods with counterparty
     public fun create<T: key + store, ExchangeForT: key + store>(
@@ -55,10 +55,10 @@ module DeFi::SharedEscrow {
         escrow: &mut EscrowedObj<T, ExchangeForT>,
         ctx: &mut TxContext
     ) {
-        assert!(Option::is_some(&escrow.escrowed), EALREADY_EXCHANGED_OR_CANCELLED);
+        assert!(Option::is_some(&escrow.escrowed), EAlreadyExchangedOrCancelled);
         let escrowed_item = Option::extract<T>(&mut escrow.escrowed);
-        assert!(&TxContext::sender(ctx) == &escrow.recipient, EWRONG_RECIPIENT);
-        assert!(ID::id(&obj) == &escrow.exchange_for, EWRONG_EXCHANGE_OBJECT);
+        assert!(&TxContext::sender(ctx) == &escrow.recipient, EWrongRecipient);
+        assert!(ID::id(&obj) == &escrow.exchange_for, EWrongExchangeObject);
         // everything matches. do the swap!
         Transfer::transfer(escrowed_item, TxContext::sender(ctx));
         Transfer::transfer(obj, escrow.creator);
@@ -69,8 +69,8 @@ module DeFi::SharedEscrow {
         escrow: &mut EscrowedObj<T, ExchangeForT>,
         ctx: &mut TxContext
     ) {
-        assert!(&TxContext::sender(ctx) == &escrow.creator, EWRONG_OWNER);
-        assert!(Option::is_some(&escrow.escrowed), EALREADY_EXCHANGED_OR_CANCELLED);
+        assert!(&TxContext::sender(ctx) == &escrow.creator, EWrongOwner);
+        assert!(Option::is_some(&escrow.escrowed), EAlreadyExchangedOrCancelled);
         Transfer::transfer(Option::extract<T>(&mut escrow.escrowed), escrow.creator);
     }
 }

--- a/sui_programmability/examples/defi/tests/EscrowTests.move
+++ b/sui_programmability/examples/defi/tests/EscrowTests.move
@@ -15,8 +15,8 @@ module DeFi::EscrowTests {
     const RANDOM_ADDRESS: address = @123;
 
     // Error codes.
-    const ESWAP_TRANSFER_FAILED: u64 = 0;
-    const ERETURN_TRANSFER_FAILED: u64 = 0;
+    const ESwapTransferFailed: u64 = 0;
+    const EReturnTransferFailed: u64 = 0;
 
     // Example of an object type used for exchange
     struct ItemA has key, store {
@@ -35,8 +35,8 @@ module DeFi::EscrowTests {
         swap(scenario, &THIRD_PARTY_ADDRESS);
 
         // Alice now owns item B, and Bob now owns item A
-        assert!(owns_object<ItemB>(scenario, &ALICE_ADDRESS), ESWAP_TRANSFER_FAILED);
-        assert!(owns_object<ItemA>(scenario, &BOB_ADDRESS), ESWAP_TRANSFER_FAILED);
+        assert!(owns_object<ItemB>(scenario, &ALICE_ADDRESS), ESwapTransferFailed);
+        assert!(owns_object<ItemA>(scenario, &BOB_ADDRESS), ESwapTransferFailed);
     }
 
     #[test]
@@ -57,8 +57,8 @@ module DeFi::EscrowTests {
         };
 
         // Alice now owns item A, and Bob now owns item B
-        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
-        assert!(owns_object<ItemB>(scenario, &BOB_ADDRESS), ERETURN_TRANSFER_FAILED);
+        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), EReturnTransferFailed);
+        assert!(owns_object<ItemB>(scenario, &BOB_ADDRESS), EReturnTransferFailed);
     }
 
     #[test]

--- a/sui_programmability/examples/defi/tests/SharedEscrowTest.move
+++ b/sui_programmability/examples/defi/tests/SharedEscrowTest.move
@@ -15,8 +15,8 @@ module DeFi::SharedEscrowTests {
     const RANDOM_ADDRESS: address = @123;
 
     // Error codes.
-    const ESWAP_TRANSFER_FAILED: u64 = 0;
-    const ERETURN_TRANSFER_FAILED: u64 = 0;
+    const ESwapTransferFailed: u64 = 0;
+    const EReturnTransferFailed: u64 = 0;
 
     // Example of an object type used for exchange
     struct ItemA has key, store {
@@ -37,8 +37,8 @@ module DeFi::SharedEscrowTests {
         exchange(&mut scenario, &BOB_ADDRESS, item_b_versioned_id);
 
         // Alice now owns item B, and Bob now owns item A
-        assert!(owns_object<ItemB>(&mut scenario, &ALICE_ADDRESS), ESWAP_TRANSFER_FAILED);
-        assert!(owns_object<ItemA>(&mut scenario, &BOB_ADDRESS), ESWAP_TRANSFER_FAILED);
+        assert!(owns_object<ItemB>(&mut scenario, &ALICE_ADDRESS), ESwapTransferFailed);
+        assert!(owns_object<ItemA>(&mut scenario, &BOB_ADDRESS), ESwapTransferFailed);
     }
 
     #[test]
@@ -48,13 +48,13 @@ module DeFi::SharedEscrowTests {
         ID::delete(id);
         let scenario = &mut scenario;
         // Alice does not own item A
-        assert!(!owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+        assert!(!owns_object<ItemA>(scenario, &ALICE_ADDRESS), EReturnTransferFailed);
 
         // Alice cancels the escrow
         cancel(scenario, &ALICE_ADDRESS);
 
         // Alice now owns item A
-        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), EReturnTransferFailed);
     }
 
     #[test]
@@ -103,13 +103,13 @@ module DeFi::SharedEscrowTests {
         ID::delete(id);
         let scenario = &mut scenario;
         // Alice does not own item A
-        assert!(!owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+        assert!(!owns_object<ItemA>(scenario, &ALICE_ADDRESS), EReturnTransferFailed);
 
         // Alice cancels the escrow
         cancel(scenario, &ALICE_ADDRESS);
 
         // Alice now owns item A
-        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), ERETURN_TRANSFER_FAILED);
+        assert!(owns_object<ItemA>(scenario, &ALICE_ADDRESS), EReturnTransferFailed);
 
         // Alice tries to cancel the escrow again
         cancel(scenario, &ALICE_ADDRESS);

--- a/sui_programmability/examples/fungible_tokens/sources/BASKET.move
+++ b/sui_programmability/examples/fungible_tokens/sources/BASKET.move
@@ -30,7 +30,7 @@ module FungibleTokens::BASKET {
     }
 
     /// Needed to deposit a 1:1 ratio of SUI and MANAGED for minting, but deposited a different ratio
-    const EBAD_DEPOSIT_RATIO: u64 = 0;
+    const EBadDepositRatio: u64 = 0;
 
     fun init(ctx: &mut TxContext) {
         // Get a treasury cap for the coin put it in the reserve
@@ -50,7 +50,7 @@ module FungibleTokens::BASKET {
         reserve: &mut Reserve, sui: Coin<SUI>, managed: Coin<MANAGED>, ctx: &mut TxContext
     ): Coin<BASKET> {
         let num_sui = Coin::value(&sui);
-        assert!(num_sui == Coin::value(&managed), EBAD_DEPOSIT_RATIO);
+        assert!(num_sui == Coin::value(&managed), EBadDepositRatio);
 
         Coin::join(&mut reserve.sui, sui);
         Coin::join(&mut reserve.managed, managed);

--- a/sui_programmability/examples/games/sources/SharedTicTacToe.move
+++ b/sui_programmability/examples/games/sources/SharedTicTacToe.move
@@ -35,13 +35,13 @@ module Games::SharedTicTacToe {
 
     // Error codes
     /// Trying to place a mark when it's not your turn.
-    const EINVALID_TURN: u64 = 0;
+    const EInvalidTurn: u64 = 0;
     /// Trying to place a mark when the game has already ended.
-    const EGAME_ENDED: u64 = 1;
+    const EGameEnded: u64 = 1;
     /// Trying to place a mark in an invalid location, i.e. row/column out of bound.
-    const EINVALID_LOCATION: u64 = 2;
+    const EInvalidLocation: u64 = 2;
     /// The cell to place a new mark at is already oocupied.
-    const ECELL_OCCUPIED: u64 = 3;
+    const ECellOccupied: u64 = 3;
 
     struct TicTacToe has key {
         id: VersionedID,
@@ -84,13 +84,13 @@ module Games::SharedTicTacToe {
     }
 
     public(script) fun place_mark(game: &mut TicTacToe, row: u8, col: u8, ctx: &mut TxContext) {
-        assert!(row < 3 && col < 3, EINVALID_LOCATION);
-        assert!(game.game_status == IN_PROGRESS, EGAME_ENDED);
+        assert!(row < 3 && col < 3, EInvalidLocation);
+        assert!(game.game_status == IN_PROGRESS, EGameEnded);
         let addr = get_cur_turn_address(game);
-        assert!(addr == TxContext::sender(ctx), EINVALID_TURN);
+        assert!(addr == TxContext::sender(ctx), EInvalidTurn);
 
         let cell = Vector::borrow_mut(Vector::borrow_mut(&mut game.gameboard, (row as u64)), (col as u64));
-        assert!(*cell == MARK_EMPTY, ECELL_OCCUPIED);
+        assert!(*cell == MARK_EMPTY, ECellOccupied);
 
         *cell = game.cur_turn % 2;
         update_winner(game);

--- a/sui_programmability/examples/games/sources/TicTacToe.move
+++ b/sui_programmability/examples/games/sources/TicTacToe.move
@@ -34,8 +34,8 @@ module Games::TicTacToe {
     const FINAL_TURN: u8 = 8;
 
     // Error codes
-    const INVALID_LOCATION: u64 = 0;
-    const NO_MORE_MARK: u64 = 1;
+    const EInvalidLocation: u64 = 0;
+    const ENoMoreMark: u64 = 1;
 
     struct TicTacToe has key {
         id: VersionedID,
@@ -119,7 +119,7 @@ module Games::TicTacToe {
         ctx: &mut TxContext,
     ) {
         if (row > 2 || col > 2) {
-            abort INVALID_LOCATION
+            abort EInvalidLocation
         };
         let mark = mint_mark(cap, row, col, ctx);
         // Once an event is emitted, it should be observed by a game server.
@@ -195,7 +195,7 @@ module Games::TicTacToe {
 
     fun mint_mark(cap: &mut MarkMintCap, row: u64, col: u64, ctx: &mut TxContext): Mark {
         if (cap.remaining_supply == 0) {
-            abort NO_MORE_MARK
+            abort ENoMoreMark
         };
         cap.remaining_supply = cap.remaining_supply - 1;
         Mark {

--- a/sui_programmability/examples/nfts/sources/Auction.move
+++ b/sui_programmability/examples/nfts/sources/Auction.move
@@ -45,7 +45,7 @@ module NFTs::Auction {
     // Error codes.
 
     /// A bid submitted for the wrong (e.g. non-existent) auction.
-    const EWRONG_AUCTION: u64 = 1;
+    const EWrongAuction: u64 = 1;
 
     /// Represents a bid sent by a bidder to the auctioneer.
     struct Bid has key {
@@ -88,7 +88,7 @@ module NFTs::Auction {
     public(script) fun update_auction<T: key + store>(auction: &mut Auction<T>, bid: Bid, _ctx: &mut TxContext) {
         let Bid { id, bidder, auction_id, coin } = bid;
         ID::delete(id);
-        assert!(AuctionLib::auction_id(auction) == &auction_id, EWRONG_AUCTION);
+        assert!(AuctionLib::auction_id(auction) == &auction_id, EWrongAuction);
         AuctionLib::update_auction(auction, bidder, coin);
     }
 

--- a/sui_programmability/examples/nfts/sources/DiscountCoupon.move
+++ b/sui_programmability/examples/nfts/sources/DiscountCoupon.move
@@ -9,10 +9,10 @@ module NFTs::DiscountCoupon {
     use Sui::TxContext::{Self, TxContext};
 
     /// Sending to wrong recipient.
-    const EWRONG_RECIPIENT: u64 = 0;
+    const EWrongRecipient: u64 = 0;
 
     /// Percentage discount out of range.
-    const EOUT_OF_RANGE_DISCOUNT: u64 = 1;
+    const EOutOfRangeDiscount: u64 = 1;
 
     /// Discount coupon NFT.
     struct DiscountCoupon has key, store {
@@ -38,7 +38,7 @@ module NFTs::DiscountCoupon {
         recipient: address,
         ctx: &mut TxContext,
     ) {
-        assert!(discount > 0 && discount <= 100, EOUT_OF_RANGE_DISCOUNT);
+        assert!(discount > 0 && discount <= 100, EOutOfRangeDiscount);
         let coupon = DiscountCoupon {
             id: TxContext::new_id(ctx),
             issuer: TxContext::sender(ctx),
@@ -59,7 +59,7 @@ module NFTs::DiscountCoupon {
     //  TODO: Consider adding more valid recipients.
     //      If we stick with issuer-as-receiver only, then `recipient` input won't be required).
     public(script) fun transfer(coupon: DiscountCoupon, recipient: address, _ctx: &mut TxContext) {
-        assert!(&coupon.issuer == &recipient, EWRONG_RECIPIENT);
+        assert!(&coupon.issuer == &recipient, EWrongRecipient);
         Transfer::transfer(coupon, recipient);
     }
 }

--- a/sui_programmability/examples/nfts/sources/Geniteam.move
+++ b/sui_programmability/examples/nfts/sources/Geniteam.move
@@ -12,16 +12,16 @@ module NFTs::Geniteam {
     use Std::Vector;
 
     /// Trying to add more than 1 farm to a Player
-    const ETOO_MANY_FARMS: u64 = 1;
+    const ETooManyFarms: u64 = 1;
 
     /// Monster collection not owned by farm
-    const EMONSTER_COLLECTION_NOT_OWNED_BY_FARM: u64 = 2;
+    const EMonsterCollectionNotOwnedByFarm: u64 = 2;
 
     /// Inventory not owned by player
-    const EINVENTORY_NOT_OWNED_BY_PLAYER: u64 = 3;
+    const EInventoryNotOwnedByPlayer: u64 = 3;
 
     /// Invalid cosmetic slot
-    const EINVALID_COSMETICS_SLOT: u64 = 4;
+    const EInvalidCosmeticsSlot: u64 = 4;
 
     struct Player has key {
         id: VersionedID,
@@ -108,7 +108,7 @@ module NFTs::Geniteam {
         total_monster_slots: u64, ctx: &mut TxContext
     ) {
         // We only allow one farm for now
-        assert!(Option::is_none(&player.owned_farm), ETOO_MANY_FARMS);
+        assert!(Option::is_none(&player.owned_farm), ETooManyFarms);
 
         let farm = new_farm(farm_name, farm_img_index, total_monster_slots, ctx);
 
@@ -145,7 +145,7 @@ module NFTs::Geniteam {
         // Check if this is the right collection
         assert!(
             Transfer::is_child(&farm.pet_monsters, pet_monsters),
-            EMONSTER_COLLECTION_NOT_OWNED_BY_FARM,
+            EMonsterCollectionNotOwnedByFarm,
         );
 
         // TODO: Decouple adding monster to farm from creating a monster.
@@ -161,7 +161,7 @@ module NFTs::Geniteam {
         // Check if this is the right collection
         assert!(
             Transfer::is_child(&player.inventory, inventory),
-            EINVENTORY_NOT_OWNED_BY_PLAYER,
+            EInventoryNotOwnedByPlayer,
         );
 
         // Create the farm cosmetic object
@@ -183,7 +183,7 @@ module NFTs::Geniteam {
         // Check if this is the right collection
         assert!(
             Transfer::is_child(&player.inventory, inventory),
-            EINVENTORY_NOT_OWNED_BY_PLAYER,
+            EInventoryNotOwnedByPlayer,
         );
 
         // Create the farm cosmetic object
@@ -252,7 +252,7 @@ module NFTs::Geniteam {
         farm_cosmetic: FarmCosmetic, cosmetic_slot_id: u64, _ctx: &mut TxContext
     ) {
         // Only 2 slots allowed
-        assert!(cosmetic_slot_id <= 1 , EINVALID_COSMETICS_SLOT);
+        assert!(cosmetic_slot_id <= 1 , EInvalidCosmeticsSlot);
 
         // Transfer ownership of cosmetic to this farm
         let child_ref = Transfer::transfer_to_object(farm_cosmetic, farm);
@@ -275,7 +275,7 @@ module NFTs::Geniteam {
          _ctx: &mut TxContext
     ) {
         // Only 2 slots allowed
-        assert!(cosmetic_slot_id <= 1 , EINVALID_COSMETICS_SLOT);
+        assert!(cosmetic_slot_id <= 1 , EInvalidCosmeticsSlot);
 
         // Transfer ownership of cosmetic to this monster
         let child_ref = Transfer::transfer_to_object(monster_cosmetic, monster);

--- a/sui_programmability/examples/nfts/sources/Marketplace.move
+++ b/sui_programmability/examples/nfts/sources/Marketplace.move
@@ -9,16 +9,10 @@ module NFTs::Marketplace {
     use Sui::Coin::{Self, Coin};
 
     // For when amount paid does not match the expected.
-    const EAMOUNT_INCORRECT: u64 = 0;
+    const EAmountIncorrect: u64 = 0;
 
     // For when someone tries to delist without ownership.
-    const ENOT_OWNER: u64 = 1;
-
-    // For when trying to remove object that's not on the Marketplace.
-    const EOBJECT_NOT_FOUND: u64 = 2;
-
-    /// Adding the same object to the markeplace twice is not allowed.
-    const EOBJECT_DOUBLE_ADD: u64 = 3;
+    const ENotOwner: u64 = 1;
 
     struct Marketplace has key {
         id: VersionedID,
@@ -72,7 +66,7 @@ module NFTs::Marketplace {
         let listing = Bag::remove(objects, listing);
         let Listing { id, item, ask: _, owner } = listing;
 
-        assert!(TxContext::sender(ctx) == owner, ENOT_OWNER);
+        assert!(TxContext::sender(ctx) == owner, ENotOwner);
 
         ID::delete(id);
         item
@@ -99,7 +93,7 @@ module NFTs::Marketplace {
         let listing = Bag::remove(objects, listing);
         let Listing { id, item, ask, owner } = listing;
 
-        assert!(ask == Coin::value(&paid), EAMOUNT_INCORRECT);
+        assert!(ask == Coin::value(&paid), EAmountIncorrect);
 
         Transfer::transfer(paid, owner);
         ID::delete(id);

--- a/sui_programmability/examples/nfts/sources/Num.move
+++ b/sui_programmability/examples/nfts/sources/Num.move
@@ -26,7 +26,7 @@ module NFTs::Num {
     const MAX_SUPPLY: u64 = 10;
 
     /// Created more than the maximum supply of Num NFT's
-    const ETOO_MANY_NUMS: u64 = 0;
+    const ETooManyNums: u64 = 0;
 
     /// Create a unique issuer cap and give it to the transaction sender
     fun init(ctx: &mut TxContext) {
@@ -43,7 +43,7 @@ module NFTs::Num {
         let n = cap.issued_counter;
         cap.issued_counter = n + 1;
         cap.supply = cap.supply + 1;
-        assert!(n <= MAX_SUPPLY, ETOO_MANY_NUMS);
+        assert!(n <= MAX_SUPPLY, ETooManyNums);
         Num { id: TxContext::new_id(ctx), n }
     }
 

--- a/sui_programmability/examples/nfts/sources/SharedAuction.move
+++ b/sui_programmability/examples/nfts/sources/SharedAuction.move
@@ -36,7 +36,7 @@ module NFTs::SharedAuction {
     // Error codes.
 
     /// An attempt to end auction by a different user than the owner
-    const EWRONG_OWNER: u64 = 1;
+    const EWrongOwner: u64 = 1;
 
     // Entry functions.
 
@@ -62,7 +62,7 @@ module NFTs::SharedAuction {
     /// auctioned.
     public(script) fun end_auction<T: key + store>(auction: &mut Auction<T>, ctx: &mut TxContext) {
         let owner = AuctionLib::auction_owner(auction);
-        assert!(TxContext::sender(ctx) == owner, EWRONG_OWNER);
+        assert!(TxContext::sender(ctx) == owner, EWrongOwner);
         AuctionLib::end_shared_auction(auction);
     }
 

--- a/sui_programmability/framework/sources/Bag.move
+++ b/sui_programmability/framework/sources/Bag.move
@@ -18,20 +18,20 @@ module Sui::Bag {
     use Sui::TxContext::{Self, TxContext};
 
     // Error codes
-    /// When removing an object from the collection, EOBJECT_NOT_FOUND
+    /// When removing an object from the collection, EObjectNotFound
     /// will be triggered if the object is not owned by the collection.
-    const EOBJECT_NOT_FOUND: u64 = 0;
+    const EObjectNotFound: u64 = 0;
 
     /// Adding the same object to the collection twice is not allowed.
-    const EOBJECT_DOUBLE_ADD: u64 = 1;
+    const EObjectDoubleAdd: u64 = 1;
 
     /// The max capacity set for the collection cannot exceed the hard limit
     /// which is DEFAULT_MAX_CAPACITY.
-    const EINVALID_MAX_CAPACITY: u64 = 2;
+    const EInvalidMaxCapacity: u64 = 2;
 
     /// Trying to add object to the collection when the collection is
     /// already at its maximum capacity.
-    const EMAX_CAPACITY_EXCEEDED: u64 = 3;
+    const EMaxCapacityExceeded: u64 = 3;
 
     // TODO: this is a placeholder number
     const DEFAULT_MAX_CAPACITY: u64 = 65536;
@@ -51,7 +51,7 @@ module Sui::Bag {
     public fun new_with_max_capacity(ctx: &mut TxContext, max_capacity: u64): Bag {
         assert!(
             max_capacity <= DEFAULT_MAX_CAPACITY && max_capacity > 0 ,
-            Errors::limit_exceeded(EINVALID_MAX_CAPACITY)
+            Errors::limit_exceeded(EInvalidMaxCapacity)
         );
         Bag {
             id: TxContext::new_id(ctx),
@@ -77,11 +77,11 @@ module Sui::Bag {
     fun add_impl<T: key>(c: &mut Bag, object: T, old_child_ref: Option<ChildRef<T>>) {
         assert!(
             size(c) + 1 <= c.max_capacity,
-            Errors::limit_exceeded(EMAX_CAPACITY_EXCEEDED)
+            Errors::limit_exceeded(EMaxCapacityExceeded)
         );
         let id = ID::id(&object);
         if (contains(c, id)) {
-            abort EOBJECT_DOUBLE_ADD
+            abort EObjectDoubleAdd
         };
         Vector::push_back(&mut c.objects, *id);
         Transfer::transfer_to_object_unsafe(object, old_child_ref, c);
@@ -111,7 +111,7 @@ module Sui::Bag {
     public fun remove<T: key>(c: &mut Bag, object: T): T {
         let idx = find(c, ID::id(&object));
         if (Option::is_none(&idx)) {
-            abort EOBJECT_NOT_FOUND
+            abort EObjectNotFound
         };
         Vector::remove(&mut c.objects, *Option::borrow(&idx));
         object

--- a/sui_programmability/framework/sources/Balance.move
+++ b/sui_programmability/framework/sources/Balance.move
@@ -9,9 +9,9 @@ module Sui::Balance {
     friend Sui::Coin;
 
     /// For when trying to destroy a non-zero balance.
-    const ENONZERO: u64 = 0;
+    const ENonZero: u64 = 0;
     /// For when trying to withdraw more than there is.
-    const EVALUE: u64 = 0;
+    const ENotEnough: u64 = 0;
 
     /// Storable balance - an inner struct of a Coin type.
     /// Can be used to store coins which don't need to have the
@@ -38,14 +38,14 @@ module Sui::Balance {
 
     /// Split a `Balance` and take a sub balance from it.
     public fun split<T>(self: &mut Balance<T>, value: u64): Balance<T> {
-        assert!(self.value >= value, EVALUE);
+        assert!(self.value >= value, ENotEnough);
         self.value = self.value - value;
         Balance { value }
     }
 
     /// Destroy a zero `Balance`.
     public fun destroy_zero<T>(balance: Balance<T>) {
-        assert!(balance.value == 0, ENONZERO);
+        assert!(balance.value == 0, ENonZero);
         let Balance { value: _ } = balance;
     }
 

--- a/sui_programmability/framework/sources/Collection.move
+++ b/sui_programmability/framework/sources/Collection.move
@@ -20,20 +20,20 @@ module Sui::Collection {
     use Sui::TxContext::{Self, TxContext};
 
     // Error codes
-    /// When removing an object from the collection, EOBJECT_NOT_FOUND
+    /// When removing an object from the collection, EObjectNotFound
     /// will be triggered if the object is not owned by the collection.
-    const EOBJECT_NOT_FOUND: u64 = 0;
+    const EObjectNotFound: u64 = 0;
 
     /// Adding the same object to the collection twice is not allowed.
-    const EOBJECT_DOUBLE_ADD: u64 = 1;
+    const EObjectDoubleAdd: u64 = 1;
 
     /// The max capacity set for the collection cannot exceed the hard limit
     /// which is DEFAULT_MAX_CAPACITY.
-    const EINVALID_MAX_CAPACITY: u64 = 2;
+    const EInvalidMaxCapacity: u64 = 2;
 
     /// Trying to add object to the collection when the collection is
     /// already at its maximum capacity.
-    const EMAX_CAPACITY_EXCEEDED: u64 = 3;
+    const EMaxCapacityExceeded: u64 = 3;
 
     // TODO: this is a placeholder number
     // We want to limit the capacity of collection because it requires O(N)
@@ -56,7 +56,7 @@ module Sui::Collection {
     public fun new_with_max_capacity<T: key>(ctx: &mut TxContext, max_capacity: u64): Collection<T> {
         assert!(
             max_capacity <= DEFAULT_MAX_CAPACITY && max_capacity > 0 ,
-            Errors::limit_exceeded(EINVALID_MAX_CAPACITY)
+            Errors::limit_exceeded(EInvalidMaxCapacity)
         );
         Collection {
             id: TxContext::new_id(ctx),
@@ -82,10 +82,10 @@ module Sui::Collection {
     fun add_impl<T: key>(c: &mut Collection<T>, object: T, old_child_ref: Option<ChildRef<T>>) {
         assert!(
             size(c) + 1 <= c.max_capacity,
-            Errors::limit_exceeded(EMAX_CAPACITY_EXCEEDED)
+            Errors::limit_exceeded(EMaxCapacityExceeded)
         );
         let id = ID::id(&object);
-        assert!(!contains(c, id), EOBJECT_DOUBLE_ADD);
+        assert!(!contains(c, id), EObjectDoubleAdd);
         let child_ref = if (Option::is_none(&old_child_ref)) {
             Transfer::transfer_to_object(object, c)
         } else {
@@ -119,7 +119,7 @@ module Sui::Collection {
     /// Abort if the object is not found.
     public fun remove<T: key>(c: &mut Collection<T>, object: T): (T, ChildRef<T>) {
         let idx = find(c, ID::id(&object));
-        assert!(Option::is_some(&idx), EOBJECT_NOT_FOUND);
+        assert!(Option::is_some(&idx), EObjectNotFound);
         let child_ref = Vector::remove(&mut c.objects, *Option::borrow(&idx));
         (object, child_ref)
     }

--- a/sui_programmability/framework/sources/CrossChainAirdrop.move
+++ b/sui_programmability/framework/sources/CrossChainAirdrop.move
@@ -49,7 +49,7 @@ module Sui::CrossChainAirdrop {
     // Error codes
 
     /// Trying to claim a token that has already been claimed
-    const ETOKEN_ID_CLAIMED: u64 = 0;
+    const ETokenIDClaimed: u64 = 0;
 
     /// Create the `Orcacle` capability and hand it off to the oracle
     fun init(ctx: &mut TxContext) {
@@ -75,7 +75,7 @@ module Sui::CrossChainAirdrop {
         let contract = get_or_create_contract(oracle, &source_contract_address);
         let token_id = ERC721Metadata::new_token_id(source_token_id);
         // NOTE: this is where the globally uniqueness check happens
-        assert!(!is_token_claimed(contract, &token_id), ETOKEN_ID_CLAIMED);
+        assert!(!is_token_claimed(contract, &token_id), ETokenIDClaimed);
         let nft = ERC721 {
             id: TxContext::new_id(ctx),
             source_contract_address: SourceContractAddress { address: source_contract_address },

--- a/sui_programmability/framework/sources/ID.move
+++ b/sui_programmability/framework/sources/ID.move
@@ -19,7 +19,7 @@ module Sui::ID {
     const ID_SIZE: u64 = 20;
 
     /// Attempting to construct an object ID with the wrong number of bytes--expected 20.
-    const EBAD_ID_LENGTH: u64 = 0;
+    const EBadIDLength: u64 = 0;
 
     /// Globally unique identifier of an object. This is a privileged type
     /// that can only be derived from a `TxContext`.
@@ -63,10 +63,10 @@ module Sui::ID {
     }
 
     /// Create an `ID` from raw bytes.
-    /// Aborts with `EBAD_ID_LENGTH` if the length of `bytes` is not `ID_SIZE`
+    /// Aborts with `EBadIDLength` if the length of `bytes` is not `ID_SIZE`
     public fun new_from_bytes(bytes: vector<u8>): ID {
         if (Vector::length(&bytes) != ID_SIZE) {
-            abort(EBAD_ID_LENGTH)
+            abort(EBadIDLength)
         };
         ID { bytes: bytes_to_address(bytes) }
     }

--- a/sui_programmability/framework/sources/TestScenario.move
+++ b/sui_programmability/framework/sources/TestScenario.move
@@ -8,36 +8,30 @@ module Sui::TestScenario {
     use Std::Option::{Self, Option};
     use Std::Vector;
 
-    /// Attempted an operation that required a concluded transaction, but there are none
-    const ENO_CONCLUDED_TRANSACTIONS: u64 = 0;
-
     /// Requested a transfer or user-defined event on an invalid transaction index
-    const EINVALID_TX_INDEX: u64 = 1;
+    const EInvalidTxIndex: u64 = 1;
 
     /// Attempted to return an object to the inventory that was not previously removed from the
     /// inventory during the current transaction. Can happen if the user attempts to call
     /// `return_object` on a locally constructed object rather than one returned from a `TestScenario`
     /// function such as `take_object`.
-    const ECANT_RETURN_OBJECT: u64 = 2;
+    const ECantReturnObject: u64 = 2;
 
     /// Attempted to retrieve an object of a particular type from the inventory, but it is empty.
     /// Can happen if the user already transferred the object or a previous transaction failed to
     /// transfer the object to the user.
-    const EEMPTY_INVENTORY: u64 = 3;
+    const EEmptyInventory: u64 = 3;
 
     /// Expected 1 object of this type in the tx sender's inventory, but found >1.
     /// Consider using TestScenario::take_object_by_id to select a specific object
-    const EINVENTORY_AMBIGUITY: u64 = 4;
+    const EInventoryAbiguity: u64 = 4;
 
     /// The inventory previously contained an object of this type, but it was removed during the current
     /// transaction.
-    const EALREADY_REMOVED_OBJECT: u64 = 5;
+    const EAlreadyRemovedObject: u64 = 5;
 
     /// Object of given ID cannot be found in the inventory.
-    const EOBJECT_ID_NOT_FOUND: u64 = 6;
-
-    /// Found two objects with the same ID in the inventory.
-    const EDUPLICATE_OBJCET_ID_FOUND: u64 = 7;
+    const EObjectIDNotFound: u64 = 6;
 
     /// Utility for mocking a multi-transaction Sui execution in a single Move procedure.
     /// A `Scenario` maintains a view of the global object pool built up by the execution.
@@ -198,11 +192,11 @@ module Sui::TestScenario {
     public fun take_object_by_id<T: key>(scenario: &mut Scenario, id: ID): T {
         let object_opt: Option<T> = find_object_by_id_in_inventory(scenario, &id);
 
-        assert!(Option::is_some(&object_opt), EOBJECT_ID_NOT_FOUND);
+        assert!(Option::is_some(&object_opt), EObjectIDNotFound);
         let object = Option::extract(&mut object_opt);
         Option::destroy_none(object_opt);
 
-        assert!(!Vector::contains(&scenario.removed, &id), EALREADY_REMOVED_OBJECT);
+        assert!(!Vector::contains(&scenario.removed, &id), EAlreadyRemovedObject);
         Vector::push_back(&mut scenario.removed, id);
 
         object
@@ -242,7 +236,7 @@ module Sui::TestScenario {
         // TODO: add Vector::remove_element to Std that does this 3-liner
         let (is_mem, idx) = Vector::index_of(removed, id);
         // can't return an object we haven't removed
-        assert!(is_mem, ECANT_RETURN_OBJECT);
+        assert!(is_mem, ECantReturnObject);
         Vector::remove(removed, idx);
 
         // Update the object content in the inventory.
@@ -300,7 +294,7 @@ module Sui::TestScenario {
     fun tx_start_index(scenario: &Scenario, tx_idx: u64): u64 {
         let idxs = &scenario.event_start_indexes;
         let len = Vector::length(idxs);
-        assert!(tx_idx < len, EINVALID_TX_INDEX);
+        assert!(tx_idx < len, EInvalidTxIndex);
         *Vector::borrow(idxs, tx_idx)
     }
 
@@ -320,13 +314,13 @@ module Sui::TestScenario {
             let id = ID::id(&t);
             Vector::destroy_empty(inventory);
 
-            assert!(!Vector::contains(&scenario.removed, id), EALREADY_REMOVED_OBJECT);
+            assert!(!Vector::contains(&scenario.removed, id), EAlreadyRemovedObject);
             Vector::push_back(&mut scenario.removed, *id);
             t
         } else if (objects_len == 0) {
-            abort(EEMPTY_INVENTORY)
+            abort(EEmptyInventory)
         } else { // objects_len > 1
-            abort(EINVENTORY_AMBIGUITY)
+            abort(EInventoryAbiguity)
         }
     }
 

--- a/sui_programmability/framework/sources/Transfer.move
+++ b/sui_programmability/framework/sources/Transfer.move
@@ -3,7 +3,6 @@
 
 module Sui::Transfer {
     use Std::Option::{Self, Option};
-
     use Sui::ID::{Self, ID, VersionedID};
 
     // To allow access to transfer_to_object_unsafe.
@@ -13,7 +12,7 @@ module Sui::Transfer {
 
     // When transferring a child object, this error is thrown if the child object
     // doesn't match the ChildRef that represents the onwershp.
-    const ECHILD_ID_MISMATCH: u64 = 0;
+    const EChildIDMismatch: u64 = 0;
 
     /// Represents a reference to a child object, whose type is T.
     /// This is used to track ownership between objects.
@@ -109,7 +108,7 @@ module Sui::Transfer {
     /// consume a ChildRef. It will return a ChildRef that represents the new ownership.
     public fun transfer_child_to_object<T: key, R: key>(child: T, child_ref: ChildRef<T>, owner: &mut R): ChildRef<T> {
         let ChildRef { child_id } = child_ref;
-        assert!(&child_id == ID::id(&child), ECHILD_ID_MISMATCH);
+        assert!(&child_id == ID::id(&child), EChildIDMismatch);
         transfer_to_object(child, owner)
     }
 
@@ -120,7 +119,7 @@ module Sui::Transfer {
     // Currently one has to first transfer it to an address, and then delete it.
     public fun transfer_child_to_address<T: key>(child: T, child_ref: ChildRef<T>, recipient: address) {
         let ChildRef { child_id } = child_ref;
-        assert!(&child_id == ID::id(&child), ECHILD_ID_MISMATCH);
+        assert!(&child_id == ID::id(&child), EChildIDMismatch);
         transfer(child, recipient)
     }
 
@@ -130,7 +129,7 @@ module Sui::Transfer {
     /// be dangling reference to the child object through ownership.
     public fun delete_child_object<T: key>(child: T, child_ref: ChildRef<T>) {
         let ChildRef { child_id } = child_ref;
-        assert!(&child_id == ID::id(&child), ECHILD_ID_MISMATCH);
+        assert!(&child_id == ID::id(&child), EChildIDMismatch);
         delete_child_object_internal(child);
     }
 

--- a/sui_programmability/framework/sources/TxContext.move
+++ b/sui_programmability/framework/sources/TxContext.move
@@ -16,11 +16,11 @@ module Sui::TxContext {
     const TX_HASH_LENGTH: u64 = 32;
 
     /// Expected an tx hash of length 32, but found a different length
-    const EBAD_TX_HASH_LENGTH: u64 = 0;
+    const EBadTxHashLength: u64 = 0;
 
     #[test_only]
     /// Attempt to get the most recent created object ID when none has been created.
-    const ENO_IDS_CREATED: u64 = 1;
+    const ENoIDsCreated: u64 = 1;
 
     /// Information about the transaction currently being executed.
     /// This cannot be constructed by a transaction--it is a privileged object created by
@@ -70,7 +70,7 @@ module Sui::TxContext {
     public fun new(signer: signer, tx_hash: vector<u8>, ids_created: u64): TxContext {
         assert!(
             Vector::length(&tx_hash) == TX_HASH_LENGTH,
-            Errors::invalid_argument(EBAD_TX_HASH_LENGTH)
+            Errors::invalid_argument(EBadTxHashLength)
         );
         TxContext { signer, tx_hash, ids_created }
     }
@@ -110,7 +110,7 @@ module Sui::TxContext {
     /// Return the most recent created object ID.
     public fun last_created_object_id(self: &TxContext): ID {
         let ids_created = self.ids_created;
-        assert!(ids_created > 0, ENO_IDS_CREATED);
+        assert!(ids_created > 0, ENoIDsCreated);
         ID::new(derive_id(*&self.tx_hash, ids_created - 1))
     }
 

--- a/sui_programmability/framework/sources/Url.move
+++ b/sui_programmability/framework/sources/Url.move
@@ -13,7 +13,7 @@ module Sui::Url {
     const HASH_VECTOR_LENGTH: u64 = 32;
 
     /// Error code when the length of the hash vector is not HASH_VECTOR_LENGTH
-    const EHASH_LENGTH_MISMATCH: u64 = 0;
+    const EHashLengthMismatch: u64 = 0;
 
     /// Represents an arbitrary URL. Clients rendering values of this type should fetch the resource at `url` and render it using a to-be-defined Sui standard.
     struct Url has store, drop {
@@ -46,7 +46,7 @@ module Sui::Url {
     /// Create a `UrlCommitment`, and set the immutable hash
     public fun new_unsafe_url_commitment(url: Url, resource_hash: vector<u8>): UrlCommitment {
         // Length must be exact
-        assert!(Vector::length(&resource_hash) == HASH_VECTOR_LENGTH, EHASH_LENGTH_MISMATCH);
+        assert!(Vector::length(&resource_hash) == HASH_VECTOR_LENGTH, EHashLengthMismatch);
 
         UrlCommitment { url, resource_hash }
     }


### PR DESCRIPTION
- This PR aims to change our style to separate ECONSTS from EErrors.
- The first capital `E` is a must-have requirement in Move for consts, so it is a "hack"

