### PR TITLE
add left padding to search text

### DIFF
--- a/explorer/client/src/components/search/Search.module.css
+++ b/explorer/client/src/components/search/Search.module.css
@@ -3,8 +3,8 @@
 }
 
 .searchbtn {
-    @apply bg-sui hover:bg-suidark hover:text-white 
-  border-none text-black rounded-r-md 
+    @apply bg-sui hover:bg-suidark hover:text-white
+  border-none text-black rounded-r-md
   cursor-pointer font-sans
   leading-8 flex-initial mr-[5vw] ml-0;
 }
@@ -16,4 +16,6 @@
 .searchtext {
     @apply border-none rounded-l-md font-mono leading-8 flex-1 ml-[5vw]
     text-xs mr-0 bg-offwhite;
+
+    padding-left: 0.75rem;
 }


### PR DESCRIPTION
Number 22 in the bug spreadsheet.

the chosen padding of `0.75rem` is just what i thought looked good.  used `rem` units for consistency with other properties.

## before:
<img width="158" alt="image" src="https://user-images.githubusercontent.com/14057748/166521153-d8c9c4b6-91f2-4eb3-bec7-646a7ea325f0.png">


## after:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/14057748/166521120-5db43cf5-838d-41ba-8c5b-353b6b8568aa.png">

## after, with search text entered:
<img width="153" alt="image" src="https://user-images.githubusercontent.com/14057748/166521575-138a64d7-4991-4342-8d6a-74e0fc5cd04d.png">
