### PR TITLE
[MoveLib] Rename all take_/return_ function names

### DIFF
--- a/doc/src/build/move.md
+++ b/doc/src/build/move.md
@@ -680,7 +680,7 @@ function:
         TestScenario::next_tx(scenario, &initial_owner);
         {
             // extract the sword owned by the initial owner
-            let sword = TestScenario::take_object<Sword>(scenario);
+            let sword = TestScenario::take_owned<Sword>(scenario);
             // transfer the sword to the final owner
             sword_transfer(sword, final_owner, TestScenario::ctx(scenario));
         };
@@ -688,11 +688,11 @@ function:
         TestScenario::next_tx(scenario, &final_owner);
         {
             // extract the sword owned by the final owner
-            let sword = TestScenario::take_object<Sword>(scenario);
+            let sword = TestScenario::take_owned<Sword>(scenario);
             // verify that the sword has expected properties
             assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
             // return the sword to the object pool (it cannot be simply "dropped")
-            TestScenario::return_object(scenario, sword)
+            TestScenario::return_owned(scenario, sword)
         }
     }
 ```
@@ -711,7 +711,7 @@ the sword it now owns to its final owner. Please note that in *pure
 Move* we do not have the notion of Sui storage and, consequently, no
 easy way for the emulated Sui transaction to retrieve it from
 storage. This is where the `TestScenario` module comes to help - its
-`take_object` function makes an object of a given type (in this case
+`take_owned` function makes an object of a given type (in this case
 of type `Sword`) owned by an address executing the current transaction
 available for manipulation by the Move code. (For now, we assume that
 there is only one such object.) In this case, the object retrieved
@@ -730,7 +730,7 @@ by transferring the sword object to the fake address. But the
 `TestScenario` package gives us a more elegant solution, which is
 closer to what happens when Move code is actually executed in the
 context of Sui - we can simply return the sword to the object pool
-using the `TestScenario::return_object` function.
+using the `TestScenario::return_owned` function.
 
 We can now run the test command again and see that we now have two
 successful tests for our module:
@@ -870,11 +870,11 @@ We can now create a function to test the module initialization:
         TestScenario::next_tx(scenario, &admin);
         {
             // extract the Forge object
-            let forge = TestScenario::take_object<Forge>(scenario);
+            let forge = TestScenario::take_owned<Forge>(scenario);
             // verify number of created swords
             assert!(swords_created(&forge) == 0, 1);
             // return the Forge object to the object pool
-            TestScenario::return_object(scenario, forge)
+            TestScenario::return_owned(scenario, forge)
         }
     }
 

--- a/doc/src/build/programming-with-objects/ch1-object-basics.md
+++ b/doc/src/build/programming-with-objects/ch1-object-basics.md
@@ -114,27 +114,27 @@ let not_owner = @0x2;
 // Check that @not_owner does not own the just-created ColorObject.
 TestScenario::next_tx(scenario, &not_owner);
 {
-    assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+    assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
 };
 ```
 
 `TestScenario::next_tx` switches the transaction sender to `@0x2`, which is a new address than the previous one.
-`TestScenario::can_take_object` checks whether an object with the given type actually exists in the global storage owned by the current sender of the transaction. In this code, we assert that we should not be able to remove such an object, because `@0x2` does not own any object.
+`TestScenario::can_take_owned` checks whether an object with the given type actually exists in the global storage owned by the current sender of the transaction. In this code, we assert that we should not be able to remove such an object, because `@0x2` does not own any object.
 > :bulb: The second parameter of `assert!` is the error code. In non-test code, we usually define a list of dedicated error code constants for each type of error that could happen in production. For unit tests though, it's usually unnecessary because there will be way too many assetions and the stacktrace upon error is sufficient to tell where the error happened. Hence we recommend just putting `0` there in unit tests for assertions.
 
 Finally we check that `@0x1` owns the object and the object value is consistent:
 ```rust
 TestScenario::next_tx(scenario, &owner);
 {
-    let object = TestScenario::take_object<ColorObject>(scenario);
+    let object = TestScenario::take_owned<ColorObject>(scenario);
     let (red, green, blue) = ColorObject::get_color(&object);
     assert!(red == 255 && green == 0 && blue == 255, 0);
-    TestScenario::return_object(scenario, object);
+    TestScenario::return_owned(scenario, object);
 };
 ```
 
-`TestScenario::take_object` removes the object of given type from global storage that's owned by the current transaction sender (it also implicitly checks `can_take_object`). If this line of code succeeds, it means that `owner` indeed owns an object of type `ColorObject`.
-We also check that the field values of the object match with what we set in creation. At the end, we must return the object back to the global storage by calling `TestScenario::return_object` so that it's back to the global storage. This also ensures that if any mutations happened to the object during the test, the global storage is aware of the changes.
+`TestScenario::take_owned` removes the object of given type from global storage that's owned by the current transaction sender (it also implicitly checks `can_take_owned`). If this line of code succeeds, it means that `owner` indeed owns an object of type `ColorObject`.
+We also check that the field values of the object match with what we set in creation. At the end, we must return the object back to the global storage by calling `TestScenario::return_owned` so that it's back to the global storage. This also ensures that if any mutations happened to the object during the test, the global storage is aware of the changes.
 
 Again, you can find the full code in [ColorObject.move](../../../../sui_programmability/examples/objects_tutorial/sources/ColorObject.move).
 

--- a/doc/src/build/programming-with-objects/ch2-using-objects.md
+++ b/doc/src/build/programming-with-objects/ch2-using-objects.md
@@ -32,7 +32,7 @@ In the above function signature, `from_object` can be a read-only reference beca
 > :bulb: Although `from_object` is a read-only reference in this transaction, it is still a mutable object in Sui storage--another transaction could be sent to mutate the object at the same time! To prevent this, Sui must lock any mutable object used as a transaction input, even when it's passed as a read-only reference. In addition, only an object's owner can send a transaction that locks the object.
 
 Let's write a unit test to see how we could interact with multiple objects of the same type in tests.
