### PR TITLE
[wallet bugfix] - Wallet interactive mode does not accept whitespaces in arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4796,6 +4796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,6 +5017,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_with",
+ "shell-words",
  "strum",
  "strum_macros",
  "sui-adapter",

--- a/sui/Cargo.toml
+++ b/sui/Cargo.toml
@@ -65,6 +65,7 @@ once_cell = "1.10.0"
 jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee.git", rev = "661870a0ab4159b2bb104ace25a2cb817a097e03", features = ["full"] }
 jsonrpsee-proc-macros = "0.11.0"
 schemars = "0.8.8"
+shell-words = "1.1.0"
 
 [dev-dependencies]
 tracing-test = "0.2.1"

--- a/sui/src/shell.rs
+++ b/sui/src/shell.rs
@@ -87,7 +87,7 @@ impl<P: Display, S: Send, H: AsyncHandler<S>> Shell<P, S, H> {
             let line = substitute_env_variables(line);
 
             // Runs the line
-            match Self::split_and_unescape(line.trim()) {
+            match split_and_unescape(line.trim()) {
                 Ok(line) => {
                     if let Some(s) = line.first() {
                         // These are shell only commands.
@@ -138,18 +138,18 @@ impl<P: Display, S: Send, H: AsyncHandler<S>> Shell<P, S, H> {
         }
         Ok(())
     }
+}
 
-    fn split_and_unescape(line: &str) -> Result<Vec<String>, anyhow::Error> {
-        let mut commands = Vec::new();
-        let split: Vec<String> = shell_words::split(line)?;
+fn split_and_unescape(line: &str) -> Result<Vec<String>, anyhow::Error> {
+    let mut commands = Vec::new();
+    let split: Vec<String> = shell_words::split(line)?;
 
-        for word in split {
-            let command = unescape(&word)
-                .ok_or_else(|| anyhow!("Error: Unhandled escape sequence {word}"))?;
-            commands.push(command);
-        }
-        Ok(commands)
+    for word in split {
+        let command =
+            unescape(&word).ok_or_else(|| anyhow!("Error: Unhandled escape sequence {word}"))?;
+        commands.push(command);
     }
+    Ok(commands)
 }
 
 fn substitute_env_variables(s: String) -> String {

--- a/sui/src/unit_tests/shell_tests.rs
+++ b/sui/src/unit_tests/shell_tests.rs
@@ -11,6 +11,7 @@ use rustyline::Context;
 
 use sui_types::base_types::ObjectID;
 
+use crate::shell::split_and_unescape;
 use crate::shell::{
     substitute_env_variables, CacheKey, CommandStructure, CompletionCache, ShellHelper,
 };
@@ -215,4 +216,20 @@ fn test_completer_with_cache() {
         .map(|pair| pair.display.clone())
         .collect::<Vec<_>>();
     assert_eq!(vec!["--gas"], candidates);
+}
+
+#[test]
+fn test_split_line() {
+    let test = "create-example-nft --name \"test 1\" --description \"t e s t 2\"";
+    let result = split_and_unescape(test).unwrap();
+    assert_eq!(
+        vec![
+            "create-example-nft",
+            "--name",
+            "test 1",
+            "--description",
+            "t e s t 2"
+        ],
+        result
+    );
 }


### PR DESCRIPTION
use `shell_words::split(line)` to split cmd line input for the interactive shell instead of splitting by whitespace, `shell_words::split` perform the same split as unix split (remove quotes etc), this makes the wallet command behave the same in interactive or non-interactive mode.