### PR TITLE
Add `QuorumSignInfo` and merge `CertifiedTransaction` with other Transaction types

### DIFF
--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -581,7 +581,7 @@
         "description": "",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
+          "$ref": "#/components/schemas/TransactionEnvelope_for_AuthorityQuorumSignInfo"
         }
       }
     },
@@ -615,6 +615,37 @@
     "schemas": {
       "AccountAddress": {
         "$ref": "#/components/schemas/Hex"
+      },
+      "AuthorityQuorumSignInfo": {
+        "description": "Represents at least a quorum (could be more) of authority signatures.",
+        "type": "object",
+        "required": [
+          "epoch",
+          "signatures"
+        ],
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "signatures": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/PublicKeyBytes"
+                },
+                {
+                  "$ref": "#/components/schemas/AuthoritySignature"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          }
+        }
       },
       "AuthoritySignature": {
         "description": "A signature emitted by an authority. It's useful to decouple this from user signatures, as their set of supported schemes will probably diverge",
@@ -880,7 +911,7 @@
             "description": "Certificate of the transaction",
             "allOf": [
               {
-                "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
+                "$ref": "#/components/schemas/TransactionEnvelope_for_AuthorityQuorumSignInfo"
               }
             ]
           },
@@ -1387,7 +1418,7 @@
             "description": "Certificate of the transaction",
             "allOf": [
               {
-                "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
+                "$ref": "#/components/schemas/TransactionEnvelope_for_AuthorityQuorumSignInfo"
               }
             ]
           },
@@ -1422,36 +1453,6 @@
                 "$ref": "#/components/schemas/Object"
               }
             ]
-          }
-        }
-      },
-      "QuorumSignInfo": {
-        "type": "object",
-        "required": [
-          "epoch",
-          "signatures"
-        ],
-        "properties": {
-          "epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "signatures": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": [
-                {
-                  "$ref": "#/components/schemas/PublicKeyBytes"
-                },
-                {
-                  "$ref": "#/components/schemas/AuthoritySignature"
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2
-            }
           }
         }
       },
@@ -1578,7 +1579,7 @@
             "description": "Certificate of the transaction",
             "allOf": [
               {
-                "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
+                "$ref": "#/components/schemas/TransactionEnvelope_for_AuthorityQuorumSignInfo"
               }
             ]
           },
@@ -1902,7 +1903,7 @@
           }
         }
       },
-      "TransactionEnvelope_for_QuorumSignInfo": {
+      "TransactionEnvelope_for_AuthorityQuorumSignInfo": {
         "description": "A transaction signed by a client, optionally signed by an authority (depending on `S`). `S` indicates the authority signing state. It can be either empty or signed. We make the authority signature templated so that `TransactionEnvelope<S>` can be used universally in the transactions storage in `SuiDataStore`, shared by both authorities and non-authorities: authorities store signed transactions, while non-authorities store unsigned transactions.",
         "type": "object",
         "required": [
@@ -1915,7 +1916,7 @@
             "description": "authority signature information, if available, is signed by an authority, applied on `data`.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/QuorumSignInfo"
+                "$ref": "#/components/schemas/AuthorityQuorumSignInfo"
               }
             ]
           },
@@ -1977,7 +1978,7 @@
                 "type": "array",
                 "items": [
                   {
-                    "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
+                    "$ref": "#/components/schemas/TransactionEnvelope_for_AuthorityQuorumSignInfo"
                   },
                   {
                     "$ref": "#/components/schemas/TransactionEffects"

--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -581,7 +581,7 @@
         "description": "",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/CertifiedTransaction"
+          "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
         }
       }
     },
@@ -685,41 +685,6 @@
           }
         ]
       },
-      "CertifiedTransaction": {
-        "description": "An transaction signed by a quorum of authorities\n\nNote: the signature set of this data structure is not necessarily unique in the system, i.e. there can be several valid certificates per transaction.\n\nAs a consequence, we check this struct does not implement Hash or Eq, see the note below.",
-        "type": "object",
-        "required": [
-          "epoch",
-          "signatures",
-          "transaction"
-        ],
-        "properties": {
-          "epoch": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "signatures": {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": [
-                {
-                  "$ref": "#/components/schemas/PublicKeyBytes"
-                },
-                {
-                  "$ref": "#/components/schemas/AuthoritySignature"
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2
-            }
-          },
-          "transaction": {
-            "$ref": "#/components/schemas/TransactionEnvelope_for_EmptySignInfo"
-          }
-        }
-      },
       "Data": {
         "oneOf": [
           {
@@ -749,9 +714,6 @@
             "additionalProperties": false
           }
         ]
-      },
-      "EmptySignInfo": {
-        "type": "object"
       },
       "Event": {
         "description": "User-defined event emitted by executing Move code. Executing a transaction produces an ordered log of these",
@@ -918,7 +880,7 @@
             "description": "Certificate of the transaction",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CertifiedTransaction"
+                "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
               }
             ]
           },
@@ -1425,7 +1387,7 @@
             "description": "Certificate of the transaction",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CertifiedTransaction"
+                "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
               }
             ]
           },
@@ -1460,6 +1422,36 @@
                 "$ref": "#/components/schemas/Object"
               }
             ]
