### PR TITLE
[TypeScript SDK] Add Parsing for ID and Coin type

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignedTransaction, TransactionResponse, TransferTransaction, TxnDataSerializer, ObjectRef, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, ObjectType, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, Transfer, RawAuthoritySignInfo, SingleTransactionKind, TransactionKind, TransactionData, Transaction, CertifiedTransaction, TransactionDigest, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, MoveTypeTag, MoveCall, EmptySignInfo, AuthorityName, AuthoritySignature } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignedTransaction, TransactionResponse, TransferTransaction, TxnDataSerializer, TransactionDigest, SuiAddress, ObjectRef, ObjectContent, ObjectOwner, SuiObject, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, ObjectType, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, Transfer, RawAuthoritySignInfo, SingleTransactionKind, TransactionKind, TransactionData, Transaction, CertifiedTransaction, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, MoveTypeTag, MoveCall, EmptySignInfo, AuthorityName, AuthoritySignature } from "./index";
 import { BN } from "bn.js";
 
 export function isEd25519KeypairData(obj: any, _argumentName?: string): obj is Ed25519KeypairData {
@@ -90,6 +90,18 @@ export function isTxnDataSerializer(obj: any, _argumentName?: string): obj is Tx
     )
 }
 
+export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
+    return (
+        typeof obj === "string"
+    )
+}
+
+export function isSuiAddress(obj: any, _argumentName?: string): obj is SuiAddress {
+    return (
+        typeof obj === "string"
+    )
+}
+
 export function isObjectRef(obj: any, _argumentName?: string): obj is ObjectRef {
     return (
         (obj !== null &&
@@ -101,13 +113,59 @@ export function isObjectRef(obj: any, _argumentName?: string): obj is ObjectRef 
     )
 }
 
+export function isObjectContent(obj: any, _argumentName?: string): obj is ObjectContent {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.fields !== null &&
+            typeof obj.fields === "object" ||
+            typeof obj.fields === "function") &&
+        Object.entries<any>(obj.fields)
+            .every(([key, value]) => ((isTransactionResponse(value) as boolean ||
+                isSequenceNumber(value) as boolean ||
+                value === false ||
+                value === true ||
+                isObjectContent(value) as boolean) &&
+                isTransactionResponse(key) as boolean)) &&
+        isTransactionResponse(obj.type) as boolean
+    )
+}
+
+export function isObjectOwner(obj: any, _argumentName?: string): obj is ObjectOwner {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            isTransactionResponse(obj.AddressOwner) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isTransactionResponse(obj.ObjectOwner) as boolean ||
+            obj === "Shared" ||
+            obj === "Immutable")
+    )
+}
+
+export function isSuiObject(obj: any, _argumentName?: string): obj is SuiObject {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isObjectContent(obj.contents) as boolean &&
+        isObjectOwner(obj.owner) as boolean &&
+        isTransactionResponse(obj.tx_digest) as boolean
+    )
+}
+
 export function isObjectExistsInfo(obj: any, _argumentName?: string): obj is ObjectExistsInfo {
     return (
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
         isObjectRef(obj.objectRef) as boolean &&
-        isObjectType(obj.objectType) as boolean
+        isObjectType(obj.objectType) as boolean &&
+        isSuiObject(obj.object) as boolean
     )
 }
 
@@ -268,12 +326,6 @@ export function isCertifiedTransaction(obj: any, _argumentName?: string): obj is
         obj.signatures.every((e: any) =>
             isRawAuthoritySignInfo(e) as boolean
         )
-    )
-}
-
-export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
-    return (
-        typeof obj === "string"
     )
 }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -17,7 +17,6 @@ export * from './signers/txn-data-serializers/txn-data-serializer';
 export * from './signers/raw-signer';
 export * from './signers/signer-with-provider';
 
-export * from './types/objects';
-export * from './types/transactions';
+export * from './types';
 
 export * as BCS from './bcs';

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -1,17 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  SignedTransaction,
-  TransactionResponse,
-  Provider,
-} from './provider';
+import { SignedTransaction, TransactionResponse, Provider } from './provider';
 import { JsonRpcClient } from '../rpc/client';
