### PR TITLE
nexlint: introduce project linting

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -8,3 +8,4 @@ xclippy = [
     "-Wclippy::all",
     "-Wclippy::disallowed_methods",
 ]
+xlint = "run --package x --bin x -- lint"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,10 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
       - run: scripts/license_check.sh
+      - run: cargo xlint
 
   test:
     needs: diff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,12 +422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +630,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde 1.0.137",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde 1.0.137",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.9",
+ "serde 1.0.137",
+ "serde_json",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +682,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.1",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3431df59f28accaf4cb4eed4a9acc66bea3f3c3753aa6cdc2f024174ef232af7"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -836,6 +871,17 @@ dependencies = [
  "atty",
  "lazy_static 1.4.0",
  "winapi",
+]
+
+[[package]]
+name = "colored-diff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410208eb08c3f3ad44b95b51c4fc0d5993cbcc9dd39cfadb4214b9115a97dcb5"
+dependencies = [
+ "ansi_term",
+ "dissimilar",
+ "itertools",
 ]
 
 [[package]]
@@ -1200,16 +1246,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "datatest-stable"
-version = "0.1.1"
+name = "debug-ignore"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ff02642cff6f40d39f61c8d51cb394fd313e1aa2057833b91ad788c4e9331f"
-dependencies = [
- "regex",
- "structopt",
- "termcolor",
- "walkdir",
-]
+checksum = "7e51694c5f8b91baf933e6429a3df4ff3e9f1160386d150790b97bef73337d1b"
 
 [[package]]
 name = "derivative"
@@ -1265,6 +1305,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "determinator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6cd961d655fa64c18f515cf6c2e4bd38deaeaa1a8c7d0142c18d750ef73d18"
+dependencies = [
+ "camino",
+ "globset",
+ "guppy",
+ "itertools",
+ "once_cell",
+ "petgraph 0.6.0",
+ "rayon",
+ "serde 1.0.137",
+ "toml",
+]
+
+[[package]]
 name = "deunicode"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1338,15 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "diffus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0ff24a73b51d9009c40897faf87d31b77345c90ffbf4dc3a1d2957032c5653"
+dependencies = [
+ "itertools",
+]
 
 [[package]]
 name = "digest"
@@ -1360,6 +1426,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
 name = "dyn-clone"
@@ -1762,6 +1834,54 @@ dependencies = [
  "ignore",
  "walkdir",
 ]
