### PR TITLE
WIP: Add store dump tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,7 +5166,7 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "tonic",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d2976a45420147ad821baae96e6fe4b12215f743)",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=c37d291668838108137a2028ab34a593ee9e6800)",
  "zeroize",
 ]
 
@@ -5226,7 +5226,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.1",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d2976a45420147ad821baae96e6fe4b12215f743)",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=c37d291668838108137a2028ab34a593ee9e6800)",
 ]
 
 [[package]]
@@ -5363,7 +5363,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.1",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d2976a45420147ad821baae96e6fe4b12215f743)",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=c37d291668838108137a2028ab34a593ee9e6800)",
 ]
 
 [[package]]
@@ -5834,7 +5834,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-infra?rev=d2976a45420147ad821baae96e6fe4b12215f743#d2976a45420147ad821baae96e6fe4b12215f743"
+source = "git+https://github.com/MystenLabs/mysten-infra?rev=c37d291668838108137a2028ab34a593ee9e6800#c37d291668838108137a2028ab34a593ee9e6800"
 dependencies = [
  "bincode",
  "collectable",

--- a/sui/src/bin/store_dump.rs
+++ b/sui/src/bin/store_dump.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+extern crate core;
+
+use std::path::PathBuf;
+
+use clap::*;
+use sui_core::store_dump::dump_table;
+
+#[cfg(test)]
+#[path = "../unit_tests/cli_tests.rs"]
+mod cli_tests;
+
+#[derive(Parser)]
+#[clap(
+    name = "Sui Store Dump",
+    about = "Dumps store tables",
+    rename_all = "kebab-case"
+)]
+struct StoreOpt {
+    /// Path of the DB to dump
+    #[clap(name = "db_path")]
+    db_path: String,
+    /// If this is a gateway DB or authority DB
+    #[clap(name = "gateway", long)]
+    gateway: bool,
+    /// The name of the table to dump
+    #[clap(name = "table_name")]
+    table_name: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let options: StoreOpt = StoreOpt::parse();
+    let mp = dump_table(
+        options.gateway,
+        PathBuf::from(options.db_path),
+        &options.table_name,
+    );
+    for (k, v) in mp {
+        println!("{:?}: {:?}", k, v);
+    }
+}

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -44,7 +44,7 @@ move-package = { git = "https://github.com/move-language/move", rev = "4e025186a
 move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e025186af502c931318884df53c11bf34a664bc" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "4e025186af502c931318884df53c11bf34a664bc" }
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d2976a45420147ad821baae96e6fe4b12215f743"}
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "c37d291668838108137a2028ab34a593ee9e6800"}
 
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "72efe71f0615f91f861cc658e031b763ba30fd5b", package = "executor" }
 

--- a/sui_core/src/lib.rs
+++ b/sui_core/src/lib.rs
@@ -12,5 +12,6 @@ pub mod consensus_adapter;
 pub mod execution_engine;
 pub mod gateway_state;
 pub mod safe_client;
+pub mod store_dump;
 pub mod sui_json;
 pub mod transaction_input_checker;

