### PR TITLE
Check for missing object result in search

### DIFF
--- a/explorer/client/src/utils/api/searchUtil.ts
+++ b/explorer/client/src/utils/api/searchUtil.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isObjectNotExistsInfo, isObjectRef } from "sui.js";
+
 import { DefaultRpcClient as rpc } from './DefaultRpcClient';
 
 export const navigateWithUnknown = async (
@@ -15,10 +17,17 @@ export const navigateWithUnknown = async (
             data: data,
         };
     });
-    const objInfoPromise = rpc.getObjectInfo(input).then((data) => ({
-        category: 'objects',
-        data: data,
-    }));
+    const objInfoPromise = rpc.getObjectInfo(input).then((data) => {
+        const deets = data.details;
+        if(isObjectNotExistsInfo(deets) && !isObjectRef(deets)) {
+            throw new Error('no object found');
+        }
+
+        return {
+            category: 'objects',
+            data: data
+        }
+    });
 
     const txDetailsPromise = rpc.getTransaction(input).then((data) => ({
         category: 'transactions',

--- a/explorer/client/src/utils/api/searchUtil.ts
+++ b/explorer/client/src/utils/api/searchUtil.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isObjectNotExistsInfo, isObjectRef } from "sui.js";
+import { isObjectNotExistsInfo, isObjectRef } from 'sui.js';
 
 import { DefaultRpcClient as rpc } from './DefaultRpcClient';
 
@@ -19,14 +19,14 @@ export const navigateWithUnknown = async (
     });
     const objInfoPromise = rpc.getObjectInfo(input).then((data) => {
         const deets = data.details;
-        if(isObjectNotExistsInfo(deets) && !isObjectRef(deets)) {
+        if (isObjectNotExistsInfo(deets) && !isObjectRef(deets)) {
             throw new Error('no object found');
         }
 
         return {
             category: 'objects',
-            data: data
-        }
+            data: data,
+        };
     });
 
     const txDetailsPromise = rpc.getTransaction(input).then((data) => ({

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -18,5 +18,6 @@ export * from './signers/raw-signer';
 export * from './signers/signer-with-provider';
 
 export * from './types';
+export * from './index.guard';
 
 export * as BCS from './bcs';


### PR DESCRIPTION
When the query for object info doesn't find an object, the Promise doesn't reject, but returns with an `ObjectNotExistsInfo`.  this adds a type check, so we `throw` when an object isn't found. 

This should resolve the way the `Promise.any` call works below, and thus this issue with being routed to the object error page: #1746 


Now, you'll be routed to the `/missing/` page properly, like this:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/14057748/166568889-e34ef491-2dea-4a56-af89-6ffd74bf0f6b.png">