+
+[[package]]
+name = "guppy"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2086fdcefd1a3dc6f4ba4568147648231e2211be1fcc4d1063601c6baadd2e"
+dependencies = [
+ "camino",
+ "cargo_metadata",
+ "cfg-if 1.0.0",
+ "debug-ignore",
+ "fixedbitset 0.4.1",
+ "guppy-summaries",
+ "guppy-workspace-hack",
+ "indexmap",
+ "itertools",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph 0.6.0",
+ "rayon",
+ "semver 1.0.9",
+ "serde 1.0.137",
+ "serde_json",
+ "smallvec",
+ "target-spec",
+ "toml",
+]
+
+[[package]]
+name = "guppy-summaries"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca5ad97ff788027e546992f7f374e277da50ca4e06dab268f33088a74897e9e"
+dependencies = [
+ "camino",
+ "cfg-if 1.0.0",
+ "diffus",
+ "semver 1.0.9",
+ "serde 1.0.137",
+ "toml",
+]
+
+[[package]]
+name = "guppy-workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
@@ -2734,25 +2854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-ir-compiler"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e025186af502c931318884df53c11bf34a664bc#4e025186af502c931318884df53c11bf34a664bc"
-dependencies = [
- "anyhow",
- "bcs",
- "clap 3.1.14",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode",
- "move-ir-types",
- "move-symbol-pool",
- "serde_json",
-]
-
-[[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=4e025186af502c931318884df53c11bf34a664bc#4e025186af502c931318884df53c11bf34a664bc"
@@ -3040,37 +3141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "move-transactional-test-runner"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e025186af502c931318884df53c11bf34a664bc#4e025186af502c931318884df53c11bf34a664bc"
-dependencies = [
- "anyhow",
- "clap 3.1.14",
- "colored",
- "move-binary-format",
- "move-bytecode-source-map",
- "move-bytecode-utils",
- "move-cli",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-disassembler",
- "move-ir-compiler",
- "move-ir-types",
- "move-resource-viewer",
- "move-stackless-bytecode-interpreter",
- "move-stdlib",
- "move-symbol-pool",
- "move-vm-runtime",
- "move-vm-test-utils",
- "move-vm-types",
- "once_cell",
- "rayon",
- "regex",
- "tempfile",
-]
-
-[[package]]
 name = "move-unit-test"
 version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=4e025186af502c931318884df53c11bf34a664bc#4e025186af502c931318884df53c11bf34a664bc"
@@ -3170,6 +3240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
 name = "network"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/narwhal?rev=72efe71f0615f91f861cc658e031b763ba30fd5b#72efe71f0615f91f861cc658e031b763ba30fd5b"
@@ -3182,6 +3258,36 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.1",
  "tracing",
+]
+
+[[package]]
+name = "nexlint"
+version = "0.1.0"
+source = "git+https://github.com/nextest-rs/nexlint.git?rev=61421e7f5fe3a2ff5eb780aca7f5ef28c6bd9652#61421e7f5fe3a2ff5eb780aca7f5ef28c6bd9652"
+dependencies = [
+ "camino",
+ "debug-ignore",
+ "determinator",
+ "guppy",
+ "hex",
+ "once_cell",
+ "serde 1.0.137",
+]
+
+[[package]]
+name = "nexlint-lints"
+version = "0.1.0"
+source = "git+https://github.com/nextest-rs/nexlint.git?rev=61421e7f5fe3a2ff5eb780aca7f5ef28c6bd9652#61421e7f5fe3a2ff5eb780aca7f5ef28c6bd9652"
+dependencies = [
+ "anyhow",
+ "camino",
+ "colored-diff",
+ "globset",
+ "guppy",
+ "nexlint",
+ "regex",
+ "serde 1.0.137",
+ "toml",
 ]
 
 [[package]]
@@ -3610,6 +3716,15 @@ name = "paste"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+dependencies = [
+ "camino",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -4243,7 +4358,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -4428,6 +4543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+dependencies = [
+ "serde 1.0.137",
 ]
 
 [[package]]
@@ -4820,30 +4944,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static 1.4.0",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4897,7 +4997,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.7.3",
  "rayon",
  "rocksdb",
  "rustyline",
@@ -4949,14 +5049,6 @@ dependencies = [
  "sui-framework",
  "sui-types",
  "sui-verifier",
-]
-
-[[package]]
-name = "sui-adapter-transactional-tests"
-version = "0.1.0"
-dependencies = [
- "datatest-stable",
- "sui-transactional-test-runner",
 ]
 
 [[package]]
@@ -5034,39 +5126,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sui-transactional-test-runner"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bimap",
- "clap 3.1.14",
- "colored",
- "hex",
- "itertools",
- "move-binary-format",
- "move-bytecode-utils",
- "move-bytecode-verifier",
- "move-cli",
- "move-command-line-common",
- "move-compiler",
- "move-core-types",
- "move-stdlib",
- "move-symbol-pool",
- "move-transactional-test-runner",
- "move-vm-runtime",
- "move-vm-types",
- "once_cell",
- "rayon",
- "regex",
- "sui-adapter",
- "sui-framework",
- "sui-types",
- "sui-verifier",
- "sui_core",
- "tempfile",
 ]
 
 [[package]]
@@ -5195,6 +5254,23 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
+
+[[package]]
+name = "target-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc03d14ed79a75163d3509ebf1970a2ec67945c5cac68d947d1dddace43cec0"
+dependencies = [
+ "cfg-expr",
+ "serde 1.0.137",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -5484,6 +5560,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
+ "indexmap",
  "serde 1.0.137",
 ]
 
@@ -6213,6 +6290,16 @@ dependencies = [
  "tracing",
  "typed-store 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=808de09203d147b43d59114b8afd9e51cbcf5778)",
  "types",
+]
+
+[[package]]
+name = "x"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 3.1.14",
+ "nexlint",
+ "nexlint-lints",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [workspace]
 members = [
-        "sui_core",
-        "sui",
-        "sui_programmability/adapter",
-        "sui_programmability/framework",
-        "sui_programmability/transactional-test-runner",
-        "sui_programmability/adapter/transactional-tests",
-	"sui_types",
-        "faucet",
-        "test_utils",
-        "crates/sui-network",
+    "crates/sui-network",
+    "crates/x",
+    "faucet",
+    "sui",
+    "sui/open_rpc",
+    "sui/open_rpc/macros",
+    "sui_core",
+    "sui_programmability/adapter",
+    "sui_programmability/framework",
+    "sui_programmability/verifier",
+    "sui_types",
+    "test_utils",
 ]
 
 [profile.release]

--- a/crates/x/Cargo.toml
+++ b/crates/x/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "x"
+version = "0.1.0"
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.52"
+nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "61421e7f5fe3a2ff5eb780aca7f5ef28c6bd9652" }
+nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "61421e7f5fe3a2ff5eb780aca7f5ef28c6bd9652" }
+clap = { version = "3.1.14", features = ["derive"] }

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use nexlint::{prelude::*, NexLintContext};
+use nexlint_lints::{
+    content::*,
+    handle_lint_results,
+    package::*,
+    project::{DirectDepDups, DirectDepDupsConfig},
+};
+
+static LICENSE_HEADER: &str = "Copyright (c) 2022, Mysten Labs, Inc.\n\
+                               SPDX-License-Identifier: Apache-2.0\n\
+                               ";
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[clap(long)]
+    fail_fast: bool,
+}
+
+pub fn run(args: Args) -> crate::Result<()> {
+    let direct_dups_config = DirectDepDupsConfig { allow: vec![] };
+    let project_linters: &[&dyn ProjectLinter] = &[&DirectDepDups::new(&direct_dups_config)];
+
+    let package_linters: &[&dyn PackageLinter] = &[
+        // &CrateNamesPaths,
+        &IrrelevantBuildDeps,
+        // This one seems to be broken
+        //&UnpublishedPackagesOnlyUsePathDependencies::new(),
+        &PublishedPackagesDontDependOnUnpublishedPackages,
+        &OnlyPublishToCratesIo,
+        &CratesInCratesDirectory,
+    ];
+
+    let file_path_linters: &[&dyn FilePathLinter] = &[
+        // &AllowedPaths::new(DEFAULT_ALLOWED_PATHS_REGEX)?
+        ];
+
+    // allow whitespace exceptions for markdown files
+    // let whitespace_exceptions = build_exceptions(&["*.md".to_owned()])?;
+    let content_linters: &[&dyn ContentLinter] = &[
+        &LicenseHeader::new(LICENSE_HEADER),
+        &RootToml,
+        // &EofNewline::new(&whitespace_exceptions),
+        // &TrailingWhitespace::new(&whitespace_exceptions),
+    ];
+
+    let nexlint_context = NexLintContext::from_current_dir()?;
+    let engine = LintEngineConfig::new(&nexlint_context)
+        .with_project_linters(project_linters)
+        .with_package_linters(package_linters)
+        .with_file_path_linters(file_path_linters)
+        .with_content_linters(content_linters)
+        .fail_fast(args.fail_fast)
+        .build();
+
+    let results = engine.run()?;
+
+    handle_lint_results(results)
+}

