### PR TITLE
[refactoring] Rename check signature to verify signature

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -228,8 +228,7 @@ impl AuthorityState {
         transaction: Transaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         // Check the sender's signature.
-        transaction.check_signature()?;
-
+        transaction.verify_signature()?;
         let transaction_digest = *transaction.digest();
 
         let response = self.handle_transaction_impl(transaction).await;
@@ -263,7 +262,7 @@ impl AuthorityState {
 
         // Check the certificate and retrieve the transfer data.
         tracing::trace_span!("cert_check_signature")
-            .in_scope(|| confirmation_transaction.certificate.check(&self.committee))?;
+            .in_scope(|| confirmation_transaction.certificate.verify(&self.committee))?;
 
         self.process_certificate(confirmation_transaction).await
     }
@@ -426,7 +425,7 @@ impl AuthorityState {
         }
 
         // Check the certificate.
-        certificate.check(&self.committee)?;
+        certificate.verify(&self.committee)?;
 
         // Persist the certificate since we are about to lock one or more shared object.
         // We thus need to make sure someone (if not the client) can continue the protocol.

--- a/sui_core/src/authority_server.rs
+++ b/sui_core/src/authority_server.rs
@@ -159,8 +159,8 @@ impl Validator for AuthorityServer {
         obligation
             .verify_all()
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
-        //TODO This is really really bad, we should have different types for checked transactions
-        transaction.is_checked = true;
+        //TODO This is really really bad, we should have different types for signature-verified transactions
+        transaction.is_verified = true;
 
         let tx_digest = transaction.digest();
 
@@ -200,8 +200,8 @@ impl Validator for AuthorityServer {
         obligation
             .verify_all()
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
-        //TODO This is really really bad, we should have different types for checked transactions
-        transaction.is_checked = true;
+        //TODO This is really really bad, we should have different types for signature verified transactions
+        transaction.is_verified = true;
 
         let tx_digest = transaction.digest();
         let span = tracing::debug_span!(

--- a/sui_core/src/consensus_adapter.rs
+++ b/sui_core/src/consensus_adapter.rs
@@ -120,7 +120,7 @@ impl ConsensusAdapter {
         certificate: &ConsensusTransaction,
     ) -> SuiResult<TransactionInfoResponse> {
         // Check the Sui certificate (submitted by the user).
-        certificate.check(&self.committee)?;
+        certificate.verify(&self.committee)?;
 
         // Serialize the certificate in a way that is understandable to consensus (i.e., using
         // bincode) and it certificate to consensus.

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -270,7 +270,7 @@ where
         &self,
         transaction: Transaction,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        transaction.check_signature()?;
+        transaction.verify_signature()?;
         self.check_gas(
             transaction.gas_payment_object_ref().0,
             transaction.data.gas_budget,

--- a/sui_core/src/safe_client.rs
+++ b/sui_core/src/safe_client.rs
@@ -43,7 +43,7 @@ impl<C> SafeClient<C> {
     ) -> SuiResult {
         if let Some(signed_transaction) = &response.signed_transaction {
             // Check the transaction signature
-            signed_transaction.check(&self.committee)?;
+            signed_transaction.verify(&self.committee)?;
             // Check it has the right signer
             fp_ensure!(
                 signed_transaction.auth_sign_info.authority == self.address,
@@ -62,7 +62,7 @@ impl<C> SafeClient<C> {
 
         if let Some(certificate) = &response.certified_transaction {
             // Check signatures and quorum
-            certificate.check(&self.committee)?;
+            certificate.verify(&self.committee)?;
             // Check it's the right transaction
             fp_ensure!(
                 certificate.digest() == &digest,
@@ -77,7 +77,7 @@ impl<C> SafeClient<C> {
             signed_effects
                 .auth_signature
                 .signature
-                .check(&signed_effects.effects, self.address)?;
+                .verify(&signed_effects.effects, self.address)?;
             // Checks it concerns the right tx
             fp_ensure!(
                 signed_effects.effects.transaction_digest == digest,
@@ -104,7 +104,7 @@ impl<C> SafeClient<C> {
     ) -> SuiResult {
         // If we get a certificate make sure it is a valid certificate
         if let Some(certificate) = &response.parent_certificate {
-            certificate.check(&self.committee)?;
+            certificate.verify(&self.committee)?;
         }
 
         // Check the right object ID and version is returned
@@ -160,7 +160,7 @@ impl<C> SafeClient<C> {
             };
 
             if let Some(signed_transaction) = &object_and_lock.lock {
-                signed_transaction.check(&self.committee)?;
+                signed_transaction.verify(&self.committee)?;
                 // Check it has the right signer
                 fp_ensure!(
                     signed_transaction.auth_sign_info.authority == self.address,
@@ -186,7 +186,7 @@ impl<C> SafeClient<C> {
         // check the signature of the batch
         signed_batch
             .signature
-            .check(&signed_batch.batch, signed_batch.authority)?;
+            .verify(&signed_batch.batch, signed_batch.authority)?;
 
         // ensure transactions enclosed match requested range
 

--- a/sui_types/src/crypto.rs
+++ b/sui_types/src/crypto.rs
@@ -284,7 +284,7 @@ impl Signature {
 
     /// This performs signature verification on the passed-in signature, additionally checking
     /// that the signature was performed with a PublicKey belonging to an expected author, indicated by its Sui Address
-    pub fn check<T>(&self, value: &T, author: SuiAddress) -> Result<(), SuiError>
+    pub fn verify<T>(&self, value: &T, author: SuiAddress) -> Result<(), SuiError>
     where
         T: Signable<Vec<u8>>,
     {
@@ -402,7 +402,7 @@ impl AuthoritySignature {
     }
 
     /// Signature verification for a single signature
-    pub fn check<T>(&self, value: &T, author: PublicKeyBytes) -> Result<(), SuiError>
+    pub fn verify<T>(&self, value: &T, author: PublicKeyBytes) -> Result<(), SuiError>
     where
         T: Signable<Vec<u8>>,
     {

--- a/sui_types/src/signature_seed.rs
+++ b/sui_types/src/signature_seed.rs
@@ -197,7 +197,7 @@ impl SignatureSeed {
     ///     let sui_address = seed
     ///         .new_deterministic_address(&id, Some(&domain))
     ///         .unwrap();
-    ///     let verification = signature.check(&msg, sui_address);
+    ///     let verification = signature.verify(&msg, sui_address);
     ///     assert!(verification.is_ok());
     /// # }
     /// ```

--- a/sui_types/src/unit_tests/base_types_tests.rs
+++ b/sui_types/src/unit_tests/base_types_tests.rs
@@ -36,10 +36,10 @@ fn test_signatures() {
     let bar = Bar("hello".into());
 
     let s = Signature::new(&foo, &sec1);
-    assert!(s.check(&foo, addr1).is_ok());
-    assert!(s.check(&foo, addr2).is_err());
-    assert!(s.check(&foox, addr1).is_err());
-    assert!(s.check(&bar, addr1).is_err());
+    assert!(s.verify(&foo, addr1).is_ok());
+    assert!(s.verify(&foo, addr2).is_err());
+    assert!(s.verify(&foox, addr1).is_err());
+    assert!(s.verify(&bar, addr1).is_err());
 }
 
 #[test]

--- a/sui_types/src/unit_tests/messages_tests.rs
+++ b/sui_types/src/unit_tests/messages_tests.rs
@@ -49,7 +49,7 @@ fn test_signed_values() {
         *sec1.public_key_bytes(),
         &sec1,
     );
-    assert!(v.check(&committee).is_ok());
+    assert!(v.verify(&committee).is_ok());
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -57,7 +57,7 @@ fn test_signed_values() {
         *sec2.public_key_bytes(),
         &sec2,
     );
-    assert!(v.check(&committee).is_err());
+    assert!(v.verify(&committee).is_err());
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -65,7 +65,7 @@ fn test_signed_values() {
         *sec3.public_key_bytes(),
         &sec3,
     );
-    assert!(v.check(&committee).is_err());
+    assert!(v.verify(&committee).is_err());
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -73,7 +73,7 @@ fn test_signed_values() {
         *sec1.public_key_bytes(),
         &sec1,
     );
-    assert!(v.check(&committee).is_err());
+    assert!(v.verify(&committee).is_err());
 }
 
 #[test]
@@ -130,9 +130,9 @@ fn test_certificates() {
         .append(v2.auth_sign_info.authority, v2.auth_sign_info.signature)
         .unwrap()
         .unwrap();
-    assert!(c.check(&committee).is_ok());
+    assert!(c.verify(&committee).is_ok());
     c.auth_sign_info.signatures.pop();
-    assert!(c.check(&committee).is_err());
+    assert!(c.verify(&committee).is_err());
 
     let mut builder = SignatureAggregator::try_new(transaction, &committee).unwrap();
     assert!(builder

--- a/sui_types/src/unit_tests/signature_seed_tests.rs
+++ b/sui_types/src/unit_tests/signature_seed_tests.rs
@@ -98,18 +98,18 @@ fn test_deterministic_signing() {
     assert!(sig_1.is_ok());
 
     // Verify signatures.
-    let ver_0 = sig_0_ok.clone().check(&msg0, sui_address_0);
+    let ver_0 = sig_0_ok.clone().verify(&msg0, sui_address_0);
     assert!(ver_0.is_ok());
 
-    let ver_1 = sig_1.unwrap().check(&msg0, sui_address_1);
+    let ver_1 = sig_1.unwrap().verify(&msg0, sui_address_1);
     assert!(ver_1.is_ok());
 
     // Ensure that signatures cannot be verified against another address.
-    let ver_0_with_address_1 = sig_0_ok.clone().check(&msg0, sui_address_1);
+    let ver_0_with_address_1 = sig_0_ok.clone().verify(&msg0, sui_address_1);
     assert!(ver_0_with_address_1.is_err());
 
     // Ensure that signatures cannot be verified against another message.
-    let ver_0_with_msg1 = sig_0_ok.clone().check(&msg1, sui_address_0);
+    let ver_0_with_msg1 = sig_0_ok.clone().verify(&msg1, sui_address_0);
     assert!(ver_0_with_msg1.is_err());
 
     // As we use ed25519, ensure that signatures on the same message are deterministic.


### PR DESCRIPTION
"Check signature" can be confusing in cryptography, because the meaning is broader and might imply check for canonicity, serialization etc; the idiomatic expression is "verify"