### PR TITLE
[Typescript SDK] Fix data types for transactions

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignedTransaction, TransactionResponse, TransferTransaction, TxnDataSerializer, TransactionDigest, SuiAddress, ObjectRef, ObjectContent, ObjectOwner, SuiObject, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, ObjectType, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, Transfer, RawAuthoritySignInfo, SingleTransactionKind, TransactionKind, TransactionData, Transaction, CertifiedTransaction, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, MoveTypeTag, MoveCall, EmptySignInfo, AuthorityName, AuthoritySignature } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignedTransaction, TransactionResponse, TransferTransaction, TxnDataSerializer, TransactionDigest, SuiAddress, ObjectRef, ObjectContent, ObjectOwner, SuiObject, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, ObjectType, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, Transfer, RawAuthoritySignInfo, SingleTransactionKind, TransactionKind, TransactionData, Transaction, EpochId, CertifiedTransaction, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, StructTag, MoveTypeTag, MoveCall, MoveCallArg, EmptySignInfo, AuthorityName, AuthoritySignature } from "./index";
 import { BN } from "bn.js";
 
 export function isEd25519KeypairData(obj: any, _argumentName?: string): obj is Ed25519KeypairData {
@@ -173,7 +173,8 @@ export function isObjectNotExistsInfo(obj: any, _argumentName?: string): obj is 
     return (
         (obj !== null &&
             typeof obj === "object" ||
-            typeof obj === "function")
+            typeof obj === "function") &&
+        isTransactionResponse(obj.objectId) as boolean
     )
 }
 
@@ -316,11 +317,18 @@ export function isTransaction(obj: any, _argumentName?: string): obj is Transact
     )
 }
 
+export function isEpochId(obj: any, _argumentName?: string): obj is EpochId {
+    return (
+        typeof obj === "number"
+    )
+}
+
 export function isCertifiedTransaction(obj: any, _argumentName?: string): obj is CertifiedTransaction {
     return (
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
+        isSequenceNumber(obj.epoch) as boolean &&
         isTransaction(obj.transaction) as boolean &&
         Array.isArray(obj.signatures) &&
         obj.signatures.every((e: any) =>
@@ -354,6 +362,21 @@ export function isMoveModulePublish(obj: any, _argumentName?: string): obj is Mo
     )
 }
 
+export function isStructTag(obj: any, _argumentName?: string): obj is StructTag {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isTransactionResponse(obj.address) as boolean &&
+        isTransactionResponse(obj.module) as boolean &&
+        isTransactionResponse(obj.name) as boolean &&
+        Array.isArray(obj.type_args) &&
+        obj.type_args.every((e: any) =>
+            isMoveTypeTag(e) as boolean
+        )
+    )
+}
+
 export function isMoveTypeTag(obj: any, _argumentName?: string): obj is MoveTypeTag {
     return (
         (obj === "bool" ||
@@ -362,8 +385,17 @@ export function isMoveTypeTag(obj: any, _argumentName?: string): obj is MoveType
             obj === "u128" ||
             obj === "address" ||
             obj === "signer" ||
-            obj === "vector" ||
-            obj === "struct")
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            Array.isArray(obj.vector) &&
+            obj.vector.every((e: any) =>
+                isMoveTypeTag(e) as boolean
+            ) ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isStructTag(obj.struct) as boolean)
     )
 }
 
