### PR TITLE
chore: auto-label documentation PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'Type: Documentation' to any changes within 'doc' folder or any subfolders
+"Type: Documentation":
+- doc/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
We spend a lot of time labeling doc PRs. This automates that part of the work and offers enough flexibility to extend the labeling.

See https://github.com/huitseeker/sui/pull/2 and specifically https://github.com/huitseeker/sui/runs/6241519383?check_suite_focus=true for an example successful run.