### PR TITLE
make object property boxes fit content

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectResult.module.css
+++ b/explorer/client/src/pages/object-result/ObjectResult.module.css
@@ -9,7 +9,7 @@ h1.title {
 /* Display Box CSS */
 
 .display {
-    @apply ml-[5vw] mx-auto mt-[1vh] 
+    @apply ml-[5vw] mx-auto mt-[1vh]
     w-[88vw] lg:w-[35vw] min-h-[88vw] lg:min-h-[35vw];
 }
 
@@ -54,7 +54,9 @@ div.propertybox {
 }
 
 div.propertybox > div {
-    @apply w-[10rem] p-[0.5rem] mx-[1vw] my-[1vh] text-center border-solid rounded-xl bg-slate-200;
+    @apply p-[0.5rem] mx-[1vw] my-[1vh] text-center border-solid rounded-xl bg-slate-200;
+
+    overflow-wrap: anywhere;
 }
 
 div.propertybox > div > p {


### PR DESCRIPTION
fix the cosmetic issue with object property boxes being too small for content.


This removes the Tailwind.css width class applied to properties.

The other line's change is trailing whitespace being removed automatically.


BEFORE:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/14057748/166394272-fdb9a871-4ea2-4201-b5b2-f7d68b6eb6cd.png">


AFTER:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/14057748/166394333-6cc0c7e5-db5e-4a66-90aa-5eca955a27a2.png">



WITH EXTRA LARGE TEXT THAT WRAPS:

<img width="809" alt="image" src="https://user-images.githubusercontent.com/14057748/166394304-53b55bf9-2d70-4b03-b94f-afaf7d95f488.png">