--- a/sui_core/src/store_dump.rs
+++ b/sui_core/src/store_dump.rs
@@ -1,0 +1,281 @@
+use narwhal_executor::ExecutionIndices;
+use rocksdb::Options;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
+use sui_types::batch::{SignedBatch, TxSequenceNumber};
+use sui_types::crypto::{AuthoritySignInfo, EmptySignInfo};
+use sui_types::messages::{CertifiedTransaction, TransactionEffectsEnvelope, TransactionEnvelope};
+use sui_types::object::Object;
+use typed_store::rocks::DBMap;
+use typed_store::{reopen, traits::Map};
+
+pub type AuthorityStoreReadOnly = SuiDataStoreReadonly<AuthoritySignInfo>;
+pub type GatewayStoreReadOnly = SuiDataStoreReadonly<EmptySignInfo>;
+
+const OBJECTS_TABLE_NAME: &str = "objects";
+const ALL_OBJ_VER_TABLE_NAME: &str = "all_object_versions";
+const OWNER_INDEX_TABLE_NAME: &str = "owner_index";
+const TX_LOCK_TABLE_NAME: &str = "transaction_lock";
+const TX_TABLE_NAME: &str = "transactions";
+const CERTS_TABLE_NAME: &str = "certificates";
+const PARENT_SYNC_TABLE_NAME: &str = "parent_sync";
+const EFFECTS_TABLE_NAME: &str = "effects";
+const SEQUENCED_TABLE_NAME: &str = "sequenced";
+const SCHEDULE_TABLE_NAME: &str = "schedule";
+const BATCHES_TABLE_NAME: &str = "batches";
+const EXEC_SEQ_TABLE_NAME: &str = "executed_sequence";
+const LAST_CONSENSUS_TABLE_NAME: &str = "last_consensus_index";
+
+/// S is a template on Authority signature state. This allows SuiDataStore to be used on either
+/// authorities or non-authorities. Specifically, when storing transactions and effects,
+/// S allows SuiDataStore to either store the authority signed version or unsigned version.
+pub struct SuiDataStoreReadonly<S> {
+    /// This is a map between the object ID and the latest state of the object, namely the
+    /// state that is needed to process new transactions. If an object is deleted its entry is
+    /// removed from this map.
+    objects: DBMap<ObjectID, Object>,
+
+    /// Stores all history versions of all objects.
+    /// This is not needed by an authority, but is needed by a replica.
+    #[allow(dead_code)]
+    all_object_versions: DBMap<(ObjectID, SequenceNumber), Object>,
+
+    /// This is a map between object references of currently active objects that can be mutated,
+    /// and the transaction that they are lock on for use by this specific authority. Where an object
+    /// lock exists for an object version, but no transaction has been seen using it the lock is set
+    /// to None. The safety of consistent broadcast depend on each honest authority never changing
+    /// the lock once it is set. After a certificate for this object is processed it can be
+    /// forgotten.
+    transaction_lock: DBMap<ObjectRef, Option<TransactionDigest>>,
+
+    /// This is a an index of object references to currently existing objects, indexed by the
+    /// composite key of the SuiAddress of their owner and the object ID of the object.
+    /// This composite index allows an efficient iterator to list all objected currently owned
+    /// by a specific user, and their object reference.
+    owner_index: DBMap<(SuiAddress, ObjectID), ObjectRef>,
+
+    /// This is map between the transaction digest and transactions found in the `transaction_lock`.
+    /// NOTE: after a lock is deleted (after a certificate is processed) the corresponding entry here
+    /// could be deleted, but right now this is only done on gateways, not done on authorities.
+    transactions: DBMap<TransactionDigest, TransactionEnvelope<S>>,
+
+    /// This is a map between the transaction digest and the corresponding certificate for all
+    /// certificates that have been successfully processed by this authority. This set of certificates
+    /// along with the genesis allows the reconstruction of all other state, and a full sync to this
+    /// authority.
+    certificates: DBMap<TransactionDigest, CertifiedTransaction>,
+
+    /// The map between the object ref of objects processed at all versions and the transaction
+    /// digest of the certificate that lead to the creation of this version of the object.
+    ///
+    /// When an object is deleted we include an entry into this table for its next version and
+    /// a digest of ObjectDigest::deleted(), along with a link to the transaction that deleted it.
+    parent_sync: DBMap<ObjectRef, TransactionDigest>,
+
+    /// A map between the transaction digest of a certificate that was successfully processed
+    /// (ie in `certificates`) and the effects its execution has on the authority state. This
+    /// structure is used to ensure we do not double process a certificate, and that we can return
+    /// the same response for any call after the first (ie. make certificate processing idempotent).
+    effects: DBMap<TransactionDigest, TransactionEffectsEnvelope<S>>,
+
+    /// Hold the lock for shared objects. These locks are written by a single task: upon receiving a valid
+    /// certified transaction from consensus, the authority assigns a lock to each shared objects of the
+    /// transaction. Note that all authorities are guaranteed to assign the same lock to these objects.
+    /// TODO: These two maps should be merged into a single one (no reason to have two).
+    sequenced: DBMap<(TransactionDigest, ObjectID), SequenceNumber>,
+    schedule: DBMap<ObjectID, SequenceNumber>,
+
+    // Tables used for authority batch structure
+    /// A sequence on all executed certificates and effects.
+    pub executed_sequence: DBMap<TxSequenceNumber, TransactionDigest>,
+
+    /// A sequence of batches indexing into the sequence of executed transactions.
+    pub batches: DBMap<TxSequenceNumber, SignedBatch>,
+
+    /// The following table is used to store a single value (the corresponding key is a constant). The value
+    /// represents the index of the latest consensus message this authority processed. This field is written
+    /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
+    /// every message output by consensus (and in the right order).
+    last_consensus_index: DBMap<u64, ExecutionIndices>,
+}
+
+impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStoreReadonly<S> {
+    /// Open an authority store by directory path
+    pub fn open<P: AsRef<Path>>(path: P, db_options: Option<Options>) -> Self {
+        let mut options = db_options.unwrap_or_default();
+
+        // One common issue when running tests on Mac is that the default ulimit is too low,
+        // leading to I/O errors such as "Too many open files". Raising fdlimit to bypass it.
+        options.set_max_open_files(-1);
+
+        /* The table cache is locked for updates and this determines the number
+           of shareds, ie 2^10. Increase in case of lock contentions.
+        */
+        let row_cache = rocksdb::Cache::new_lru_cache(1_000_000).expect("Cache is ok");
+        options.set_row_cache(&row_cache);
+        options.set_table_cache_num_shard_bits(10);
+        options.set_compression_type(rocksdb::DBCompressionType::None);
+
+        let mut point_lookup = options.clone();
+        point_lookup.optimize_for_point_lookup(1024 * 1024);
+        point_lookup.set_memtable_whole_key_filtering(true);
+
+        let transform = rocksdb::SliceTransform::create("bytes_8_to_16", |key| &key[8..16], None);
+        point_lookup.set_prefix_extractor(transform);
+        point_lookup.set_memtable_prefix_bloom_ratio(0.2);
+
+        let db = {
+            let path = &path;
+            let db_options = Some(options.clone());
+            let opt_cfs: &[(&str, &rocksdb::Options)] = &[
+                (OBJECTS_TABLE_NAME, &point_lookup),
+                (ALL_OBJ_VER_TABLE_NAME, &options),
+                (TX_TABLE_NAME, &point_lookup),
+                (OWNER_INDEX_TABLE_NAME, &options),
+                (TX_LOCK_TABLE_NAME, &point_lookup),
+                (CERTS_TABLE_NAME, &point_lookup),
+                (PARENT_SYNC_TABLE_NAME, &options),
+                (EFFECTS_TABLE_NAME, &point_lookup),
+                (SEQUENCED_TABLE_NAME, &options),
+                (SCHEDULE_TABLE_NAME, &options),
+                (EXEC_SEQ_TABLE_NAME, &options),
+                (BATCHES_TABLE_NAME, &options),
+                (LAST_CONSENSUS_TABLE_NAME, &options),
+            ];
+            typed_store::rocks::open_cf_opts_secondary(path, db_options, opt_cfs)
+        }
+        .expect("Cannot open DB.");
+
+        let executed_sequence =
+            DBMap::reopen(&db, Some(EXEC_SEQ_TABLE_NAME)).expect("Cannot open CF.");
+
+        let (
+            objects,
+            all_object_versions,
+            owner_index,
+            transaction_lock,
+            transactions,
+            certificates,
+            parent_sync,
+            effects,
+            sequenced,
+            schedule,
+            batches,
+            last_consensus_index,
+        ) = reopen! (
+            &db,
+            OBJECTS_TABLE_NAME;<ObjectID, Object>,
+            ALL_OBJ_VER_TABLE_NAME;<(ObjectID, SequenceNumber), Object>,
+            OWNER_INDEX_TABLE_NAME;<(SuiAddress, ObjectID), ObjectRef>,
+            TX_LOCK_TABLE_NAME;<ObjectRef, Option<TransactionDigest>>,
+            TX_TABLE_NAME;<TransactionDigest, TransactionEnvelope<S>>,
+            CERTS_TABLE_NAME;<TransactionDigest, CertifiedTransaction>,
+            PARENT_SYNC_TABLE_NAME;<ObjectRef, TransactionDigest>,
+            EFFECTS_TABLE_NAME;<TransactionDigest, TransactionEffectsEnvelope<S>>,
+            SEQUENCED_TABLE_NAME;<(TransactionDigest, ObjectID), SequenceNumber>,
+            SCHEDULE_TABLE_NAME;<ObjectID, SequenceNumber>,
+            BATCHES_TABLE_NAME;<TxSequenceNumber, SignedBatch>,
+            LAST_CONSENSUS_TABLE_NAME;<u64, ExecutionIndices>
+        );
+        Self {
+            objects,
+            all_object_versions,
+            owner_index,
+            transaction_lock,
+            transactions,
+            certificates,
+            parent_sync,
+            effects,
+            sequenced,
+            schedule,
+            executed_sequence,
+            batches,
+            last_consensus_index,
+        }
+    }
+}
+
+fn dump<Q>(store: SuiDataStoreReadonly<Q>, table_name: &str) -> BTreeMap<String, String>
+where
+    Q: Eq + Serialize + for<'de> Deserialize<'de> + Debug,
+{
+    match table_name {
+        OBJECTS_TABLE_NAME => store
+            .objects
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        ALL_OBJ_VER_TABLE_NAME => store
+            .all_object_versions
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        OWNER_INDEX_TABLE_NAME => store
+            .owner_index
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        TX_LOCK_TABLE_NAME => store
+            .transaction_lock
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        TX_TABLE_NAME => store
+            .transactions
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        CERTS_TABLE_NAME => store
+            .certificates
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        PARENT_SYNC_TABLE_NAME => store
+            .parent_sync
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        EFFECTS_TABLE_NAME => store
+            .effects
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        SEQUENCED_TABLE_NAME => store
+            .sequenced
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        SCHEDULE_TABLE_NAME => store
+            .schedule
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        BATCHES_TABLE_NAME => store
+            .batches
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        LAST_CONSENSUS_TABLE_NAME => store
+            .last_consensus_index
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        EXEC_SEQ_TABLE_NAME => store
+            .executed_sequence
+            .iter()
+            .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+            .collect::<BTreeMap<_, _>>(),
+        _ => panic!("No such table name"),
+    }
+}
+
+pub fn dump_table(gateway: bool, path: PathBuf, table_name: &str) -> BTreeMap<String, String> {
+    if gateway {
+        dump(GatewayStoreReadOnly::open(path, None), table_name)
+    } else {
+        dump(AuthorityStoreReadOnly::open(path, None), table_name)
+    }
+}

