### PR TITLE
Add more gateway_state and authority_aggregator tests

### DIFF
--- a/sui_core/src/authority_client.rs
+++ b/sui_core/src/authority_client.rs
@@ -186,8 +186,25 @@ impl AuthorityAPI for NetworkAuthorityClient {
     }
 }
 
+#[derive(Clone, Copy, Default)]
+pub struct LocalAuthorityClientFaultConfig {
+    pub fail_before_handle_transaction: bool,
+    pub fail_after_handle_transaction: bool,
+    pub fail_before_handle_confirmation: bool,
+    pub fail_after_handle_confirmation: bool,
+}
+
+impl LocalAuthorityClientFaultConfig {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
 #[derive(Clone)]
-pub struct LocalAuthorityClient(pub Arc<Mutex<AuthorityState>>);
+pub struct LocalAuthorityClient {
+    pub state: Arc<Mutex<AuthorityState>>,
+    pub fault_config: LocalAuthorityClientFaultConfig,
+}
 
 #[async_trait]
 impl AuthorityAPI for LocalAuthorityClient {
@@ -195,8 +212,18 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         transaction: Transaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let state = self.0.clone();
+        if self.fault_config.fail_before_handle_transaction {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error before handle_transaction".to_owned(),
+            });
+        }
+        let state = self.state.clone();
         let result = state.lock().await.handle_transaction(transaction).await;
+        if self.fault_config.fail_after_handle_transaction {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error after handle_transaction".to_owned(),
+            });
+        }
         result
     }
 
@@ -204,12 +231,22 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         transaction: ConfirmationTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let state = self.0.clone();
+        if self.fault_config.fail_before_handle_confirmation {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error before handle_confirmation_transaction".to_owned(),
+            });
+        }
+        let state = self.state.clone();
         let result = state
             .lock()
             .await
             .handle_confirmation_transaction(transaction)
             .await;
+        if self.fault_config.fail_after_handle_confirmation {
+            return Err(SuiError::GenericAuthorityError {
+                error: "Mock error after handle_confirmation_transaction".to_owned(),
+            });
+        }
         result
     }
 
@@ -217,7 +254,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         request: AccountInfoRequest,
     ) -> Result<AccountInfoResponse, SuiError> {
-        let state = self.0.clone();
+        let state = self.state.clone();
 
         let result = state
             .lock()
@@ -231,7 +268,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         request: ObjectInfoRequest,
     ) -> Result<ObjectInfoResponse, SuiError> {
-        let state = self.0.clone();
+        let state = self.state.clone();
         let x = state.lock().await.handle_object_info_request(request).await;
         x
     }
@@ -241,7 +278,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let state = self.0.clone();
+        let state = self.state.clone();
 
         let result = state
             .lock()
@@ -256,7 +293,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         &self,
         request: BatchInfoRequest,
     ) -> Result<BatchInfoResponseItemStream, io::Error> {
-        let state = self.0.clone();
+        let state = self.state.clone();
 
         let update_items = state.lock().await.handle_batch_info_request(request).await;
 
@@ -294,7 +331,10 @@ impl LocalAuthorityClient {
             &mut genesis::get_genesis_context(),
         )
         .await;
-        Self(Arc::new(Mutex::new(state)))
+        Self {
+            state: Arc::new(Mutex::new(state)),
+            fault_config: LocalAuthorityClientFaultConfig::default(),
+        }
     }
 
     #[cfg(test)]
@@ -306,7 +346,7 @@ impl LocalAuthorityClient {
     ) -> Self {
         let client = Self::new(committee, address, secret).await;
         {
-            let client_ref = client.0.as_ref().try_lock().unwrap();
+            let client_ref = client.state.as_ref().try_lock().unwrap();
             for object in objects {
                 client_ref.insert_genesis_object(object).await;
             }

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -31,6 +31,11 @@ impl<C> SafeClient<C> {
         }
     }
 
+    #[cfg(test)]
+    pub fn authority_client(&mut self) -> &mut C {
+        &mut self.authority_client
+    }
+
     // Here we centralize all checks for transaction info responses
     fn check_transaction_response(
         &self,


### PR DESCRIPTION
This PR adds more tests to gateway_state_tests and authority_aggregator_tests:
1. In gateway_state_tests, we added a case to see if a single gateway is resilient to concurrent equivocation.
2. In both tests, we added cases where we purposely introduce nodes that may behave incorrectly in specific cases, and check that the result is consistent with what we expect.

Last step towards https://github.com/MystenLabs/sui/issues/1279