### PR TITLE
network: some cleanups from the grpc conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5165,6 +5165,7 @@ dependencies = [
  "signature",
  "static_assertions",
  "thiserror",
+ "tonic",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d2976a45420147ad821baae96e6fe4b12215f743)",
  "zeroize",
 ]

--- a/sui_core/src/authority_client.rs
+++ b/sui_core/src/authority_client.rs
@@ -113,12 +113,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         transaction: Transaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let request = BincodeEncodedPayload::try_from(&transaction).unwrap();
-        let response = self
-            .client()
-            .transaction(request)
-            .await
-            .map_err(|_| SuiError::UnexpectedMessage)?
-            .into_inner();
+        let response = self.client().transaction(request).await?.into_inner();
 
         response
             .deserialize()
@@ -134,8 +129,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         let response = self
             .client()
             .confirmation_transaction(request)
-            .await
-            .map_err(|_| SuiError::UnexpectedMessage)?
+            .await?
             .into_inner();
 
         response
@@ -151,10 +145,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         let response = self
             .client()
             .consensus_transaction(request)
-            .await
-            .map_err(|e| SuiError::GenericAuthorityError {
-                error: e.to_string(),
-            })?
+            .await?
             .into_inner();
 
         response
@@ -169,12 +160,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         request: AccountInfoRequest,
     ) -> Result<AccountInfoResponse, SuiError> {
         let request = BincodeEncodedPayload::try_from(&request).unwrap();
-        let response = self
-            .client()
-            .account_info(request)
-            .await
-            .map_err(|_| SuiError::UnexpectedMessage)?
-            .into_inner();
+        let response = self.client().account_info(request).await?.into_inner();
 
         response
             .deserialize()
@@ -186,12 +172,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         request: ObjectInfoRequest,
     ) -> Result<ObjectInfoResponse, SuiError> {
         let request = BincodeEncodedPayload::try_from(&request).unwrap();
-        let response = self
-            .client()
-            .object_info(request)
-            .await
-            .map_err(|_| SuiError::UnexpectedMessage)?
-            .into_inner();
+        let response = self.client().object_info(request).await?.into_inner();
 
         response
             .deserialize()
@@ -204,12 +185,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let request = BincodeEncodedPayload::try_from(&request).unwrap();
-        let response = self
-            .client()
-            .transaction_info(request)
-            .await
-            .map_err(|_| SuiError::UnexpectedMessage)?
-            .into_inner();
+        let response = self.client().transaction_info(request).await?.into_inner();
 
         response
             .deserialize()
@@ -222,14 +198,7 @@ impl AuthorityAPI for NetworkAuthorityClient {
         request: BatchInfoRequest,
     ) -> Result<BatchInfoResponseItemStream, SuiError> {
         let request = BincodeEncodedPayload::try_from(&request).unwrap();
-        let response_stream = self
-            .client()
-            .batch_info(request)
-            .await
-            .map_err(|e| SuiError::GenericAuthorityError {
-                error: format!("Batch error: {}", e),
-            })?
-            .into_inner();
+        let response_stream = self.client().batch_info(request).await?.into_inner();
 
         let stream = response_stream
             .map_err(|_| SuiError::UnexpectedMessage)

--- a/sui_core/src/consensus_adapter.rs
+++ b/sui_core/src/consensus_adapter.rs
@@ -124,7 +124,6 @@ impl ConsensusAdapter {
 
         // Serialize the certificate in a way that is understandable to consensus (i.e., using
         // bincode) and it certificate to consensus.
-        //let serialized = serialize_consensus_transaction(certificate);
         let serialized = bincode::serialize(certificate).expect("Failed to serialize consensus tx");
         let bytes = Bytes::from(serialized.clone());
 

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -740,6 +740,9 @@ SuiError:
     101:
       SignatureKeyGenError:
         NEWTYPE: STR
+    102:
+      RpcError:
+        NEWTYPE: STR
 TransactionData:
   STRUCT:
     - kind:

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -32,6 +32,7 @@ zeroize = "1.5.4"
 hkdf = "0.12.3"
 digest = "0.10.3"
 schemars ="0.8.8"
+tonic = "0.7"
 
 name_variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "97a056f85555fa2afe497d6abb7cf6bf8faa63cf" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d2976a45420147ad821baae96e6fe4b12215f743" }

--- a/sui_types/src/serialize.rs
+++ b/sui_types/src/serialize.rs
@@ -105,14 +105,6 @@ where
     serialize_into(writer, &ShallowSerializedMessage::Cert(value))
 }
 
-pub fn serialize_account_info_request(value: &AccountInfoRequest) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::AccountInfoReq(value))
-}
-
-pub fn serialize_account_info_response(value: &AccountInfoResponse) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::AccountInfoResp(value))
-}
-
 pub fn serialize_object_info_request(value: &ObjectInfoRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::ObjectInfoReq(value))
 }
