### PR TITLE
remove tx id when there are no transactions

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -167,7 +167,7 @@ function LatestTxCard() {
     }
 
     if (results.loadState === 'loaded' && !results.latestTx.length) {
-        return <ErrorResult id="latestTx" errorMsg="No Transactions Found" />;
+        return <ErrorResult id="" errorMsg="No Transactions Found" />;
     }
 
     return (


### PR DESCRIPTION
When there are no recent transactions, the error display would display `latestTx` in big red text, which didn't make sense in context.

This make it so all we show when we lack transactions is "No Transactions Found"