### PR TITLE
add home page link for Sui Explorer header

### DIFF
--- a/explorer/client/src/app/App.module.css
+++ b/explorer/client/src/app/App.module.css
@@ -6,6 +6,18 @@ h2.suititle {
     @apply m-0 p-0 ml-[5vw] py-[1vh] text-lg;
 }
 
+h2.suititle > a {
+    @apply text-offwhite;
+
+    text-decoration: none;
+}
+
+h2.suititle > a:hover {
+    @apply text-offwhite;
+
+    text-decoration: underline;
+}
+
 .search {
     @apply bg-offblack text-offwhite pb-4 w-[100vw];
 }

--- a/explorer/client/src/app/App.tsx
+++ b/explorer/client/src/app/App.tsx
@@ -14,7 +14,7 @@ function App() {
         <div className={styles.app}>
             <div className={styles.search}>
                 <h2 className={styles.suititle}>
-                    <Link to="/">Sui Explorer</Link>
+                    <Link to="/">SuiExplorer</Link>
                 </h2>
                 <Search />
             </div>

--- a/explorer/client/src/app/App.tsx
+++ b/explorer/client/src/app/App.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Link } from 'react-router-dom';
+
 import Footer from '../components/footer/Footer';
 import Search from '../components/search/Search';
 import AppRoutes from '../pages/config/AppRoutes';
@@ -11,7 +13,9 @@ function App() {
     return (
         <div className={styles.app}>
             <div className={styles.search}>
-                <h2 className={styles.suititle}>SuiExplorer</h2>
+                <h2 className={styles.suititle}>
+                    <Link to="/">Sui Explorer</Link>
+                </h2>
                 <Search />
             </div>
             <main>


### PR DESCRIPTION
Make the title header a home page link.

Here's how it looks by default:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/14057748/166504768-67f38183-3fdd-4c51-8fdc-1dbe13252ec2.png">

it will underline on hover to indicate clickability:
<img width="183" alt="image" src="https://user-images.githubusercontent.com/14057748/166504842-0b6c4b2a-7e8f-4de2-b83a-0ba98a4d3db4.png">


I also added the space between "Sui" and "Explorer" - having them together seemed to read less easily. 