--- a/sui_types/Cargo.toml
+++ b/sui_types/Cargo.toml
@@ -35,7 +35,7 @@ schemars ="0.8.8"
 tonic = "0.7"
 
 name_variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "97a056f85555fa2afe497d6abb7cf6bf8faa63cf" }
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d2976a45420147ad821baae96e6fe4b12215f743" }
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "c37d291668838108137a2028ab34a593ee9e6800" }
 
 move-binary-format = { git = "https://github.com/move-language/move", rev = "4e025186af502c931318884df53c11bf34a664bc" }
 move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e025186af502c931318884df53c11bf34a664bc" }

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -22,7 +22,7 @@ sui-adapter = { path = "../sui_programmability/adapter" }
 sui-framework = { path = "../sui_programmability/framework" }
 move-package = { git = "https://github.com/move-language/move", rev = "4e025186af502c931318884df53c11bf34a664bc" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "4e025186af502c931318884df53c11bf34a664bc", features = ["address20"] }
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="d2976a45420147ad821baae96e6fe4b12215f743"}
+typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="c37d291668838108137a2028ab34a593ee9e6800"}
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "72efe71f0615f91f861cc658e031b763ba30fd5b", package = "config" }
 
 sui-types = { path = "../sui_types" }


### PR DESCRIPTION
Allows one to dump the DB contents