-import { isGetObjectInfoResponse, isGetOwnedObjectRefsResponse, isGetTxnDigestsResponse, isCertifiedTransaction } from '../index.guard';
-import { CertifiedTransaction, GatewayTxSeqNumber, GetTxnDigestsResponse, TransactionDigest } from '../types/transactions';
-import { GetObjectInfoResponse, ObjectRef } from '../types/objects';
+import {
+  isGetObjectInfoResponse,
+  isGetOwnedObjectRefsResponse,
+  isGetTxnDigestsResponse,
+  isCertifiedTransaction,
+} from '../index.guard';
+import {
+  CertifiedTransaction,
+  GatewayTxSeqNumber,
+  GetTxnDigestsResponse,
+  GetObjectInfoResponse,
+  ObjectRef,
+  TransactionDigest,
+} from '../types';
 
-const isNumber = (val: any): val is number => typeof(val) === 'number';
+const isNumber = (val: any): val is number => typeof val === 'number';
 
 export class JsonRpcProvider extends Provider {
   private client: JsonRpcClient;

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -1,9 +1,12 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { GetObjectInfoResponse, ObjectRef } from "../types/objects";
-import { GatewayTxSeqNumber, GetTxnDigestsResponse } from "../types/transactions";
-
+import {
+  GetObjectInfoResponse,
+  ObjectRef,
+  GatewayTxSeqNumber,
+  GetTxnDigestsResponse,
+} from '../types';
 
 export interface SignedTransaction {
   txBytes: string;

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -5,17 +5,11 @@ import {
   CertifiedTransaction,
   TransactionDigest,
   GetTxnDigestsResponse,
-  GatewayTxSeqNumber
-} from '../types/transactions';
-import {
-  Provider,
-  SignedTransaction,
-  TransactionResponse,
-} from './provider';
-import {
+  GatewayTxSeqNumber,
   ObjectRef,
   GetObjectInfoResponse,
-} from '../types/objects';
+} from '../types';
+import { Provider, SignedTransaction, TransactionResponse } from './provider';
 
 export class VoidProvider extends Provider {
   // Objects

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -1,0 +1,5 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export type TransactionDigest = string;
+export type SuiAddress = string;

--- a/sdk/typescript/src/types/framework/coin.ts
+++ b/sdk/typescript/src/types/framework/coin.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ObjectContent } from '../objects';
+import { MoveVersionedID } from './id';
+import { MoveObjectContent, MoveObjectType } from './move-object';
+
+/**
+ * Typescript version for Sui::Coin module
+ * as defined in https://github.com/MystenLabs/sui/blob/ca9046fd8b1a9e8634a4b74b0e7dabdc7ea54475/sui_programmability/framework/sources/Coin.move#L4
+ */
+export class Coin extends MoveObjectContent {
+  static isInstance(data: ObjectContent): boolean {
+    return (
+      MoveObjectContent.parseType(data).getWithoutGeneric() == '0x2::Coin::Coin'
+    );
+  }
+
+  amount(): number {
+    return this.data.fields['value'] as number;
+  }
+
+  symbol(): string {
+    return this.getCoinType()
+      .getStructName()
+      .getStructName();
+  }
+
+  id(): MoveVersionedID {
+    return new MoveVersionedID(this.data.fields['id'] as ObjectContent);
+  }
+
+  private getCoinType(): MoveObjectType {
+    return this.getType().getGenericType()!;
+  }
+
+  toJSON(): string {
+    return JSON.stringify({
+      amount: this.amount(),
+      symbol: this.symbol(),
+      versioned_id: this.id().toJSON(),
+    });
+  }
+}

--- a/sdk/typescript/src/types/framework/id.ts
+++ b/sdk/typescript/src/types/framework/id.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ObjectContent } from '../objects';
+import { MoveObjectContent } from './move-object';
+
+/**
+ * Typescript version for Sui::ID Module
+ * as defined in https://github.com/MystenLabs/sui/blob/ca9046fd8b1a9e8634a4b74b0e7dabdc7ea54475/sui_programmability/framework/sources/ID.move#L48
+ */
+export class MoveID extends MoveObjectContent {
+  static isInstance(data: ObjectContent): boolean {
+    return MoveObjectContent.parseType(data).getFullType() == '0x2::ID::ID';
+  }
+
+  id(): string {
+    return this.data.fields['bytes'] as string;
+  }
+
+  toJSON() {
+    return JSON.stringify({
+      id: this.id(),
+    });
+  }
+}
+
+export class MoveUniqueID extends MoveObjectContent {
+  static isInstance(data: ObjectContent): boolean {
+    return (
+      MoveObjectContent.parseType(data).getFullType() == '0x2::ID::UniqueID'
+    );
+  }
+
+  id(): MoveID {
+    return new MoveID(this.data.fields['id'] as ObjectContent);
+  }
+
+  toJSON() {
+    return this.id().toJSON();
+  }
+}
+
+export class MoveVersionedID extends MoveObjectContent {
+  static isInstance(data: ObjectContent): boolean {
+    return (
+      MoveObjectContent.parseType(data).getFullType() == '0x2::ID::VersionedID'
+    );
+  }
+
+  typedID(): MoveUniqueID {
+    return new MoveUniqueID(this.data.fields['id'] as ObjectContent);
+  }
+
+  id(): string {
+    return new MoveUniqueID(this.data.fields['id'] as ObjectContent).id().id();
+  }
+
+  version(): number {
+    return this.data.fields['version'] as number;
+  }
+
+  toJSON() {
+    return JSON.stringify({
+      id: this.id(),
+      version: this.version(),
+    });
+  }
+}

