### PR TITLE
Change Package display to link, label and typo fixes

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -188,7 +188,7 @@ function LatestTxCard() {
                         <div className={styles.txtype}>TxType</div>
                         <div className={styles.txgas}>Status</div>
                         <div className={styles.txgas}>Gas</div>
-                        <div className={styles.txadd}>Sender & Receiver</div>
+                        <div className={styles.txadd}>Addresses</div>
                     </div>
                     {results.latestTx.map((tx, index) => (
                         <div

--- a/explorer/client/src/components/transaction-card/TransactionCard.tsx
+++ b/explorer/client/src/components/transaction-card/TransactionCard.tsx
@@ -57,7 +57,7 @@ function formatTxResponse(tx: TxDataProps, txId: string) {
         // txKind Transfer or Call
         ...(formatByTransactionKind(txKindName, tx.data) ?? []),
         {
-            label: 'Transactions Signature',
+            label: 'Transaction Signature',
             value: tx.tx_signature,
         },
         ...(tx.mutated.length
@@ -143,8 +143,8 @@ function formatByTransactionKind(
                 },
                 {
                     label: 'Package',
-                    value: moveCall.package,
-                    list: true,
+                    value: moveCall.package[0],
+                    link: true,
                 },
                 {
                     label: 'Module',


### PR DESCRIPTION
- Display `Package`  on the transaction page as a link
- Change the header label from `Sender & Receiver` to `Addresses`
- Fixed typo from `Transactions Signature` to `Transaction Signature`

<img width="1303" alt="Screen Shot 2022-05-04 at 3 35 58 PM" src="https://user-images.githubusercontent.com/8676844/166814615-9c1f106d-0c6d-4b5f-a8aa-b373ce25bcaf.png">