_Why am I not using existing DB dump tools?_
We use bincode ser-de for or k-v pairs, which makes the outputs of dumps difficult to understand. Easiest way is to use same interface for read-write and dumping


DB is opened as a secondary (in read only mode)

Ideally this should be part of authority store to avoid code duplication, but hesitant to touch core logic this close to devnet
Many other enhancements can be made, but keeping this simple for now.
This PR depends on a specific mysten-infra commit. PR [here](https://github.com/MystenLabs/mysten-infra/pull/67) 

Feedback is welcome

use the --gateway flag when dumping gateway store

```
mbp>  ./store_dump --db-path  /Users/ade/.sui/sui_config/authorities_db/0bb5f1309b63a195bdf6c7709fe8ab931eced3bb3efe899e784833d694a02046 --table-name  owner_index
"(k#8a3e8bdf2960fe9aa7749f7b3fbcd18b9c3562fa, A3AA18537245BDD7130133D701190F21C27BF503)": "(A3AA18537245BDD7130133D701190F21C27BF503, SequenceNumber(1), o#f57dfea24f73e02723b403a4a650b87a3155fa6268cd5aa86b612d110ba596cf)"
"(k#8a3e8bdf2960fe9aa7749f7b3fbcd18b9c3562fa, AABE3832D5F0B7828259237E9D21A79F0CFFCF67)": "(AABE3832D5F0B7828259237E9D21A79F0CFFCF67, SequenceNumber(0), o#a0ba3eda1b1f27fb8c8ee7e77ac20cd791fffe9762124baa526b5090c999b37f)"
"(k#8a3e8bdf2960fe9aa7749f7b3fbcd18b9c3562fa, D0385DF17E49A46E14A22C03F5AE1E165EE2D500)": "(D0385DF17E49A46E14A22C03F5AE1E165EE2D500, SequenceNumber(0), o#359b2def02ea857741a442857b3c5ddd68d8a12c4573d67b2beef6ec37122459)"
"(k#8d09100321ff39733c8c2bff1b06f12446219b62, 0D5CF104ED78643DA9CDE31013D232D9F200D9CD)": "(0D5CF104ED78643DA9CDE31013D232D9F200D9CD, SequenceNumber(0), o#0824c9bef3c8c40cdcd201d7e2b8d47b225fbde4ef0ffb4194f1a5b986057c03)"
```