### PR TITLE
[wallet] - rename transfer to transfer-coin

### DIFF
--- a/sui/src/bin/wallet.rs
+++ b/sui/src/bin/wallet.rs
@@ -217,8 +217,7 @@ async fn handle_command(
                     .collect::<Vec<_>>();
                 cache.insert(CacheKey::new("object", "--id"), objects.clone());
                 cache.insert(CacheKey::flag("--gas"), objects.clone());
-                cache.insert(CacheKey::flag("--coin-object-id"), objects.clone());
-                cache.insert(CacheKey::flag("--object-id"), objects);
+                cache.insert(CacheKey::flag("--coin-object-id"), objects);
             }
             _ => {}
         }

--- a/sui/src/bin/wallet.rs
+++ b/sui/src/bin/wallet.rs
@@ -217,6 +217,7 @@ async fn handle_command(
                     .collect::<Vec<_>>();
                 cache.insert(CacheKey::new("object", "--id"), objects.clone());
                 cache.insert(CacheKey::flag("--gas"), objects.clone());
+                cache.insert(CacheKey::flag("--coin-object-id"), objects.clone());
                 cache.insert(CacheKey::flag("--object-id"), objects);
             }
             _ => {}

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -523,7 +523,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     // Send an object
     WalletCommands::Transfer {
         to: recipient,
-        object_id: object_to_send,
+        coin_object_id: object_to_send,
         gas: Some(object_id),
         gas_budget: 50000,
     }
@@ -905,7 +905,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     let resp = WalletCommands::Transfer {
         gas: Some(gas_obj_id),
         to: recipient,
-        object_id: obj_id,
+        coin_object_id: obj_id,
         gas_budget: 50000,
     }
     .execute(&mut context)
@@ -999,7 +999,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     let resp = WalletCommands::Transfer {
         gas: None,
         to: recipient,
-        object_id: obj_id,
+        coin_object_id: obj_id,
         gas_budget: 50000,
     }
     .execute(&mut context)

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -130,16 +130,16 @@ pub enum WalletCommands {
         gas_budget: u64,
     },
 
-    /// Transfer an object
-    #[clap(name = "transfer")]
+    /// Transfer coin object
+    #[clap(name = "transfer-coin")]
     Transfer {
         /// Recipient address
         #[clap(long, parse(try_from_str = decode_bytes_hex))]
         to: SuiAddress,
 
-        /// Object to transfer, in 20 bytes Hex string
+        /// Coin to transfer, in 20 bytes Hex string
         #[clap(long)]
-        object_id: ObjectID,
+        coin_object_id: ObjectID,
 
         /// ID of the gas object for gas payment, in 20 bytes Hex string
         /// If not provided, a gas object with at least gas_budget value will be selected
@@ -304,7 +304,7 @@ impl WalletCommands {
 
             WalletCommands::Transfer {
                 to,
-                object_id,
+                coin_object_id: object_id,
                 gas,
                 gas_budget,
             } => {

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -50,7 +50,7 @@ pub enum SuiError {
     LockErrors { errors: Vec<SuiError> },
     #[error("Attempt to transfer an object that's not owned.")]
     TransferUnownedError,
-    #[error("Attempt to transfer an object that's not a coin. Object transfer must be done using Move function call.")]
+    #[error("Attempt to transfer an object that's not a coin. Object transfer must be done using a distinct Move function call.")]
     TransferNonCoinError,
     #[error("A move package is expected, instead a move object is passed: {object_id}")]
     MoveObjectAsPackage { object_id: ObjectID },

--- a/sui_types/src/error.rs
+++ b/sui_types/src/error.rs
@@ -50,7 +50,7 @@ pub enum SuiError {
     LockErrors { errors: Vec<SuiError> },
     #[error("Attempt to transfer an object that's not owned.")]
     TransferUnownedError,
-    #[error("Attempt to transfer an object that's not a coin.")]
+    #[error("Attempt to transfer an object that's not a coin. Object transfer must be done using Move function call.")]
     TransferNonCoinError,
     #[error("A move package is expected, instead a move object is passed: {object_id}")]
     MoveObjectAsPackage { object_id: ObjectID },
@@ -62,7 +62,7 @@ pub enum SuiError {
     UnsupportedSharedObjectError,
     #[error("Object used as shared is not shared.")]
     NotSharedObjectError,
-    #[error("An object that's owned by another object cannot be deleted or wrapped. It must be transerred to an account address first before deletion")]
+    #[error("An object that's owned by another object cannot be deleted or wrapped. It must be transferred to an account address first before deletion")]
     DeleteObjectOwnedObject,
     #[error("The shared locks for this transaction have not yet been set.")]
     SharedObjectLockNotSetObject,


### PR DESCRIPTION
the command now looks like this 

```
sui>-$ transfer-coin --to 3E809385696FAE27E41DB735AD0179892FCFE996 --coin-object-id 4604C9B1FBE3C38C21665DC8D84EBE1DE180C743 --gas 67584724B900A5EDDCBE04B276B6E9AE5A978BC8 --gas-budget 1000
```

The changes :  `transfer` -> `transfer-coin`, `--object-id`  -> `--coin-object-id `