--- a/sdk/typescript/src/types/framework/move-object.ts
+++ b/sdk/typescript/src/types/framework/move-object.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isObjectContent } from '../../index.guard';
+import { ObjectContent } from '../objects';
+
+export class MoveStructName {
+  constructor(public data: string) {}
+
+  getFullType(): string {
+    return this.data;
+  }
+
+  isNested(): boolean {
+    return (this.data.match(/</g) || []).length > 1;
+  }
+
+  getRawStructName(): string {
+    return this.data;
+  }
+
+  getStructName(): string {
+    return this.data.split('<')[0];
+  }
+
+  // TODO: handle multiple generic types
+  getGenericType(): MoveObjectType | null {
+    if (!this.hasGenericType()) {
+      return null;
+    }
+
+    const generic = this.data.match(/^\w+<(.*)>$/)![1];
+    return new MoveObjectType(generic);
+  }
+
+  hasGenericType(): boolean {
+    return this.data.includes('<');
+  }
+}
+
+export class MoveObjectType {
+  constructor(public data: string) {}
+
+  getFullType(): string {
+    return this.data;
+  }
+
+  getPackageAddress(): string {
+    return this.data.split('::')[0];
+  }
+
+  getModuleName(): string {
+    return this.data.split('::')[1];
+  }
+
+  getStructName(): MoveStructName {
+    const re = /^\w+::\w+::(.+)$/;
+    const found = this.data.match(re)![1];
+    return new MoveStructName(found);
+  }
+
+  hasGenericType(): boolean {
+    return this.getStructName().hasGenericType();
+  }
+
+  getWithoutGeneric(): string {
+    return this.data.split('<')[0];
+  }
+
+  getGenericType(): MoveObjectType | null {
+    return this.getStructName().getGenericType();
+  }
+
+  toString() {
+    return this.data;
+  }
+}
+
+export abstract class MoveObjectContent {
+  // static methods
+  // Needs override
+  static isInstance(_data: ObjectContent): boolean {
+    return false;
+  }
+
+  static parseType(data: ObjectContent): MoveObjectType {
+    return new MoveObjectType(data.type);
+  }
+
+  // instance methods
+  constructor(public data: ObjectContent) {}
+
+  getType(): MoveObjectType {
+    return new MoveObjectType(this.data.type);
+  }
+
+  toJSON(): string {
+    return MoveObjectContent.parseJSON(this.data);
+  }
+
+  toString(): string {
+    return this.toJSON();
+  }
+
+  static parseJSON(data: ObjectContent): string {
+    let obj: Record<string, string> = {};
+    Object.entries<any>(data.fields).forEach(([key, value]) => {
+      if (isObjectContent(value)) {
+        obj[key] = this.parseJSON(value) || '';
+      } else {
+        obj[key] = value;
+      }
+    });
+    return JSON.stringify(obj);
+  }
+}

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -1,0 +1,9 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './common';
+export * from './objects';
+export * from './transactions';
+export * from './framework/coin';
+export * from './framework/move-object';
+export * from './framework/id';

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -1,30 +1,46 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { TransactionDigest } from "./transactions";
+import { SuiAddress } from './common';
+import { TransactionDigest } from './common';
 
 export type ObjectRef = {
-  digest: TransactionDigest,
-  objectId: string,
-  version: number,
+  digest: TransactionDigest;
+  objectId: string;
+  version: number;
+};
+
+export type ObjectContent = {
+  fields: Record<string, ObjectContent | string | boolean | number>;
+  type: string;
+};
+export type ObjectOwner =
+  | { AddressOwner: SuiAddress }
+  | { ObjectOwner: SuiAddress }
+  | 'Shared'
+  | 'Immutable';
+
+export type SuiObject = {
+  contents: ObjectContent;
+  owner: ObjectOwner;
+  tx_digest: TransactionDigest;
 };
 
 export type ObjectExistsInfo = {
-  objectRef: ObjectRef,
-  objectType: ObjectType,
-  object: any,
+  objectRef: ObjectRef;
+  objectType: ObjectType;
+  object: SuiObject;
 };
 
 export type ObjectNotExistsInfo = {
-  objectId: any,
+  objectId: any;
 };
 
 export type ObjectStatus = 'Exists' | 'NotExists' | 'Deleted';
 export type ObjectType = 'moveObject' | 'movePackage';
 
