### PR TITLE
[wallet] - Add transaction digest to wallet output

### DIFF
--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -928,6 +928,7 @@ impl BcsSignable for TransactionEffects {}
 impl Display for TransactionEffects {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
+        writeln!(writer, "Transaction Digest : {:?}", self.transaction_digest)?;
         writeln!(writer, "Status : {:?}", self.status)?;
         if !self.created.is_empty() {
             writeln!(writer, "Created Objects:")?;


### PR DESCRIPTION
added tx transfer to the Transaction Effect display implementation 

the output look like this:

```
sui>-$ transfer-coin --to 52B829C72C1AB6DD3E44C578EE504A14ED37DD06 --coin-object-id 6E999BFBFF14D8FE9C2FE5BFF073C39B515F3D8A --gas C3B20C347138864B0151DD4F6E6BFD494799375D --gas-budget 1000
Transfer confirmed after 5499 us
----- Certificate ----
Transaction Hash: vysDkTR9/BeldaXOzS+2KaqhyHCMo7xzmb2BUaaOOnQ=
Signed Authorities : [k#b26161df4c9220da5cfe997cea14783933ffba3fdca5db69747a7b10e5f2def9, k#f7a55d3b0127b4877647a206a62b1a89ee76c517774ff003ff200368a92d94cd, k#d725fcc664aa0ac580ef2a6c764bf81d9aff1d1241c906f3be6cced65a51fccd]
Transaction Kind : Transfer
Recipient : 52B829C72C1AB6DD3E44C578EE504A14ED37DD06
Object ID : 6E999BFBFF14D8FE9C2FE5BFF073C39B515F3D8A
Sequence Number : SequenceNumber(1)
Object Digest : 31784ae565ea7610f7a650e21108357ba788f0c23e231749de0114c390dfd202

----- Transaction Effects ----
Transaction Digest : vysDkTR9/BeldaXOzS+2KaqhyHCMo7xzmb2BUaaOOnQ=
Status : Success { gas_cost: GasCostSummary { computation_cost: 41, storage_cost: 30, storage_rebate: 15 } }
Mutated Objects:
  - ID: 6E999BFBFF14D8FE9C2FE5BFF073C39B515F3D8A , Owner: Account Address ( 52B829C72C1AB6DD3E44C578EE504A14ED37DD06 )
  - ID: C3B20C347138864B0151DD4F6E6BFD494799375D , Owner: Account Address ( 4E7545FE108DBA51AD4A6A031DB6212AAB453916 )
```