### PR TITLE
[explorer] Updates Owned Objects to match RPC Model

### DIFF
--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -149,28 +149,35 @@ function OwnedObjectView({ results }: { results: resultType }) {
     );
 }
 
-function OwnedObject({ id }: { id: string }) {
-    const [component, setComponent] = useState(<div />);
+function GetObjectsStatic({ id }: { id: string }) {
+    const objects = findOwnedObjectsfromID(id);
 
-    if (process.env.REACT_APP_DATA === 'static') {
-        const objects = findOwnedObjectsfromID(id);
-        if (objects === undefined) return <div />;
-        setComponent(
+    if (objects !== undefined) {
+        return (
             <OwnedObjectSection
                 objects={objects.map(({ objectId }) => objectId)}
             />
         );
-    } else {
-        rpc.getOwnedObjectRefs(id).then((objects) =>
-            setComponent(
-                <OwnedObjectSection
-                    objects={objects.map(({ objectId }) => objectId)}
-                />
-            )
-        );
     }
 
-    return component;
+    return <div />;
+}
+
+function GetObjectsAPI({ id }: { id: string }) {
+    const [objects, setObjects] = useState([{ objectId: 'Please Wait' }]);
+    useEffect(() => {
+        rpc.getOwnedObjectRefs(id).then((objects) => setObjects(objects));
+    }, [id]);
+    return (
+        <OwnedObjectSection objects={objects.map(({ objectId }) => objectId)} />
+    );
+}
+function OwnedObject({ id }: { id: string }) {
+    if (process.env.REACT_APP_DATA === 'static') {
+        return <GetObjectsStatic id={id} />;
+    } else {
+        return <GetObjectsAPI id={id} />;
+    }
 }
 
 function OwnedObjectSection({ objects }: { objects: string[] }) {

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -15,6 +15,8 @@ import {
 import { processDisplayValue, trimStdLibPrefix } from '../../utils/stringUtils';
 import DisplayBox from '../displaybox/DisplayBox';
 
+import type { ObjectRef } from 'sui.js';
+
 import styles from './OwnedObjects.module.css';
 
 type resultType = {
@@ -164,7 +166,7 @@ function GetObjectsStatic({ id }: { id: string }) {
 }
 
 function GetObjectsAPI({ id }: { id: string }) {
-    const [objects, setObjects] = useState([{ objectId: 'Please Wait' }]);
+    const [objects, setObjects] = useState<ObjectRef[]>([]);
     useEffect(() => {
         rpc.getOwnedObjectRefs(id).then((objects) => setObjects(objects));
     }, [id]);

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -7,7 +7,10 @@ import { useNavigate } from 'react-router-dom';
 import { DefaultRpcClient as rpc } from '../../utils/api/SuiRpcClient';
 import { parseImageURL } from '../../utils/objectUtils';
 import { navigateWithUnknown } from '../../utils/searchUtil';
-import { findDataFromID } from '../../utils/static/searchUtil';
+import {
+    findDataFromID,
+    findOwnedObjectsfromID,
+} from '../../utils/static/searchUtil';
 import { trimStdLibPrefix, processDisplayValue } from '../../utils/stringUtils';
 import DisplayBox from '../displaybox/DisplayBox';
 
@@ -139,7 +142,21 @@ function OwnedObjectView({ results }: { results: resultType }) {
     );
 }
 
-function OwnedObject({ objects }: { objects: string[] }) {
+function OwnedObject({ id }: { id: string }) {
+    let objects;
+    if (process.env.REACT_APP_DATA === 'static') {
+        objects = findOwnedObjectsfromID(id);
+        if (objects === undefined) return <div />;
+    } else {
+        objects = [{ objectId: 'apples' }];
+    }
+
+    return (
+        <OwnedObjectSection objects={objects.map(({ objectId }) => objectId)} />
+    );
+}
+
+function OwnedObjectSection({ objects }: { objects: string[] }) {
     const [pageIndex, setPageIndex] = useState(0);
 
     const ITEMS_PER_PAGE = 12;

--- a/explorer/client/src/pages/address-result/AddressResult.tsx
+++ b/explorer/client/src/pages/address-result/AddressResult.tsx
@@ -43,15 +43,7 @@ function Loaded({ data }: { data: DataType }) {
             </div>
             <div>
                 <div>Owned Objects</div>
-                <div>
-                    {
-                        <OwnedObjects
-                            objects={data.objects.map(
-                                ({ objectId }) => objectId
-                            )}
-                        />
-                    }
-                </div>
+                <div>{<OwnedObjects id={data.id} />}</div>
             </div>
         </div>
     );

--- a/explorer/client/src/pages/address-result/AddressResult.tsx
+++ b/explorer/client/src/pages/address-result/AddressResult.tsx
@@ -1,14 +1,12 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import ErrorResult from '../../components/error-result/ErrorResult';
 import Longtext from '../../components/longtext/Longtext';
 import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 import theme from '../../styles/theme.module.css';
-import { DefaultRpcClient as rpc } from '../../utils/api/SuiRpcClient';
 
 type DataType = {
     id: string;
@@ -24,116 +22,30 @@ function instanceOfDataType(object: any): object is DataType {
     return object !== undefined && ['id', 'objects'].every((x) => x in object);
 }
 
-function instanceOfResponseType(input: any): input is ResponseType {
-    return input && input.length > 0 && input[0].objectId;
-}
-
-function Loaded({ data }: { data: DataType }) {
-    return (
-        <div className={theme.textresults} id="textResults">
-            <div>
-                <div>Address ID</div>
-                <div id="addressID">
-                    <Longtext
-                        text={data.id}
-                        category="addresses"
-                        isLink={false}
-                    />
-                </div>
-            </div>
-            <div>
-                <div>Owned Objects</div>
-                <div>{<OwnedObjects id={data.id} />}</div>
-            </div>
-        </div>
-    );
-}
-
-function Pending() {
-    return <div className={theme.pending}>Please wait for results to load</div>;
-}
-
-function Fail({ id }: { id: string | undefined }) {
-    return (
-        <ErrorResult
-            id={id}
-            errorMsg="No objects were found for the queried address value"
-        />
-    );
-}
-
-function AddressResultStatic({ addressID }: { addressID: string | undefined }) {
-    const { findDataFromID } = require('../../utils/static/searchUtil');
-    const data = findDataFromID(addressID, undefined);
-
-    if (instanceOfDataType(data) && instanceOfResponseType(data.objects)) {
-        return <Loaded data={data} />;
-    } else {
-        return <Fail id={addressID} />;
-    }
-}
-
-function AddressResultAPI({ addressID }: { addressID: string | undefined }) {
-    const defaultData = (addressID: string | undefined) => ({
-        id: addressID,
-        objects: [{}],
-        loadState: 'pending',
-    });
-    const [data, setData] = useState(defaultData(addressID));
-
-    useEffect(() => {
-        if (addressID === undefined) return;
-
-        rpc.getAddressObjects(addressID as string)
-            .then((json) => {
-                setData({
-                    id: addressID,
-                    objects: json,
-                    loadState: 'loaded',
-                });
-            })
-            .catch((error) => {
-                console.log(error);
-                setData({ ...defaultData(addressID), loadState: 'fail' });
-            });
-    }, [addressID]);
-
-    if (
-        instanceOfDataType(data) &&
-        instanceOfResponseType(data.objects) &&
-        data.loadState === 'loaded'
-    ) {
-        return <Loaded data={data} />;
-    }
-
-    if (data.loadState === 'pending') {
-        return <Pending />;
-    }
-
-    return <Fail id={addressID} />;
-}
-
 function AddressResult() {
     const { id: addressID } = useParams();
-    const { state } = useLocation();
 
-    if (instanceOfResponseType(state)) {
-        const stringid = addressID === undefined ? '' : addressID;
+    if (addressID !== undefined) {
         return (
-            <Loaded
-                data={{
-                    id: stringid,
-                    objects: state,
-                    loadState: 'loaded',
-                }}
-            />
+            <div className={theme.textresults} id="textResults">
+                <div>
+                    <div>Address ID</div>
+                    <div id="addressID">
+                        <Longtext
+                            text={addressID}
+                            category="addresses"
+                            isLink={false}
+                        />
+                    </div>
+                </div>
+                <div>
+                    <div>Owned Objects</div>
+                    <div>{<OwnedObjects id={addressID} />}</div>
+                </div>
+            </div>
         );
-    }
-
-    if (process.env.REACT_APP_DATA !== 'static') {
-        return <AddressResultAPI addressID={addressID} />;
     } else {
-        return <AddressResultStatic addressID={addressID} />;
+        return <ErrorResult id={addressID} errorMsg={'Something went wrong'} />;
     }
 }
 

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -364,7 +364,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                                 key={`ConnectedEntity-${index1}`}
                                             >
                                                 <div>{prepLabel(key)}</div>
-                                                <OwnedObjects objects={value} />
+                                                <OwnedObjects id={data.id} />
                                             </div>
                                         )
                                     )}

--- a/explorer/client/src/utils/api/searchUtil.ts
+++ b/explorer/client/src/utils/api/searchUtil.ts
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DefaultRpcClient as rpc } from './DefaultRpcClient';
-import { DefaultRpcClient as legacyAPI } from './SuiRpcClient';
 
 export const navigateWithUnknown = async (
     input: string,
     navigate: Function
 ) => {
-    // TODO - replace multi-request search with backend function when ready
-    const addrPromise = legacyAPI.getAddressObjects(input).then((data) => {
+    const addrPromise = rpc.getOwnedObjectRefs(input).then((data) => {
         if (data.length <= 0) throw new Error('No objects for Address');
 
         return {
@@ -17,7 +15,6 @@ export const navigateWithUnknown = async (
             data: data,
         };
     });
-
     const objInfoPromise = rpc.getObjectInfo(input).then((data) => ({
         category: 'objects',
         data: data,

--- a/explorer/client/src/utils/static/owned_object.json
+++ b/explorer/client/src/utils/static/owned_object.json
@@ -1,0 +1,139 @@
+{
+    "data": [
+        {
+            "id": "ownsAllAddress",
+            "objects": [
+                {
+                    "objectId": "playerOne"
+                },
+                {
+                    "objectId": "7bc832ec31709638cd8d9323e90edf332gff4389"
+                },
+                {
+                    "objectId": "7bc832ec31709638cd8d9323e90edf332gff4389"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "7bc832ec31709638cd8d9323e90edf332gff4389"
+                },
+                {
+                    "objectId": "7bc832ec31709638cd8d9323e90edf332gff4389"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "ComponentObject"
+                },
+                {
+                    "objectId": "7bc832ec31709638cd8d9323e90edf332gff4389"
+                },
+                {
+                    "objectId": "playerTwo"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "7bc832ec31709638cd8d9323e90edf332gff4389"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "standaloneObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                },
+                {
+                    "objectId": "CollectionObject"
+                }
+            ]
+        },
+        {
+            "id": "CollectionObject",
+            "objects": [
+                {
+                    "objectId": "ComponentObject",
+                    "version": 1
+                }
+            ]
+        },
+        {
+            "id": "playerTwo",
+            "objects": [
+                {
+                    "objectId": "standaloneObject",
+                    "version": 1
+                }
+            ]
+        },
+        {
+            "id": "ObjectThatOwns",
+            "objects": [
+                {
+                    "objectId": "ChildObjectWImage",
+                    "version": 1
+                },
+                {
+                    "objectId": "ChildObjectWBrokenImage",
+                    "version": 1
+                }
+            ]
+        },
+
+        {
+            "id": "receiverAddress",
+            "objects": [
+                {
+                    "objectId": "playerOne",
+                    "version": 6
+                },
+                {
+                    "objectId": "playerTwo",
+                    "version": 5
+                }
+            ]
+        },
+        {
+            "id": "senderAddress",
+            "objects": []
+        }
+    ]
+}

--- a/explorer/client/src/utils/static/searchUtil.ts
+++ b/explorer/client/src/utils/static/searchUtil.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import mockTransactionData from './mock_data.json';
+import mockObjectData from './mock_data.json';
+import mockOwnedObjectData from './owned_object.json';
 
 const navigateWithUnknown = async (input: string, navigate: Function) => {
     const data = findDataFromID(input, false);
@@ -21,6 +22,9 @@ const navigateWithUnknown = async (input: string, navigate: Function) => {
 const findDataFromID = (targetID: string | undefined, state: any) =>
     state?.category !== undefined
         ? state
-        : mockTransactionData.data.find(({ id }) => id === targetID);
+        : mockObjectData.data.find(({ id }) => id === targetID);
 
-export { findDataFromID, navigateWithUnknown };
+const findOwnedObjectsfromID = (targetID: string | undefined) =>
+    mockOwnedObjectData?.data?.find(({ id }) => id === targetID)?.objects;
+
+export { findDataFromID, navigateWithUnknown, findOwnedObjectsfromID };


### PR DESCRIPTION
This updates the Owned Objects Component such that the Address Results now display owned objects:

![image](https://user-images.githubusercontent.com/11377188/166064826-57952f7c-f681-4a6b-aa29-3fc6307dc1e3.png)

Note that comprehensive testing is inhibited by apparent errors in the API.