@@ -121,20 +113,12 @@ pub fn serialize_object_info_response(value: &ObjectInfoResponse) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::ObjectInfoResp(value))
 }
 
-pub fn serialize_transaction_info_request(value: &TransactionInfoRequest) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::TransactionInfoReq(value))
-}
-
 pub fn serialize_vote(value: &SignedTransaction) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::Vote(value))
 }
 
 pub fn serialize_batch_request(request: &BatchInfoRequest) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::BatchInfoReq(request))
-}
-
-pub fn serialize_batch_item(item: &BatchInfoResponseItem) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::BatchInfoResp(item))
 }
 
 pub fn serialize_vote_into<W>(writer: W, value: &SignedTransaction) -> Result<(), anyhow::Error>
@@ -146,28 +130,6 @@ where
 
 pub fn serialize_transaction_info(value: &TransactionInfoResponse) -> Vec<u8> {
     serialize(&ShallowSerializedMessage::TransactionResp(value))
-}
-
-pub fn serialize_transaction_info_into<W>(
-    writer: W,
-    value: &TransactionInfoResponse,
-) -> Result<(), anyhow::Error>
-where
-    W: std::io::Write,
-{
-    serialize_into(writer, &ShallowSerializedMessage::TransactionResp(value))
-}
-
-pub fn serialize_consensus_transaction(value: &ConsensusTransaction) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::ConsensusTransaction(value))
-}
-
-pub fn serialize_consensus_output(value: &ConsensusOutput) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::ConsensusOutput(value))
-}
-
-pub fn serialize_consensus_sync(value: &ConsensusSync) -> Vec<u8> {
-    serialize(&ShallowSerializedMessage::ConsensusSync(value))
 }
 
 pub fn deserialize_message<R>(reader: R) -> Result<SerializedMessage, anyhow::Error>

--- a/sui_types/src/serialize.rs
+++ b/sui_types/src/serialize.rs
@@ -177,39 +177,11 @@ where
     bincode::deserialize_from(reader).map_err(|err| format_err!("{err}"))
 }
 
-pub fn deserialize_object_info(message: SerializedMessage) -> Result<ObjectInfoResponse, SuiError> {
-    match message {
-        SerializedMessage::ObjectInfoResp(resp) => Ok(*resp),
-        SerializedMessage::Error(error) => Err(*error),
-        _ => Err(SuiError::UnexpectedMessage),
-    }
-}
-
-pub fn deserialize_account_info(
-    message: SerializedMessage,
-) -> Result<AccountInfoResponse, SuiError> {
-    match message {
-        SerializedMessage::AccountInfoResp(resp) => Ok(*resp),
-        SerializedMessage::Error(error) => Err(*error),
-        _ => Err(SuiError::UnexpectedMessage),
-    }
-}
-
 pub fn deserialize_transaction_info(
     message: SerializedMessage,
 ) -> Result<TransactionInfoResponse, SuiError> {
     match message {
         SerializedMessage::TransactionResp(resp) => Ok(*resp),
-        SerializedMessage::Error(error) => Err(*error),
-        _ => Err(SuiError::UnexpectedMessage),
-    }
-}
-
-pub fn deserialize_batch_info(
-    message: SerializedMessage,
-) -> Result<BatchInfoResponseItem, SuiError> {
-    match message {
-        SerializedMessage::BatchInfoResp(resp) => Ok(*resp),
         SerializedMessage::Error(error) => Err(*error),
         _ => Err(SuiError::UnexpectedMessage),
     }


### PR DESCRIPTION
This PR includes a few cleanups from the grpc conversion:
* Properly utilize parallelization in the microbenchmark resulting in perf increase from ~20k -> ~90k tps
* Proper conversion of tonic::Status errors to SuiErrors so that context from a failed rpc isn't lost.
Fixes: #1752