-In the previous chapter, we introduced the `take_object<T>` API, which takes an object of type `T` from the global storage created by previous transactions. However, what if there are multiple objects of the same type? `take_object<T>` will no longer be able to tell which one to return. To solve this problem, we need to use two new APIs. The first is `TxContext::last_created_object_id(ctx)`, which returns the ID of the most recent created object. The second is `TestScenario::take_object_by_id<T>`, which returns an object of type `T` with a specific object ID.
+In the previous chapter, we introduced the `take_owned<T>` API, which takes an object of type `T` from the global storage created by previous transactions. However, what if there are multiple objects of the same type? `take_owned<T>` will no longer be able to tell which one to return. To solve this problem, we need to use two new APIs. The first is `TxContext::last_created_object_id(ctx)`, which returns the ID of the most recent created object. The second is `TestScenario::take_owned_by_id<T>`, which returns an object of type `T` with a specific object ID.
 Now let's take a look at the test (`test_copy_into`):
 ```rust
 let owner = @0x1;
@@ -51,25 +51,25 @@ The above code created two objects. Note that right after each call, we make a c
 ```rust
 TestScenario::next_tx(scenario, &owner);
 {
-    let obj1 = TestScenario::take_object_by_id<ColorObject>(scenario, id1);
-    let obj2 = TestScenario::take_object_by_id<ColorObject>(scenario, id2);
+    let obj1 = TestScenario::take_owned_by_id<ColorObject>(scenario, id1);
+    let obj2 = TestScenario::take_owned_by_id<ColorObject>(scenario, id2);
     let (red, green, blue) = ColorObject::get_color(&obj1);
     assert!(red == 255 && green == 255 && blue == 255, 0);
 
     let ctx = TestScenario::ctx(scenario);
     ColorObject::copy_into(&obj2, &mut obj1, ctx);
-    TestScenario::return_object(scenario, obj1);
-    TestScenario::return_object(scenario, obj2);
+    TestScenario::return_owned(scenario, obj1);
+    TestScenario::return_owned(scenario, obj2);
 };
 ```
-We used `take_object_by_id` to take both objects using different IDs. We then used `copy_into` to update `obj1`'s value using `obj2`'s. We can verify that the mutation works:
+We used `take_owned_by_id` to take both objects using different IDs. We then used `copy_into` to update `obj1`'s value using `obj2`'s. We can verify that the mutation works:
 ```rust
 TestScenario::next_tx(scenario, &owner);
 {
-    let obj1 = TestScenario::take_object_by_id<ColorObject>(scenario, id1);
+    let obj1 = TestScenario::take_owned_by_id<ColorObject>(scenario, id1);
     let (red, green, blue) = ColorObject::get_color(&obj1);
     assert!(red == 0 && green == 0 && blue == 0, 0);
-    TestScenario::return_object(scenario, obj1);
+    TestScenario::return_owned(scenario, obj1);
 }
 ```
 
@@ -108,14 +108,14 @@ let scenario = &mut TestScenario::begin(&owner);
 // Delete the ColorObject we just created.
 TestScenario::next_tx(scenario, &owner);
 {
-    let object = TestScenario::take_object<ColorObject>(scenario);
+    let object = TestScenario::take_owned<ColorObject>(scenario);
     let ctx = TestScenario::ctx(scenario);
     ColorObject::delete(object, ctx);
 };
 // Verify that the object was indeed deleted.
 TestScenario::next_tx(scenario, &owner);
 {
-    assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+    assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
 }
 ```
 The first part is the same as what we have seen in [Chapter 1](./ch1-object-basics.md#writing-unit-tests), which creates a new `ColorObject` and puts it in the owner's account. The second transaction is what we are testing: retrieve the object from the storage and then delete it. Since the object is deleted, there is no need (in fact, it is impossible) to return it to the storage. The last part of the test checks that the object is indeed no longer in the global storage and hence cannot be retrieved from there.
@@ -142,7 +142,7 @@ let scenario = &mut TestScenario::begin(&owner);
 let recipient = @0x2;
 TestScenario::next_tx(scenario, &owner);
 {
-    let object = TestScenario::take_object<ColorObject>(scenario);
+    let object = TestScenario::take_owned<ColorObject>(scenario);
     let ctx = TestScenario::ctx(scenario);
     ColorObject::transfer(object, recipient, ctx);
 };
@@ -152,12 +152,12 @@ Note that in the second transaction, the sender of the transaction should still 
 // Check that owner no longer owns the object.
 TestScenario::next_tx(scenario, &owner);
 {
-    assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+    assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
 };
 // Check that recipient now owns the object.
 TestScenario::next_tx(scenario, &recipient);
 {
-    assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
+    assert!(TestScenario::can_take_owned<ColorObject>(scenario), 0);
 };
 ```
 

--- a/doc/src/build/programming-with-objects/ch3-immutable-objects.md
+++ b/doc/src/build/programming-with-objects/ch3-immutable-objects.md
@@ -45,7 +45,7 @@ Since immutable objects can never be mutated, there will never be a data race ev
 ### Test immutable object
 Let's take a look at how we interact with immutable objects in unit tests.
 
-Previously, we used the `TestScenario::take_object` API to take an object from the global storage that's owned by the sender of the transaction in a unit test. Since immutable objects are not owned by anyone, `TestScenario::take_object` works for immutable objects as well! That is, if there exists an immutable object of type `T` in the global storage, `take_object<T>` will return that object.
+Previously, we used the `TestScenario::take_owned` API to take an object from the global storage that's owned by the sender of the transaction in a unit test. Since immutable objects are not owned by anyone, `TestScenario::take_owned` works for immutable objects as well! That is, if there exists an immutable object of type `T` in the global storage, `take_owned<T>` will return that object.
 
 Let's see it work in action:
 ```rust
@@ -59,12 +59,12 @@ public(script) fun test_immutable() {
     };
     TestScenario::next_tx(scenario, &sender1);
     {
-        assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
+        assert!(TestScenario::can_take_owned<ColorObject>(scenario), 0);
     };
     let sender2 = @0x2;
     TestScenario::next_tx(scenario, &sender2);
     {
-        assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
+        assert!(TestScenario::can_take_owned<ColorObject>(scenario), 0);
     };
 }
 ```
@@ -95,10 +95,10 @@ public(script) fun test_mutate_immutable() {
     };
     TestScenario::next_tx(scenario, &sender1);
     {
-        let object = TestScenario::take_object<ColorObject>(scenario);
+        let object = TestScenario::take_owned<ColorObject>(scenario);
         let ctx = TestScenario::ctx(scenario);
         ColorObject::update(&mut object, 0, 0, 0, ctx);
-        TestScenario::return_object(scenario, object);
+        TestScenario::return_owned(scenario, object);
     };
 }
 ```

--- a/sui_core/src/unit_tests/data/hero/sources/Hero.move
+++ b/sui_core/src/unit_tests/data/hero/sources/Hero.move
@@ -313,32 +313,32 @@ module Examples::Hero {
         // Admin mints 500 coins and sends them to the Player so they can buy game items
         TestScenario::next_tx(scenario, &admin);
         {
-            let treasury_cap = TestScenario::take_object<TreasuryCap<EXAMPLE>>(scenario);
+            let treasury_cap = TestScenario::take_owned<TreasuryCap<EXAMPLE>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             let coins = Coin::mint(500, &mut treasury_cap, ctx);
             Coin::transfer(coins, copy player);
-            TestScenario::return_object(scenario, treasury_cap);
+            TestScenario::return_owned(scenario, treasury_cap);
         };
         // Player purchases a hero with the coins
         TestScenario::next_tx(scenario, &player);
         {
-            let coin = TestScenario::take_object<Coin<EXAMPLE>>(scenario);
+            let coin = TestScenario::take_owned<Coin<EXAMPLE>>(scenario);
             acquire_hero(coin, TestScenario::ctx(scenario));
         };
         // Admin sends a boar to the Player
         TestScenario::next_tx(scenario, &admin);
         {
-            let admin_cap = TestScenario::take_object<GameAdmin>(scenario);
+            let admin_cap = TestScenario::take_owned<GameAdmin>(scenario);
             send_boar(&mut admin_cap, 10, 10, player, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, admin_cap)
+            TestScenario::return_owned(scenario, admin_cap)
         };
         // Player slays the boar!
         TestScenario::next_tx(scenario, &player);
         {
-            let hero = TestScenario::take_object<Hero>(scenario);
-            let boar = TestScenario::take_object<Boar>(scenario);
+            let hero = TestScenario::take_owned<Hero>(scenario);
+            let boar = TestScenario::take_owned<Boar>(scenario);
             slay(&mut hero, boar, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, hero)
+            TestScenario::return_owned(scenario, hero)
         };
     }
 }

