### PR TITLE
[Move] Constrain use of child object of shared object in Move calls

### DIFF
--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -458,32 +458,42 @@ SuiError:
     67:
       CircularObjectOwnership: UNIT
     68:
+      InvalidSharedChildUse:
+        STRUCT:
+          - child:
+              TYPENAME: ObjectID
+          - child_module: STR
+          - ancestor:
+              TYPENAME: ObjectID
+          - ancestor_module: STR
+          - current_module: STR
+    69:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    69:
+    70:
       InsufficientGas:
         STRUCT:
           - error: STR
-    70:
-      InvalidTxUpdate: UNIT
     71:
-      TransactionLockExists: UNIT
+      InvalidTxUpdate: UNIT
     72:
-      TransactionLockDoesNotExist: UNIT
+      TransactionLockExists: UNIT
     73:
-      TransactionLockReset: UNIT
+      TransactionLockDoesNotExist: UNIT
     74:
+      TransactionLockReset: UNIT
+    75:
       TransactionNotFound:
         STRUCT:
           - digest:
               TYPENAME: TransactionDigest
-    75:
+    76:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    76:
+    77:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -491,26 +501,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    77:
+    78:
       BadObjectType:
         STRUCT:
           - error: STR
-    78:
-      MoveExecutionFailure: UNIT
     79:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     80:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     81:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     82:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     83:
+      AuthorityUpdateFailure: UNIT
+    84:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    84:
+    85:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -521,31 +531,31 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    85:
+    86:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    86:
-      BatchErrorSender: UNIT
     87:
+      BatchErrorSender: UNIT
+    88:
       GenericAuthorityError:
         STRUCT:
           - error: STR
-    88:
+    89:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    89:
+    90:
       ObjectSerializationError:
         STRUCT:
           - error: STR
-    90:
-      ConcurrentTransactionError: UNIT
     91:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     92:
+      IncorrectRecipientError: UNIT
+    93:
       TooManyIncorrectAuthorities:
         STRUCT:
           - errors:
@@ -553,34 +563,34 @@ SuiError:
                 TUPLE:
                   - TYPENAME: PublicKeyBytes
                   - TYPENAME: SuiError
-    93:
+    94:
       InconsistentGatewayResult:
         STRUCT:
           - error: STR
-    94:
+    95:
       GatewayInvalidTxRangeQuery:
         STRUCT:
           - error: STR
-    95:
-      OnlyOneConsensusClientPermitted: UNIT
     96:
+      OnlyOneConsensusClientPermitted: UNIT
+    97:
       ConsensusConnectionBroken:
         NEWTYPE: STR
-    97:
+    98:
       SharedObjectLockingFailure:
         NEWTYPE: STR
-    98:
-      ListenerCapacityExceeded: UNIT
     99:
+      ListenerCapacityExceeded: UNIT
+    100:
       SignatureSeedInvalidLength:
         NEWTYPE: U64
-    100:
+    101:
       HkdfError:
         NEWTYPE: STR
-    101:
+    102:
       SignatureKeyGenError:
         NEWTYPE: STR
-    102:
+    103:
       RpcError:
         NEWTYPE: STR
 TransactionDigest:

--- a/sui_programmability/adapter/src/adapter.rs
+++ b/sui_programmability/adapter/src/adapter.rs
@@ -680,6 +680,10 @@ pub fn resolve_and_type_check(
     let mut mutable_ref_objects = BTreeMap::new();
     let mut by_value_objects = BTreeSet::new();
 
+    // Track the mapping from each input object to its Move type.
+    // This will be needed latter in `check_child_object_of_shared_object`.
+    let mut object_type_map = BTreeMap::new();
+
     let bcs_args = args
         .into_iter()
         .enumerate()
@@ -787,9 +791,12 @@ pub fn resolve_and_type_check(
                 }
             };
             type_check_struct(module, type_args, &move_object.type_, inner_param_type)?;
+            object_type_map.insert(id, move_object.type_.module_id());
             Ok(object_arg)
         })
         .collect::<SuiResult<Vec<_>>>()?;
