### PR TITLE
chore: add link checking in CI

### DIFF
--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -1,0 +1,79 @@
+name: Links Checker
+
+on:
+  ## Allow triggering this workflow manually via GitHub CLI/web
+  workflow_dispatch:
+
+  ## Run this workflow automatically every week
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  link_checker:
+    name: Check links and create automated issue if needed
+    runs-on: ubuntu-latest
+    env:
+      LYCHEE_OUT: ./lychee/links-report
+    steps:
+      ## Check out code using Git
+      - uses: actions/checkout@v3
+
+      - name: Check all links at *.md and doc files
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.4.1
+        with:
+          output: ${{ env.LYCHEE_OUT }}
+          format: markdown
+          ## Do not fail this step on broken links
+          fail: false
+          ## Allow pages replying with 200 (Ok)in at most 20 seconds
+          ## This checks all md files in the repo
+          args: >-
+            --verbose
+            --accept 200
+            --timeout 20
+            --max-concurrency 10
+            --no-progress
+            './**/*.md'
+        env:
+          ## Avoid rate limiting when checking github.com links
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find the last report issue open
+        uses: micalevisk/last-issue-action@v1.2
+        id: last_issue
+        with:
+          state: open
+          labels: |
+            report
+            automated issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create issue from report file
+        if: ${{ steps.last_issue.outputs.has_found == 'false' }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link checker report
+          content-filepath: ${{ env.LYCHEE_OUT }}
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}
+          labels: |
+            report
+            automated issue
+
+      - name: Update last report open issue created
+        if: ${{ steps.last_issue.outputs.has_found == 'true' }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link checker report
+          content-filepath: ${{ env.LYCHEE_OUT }}
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}
+          labels: |
+            report
+            automated issue
+
+      - name: Close last report open issue
+        if: ${{ steps.lychee.outputs.exit_code == 0 }}
+        uses: peter-evans/close-issue@v2
+        with:
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}


### PR DESCRIPTION
This adds a link-checking action run on a weekly basis (Mondays) using [lychee](https://github.com/lycheeverse/lychee):

The check can also be [triggered manually using the Github CLI or the 'Actions' tab interface for contributors of the repo](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).

This does not act on PRs but rather publishes / updates an issue on the repo with the link check report.

Demo run:
https://github.com/huitseeker/sui/runs/6282514162?check_suite_focus=true

Demo resulting issue:
https://github.com/huitseeker/sui/issues/4

We should also include a configuration file `./lychee.toml` with possible excludes and other details, see [documentation](https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml). This is a first stab, though.