--- a/sui_programmability/examples/basics/sources/Counter.move
+++ b/sui_programmability/examples/basics/sources/Counter.move
@@ -71,7 +71,7 @@ module Basics::CounterTest {
 
         TestScenario::next_tx(scenario, &user1);
         {
-            let counter_wrapper = TestScenario::take_shared_object<Counter::Counter>(scenario);
+            let counter_wrapper = TestScenario::take_shared<Counter::Counter>(scenario);
             let counter = TestScenario::borrow_mut(&mut counter_wrapper);
 
             assert!(Counter::owner(counter) == owner, 0);
@@ -80,12 +80,12 @@ module Basics::CounterTest {
             Counter::increment(counter, TestScenario::ctx(scenario));
             Counter::increment(counter, TestScenario::ctx(scenario));
             Counter::increment(counter, TestScenario::ctx(scenario));
-            TestScenario::return_shared_object(scenario, counter_wrapper);
+            TestScenario::return_shared(scenario, counter_wrapper);
         };
 
         TestScenario::next_tx(scenario, &owner);
         {
-            let counter_wrapper = TestScenario::take_shared_object<Counter::Counter>(scenario);
+            let counter_wrapper = TestScenario::take_shared<Counter::Counter>(scenario);
             let counter = TestScenario::borrow_mut(&mut counter_wrapper);
 
             assert!(Counter::owner(counter) == owner, 0);
@@ -93,12 +93,12 @@ module Basics::CounterTest {
 
             Counter::set_value(counter, 100, TestScenario::ctx(scenario));
 
-            TestScenario::return_shared_object(scenario, counter_wrapper);
+            TestScenario::return_shared(scenario, counter_wrapper);
         };
 
         TestScenario::next_tx(scenario, &user1);
         {
-            let counter_wrapper = TestScenario::take_shared_object<Counter::Counter>(scenario);
+            let counter_wrapper = TestScenario::take_shared<Counter::Counter>(scenario);
             let counter = TestScenario::borrow_mut(&mut counter_wrapper);
 
             assert!(Counter::owner(counter) == owner, 0);
@@ -108,7 +108,7 @@ module Basics::CounterTest {
 
             assert!(Counter::value(counter) == 101, 2);
 
-            TestScenario::return_shared_object(scenario, counter_wrapper);
+            TestScenario::return_shared(scenario, counter_wrapper);
         };
     }
 }

--- a/sui_programmability/examples/basics/sources/Lock.move
+++ b/sui_programmability/examples/basics/sources/Lock.move
@@ -127,7 +127,7 @@ module Basics::LockTest {
         // key to User2, so that he can have access to the stored treasure.
         TestScenario::next_tx(scenario, &user1);
         {
-            let key = TestScenario::take_object<Key<Treasure>>(scenario);
+            let key = TestScenario::take_owned<Key<Treasure>>(scenario);
 
             Transfer::transfer(key, user2);
         };
@@ -135,15 +135,15 @@ module Basics::LockTest {
         // User2 is impatient and he decides to take the treasure.
         TestScenario::next_tx(scenario, &user2);
         {
-            let lock_wrapper = TestScenario::take_shared_object<Lock<Treasure>>(scenario);
+            let lock_wrapper = TestScenario::take_shared<Lock<Treasure>>(scenario);
             let lock = TestScenario::borrow_mut(&mut lock_wrapper);
-            let key = TestScenario::take_object<Key<Treasure>>(scenario);
+            let key = TestScenario::take_owned<Key<Treasure>>(scenario);
             let ctx = TestScenario::ctx(scenario);
 
             Lock::take<Treasure>(lock, &key, ctx);
 
-            TestScenario::return_shared_object(scenario, lock_wrapper);
-            TestScenario::return_object(scenario, key);
+            TestScenario::return_shared(scenario, lock_wrapper);
+            TestScenario::return_owned(scenario, key);
         };
     }
 }

--- a/sui_programmability/examples/basics/sources/Sandwich.move
+++ b/sui_programmability/examples/basics/sources/Sandwich.move
@@ -129,7 +129,7 @@ module Basics::TestSandwich {
 
         TestScenario::next_tx(scenario, &the_guy);
         {
-            let grocery_wrapper = TestScenario::take_shared_object<Grocery>(scenario);
+            let grocery_wrapper = TestScenario::take_shared<Grocery>(scenario);
             let grocery = TestScenario::borrow_mut(&mut grocery_wrapper);
             let ctx = TestScenario::ctx(scenario);
 
@@ -145,29 +145,29 @@ module Basics::TestSandwich {
                 ctx
             );
 
-            TestScenario::return_shared_object(scenario, grocery_wrapper);
+            TestScenario::return_shared(scenario, grocery_wrapper);
         };
 
         TestScenario::next_tx(scenario, &the_guy);
         {
-            let ham = TestScenario::take_object<Ham>(scenario);
-            let bread = TestScenario::take_object<Bread>(scenario);
+            let ham = TestScenario::take_owned<Ham>(scenario);
+            let bread = TestScenario::take_owned<Bread>(scenario);
 
             Sandwich::make_sandwich(ham, bread, TestScenario::ctx(scenario));
         };
 
         TestScenario::next_tx(scenario, &owner);
         {
-            let grocery_wrapper = TestScenario::take_shared_object<Grocery>(scenario);
+            let grocery_wrapper = TestScenario::take_shared<Grocery>(scenario);
             let grocery = TestScenario::borrow_mut(&mut grocery_wrapper);
-            let capability = TestScenario::take_object<GroceryOwnerCapability>(scenario);
+            let capability = TestScenario::take_owned<GroceryOwnerCapability>(scenario);
 
             assert!(Sandwich::profits(grocery) == 12, 0);
             Sandwich::collect_profits(&capability, grocery, TestScenario::ctx(scenario));
             assert!(Sandwich::profits(grocery) == 0, 0);
 
-            TestScenario::return_object(scenario, capability);
-            TestScenario::return_shared_object(scenario, grocery_wrapper);
+            TestScenario::return_owned(scenario, capability);
+            TestScenario::return_shared(scenario, grocery_wrapper);
         };
     }
 }

--- a/sui_programmability/examples/defi/tests/EscrowTests.move
+++ b/sui_programmability/examples/defi/tests/EscrowTests.move
@@ -47,11 +47,11 @@ module DeFi::EscrowTests {
         // The third party returns item A to Alice, item B to Bob
         TestScenario::next_tx(scenario, &THIRD_PARTY_ADDRESS);
         {
-            let item_a = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let item_a = TestScenario::take_owned<EscrowedObj<ItemA, ItemB>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             Escrow::return_to_sender<ItemA, ItemB>(item_a, ctx);
 
-            let item_b = TestScenario::take_object<EscrowedObj<ItemB, ItemA>>(scenario);
+            let item_b = TestScenario::take_owned<EscrowedObj<ItemB, ItemA>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             Escrow::return_to_sender<ItemB, ItemA>(item_b, ctx);
         };
@@ -82,8 +82,8 @@ module DeFi::EscrowTests {
     public(script) fun swap(scenario: &mut Scenario, third_party: &address) {
         TestScenario::next_tx(scenario, third_party);
         {
-            let item_a = TestScenario::take_object<EscrowedObj<ItemA, ItemB>>(scenario);
-            let item_b = TestScenario::take_object<EscrowedObj<ItemB, ItemA>>(scenario);
+            let item_a = TestScenario::take_owned<EscrowedObj<ItemA, ItemB>>(scenario);
+            let item_b = TestScenario::take_owned<EscrowedObj<ItemB, ItemA>>(scenario);
             let ctx = TestScenario::ctx(scenario);
             Escrow::swap(item_a, item_b, ctx);
         };
@@ -157,6 +157,6 @@ module DeFi::EscrowTests {
 
     fun owns_object<T: key + store>(scenario: &mut Scenario, owner: &address): bool{
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_take_object<T>(scenario)
+        TestScenario::can_take_owned<T>(scenario)
     }
 }

--- a/sui_programmability/examples/defi/tests/FlashLenderTests.move
+++ b/sui_programmability/examples/defi/tests/FlashLenderTests.move
@@ -23,7 +23,7 @@ module DeFi::FlashLenderTests {
         // borrower requests and repays a loan of 10 coins + the fee
         TestScenario::next_tx(scenario, &borrower);
         {
-            let lender_wrapper = TestScenario::take_shared_object<FlashLender<SUI>>(scenario);
+            let lender_wrapper = TestScenario::take_shared<FlashLender<SUI>>(scenario);
             let lender = TestScenario::borrow_mut(&mut lender_wrapper);
             let ctx = TestScenario::ctx(scenario);
 
@@ -36,14 +36,14 @@ module DeFi::FlashLenderTests {
             Coin::keep(to_keep, ctx);
             FlashLender::repay(lender, profit, receipt);
 
-            TestScenario::return_shared_object(scenario, lender_wrapper);
+            TestScenario::return_shared(scenario, lender_wrapper);
         };
         // admin withdraws the 1 coin profit from lending
         TestScenario::next_tx(scenario, &admin);
         {
-            let lender_wrapper = TestScenario::take_shared_object<FlashLender<SUI>>(scenario);
+            let lender_wrapper = TestScenario::take_shared<FlashLender<SUI>>(scenario);
             let lender = TestScenario::borrow_mut(&mut lender_wrapper);
-            let admin_cap = TestScenario::take_object<AdminCap>(scenario);
+            let admin_cap = TestScenario::take_owned<AdminCap>(scenario);
             let ctx = TestScenario::ctx(scenario);
 
             // max loan size should have increased because of the fee payment
@@ -54,8 +54,8 @@ module DeFi::FlashLenderTests {
             assert!(FlashLender::max_loan(lender) == 100, 0);
             Coin::keep(coin, ctx);
 
-            TestScenario::return_shared_object(scenario, lender_wrapper);
-            TestScenario::return_object(scenario, admin_cap);
+            TestScenario::return_shared(scenario, lender_wrapper);
+            TestScenario::return_owned(scenario, admin_cap);
         }
     }
 }

--- a/sui_programmability/examples/defi/tests/SharedEscrowTest.move
+++ b/sui_programmability/examples/defi/tests/SharedEscrowTest.move
@@ -118,25 +118,25 @@ module DeFi::SharedEscrowTests {
     public(script) fun cancel(scenario: &mut Scenario, initiator: &address) {
         TestScenario::next_tx(scenario, initiator);
         {
-            let escrow_wrapper = TestScenario::take_shared_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow_wrapper = TestScenario::take_shared<EscrowedObj<ItemA, ItemB>>(scenario);
             let escrow = TestScenario::borrow_mut(&mut escrow_wrapper);
             let ctx = TestScenario::ctx(scenario);
             SharedEscrow::cancel(escrow, ctx);
-            TestScenario::return_shared_object(scenario, escrow_wrapper);
+            TestScenario::return_shared(scenario, escrow_wrapper);
         };
     }
 
     public(script) fun exchange(scenario: &mut Scenario, bob: &address, item_b_verioned_id: VersionedID) {
         TestScenario::next_tx(scenario, bob);
         {
-            let escrow_wrapper = TestScenario::take_shared_object<EscrowedObj<ItemA, ItemB>>(scenario);
+            let escrow_wrapper = TestScenario::take_shared<EscrowedObj<ItemA, ItemB>>(scenario);
             let escrow = TestScenario::borrow_mut(&mut escrow_wrapper);
             let item_b = ItemB {
                 id: item_b_verioned_id
             };
             let ctx = TestScenario::ctx(scenario);
             SharedEscrow::exchange(item_b, escrow, ctx);
-            TestScenario::return_shared_object(scenario, escrow_wrapper);
+            TestScenario::return_shared(scenario, escrow_wrapper);
         };
     }
 
@@ -173,6 +173,6 @@ module DeFi::SharedEscrowTests {
 
     fun owns_object<T: key + store>(scenario: &mut Scenario, owner: &address): bool{
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_take_object<T>(scenario)
+        TestScenario::can_take_owned<T>(scenario)
     }
 }

--- a/sui_programmability/examples/fungible_tokens/tests/BASKETTests.move
+++ b/sui_programmability/examples/fungible_tokens/tests/BASKETTests.move
@@ -20,7 +20,7 @@ module FungibleTokens::BASKETTests {
         };
         TestScenario::next_tx(scenario, &user);
         {
-            let reserve_wrapper = TestScenario::take_shared_object<Reserve>(scenario);
+            let reserve_wrapper = TestScenario::take_shared<Reserve>(scenario);
             let reserve = TestScenario::borrow_mut(&mut reserve_wrapper);
             let ctx = TestScenario::ctx(scenario);
             assert!(BASKET::total_supply(reserve) == 0, 0);
@@ -38,7 +38,7 @@ module FungibleTokens::BASKETTests {
 
             Coin::keep(sui, ctx);
             Coin::keep(managed, ctx);
-            TestScenario::return_shared_object(scenario, reserve_wrapper);
+            TestScenario::return_shared(scenario, reserve_wrapper);
         }
     }
 

--- a/sui_programmability/examples/games/hero/sources/Hero.move
+++ b/sui_programmability/examples/games/hero/sources/Hero.move
@@ -316,17 +316,17 @@ module HeroGame::Hero {
         // Admin sends a boar to the Player
         TestScenario::next_tx(scenario, &admin);
         {
-            let admin_cap = TestScenario::take_object<GameAdmin>(scenario);
+            let admin_cap = TestScenario::take_owned<GameAdmin>(scenario);
             send_boar(&mut admin_cap, 10, 10, player, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, admin_cap)
+            TestScenario::return_owned(scenario, admin_cap)
         };
         // Player slays the boar!
         TestScenario::next_tx(scenario, &player);
         {
-            let hero = TestScenario::take_object<Hero>(scenario);
-            let boar = TestScenario::take_object<Boar>(scenario);
+            let hero = TestScenario::take_owned<Hero>(scenario);
+            let boar = TestScenario::take_owned<Boar>(scenario);
             slay(&mut hero, boar, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, hero)
+            TestScenario::return_owned(scenario, hero)
         };
     }
 }

--- a/sui_programmability/examples/games/tests/RockPaperScissorsTests.move
+++ b/sui_programmability/examples/games/tests/RockPaperScissorsTests.move
@@ -31,8 +31,8 @@ module Games::RockPaperScissorsTests {
         // Now it's time for The Main Guy to accept his turn.
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::take_object<Game>(scenario);
-            let cap = TestScenario::take_object<PlayerTurn>(scenario);
+            let game = TestScenario::take_owned<Game>(scenario);
+            let cap = TestScenario::take_owned<PlayerTurn>(scenario);
 
             assert!(Game::status(&game) == 0, 0); // STATUS_READY
 
@@ -40,7 +40,7 @@ module Games::RockPaperScissorsTests {
 
             assert!(Game::status(&game) == 1, 0); // STATUS_HASH_SUBMISSION
 
-            TestScenario::return_object(scenario, game);
+            TestScenario::return_owned(scenario, game);
         };
 
         // Same for Mr Lizard. He uses his secret phrase to encode his turn.
@@ -52,13 +52,13 @@ module Games::RockPaperScissorsTests {
 
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::take_object<Game>(scenario);
-            let cap = TestScenario::take_object<PlayerTurn>(scenario);
+            let game = TestScenario::take_owned<Game>(scenario);
+            let cap = TestScenario::take_owned<PlayerTurn>(scenario);
             Game::add_hash(&mut game, cap, TestScenario::ctx(scenario));
 
             assert!(Game::status(&game) == 2, 0); // STATUS_HASHES_SUBMITTED
 
-            TestScenario::return_object(scenario, game);
+            TestScenario::return_owned(scenario, game);
         };
 
         // Now that both sides made their moves, it's time for  Mr Spock and Mr Lizard to
@@ -69,13 +69,13 @@ module Games::RockPaperScissorsTests {
 
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::take_object<Game>(scenario);
-            let secret = TestScenario::take_object<Secret>(scenario);
+            let game = TestScenario::take_owned<Game>(scenario);
+            let secret = TestScenario::take_owned<Secret>(scenario);
             Game::match_secret(&mut game, secret, TestScenario::ctx(scenario));
 
             assert!(Game::status(&game) == 3, 0); // STATUS_REVEALING
 
-            TestScenario::return_object(scenario, game);
+            TestScenario::return_owned(scenario, game);
         };
 
         TestScenario::next_tx(scenario, &mr_lizard);
@@ -85,8 +85,8 @@ module Games::RockPaperScissorsTests {
         // calls the [`select_winner`] function to release The Prize.
         TestScenario::next_tx(scenario, &the_main_guy);
         {
-            let game = TestScenario::take_object<Game>(scenario);
-            let secret = TestScenario::take_object<Secret>(scenario);
+            let game = TestScenario::take_owned<Game>(scenario);
+            let secret = TestScenario::take_owned<Secret>(scenario);
             Game::match_secret(&mut game, secret, TestScenario::ctx(scenario));
 
             assert!(Game::status(&game) == 4, 0); // STATUS_REVEALED
@@ -96,9 +96,9 @@ module Games::RockPaperScissorsTests {
 
         TestScenario::next_tx(scenario, &mr_spock);
         // If it works, then MrSpock is in possession of the prize;
-        let prize = TestScenario::take_object<ThePrize>(scenario);
+        let prize = TestScenario::take_owned<ThePrize>(scenario);
         // Don't forget to give it back!
-        TestScenario::return_object(scenario, prize);
+        TestScenario::return_owned(scenario, prize);
     }
 
     // Copy of the hashing function from the main module.

--- a/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/SharedTicTacToeTests.move
@@ -72,11 +72,11 @@ module Games::SharedTicTacToeTests {
 
         // X has the Trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(TestScenario::can_take_owned<Trophy>(scenario), 1);
 
         TestScenario::next_tx(scenario, &player_o);
         // O has no Trophy
-        assert!(!TestScenario::can_take_object<Trophy>(scenario), 2);
+        assert!(!TestScenario::can_take_owned<Trophy>(scenario), 2);
     }
 
 
@@ -182,9 +182,9 @@ module Games::SharedTicTacToeTests {
 
         // No one has the trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_owned<Trophy>(scenario), 1);
         TestScenario::next_tx(scenario, &player_o);
-        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_owned<Trophy>(scenario), 1);
     }
 
 
@@ -199,11 +199,11 @@ module Games::SharedTicTacToeTests {
         TestScenario::next_tx(scenario, player);
         let status;
         {
-            let game_wrapper = TestScenario::take_shared_object<TicTacToe>(scenario);
+            let game_wrapper = TestScenario::take_shared<TicTacToe>(scenario);
             let game = TestScenario::borrow_mut(&mut game_wrapper);
             SharedTicTacToe::place_mark(game, row, col, TestScenario::ctx(scenario));
             status = SharedTicTacToe::get_status(game);
-            TestScenario::return_shared_object(scenario, game_wrapper);
+            TestScenario::return_shared(scenario, game_wrapper);
         };
         status
     }

--- a/sui_programmability/examples/games/tests/TicTacToeTests.move
+++ b/sui_programmability/examples/games/tests/TicTacToeTests.move
@@ -75,11 +75,11 @@ module Games::TicTacToeTests {
 
         // X has the trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(TestScenario::can_take_owned<Trophy>(scenario), 1);
 
         TestScenario::next_tx(scenario, &player_o);
         // O has no Trophy
-        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_owned<Trophy>(scenario), 1);
     }
 
 
@@ -186,9 +186,9 @@ module Games::TicTacToeTests {
 
         // No one has the trophy
         TestScenario::next_tx(scenario, &player_x);
-        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_owned<Trophy>(scenario), 1);
         TestScenario::next_tx(scenario, &player_o);
-        assert!(!TestScenario::can_take_object<Trophy>(scenario), 1);
+        assert!(!TestScenario::can_take_owned<Trophy>(scenario), 1);
     }
 
     public(script) fun place_mark(
@@ -201,22 +201,22 @@ module Games::TicTacToeTests {
         // Step 1: player creates a mark and sends it to the game.
         TestScenario::next_tx(scenario, player);
         {
-            let cap = TestScenario::take_object<MarkMintCap>(scenario);
+            let cap = TestScenario::take_owned<MarkMintCap>(scenario);
             TicTacToe::send_mark_to_game(&mut cap, *admin, row, col, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, cap);
+            TestScenario::return_owned(scenario, cap);
         };
         // Step 2: Admin places the received mark on the game board.
         TestScenario::next_tx(scenario, admin);
         let status;
         {
-            let game = TestScenario::take_object<TicTacToe>(scenario);
-            let mark = TestScenario::take_object<Mark>(scenario);
+            let game = TestScenario::take_owned<TicTacToe>(scenario);
+            let mark = TestScenario::take_owned<Mark>(scenario);
             assert!(TicTacToe::mark_player(&mark) == player, 0);
             assert!(TicTacToe::mark_row(&mark) == row, 1);
             assert!(TicTacToe::mark_col(&mark) == col, 2);
             TicTacToe::place_mark(&mut game, mark, TestScenario::ctx(scenario));
             status = TicTacToe::get_status(&game);
-            TestScenario::return_object(scenario, game);
+            TestScenario::return_owned(scenario, game);
         };
         // return the game status
         status

--- a/sui_programmability/examples/nfts/sources/Marketplace.move
+++ b/sui_programmability/examples/nfts/sources/Marketplace.move
@@ -168,14 +168,14 @@ module NFTs::MarketplaceTests {
     // SELLER lists Kitty at the Marketplace for 100 SUI.
     public(script) fun list_kitty(scenario: &mut Scenario) {
         TestScenario::next_tx(scenario, &SELLER);
-        let mkp_wrapper = TestScenario::take_shared_object<Marketplace>(scenario);
+        let mkp_wrapper = TestScenario::take_shared<Marketplace>(scenario);
         let mkp = TestScenario::borrow_mut(&mut mkp_wrapper);
         let bag = TestScenario::take_child_object<Marketplace, Bag>(scenario, mkp);
-        let nft = TestScenario::take_object<Kitty>(scenario);
+        let nft = TestScenario::take_owned<Kitty>(scenario);
 
         Marketplace::list<Kitty, SUI>(mkp, &mut bag, nft, 100, TestScenario::ctx(scenario));
-        TestScenario::return_shared_object(scenario, mkp_wrapper);
-        TestScenario::return_object(scenario, bag);
+        TestScenario::return_shared(scenario, mkp_wrapper);
+        TestScenario::return_owned(scenario, bag);
     }
 
     #[test]
@@ -188,7 +188,7 @@ module NFTs::MarketplaceTests {
 
         TestScenario::next_tx(scenario, &SELLER);
         {
-            let mkp_wrapper = TestScenario::take_shared_object<Marketplace>(scenario);
+            let mkp_wrapper = TestScenario::take_shared<Marketplace>(scenario);
             let mkp = TestScenario::borrow_mut(&mut mkp_wrapper);
             let bag = TestScenario::take_child_object<Marketplace, Bag>(scenario, mkp);
             let listing = TestScenario::take_child_object<Bag, Listing<Kitty, SUI>>(scenario, &bag);
@@ -199,8 +199,8 @@ module NFTs::MarketplaceTests {
 
             assert!(kitty_id == 1, 0);
 
-            TestScenario::return_shared_object(scenario, mkp_wrapper);
-            TestScenario::return_object(scenario, bag);
+            TestScenario::return_shared(scenario, mkp_wrapper);
+            TestScenario::return_owned(scenario, bag);
         };
     }
 
@@ -217,7 +217,7 @@ module NFTs::MarketplaceTests {
         // BUYER attempts to delist Kitty and he has no right to do so. :(
         TestScenario::next_tx(scenario, &BUYER);
         {
-            let mkp_wrapper = TestScenario::take_shared_object<Marketplace>(scenario);
+            let mkp_wrapper = TestScenario::take_shared<Marketplace>(scenario);
             let mkp = TestScenario::borrow_mut(&mut mkp_wrapper);
             let bag = TestScenario::take_child_object<Marketplace, Bag>(scenario, mkp);
             let listing = TestScenario::take_child_object<Bag, Listing<Kitty, SUI>>(scenario, &bag);
@@ -226,8 +226,8 @@ module NFTs::MarketplaceTests {
             let nft = Marketplace::delist<Kitty, SUI>(mkp, &mut bag, listing, TestScenario::ctx(scenario));
             let _ = burn_kitty(nft);
 
-            TestScenario::return_shared_object(scenario, mkp_wrapper);
-            TestScenario::return_object(scenario, bag);
+            TestScenario::return_shared(scenario, mkp_wrapper);
+            TestScenario::return_owned(scenario, bag);
         };
     }
 
@@ -248,8 +248,8 @@ module NFTs::MarketplaceTests {
         // BUYER takes 100 SUI from his wallet and purchases Kitty.
         TestScenario::next_tx(scenario, &BUYER);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
-            let mkp_wrapper = TestScenario::take_shared_object<Marketplace>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
+            let mkp_wrapper = TestScenario::take_shared<Marketplace>(scenario);
             let mkp = TestScenario::borrow_mut(&mut mkp_wrapper);
             let bag = TestScenario::take_child_object<Marketplace, Bag>(scenario, mkp);
             let listing = TestScenario::take_child_object<Bag, Listing<Kitty, SUI>>(scenario, &bag);
@@ -261,9 +261,9 @@ module NFTs::MarketplaceTests {
 
             assert!(kitty_id == 1, 0);
 
-            TestScenario::return_shared_object(scenario, mkp_wrapper);
-            TestScenario::return_object(scenario, bag);
-            TestScenario::return_object(scenario, coin);
+            TestScenario::return_shared(scenario, mkp_wrapper);
+            TestScenario::return_owned(scenario, bag);
+            TestScenario::return_owned(scenario, coin);
         };
     }
 
@@ -280,8 +280,8 @@ module NFTs::MarketplaceTests {
         // BUYER takes 100 SUI from his wallet and purchases Kitty.
         TestScenario::next_tx(scenario, &BUYER);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
-            let mkp_wrapper = TestScenario::take_shared_object<Marketplace>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
+            let mkp_wrapper = TestScenario::take_shared<Marketplace>(scenario);
             let mkp = TestScenario::borrow_mut(&mut mkp_wrapper);
             let bag = TestScenario::take_child_object<Marketplace, Bag>(scenario, mkp);
             let listing = TestScenario::take_child_object<Bag, Listing<Kitty, SUI>>(scenario, &bag);
@@ -293,9 +293,9 @@ module NFTs::MarketplaceTests {
             let nft = Marketplace::buy<Kitty, SUI>(&mut bag, listing, payment);
             let _ = burn_kitty(nft);
 
-            TestScenario::return_shared_object(scenario, mkp_wrapper);
-            TestScenario::return_object(scenario, bag);
-            TestScenario::return_object(scenario, coin);
+            TestScenario::return_shared(scenario, mkp_wrapper);
+            TestScenario::return_owned(scenario, bag);
+            TestScenario::return_owned(scenario, coin);
         };
     }
 

--- a/sui_programmability/examples/nfts/tests/AuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/AuctionTests.move
@@ -71,7 +71,7 @@ module NFTs::AuctionTests {
         // a transaction by the first bidder to create and put a bid
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
 
             Auction::bid(coin, auction_id, auctioneer, TestScenario::ctx(scenario));
         };
@@ -79,19 +79,19 @@ module NFTs::AuctionTests {
         // a transaction by the auctioneer to update state of the auction
         TestScenario::next_tx(scenario, &auctioneer);
         {
-            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_owned<Auction<SomeItemToSell>>(scenario);
 
-            let bid = TestScenario::take_object<Bid>(scenario);
+            let bid = TestScenario::take_owned<Bid>(scenario);
             Auction::update_auction(&mut auction, bid, TestScenario::ctx(scenario));
 
-            TestScenario::return_object(scenario, auction);
+            TestScenario::return_owned(scenario, auction);
         };
         // a transaction by the second bidder to create and put a bid (a
         // bid will fail as it has the same value as that of the first
         // bidder's)
         TestScenario::next_tx(scenario, &bidder2);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
 
             Auction::bid(coin, auction_id, auctioneer, TestScenario::ctx(scenario));
         };
@@ -99,18 +99,18 @@ module NFTs::AuctionTests {
         // a transaction by the auctioneer to update state of the auction
         TestScenario::next_tx(scenario, &auctioneer);
         {
-            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_owned<Auction<SomeItemToSell>>(scenario);
 
-            let bid = TestScenario::take_object<Bid>(scenario);
+            let bid = TestScenario::take_owned<Bid>(scenario);
             Auction::update_auction(&mut auction, bid, TestScenario::ctx(scenario));
 
-            TestScenario::return_object(scenario, auction);
+            TestScenario::return_owned(scenario, auction);
         };
 
         // a transaction by the auctioneer to end auction
         TestScenario::next_tx(scenario, &auctioneer);
         {
-            let auction = TestScenario::take_object<Auction<SomeItemToSell>>(scenario);
+            let auction = TestScenario::take_owned<Auction<SomeItemToSell>>(scenario);
 
             Auction::end_auction(auction, TestScenario::ctx(scenario));
         };
@@ -119,11 +119,11 @@ module NFTs::AuctionTests {
         // second bidder's bid was the same as that of the first one)
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let acquired_item = TestScenario::take_object<SomeItemToSell>(scenario);
+            let acquired_item = TestScenario::take_owned<SomeItemToSell>(scenario);
 
             assert!(acquired_item.value == 42, EWRONG_ITEM_VALUE);
 
-            TestScenario::return_object(scenario, acquired_item);
+            TestScenario::return_owned(scenario, acquired_item);
         };
     }
 }

--- a/sui_programmability/examples/nfts/tests/DiscountCouponTests.move
+++ b/sui_programmability/examples/nfts/tests/DiscountCouponTests.move
@@ -34,16 +34,16 @@ module NFTs::DiscountCouponTests {
         // Mint and transfer NFT + top up recipient's address.
         TestScenario::next_tx(scenario, &ISSUER_ADDRESS);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
             DiscountCoupon::mint_and_topup(coin, 10, 1648820870, USER1_ADDRESS, TestScenario::ctx(scenario));
         };
 
         TestScenario::next_tx(scenario, &USER1_ADDRESS);
         {
-            assert!(TestScenario::can_take_object<DiscountCoupon>(scenario), 0);
-            let nft_coupon = TestScenario::take_object<DiscountCoupon>(scenario); // if can remove, object exists
+            assert!(TestScenario::can_take_owned<DiscountCoupon>(scenario), 0);
+            let nft_coupon = TestScenario::take_owned<DiscountCoupon>(scenario); // if can remove, object exists
             assert!(DiscountCoupon::issuer(&nft_coupon) == ISSUER_ADDRESS, 0);
-            TestScenario::return_object(scenario, nft_coupon);
+            TestScenario::return_owned(scenario, nft_coupon);
         }
     }
 }

--- a/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
+++ b/sui_programmability/examples/nfts/tests/SharedAuctionTests.move
@@ -68,13 +68,13 @@ module NFTs::SharedAuctionTests {
         // a transaction by the first bidder to put a bid
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
-            let auction_wrapper = TestScenario::take_shared_object<Auction<SomeItemToSell>>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
+            let auction_wrapper = TestScenario::take_shared<Auction<SomeItemToSell>>(scenario);
             let auction = TestScenario::borrow_mut(&mut auction_wrapper);
 
             SharedAuction::bid(coin, auction, TestScenario::ctx(scenario));
 
-            TestScenario::return_shared_object(scenario, auction_wrapper);
+            TestScenario::return_shared(scenario, auction_wrapper);
         };
 
         // a transaction by the second bidder to put a bid (a bid will
@@ -82,48 +82,48 @@ module NFTs::SharedAuctionTests {
         // bidder's)
         TestScenario::next_tx(scenario, &bidder2);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
-            let auction_wrapper = TestScenario::take_shared_object<Auction<SomeItemToSell>>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
+            let auction_wrapper = TestScenario::take_shared<Auction<SomeItemToSell>>(scenario);
             let auction = TestScenario::borrow_mut(&mut auction_wrapper);
 
             SharedAuction::bid(coin, auction, TestScenario::ctx(scenario));
 
-            TestScenario::return_shared_object(scenario, auction_wrapper);
+            TestScenario::return_shared(scenario, auction_wrapper);
         };
 
         // a transaction by the second bidder to verify that the funds
         // have been returned (as a result of the failed bid).
         TestScenario::next_tx(scenario, &bidder2);
         {
-            let coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let coin = TestScenario::take_owned<Coin<SUI>>(scenario);
 
             assert!(Coin::value(&coin) == COIN_VALUE, EWRONG_COIN_VALUE);
 
-            TestScenario::return_object(scenario, coin);
+            TestScenario::return_owned(scenario, coin);
         };
 
         // a transaction by the owner to end auction
         TestScenario::next_tx(scenario, &owner);
         {
-            let auction_wrapper = TestScenario::take_shared_object<Auction<SomeItemToSell>>(scenario);
+            let auction_wrapper = TestScenario::take_shared<Auction<SomeItemToSell>>(scenario);
             let auction = TestScenario::borrow_mut(&mut auction_wrapper);
 
             // pass auction as mutable reference as its a shared
             // object that cannot be deleted
             SharedAuction::end_auction(auction, TestScenario::ctx(scenario));
 
-            TestScenario::return_shared_object(scenario, auction_wrapper);
+            TestScenario::return_shared(scenario, auction_wrapper);
         };
 
         // a transaction to check if the first bidder won (as the
         // second bidder's bid was the same as that of the first one)
         TestScenario::next_tx(scenario, &bidder1);
         {
-            let acquired_item = TestScenario::take_object<SomeItemToSell>(scenario);
+            let acquired_item = TestScenario::take_owned<SomeItemToSell>(scenario);
 
             assert!(acquired_item.value == 42, EWRONG_ITEM_VALUE);
 
-            TestScenario::return_object(scenario, acquired_item);
+            TestScenario::return_owned(scenario, acquired_item);
         };
     }
 }

--- a/sui_programmability/examples/objects_tutorial/sources/ColorObject.move
+++ b/sui_programmability/examples/objects_tutorial/sources/ColorObject.move
@@ -94,16 +94,16 @@ module Tutorial::ColorObjectTests {
         let not_owner = @0x2;
         TestScenario::next_tx(scenario, &not_owner);
         {
-            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
         };
         // Check that @owner indeed owns the just-created ColorObject.
         // Also checks the value fields of the object.
         TestScenario::next_tx(scenario, &owner);
         {
-            let object = TestScenario::take_object<ColorObject>(scenario);
+            let object = TestScenario::take_owned<ColorObject>(scenario);
             let (red, green, blue) = ColorObject::get_color(&object);
             assert!(red == 255 && green == 0 && blue == 255, 0);
-            TestScenario::return_object(scenario, object);
+            TestScenario::return_owned(scenario, object);
         };
     }
 
@@ -124,22 +124,22 @@ module Tutorial::ColorObjectTests {
         };
         TestScenario::next_tx(scenario, &owner);
         {
-            let obj1 = TestScenario::take_object_by_id<ColorObject>(scenario, id1);
-            let obj2 = TestScenario::take_object_by_id<ColorObject>(scenario, id2);
+            let obj1 = TestScenario::take_owned_by_id<ColorObject>(scenario, id1);
+            let obj2 = TestScenario::take_owned_by_id<ColorObject>(scenario, id2);
             let (red, green, blue) = ColorObject::get_color(&obj1);
             assert!(red == 255 && green == 255 && blue == 255, 0);
 
             let ctx = TestScenario::ctx(scenario);
             ColorObject::copy_into(&obj2, &mut obj1, ctx);
-            TestScenario::return_object(scenario, obj1);
-            TestScenario::return_object(scenario, obj2);
+            TestScenario::return_owned(scenario, obj1);
+            TestScenario::return_owned(scenario, obj2);
         };
         TestScenario::next_tx(scenario, &owner);
         {
-            let obj1 = TestScenario::take_object_by_id<ColorObject>(scenario, id1);
+            let obj1 = TestScenario::take_owned_by_id<ColorObject>(scenario, id1);
             let (red, green, blue) = ColorObject::get_color(&obj1);
             assert!(red == 0 && green == 0 && blue == 0, 0);
-            TestScenario::return_object(scenario, obj1);
+            TestScenario::return_owned(scenario, obj1);
         }
     }
 
@@ -155,14 +155,14 @@ module Tutorial::ColorObjectTests {
         // Delete the ColorObject we just created.
         TestScenario::next_tx(scenario, &owner);
         {
-            let object = TestScenario::take_object<ColorObject>(scenario);
+            let object = TestScenario::take_owned<ColorObject>(scenario);
             let ctx = TestScenario::ctx(scenario);
             ColorObject::delete(object, ctx);
         };
         // Verify that the object was indeed deleted.
         TestScenario::next_tx(scenario, &owner);
         {
-            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
         }
     }
 
@@ -179,19 +179,19 @@ module Tutorial::ColorObjectTests {
         let recipient = @0x2;
         TestScenario::next_tx(scenario, &owner);
         {
-            let object = TestScenario::take_object<ColorObject>(scenario);
+            let object = TestScenario::take_owned<ColorObject>(scenario);
             let ctx = TestScenario::ctx(scenario);
             ColorObject::transfer(object, recipient, ctx);
         };
         // Check that owner no longer owns the object.
         TestScenario::next_tx(scenario, &owner);
         {
-            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
         };
         // Check that recipient now owns the object.
         TestScenario::next_tx(scenario, &recipient);
         {
-            assert!(TestScenario::can_take_object<ColorObject>(scenario), 0);
+            assert!(TestScenario::can_take_owned<ColorObject>(scenario), 0);
         };
     }
 
@@ -207,16 +207,16 @@ module Tutorial::ColorObjectTests {
         };
         TestScenario::next_tx(scenario, &sender1);
         {
-            assert!(!TestScenario::can_take_object<ColorObject>(scenario), 0);
+            assert!(!TestScenario::can_take_owned<ColorObject>(scenario), 0);
         };
         let sender2 = @0x2;
         TestScenario::next_tx(scenario, &sender2);
         {
-            let object_wrapper = TestScenario::take_immutable_object<ColorObject>(scenario);
+            let object_wrapper = TestScenario::take_immutable<ColorObject>(scenario);
             let object = TestScenario::borrow(&object_wrapper);
             let (red, green, blue) = ColorObject::get_color(object);
             assert!(red == 255 && green == 0 && blue == 255, 0);
-            TestScenario::return_immutable_object(scenario, object_wrapper);
+            TestScenario::return_immutable(scenario, object_wrapper);
         };
     }
 }

--- a/sui_programmability/framework/tests/BagTests.move
+++ b/sui_programmability/framework/tests/BagTests.move
@@ -33,7 +33,7 @@ module Sui::BagTests {
         // Add two objects of different types into the bag.
         TestScenario::next_tx(scenario, &sender);
         {
-            let bag = TestScenario::take_object<Bag>(scenario);
+            let bag = TestScenario::take_owned<Bag>(scenario);
             assert!(Bag::size(&bag) == 0, EBAG_SIZE_MISMATCH);
 
             let obj1 = Object1 { id: TxContext::new_id(TestScenario::ctx(scenario)) };
@@ -48,7 +48,7 @@ module Sui::BagTests {
             assert!(Bag::contains(&bag, &id1), EOBJECT_NOT_FOUND);
             assert!(Bag::contains(&bag, &id2), EOBJECT_NOT_FOUND);
 
-            TestScenario::return_object(scenario, bag);
+            TestScenario::return_owned(scenario, bag);
         };
         // TODO: Test object removal once we can retrieve object owned objects from TestScenario.
     }

--- a/sui_programmability/framework/tests/CollectionTests.move
+++ b/sui_programmability/framework/tests/CollectionTests.move
@@ -27,7 +27,7 @@ module Sui::CollectionTests {
         // Add two objects of different types into the collection.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::take_object<Collection<Object>>(scenario);
+            let collection = TestScenario::take_owned<Collection<Object>>(scenario);
             assert!(Collection::size(&collection) == 0, 0);
 
             let obj1 = Object { id: TxContext::new_id(TestScenario::ctx(scenario)) };
@@ -42,7 +42,7 @@ module Sui::CollectionTests {
             assert!(Collection::contains(&collection, &id1), 0);
             assert!(Collection::contains(&collection, &id2), 0);
 
-            TestScenario::return_object(scenario, collection);
+            TestScenario::return_owned(scenario, collection);
         };
     }
 
@@ -61,17 +61,17 @@ module Sui::CollectionTests {
         // Add a new object to the Collection.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::take_object<Collection<Object>>(scenario);
+            let collection = TestScenario::take_owned<Collection<Object>>(scenario);
             let obj = Object { id: TxContext::new_id(TestScenario::ctx(scenario)) };
             Collection::add(&mut collection, obj);
-            TestScenario::return_object(scenario, collection);
+            TestScenario::return_owned(scenario, collection);
         };
 
         // Remove the object from the collection and add it to the bag.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::take_object<Collection<Object>>(scenario);
-            let bag = TestScenario::take_object<Bag>(scenario);
+            let collection = TestScenario::take_owned<Collection<Object>>(scenario);
+            let bag = TestScenario::take_owned<Bag>(scenario);
             let obj = TestScenario::take_child_object<Collection<Object>, Object>(scenario, &collection);
             let id = *ID::id(&obj);
 
@@ -82,15 +82,15 @@ module Sui::CollectionTests {
             assert!(Bag::size(&bag) == 1, 0);
             assert!(Bag::contains(&bag, &id), 0);
 
-            TestScenario::return_object(scenario, collection);
-            TestScenario::return_object(scenario, bag);
+            TestScenario::return_owned(scenario, collection);
+            TestScenario::return_owned(scenario, bag);
         };
 
         // Remove the object from the bag and add it back to the collection.
         TestScenario::next_tx(scenario, &sender);
         {
-            let collection = TestScenario::take_object<Collection<Object>>(scenario);
-            let bag = TestScenario::take_object<Bag>(scenario);
+            let collection = TestScenario::take_owned<Collection<Object>>(scenario);
+            let bag = TestScenario::take_owned<Bag>(scenario);
             let obj = TestScenario::take_child_object<Bag, Object>(scenario, &bag);
             let id = *ID::id(&obj);
 
@@ -101,8 +101,8 @@ module Sui::CollectionTests {
             assert!(Bag::size(&bag) == 0, 0);
             assert!(Collection::contains(&collection, &id), 0);
 
-            TestScenario::return_object(scenario, collection);
-            TestScenario::return_object(scenario, bag);
+            TestScenario::return_owned(scenario, collection);
+            TestScenario::return_owned(scenario, bag);
         };
 
     }

--- a/sui_programmability/framework/tests/CrossChainAirdropTests.move
+++ b/sui_programmability/framework/tests/CrossChainAirdropTests.move
@@ -59,7 +59,7 @@ module Sui::CrossChainAirdropTests {
     public(script) fun claim_token(scenario: &mut Scenario, oracle_address: &address, token_id: u64) {
         TestScenario::next_tx(scenario, oracle_address);
         {
-            let oracle = TestScenario::take_object<CrossChainAirdropOracle>(scenario);
+            let oracle = TestScenario::take_owned<CrossChainAirdropOracle>(scenario);
             let ctx = TestScenario::ctx(scenario);
             CrossChainAirdrop::claim(
                 &mut oracle,
@@ -70,13 +70,13 @@ module Sui::CrossChainAirdropTests {
                 TOKEN_URI,
                 ctx,
             );
-            TestScenario::return_object(scenario, oracle);
+            TestScenario::return_owned(scenario, oracle);
         };
     }
 
     public(script) fun owns_object(scenario: &mut Scenario, owner: &address): bool{
         // Verify the token has been transfer to the recipient
         TestScenario::next_tx(scenario, owner);
-        TestScenario::can_take_object<ERC721>(scenario)
+        TestScenario::can_take_owned<ERC721>(scenario)
     }
 }

--- a/sui_programmability/framework/tests/TestScenarioTests.move
+++ b/sui_programmability/framework/tests/TestScenarioTests.move
@@ -40,15 +40,15 @@ module Sui::TestScenarioTests {
         TestScenario::next_tx(&mut scenario, &sender);
         {
             let id = TestScenario::new_id(&mut scenario);
-            let child = TestScenario::take_object<Object>(&mut scenario);
+            let child = TestScenario::take_owned<Object>(&mut scenario);
             let wrapper = Wrapper { id, child };
             Transfer::transfer(wrapper, copy sender);
         };
         // wrapped object should no longer be removable, but wrapper should be
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
-            assert!(TestScenario::can_take_object<Wrapper>(&scenario), 1);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0);
+            assert!(TestScenario::can_take_owned<Wrapper>(&scenario), 1);
         }
     }
 
@@ -64,13 +64,13 @@ module Sui::TestScenarioTests {
         // object gets removed, then returned
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let object = TestScenario::take_object<Object>(&mut scenario);
-            TestScenario::return_object(&mut scenario, object);
+            let object = TestScenario::take_owned<Object>(&mut scenario);
+            TestScenario::return_owned(&mut scenario, object);
         };
         // Object should remain accessible
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            assert!(TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(TestScenario::can_take_owned<Object>(&scenario), 0);
         }
     }
 
@@ -85,16 +85,16 @@ module Sui::TestScenarioTests {
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj = TestScenario::take_object<Object>(&mut scenario);
+            let obj = TestScenario::take_owned<Object>(&mut scenario);
             assert!(obj.value == 10, 0);
             obj.value = 100;
-            TestScenario::return_object(&mut scenario, obj);
+            TestScenario::return_owned(&mut scenario, obj);
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj = TestScenario::take_object<Object>(&mut scenario);
+            let obj = TestScenario::take_owned<Object>(&mut scenario);
             assert!(obj.value == 100, 1);
-            TestScenario::return_object(&mut scenario, obj);
+            TestScenario::return_owned(&mut scenario, obj);
         }
     }
 