+
+    check_child_object_of_shared_object(objects, &object_type_map, module.self_id())?;
 
     Ok(TypeCheckSuccess {
         module_id,
@@ -798,6 +805,69 @@ pub fn resolve_and_type_check(
         mutable_ref_objects,
         args: bcs_args,
     })
+}
+
+/// Check that for each pair of a shared object and a descendant of it (through object ownership),
+/// at least one of the types of the shared object and the descendant must be defined in the
+/// same module as the function being called (somewhat similar to Rust's orphan rule).
+fn check_child_object_of_shared_object(
+    objects: &BTreeMap<ObjectID, impl Borrow<Object>>,
+    object_type_map: &BTreeMap<ObjectID, ModuleId>,
+    current_module: ModuleId,
+) -> SuiResult {
+    // ancestor_map is a cache that remembers the top ancestor of each object.
+    // Top ancestor is the object at the top in the object ownership chain whose
+    // parent is no longer an object.
+    let mut ancestor_map: BTreeMap<ObjectID, ObjectID> = BTreeMap::new();
+    for (object_id, obj) in objects {
+        // We only need to look at objects that are owned by other objects.
+        if !matches!(obj.borrow().owner, Owner::ObjectOwner(_)) {
+            continue;
+        }
+        // We trace the object up through the ownership chain, until we either hit
+        // the top (no more parent object), or we hit an object that's already
+        // in the `ancestor_map` (because we visited this object previously).
+        // We then have a pair between this object and its top ancestor. If the top
+        // ancestor is a shared object, we check on their types.
+        let mut ancestor_stack = vec![];
+        let mut cur_id = *object_id;
+        let ancestor_id = loop {
+            if let Some(ancestor) = ancestor_map.get(&cur_id) {
+                break *ancestor;
+            }
+            ancestor_stack.push(cur_id);
+            let owner = objects.get(&cur_id).unwrap().borrow().owner;
+            match owner {
+                Owner::ObjectOwner(parent_id) => {
+                    cur_id = parent_id.into();
+                }
+                _ => {
+                    break cur_id;
+                }
+            }
+        };
+        // For each ancestor we have visited, cache their top ancestor so that if we
+        // ever visit them in the future, we know the answer.
+        while let Some(id) = ancestor_stack.pop() {
+            ancestor_map.insert(id, ancestor_id);
+        }
+        // Check the orphan rule.
+        if objects.get(&ancestor_id).unwrap().borrow().is_shared() {
+            let child_module = object_type_map.get(object_id).unwrap();
+            let ancestor_module = object_type_map.get(&ancestor_id).unwrap();
+            fp_ensure!(
+                child_module == &current_module || ancestor_module == &current_module,
+                SuiError::InvalidSharedChildUse {
+                    child: *object_id,
+                    child_module: current_module.to_string(),
+                    ancestor: ancestor_id,
+                    ancestor_module: ancestor_module.to_string(),
+                    current_module: current_module.to_string(),
+                }
+            );
+        }
+    }
+    Ok(())
 }
 
 fn is_primitive(

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -197,7 +197,10 @@ fn call(
     // TODO improve API here
     let args = object_args
         .into_iter()
-        .map(|obj| CallArg::ImmOrOwnedObject(obj.compute_object_reference()))
+        .map(|obj| match obj.owner {
+            Owner::Shared => CallArg::SharedObject(obj.id()),
+            _ => CallArg::ImmOrOwnedObject(obj.compute_object_reference()),
+        })
         .chain(pure_args.into_iter().map(CallArg::Pure))
         .collect();
     adapter::execute(
@@ -899,6 +902,110 @@ fn test_simple_call() {
         u64::from_le_bytes(move_obj.type_specific_contents().try_into().unwrap()),
         obj_val
     );
+}
+
+#[test]
+fn test_child_of_shared_object() {
+    let native_functions =
+        sui_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS);
+    let genesis_objects = genesis::clone_genesis_packages();
+    let mut storage = InMemoryStorage::new(genesis_objects);
+
+    // crate gas object for payment
+    let gas_object =
+        Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
+
+    publish_from_src(
+        &mut storage,
+        &native_functions,
+        "src/unit_tests/data/child_of_shared_object",
+        gas_object,
+        GAS_BUDGET,
+    )
+    .unwrap();
+    storage.flush();
+
+    call(
+        &mut storage,
+        &native_functions,
+        "O3",
+        "create",
+        GAS_BUDGET,
+        vec![],
+        vec![],
+        vec![],
+    )
+    .unwrap();
+
+    let o3_id = storage.get_created_keys().pop().unwrap();
+    storage.flush();
+    let o3 = storage.read_object(&o3_id).unwrap().clone();
+
+    call(
+        &mut storage,
+        &native_functions,
+        "O2",
+        "create_shared",
+        GAS_BUDGET,
+        vec![],
+        vec![o3],
+        vec![],
+    )
+    .unwrap();
+
+    let o2_id = storage.get_created_keys().pop().unwrap();
+    storage.flush();
+    let o2_shared = storage.read_object(&o2_id).unwrap().clone();
+    let o3 = storage.read_object(&o3_id).unwrap().clone();
+
+    call(
+        &mut storage,
+        &native_functions,
+        "O2",
+        "use_o2_o3",
+        GAS_BUDGET,
+        vec![],
+        vec![o2_shared, o3],
+        vec![],
+    )
+    .unwrap();
+
+    storage.flush();
+    let o2_shared = storage.read_object(&o2_id).unwrap().clone();
+    let o3 = storage.read_object(&o3_id).unwrap().clone();
+
+    let result = call(
+        &mut storage,
+        &native_functions,
+        "O1",
+        "use_o2_o3",
+        GAS_BUDGET,
+        vec![],
+        vec![o2_shared, o3],
+        vec![],
+    );
+    // Using O2 and O3 in O1 is illegable when O2 is a shared object and O3 is its child.
+    assert!(matches!(
+        result,
+        Err(SuiError::InvalidSharedChildUse { .. })
+    ));
+
+    storage.flush();
+    let o2_shared = storage.read_object(&o2_id).unwrap().clone();
+    let o3 = storage.read_object(&o3_id).unwrap().clone();
+
+    // Using O2 and O3 in O2 should be OK.
+    call(
+        &mut storage,
+        &native_functions,
+        "O2",
+        "use_o2_o3",
+        GAS_BUDGET,
+        vec![],
+        vec![o2_shared, o3],
+        vec![],
+    )
+    .unwrap();
 }
 
 #[test]

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -906,6 +906,7 @@ fn test_simple_call() {
 
 #[test]
 fn test_child_of_shared_object() {
+    // TODO: Also add test cases where there are circular dependencies in the input.
     let native_functions =
         sui_framework::natives::all_natives(MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS);
     let genesis_objects = genesis::clone_genesis_packages();

--- a/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
+++ b/sui_programmability/adapter/src/unit_tests/adapter_tests.rs
@@ -855,7 +855,7 @@ fn test_simple_call() {
     let genesis_objects = genesis::clone_genesis_packages();
     let mut storage = InMemoryStorage::new(genesis_objects);
 
-    // crate gas object for payment
+    // create gas object for payment
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
 
@@ -911,7 +911,7 @@ fn test_child_of_shared_object() {
     let genesis_objects = genesis::clone_genesis_packages();
     let mut storage = InMemoryStorage::new(genesis_objects);
 
-    // crate gas object for payment
+    // create gas object for payment
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
 
@@ -984,7 +984,7 @@ fn test_child_of_shared_object() {
         vec![o2_shared, o3],
         vec![],
     );
-    // Using O2 and O3 in O1 is illegable when O2 is a shared object and O3 is its child.
+    // Using O2 and O3 in O1 is illegal when O2 is a shared object and O3 is its child.
     assert!(matches!(
         result,
         Err(SuiError::InvalidSharedChildUse { .. })
@@ -1017,7 +1017,7 @@ fn test_publish_init() {
     let genesis_objects = genesis::clone_genesis_packages();
     let mut storage = InMemoryStorage::new(genesis_objects);
 
-    // crate gas object for payment
+    // create gas object for payment
     let gas_object =
         Object::with_id_owner_for_testing(ObjectID::random(), base_types::SuiAddress::default());
 
@@ -1032,7 +1032,7 @@ fn test_publish_init() {
     .unwrap();
 
     // a package object and a fresh object in the constructor should
-    // have been crated
+    // have been created
     assert_eq!(storage.created().len(), 2);
     let to_check = mem::take(&mut storage.temporary.created);
     let mut move_obj_exists = false;

--- a/sui_programmability/adapter/src/unit_tests/data/child_of_shared_object/Move.toml
+++ b/sui_programmability/adapter/src/unit_tests/data/child_of_shared_object/Move.toml
@@ -1,0 +1,13 @@
+[package]
+name = "child_of_shared_object"
+version = "0.0.0"
+
+[addresses]
+Test = "0x0"
+
+[dependencies]
+MoveStdlib = { local = "../../../../../framework/deps/move-stdlib/" }
+Sui =      { local = "../../../../../framework" }
+
+
+

--- a/sui_programmability/adapter/src/unit_tests/data/child_of_shared_object/sources/ChildOfSharedObject.move
+++ b/sui_programmability/adapter/src/unit_tests/data/child_of_shared_object/sources/ChildOfSharedObject.move
@@ -1,0 +1,71 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module Test::O1 {
+    use Sui::ID::VersionedID;
+    use Sui::Transfer::{Self, ChildRef};
+    use Sui::TxContext::{Self, TxContext};
+    use Test::O2::O2;
+    use Test::O3::O3;
+
+    struct O1 has key {
+        id: VersionedID,
+        child: ChildRef<O2>,
+    }
+
+    public(script) fun create_shared(child: O2, ctx: &mut TxContext) {
+        Transfer::share_object(new(child, ctx))
+    }
+
+    // This function will be invalid if _o2 is a shared object and owns _o3.
+    public(script) fun use_o2_o3(_o2: &mut O2, _o3: &mut O3, _ctx: &mut TxContext) {}
+
+    fun new(child: O2, ctx: &mut TxContext): O1 {
+        let id = TxContext::new_id(ctx);
+        let (id, child) = Transfer::transfer_to_object_id(child, id);
+        O1 { id, child }
+    }
+}
+
+module Test::O2 {
+    use Sui::ID::VersionedID;
+    use Sui::Transfer::{Self, ChildRef};
+    use Sui::TxContext::{Self, TxContext};
+    use Test::O3::O3;
+
+    struct O2 has key {
+        id: VersionedID,
+        child: ChildRef<O3>,
+    }
+
+    public(script) fun create_shared(child: O3, ctx: &mut TxContext) {
+        Transfer::share_object(new(child, ctx))
+    }
+
+    public(script) fun create_owned(child: O3, ctx: &mut TxContext) {
+        Transfer::transfer(new(child, ctx), TxContext::sender(ctx))
+    }
+
+    public(script) fun use_o2_o3(_o2: &mut O2, _o3: &mut O3, _ctx: &mut TxContext) {}
+
+    fun new(child: O3, ctx: &mut TxContext): O2 {
+        let id = TxContext::new_id(ctx);
+        let (id, child) = Transfer::transfer_to_object_id(child, id);
+        O2 { id, child }
+    }
+}
+
+module Test::O3 {
+    use Sui::ID::VersionedID;
+    use Sui::Transfer;
+    use Sui::TxContext::{Self, TxContext};
+
+    struct O3 has key {
+        id: VersionedID,
+    }
+
+    public(script) fun create(ctx: &mut TxContext) {
+        let o = O3 { id: TxContext::new_id(ctx) };
+        Transfer::transfer(o, TxContext::sender(ctx))
+    }
+}

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -222,7 +222,7 @@ impl TxContext {
     /// Updates state of the context instance. It's intended to use
     /// when mutable context is passed over some boundary via
     /// serialize/deserialize and this is the reason why this method
-    /// consumes the other contex..
+    /// consumes the other context..
     pub fn update_state(&mut self, other: TxContext) -> Result<(), SuiError> {
         if self.sender != other.sender
             || self.digest != other.digest
@@ -656,6 +656,13 @@ impl From<hex::FromHexError> for ObjectIDParseError {
 impl From<[u8; ObjectID::LENGTH]> for ObjectID {
     fn from(bytes: [u8; ObjectID::LENGTH]) -> Self {
         Self::new(bytes)
+    }
+}
+
+impl From<SuiAddress> for ObjectID {
+    fn from(address: SuiAddress) -> ObjectID {
+        let tmp: AccountAddress = address.into();
+        tmp.into()
     }
 }
 

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -215,6 +215,18 @@ pub enum SuiError {
     InvalidMoveEvent { error: String },
     #[error("Circular object ownership detected")]
     CircularObjectOwnership,
+    #[error("When an (either direct or indirect) child object of a shared object is passed as a Move argument,\
+        either the child object's type or the shared object's type must be defined in the same module \
+        as the called function. This is violated by object {child} (defined in module '{child_module}'), \
+        whose ancestor {ancestor} is a shared object (defined in module '{ancestor_module}'), \
+        and neither are defined in this module '{current_module}'")]
+    InvalidSharedChildUse {
+        child: ObjectID,
+        child_module: String,
+        ancestor: ObjectID,
+        ancestor_module: String,
+        current_module: String,
+    },
 
     // Gas related errors
     #[error("Gas budget set higher than max: {error:?}.")]


### PR DESCRIPTION
This PR adds the constrain on how we use child objects of shared objects in Move calls.
Related to https://github.com/MystenLabs/sui/issues/1228
Fixes https://github.com/MystenLabs/sui/issues/1327
We require that one of the types must be defined in the same module.
This does not fully resolve the restricted transfer problem, but it at least makes sure people cannot attack on shared objects by arbitrarily manipulating the child objects.

Added a test, but I would hope for a more comprehensive test. I hope that soon the transaction test framework can support making Move calls so I could write a better test in Move.