### PR TITLE
[node] Log less gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5236,6 +5236,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.1",
  "tracing",
+ "tracing-test",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d2976a45420147ad821baae96e6fe4b12215f743)",
 ]
 

--- a/sui_core/Cargo.toml
+++ b/sui_core/Cargo.toml
@@ -54,6 +54,7 @@ serde_yaml = "0.8.23"
 pretty_assertions = "1.2.1"
 temp_testdir = "0.2.3"
 hex = "0.4.3"
+tracing-test = "0.2.1"
 
 test_utils = { path = "../test_utils" }
 

--- a/sui_core/src/authority_active/gossip/tests.rs
+++ b/sui_core/src/authority_active/gossip/tests.rs
@@ -9,7 +9,9 @@ use sui_types::{base_types::SequenceNumber, crypto::get_key_pair, object::Object
 use tracing_test::traced_test;
 
 use super::*;
-use crate::{authority_aggregator::authority_aggregator_tests::*, authority_client::NetworkAuthorityClient};
+use crate::{
+    authority_aggregator::authority_aggregator_tests::*, authority_client::NetworkAuthorityClient,
+};
 
 #[tokio::test]
 pub async fn test_gossip() {
@@ -80,24 +82,27 @@ pub async fn test_gossip_no_network() {
         authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
 
     let (_aggregator, states) = init_local_authorities(genesis_objects).await;
-    
+
     // Connect to non-existing peer
     let aggregator = AuthorityAggregator::new(
-        _aggregator.committee.clone(), 
-        _aggregator.authority_clients.iter().map(|(name, _)| {
-            let net = NetworkAuthorityClient::new(NetworkClient::new(
-                "127.0.0.1".to_string(),
-                // !!! This port does not exist                 
-                332,
-                65_000,
-                Duration::from_secs(1),
-                Duration::from_secs(1),
-            ));
-            (*name, net)
-
-        }).collect()
+        _aggregator.committee.clone(),
+        _aggregator
+            .authority_clients
+            .iter()
+            .map(|(name, _)| {
+                let net = NetworkAuthorityClient::new(NetworkClient::new(
+                    "127.0.0.1".to_string(),
+                    // !!! This port does not exist
+                    332,
+                    65_000,
+                    Duration::from_secs(1),
+                    Duration::from_secs(1),
+                ));
+                (*name, net)
+            })
+            .collect(),
     );
-    
+
     let clients = aggregator.authority_clients.clone();
 
     // Start batch processes, and active processes.

--- a/sui_core/src/authority_active/gossip/tests.rs
+++ b/sui_core/src/authority_active/gossip/tests.rs
@@ -4,10 +4,12 @@
 use std::time::Duration;
 
 use sui_adapter::genesis;
+use sui_network::network::NetworkClient;
 use sui_types::{base_types::SequenceNumber, crypto::get_key_pair, object::Object};
+use tracing_test::traced_test;
 
 use super::*;
-use crate::authority_aggregator::authority_aggregator_tests::*;
+use crate::{authority_aggregator::authority_aggregator_tests::*, authority_client::NetworkAuthorityClient};
 
 #[tokio::test]
 pub async fn test_gossip() {
@@ -64,4 +66,58 @@ pub async fn test_gossip() {
     println!("Ref: {:?}", gas_ref_1);
 
     assert_eq!(gas_ref_1.1, SequenceNumber::from(1));
+}
+
+#[tokio::test]
+#[traced_test]
+pub async fn test_gossip_no_network() {
+    info!("Start running test");
+
+    let (addr1, _) = get_key_pair();
+    let gas_object1 = Object::with_owner_for_testing(addr1);
+    let gas_object2 = Object::with_owner_for_testing(addr1);
+    let genesis_objects =
+        authority_genesis_objects(4, vec![gas_object1.clone(), gas_object2.clone()]);
+
+    let (_aggregator, states) = init_local_authorities(genesis_objects).await;
+    
+    // Connect to non-existing peer
+    let aggregator = AuthorityAggregator::new(
+        _aggregator.committee.clone(), 
+        _aggregator.authority_clients.iter().map(|(name, _)| {
+            let net = NetworkAuthorityClient::new(NetworkClient::new(
+                "127.0.0.1".to_string(),
+                // !!! This port does not exist                 
+                332,
+                65_000,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+            ));
+            (*name, net)
+
+        }).collect()
+    );
+    
+    let clients = aggregator.authority_clients.clone();
+
+    // Start batch processes, and active processes.
+    for state in states {
+        let inner_state = state.clone();
+        let inner_clients = clients.clone();
+
+        let _active_handle = tokio::task::spawn(async move {
+            let active_state = ActiveAuthority::new(inner_state, inner_clients).unwrap();
+            active_state.spawn_all_active_processes().await
+        });
+
+        // Just do one
+        break;
+    }
+
+    // Let the helper tasks start
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_secs(20)).await;
+
+    // There have been timeouts and as a result the logs contain backoff messages
+    logs_contain("Waiting for 1.99");
 }

--- a/sui_core/src/authority_active/gossip/tests.rs
+++ b/sui_core/src/authority_active/gossip/tests.rs
@@ -118,8 +118,8 @@ pub async fn test_gossip_no_network() {
 
     // Let the helper tasks start
     tokio::task::yield_now().await;
-    tokio::time::sleep(Duration::from_secs(20)).await;
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     // There have been timeouts and as a result the logs contain backoff messages
-    logs_contain("Waiting for 1.99");
+    assert!(logs_contain("Waiting for 3.99"));
 }

--- a/sui_core/src/authority_active/gossip/tests.rs
+++ b/sui_core/src/authority_active/gossip/tests.rs
@@ -106,17 +106,14 @@ pub async fn test_gossip_no_network() {
     let clients = aggregator.authority_clients.clone();
 
     // Start batch processes, and active processes.
-    for state in states {
-        let inner_state = state.clone();
+    if let Some(state) = states.into_iter().next() {
+        let inner_state = state;
         let inner_clients = clients.clone();
 
         let _active_handle = tokio::task::spawn(async move {
             let active_state = ActiveAuthority::new(inner_state, inner_clients).unwrap();
             active_state.spawn_all_active_processes().await
         });
-
-        // Just do one
-        break;
     }
 
     // Let the helper tasks start

--- a/sui_types/src/committee.rs
+++ b/sui_types/src/committee.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::OsRng;
 use std::borrow::Borrow;
-use std::collections::{BTreeMap, HashMap, };
+use std::collections::{BTreeMap, HashMap};
 
 pub type EpochId = u64;
 
@@ -73,21 +73,29 @@ impl Committee {
 
     /// Given a sequence of (AuthorityName, value) for values that are ordered, provide the
     /// value at the particular threshold by stake. This orders all provided values and pick
-    /// the appropriate value that has under it threshold stake. You may use the function 
-    /// `quorum_threshold` or `validity_threshold` to pick the f+1 or 2f+1 thresholds 
+    /// the appropriate value that has under it threshold stake. You may use the function
+    /// `quorum_threshold` or `validity_threshold` to pick the f+1 or 2f+1 thresholds
     /// respectivelly.
-    pub fn robust_value<A, V>(&self, items: impl Iterator<Item=(A, V)>, threshold: usize) -> (AuthorityName, V) 
-        where A : Borrow<AuthorityName> + Ord,
-              V : Ord,
+    pub fn robust_value<A, V>(
+        &self,
+        items: impl Iterator<Item = (A, V)>,
+        threshold: usize,
+    ) -> (AuthorityName, V)
+    where
+        A: Borrow<AuthorityName> + Ord,
+        V: Ord,
     {
         debug_assert!(threshold < self.total_votes);
 
-        let vec : Vec<_> = items.map(|(a, v)| (v, self.voting_rights[a.borrow()], *a.borrow())).sorted().collect();
+        let vec: Vec<_> = items
+            .map(|(a, v)| (v, self.voting_rights[a.borrow()], *a.borrow()))
+            .sorted()
+            .collect();
         let mut total = 0;
         for (v, s, a) in vec {
             total += s;
             if threshold < total {
-                return (a, v)
+                return (a, v);
             }
         }
         unreachable!();

--- a/sui_types/src/committee.rs
+++ b/sui_types/src/committee.rs
@@ -73,16 +73,16 @@ impl Committee {
 
     /// Given a sequence of (AuthorityName, value) for values, provide the
     /// value at the particular threshold by stake. This orders all provided values
-    /// in asceding order and pick the appropriate value that has under it threshold 
-    /// stake. You may use the function `validity_threshold` or `quorum_threshold` to 
+    /// in asceding order and pick the appropriate value that has under it threshold
+    /// stake. You may use the function `validity_threshold` or `quorum_threshold` to
     /// pick the f+1 (1/3 stake) or 2f+1 (2/3 stake) thresholds respectivelly.
-    /// 
+    ///
     /// This function may be used in a number of settings:
     /// - When we pass in a set of values produced by authorities with at least 2/3 stake
     ///   and pick a validity_threshold it ensures that the resulting value is either itself
     ///   or is in between values provided by an honest node.
     /// - When we pass in values associated with the totality of stake and set a threshold
-    ///   of quorum_threshold, we ensure that at least a majority of honest nodes (ie >1/3 
+    ///   of quorum_threshold, we ensure that at least a majority of honest nodes (ie >1/3
     ///   out of the 2/3 threshold) have a value smaller than the value returned.
     pub fn robust_value<A, V>(
         &self,


### PR DESCRIPTION
The PR implements a mechanism for the active authority to keep track of failed peers and connections, as well as retries, and to slow down connecting to others when a quorum of nodes is not yet live, as when the network starts.