### PR TITLE
[explorer] Render example nft

### DIFF
--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -57,7 +57,7 @@ function OwnedObjectAPI({ objects }: { objects: string[] }) {
                         Version: version,
                         display: parseImageURL(data)
                             ? processDisplayValue(parseImageURL(data))
-                            : '',
+                            : undefined,
                     }))
                 );
                 setIsLoaded(true);
@@ -91,7 +91,15 @@ function OwnedObjectView({ results }: { results: resultType }) {
                         <div className={styles.previewimage}>
                             <DisplayBox
                                 display={entryObj.display}
-                                tag="imageURL"
+                                // TODO: clean this logic
+                                tag={
+                                    typeof entryObj.display === 'object' &&
+                                    'category' in entryObj.display &&
+                                    entryObj.display['category'] ===
+                                        'moveScript'
+                                        ? 'moveScript'
+                                        : 'imageURL'
+                                }
                             />
                         </div>
                     )}

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { DefaultRpcClient as rpc } from '../../utils/api/SuiRpcClient';
+import { parseImageURL } from '../../utils/objectUtils';
 import { navigateWithUnknown } from '../../utils/searchUtil';
 import { findDataFromID } from '../../utils/static/searchUtil';
 import { trimStdLibPrefix, processDisplayValue } from '../../utils/stringUtils';