@@ -372,22 +404,37 @@ export function isMoveCall(obj: any, _argumentName?: string): obj is MoveCall {
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
-        isRawObjectRef(obj.packages) as boolean &&
+        isRawObjectRef(obj.package) as boolean &&
         isTransactionResponse(obj.module) as boolean &&
         isTransactionResponse(obj.function) as boolean &&
         Array.isArray(obj.type_arguments) &&
         obj.type_arguments.every((e: any) =>
             isMoveTypeTag(e) as boolean
         ) &&
-        Array.isArray(obj.object_arguments) &&
-        obj.object_arguments.every((e: any) =>
-            isRawObjectRef(e) as boolean
-        ) &&
-        Array.isArray(obj.shared_object_arguments) &&
-        obj.shared_object_arguments.every((e: any) =>
-            isTransactionResponse(e) as boolean
-        ) &&
-        Array.isArray(obj.pure_arguments)
+        Array.isArray(obj.arguments) &&
+        obj.arguments.every((e: any) =>
+            isMoveCallArg(e) as boolean
+        )
+    )
+}
+
+export function isMoveCallArg(obj: any, _argumentName?: string): obj is MoveCallArg {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            Array.isArray(obj.Pure) &&
+            obj.Pure.every((e: any) =>
+                isSequenceNumber(e) as boolean
+            ) ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isRawObjectRef(obj.ImmOrOwnedObject) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isTransactionResponse(obj.SharedObject) as boolean)
     )
 }
 

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -33,7 +33,7 @@ export type ObjectExistsInfo = {
 };
 
 export type ObjectNotExistsInfo = {
-  objectId: any;
+  objectId: ObjectId;
 };
 
 export type ObjectStatus = 'Exists' | 'NotExists' | 'Deleted';

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { TransactionDigest } from './common';
-import { RawObjectRef } from './objects';
+import { SuiAddress, TransactionDigest } from './common';
+import { ObjectId, RawObjectRef } from './objects';
 
 export type Transfer = {
   recipient: string;
@@ -27,7 +27,11 @@ export type Transaction = {
   tx_signature: string;
 };
 
+// TODO: support u64
+export type EpochId = number;
+
 export type CertifiedTransaction = {
+  epoch: EpochId;
   transaction: Transaction;
   signatures: RawAuthoritySignInfo[];
 };
@@ -40,6 +44,12 @@ export type MoveModulePublish = {
   modules: any;
 };
 
+export type StructTag = {
+  address: SuiAddress;
+  module: string;
+  name: string;
+  type_args: MoveTypeTag[];
+};
 export type MoveTypeTag =
   | 'bool'
   | 'u8'
@@ -47,18 +57,22 @@ export type MoveTypeTag =
   | 'u128'
   | 'address'
   | 'signer'
-  | 'vector'
-  | 'struct';
+  | { vector: MoveTypeTag[] }
+  | { struct: StructTag };
 
 export type MoveCall = {
-  packages: RawObjectRef;
+  package: RawObjectRef;
   module: string;
   function: string;
   type_arguments: MoveTypeTag[];
-  object_arguments: RawObjectRef[];
-  shared_object_arguments: string[];
-  pure_arguments: any[];
+  arguments: MoveCallArg[];
 };
+
+export type MoveCallArg =
+  // TODO: convert to Uint8Array
+  | { Pure: number[] }
+  | { ImmOrOwnedObject: RawObjectRef }
+  | { SharedObject: ObjectId };
 
 export type EmptySignInfo = object;
 export type AuthorityName = string;

--- a/sdk/typescript/test/mocks/data/transactions.json
+++ b/sdk/typescript/test/mocks/data/transactions.json
@@ -1,0 +1,324 @@
+{
+  "move_call": {
+    "epoch": 0,
+    "transaction": {
+      "data": {
+        "kind": {
+          "Single": {
+            "Call": {
+              "package": [
+                "0000000000000000000000000000000000000002",
+                1,
+                "y0O4zWdaLaxiUzWa8dmjpkMvrWCa1Vtut/YHf7Ei9W4="
+              ],
+              "module": "DevNetNFT",
+              "function": "mint",
+              "type_arguments": [],
+              "arguments": [
+                {
+                  "Pure": [11, 69, 120, 97, 109, 112, 108, 101, 32, 78, 70, 84]
+                },
+                {
+                  "Pure": [
+                    46,
+                    65,
+                    110,
+                    32,
+                    78,
+                    70,
+                    84,
+                    32,
+                    99,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    100,
+                    32,
+                    98,
+                    121,
+                    32,
+                    116,
+                    104,
+                    101,
+                    32,
+                    119,
+                    97,
+                    108,
+                    108,
+                    101,
+                    116,
+                    32,
+                    67,
+                    111,
+                    109,
+                    109,
+                    97,
+                    110,
+                    100,
+                    32,
+                    76,
+                    105,
+                    110,
+                    101,
+                    32,
+                    84,
+                    111,
+                    111,
+                    108
+                  ]
+                },
+                {
+                  "Pure": [
+                    66,
+                    105,
+                    112,
+                    102,
+                    115,
+                    58,
+                    47,
+                    47,
+                    98,
+                    97,
+                    102,
+                    107,
+                    114,
+                    101,
+                    105,
+                    98,
+                    110,
+                    103,
+                    113,
+                    104,
+                    108,
+                    51,
+                    103,
+                    97,
+                    97,
+                    55,
+                    100,
+                    97,
+                    111,
+                    98,
+                    52,
+                    105,
+                    50,
+                    118,
+                    99,
+                    99,
+                    122,
+                    105,
+                    97,
+                    121,
+                    50,
+                    106,
+                    106,
+                    108,
+                    112,
+                    52,
+                    51,
+                    53,
+                    99,
+                    102,
+                    54,
+                    54,
+                    118,
+                    104,
+                    111,
+                    110,
+                    111,
+                    55,
+                    110,
+                    114,
+                    118,
+                    119,
+                    119,
+                    53,
+                    51,
+                    116,
+                    121
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "sender": "f16a5aedcdf9f2a9c2bd0f077279ec3d5ff0dfee",
+        "gas_payment": [
+          "55ed6fb404529aea778ec1979a8ca237258a9920",
+          3,
+          "KaDRuhGkX2yIXcTaFo5BWIBkzjmyOIp3XPSTasNt+Lo="
+        ],
+        "gas_budget": 1000
+      },
+      "tx_signature": "xVfT3rZyFtu2vdqqw8cjh3MgNeH289sGGENZSwUS1lN4n+17nnNiTq4Uya7/Z9Ruu6sWtStJCt4dEv1DS9mJAGQCvNFPnU/FaUP/6N14SXySxXctZ9UF86qYD0+Aw6ZW",
+      "auth_sign_info": {}
+    },
+    "signatures": [
+      [
+        "HUetNOK8VYmILFADRclTtYN+MNZknTFcYWkLp6HijSM=",
+        "ckT1Y2N5Kq0UM0mlmp5kG+hBilLaRM5mBWcFC2DL2W3/VULJYZIEgNjy3mx5Y351Irrau76pdeKn/9V0ZJh+Dg=="
+      ],
+      [
+        "6VmSg8DaGsLu3riaVvxJzY88DY1N26mwoKUFT+ffP/0=",
+        "0UP9YeiH/+baS3jKpRbmO/g0iGKOzO1I5Sy7knu6cT6XBzBzduek/EkYwQFmMAcd+Xg5GU0VwAktY49TF4sCCA=="
+      ],
+      [
+        "J2E+G3jRyOuxrCY+9xgPF+uc/6OrVUTNNp+L4XmwMn4=",
+        "zEzce+riNmR3fZDV2N4XB8cNhO3rtW+3k1qPNLfu1qjaBWq9QwwBqiQ4yQrGrnId0zZFy/G2Z08cT1l09jGUCw=="
+      ]
+    ]
+  },
+
+  "coin_split": {
+    "epoch": 0,
+    "transaction": {
+      "data": {
+        "kind": {
+          "Single": {
+            "Call": {
+              "package": [
+                "0000000000000000000000000000000000000002",
+                1,
+                "y0O4zWdaLaxiUzWa8dmjpkMvrWCa1Vtut/YHf7Ei9W4="
+              ],
+              "module": "Coin",
+              "function": "split_vec",
+              "type_arguments": [
+                {
+                  "struct": {
+                    "address": "0000000000000000000000000000000000000002",
+                    "module": "SUI",
+                    "name": "SUI",
+                    "type_args": []
+                  }
+                }
+              ],
+              "arguments": [
+                {
+                  "ImmOrOwnedObject": [
+                    "f217f564369714819363b2e9e612fd70860c2428",
+                    0,
+                    "+RZn/X5J/HR3YIye+kUjyhGKPzBQD/YaOchac21EruM="
+                  ]
+                },
+                {
+                  "Pure": [
+                    5,
+                    80,
+                    195,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    80,
+                    195,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    80,
+                    195,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    80,
+                    195,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    80,
+                    195,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "sender": "813ec1ab1e1797c79d1e1fcbebebc27a1fd21f07",
+        "gas_payment": [
+          "ef3bf894329b533495a36e6bf4fc33e195fba2cd",
+          0,
+          "2+IZoI0/1ifLd/E4gd/+bkECAxaO4byCWs0sADR1+vc="
+        ],
+        "gas_budget": 1000
+      },
+      "tx_signature": "chvjo2QnFjeF1gYJmpGY9UXHbiHIFrVbraNReJgWPBoWgOs39pDAoIBuMqcjQIVhf6lfMcuGAB1oEr7OS9ZOANRj4Rx5FZRehqwrctiLgZDPrY/3tI5+uJLCdaXPCj6C",
+      "auth_sign_info": {}
+    },
+    "signatures": [
+      [
+        "ImYYav2doQpD3T7XPRA5xnk9LYUU22okB/z4NRMuhjs=",
+        "fv8edfbQxHqj58LYppT6pKfkb8XPqgC1lllRe4+FycsyO6FnX6oHLUA/DmadKNGpkssLFI3oYeh9xtbnUjg8Cg=="
+      ],
+      [
+        "6VmSg8DaGsLu3riaVvxJzY88DY1N26mwoKUFT+ffP/0=",
+        "o3jOtm3cjNb75Z1v/gkiJVBbp9oePQ1M8VxMyVe9x2JCIF1SP3yjzW7m7qomPmtzYIvQFVtlMVHRxb7cG1b2CQ=="
+      ],
+      [
+        "HUetNOK8VYmILFADRclTtYN+MNZknTFcYWkLp6HijSM=",
+        "ONhBGpvySS4ozzbhgLijfmGiLHYot/k3RX3KwsbNCQJzRTtjzHw+TypIpnJyQEdygRZz3YFFtEFur4HrIVqRAA=="
+      ]
+    ]
+  },
+
+  "transfer": {
+    "epoch": 0,
+    "transaction": {
+      "data": {
+        "kind": {
+          "Single": {
+            "Transfer": {
+              "recipient": "f16a5aedcdf9f2a9c2bd0f077279ec3d5ff0dfee",
+              "object_ref": [
+                "78eda95cc78a24d138398f7448d9b74ca3ec9cd7",
+                1,
+                "dKPJW7a5tvr1EPC8UvnxmvbyChyb2dZsGujkWgRHiKc="
+              ]
+            }
+          }
+        },
+        "sender": "813ec1ab1e1797c79d1e1fcbebebc27a1fd21f07",
+        "gas_payment": [
+          "ef3bf894329b533495a36e6bf4fc33e195fba2cd",
+          1,
+          "znEsPOJM20hMJRZZ4IINL/jK0pL7JTxF64b+bhdiC7E="
+        ],
+        "gas_budget": 1000
+      },
+      "tx_signature": "tm9YSFGu56NrVBlA1BgPZ9dvKGtB29g4Sr59WGr3awtqU6Chuj31Yp6QJaX7TcutREYg1n30keXQhr7uUIRNAdRj4Rx5FZRehqwrctiLgZDPrY/3tI5+uJLCdaXPCj6C",
+      "auth_sign_info": {}
+    },
+    "signatures": [
+      [
+        "ImYYav2doQpD3T7XPRA5xnk9LYUU22okB/z4NRMuhjs=",
+        "mm6hc/pbo66O9U2ATkK3shUrgbm7fjgLdUZLeVuAhyheximgM1v8PHT3WOrkLNV2Qmn4e7rKJMwLgXUhqwoLAQ=="
+      ],
+      [
+        "6VmSg8DaGsLu3riaVvxJzY88DY1N26mwoKUFT+ffP/0=",
+        "Au/D+sQogc8HRRD3vgrVCBoF8F965ZvN65nxvOTTWcdhioVjwO8QcjfpkroPix3j4BoUJYBPzi3mISlfEzGRDw=="
+      ],
+      [
+        "HUetNOK8VYmILFADRclTtYN+MNZknTFcYWkLp6HijSM=",
+        "Z32t6Fv9eb8FAaXLw0YvwOqv3QpTLBpxjPnS5F7Ckz3gycyAOun1IFTQAMwHMX4DELgv08WiXGJ/IrJm9/nICg=="
+      ]
+    ]
+  }
+}

--- a/sdk/typescript/test/types/transactions.test.ts
+++ b/sdk/typescript/test/types/transactions.test.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import mockTransactionData from '../mocks/data/transactions.json';
+
+import { isCertifiedTransaction } from '../../src/index.guard';
+
+describe('Test Transaction Definition', () => {
+  it('Test against different transaction definitions', () => {
+    const txns = mockTransactionData;
+    expect(isCertifiedTransaction(txns['transfer'])).toBeTruthy();
+    expect(isCertifiedTransaction(txns['move_call'])).toBeTruthy();
+    expect(isCertifiedTransaction(txns['coin_split'])).toBeTruthy();
+  });
+});

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -31,5 +31,6 @@
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
     "noEmit": true,
+    "resolveJsonModule": true,
   }
 }


### PR DESCRIPTION
There was some data type mismatch in the SDK with the RPC server, causing @Jibz1 to see some error thrown by SDK on the frontend for txn digest `edEqyhYjoTVzN+Lky9SqXGKL4GWSdPZFSnYWk+fPyqg=`.

Added unit tests and also test against the problematic txn digest provided by @Jibz1 

![CleanShot 2022-04-29 at 15 54 33](https://user-images.githubusercontent.com/76067158/166081096-39ba19ae-8a89-457b-96c6-41c95fa440b8.gif)