@@ -107,7 +107,7 @@ module Sui::TestScenarioTests {
             let obj = Object { id, value: 10 };
             Transfer::transfer(obj, copy sender);
             // an object transferred during the tx shouldn't be available in that tx
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0)
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0)
         };
     }
 
@@ -123,10 +123,10 @@ module Sui::TestScenarioTests {
         };
         TestScenario::next_tx(&mut scenario, &sender);
         {
-            let obj1 = TestScenario::take_object<Object>(&mut scenario);
-            let obj2 = TestScenario::take_object<Object>(&mut scenario);
-            TestScenario::return_object(&mut scenario, obj1);
-            TestScenario::return_object(&mut scenario, obj2);
+            let obj1 = TestScenario::take_owned<Object>(&mut scenario);
+            let obj2 = TestScenario::take_owned<Object>(&mut scenario);
+            TestScenario::return_owned(&mut scenario, obj1);
+            TestScenario::return_owned(&mut scenario, obj2);
         }
     }
 
@@ -147,34 +147,34 @@ module Sui::TestScenarioTests {
         // addr1 -> addr2
         TestScenario::next_tx(&mut scenario, &addr1);
         {
-            let obj = TestScenario::take_object<Object>(&mut scenario);
+            let obj = TestScenario::take_owned<Object>(&mut scenario);
             Transfer::transfer(obj, copy addr2)
         };
         // addr1 cannot access
         TestScenario::next_tx(&mut scenario, &addr1);
         {
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0);
         };
         // addr2 -> addr3
         TestScenario::next_tx(&mut scenario, &addr2);
         {
-            let obj = TestScenario::take_object<Object>(&mut scenario);
+            let obj = TestScenario::take_owned<Object>(&mut scenario);
             Transfer::transfer(obj, copy addr3)
         };
         // addr1 cannot access
         TestScenario::next_tx(&mut scenario, &addr1);
         {
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0);
         };
         // addr2 cannot access
         TestScenario::next_tx(&mut scenario, &addr2);
         {
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0);
         };
         // addr3 *can* access
         TestScenario::next_tx(&mut scenario, &addr3);
         {
-            assert!(TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(TestScenario::can_take_owned<Object>(&scenario), 0);
         }
     }
 