+          }
+        }
+      },
+      "QuorumSignInfo": {
+        "type": "object",
+        "required": [
+          "epoch",
+          "signatures"
+        ],
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "signatures": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/components/schemas/PublicKeyBytes"
+                },
+                {
+                  "$ref": "#/components/schemas/AuthoritySignature"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
           }
         }
       },
@@ -1586,7 +1578,7 @@
             "description": "Certificate of the transaction",
             "allOf": [
               {
-                "$ref": "#/components/schemas/CertifiedTransaction"
+                "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
               }
             ]
           },
@@ -1910,7 +1902,7 @@
           }
         }
       },
-      "TransactionEnvelope_for_EmptySignInfo": {
+      "TransactionEnvelope_for_QuorumSignInfo": {
         "description": "A transaction signed by a client, optionally signed by an authority (depending on `S`). `S` indicates the authority signing state. It can be either empty or signed. We make the authority signature templated so that `TransactionEnvelope<S>` can be used universally in the transactions storage in `SuiDataStore`, shared by both authorities and non-authorities: authorities store signed transactions, while non-authorities store unsigned transactions.",
         "type": "object",
         "required": [
@@ -1923,7 +1915,7 @@
             "description": "authority signature information, if available, is signed by an authority, applied on `data`.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/EmptySignInfo"
+                "$ref": "#/components/schemas/QuorumSignInfo"
               }
             ]
           },