@@ -54,7 +55,9 @@ function OwnedObjectAPI({ objects }: { objects: string[] }) {
                         id: id,
                         Type: objType,
                         Version: version,
-                        display: processDisplayValue(data.contents?.display),
+                        display: parseImageURL(data)
+                            ? processDisplayValue(parseImageURL(data))
+                            : '',
                     }))
                 );
                 setIsLoaded(true);

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -213,7 +213,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
     return (
         <>
             <div className={styles.resultbox}>
-                {viewedData.url && (
+                {viewedData.url !== '' && (
                     <div className={styles.display}>
                         <DisplayBox display={viewedData.url} tag="imageURL" />
                     </div>

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -105,7 +105,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
     type SuiIdBytes = { bytes: number[] };
 
     function handleSpecialDemoNameArrays(data: {
-        name?: SuiIdBytes | string;
+        name?: string;
         player_name?: SuiIdBytes | string;
         monster_name?: SuiIdBytes | string;
         farm_name?: SuiIdBytes | string;
@@ -128,9 +128,10 @@ function ObjectLoaded({ data }: { data: DataType }) {
             delete data.farm_name;
             return ascii;
         } else if ('name' in data) {
-            bytesObj = data.name as SuiIdBytes;
-            return asciiFromNumberBytes(bytesObj.bytes);
-        } else bytesObj = { bytes: [] };
+            return data['name'] as string;
+        } else {
+            bytesObj = { bytes: [] };
+        }
 
         return asciiFromNumberBytes(bytesObj.bytes);
     }
@@ -212,10 +213,10 @@ function ObjectLoaded({ data }: { data: DataType }) {
     return (
         <>
             <div className={styles.resultbox}>
-                {viewedData.data?.contents?.display && (
+                {viewedData.data?.contents?.url && (
                     <div className={styles.display}>
                         <DisplayBox
-                            display={viewedData.data.contents.display}
+                            display={viewedData.data.contents.url.fields['url']}
                             tag="imageURL"
                         />
                     </div>
@@ -227,7 +228,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             : styles.noaccommodate
                     }`}
                 >
-                    {data.name && <h1>{data.name}</h1>} {' '}
+                    {data.name && <h1>{data.name}</h1>}{' '}
                     {typeof nameKeyValue[0] === 'string' && (
                         <h1>{nameKeyValue}</h1>
                     )}

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -8,6 +8,7 @@ import Longtext from '../../components/longtext/Longtext';
 import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 import theme from '../../styles/theme.module.css';
 import { type AddressOwner } from '../../utils/api/SuiRpcClient';
+import { parseImageURL } from '../../utils/objectUtils';
 import {
     asciiFromNumberBytes,
     trimStdLibPrefix,
@@ -15,7 +16,6 @@ import {
 import { type DataType } from './ObjectResultType';
 
 import styles from './ObjectResult.module.css';
-import { parseImageURL } from '../../utils/objectUtils';
 
 function ObjectLoaded({ data }: { data: DataType }) {
     // TODO - restore or remove this functionality

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -206,9 +206,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
     const properties = Object.entries(viewedData.data?.contents)
         //TO DO: remove when have distinct 'name' field in Description
         .filter(([key, _]) => !/name/i.test(key))
-        .filter(([_, value]) => checkIsPropertyType(value))
-        // TODO: 'display' is a object property added during demo, replace with metadata ptr?
-        .filter(([key, _]) => key !== 'display');
+        .filter(([_, value]) => checkIsPropertyType(value));
 
     return (
         <>
@@ -223,7 +221,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                 )}
                 <div
                     className={`${styles.textbox} ${
-                        data?.data.contents.display
+                        data?.data.contents?.url
                             ? styles.accommodate
                             : styles.noaccommodate
                     }`}

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -15,6 +15,7 @@ import {
 import { type DataType } from './ObjectResultType';
 
 import styles from './ObjectResult.module.css';
+import { parseImageURL } from '../../utils/objectUtils';
 
 function ObjectLoaded({ data }: { data: DataType }) {
     // TODO - restore or remove this functionality
@@ -176,6 +177,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                 ? toHexString(data.data.tx_digest as number[])
                 : data.data.tx_digest,
         owner: processOwner(data.owner),
+        url: parseImageURL(data.data),
     };
 
     //TO DO remove when have distinct name field under Description
@@ -211,17 +213,14 @@ function ObjectLoaded({ data }: { data: DataType }) {
     return (
         <>
             <div className={styles.resultbox}>
-                {viewedData.data?.contents?.url && (
+                {viewedData.url && (
                     <div className={styles.display}>
-                        <DisplayBox
-                            display={viewedData.data.contents.url.fields['url']}
-                            tag="imageURL"
-                        />
+                        <DisplayBox display={viewedData.url} tag="imageURL" />
                     </div>
                 )}
                 <div
                     className={`${styles.textbox} ${
-                        data?.data.contents?.url
+                        viewedData.url
                             ? styles.accommodate
                             : styles.noaccommodate
                     }`}

--- a/explorer/client/src/utils/api/DefaultRpcClient.ts
+++ b/explorer/client/src/utils/api/DefaultRpcClient.ts
@@ -11,7 +11,7 @@ export type AddressOwner = { AddressOwner: AddressBytes };
 export type AnyVec = { vec: any[] };
 export type JsonBytes = { bytes: number[] };
 
-const useLocal = true;
+const useLocal = false;
 const LOCAL = 'http://127.0.0.1:5001';
 const DEVNET = 'http://34.105.36.61:9000';
 

--- a/explorer/client/src/utils/objectUtils.ts
+++ b/explorer/client/src/utils/objectUtils.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export function parseImageURL(data: any): string {
+    if (data?.contents?.url?.fields) {
+        return data.contents.url.fields['url'];
+    }
+    // TODO: Remove Legacy format
+    if (data?.contents?.display) {
+        return data.contents.display;
+    }
+    return '';
+}

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -24,7 +24,7 @@ export const processDisplayValue = (display: { bytes: number[] } | string) => {
         typeof display === 'object' && 'bytes' in display
             ? asciiFromNumberBytes(display.bytes)
             : display;
-    return transformURL(url);
+    return typeof url === 'string' ? transformURL(url) : url;
 };
 
 function transformURL(url: string) {

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -19,10 +19,21 @@ export function hexToAscii(hex: string) {
 export const trimStdLibPrefix = (str: string): string =>
     str.replace(/^0x2::/, '');
 
-export const processDisplayValue = (display: { bytes: number[] } | string) =>
-    typeof display === 'object' && 'bytes' in display
-        ? asciiFromNumberBytes(display.bytes)
-        : display;
+export const processDisplayValue = (display: { bytes: number[] } | string) => {
+    const url =
+        typeof display === 'object' && 'bytes' in display
+            ? asciiFromNumberBytes(display.bytes)
+            : display;
+    return transformURL(url);
+};
+
+function transformURL(url: string) {
+    const found = url.match(/^ipfs:\/\/(.*)/);
+    if (!found) {
+        return url;
+    }
+    return `https://ipfs.io/ipfs/${found[1]}`;
+}
 
 /* Currently unused but potentially useful:
  *

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -387,8 +387,7 @@ export function isExecutionStatus(obj: any, _argumentName?: string): obj is Exec
             (obj.Failure !== null &&
                 typeof obj.Failure === "object" ||
                 typeof obj.Failure === "function") &&
-            isGasCostSummary(obj.Failure.gas_cost) as boolean &&
-            isTransactionResponse(obj.Failure.error) as boolean)
+            isGasCostSummary(obj.Failure.gas_cost) as boolean)
     )
 }
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -47,7 +47,7 @@ export type GasCostSummary = {
 
 export type ExecutionStatus =
   | { Success: { gas_cost: GasCostSummary } }
-  | { Failure: { gas_cost: GasCostSummary; error: string } };
+  | { Failure: { gas_cost: GasCostSummary; error: any } };
 
 // TODO: change the tuple to struct from the server end
 export type OwnedObjectRef = [RawObjectRef, ObjectOwner];

--- a/sdk/typescript/test/mocks/data/transactions.json
+++ b/sdk/typescript/test/mocks/data/transactions.json
@@ -528,5 +528,258 @@
       "events": [],
       "dependencies": []
     }
+  },
+
+  "fail": {
+    "certificate": {
+      "data": {
+        "kind": {
+          "Single": {
+            "Call": {
+              "package": [
+                "0000000000000000000000000000000000000002",
+                1,
+                "0YGqZ5DhiIVttKzuC3lirSE/EHi8rHT9rrcAzpf5Muw="
+              ],
+              "module": "DevNetNFT",
+              "function": "mint",
+              "type_arguments": [],
+              "arguments": [
+                {
+                  "Pure": [
+                    13,
+                    71,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    115,
+                    116,
+                    32,
+                    67,
+                    104,
+                    101,
+                    102
+                  ]
+                },
+                {
+                  "Pure": [
+                    30,
+                    84,
+                    104,
+                    101,
+                    32,
+                    103,
+                    114,
+                    101,
+                    97,
+                    116,
+                    101,
+                    115,
+                    116,
+                    32,
+                    99,
+                    104,
+                    101,
+                    102,
+                    32,
+                    105,
+                    110,
+                    32,
+                    116,
+                    104,
+                    101,
+                    32,
+                    119,
+                    111,
+                    114,
+                    108,
+                    100
+                  ]
+                },
+                {
+                  "Pure": [
+                    101,
+                    104,
+                    116,
+                    116,
+                    112,
+                    115,
+                    58,
+                    47,
+                    47,
+                    117,
+                    115,
+                    101,
+                    114,
+                    45,
+                    105,
+                    109,
+                    97,
+                    103,
+                    101,
+                    115,
+                    46,
+                    103,
+                    105,
+                    116,
+                    104,
+                    117,
+                    98,
+                    117,
+                    115,
+                    101,
+                    114,
+                    99,
+                    111,
+                    110,
+                    116,
+                    101,
+                    110,
+                    116,
+                    46,
+                    99,
+                    111,
+                    109,
+                    47,
+                    55,
+                    54,
+                    48,
+                    54,
+                    55,
+                    49,
+                    53,
+                    56,
+                    47,
+                    49,
+                    54,
+                    54,
+                    49,
+                    51,
+                    54,
+                    50,
+                    56,
+                    54,
+                    45,
+                    99,
+                    54,
+                    48,
+                    102,
+                    101,
+                    55,
+                    48,
+                    101,
+                    45,
+                    98,
+                    57,
+                    56,
+                    50,
+                    45,
+                    52,
+                    56,
+                    49,
+                    51,
+                    45,
+                    57,
+                    51,
+                    50,
+                    97,
+                    45,
+                    48,
+                    52,
+                    49,
+                    52,
+                    100,
+                    48,
+                    102,
+                    53,
+                    53,
+                    99,
+                    102,
+                    98,
+                    46,
+                    112,
+                    110,
+                    103
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "sender": "813ec1ab1e1797c79d1e1fcbebebc27a1fd21f07",
+        "gas_payment": [
+          "003e1d8b91a4cb1538cdb50c3cae8e62e1960b1c",
+          0,
+          "HGSxZaaBFyRVSWgyvzxXw9W7kqsWeQCVrpO1mdRH3bs="
+        ],
+        "gas_budget": 1000
+      },
+      "tx_signature": "y0xGKqG4zKKdGStb6Kej0NuG0Ex2n7o5h34h287GDAT0aADdZN38Vk4xmWVNXEFsIC7DNgpQQ7GuJg5tqsf4CdRj4Rx5FZRehqwrctiLgZDPrY/3tI5+uJLCdaXPCj6C",
+      "auth_sign_info": {
+        "epoch": 0,
+        "signatures": [
+          [
+            "ImYYav2doQpD3T7XPRA5xnk9LYUU22okB/z4NRMuhjs=",
+            "RzxVVfKp468Bl+CXznmb48JshKhyJ5y6vh9C5+m1DkHSp73Nma5HBSYMmz8DKVNgXtexEa+qIr+0UIrlRIKNAA=="
+          ],
+          [
+            "J2E+G3jRyOuxrCY+9xgPF+uc/6OrVUTNNp+L4XmwMn4=",
+            "vS5KV5kujZC/Rew9BjoPVm9ABMMlEwtPtkPRUsSObqmPLhir6o3UbpCglUYsQLXyKewA+1qK0KZFfhA8hBskDQ=="
+          ],
+          [
+            "HUetNOK8VYmILFADRclTtYN+MNZknTFcYWkLp6HijSM=",
+            "G+S5s07mk8aKeMnAT7aBkMOZ0OutkM2V8TD8EvHlMM9KPPKPUITjrGJr5aThczg5sRLAm7tpjMpYlSCRf0vACQ=="
+          ]
+        ]
+      }
+    },
+    "effects": {
+      "status": {
+        "Failure": {
+          "gas_cost": {
+            "computation_cost": 1000,
+            "storage_cost": 0,
+            "storage_rebate": 0
+          },
+          "error": {
+            "InsufficientGas": {
+              "error": "Ran out of gas while deducting computation cost"
+            }
+          }
+        }
+      },
+      "shared_objects": [],
+      "transaction_digest": "EnpPw9jQI4/k8IIoWFtMhoZKIOeXVsBWPbbMG07QvDM=",
+      "created": [],
+      "mutated": [
+        [
+          [
+            "003e1d8b91a4cb1538cdb50c3cae8e62e1960b1c",
+            1,
+            "jtJSPH26Z/iwtaFEGpd4CQFR4G/fNR1yyb2BV2F3pd4="
+          ],
+          {
+            "AddressOwner": "813ec1ab1e1797c79d1e1fcbebebc27a1fd21f07"
+          }
+        ]
+      ],
+      "unwrapped": [],
+      "deleted": [],
+      "wrapped": [],
+      "gas_object": [
+        [
+          "003e1d8b91a4cb1538cdb50c3cae8e62e1960b1c",
+          1,
+          "jtJSPH26Z/iwtaFEGpd4CQFR4G/fNR1yyb2BV2F3pd4="
+        ],
+        {
+          "AddressOwner": "813ec1ab1e1797c79d1e1fcbebebc27a1fd21f07"
+        }
+      ],
+      "events": [],
+      "dependencies": []
+    }
   }
 }

--- a/sdk/typescript/test/types/transactions.test.ts
+++ b/sdk/typescript/test/types/transactions.test.ts
@@ -11,5 +11,6 @@ describe('Test Transaction Definition', () => {
     expect(isTransactionEffectsResponse(txns['move_call'])).toBeTruthy();
     expect(isTransactionEffectsResponse(txns['transfer'])).toBeTruthy();
     expect(isTransactionEffectsResponse(txns['coin_split'])).toBeTruthy();
+    expect(isTransactionEffectsResponse(txns['fail'])).toBeTruthy();
   });
 });

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -495,7 +495,7 @@ impl WalletCommands {
                     &Identifier::new("mint").unwrap(),
                     &[],
                     gas,
-                    &gas_budget.unwrap_or(1000),
+                    &gas_budget.unwrap_or(3000),
                     &args,
                     context,
                 )


### PR DESCRIPTION
Render the NFT created by the CLI correctly.


```
wallet create-example-nft --url=https://user-images.githubusercontent.com/76067158/166136286-c60fe70e-b982-4813-932a-0414d0f55cfb.png --description="The greatest chef in the world" --name="Greatest Chef"
```
![CleanShot 2022-05-01 at 11 45 10](https://user-images.githubusercontent.com/76067158/166160010-0f9130e1-f81a-4478-bdb1-f8ba90c9f738.png)



```
wallet create-example-nft 
```
![CleanShot 2022-05-01 at 11 44 16](https://user-images.githubusercontent.com/76067158/166159991-47cd2509-d8fa-4f18-a9f6-07062c41f0d3.png)



NOTE:
This PR only aims to make sure the data flow is correct. I will leave the UI layout improvement to @Andrew47  or @Jibz1 in separate PRs