@@ -191,13 +191,13 @@ module Sui::TestScenarioTests {
             let obj = Object { id, value: 100 };
             Transfer::transfer(obj, copy tx2_sender);
             // sender cannot access the object
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0);
         };
         // check that tx2_sender can get the object, and it's the same one
         TestScenario::next_tx(&mut scenario, &tx2_sender);
         {
-            assert!(TestScenario::can_take_object<Object>(&scenario), 1);
-            let received_obj = TestScenario::take_object<Object>(&mut scenario);
+            assert!(TestScenario::can_take_owned<Object>(&scenario), 1);
+            let received_obj = TestScenario::take_owned<Object>(&mut scenario);
             let Object { id: received_id, value } = received_obj;
             assert!(ID::inner(&received_id) == &id_bytes, ID_BYTES_MISMATCH);
             assert!(value == 100, VALUE_MISMATCH);
@@ -206,12 +206,12 @@ module Sui::TestScenarioTests {
         // check that the object is no longer accessible after deletion
         TestScenario::next_tx(&mut scenario, &tx2_sender);
         {
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 2);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 2);
         }
     }
 
     #[test]
-    fun test_take_object_by_id() {
+    fun test_take_owned_by_id() {
         let sender = @0x0;
         let scenario = TestScenario::begin(&sender);
         let versioned_id1 = TestScenario::new_id(&mut scenario);
@@ -231,26 +231,26 @@ module Sui::TestScenarioTests {
         TestScenario::next_tx(&mut scenario, &sender);
         {
             assert!(
-                TestScenario::can_take_object_by_id<Object>(&mut scenario, id1),
+                TestScenario::can_take_owned_by_id<Object>(&mut scenario, id1),
                 OBJECT_ID_NOT_FOUND
             );
             assert!(
-                TestScenario::can_take_object_by_id<Object>(&mut scenario, id2),
+                TestScenario::can_take_owned_by_id<Object>(&mut scenario, id2),
                 OBJECT_ID_NOT_FOUND
             );
             assert!(
-                TestScenario::can_take_object_by_id<Object>(&mut scenario, id3),
+                TestScenario::can_take_owned_by_id<Object>(&mut scenario, id3),
                 OBJECT_ID_NOT_FOUND
             );
-            let obj1 = TestScenario::take_object_by_id<Object>(&mut scenario, id1);
-            let obj3 = TestScenario::take_object_by_id<Object>(&mut scenario, id3);
-            let obj2 = TestScenario::take_object_by_id<Object>(&mut scenario, id2);
+            let obj1 = TestScenario::take_owned_by_id<Object>(&mut scenario, id1);
+            let obj3 = TestScenario::take_owned_by_id<Object>(&mut scenario, id3);
+            let obj2 = TestScenario::take_owned_by_id<Object>(&mut scenario, id2);
             assert!(obj1.value == 10, VALUE_MISMATCH);
             assert!(obj2.value == 20, VALUE_MISMATCH);
             assert!(obj3.value == 30, VALUE_MISMATCH);
-            TestScenario::return_object(&mut scenario, obj1);
-            TestScenario::return_object(&mut scenario, obj2);
-            TestScenario::return_object(&mut scenario, obj3);
+            TestScenario::return_owned(&mut scenario, obj1);
+            TestScenario::return_owned(&mut scenario, obj2);
+            TestScenario::return_owned(&mut scenario, obj3);
         };
     }
 
@@ -277,15 +277,15 @@ module Sui::TestScenarioTests {
         TestScenario::next_tx(&mut scenario, &sender);
         {
             // sender cannot take object directly.
-            assert!(!TestScenario::can_take_object<Object>(&scenario), 0);
+            assert!(!TestScenario::can_take_owned<Object>(&scenario), 0);
             // sender can take parent, however.
-            assert!(TestScenario::can_take_object<Parent>(&scenario), 0);
+            assert!(TestScenario::can_take_owned<Parent>(&scenario), 0);
 
-            let parent = TestScenario::take_object<Parent>(&mut scenario);
+            let parent = TestScenario::take_owned<Parent>(&mut scenario);
             // Make sure we can take the child object with the parent object.
             let child = TestScenario::take_child_object<Parent, Object>(&mut scenario, &parent);
-            TestScenario::return_object(&mut scenario, parent);
-            TestScenario::return_object(&mut scenario, child);
+            TestScenario::return_owned(&mut scenario, parent);
+            TestScenario::return_owned(&mut scenario, child);
         };
     }
 
@@ -297,16 +297,16 @@ module Sui::TestScenarioTests {
         create_parent_and_object(&mut scenario);
 
         TestScenario::next_tx(&mut scenario, &sender);
-        let parent = TestScenario::take_object<Parent>(&mut scenario);
+        let parent = TestScenario::take_owned<Parent>(&mut scenario);
 
         let another = @0x1;
         TestScenario::next_tx(&mut scenario, &another);
         // This should fail even though we have parent object here.
         // Because the signer doesn't match.
         let child = TestScenario::take_child_object<Parent, Object>(&mut scenario, &parent);
-        TestScenario::return_object(&mut scenario, child);
+        TestScenario::return_owned(&mut scenario, child);
 
-        TestScenario::return_object(&mut scenario, parent);
+        TestScenario::return_owned(&mut scenario, parent);
     }
 
     /// Create object and parent. object is a child of parent.

--- a/sui_programmability/framework/tests/ValidatorTests.move
+++ b/sui_programmability/framework/tests/ValidatorTests.move
@@ -31,9 +31,9 @@ module Sui::ValidatorTests {
         // Check that after destroy, the original stake still exists.
         TestScenario::next_tx(scenario, &sender);
         {
-            let stake_coin = TestScenario::take_object<Coin<SUI>>(scenario);
+            let stake_coin = TestScenario::take_owned<Coin<SUI>>(scenario);
             assert!(Coin::value(&stake_coin) == 10, 0);
-            TestScenario::return_object(scenario, stake_coin);
+            TestScenario::return_owned(scenario, stake_coin);
         };
     }
 
@@ -70,9 +70,9 @@ module Sui::ValidatorTests {
 
         TestScenario::next_tx(scenario, &sender);
         {
-            let withdraw = TestScenario::take_object<Coin<SUI>>(scenario);
+            let withdraw = TestScenario::take_owned<Coin<SUI>>(scenario);
             assert!(Coin::value(&withdraw) == 5, 0);
-            TestScenario::return_object(scenario, withdraw);
+            TestScenario::return_owned(scenario, withdraw);
         };
 
         Validator::destroy(validator)

--- a/sui_programmability/tutorial/sources/M1.move
+++ b/sui_programmability/tutorial/sources/M1.move
@@ -78,11 +78,11 @@ module MyFirstPackage::M1 {
         TestScenario::next_tx(scenario, &admin);
         {
             // extract the Forge object
-            let forge = TestScenario::take_object<Forge>(scenario);
+            let forge = TestScenario::take_owned<Forge>(scenario);
             // verify number of created swords
             assert!(swords_created(&forge) == 0, 1);
             // return the Forge object to the object pool
-            TestScenario::return_object(scenario, forge)
+            TestScenario::return_owned(scenario, forge)
         }
     }
 
@@ -103,16 +103,16 @@ module MyFirstPackage::M1 {
         // second transaction executed by admin to create the sword
         TestScenario::next_tx(scenario, &admin);
         {
-            let forge = TestScenario::take_object<Forge>(scenario);
+            let forge = TestScenario::take_owned<Forge>(scenario);
             // create the sword and transfer it to the initial owner
             sword_create(&mut forge, 42, 7, initial_owner, TestScenario::ctx(scenario));
-            TestScenario::return_object(scenario, forge)
+            TestScenario::return_owned(scenario, forge)
         };
         // third transaction executed by the initial sword owner
         TestScenario::next_tx(scenario, &initial_owner);
         {
             // extract the sword owned by the initial owner
-            let sword = TestScenario::take_object<Sword>(scenario);
+            let sword = TestScenario::take_owned<Sword>(scenario);
             // transfer the sword to the final owner
             sword_transfer(sword, final_owner, TestScenario::ctx(scenario));
         };
@@ -121,11 +121,11 @@ module MyFirstPackage::M1 {
         {
 
             // extract the sword owned by the final owner
-            let sword = TestScenario::take_object<Sword>(scenario);
+            let sword = TestScenario::take_owned<Sword>(scenario);
             // verify that the sword has expected properties
             assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
             // return the sword to the object pool (it cannot be simply "dropped")
-            TestScenario::return_object(scenario, sword)
+            TestScenario::return_owned(scenario, sword)
         }
     }
 


### PR DESCRIPTION
This PR renames globally the following APIs in the TestScenario.move:
1. take_object -> take_owned
2. return_object -> return_owned
3. can_take_object -> can_take_owned
4. take_object_by_id -> take_owned_by_id
5. can_take_object_by_id -> can_take_owned_by_id
6. take_immutable_object -> take_immutable
7. return_immutable_object -> return_immutable
8. take_shared_object -> take_shared
9. return_shared_object -> return_shared