### PR TITLE
Remove duplicate search bar from explorer home

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -144,7 +144,7 @@ function LatestTxCard() {
     return (
         <div className={styles.txlatestesults}>
             <div className={styles.txcardgrid}>
-                <h3>Latest Transaction</h3>
+                <h3>Latest Transactions</h3>
             </div>
             <div className={styles.transactioncard}>
                 <div>

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -11,7 +11,6 @@ import {
 } from 'sui.js';
 
 import Longtext from '../../components/longtext/Longtext';
-import Search from '../../components/search/Search';
 import theme from '../../styles/theme.module.css';
 import { DefaultRpcClient as rpc } from '../../utils/api/DefaultRpcClient';
 import ErrorResult from '../error-result/ErrorResult';
@@ -147,7 +146,6 @@ function LatestTxCard() {
             <div className={styles.txcardgrid}>
                 <h3>Latest Transaction</h3>
             </div>
-            <div className={styles.txsearch}>{isLoaded && <Search />}</div>
             <div className={styles.transactioncard}>
                 <div>
                     <div


### PR DESCRIPTION
Bug number 7 in the bug bash sheet says we should remove the top search from the home page, but that's inconsistent with every other page on the site.

instead, i've removed the redundant search box included with the transactions element.

This also pluralizes "Latest Transactions".

Here's how the homepage looks after the change
<img width="775" alt="image" src="https://user-images.githubusercontent.com/14057748/166395083-54eec8a1-77f0-41de-89f5-c87dfdb74948.png">