--- a/crates/x/src/main.rs
+++ b/crates/x/src/main.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Parser;
+
+mod lint;
+
+/// Simple program to greet a person
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Debug, Parser)]
+enum Command {
+    #[clap(name = "lint")]
+    /// Run lints
+    Lint(lint::Args),
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    match args.cmd {
+        Command::Lint(args) => lint::run(args),
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -156,6 +156,12 @@ version = "*"
 expression = "MIT AND Apache-2.0"
 license-files = [
 ]
+[[licenses.clarify]]
+name = "target-lexicon"
+version = "*"
+expression = "Apache-2.0"
+license-files = [
+]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only

--- a/doc/utils/latex-md.sh
+++ b/doc/utils/latex-md.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2022, Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # Prereqs: Pandoc installed and in PATH - https://pandoc.org/
 # Usage: convert a directory of files from LaTex to Markdown
 # Run `latex-md.sh` from the directory containing the files

--- a/scripts/changed-files.sh
+++ b/scripts/changed-files.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2022, Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 

--- a/scripts/license_check.sh
+++ b/scripts/license_check.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2022, Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # shellcheck disable=SC2044,SC2086,SC2016
 # This script checks each file starts with a license comment
 set -e

--- a/sdk/typescript/type_guards.sh
+++ b/sdk/typescript/type_guards.sh
@@ -1,4 +1,6 @@
 #!/bin/zsh
+# Copyright (c) 2022, Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 # generate TS type guards for project
 npx ts-auto-guard --export-all src/rpc/client.ts src/**.ts

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.80"
 tempfile = "3.3.0"
 tokio = { version = "1.17.0", features = ["full"] }
-rand = "0.8.4"
+rand = "0.7.3"
 toml = "0.5.9"
 strum = "0.24.0"
 strum_macros = "0.24.0"

--- a/sui/src/benchmark/transaction_creator.rs
+++ b/sui/src/benchmark/transaction_creator.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![deny(warnings)]
-
 use crate::benchmark::validator_preparer::ValidatorPreparer;
 use bytes::Bytes;
 use move_core_types::account_address::AccountAddress;

--- a/sui/src/bin/bench.rs
+++ b/sui/src/bin/bench.rs
@@ -1,30 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/*** How-to
- * subcommand: `microbench` to run micro benchmarks
- * args:
- *      running_mode:
- *          local-single-validator-thread:
- *              start a validator in a different thread.
- *          local-single-validator-process:
- *              start a validator in a new local process.
- *              --working-dir needs to be specified on this mode where a `validator` binary exists
- *
- * Examples:
- * ./bench microbench local-single-validator-process --port=9555 throughput --working-dir=$YOUR_WORKPLACE/sui/target/release
- * ./bench microbench local-single-validator-process latency --working-dir=$YOUR_WORKPLACE/sui/target/release
- * ./bench microbench local-single-validator-thread throughput
- * ./bench microbench local-single-validator-thread latency
- *
-*/
+// How-to
+// subcommand: `microbench` to run micro benchmarks
+// args:
+//      running_mode:
+//          local-single-validator-thread:
+//              start a validator in a different thread.
+//          local-single-validator-process:
+//              start a validator in a new local process.
+//              --working-dir needs to be specified on this mode where a `validator` binary exists
 
-#![deny(warnings)]
+// Examples:
+// ./bench microbench local-single-validator-process --port=9555 throughput --working-dir=$YOUR_WORKPLACE/sui/target/release
+// ./bench microbench local-single-validator-process latency --working-dir=$YOUR_WORKPLACE/sui/target/release
+// ./bench microbench local-single-validator-thread throughput
+// ./bench microbench local-single-validator-thread latency
 
 use clap::*;
-
-use sui::benchmark::validator_preparer::VALIDATOR_BINARY_NAME;
-use sui::benchmark::{bench_types, run_benchmark};
+use sui::benchmark::{bench_types, run_benchmark, validator_preparer::VALIDATOR_BINARY_NAME};
 use tracing::subscriber::set_global_default;
 use tracing_subscriber::EnvFilter;
 

--- a/sui_types/src/lib.rs
+++ b/sui_types/src/lib.rs
@@ -6,7 +6,6 @@
     rust_2018_idioms,
     rust_2021_compatibility
 )]
-#![deny(warnings)]
 
 use move_core_types::account_address::AccountAddress;
 


### PR DESCRIPTION
This introduces custom project linting using the [`nexlint`](https://github.com/nextest-rs/nexlint) linting
framework. As a start this patch enables the following lints via `cargo
xlint`:

* detection of duplicate versions of direct dependencies
* detection of irrelevant build dependencies
* checking of license headers on various file types
* ensuring the root Cargo.toml file is canonical