### PR TITLE
[Wallet CLI] Add command to configure gateway URL

### DIFF
--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -303,11 +303,11 @@ async fn test_create_example_nft_command() -> Result<(), anyhow::Error> {
     let (network, mut context, address) = setup_network_and_wallet().await?;
 
     let result = WalletCommands::CreateExampleNFT {
-        name: Option::None,
-        description: Option::None,
-        url: Option::None,
-        gas: Option::None,
-        gas_budget: Option::None,
+        name: None,
+        description: None,
+        url: None,
+        gas: None,
+        gas_budget: None,
     }
     .execute(&mut context)
     .await?;
@@ -1059,16 +1059,22 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
 
     // Switch the address
     let addr2 = context.config.accounts.get(1).cloned().unwrap();
-    let resp = WalletCommands::Switch { address: addr2 }
-        .execute(&mut context)
-        .await?;
+    let resp = WalletCommands::Switch {
+        address: Some(addr2),
+        gateway: None,
+    }
+    .execute(&mut context)
+    .await?;
     assert_eq!(addr2, context.active_address()?);
     assert_ne!(addr1, context.active_address()?);
     assert_eq!(
         format!("{resp}"),
         format!(
             "{}",
-            WalletCommandResult::Switch(SwitchResponse { address: addr2 })
+            WalletCommandResult::Switch(SwitchResponse {
+                address: Some(addr2),
+                gateway: None
+            })
         )
     );
 
@@ -1086,15 +1092,21 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
 
     // Check that we can switch to this address
     // Switch the address
-    let resp = WalletCommands::Switch { address: new_addr }
-        .execute(&mut context)
-        .await?;
+    let resp = WalletCommands::Switch {
+        address: Some(new_addr),
+        gateway: None,
+    }
+    .execute(&mut context)
+    .await?;
     assert_eq!(new_addr, context.active_address()?);
     assert_eq!(
         format!("{resp}"),
         format!(
             "{}",
-            WalletCommandResult::Switch(SwitchResponse { address: new_addr })
+            WalletCommandResult::Switch(SwitchResponse {
+                address: Some(new_addr),
+                gateway: None
+            })
         )
     );
     network.kill().await?;
@@ -1136,14 +1148,20 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
     assert_eq!(a, addr1);
 
     let addr2 = context.config.accounts.get(1).cloned().unwrap();
-    let resp = WalletCommands::Switch { address: addr2 }
-        .execute(&mut context)
-        .await?;
+    let resp = WalletCommands::Switch {
+        address: Some(addr2),
+        gateway: None,
+    }
+    .execute(&mut context)
+    .await?;
     assert_eq!(
         format!("{resp}"),
         format!(
             "{}",
-            WalletCommandResult::Switch(SwitchResponse { address: addr2 })
+            WalletCommandResult::Switch(SwitchResponse {
+                address: Some(addr2),
+                gateway: None
+            })
         )
     );
     network.kill().await?;

--- a/sui_core/src/gateway_state/gateway_responses.rs
+++ b/sui_core/src/gateway_state/gateway_responses.rs
@@ -168,13 +168,19 @@ impl Display for PublishResponse {
 #[derive(Serialize, Clone, Debug)]
 pub struct SwitchResponse {
     /// Active address
-    pub address: SuiAddress,
+    pub address: Option<SuiAddress>,
+    pub gateway: Option<String>,
 }
 
 impl Display for SwitchResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
-        writeln!(writer, "Active address switched to {}", self.address)?;
+        if let Some(addr) = self.address {
+            writeln!(writer, "Active address switched to {}", addr)?;
+        }
+        if let Some(gateway) = &self.gateway {
+            writeln!(writer, "Active gateway switched to {}", gateway)?;
+        }
         write!(f, "{}", writer)
     }
 }


### PR DESCRIPTION
Right now to configure gateway url, the user has to manually edit `~/.sui/sui_config/wallet.conf`. This command offers them(mainly the devnet users who do not need local development) a shortcut. Once we have a stable devnet url, we can add alias/default value to this command


```
➜ target/debug/wallet switch --gateway "http://127.0.0.1:5001"
Active gateway switched to http://127.0.0.1:5001

➜ target/debug/wallet switch --gateway "http://34.105.36.61:9000"
Active gateway switched to http://34.105.36.61:9000

➜ target/debug/wallet switch --address 1D020466942295DE629101E5A8BDD29427FA1EC1
Active address switched to 1D020466942295DE629101E5A8BDD29427FA1EC1

➜ target/debug/wallet switch
No address or gateway specified. Please Specify one.
```