### PR TITLE
Fix a bug in how we hash/compare AuthoritySignInfo

### DIFF
--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -1914,13 +1914,13 @@
         "description": "A transaction signed by a client, optionally signed by an authority (depending on `S`). `S` indicates the authority signing state. It can be either empty or signed. We make the authority signature templated so that `TransactionEnvelope<S>` can be used universally in the transactions storage in `SuiDataStore`, shared by both authorities and non-authorities: authorities store signed transactions, while non-authorities store unsigned transactions.",
         "type": "object",
         "required": [
-          "auth_signature",
+          "auth_sign_info",
           "data",
           "tx_signature"
         ],
         "properties": {
-          "auth_signature": {
-            "description": "auth_signature, if available, is signed by an authority, applied on `data`.",
+          "auth_sign_info": {
+            "description": "authority signature information, if available, is signed by an authority, applied on `data`.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/EmptySignInfo"

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -836,7 +836,7 @@ where
                             }) => {
                                 state.signatures.push((
                                     name,
-                                    inner_signed_transaction.auth_signature.signature,
+                                    inner_signed_transaction.auth_sign_info.signature,
                                 ));
                                 state.good_stake += weight;
                                 if state.good_stake >= threshold {

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -42,7 +42,7 @@ impl<C> SafeClient<C> {
             signed_transaction.check(&self.committee)?;
             // Check it has the right signer
             fp_ensure!(
-                signed_transaction.auth_signature.authority == self.address,
+                signed_transaction.auth_sign_info.authority == self.address,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -159,7 +159,7 @@ impl<C> SafeClient<C> {
                 signed_transaction.check(&self.committee)?;
                 // Check it has the right signer
                 fp_ensure!(
-                    signed_transaction.auth_signature.authority == self.address,
+                    signed_transaction.auth_sign_info.authority == self.address,
                     SuiError::ByzantineAuthoritySuspicion {
                         authority: self.address
                     }
@@ -378,7 +378,7 @@ where
                             client.report_client_error(err.clone());
                             Some(Err(err))
                         } else {
-                            // Save the seqeunce number of this batch
+                            // Save the sequence number of this batch
                             *seq = signed_batch.batch.next_sequence_number;
                             // Insert a fresh vector for the new batch of transactions
                             let _ =

--- a/sui_core/src/unit_tests/authority_aggregator_tests.rs
+++ b/sui_core/src/unit_tests/authority_aggregator_tests.rs
@@ -188,8 +188,8 @@ async fn extract_cert<A: AuthorityAPI>(
             .await
         {
             votes.push((
-                signed.auth_signature.authority,
-                signed.auth_signature.signature,
+                signed.auth_sign_info.authority,
+                signed.auth_sign_info.signature,
             ));
             if let Some(inner_transaction) = transaction {
                 assert!(inner_transaction.data == signed.data);

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -341,7 +341,7 @@ pub async fn send_and_confirm_transaction(
     // Collect signatures from a quorum of authorities
     let mut builder = SignatureAggregator::try_new(transaction, &authority.committee).unwrap();
     let certificate = builder
-        .append(vote.auth_signature.authority, vote.auth_signature.signature)
+        .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
         .unwrap()
         .unwrap();
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
@@ -1307,7 +1307,7 @@ fn init_certified_transfer_transaction(
     let mut builder =
         SignatureAggregator::try_new(transfer_transaction, &authority_state.committee).unwrap();
     builder
-        .append(vote.auth_signature.authority, vote.auth_signature.signature)
+        .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
         .unwrap()
         .unwrap()
 }
@@ -1492,7 +1492,7 @@ async fn shared_object() {
     let vote = response.signed_transaction.unwrap();
     let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
         .unwrap()
-        .append(vote.auth_signature.authority, vote.auth_signature.signature)
+        .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
         .unwrap()
         .unwrap();
     let confirmation_transaction = ConfirmationTransaction::new(certificate.clone());

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -82,7 +82,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         let vote = response.signed_transaction.unwrap();
         let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
             .unwrap()
-            .append(vote.auth_signature.authority, vote.auth_signature.signature)
+            .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
             .unwrap()
             .unwrap();
         certificates.push(certificate);

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -908,7 +908,7 @@ UpdateItem:
         TYPENAME: TransactionData
     - tx_signature:
         TYPENAME: Signature
-    - auth_signature:
+    - auth_sign_info:
         TYPENAME: AuthoritySignInfo
 "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptySignInfo>":
   STRUCT:
@@ -916,6 +916,6 @@ UpdateItem:
         TYPENAME: TransactionData
     - tx_signature:
         TYPENAME: Signature
-    - auth_signature:
+    - auth_sign_info:
         TYPENAME: EmptySignInfo
 

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -575,15 +575,15 @@ impl SignedTransaction {
 impl Hash for SignedTransaction {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.data.hash(state);
-        self.auth_signature.authority.hash(state);
+        self.auth_signature.hash(state);
     }
 }
 
 impl PartialEq for SignedTransaction {
     fn eq(&self, other: &Self) -> bool {
-        // We do not compare the signatures, because there can be multiple
+        // We do not compare the tx_signature, because there can be multiple
         // valid signatures for the same data and signer.
-        self.data == other.data && self.auth_signature.authority == other.auth_signature.authority
+        self.data == other.data && self.auth_signature == other.auth_signature
     }
 }
 
@@ -849,7 +849,7 @@ impl ExecutionStatus {
 pub struct TransactionEffects {
     // The status of the execution
     pub status: ExecutionStatus,
-    // The object references of the shared objects used in this trasnaction. Empty if no shared objects were used.
+    // The object references of the shared objects used in this transaction. Empty if no shared objects were used.
     pub shared_objects: Vec<ObjectRef>,
     // The transaction digest
     pub transaction_digest: TransactionDigest,
@@ -986,10 +986,7 @@ impl SignedTransactionEffects {
 
 impl PartialEq for SignedTransactionEffects {
     fn eq(&self, other: &Self) -> bool {
-        // We do not compare the authority signatures, because there can be multiple
-        // valid signatures for the same data and signer.
-        self.effects == other.effects
-            && self.auth_signature.authority == other.auth_signature.authority
+        self.effects == other.effects && self.auth_signature == other.auth_signature
     }
 }
 

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -334,8 +334,8 @@ pub struct TransactionEnvelope<S> {
     pub data: TransactionData,
     /// tx_signature is signed by the transaction sender, applied on `data`.
     pub tx_signature: Signature,
-    /// auth_signature, if available, is signed by an authority, applied on `data`.
-    pub auth_signature: S,
+    /// authority signature information, if available, is signed by an authority, applied on `data`.
+    pub auth_sign_info: S,
     // Note: If any new field is added here, make sure the Hash and PartialEq
     // implementation are adjusted to include that new field (unless the new field
     // does not participate in the hash and comparison).
@@ -511,7 +511,7 @@ impl Transaction {
             is_checked: false,
             data,
             tx_signature: signature,
-            auth_signature: EmptySignInfo {},
+            auth_sign_info: EmptySignInfo {},
         }
     }
 }
@@ -545,7 +545,7 @@ impl SignedTransaction {
             is_checked: transaction.is_checked,
             data: transaction.data,
             tx_signature: transaction.tx_signature,
-            auth_signature: AuthoritySignInfo {
+            auth_sign_info: AuthoritySignInfo {
                 epoch,
                 authority,
                 signature,
@@ -556,11 +556,11 @@ impl SignedTransaction {
     /// Verify the signature and return the non-zero voting right of the authority.
     pub fn check(&self, committee: &Committee) -> Result<usize, SuiError> {
         self.check_signature()?;
-        let weight = committee.weight(&self.auth_signature.authority);
+        let weight = committee.weight(&self.auth_sign_info.authority);
         fp_ensure!(weight > 0, SuiError::UnknownSigner);
-        self.auth_signature
+        self.auth_sign_info
             .signature
-            .check(&self.data, self.auth_signature.authority)?;
+            .check(&self.data, self.auth_sign_info.authority)?;
         Ok(weight)
     }
 
@@ -575,7 +575,7 @@ impl SignedTransaction {
 impl Hash for SignedTransaction {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.data.hash(state);
-        self.auth_signature.hash(state);
+        self.auth_sign_info.hash(state);
     }
 }
 
@@ -583,7 +583,7 @@ impl PartialEq for SignedTransaction {
     fn eq(&self, other: &Self) -> bool {
         // We do not compare the tx_signature, because there can be multiple
         // valid signatures for the same data and signer.
-        self.data == other.data && self.auth_signature == other.auth_signature
+        self.data == other.data && self.auth_sign_info == other.auth_sign_info
     }
 }
 

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -123,11 +123,11 @@ fn test_certificates() {
 
     let mut builder = SignatureAggregator::try_new(transaction.clone(), &committee).unwrap();
     assert!(builder
-        .append(v1.auth_signature.authority, v1.auth_signature.signature)
+        .append(v1.auth_sign_info.authority, v1.auth_sign_info.signature)
         .unwrap()
         .is_none());
     let mut c = builder
-        .append(v2.auth_signature.authority, v2.auth_signature.signature)
+        .append(v2.auth_sign_info.authority, v2.auth_sign_info.signature)
         .unwrap()
         .unwrap();
     assert!(c.check(&committee).is_ok());
@@ -136,11 +136,11 @@ fn test_certificates() {
 
     let mut builder = SignatureAggregator::try_new(transaction, &committee).unwrap();
     assert!(builder
-        .append(v1.auth_signature.authority, v1.auth_signature.signature)
+        .append(v1.auth_sign_info.authority, v1.auth_sign_info.signature)
         .unwrap()
         .is_none());
     assert!(builder
-        .append(v3.auth_signature.authority, v3.auth_signature.signature)
+        .append(v3.auth_sign_info.authority, v3.auth_sign_info.signature)
         .is_err());
 
     assert!(SignatureAggregator::try_new(bad_transaction, &committee).is_err());

--- a/sui_types/src/unit_tests/serialize_tests.rs
+++ b/sui_types/src/unit_tests/serialize_tests.rs
@@ -329,9 +329,9 @@ fn test_time_vote() {
     let now = Instant::now();
     for _ in 0..100 {
         if let SerializedMessage::Vote(vote) = deserialize_message(&mut buf2).unwrap() {
-            vote.auth_signature
+            vote.auth_sign_info
                 .signature
-                .check(&vote.data, vote.auth_signature.authority)
+                .check(&vote.data, vote.auth_sign_info.authority)
                 .unwrap();
         }
     }

--- a/test_utils/src/messages.rs
+++ b/test_utils/src/messages.rs
@@ -135,7 +135,7 @@ pub fn make_certificates(transactions: Vec<Transaction>) -> Vec<CertifiedTransac
                 &key,
             );
             if let Some(certificate) = aggregator
-                .append(vote.auth_signature.authority, vote.auth_signature.signature)
+                .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
                 .unwrap()
             {
                 certificates.push(certificate);


### PR DESCRIPTION
Now that we have added `epoch` to AuthoritySignInfo, we need to make sure that we use epoch for both comparisons and hashes.
To make this easier, this PR implemented Hash and PartialEq for AuthoritySignInfo, so that we could call them directly from outside.