-
 export type GetOwnedObjectRefsResponse = {
-  objects: ObjectRef[]
+  objects: ObjectRef[];
 };
 
 export type GetObjectInfoResponse = {
@@ -37,8 +53,4 @@ export type ObjectId = string;
 export type SequenceNumber = number;
 
 // TODO: get rid of this by implementing some conversion logic from ObjectRef
-export type RawObjectRef = [
-  ObjectId,
-  SequenceNumber,
-  ObjectDigest,
-];
+export type RawObjectRef = [ObjectId, SequenceNumber, ObjectDigest];

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { TransactionDigest } from './common';
 import { RawObjectRef } from './objects';
 
 export type Transfer = {
@@ -31,7 +32,6 @@ export type CertifiedTransaction = {
   signatures: RawAuthoritySignInfo[];
 };
 
-export type TransactionDigest = string;
 export type GatewayTxSeqNumber = number;
 
 export type GetTxnDigestsResponse = [GatewayTxSeqNumber, TransactionDigest][];

--- a/sdk/typescript/test/types/coin.test.ts
+++ b/sdk/typescript/test/types/coin.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Coin } from '../../src';
+
+const COIN_DATA = {
+  fields: {
+    id: {
+      fields: {
+        id: {
+          fields: {
+            id: {
+              fields: {
+                bytes: '37196de8502e6d80e6a31fba1a5d6986cc018805',
+              },
+              type: '0x2::ID::ID',
+            },
+          },
+          type: '0x2::ID::UniqueID',
+        },
+        version: 0,
+      },
+      type: '0x2::ID::VersionedID',
+    },
+    value: 100000,
+  },
+  type: '0x2::Coin::Coin<0x2::SUI::SUI>',
+};
+
+describe('Coin type Parsing', () => {
+  it('parse Coin Type', async () => {
+    const t = new Coin(COIN_DATA);
+    expect(t.symbol()).toEqual('SUI');
+    expect(t.amount()).toEqual(100000);
+    expect(t.id().id()).toEqual('37196de8502e6d80e6a31fba1a5d6986cc018805');
+    expect(t.toJSON()).toEqual(
+      '{"amount":100000,"symbol":"SUI","versioned_id":"{\\"id\\":\\"37196de8502e6d80e6a31fba1a5d6986cc018805\\",\\"version\\":0}"}'
+    );
+  });
+});

--- a/sdk/typescript/test/types/id.test.ts
+++ b/sdk/typescript/test/types/id.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MoveVersionedID } from '../../src';
+
+const DATA = {
+  fields: {
+    id: {
+      fields: {
+        id: {
+          fields: {
+            bytes: '37196de8502e6d80e6a31fba1a5d6986cc018805',
+          },
+          type: '0x2::ID::ID',
+        },
+      },
+      type: '0x2::ID::UniqueID',
+    },
+    version: 0,
+  },
+  type: '0x2::ID::VersionedID',
+};
+
+describe('ID Types Parsing', () => {
+  it('parse ID Type', async () => {
+    const t = new MoveVersionedID(DATA);
+    expect(t.id()).toEqual('37196de8502e6d80e6a31fba1a5d6986cc018805');
+    expect(t.version()).toEqual(0);
+    expect(t.toJSON()).toEqual(
+      '{"id":"37196de8502e6d80e6a31fba1a5d6986cc018805","version":0}'
+    );
+  });
+});

