### PR TITLE
wallet: correctly pull git revision for build environment

### DIFF
--- a/sui/src/bin/wallet.rs
+++ b/sui/src/bin/wallet.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     #[allow(unused)]
     let guard = telemetry_subscribers::init(config);
-    if let Ok(git_rev) = std::env::var("GIT_REV") {
+    if let Some(git_rev) = std::option_env!("GIT_REV") {
         debug!("Wallet built at git revision {git_rev}");
     }
 
@@ -89,9 +89,9 @@ async fn main() -> Result<(), anyhow::Error> {
             .get_long_version()
             .unwrap_or_else(|| app.get_version().unwrap_or("unknown"))
             .to_owned();
-        if let Ok(git_rev) = std::env::var("GIT_REV") {
+        if let Some(git_rev) = std::option_env!("GIT_REV") {
             version.push('-');
-            version.push_str(&git_rev);
+            version.push_str(git_rev);
         }
         writeln!(out, "--- sui wallet {version} ---")?;
         writeln!(out)?;


### PR DESCRIPTION
The initial attempt at including git revision in the wallet binary
incorrectly used the wrong method for querying environment information
from the build environment. Instead it was querying the environment at
runtime.