### PR TITLE
[explorer] Update content

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -183,6 +183,14 @@ function ObjectLoaded({ data }: { data: DataType }) {
         .filter(([key, _]) => !/name/i.test(key))
         .filter(([_, value]) => checkIsPropertyType(value));
 
+    const descriptionTitle =
+        data.objType === 'Move Package' ? 'Package Description' : 'Description';
+
+    const detailsTitle =
+        data.objType === 'Move Package'
+            ? 'Disassembled Bytecode'
+            : 'Properties';
+
     return (
         <>
             <div className={styles.resultbox}>
@@ -206,7 +214,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                         className={styles.clickableheader}
                         onClick={clickSetShowDescription}
                     >
-                        Description {showDescription ? '' : '+'}
+                        {descriptionTitle} {showDescription ? '' : '+'}
                     </h2>
                     {showDescription && (
                         <div
@@ -322,7 +330,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                 className={styles.clickableheader}
                                 onClick={clickSetShowProperties}
                             >
-                                Properties {showProperties ? '' : '+'}
+                                {detailsTitle} {showProperties ? '' : '+'}
                             </h2>
                             {showProperties && (
                                 <div className={styles.propertybox}>
@@ -336,12 +344,17 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             )}
                         </>
                     )}
-                    <h2
-                        className={styles.clickableheader}
-                        onClick={clickSetShowConnectedEntities}
-                    >
-                        Owned Objects {showConnectedEntities ? '' : '+'}
-                    </h2>
+                    {}
+                    {data.objType !== 'Move Package' ? (
+                        <h2
+                            className={styles.clickableheader}
+                            onClick={clickSetShowConnectedEntities}
+                        >
+                            Child Objects {showConnectedEntities ? '' : '+'}
+                        </h2>
+                    ) : (
+                        <></>
+                    )}
                     {showConnectedEntities && <OwnedObjects id={data.id} />}
                 </div>
             </div>

--- a/explorer/client/src/pages/object-result/ObjectResultType.tsx
+++ b/explorer/client/src/pages/object-result/ObjectResultType.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getMovePackageContent, getObjectContent, getObjectType } from 'sui.js';
+import { getMovePackageContent, getObjectContent } from 'sui.js';
 
 import { type AddressOwner } from '../../utils/api/DefaultRpcClient';
+import { parseObjectType } from '../../utils/objectUtils';
 
 import type {
     GetObjectInfoResponse,
@@ -55,7 +56,7 @@ export function translate(o: GetObjectInfoResponse): DataType {
             return {
                 id: objectId,
                 version: version.toString(),
-                objType: getObjectType(o)!,
+                objType: parseObjectType(details as ObjectExistsInfo)!,
                 owner: parseOwner(owner),
                 data: {
                     contents:


### PR DESCRIPTION
Before:
![CleanShot 2022-05-04 at 16 41 33](https://user-images.githubusercontent.com/76067158/166842368-731ac7dc-9011-4716-9eba-4dff8dc8e018.png)
![CleanShot 2022-05-04 at 16 41 21](https://user-images.githubusercontent.com/76067158/166842371-64627aca-432f-400a-bca5-804a4456b021.png)


After:
![CleanShot 2022-05-04 at 16 34 15](https://user-images.githubusercontent.com/76067158/166842252-c080fa39-bdde-45fd-bdb9-f29e07d14ce5.png)
![CleanShot 2022-05-04 at 16 33 51](https://user-images.githubusercontent.com/76067158/166842255-895c04b2-2a99-4df1-a54a-05bbeb7416a3.png)


- removed owned objects for package objects
- rename "owned objects" to "child objects" (Per @lxfind 's request)
- fix type for move objects (previously I caused a regression to show `moveObject` instead of the concrete object types"
- rename "description" to "Package Description" and "properties" to "Source code" per @bwann52 's request
