### PR TITLE
[node] Follow latest & Safe client integration test

### DIFF
--- a/sui/src/benchmark.rs
+++ b/sui/src/benchmark.rs
@@ -253,8 +253,8 @@ async fn run_follower(network_client: NetworkClient) {
         loop {
             let receiver = authority_client
                 .handle_batch_stream(BatchInfoRequest {
-                    start,
-                    end: start + FOLLOWER_BATCH_SIZE,
+                    start: Some(start),
+                    length: FOLLOWER_BATCH_SIZE,
                 })
                 .await;
 

--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -27,7 +27,7 @@ use sui_adapter::adapter;
 use sui_types::serialize::serialize_transaction_info;
 use sui_types::{
     base_types::*,
-    batch::UpdateItem,
+    batch::{TxSequenceNumber, UpdateItem},
     committee::Committee,
     crypto::AuthoritySignature,
     error::{SuiError, SuiResult},
@@ -535,20 +535,37 @@ impl AuthorityState {
     pub async fn handle_batch_info_request(
         &self,
         request: BatchInfoRequest,
-    ) -> Result<(VecDeque<UpdateItem>, bool), SuiError> {
+    ) -> Result<
+        (
+            VecDeque<UpdateItem>,
+            // Should subscribe, computer start, computed end
+            (bool, TxSequenceNumber, TxSequenceNumber),
+        ),
+        SuiError,
+    > {
         // Ensure the range contains some elements and end > start
-        if request.end <= request.start {
+        if request.length == 0 {
             return Err(SuiError::InvalidSequenceRangeError);
         };
 
         // Ensure we are not doing too much work per request
-        if request.end - request.start > MAX_ITEMS_LIMIT {
+        if request.length > MAX_ITEMS_LIMIT {
             return Err(SuiError::TooManyItemsError(MAX_ITEMS_LIMIT));
         }
 
-        let (batches, transactions) = self
-            ._database
-            .batches_and_transactions(request.start, request.end)?;
+        // If we do not have a start, pick the low watermark from the notifier.
+        let start = match request.start {
+            Some(start) => start,
+            None => {
+                self.last_batch()?
+                    .expect("Authority is always initialized with a batch")
+                    .batch
+                    .next_sequence_number
+            }
+        };
+        let end = start + request.length;
+
+        let (batches, transactions) = self._database.batches_and_transactions(start, end)?;
 
         let mut dq_batches = std::collections::VecDeque::from(batches);
         let mut dq_transactions = std::collections::VecDeque::from(transactions);
@@ -577,7 +594,7 @@ impl AuthorityState {
 
         // whether we have sent everything requested, or need to start
         // live notifications.
-        let should_subscribe = request.end > last_batch_next_seq;
+        let should_subscribe = end > last_batch_next_seq;
 
         // If any transactions are left they must be outside a batch
         while let Some(current_transaction) = dq_transactions.pop_front() {
@@ -585,7 +602,7 @@ impl AuthorityState {
             items.push_back(UpdateItem::Transaction(current_transaction));
         }
 
-        Ok((items, should_subscribe))
+        Ok((items, (should_subscribe, start, end)))
     }
 
     pub async fn new(

--- a/sui_core/src/authority/authority_notifier.rs
+++ b/sui_core/src/authority/authority_notifier.rs
@@ -31,6 +31,10 @@ impl TransactionNotifier {
         })
     }
 
+    pub fn low_watermark(&self) -> TxSequenceNumber {
+        self.low_watermark.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
     /// Get a ticket with a sequence number
     pub fn ticket(self: &Arc<Self>) -> SuiResult<TransactionNotifierTicket> {
         if self.is_closed.load(std::sync::atomic::Ordering::SeqCst) {

--- a/sui_core/src/authority_active/gossip/mod.rs
+++ b/sui_core/src/authority_active/gossip/mod.rs
@@ -1,0 +1,199 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use std::{collections::HashSet, sync::Arc, time::Duration};
+use sui_types::{
+    base_types::AuthorityName,
+    batch::{TxSequenceNumber, UpdateItem},
+    error::SuiError,
+    messages::{
+        BatchInfoRequest, BatchInfoResponseItem, ConfirmationTransaction, TransactionInfoRequest,
+    },
+};
+
+use crate::{
+    authority::AuthorityState, authority_aggregator::AuthorityAggregator,
+    authority_client::AuthorityAPI, safe_client::SafeClient,
+};
+
+use futures::stream::FuturesOrdered;
+use tracing::{error, info};
+
+#[cfg(test)]
+mod tests;
+
+struct PeerGossip<A> {
+    peer_name: AuthorityName,
+    client: SafeClient<A>,
+    state: Arc<AuthorityState>,
+    max_seq: Option<TxSequenceNumber>,
+    aggregator: Arc<AuthorityAggregator<A>>,
+}
+
+const EACH_ITEM_DELAY_MS: u64 = 1_000;
+const REQUEST_FOLLOW_NUM_DIGESTS: u64 = 100_000;
+const REFRESH_FOLLOWER_PERIOD_SECS: u64 = 60;
+
+use super::ActiveAuthority;
+
+pub async fn gossip_process<A>(active_authority: &ActiveAuthority<A>, degree: usize)
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    // Number of tasks at most "degree" and no more than committee - 1
+    let target_num_tasks: usize = usize::min(
+        active_authority.state.committee.voting_rights.len() - 1,
+        degree,
+    );
+
+    // Keep track of names of active peers
+    let mut peer_names = HashSet::new();
+    let mut gossip_tasks = FuturesUnordered::new();
+
+    // TODO: provide a clean way to get out of the loop.
+    loop {
+        let mut k = 0;
+        while gossip_tasks.len() < target_num_tasks {
+            let name = active_authority.state.committee.sample();
+            if peer_names.contains(name) || *name == active_authority.state.name {
+                continue;
+            }
+            peer_names.insert(*name);
+            gossip_tasks.push(async move {
+                let peer_gossip = PeerGossip::new(*name, active_authority);
+                // Add more duration if we make more than 1 to ensure overlap
+                info!("Gossip: Start gossip from peer {:?}", *name);
+                peer_gossip
+                    .spawn(Duration::from_secs(REFRESH_FOLLOWER_PERIOD_SECS + k * 15))
+                    .await
+            });
+            k += 1;
+        }
+
+        // Let the peer gossip task finish
+        debug_assert!(!gossip_tasks.is_empty());
+        let (finished_name, _result) = gossip_tasks.select_next_some().await;
+        if let Err(err) = _result {
+            error!(
+                "Gossip: Peer {:?} finished with error: {}",
+                finished_name, err
+            );
+        } else {
+            info!("Gossip: End gossip from peer {:?}", finished_name);
+        }
+        peer_names.remove(&finished_name);
+    }
+}
+
+impl<A> PeerGossip<A>
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    pub fn new(peer_name: AuthorityName, active_authority: &ActiveAuthority<A>) -> PeerGossip<A> {
+        PeerGossip {
+            peer_name,
+            client: active_authority.net.authority_clients[&peer_name].clone(),
+            state: active_authority.state.clone(),
+            max_seq: None,
+            aggregator: active_authority.net.clone(),
+        }
+    }
+
+    pub async fn spawn(mut self, duration: Duration) -> (AuthorityName, Result<(), SuiError>) {
+        let peer_name = self.peer_name;
+        let result = tokio::task::spawn(async move { self.gossip_timeout(duration).await })
+            .await
+            .map(|_| ())
+            .map_err(|_err| SuiError::GenericAuthorityError {
+                error: "Gossip Join Error".to_string(),
+            });
+
+        (peer_name, result)
+    }
+
+    async fn gossip_timeout(&mut self, duration: Duration) -> Result<(), SuiError> {
+        // Global timeout, we do not exceed this time in this task.
+        let mut timeout = Box::pin(tokio::time::sleep(duration));
+        let mut queue = FuturesOrdered::new();
+
+        let req = BatchInfoRequest {
+            start: self.max_seq,
+            length: REQUEST_FOLLOW_NUM_DIGESTS,
+        };
+
+        // Get a client
+        let mut streamx = Box::pin(self.client.handle_batch_stream(req).await?);
+
+        loop {
+            tokio::select! {
+                _ = &mut timeout => {
+                    // No matter what happens we do not spend too much time
+                    // for any peer.
+
+                    break },
+
+                items = &mut streamx.next() => {
+                    match items {
+                        // Upon receiving a batch
+                        Some(Ok(BatchInfoResponseItem(UpdateItem::Batch(_signed_batch)) )) => {
+                            // Update the longer term seqeunce_number only after a batch that is signed
+                            self.max_seq = Some(_signed_batch.batch.next_sequence_number);
+                        },
+                        // Upon receiving a trasnaction digest we store it, if it is not processed already.
+                        Some(Ok(BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest))))) => {
+                            if !self.state._database.effects_exists(&_digest)? {
+                                queue.push(async move {
+                                    tokio::time::sleep(Duration::from_millis(EACH_ITEM_DELAY_MS)).await;
+                                    _digest
+                                });
+
+                            }
+
+                        },
+                        // When an error occurs we simply send back the error
+                        Some(Err( err )) => {
+                            return Err(err);
+                        },
+                        // The stream has closed, re-request:
+                        None => {
+
+                            let req = BatchInfoRequest {
+                                start: self.max_seq,
+                                length: REQUEST_FOLLOW_NUM_DIGESTS,
+                            };
+
+                            // Get a client
+                            streamx = Box::pin(self.client.handle_batch_stream(req).await?);
+                        },
+                    }
+                },
+
+                digest = &mut queue.next() , if !queue.is_empty() => {
+                    let digest = digest.unwrap();
+                    if !self.state._database.effects_exists(&digest)? {
+                        // We still do not have a transaction others have after some time
+
+                        // Download the certificate
+                        let response = self.client.handle_transaction_info_request(TransactionInfoRequest::from(digest)).await?;
+                        if let Some(certificate) = response.certified_transaction {
+
+                            // Process the certificate from one authority to ourselves
+                            self.aggregator.sync_authority_source_to_destination(
+                                ConfirmationTransaction { certificate },
+                                self.peer_name,
+                                self.state.name).await?;
+                        }
+                        else {
+                            // The authority did not return the certificate, despite returning info
+                            // But it should know the certificate!
+                            return Err(SuiError::ByzantineAuthoritySuspicion { authority :  self.peer_name });
+                        }
+                    }
+                },
+            };
+        }
+
+        Ok(())
+    }
+}

--- a/sui_core/src/authority_active/gossip/tests.rs
+++ b/sui_core/src/authority_active/gossip/tests.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use sui_adapter::genesis;
+use sui_types::{base_types::SequenceNumber, crypto::get_key_pair, object::Object};
+
+use super::*;
+use crate::authority_aggregator::authority_aggregator_tests::*;
+
+#[tokio::test]
+pub async fn test_gossip() {
+    let (addr1, key1) = get_key_pair();
+    let gas_object1 = Object::with_owner_for_testing(addr1);
+    let gas_object2 = Object::with_owner_for_testing(addr1);
+    let genesis_objects =
+        authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
+
+    let (aggregator, states) = init_local_authorities(genesis_objects).await;
+    let clients = aggregator.authority_clients.clone();
+
+    let authority_clients: Vec<_> = aggregator.authority_clients.values().collect();
+    let framework_obj_ref = genesis::get_framework_object_ref();
+
+    // Start batch processes, and active processes.
+    for state in states {
+        let inner_state = state.clone();
+        let _batch_handle = tokio::task::spawn(async move {
+            inner_state
+                .run_batch_service(5, Duration::from_millis(50))
+                .await
+        });
+        let inner_state = state.clone();
+        let inner_clients = clients.clone();
+
+        let _active_handle = tokio::task::spawn(async move {
+            let active_state = ActiveAuthority::new(inner_state, inner_clients).unwrap();
+            active_state.spawn_all_active_processes().await
+        });
+    }
+
+    // Let the helper tasks start
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Make a schedule of transactions
+    let gas_ref_1 = get_latest_ref(authority_clients[0], gas_object1.id()).await;
+    let create1 =
+        crate_object_move_transaction(addr1, &key1, addr1, 100, framework_obj_ref, gas_ref_1);
+
+    do_transaction(authority_clients[0], &create1).await;
+    do_transaction(authority_clients[1], &create1).await;
+    do_transaction(authority_clients[2], &create1).await;
+
+    // Get a cert
+    let cert1 = extract_cert(&authority_clients, &aggregator.committee, create1.digest()).await;
+
+    // Submit the cert to 1 authority.
+    let _new_ref_1 = do_cert(authority_clients[0], &cert1).await.created[0].0;
+
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    let gas_ref_1 = get_latest_ref(authority_clients[3], gas_object1.id()).await;
+    println!("Ref: {:?}", gas_ref_1);
+
+    assert_eq!(gas_ref_1.1, SequenceNumber::from(1));
+}

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -34,11 +34,12 @@ pub mod authority_aggregator_tests;
 
 pub type AsyncResult<'a, T, E> = future::BoxFuture<'a, Result<T, E>>;
 
+#[derive(Clone)]
 pub struct AuthorityAggregator<A> {
     /// Our Sui committee.
     pub committee: Committee,
     /// How to talk to this committee.
-    authority_clients: BTreeMap<AuthorityName, SafeClient<A>>,
+    pub authority_clients: BTreeMap<AuthorityName, SafeClient<A>>,
 }
 
 impl<A> AuthorityAggregator<A> {
@@ -69,7 +70,7 @@ where
     /// Note: Both source and destination may be byzantine, therefore one should always
     /// time limit the call to this function to avoid byzantine authorities consuming
     /// an unbounded amount of resources.
-    async fn sync_authority_source_to_destination(
+    pub async fn sync_authority_source_to_destination(
         &self,
         cert: ConfirmationTransaction,
         source_authority: AuthorityName,

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -14,8 +14,7 @@ use sui_network::{
     network::NetworkServer,
     tonic,
 };
-use sui_types::{
-    batch::UpdateItem, crypto::VerificationObligation, error::*, messages::*, serialize::*,
+use sui_types::{crypto::VerificationObligation, error::*, messages::*, serialize::*,
 };
 use tokio::{net::TcpListener, sync::mpsc::Sender};
 use tracing::{info, Instrument};
@@ -359,7 +358,7 @@ impl Validator for AuthorityServer {
                 let skip = match item {
                     Ok(item) => {
                         let seq = match item {
-                            UpdateItem::Transaction((seq, _)) => *seq,
+                            UpdateItem::Transaction((seq, _)) => seq,
                             UpdateItem::Batch(signed_batch) => {
                                 signed_batch.batch.next_sequence_number
                             }

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -7,15 +7,14 @@ use crate::{
     consensus_adapter::{ConsensusAdapter, ConsensusListenerMessage},
 };
 use async_trait::async_trait;
-use futures::{stream::BoxStream, FutureExt, StreamExt, TryStreamExt};
+use futures::{stream::BoxStream, FutureExt, TryStreamExt};
 use std::{io, net::SocketAddr, sync::Arc, time::Duration};
 use sui_network::{
     api::{BincodeEncodedPayload, Validator, ValidatorServer},
     network::NetworkServer,
     tonic,
 };
-use sui_types::{crypto::VerificationObligation, error::*, messages::*, serialize::*,
-};
+use sui_types::{crypto::VerificationObligation, error::*, messages::*, serialize::*};
 use tokio::{net::TcpListener, sync::mpsc::Sender};
 use tracing::{info, Instrument};
 
@@ -327,65 +326,18 @@ impl Validator for AuthorityServer {
             .deserialize()
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
 
-        // Register a subscriber to not miss any updates
-        let subscriber = self.state.subscribe_batch();
-        let message_end = request.end;
-
-        // Get the historical data requested
-        let (items, should_subscribe) = self
+        let xstream = self
             .state
-            .handle_batch_info_request(request)
+            .handle_batch_streaming(request)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        let last_seq = items
-            .back()
-            .map(|item| {
-                if let UpdateItem::Transaction((seq, _)) = item {
-                    *seq
-                } else {
-                    0
-                }
-            })
-            .unwrap_or(0);
-
-        let items = futures::stream::iter(items).map(Ok);
-        let subscriber = tokio_stream::wrappers::BroadcastStream::new(subscriber)
-            .take_while(move |_| futures::future::ready(should_subscribe))
-            .take_while(|item| futures::future::ready(item.is_ok()))
-            // Do not re-send transactions already sent from the database
-            .skip_while(move |item| {
-                let skip = match item {
-                    Ok(item) => {
-                        let seq = match item {
-                            UpdateItem::Transaction((seq, _)) => seq,
-                            UpdateItem::Batch(signed_batch) => {
-                                signed_batch.batch.next_sequence_number
-                            }
-                        };
-                        seq <= last_seq
-                    }
-                    Err(_) => false,
-                };
-                futures::future::ready(skip)
-            })
-            // We always stop sending at batch boundaries, so that we try to always
-            // start with a batch and end with a batch to allow signature verification.
-            .take_while(move |item| {
-                let take = match item {
-                    Ok(UpdateItem::Batch(signed_batch)) => {
-                        message_end >= signed_batch.batch.next_sequence_number
-                    }
-                    _ => true,
-                };
-                futures::future::ready(take)
-            });
-
-        let response = items
-            .chain(subscriber)
+        let response =
+            // items
+            // .chain(subscriber)
+            xstream
             .map_err(|e| tonic::Status::internal(e.to_string()))
             .map_ok(|item| {
-                let item = BatchInfoResponseItem(item);
                 BincodeEncodedPayload::try_from(&item).expect("serialization should not fail")
             });
 

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -189,22 +189,20 @@ impl<C> SafeClient<C> {
             .check(&signed_batch.batch, signed_batch.authority)?;
 
         // ensure transactions enclosed match requested range
-        /*
 
-        TODO: check that the batch is within bounds given that the
-              bounds may now not be known by the requester.
-
-        if let Some(start) = &request.start {
-            fp_ensure!(
-                signed_batch.batch.initial_sequence_number >= *start
-                    && signed_batch.batch.next_sequence_number
-                        <= (*start + request.length + signed_batch.batch.size),
-                SuiError::ByzantineAuthoritySuspicion {
-                    authority: self.address
-                }
-            );
-        }
-        */
+        // TODO: check that the batch is within bounds given that the
+        //      bounds may now not be known by the requester.
+        //
+        // if let Some(start) = &request.start {
+        //    fp_ensure!(
+        //        signed_batch.batch.initial_sequence_number >= *start
+        //            && signed_batch.batch.next_sequence_number
+        //                <= (*start + request.length + signed_batch.batch.size),
+        //        SuiError::ByzantineAuthoritySuspicion {
+        //            authority: self.address
+        //        }
+        //    );
+        // }
 
         // If we have seen a previous batch, use it to make sure the next batch
         // is constructed correctly:

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -5,7 +5,6 @@
 use crate::authority_client::{AuthorityAPI, BatchInfoResponseItemStream};
 use async_trait::async_trait;
 use futures::StreamExt;
-use std::io;
 use sui_types::crypto::PublicKeyBytes;
 use sui_types::{base_types::*, committee::*, fp_ensure};
 
@@ -177,7 +176,7 @@ impl<C> SafeClient<C> {
 
     fn check_update_item_batch_response(
         &self,
-        request: BatchInfoRequest,
+        _request: BatchInfoRequest,
         signed_batch: &SignedBatch,
         transactions_and_last_batch: &Option<(
             Vec<(TxSequenceNumber, TransactionDigest)>,
@@ -190,19 +189,33 @@ impl<C> SafeClient<C> {
             .check(&signed_batch.batch, signed_batch.authority)?;
 
         // ensure transactions enclosed match requested range
-        fp_ensure!(
-            signed_batch.batch.initial_sequence_number >= request.start
-                && signed_batch.batch.next_sequence_number
-                    <= (request.end + signed_batch.batch.size),
-            SuiError::ByzantineAuthoritySuspicion {
-                authority: self.address
-            }
-        );
+        /*
+
+        TODO: check that the batch is within bounds given that the
+              bounds may now not be known by the requester.
+
+        if let Some(start) = &request.start {
+            fp_ensure!(
+                signed_batch.batch.initial_sequence_number >= *start
+                    && signed_batch.batch.next_sequence_number
+                        <= (*start + request.length + signed_batch.batch.size),
+                SuiError::ByzantineAuthoritySuspicion {
+                    authority: self.address
+                }
+            );
+        }
+        */
 
         // If we have seen a previous batch, use it to make sure the next batch
         // is constructed correctly:
 
         if let Some((transactions, prev_batch)) = transactions_and_last_batch {
+            fp_ensure!(
+                !transactions.is_empty(),
+                SuiError::GenericAuthorityError {
+                    error: "Safe Client: Batches must have some contents.".to_string()
+                }
+            );
             let reconstructed_batch = AuthorityBatch::make_next(prev_batch, transactions)?;
 
             fp_ensure!(
@@ -363,7 +376,7 @@ where
     async fn handle_batch_stream(
         &self,
         request: BatchInfoRequest,
-    ) -> Result<BatchInfoResponseItemStream, io::Error> {
+    ) -> Result<BatchInfoResponseItemStream, SuiError> {
         let batch_info_items = self
             .authority_client
             .handle_batch_stream(request.clone())
@@ -371,19 +384,21 @@ where
 
         let client = self.clone();
         let address = self.address;
+        let count: u64 = 0;
         let stream = Box::pin(batch_info_items.scan(
-            (0u64, None),
-            move |(seq, txs_and_last_batch), batch_info_item| {
+            (0u64, None, count),
+            move |(seq, txs_and_last_batch, count), batch_info_item| {
                 let req_clone = request.clone();
                 let client = client.clone();
 
                 // We check if we have exceeded the batch boundary for this request.
-                if *seq >= request.end {
+                // This is to protect against server DoS
+                if *count > 10 * request.length {
                     // If we exceed it return None to end stream
                     return futures::future::ready(None);
                 }
 
-                let x = match &batch_info_item {
+                let result = match &batch_info_item {
                     Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
                         if let Err(err) = client.check_update_item_batch_response(
                             req_clone,
@@ -413,13 +428,14 @@ where
                             client.report_client_error(err.clone());
                             Some(Err(err))
                         } else {
+                            *count += 1;
                             Some(batch_info_item)
                         }
                     }
                     Err(e) => Some(Err(e.clone())),
                 };
 
-                futures::future::ready(x)
+                futures::future::ready(result)
             },
         ));
         Ok(Box::pin(stream))

--- a/sui_core/src/unit_tests/authority_aggregator_tests.rs
+++ b/sui_core/src/unit_tests/authority_aggregator_tests.rs
@@ -55,7 +55,7 @@ pub async fn init_local_authorities(
             objects,
         )
         .await;
-        states.push(client.state().clone());
+        states.push(client.state.clone());
         clients.insert(authority_name, client);
     }
     (AuthorityAggregator::new(committee, clients), states)
@@ -286,7 +286,7 @@ async fn execute_transaction_with_fault_configs(
     let gas_object2 = Object::with_owner_for_testing(addr1);
     let genesis_objects =
         authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
-    let mut authorities = init_local_authorities(genesis_objects).await;
+    let mut authorities = init_local_authorities(genesis_objects).await.0;
 
     for (index, config) in configs_before_process_transaction {
         get_local_client(&mut authorities, *index).fault_config = *config;

--- a/sui_core/src/unit_tests/authority_aggregator_tests.rs
+++ b/sui_core/src/unit_tests/authority_aggregator_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use move_core_types::{account_address::AccountAddress, ident_str};
 use signature::Signer;
@@ -13,6 +14,7 @@ use sui_types::messages::Transaction;
 use sui_types::object::{Object, GAS_VALUE_FOR_TESTING};
 
 use super::*;
+use crate::authority::AuthorityState;
 use crate::authority_client::LocalAuthorityClient;
 use crate::authority_client::LocalAuthorityClientFaultConfig;
 
@@ -29,7 +31,10 @@ pub fn authority_genesis_objects(
 
 pub async fn init_local_authorities(
     genesis_objects: Vec<Vec<Object>>,
-) -> AuthorityAggregator<LocalAuthorityClient> {
+) -> (
+    AuthorityAggregator<LocalAuthorityClient>,
+    Vec<Arc<AuthorityState>>,
+) {
     let mut key_pairs = Vec::new();
     let mut voting_rights = BTreeMap::new();
     for _ in 0..genesis_objects.len() {
@@ -41,6 +46,7 @@ pub async fn init_local_authorities(
     let committee = Committee::new(0, voting_rights);
 
     let mut clients = BTreeMap::new();
+    let mut states = Vec::new();
     for ((authority_name, secret), objects) in key_pairs.into_iter().zip(genesis_objects) {
         let client = LocalAuthorityClient::new_with_objects(
             committee.clone(),
@@ -49,9 +55,10 @@ pub async fn init_local_authorities(
             objects,
         )
         .await;
+        states.push(client.state().clone());
         clients.insert(authority_name, client);
     }
-    AuthorityAggregator::new(committee, clients)
+    (AuthorityAggregator::new(committee, clients), states)
 }
 
 pub fn get_local_client(
@@ -143,7 +150,7 @@ pub fn crate_object_move_transaction(
     )
 }
 
-fn delete_object_move_transaction(
+pub fn delete_object_move_transaction(
     src: SuiAddress,
     secret: &dyn signature::Signer<Signature>,
     object_ref: ObjectRef,
@@ -165,7 +172,7 @@ fn delete_object_move_transaction(
     )
 }
 
-fn set_object_move_transaction(
+pub fn set_object_move_transaction(
     src: SuiAddress,
     secret: &dyn signature::Signer<Signature>,
     object_ref: ObjectRef,
@@ -193,19 +200,19 @@ fn set_object_move_transaction(
     )
 }
 
-fn to_transaction(data: TransactionData, signer: &dyn Signer<Signature>) -> Transaction {
+pub fn to_transaction(data: TransactionData, signer: &dyn Signer<Signature>) -> Transaction {
     let signature = Signature::new(&data, signer);
     Transaction::new(data, signature)
 }
 
-async fn do_transaction<A: AuthorityAPI>(authority: &A, transaction: &Transaction) {
+pub async fn do_transaction<A: AuthorityAPI>(authority: &A, transaction: &Transaction) {
     authority
         .handle_transaction(transaction.clone())
         .await
         .unwrap();
 }
 
-async fn extract_cert<A: AuthorityAPI>(
+pub async fn extract_cert<A: AuthorityAPI>(
     authorities: &[&A],
     committee: &Committee,
     transaction_digest: &TransactionDigest,
@@ -241,7 +248,7 @@ async fn extract_cert<A: AuthorityAPI>(
     )
 }
 
-async fn do_cert<A: AuthorityAPI>(
+pub async fn do_cert<A: AuthorityAPI>(
     authority: &A,
     cert: &CertifiedTransaction,
 ) -> TransactionEffects {
@@ -254,7 +261,7 @@ async fn do_cert<A: AuthorityAPI>(
         .effects
 }
 
-async fn get_latest_ref<A: AuthorityAPI>(authority: &A, object_id: ObjectID) -> ObjectRef {
+pub async fn get_latest_ref<A: AuthorityAPI>(authority: &A, object_id: ObjectID) -> ObjectRef {
     if let Ok(ObjectInfoResponse {
         requested_object_reference: Some(object_ref),
         ..
@@ -311,7 +318,7 @@ async fn execute_transaction_with_fault_configs(
 
 #[tokio::test]
 async fn test_map_reducer() {
-    let authorities = init_local_authorities(authority_genesis_objects(4, vec![])).await;
+    let (authorities, _) = init_local_authorities(authority_genesis_objects(4, vec![])).await;
 
     // Test: reducer errors get propagated up
     let res = authorities
@@ -442,7 +449,7 @@ async fn test_get_all_owned_objects() {
     let gas_object2 = Object::with_owner_for_testing(addr2);
     let genesis_objects =
         authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
-    let authorities = init_local_authorities(genesis_objects).await;
+    let (authorities, _) = init_local_authorities(genesis_objects).await;
     let authority_clients: Vec<_> = authorities.authority_clients.values().collect();
 
     // Make a schedule of transactions
@@ -530,7 +537,7 @@ async fn test_sync_all_owned_objects() {
     let gas_object2 = Object::with_owner_for_testing(addr1);
     let genesis_objects =
         authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
-    let authorities = init_local_authorities(genesis_objects).await;
+    let (authorities, _) = init_local_authorities(genesis_objects).await;
     let authority_clients: Vec<_> = authorities.authority_clients.values().collect();
 
     let framework_obj_ref = genesis::get_framework_object_ref();
@@ -641,7 +648,7 @@ async fn test_process_transaction() {
     let gas_object2 = Object::with_owner_for_testing(addr1);
     let genesis_objects =
         authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
-    let authorities = init_local_authorities(genesis_objects).await;
+    let (authorities, _) = init_local_authorities(genesis_objects).await;
     let authority_clients: Vec<_> = authorities.authority_clients.values().collect();
 
     let framework_obj_ref = genesis::get_framework_object_ref();
@@ -687,7 +694,7 @@ async fn test_process_certificate() {
     let gas_object2 = Object::with_owner_for_testing(addr1);
     let genesis_objects =
         authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
-    let authorities = init_local_authorities(genesis_objects).await;
+    let (authorities, _) = init_local_authorities(genesis_objects).await;
     let authority_clients: Vec<_> = authorities.authority_clients.values().collect();
 
     let framework_obj_ref = genesis::get_framework_object_ref();

--- a/sui_core/src/unit_tests/gateway_state_tests.rs
+++ b/sui_core/src/unit_tests/gateway_state_tests.rs
@@ -30,7 +30,7 @@ async fn create_gateway_state(
         .iter()
         .flat_map(|v| v.iter().map(|o| o.get_single_owner().unwrap()))
         .collect();
-    let authorities = init_local_authorities(genesis_objects).await;
+    let (authorities, _) = init_local_authorities(genesis_objects).await;
     let path = tempfile::tempdir().unwrap().into_path();
     let gateway = GatewayState::new_with_authorities(path, authorities).unwrap();
     for owner in all_owners {

--- a/sui_core/src/unit_tests/server_tests.rs
+++ b/sui_core/src/unit_tests/server_tests.rs
@@ -114,7 +114,7 @@ async fn test_subscription() {
 
     let db = server.state.db().clone();
     let db2 = server.state.db().clone();
-    let state = server.state.clone();
+    let db3 = server.state.db().clone();
 
     let server_handle = server.spawn().await.unwrap();
 
@@ -140,7 +140,10 @@ async fn test_subscription() {
     println!("Started messahe handling.");
     // TEST 1: Get historical data
 
-    let req = BatchInfoRequest { start: 12, end: 34 };
+    let req = BatchInfoRequest {
+        start: Some(12),
+        length: 22,
+    };
 
     let mut resp = client.handle_batch_stream(req).await.unwrap();
 
@@ -175,6 +178,7 @@ async fn test_subscription() {
     let inner_server2 = state.clone();
     let _handle2 = tokio::spawn(async move {
         for i in 105..150 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
             let ticket = inner_server2.batch_notifier.ticket().expect("all good");
             db2.executed_sequence
                 .insert(&ticket.seq(), &tx_zero)
@@ -186,8 +190,8 @@ async fn test_subscription() {
     println!("TEST2: Sending realtime.");
 
     let req = BatchInfoRequest {
-        start: 101,
-        end: 112,
+        start: Some(101),
+        length: 11,
     };
 
     let mut resp = client.handle_batch_stream(req).await.unwrap();
@@ -216,7 +220,272 @@ async fn test_subscription() {
     assert_eq!(3, num_batches);
     assert_eq!(20, num_transactions);
 
+    _handle2.await.expect("Finished sending");
     println!("TEST2: Finished.");
 
-    state.batch_notifier.close();
+    println!("TEST3: Sending from very latest.");
+
+    let req = BatchInfoRequest {
+        start: None,
+        length: 10,
+    };
+
+    // let bytes: BytesMut = BytesMut::from(&serialize_batch_request(&req)[..]);
+    // tx.send(Ok(bytes)).await.expect("Problem sending");
+
+    let mut resp = client.handle_batch_stream(req).await.unwrap();
+
+    println!("TEST3: Send request.");
+
+    let mut num_batches = 0;
+    let mut num_transactions = 0;
+    let mut i = 120;
+    let inner_server2 = server.clone();
+
+    loop {
+        // Send a trasnaction
+        let ticket = inner_server2
+            .state
+            .batch_notifier
+            .ticket()
+            .expect("all good");
+        db3.executed_sequence
+            .insert(&ticket.seq(), &tx_zero)
+            .expect("Failed to write.");
+        println!("Send item {i}");
+        i += 1;
+
+        // Then we wait to receive
+        if let Some(data) = rx.next().await {
+            match deserialize_message(&data[..]).expect("Bad response") {
+                SerializedMessage::BatchInfoResp(resp) => match *resp {
+                    BatchInfoResponseItem(UpdateItem::Batch(signed_batch)) => {
+                        num_batches += 1;
+                        if signed_batch.batch.next_sequence_number >= 129 {
+                            break;
+                        }
+                    }
+                    BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest))) => {
+                        println!("Received {seq}");
+                        num_transactions += 1;
+                    }
+                },
+                _ => {
+                    panic!("Bad response");
+                }
+            }
+        }
+    }
+
+    assert_eq!(2, num_batches);
+    assert_eq!(10, num_transactions);
+
+    server.state.batch_notifier.close();
+    drop(tx);
+    handle1.await.expect("Problem closing task");
+}
+
+#[tokio::test]
+async fn test_subscription_safe_client() {
+    let sender = dbg_addr(1);
+    let object_id = dbg_object_id(1);
+    let authority_state = init_state_with_object_id(sender, object_id).await;
+
+    // The following two fields are only needed for shared objects (not by this bench).
+    let consensus_address = "127.0.0.1:0".parse().unwrap();
+    let (tx_consensus_listener, _rx_consensus_listener) = tokio::sync::mpsc::channel(1);
+
+    // Start the batch server
+    let state = Arc::new(authority_state);
+    let server = Arc::new(AuthorityServer::new(
+        "127.0.0.1".to_string(),
+        998,
+        65000,
+        state.clone(),
+        consensus_address,
+        tx_consensus_listener,
+    ));
+
+    let db = server.state.db().clone();
+    let db2 = server.state.db().clone();
+    let db3 = server.state.db().clone();
+
+    let _master_safe_client = SafeClient::new(
+        LocalAuthorityClient(state.clone()),
+        state.committee.clone(),
+        state.name,
+    );
+
+    let _join = server
+        .spawn_batch_subsystem(10, Duration::from_secs(500))
+        .await
+        .expect("Problem launching subsystem.");
+
+    let tx_zero = TransactionDigest::new([0; 32]);
+    for _i in 0u64..105 {
+        let ticket = server.state.batch_notifier.ticket().expect("all good");
+        db.executed_sequence
+            .insert(&ticket.seq(), &tx_zero)
+            .expect("Failed to write.");
+    }
+    println!("Sent tickets.");
+
+    tokio::task::yield_now().await;
+
+    println!("Started messahe handling.");
+    // TEST 1: Get historical data
+
+    let req = BatchInfoRequest {
+        start: Some(12),
+        length: 22,
+    };
+
+    let mut stream1 = _master_safe_client
+        .handle_batch_stream(req)
+        .await
+        .expect("Error following");
+
+    //let bytes: BytesMut = BytesMut::from(&serialize_batch_request(&req)[..]);
+    //tx.send(Ok(bytes)).await.expect("Problem sending");
+
+    println!("TEST1: Send request.");
+
+    let mut num_batches = 0;
+    let mut num_transactions = 0;
+
+    while let Some(data) = stream1.next().await {
+        match data.expect("Bad response") {
+            BatchInfoResponseItem(UpdateItem::Batch(signed_batch)) => {
+                num_batches += 1;
+                if signed_batch.batch.next_sequence_number >= 34 {
+                    break;
+                }
+            }
+            BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest))) => {
+                num_transactions += 1;
+            }
+        }
+    }
+
+    assert_eq!(4, num_batches);
+    assert_eq!(30, num_transactions);
+
+    println!("TEST1: Finished.");
+
+    // Test 2: Get subscription data
+
+    // Add data in real time
+    let inner_server2 = server.clone();
+    let _handle2 = tokio::spawn(async move {
+        for i in 105..120 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            let ticket = inner_server2
+                .state
+                .batch_notifier
+                .ticket()
+                .expect("all good");
+            db2.executed_sequence
+                .insert(&ticket.seq(), &tx_zero)
+                .expect("Failed to write.");
+            println!("Send item {i}");
+        }
+    });
+
+    println!("TEST2: Sending realtime.");
+
+    let req = BatchInfoRequest {
+        start: Some(101),
+        length: 11,
+    };
+
+    let mut stream1 = _master_safe_client
+        .handle_batch_stream(req)
+        .await
+        .expect("Error following");
+
+    println!("TEST2: Send request.");
+
+    let mut num_batches = 0;
+    let mut num_transactions = 0;
+
+    while let Some(data) = stream1.next().await {
+        match &data.expect("No error") {
+            BatchInfoResponseItem(UpdateItem::Batch(signed_batch)) => {
+                num_batches += 1;
+                if signed_batch.batch.next_sequence_number >= 112 {
+                    break;
+                }
+            }
+            BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest))) => {
+                println!("Received {seq}");
+                num_transactions += 1;
+            }
+        }
+    }
+
+    assert_eq!(3, num_batches);
+    assert_eq!(20, num_transactions);
+
+    _handle2.await.expect("Finished sending");
+    println!("TEST2: Finished.");
+
+    println!("TEST3: Sending from very latest.");
+
+    let req = BatchInfoRequest {
+        start: None,
+        length: 10,
+    };
+
+    let mut stream1 = _master_safe_client
+        .handle_batch_stream(req)
+        .await
+        .expect("Error following");
+
+    println!("TEST3: Send request.");
+
+    let mut num_batches = 0;
+    let mut num_transactions = 0;
+    let mut i = 120;
+    let inner_server2 = server.clone();
+
+    loop {
+        // Send a transaction
+        let ticket = inner_server2
+            .state
+            .batch_notifier
+            .ticket()
+            .expect("all good");
+        db3.executed_sequence
+            .insert(&ticket.seq(), &tx_zero)
+            .expect("Failed to write.");
+        println!("Send item {i}");
+        i += 1;
+
+        // Then we wait to receive
+        if let Some(data) = resp.next().await {
+            match deserialize_message(&data[..]).expect("Bad response") {
+                SerializedMessage::BatchInfoResp(resp) => match *resp {
+                    BatchInfoResponseItem(UpdateItem::Batch(signed_batch)) => {
+                        num_batches += 1;
+                        if signed_batch.batch.next_sequence_number >= 129 {
+                            break;
+                        }
+                    }
+                    BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest))) => {
+                        println!("Received {seq}");
+                        num_transactions += 1;
+                    }
+                }
+                BatchInfoResponseItem(UpdateItem::Transaction((seq, _digest))) => {
+                    println!("Received {seq}");
+                    num_transactions += 1;
+                }
+            }
+        }
+    }
+
+    assert_eq!(2, num_batches);
+    assert_eq!(10, num_transactions);
+
+    server.state.batch_notifier.close();
 }

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -54,8 +54,9 @@ AuthoritySignature:
       SIZE: 64
 BatchInfoRequest:
   STRUCT:
-    - start: U64
-    - end: U64
+    - start:
+        OPTION: U64
+    - length: U64
 BatchInfoResponseItem:
   NEWTYPESTRUCT:
     TYPENAME: UpdateItem

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -620,8 +620,10 @@ pub struct AccountInfoRequest {
 /// is over the batch end marker.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct BatchInfoRequest {
-    pub start: TxSequenceNumber,
-    pub end: TxSequenceNumber,
+    // The sequence number at which to start the seuqence to return, or None for the latest.
+    pub start: Option<TxSequenceNumber>,
+    // The total number of items to receive. Could receive a bit more or a bit less.
+    pub length: u64,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
We extend and test more thoroughly the follower API and safe client:
* The follower API now allows an `Option<TxSequence>` as a `start` in the batch request, and it follows the latest transactions. It also takes a `length` to denote how many items we expect.
* The follower logic moves to `AuthorityState` and now returns a nice Stream of `BatchResponses` instead of writing directly to the channel. The logic that connects that to a channel stays in `AuthorityServer`.
* Additional tests check the facilities to follow the latest updates, and also test the safe client correctly receives the stream as generated by the authority.
* Now includes the merged gossip from #1676 