@@ -1985,7 +1977,7 @@
                 "type": "array",
                 "items": [
                   {
-                    "$ref": "#/components/schemas/CertifiedTransaction"
+                    "$ref": "#/components/schemas/TransactionEnvelope_for_QuorumSignInfo"
                   },
                   {
                     "$ref": "#/components/schemas/TransactionEffects"

--- a/sui/src/benchmark/transaction_creator.rs
+++ b/sui/src/benchmark/transaction_creator.rs
@@ -68,11 +68,11 @@ fn make_serialized_cert(
 ) -> Vec<u8> {
     // Make certificate
     let mut certificate = CertifiedTransaction::new(tx);
-    certificate.epoch = committee.epoch();
+    certificate.auth_sign_info.epoch = committee.epoch();
     for i in 0..committee.quorum_threshold() {
         let (pubx, secx) = keys.get(i).unwrap();
-        let sig = AuthoritySignature::new(&certificate.transaction.data, secx);
-        certificate.signatures.push((*pubx, sig));
+        let sig = AuthoritySignature::new(&certificate.data, secx);
+        certificate.auth_sign_info.signatures.push((*pubx, sig));
     }
 
     let serialized_certificate = serialize_cert(&certificate);

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -459,9 +459,9 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
     pub fn set_transaction_lock(
         &self,
         owned_input_objects: &[ObjectRef],
-        tx_digest: TransactionDigest,
         transaction: TransactionEnvelope<S>,
     ) -> Result<(), SuiError> {
+        let tx_digest = *transaction.digest();
         let lock_batch = self
             .transaction_lock
             .batch()

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -544,11 +544,8 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
         )?;
 
         // Cleanup the lock of the shared objects.
-        let write_batch = self.remove_shared_objects_locks(
-            write_batch,
-            transaction_digest,
-            &certificate.transaction,
-        )?;
+        let write_batch =
+            self.remove_shared_objects_locks(write_batch, transaction_digest, certificate)?;
 
         // Safe to unwrap since the "true" flag ensures we get a sequence value back.
         self.batch_update_objects(
@@ -800,7 +797,7 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
         &self,
         mut write_batch: DBBatch,
         transaction_digest: &TransactionDigest,
-        transaction: &Transaction,
+        transaction: &CertifiedTransaction,
     ) -> SuiResult<DBBatch> {
         let mut sequenced_to_delete = Vec::new();
         let mut schedule_to_delete = Vec::new();
@@ -827,10 +824,10 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
         let certificate_to_write = std::iter::once((transaction_digest, &certificate));
 
         // Make an iterator to update the locks of the transaction's shared objects.
-        let ids = certificate.transaction.shared_input_objects();
+        let ids = certificate.shared_input_objects();
         let versions = self.schedule.multi_get(ids)?;
 
-        let ids = certificate.transaction.shared_input_objects();
+        let ids = certificate.shared_input_objects();
         let (sequenced_to_write, schedule_to_write): (Vec<_>, Vec<_>) = ids
             .zip(versions.iter())
             .map(|(id, v)| {

--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -83,7 +83,7 @@ where
         // represent certificates that earlier insertions depend on. Thus updating an
         // authority in the order we pop() the certificates from this stack should ensure
         // certificates are uploaded in causal order.
-        let digest = *cert.certificate.transaction.digest();
+        let digest = *cert.certificate.digest();
         let mut missing_certificates: Vec<_> = vec![cert.clone()];
 
         // We keep a list of certificates already processed to avoid duplicates
@@ -108,7 +108,7 @@ where
             // The first time we cannot find the cert from the destination authority
             // we try to get its dependencies. But the second time we have already tried
             // to update its dependencies, so we should just admit failure.
-            let cert_digest = target_cert.certificate.transaction.digest();
+            let cert_digest = target_cert.certificate.digest();
             if attempted_certificates.contains(cert_digest) {
                 return Err(SuiError::AuthorityInformationUnavailable);
             }
@@ -196,6 +196,7 @@ where
         // and its full history. We should be able to use these are source authorities.
         let mut candidate_source_authorties: HashSet<AuthorityName> = cert
             .certificate
+            .auth_sign_info
             .signatures
             .iter()
             .map(|(name, _)| *name)
@@ -239,7 +240,7 @@ where
                     let inner_err = SuiError::PairwiseSyncFailed {
                         xsource: source_authority,
                         destination: destination_authority,
-                        tx_digest: *cert.certificate.transaction.digest(),
+                        tx_digest: *cert.certificate.digest(),
                         error: Box::new(err.clone()),
                     };
 
@@ -476,7 +477,7 @@ where
                 };
 
                 let (transaction_digest, cert_option) = if let Some(cert) = parent_certificate {
-                    (*cert.transaction.digest(), Some(cert))
+                    (*cert.digest(), Some(cert))
                 } else {
                     (TransactionDigest::genesis(), None)
                 };
@@ -504,7 +505,7 @@ where
                 entry.2.push((name, signed_transaction_option));
 
                 if let Some(cert) = cert_option {
-                    certificates.insert(*cert.transaction.digest(), cert);
+                    certificates.insert(*cert.digest(), cert);
                 }
             } else {
                 error_list.push((name, result));
@@ -681,7 +682,7 @@ where
 
                 // Add authorities that need to be updated
                 let entry = certs_to_sync
-                    .entry(*cert.transaction.digest())
+                    .entry(*cert.digest())
                     .or_insert((cert.clone(), HashSet::new()));
                 entry.1.extend(authorities);
 
@@ -764,6 +765,7 @@ where
         // Find out which objects are required by this transaction and
         // ensure they are synced on authorities.
         let required_ids: Vec<ObjectID> = transaction
+            .data
             .input_objects()?
             .iter()
             .map(|o| o.object_id())
@@ -950,7 +952,7 @@ where
             ?timeout_after_quorum,
             "Broadcasting certificate to authorities"
         );
-        let contains_shared_object = certificate.transaction.contains_shared_object();
+        let contains_shared_object = certificate.contains_shared_object();
 
         let state = self
             .quorum_map_then_reduce_with_timeout(

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -222,7 +222,7 @@ impl AuthorityServer {
                 let span = tracing::debug_span!(
                     "process_cert",
                     ?tx_digest,
-                    tx_kind = message.transaction.data.kind_as_str()
+                    tx_kind = message.data.kind_as_str()
                 );
                 match self
                     .state
@@ -306,7 +306,7 @@ impl AuthorityServer {
                     match message {
                         SerializedMessage::Transaction(message) => {
                             message.is_checked = true;
-                            message.add_to_verification_obligation(&mut obligation)?;
+                            message.add_tx_sig_to_verification_obligation(&mut obligation)?;
                         }
                         SerializedMessage::Cert(message) => {
                             message.is_checked = true;
@@ -363,7 +363,7 @@ where
             /*
                 If this is an error send back the error and drop the connection.
                 Here we make the choice to bail out as soon as either any parsing
-                or signature / commitee verification operation fails. The client
+                or signature / committee verification operation fails. The client
                 should know better than give invalid input. All conditions can be
                 trivially checked on the client side, so there should be no surprises
                 here for well behaved clients.

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -242,11 +242,10 @@ where
     async fn set_transaction_lock(
         &self,
         mutable_input_objects: &[ObjectRef],
-        tx_digest: TransactionDigest,
         transaction: Transaction,
     ) -> Result<(), SuiError> {
         self.store
-            .set_transaction_lock(mutable_input_objects, tx_digest, transaction)
+            .set_transaction_lock(mutable_input_objects, transaction)
     }
 
     async fn check_gas(
@@ -268,7 +267,6 @@ where
         transaction: Transaction,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
         transaction.check_signature()?;
-        let transaction_digest = transaction.digest();
         self.check_gas(
             transaction.gas_payment_object_ref().0,
             transaction.data.gas_budget,
@@ -294,7 +292,7 @@ where
                 .instrument(tracing::trace_span!("tx_check_locks"))
                 .await?;
         let owned_objects = transaction_input_checker::filter_owned_objects(&objects_by_kind);
-        self.set_transaction_lock(&owned_objects, transaction_digest, transaction.clone())
+        self.set_transaction_lock(&owned_objects, transaction.clone())
             .instrument(tracing::trace_span!("db_set_transaction_lock"))
             .await?;
         // If execute_transaction ever fails due to panic, we should fix the panic and make sure it doesn't.

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -54,7 +54,7 @@ impl<C> SafeClient<C> {
             );
             // Check it's the right transaction
             fp_ensure!(
-                signed_transaction.digest() == digest,
+                signed_transaction.digest() == &digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -66,7 +66,7 @@ impl<C> SafeClient<C> {
             certificate.check(&self.committee)?;
             // Check it's the right transaction
             fp_ensure!(
-                certificate.transaction.digest() == digest,
+                certificate.transaction.digest() == &digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -277,7 +277,7 @@ where
         &self,
         transaction: Transaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let digest = transaction.digest();
+        let digest = *transaction.digest();
         let transaction_info = self
             .authority_client
             .handle_transaction(transaction)
@@ -294,7 +294,7 @@ where
         &self,
         transaction: ConfirmationTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let digest = transaction.certificate.transaction.digest();
+        let digest = *transaction.certificate.transaction.digest();
         let transaction_info = self
             .authority_client
             .handle_confirmation_transaction(transaction)

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -66,7 +66,7 @@ impl<C> SafeClient<C> {
             certificate.check(&self.committee)?;
             // Check it's the right transaction
             fp_ensure!(
-                certificate.transaction.digest() == &digest,
+                certificate.digest() == &digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -294,7 +294,7 @@ where
         &self,
         transaction: ConfirmationTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let digest = *transaction.certificate.transaction.digest();
+        let digest = *transaction.certificate.digest();
         let transaction_info = self
             .authority_client
             .handle_confirmation_transaction(transaction)

--- a/sui_core/src/unit_tests/authority_aggregator_tests.rs
+++ b/sui_core/src/unit_tests/authority_aggregator_tests.rs
@@ -208,7 +208,7 @@ async fn do_transaction<A: AuthorityAPI>(authority: &A, transaction: &Transactio
 async fn extract_cert<A: AuthorityAPI>(
     authorities: &[&A],
     committee: &Committee,
-    transaction_digest: TransactionDigest,
+    transaction_digest: &TransactionDigest,
 ) -> CertifiedTransaction {
     let mut votes = vec![];
     let mut transaction: Option<SignedTransaction> = None;
@@ -217,7 +217,7 @@ async fn extract_cert<A: AuthorityAPI>(
             signed_transaction: Some(signed),
             ..
         }) = authority
-            .handle_transaction_info_request(TransactionInfoRequest::from(transaction_digest))
+            .handle_transaction_info_request(TransactionInfoRequest::from(*transaction_digest))
             .await
         {
             votes.push((

--- a/sui_core/src/unit_tests/authority_aggregator_tests.rs
+++ b/sui_core/src/unit_tests/authority_aggregator_tests.rs
@@ -677,7 +677,7 @@ async fn test_process_transaction() {
 
     // The transaction still only has 3 votes, as only these are needed.
     let cert2 = extract_cert(&authority_clients, &authorities.committee, create2.digest()).await;
-    assert_eq!(3, cert2.signatures.len());
+    assert_eq!(3, cert2.auth_sign_info.signatures.len());
 }
 
 #[tokio::test]

--- a/sui_core/src/unit_tests/authority_tests.rs
+++ b/sui_core/src/unit_tests/authority_tests.rs
@@ -400,7 +400,7 @@ async fn test_publish_dependent_module_ok() {
     let signature = Signature::new(&data, &sender_key);
     let transaction = Transaction::new(data, signature);
 
-    let dependent_module_id = TxContext::new(&sender, &transaction.digest()).fresh_id();
+    let dependent_module_id = TxContext::new(&sender, transaction.digest()).fresh_id();
 
     // Object does not exist
     assert!(authority
@@ -436,7 +436,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let data = TransactionData::new_module(sender, gas_payment_object_ref, module_bytes, MAX_GAS);
     let signature = Signature::new(&data, &sender_key);
     let transaction = Transaction::new(data, signature);
-    let _module_object_id = TxContext::new(&sender, &transaction.digest()).fresh_id();
+    let _module_object_id = TxContext::new(&sender, transaction.digest()).fresh_id();
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap();
@@ -878,7 +878,7 @@ async fn test_handle_confirmation_transaction_idempotent() {
     // Now check the transaction info request is also the same
     let info3 = authority_state
         .handle_transaction_info_request(TransactionInfoRequest {
-            transaction_digest: certified_transfer_transaction.transaction.digest(),
+            transaction_digest: *certified_transfer_transaction.transaction.digest(),
         })
         .await
         .unwrap();
@@ -1482,7 +1482,7 @@ async fn shared_object() {
     );
     let signature = Signature::new(&data, &keypair);
     let transaction = Transaction::new(data, signature);
-    let transaction_digest = transaction.digest();
+    let transaction_digest = *transaction.digest();
 
     // Submit the transaction and assemble a certificate.
     let response = authority

--- a/sui_core/src/unit_tests/consensus_tests.rs
+++ b/sui_core/src/unit_tests/consensus_tests.rs
@@ -148,7 +148,7 @@ async fn submit_transaction_to_consensus() {
     objects.push(test_shared_object());
     let state = init_state_with_objects(objects).await;
     let certificate = test_certificates(&state).await.pop().unwrap();
-    let expected_transaction = certificate.transaction.clone();
+    let expected_transaction = certificate.clone().to_transaction();
 
     // Make a new consensus submitter instance.
     let submitter = ConsensusAdapter::new(
@@ -197,7 +197,7 @@ async fn submit_transaction_to_consensus() {
     let bytes = handle.await.unwrap();
     match bincode::deserialize(&bytes).unwrap() {
         ConsensusTransaction::UserTransaction(x) => {
-            assert_eq!(x.transaction, expected_transaction)
+            assert_eq!(x.to_transaction(), expected_transaction)
         }
     }
 }

--- a/sui_core/src/unit_tests/gas_tests.rs
+++ b/sui_core/src/unit_tests/gas_tests.rs
@@ -207,7 +207,8 @@ async fn test_publish_gas() -> SuiResult {
         .certified_transaction
         .as_ref()
         .unwrap()
-        .transaction
+        .data
+        .kind
         .single_transactions()
         .next()
         .unwrap()

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -32,6 +32,14 @@ AuthorityBatch:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 32
+AuthorityQuorumSignInfo:
+  STRUCT:
+    - epoch: U64
+    - signatures:
+        SEQ:
+          TUPLE:
+            - TYPENAME: PublicKeyBytes
+            - TYPENAME: AuthoritySignature
 AuthoritySignInfo:
   STRUCT:
     - epoch: U64
@@ -82,7 +90,7 @@ ConsensusTransaction:
     0:
       UserTransaction:
         NEWTYPE:
-          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthorityQuorumSignInfo>"
 Data:
   ENUM:
     0:
@@ -241,7 +249,7 @@ ObjectInfoResponse:
   STRUCT:
     - parent_certificate:
         OPTION:
-          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthorityQuorumSignInfo>"
     - requested_object_reference:
         OPTION:
           TUPLE:
@@ -277,14 +285,6 @@ Owner:
       Immutable: UNIT
 PublicKeyBytes:
   NEWTYPESTRUCT: BYTES
-QuorumSignInfo:
-  STRUCT:
-    - epoch: U64
-    - signatures:
-        SEQ:
-          TUPLE:
-            - TYPENAME: PublicKeyBytes
-            - TYPENAME: AuthoritySignature
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:
@@ -300,7 +300,7 @@ SerializedMessage:
     2:
       Cert:
         NEWTYPE:
-          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthorityQuorumSignInfo>"
     3:
       Error:
         NEWTYPE:
@@ -829,7 +829,7 @@ TransactionInfoResponse:
           TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>"
     - certified_transaction:
         OPTION:
-          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthorityQuorumSignInfo>"
     - signed_effects:
         OPTION:
           TYPENAME: TransactionEffectsEnvelope
@@ -900,6 +900,14 @@ UpdateItem:
       Batch:
         NEWTYPE:
           TYPENAME: SignedBatch
+"sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthorityQuorumSignInfo>":
+  STRUCT:
+    - data:
+        TYPENAME: TransactionData
+    - tx_signature:
+        TYPENAME: Signature
+    - auth_sign_info:
+        TYPENAME: AuthorityQuorumSignInfo
 "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>":
   STRUCT:
     - data:
@@ -916,12 +924,4 @@ UpdateItem:
         TYPENAME: Signature
     - auth_sign_info:
         TYPENAME: EmptySignInfo
-"sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>":
-  STRUCT:
-    - data:
-        TYPENAME: TransactionData
-    - tx_signature:
-        TYPENAME: Signature
-    - auth_sign_info:
-        TYPENAME: QuorumSignInfo
 

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -68,16 +68,6 @@ CallArg:
       SharedObject:
         NEWTYPE:
           TYPENAME: ObjectID
-CertifiedTransaction:
-  STRUCT:
-    - epoch: U64
-    - transaction:
-        TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::EmptySignInfo>"
-    - signatures:
-        SEQ:
-          TUPLE:
-            - TYPENAME: PublicKeyBytes
-            - TYPENAME: AuthoritySignature
 ConsensusOutput:
   STRUCT:
     - message: BYTES
@@ -92,7 +82,7 @@ ConsensusTransaction:
     0:
       UserTransaction:
         NEWTYPE:
-          TYPENAME: CertifiedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
 Data:
   ENUM:
     0:
@@ -251,7 +241,7 @@ ObjectInfoResponse:
   STRUCT:
     - parent_certificate:
         OPTION:
-          TYPENAME: CertifiedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
     - requested_object_reference:
         OPTION:
           TUPLE:
@@ -287,6 +277,14 @@ Owner:
       Immutable: UNIT
 PublicKeyBytes:
   NEWTYPESTRUCT: BYTES
+QuorumSignInfo:
+  STRUCT:
+    - epoch: U64
+    - signatures:
+        SEQ:
+          TUPLE:
+            - TYPENAME: PublicKeyBytes
+            - TYPENAME: AuthoritySignature
 SequenceNumber:
   NEWTYPESTRUCT: U64
 SerializedMessage:
@@ -302,7 +300,7 @@ SerializedMessage:
     2:
       Cert:
         NEWTYPE:
-          TYPENAME: CertifiedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
     3:
       Error:
         NEWTYPE:
@@ -831,7 +829,7 @@ TransactionInfoResponse:
           TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::AuthoritySignInfo>"
     - certified_transaction:
         OPTION:
-          TYPENAME: CertifiedTransaction
+          TYPENAME: "sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>"
     - signed_effects:
         OPTION:
           TYPENAME: TransactionEffectsEnvelope
@@ -918,4 +916,12 @@ UpdateItem:
         TYPENAME: Signature
     - auth_sign_info:
         TYPENAME: EmptySignInfo
+"sui_types::messages::TransactionEnvelope<sui_types::crypto::QuorumSignInfo>":
+  STRUCT:
+    - data:
+        TYPENAME: TransactionData
+    - tx_signature:
+        TYPENAME: Signature
+    - auth_sign_info:
+        TYPENAME: QuorumSignInfo
 

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -485,7 +485,7 @@ impl PartialEq for AuthoritySignInfo {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct QuorumSignInfo {
     pub epoch: EpochId,
     pub signatures: Vec<(AuthorityName, AuthoritySignature)>,

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -485,10 +485,30 @@ impl PartialEq for AuthoritySignInfo {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QuorumSignInfo {
+    pub epoch: EpochId,
+    pub signatures: Vec<(AuthorityName, AuthoritySignature)>,
+}
+// Note: if you meet an error due to this line it may be because you need an Eq implementation for `CertifiedTransaction`,
+// or one of the structs that include it, i.e. `ConfirmationTransaction`, `TransactionInfoResponse` or `ObjectInfoResponse`.
+//
+// Please note that any such implementation must be agnostic to the exact set of signatures in the certificate, as
+// clients are allowed to equivocate on the exact nature of valid certificates they send to the system. This assertion
+// is a simple tool to make sure certificates are accounted for correctly - should you remove it, you're on your own to
+// maintain the invariant that valid certificates with distinct signatures are equivalent, but yet-unchecked
+// certificates that differ on signers aren't.
+//
+// see also https://github.com/MystenLabs/sui/issues/266
+//
+static_assertions::assert_not_impl_any!(QuorumSignInfo: Hash, Eq, PartialEq);
+impl AuthoritySignInfoTrait for QuorumSignInfo {}
+
 mod private {
     pub trait SealedAuthoritySignInfoTrait {}
     impl SealedAuthoritySignInfoTrait for super::EmptySignInfo {}
     impl SealedAuthoritySignInfoTrait for super::AuthoritySignInfo {}
+    impl SealedAuthoritySignInfoTrait for super::QuorumSignInfo {}
 }
 
 /// Something that we know how to hash and sign.

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -485,8 +485,9 @@ impl PartialEq for AuthoritySignInfo {
     }
 }
 
+/// Represents at least a quorum (could be more) of authority signatures.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct QuorumSignInfo {
+pub struct AuthorityQuorumSignInfo {
     pub epoch: EpochId,
     pub signatures: Vec<(AuthorityName, AuthoritySignature)>,
 }
@@ -501,14 +502,14 @@ pub struct QuorumSignInfo {
 //
 // see also https://github.com/MystenLabs/sui/issues/266
 //
-static_assertions::assert_not_impl_any!(QuorumSignInfo: Hash, Eq, PartialEq);
-impl AuthoritySignInfoTrait for QuorumSignInfo {}
+static_assertions::assert_not_impl_any!(AuthorityQuorumSignInfo: Hash, Eq, PartialEq);
+impl AuthoritySignInfoTrait for AuthorityQuorumSignInfo {}
 
 mod private {
     pub trait SealedAuthoritySignInfoTrait {}
     impl SealedAuthoritySignInfoTrait for super::EmptySignInfo {}
     impl SealedAuthoritySignInfoTrait for super::AuthoritySignInfo {}
-    impl SealedAuthoritySignInfoTrait for super::QuorumSignInfo {}
+    impl SealedAuthoritySignInfoTrait for super::AuthorityQuorumSignInfo {}
 }
 
 /// Something that we know how to hash and sign.

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -5,8 +5,8 @@
 use super::{base_types::*, batch::*, committee::Committee, error::*, event::Event};
 use crate::committee::EpochId;
 use crate::crypto::{
-    sha3_hash, AuthoritySignInfo, AuthoritySignature, BcsSignable, EmptySignInfo, Signable,
-    Signature, VerificationObligation,
+    sha3_hash, AuthoritySignInfo, AuthoritySignature, BcsSignable, EmptySignInfo, QuorumSignInfo,
+    Signable, Signature, VerificationObligation,
 };
 use crate::gas::GasCostSummary;
 use crate::json_schema;
@@ -203,6 +203,22 @@ pub enum TransactionKind {
     // .. more transaction types go here
 }
 
+impl TransactionKind {
+    pub fn single_transactions(&self) -> impl Iterator<Item = &SingleTransactionKind> {
+        match self {
+            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
+            TransactionKind::Batch(b) => Either::Right(b.iter()),
+        }
+    }
+
+    pub fn into_single_transactions(self) -> impl Iterator<Item = SingleTransactionKind> {
+        match self {
+            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
+            TransactionKind::Batch(b) => Either::Right(b.into_iter()),
+        }
+    }
+}
+
 impl Display for TransactionKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
@@ -316,6 +332,35 @@ where
     pub fn to_base64(&self) -> String {
         base64ct::Base64::encode_string(&self.to_bytes())
     }
+
+    pub fn gas_payment_object_ref(&self) -> &ObjectRef {
+        &self.gas_payment
+    }
+
+    pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
+        let mut inputs = match &self.kind {
+            TransactionKind::Single(s) => s.input_objects()?,
+            TransactionKind::Batch(b) => {
+                let mut result = vec![];
+                for kind in b {
+                    fp_ensure!(
+                        !matches!(kind, &SingleTransactionKind::Publish(..)),
+                        SuiError::InvalidBatchTransaction {
+                            error: "Publish transaction is not allowed in Batch Transaction"
+                                .to_owned(),
+                        }
+                    );
+                    let sub = kind.input_objects()?;
+                    result.extend(sub);
+                }
+                result
+            }
+        };
+        inputs.push(InputObjectKind::ImmOrOwnedMoveObject(
+            *self.gas_payment_object_ref(),
+        ));
+        Ok(inputs)
+    }
 }
 
 /// A transaction signed by a client, optionally signed by an authority (depending on `S`).
@@ -356,11 +401,11 @@ impl<S> TransactionEnvelope<S> {
         }
 
         let mut obligation = VerificationObligation::default();
-        self.add_to_verification_obligation(&mut obligation)?;
+        self.add_tx_sig_to_verification_obligation(&mut obligation)?;
         obligation.verify_all().map(|_| ())
     }
 
-    pub fn add_to_verification_obligation(
+    pub fn add_tx_sig_to_verification_obligation(
         &self,
         obligation: &mut VerificationObligation,
     ) -> SuiResult<()> {
@@ -381,7 +426,7 @@ impl<S> TransactionEnvelope<S> {
     }
 
     pub fn gas_payment_object_ref(&self) -> &ObjectRef {
-        &self.data.gas_payment
+        self.data.gas_payment_object_ref()
     }
 
     pub fn contains_shared_object(&self) -> bool {
@@ -394,45 +439,6 @@ impl<S> TransactionEnvelope<S> {
             TransactionKind::Batch(b) => {
                 Either::Right(b.iter().flat_map(|kind| kind.shared_input_objects()))
             }
-        }
-    }
-
-    pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
-        let mut inputs = match &self.data.kind {
-            TransactionKind::Single(s) => s.input_objects()?,
-            TransactionKind::Batch(b) => {
-                let mut result = vec![];
-                for kind in b {
-                    fp_ensure!(
-                        !matches!(kind, &SingleTransactionKind::Publish(..)),
-                        SuiError::InvalidBatchTransaction {
-                            error: "Publish transaction is not allowed in Batch Transaction"
-                                .to_owned(),
-                        }
-                    );
-                    let sub = kind.input_objects()?;
-                    result.extend(sub);
-                }
-                result
-            }
-        };
-        inputs.push(InputObjectKind::ImmOrOwnedMoveObject(
-            *self.gas_payment_object_ref(),
-        ));
-        Ok(inputs)
-    }
-
-    pub fn single_transactions(&self) -> impl Iterator<Item = &SingleTransactionKind> {
-        match &self.data.kind {
-            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
-            TransactionKind::Batch(b) => Either::Right(b.iter()),
-        }
-    }
-
-    pub fn into_single_transactions(self) -> impl Iterator<Item = SingleTransactionKind> {
-        match self.data.kind {
-            TransactionKind::Single(s) => Either::Left(std::iter::once(s)),
-            TransactionKind::Batch(b) => Either::Right(b.into_iter()),
         }
     }
 
@@ -594,40 +600,7 @@ impl PartialEq for SignedTransaction {
     }
 }
 
-/// An transaction signed by a quorum of authorities
-///
-/// Note: the signature set of this data structure is not necessarily unique in the system,
-/// i.e. there can be several valid certificates per transaction.
-///
-/// As a consequence, we check this struct does not implement Hash or Eq, see the note below.
-///
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct CertifiedTransaction {
-    // This is a cache of an otherwise expensive to compute value.
-    // DO NOT serialize or deserialize from the network or disk.
-    #[serde(skip)]
-    transaction_digest: OnceCell<TransactionDigest>,
-    // Deserialization sets this to "false"
-    #[serde(skip)]
-    pub is_checked: bool,
-
-    pub epoch: EpochId,
-    pub transaction: Transaction,
-    pub signatures: Vec<(AuthorityName, AuthoritySignature)>,
-}
-
-// Note: if you meet an error due to this line it may be because you need an Eq implementation for `CertifiedTransaction`,
-// or one of the structs that include it, i.e. `ConfirmationTransaction`, `TransactionInfoResponse` or `ObjectInfoResponse`.
-//
-// Please note that any such implementation must be agnostic to the exact set of signatures in the certificate, as
-// clients are allowed to equivocate on the exact nature of valid certificates they send to the system. This assertion
-// is a simple tool to make sure certificates are accounted for correctly - should you remove it, you're on your own to
-// maintain the invariant that valid certificates with distinct signatures are equivalent, but yet-unchecked
-// certificates that differ on signers aren't.
-//
-// see also https://github.com/MystenLabs/sui/issues/266
-//
-static_assertions::assert_not_impl_any!(CertifiedTransaction: Hash, Eq, PartialEq);
+pub type CertifiedTransaction = TransactionEnvelope<QuorumSignInfo>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfirmationTransaction {
@@ -1076,7 +1049,7 @@ impl<'a> SignatureAggregator<'a> {
         authority: AuthorityName,
         signature: AuthoritySignature,
     ) -> Result<Option<CertifiedTransaction>, SuiError> {
-        signature.check(&self.partial.transaction.data, authority)?;
+        signature.check(&self.partial.data, authority)?;
         // Check that each authority only appears once.
         fp_ensure!(
             !self.used_authorities.contains(&authority),
@@ -1088,7 +1061,10 @@ impl<'a> SignatureAggregator<'a> {
         fp_ensure!(voting_rights > 0, SuiError::UnknownSigner);
         self.weight += voting_rights;
         // Update certificate.
-        self.partial.signatures.push((authority, signature));
+        self.partial
+            .auth_sign_info
+            .signatures
+            .push((authority, signature));
 
         if self.weight >= self.committee.quorum_threshold() {
             Ok(Some(self.partial.clone()))
@@ -1101,11 +1077,14 @@ impl<'a> SignatureAggregator<'a> {
 impl CertifiedTransaction {
     pub fn new(transaction: Transaction) -> CertifiedTransaction {
         CertifiedTransaction {
-            transaction_digest: OnceCell::new(),
+            transaction_digest: transaction.transaction_digest,
             is_checked: false,
-            epoch: 0,
-            transaction,
-            signatures: Vec::new(),
+            data: transaction.data,
+            tx_signature: transaction.tx_signature,
+            auth_sign_info: QuorumSignInfo {
+                epoch: 0,
+                signatures: Vec::new(),
+            },
         }
     }
 
@@ -1115,18 +1094,16 @@ impl CertifiedTransaction {
         signatures: Vec<(AuthorityName, AuthoritySignature)>,
     ) -> CertifiedTransaction {
         CertifiedTransaction {
-            transaction_digest: OnceCell::new(),
+            transaction_digest: transaction.transaction_digest,
             is_checked: false,
-            epoch,
-            transaction,
-            signatures,
+            data: transaction.data,
+            tx_signature: transaction.tx_signature,
+            auth_sign_info: QuorumSignInfo { epoch, signatures },
         }
     }
 
-    /// Get the transaction digest and write it to the cache
-    pub fn digest(&self) -> &TransactionDigest {
-        self.transaction_digest
-            .get_or_init(|| *self.transaction.digest())
+    pub fn to_transaction(self) -> Transaction {
+        Transaction::new(self.data, self.tx_signature)
     }
 
     /// Verify the certificate.
@@ -1151,7 +1128,7 @@ impl CertifiedTransaction {
     ) -> SuiResult<()> {
         // Check epoch
         fp_ensure!(
-            self.epoch == committee.epoch(),
+            self.auth_sign_info.epoch == committee.epoch(),
             SuiError::WrongEpoch {
                 expected_epoch: committee.epoch()
             }
@@ -1161,7 +1138,7 @@ impl CertifiedTransaction {
 
         let mut weight = 0;
         let mut used_authorities = HashSet::new();
-        for (authority, _) in self.signatures.iter() {
+        for (authority, _) in self.auth_sign_info.signatures.iter() {
             // Check that each authority only appears once.
             fp_ensure!(
                 !used_authorities.contains(authority),
@@ -1179,18 +1156,17 @@ impl CertifiedTransaction {
         );
 
         // Add the obligation of the transaction
-        self.transaction
-            .add_to_verification_obligation(obligation)?;
+        self.add_tx_sig_to_verification_obligation(obligation)?;
 
         // Create obligations for the committee signatures
 
         let mut message = Vec::new();
-        self.transaction.data.write(&mut message);
+        self.data.write(&mut message);
 
         let idx = obligation.messages.len();
         obligation.messages.push(message);
 
-        for tuple in self.signatures.iter() {
+        for tuple in self.auth_sign_info.signatures.iter() {
             let (authority, signature) = tuple;
             // do we know, or can we build a valid public key?
             match committee.expanded_keys.get(authority) {
@@ -1218,12 +1194,13 @@ impl Display for CertifiedTransaction {
         writeln!(
             writer,
             "Signed Authorities : {:?}",
-            self.signatures
+            self.auth_sign_info
+                .signatures
                 .iter()
                 .map(|(name, _)| name)
                 .collect::<Vec<_>>()
         )?;
-        write!(writer, "{}", &self.transaction.data.kind)?;
+        write!(writer, "{}", &self.data.kind)?;
         write!(f, "{}", writer)
     }
 }

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -5,8 +5,8 @@
 use super::{base_types::*, batch::*, committee::Committee, error::*, event::Event};
 use crate::committee::EpochId;
 use crate::crypto::{
-    sha3_hash, AuthoritySignInfo, AuthoritySignature, BcsSignable, EmptySignInfo, QuorumSignInfo,
-    Signable, Signature, VerificationObligation,
+    sha3_hash, AuthorityQuorumSignInfo, AuthoritySignInfo, AuthoritySignature, BcsSignable,
+    EmptySignInfo, Signable, Signature, VerificationObligation,
 };
 use crate::gas::GasCostSummary;
 use crate::json_schema;
@@ -600,7 +600,7 @@ impl PartialEq for SignedTransaction {
     }
 }
 
-pub type CertifiedTransaction = TransactionEnvelope<QuorumSignInfo>;
+pub type CertifiedTransaction = TransactionEnvelope<AuthorityQuorumSignInfo>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfirmationTransaction {
@@ -1081,7 +1081,7 @@ impl CertifiedTransaction {
             is_checked: false,
             data: transaction.data,
             tx_signature: transaction.tx_signature,
-            auth_sign_info: QuorumSignInfo {
+            auth_sign_info: AuthorityQuorumSignInfo {
                 epoch: 0,
                 signatures: Vec::new(),
             },
@@ -1098,7 +1098,7 @@ impl CertifiedTransaction {
             is_checked: false,
             data: transaction.data,
             tx_signature: transaction.tx_signature,
-            auth_sign_info: QuorumSignInfo { epoch, signatures },
+            auth_sign_info: AuthorityQuorumSignInfo { epoch, signatures },
         }
     }
 

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -131,7 +131,7 @@ fn test_certificates() {
         .unwrap()
         .unwrap();
     assert!(c.check(&committee).is_ok());
-    c.signatures.pop();
+    c.auth_sign_info.signatures.pop();
     assert!(c.check(&committee).is_err());
 
     let mut builder = SignatureAggregator::try_new(transaction, &committee).unwrap();


### PR DESCRIPTION
`CertifiedTransaction` is also just a Transaction that's signed by authorities, making it very similar to SignedTransaction.
This PR introduces `QuorumSignInfo` as a new authority signature trait type, and define `CertifiedTransaction` using it.
This also allows us to unify some of the code, for example, the `Transaction` type now also has a cached digest field.