--- a/sdk/typescript/test/types/move-object.test.ts
+++ b/sdk/typescript/test/types/move-object.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { MoveObjectType } from '../../src';
+
+const PACKAGE = '0x2';
+const MODULE_GENERIC = 'SUI';
+const IDENTIFIER_GENERIC = 'SUI';
+const GENERIC = `${PACKAGE}::${MODULE_GENERIC}::${IDENTIFIER_GENERIC}`;
+const MODULE = 'Coin';
+const IDENTIFIER = 'Coin';
+const FULL_TYPE = `${PACKAGE}::${MODULE}::${IDENTIFIER}<${GENERIC}>`;
+
+describe('Move Object Content Parsing', () => {
+  it('parse MoveObjectType', async () => {
+    const t = new MoveObjectType(FULL_TYPE);
+    expect(t.getFullType()).toEqual(FULL_TYPE);
+    expect(t.getPackageAddress()).toEqual(PACKAGE);
+    expect(t.getModuleName()).toEqual(MODULE);
+  });
+
+  it('parse MoveObjectIdentifier', async () => {
+    const identifier = new MoveObjectType(FULL_TYPE).getStructName();
+    expect(identifier.getFullType()).toEqual(`${IDENTIFIER}<${GENERIC}>`);
+    expect(identifier.getStructName()).toEqual(MODULE);
+    expect(identifier.hasGenericType()).toEqual(true);
+    const inner = identifier.getGenericType()!;
+    expect(inner.getFullType()).toEqual(GENERIC);
+    expect(inner.getPackageAddress()).toEqual(PACKAGE);
+    expect(inner.getModuleName()).toEqual(MODULE_GENERIC);
+    expect(inner.getStructName().hasGenericType()).toEqual(false);
+    expect(inner.getStructName().getStructName()).toEqual(IDENTIFIER_GENERIC);
+  });
+});


### PR DESCRIPTION
The `ID` and `Coin` types are commonly used, but their raw form are not ergonomic to use, for example:

```
{
  fields: {
    id: {
      fields: {
        id: {
          fields: {
            id: {
              fields: {
                bytes: '37196de8502e6d80e6a31fba1a5d6986cc018805',
              },
              type: '0x2::ID::ID',
            },
          },
          type: '0x2::ID::UniqueID',
        },
        version: 0,
      },
      type: '0x2::ID::VersionedID',
    },
    value: 100000,
  },
  type: '0x2::Coin::Coin<0x2::SUI::SUI>',
}

```

This PR defines a TypeScript wrapper for these two move types . In subsequent diffs, we are going to define wrapper types for other commonly used types such as URL, UTF8::String, so that we don't need to write these adhoc logic in the explorer