### PR TITLE
Add 0x prefix to all hex encoded values

### DIFF
--- a/sui/src/rpc_gateway/responses.rs
+++ b/sui/src/rpc_gateway/responses.rs
@@ -45,7 +45,7 @@ impl NamedObjectRef {
 impl From<ObjectRef> for NamedObjectRef {
     fn from((object_id, version, digest): ObjectRef) -> Self {
         Self {
-            object_id: object_id.to_hex(),
+            object_id: format!("{:#x}", object_id),
             version: version.value(),
             digest: Base64::encode_string(digest.as_ref()),
         }

--- a/sui/src/unit_tests/cli_tests.rs
+++ b/sui/src/unit_tests/cli_tests.rs
@@ -582,7 +582,7 @@ fn extract_gas_info(s: &str) -> Option<(ObjectID, SequenceNumber, u64)> {
         .unwrap()
         .to_owned();
     Some((
-        ObjectID::from_hex(id_str).unwrap(),
+        ObjectID::from_hex_literal(id_str).unwrap(),
         SequenceNumber::from_u64(tokens[1].parse::<u64>().unwrap()),
         tokens[2].parse::<u64>().unwrap(),
     ))
@@ -929,11 +929,11 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         };
 
     retry_assert!(
-        logs_contain(&format!("{:02X}", mut_obj1.0)),
+        logs_contain(&format!("{}", mut_obj1.0)),
         Duration::from_millis(5000)
     );
     retry_assert!(
-        logs_contain(&format!("{:02X}", mut_obj2.0)),
+        logs_contain(&format!("{}", mut_obj2.0)),
         Duration::from_millis(5000)
     );
 
@@ -1023,11 +1023,11 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
         };
 
     retry_assert!(
-        logs_contain(&format!("{:02X}", mut_obj1.0)),
+        logs_contain(&format!("{}", mut_obj1.0)),
         Duration::from_millis(5000)
     );
     retry_assert!(
-        logs_contain(&format!("{:02X}", mut_obj2.0)),
+        logs_contain(&format!("{}", mut_obj2.0)),
         Duration::from_millis(5000)
     );
 

--- a/sui/src/unit_tests/rpc_server_tests.rs
+++ b/sui/src/unit_tests/rpc_server_tests.rs
@@ -151,7 +151,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
 
     let json_args = vec![
         SuiJsonValue::from_str("10000")?,
-        SuiJsonValue::from_str(&format!("\"0x{}\"", address))?,
+        SuiJsonValue::from_str(&format!("{:#x}", address))?,
     ];
 
     let tx_data: TransactionBytes = http_client

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -25,7 +25,7 @@ use sui_core::gateway_state::{
 use sui_core::sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
 use sui_framework::build_move_package_to_bytes;
 use sui_types::{
-    base_types::{decode_bytes_hex, ObjectID, ObjectRef, SuiAddress},
+    base_types::{ObjectID, ObjectRef, SuiAddress},
     error::SuiError,
     fp_ensure,
     gas_coin::GasCoin,
@@ -61,7 +61,7 @@ pub enum WalletCommands {
     Switch {
         /// An Sui address to be used as the active address for subsequent
         /// commands.
-        #[clap(long, parse(try_from_str = decode_bytes_hex))]
+        #[clap(long)]
         address: Option<SuiAddress>,
         /// The gateway URL (e.g., local rpc server, devnet rpc server, etc) to be
         /// used for subsequent commands.
@@ -136,7 +136,7 @@ pub enum WalletCommands {
     #[clap(name = "transfer-coin")]
     Transfer {
         /// Recipient address
-        #[clap(long, parse(try_from_str = decode_bytes_hex))]
+        #[clap(long)]
         to: SuiAddress,
 
         /// Coin to transfer, in 20 bytes Hex string
@@ -155,7 +155,7 @@ pub enum WalletCommands {
     /// Synchronize client state with authorities.
     #[clap(name = "sync")]
     SyncClientState {
-        #[clap(long, parse(try_from_str = decode_bytes_hex))]
+        #[clap(long)]
         address: Option<SuiAddress>,
     },
 
@@ -171,7 +171,7 @@ pub enum WalletCommands {
     #[clap(name = "objects")]
     Objects {
         /// Address owning the objects
-        #[clap(long, parse(try_from_str = decode_bytes_hex))]
+        #[clap(long)]
         address: Option<SuiAddress>,
     },
 
@@ -179,7 +179,7 @@ pub enum WalletCommands {
     #[clap(name = "gas")]
     Gas {
         /// Address owning the objects
-        #[clap(long, parse(try_from_str = decode_bytes_hex))]
+        #[clap(long)]
         address: Option<SuiAddress>,
     },
 

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -680,10 +680,22 @@ impl Display for WalletCommandResult {
                 }
             }
             WalletCommandResult::Objects(object_refs) => {
-                writeln!(writer, "Showing {} results.", object_refs.len())?;
-                for object_ref in object_refs {
-                    writeln!(writer, "{:?}", object_ref)?;
+                writeln!(
+                    writer,
+                    " {0: ^42} | {1: ^10} | {2: ^68}",
+                    "Object ID", "Version", "Digest"
+                )?;
+                writeln!(writer, "{}", ["-"; 126].join(""))?;
+                for (id, version, digest) in object_refs {
+                    writeln!(
+                        writer,
+                        " {0: ^42} | {1: ^10} | {2: ^34?}",
+                        id,
+                        version.value(),
+                        digest
+                    )?;
                 }
+                writeln!(writer, "Showing {} results.", object_refs.len())?;
             }
             WalletCommandResult::SyncClientState => {
                 writeln!(writer, "Client state sync complete.")?;
@@ -695,7 +707,7 @@ impl Display for WalletCommandResult {
                 // TODO: generalize formatting of CLI
                 writeln!(
                     writer,
-                    " {0: ^40} | {1: ^10} | {2: ^11}",
+                    " {0: ^42} | {1: ^10} | {2: ^11}",
                     "Object ID", "Version", "Gas Value"
                 )?;
                 writeln!(
@@ -705,7 +717,7 @@ impl Display for WalletCommandResult {
                 for gas in gases {
                     writeln!(
                         writer,
-                        " {0: ^40} | {1: ^10} | {2: ^11}",
+                        " {0: ^42} | {1: ^10} | {2: ^11}",
                         gas.id(),
                         u64::from(gas.version()),
                         gas.value()

--- a/sui_core/src/sui_json.rs
+++ b/sui_core/src/sui_json.rs
@@ -128,7 +128,7 @@ impl SuiJsonValue {
                 if !s.starts_with(HEX_PREFIX) {
                     return Err(anyhow!("Address hex string must start with 0x.",));
                 }
-                let r: SuiAddress = decode_bytes_hex(s.trim_start_matches(HEX_PREFIX))?;
+                let r: SuiAddress = decode_bytes_hex(&s)?;
                 MoveValue::Address(r.into())
             }
             _ => return Err(anyhow!("Unexpected arg {val} for expected type {ty}")),

--- a/sui_core/src/sui_json.rs
+++ b/sui_core/src/sui_json.rs
@@ -139,7 +139,13 @@ impl SuiJsonValue {
 impl std::str::FromStr for SuiJsonValue {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, anyhow::Error> {
-        SuiJsonValue::new(serde_json::from_str(s)?)
+        // Add quotes for hex value start with 0x if it's missing
+        let s = if s.starts_with(HEX_PREFIX) {
+            serde_json::from_str(&format!("\"{}\"", s))
+        } else {
+            serde_json::from_str(s)
+        }?;
+        SuiJsonValue::new(s)
     }
 }
 

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -1,11 +1,12 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::str::FromStr;
 
-// Copyright (c) 2021, Facebook, Inc. and its affiliates
-// Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
 use anyhow::anyhow;
 use base64ct::Encoding;
 use digest::Digest;
@@ -66,6 +67,7 @@ pub struct ObjectID(
 pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 
 pub const SUI_ADDRESS_LENGTH: usize = ObjectID::LENGTH;
+
 #[serde_as]
 #[derive(
     Eq, Default, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema,
@@ -173,6 +175,7 @@ pub struct TransactionDigest(
     #[serde_as(as = "Readable<Base64, Bytes>")]
     [u8; TRANSACTION_DIGEST_LENGTH],
 );
+
 // Each object has a unique digest
 #[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
@@ -379,6 +382,7 @@ impl fmt::LowerHex for SuiAddress {
         write!(f, "{}", encode_bytes_hex(self))
     }
 }
+
 impl fmt::UpperHex for SuiAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
@@ -624,6 +628,7 @@ pub enum ObjectIDParseError {
     // #[error("Internal hex parser error: {err}")]
     // HexParserError { err: hex::FromHexError },
 }
+
 /// Wraps the underlying parsing errors
 impl From<hex::FromHexError> for ObjectIDParseError {
     fn from(err: hex::FromHexError) -> Self {
@@ -702,6 +707,7 @@ impl fmt::LowerHex for ObjectID {
         write!(f, "{}", encode_bytes_hex(self))
     }
 }
+
 impl fmt::UpperHex for ObjectID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {

--- a/sui_types/src/base_types.rs
+++ b/sui_types/src/base_types.rs
@@ -1,19 +1,13 @@
-// Copyright (c) 2021, Facebook, Inc. and its affiliates
-// Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-use anyhow::anyhow;
-use base64ct::Encoding;
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::str::FromStr;
 
-use crate::crypto::PublicKeyBytes;
-use crate::error::SuiError;
-use crate::json_schema;
-use crate::readable_serde::encoding::Base64;
-use crate::readable_serde::encoding::Hex;
-use crate::readable_serde::Readable;
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use anyhow::anyhow;
+use base64ct::Encoding;
 use digest::Digest;
 use hex::FromHex;
 use move_core_types::account_address::AccountAddress;
@@ -26,6 +20,13 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::Bytes;
 use sha3::Sha3_256;
+
+use crate::crypto::PublicKeyBytes;
+use crate::error::SuiError;
+use crate::json_schema;
+use crate::readable_serde::encoding::Base64;
+use crate::readable_serde::encoding::Hex;
+use crate::readable_serde::Readable;
 
 #[cfg(test)]
 #[path = "unit_tests/base_types_tests.rs"]
@@ -349,38 +350,41 @@ where
 }
 
 pub fn encode_bytes_hex<B: AsRef<[u8]>>(bytes: &B) -> String {
-    format!("0x{}", hex::encode(bytes.as_ref()).to_uppercase())
+    hex::encode(bytes.as_ref())
 }
 
 pub fn decode_bytes_hex<T: for<'a> TryFrom<&'a [u8]>>(s: &str) -> Result<T, anyhow::Error> {
-    let s = if let Some(s) = s.strip_prefix("0x") {
-        s
-    } else {
-        s
-    };
+    let s = s.strip_prefix("0x").unwrap_or(s);
     let value = hex::decode(s)?;
     T::try_from(&value[..]).map_err(|_| anyhow::anyhow!("byte deserialization failed"))
 }
 
 impl fmt::Display for SuiAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{:#x}", self)
     }
 }
 
 impl fmt::Debug for SuiAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{:#x}", self)
     }
 }
+
 impl fmt::LowerHex for SuiAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", encode_bytes_hex(self).to_lowercase())
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", encode_bytes_hex(self))
     }
 }
 impl fmt::UpperHex for SuiAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", encode_bytes_hex(self))
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", encode_bytes_hex(self).to_uppercase())
     }
 }
 
@@ -680,23 +684,30 @@ impl From<SuiAddress> for AccountAddress {
 
 impl fmt::Display for ObjectID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{:#x}", self)
     }
 }
 
 impl fmt::Debug for ObjectID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:X}", self)
+        write!(f, "{:#x}", self)
     }
 }
+
 impl fmt::LowerHex for ObjectID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", encode_bytes_hex(self).to_lowercase())
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", encode_bytes_hex(self))
     }
 }
 impl fmt::UpperHex for ObjectID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", encode_bytes_hex(self))
+        if f.alternate() {
+            write!(f, "0x")?;
+        }
+        write!(f, "{}", encode_bytes_hex(self).to_uppercase())
     }
 }
 

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -932,31 +932,31 @@ impl Display for TransactionEffects {
         if !self.created.is_empty() {
             writeln!(writer, "Created Objects:")?;
             for ((id, _, _), owner) in &self.created {
-                writeln!(writer, "  - ID: {:?} , Owner: {}", id, owner)?;
+                writeln!(writer, "  - ID: {} , Owner: {}", id, owner)?;
             }
         }
         if !self.mutated.is_empty() {
             writeln!(writer, "Mutated Objects:")?;
             for ((id, _, _), owner) in &self.mutated {
-                writeln!(writer, "  - ID: {:?} , Owner: {}", id, owner)?;
+                writeln!(writer, "  - ID: {} , Owner: {}", id, owner)?;
             }
         }
         if !self.deleted.is_empty() {
             writeln!(writer, "Deleted Objects:")?;
             for (id, _, _) in &self.deleted {
-                writeln!(writer, "  - ID: {:?}", id)?;
+                writeln!(writer, "  - ID: {}", id)?;
             }
         }
         if !self.wrapped.is_empty() {
             writeln!(writer, "Wrapped Objects:")?;
             for (id, _, _) in &self.wrapped {
-                writeln!(writer, "  - ID: {:?}", id)?;
+                writeln!(writer, "  - ID: {}", id)?;
             }
         }
         if !self.unwrapped.is_empty() {
             writeln!(writer, "Unwrapped Objects:")?;
             for ((id, _, _), owner) in &self.unwrapped {
-                writeln!(writer, "  - ID: {:?} , Owner: {}", id, owner)?;
+                writeln!(writer, "  - ID: {} , Owner: {}", id, owner)?;
             }
         }
         write!(f, "{}", writer)

--- a/sui_types/src/readable_serde.rs
+++ b/sui_types/src/readable_serde.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_core_types::account_address::AccountAddress;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
+use move_core_types::account_address::AccountAddress;
 use serde;
 use serde::de::{Deserialize, Deserializer, Error};
 use serde::ser::Serializer;
@@ -137,6 +137,8 @@ where
 
 pub mod encoding {
     use anyhow::anyhow;
+
+    use crate::base_types::{decode_bytes_hex, encode_bytes_hex};
     use base64ct::Encoding as _;
 
     pub trait Encoding {
@@ -148,11 +150,11 @@ pub mod encoding {
 
     impl Encoding for Hex {
         fn decode(s: String) -> Result<Vec<u8>, anyhow::Error> {
-            Ok(hex::decode(s)?)
+            decode_bytes_hex(&s)
         }
 
         fn encode<T: AsRef<[u8]>>(data: T) -> String {
-            hex::encode(data)
+            encode_bytes_hex(&data)
         }
     }
     impl Encoding for Base64 {


### PR DESCRIPTION
This PR add `0x` prefix to all (ObjectId, SuiAddress) Hex values, the changes is applied across the board everywhere hex encoding is used (wallet, JSON-RPC, config etc). 

* I have also sneak in a fix for SuiJsonValue https://github.com/MystenLabs/sui/issues/1808

Example wallet output 

```
patrick@Patricks-MBPMax release % ./wallet -i          
   _____       _    _       __      ____     __
  / ___/__  __(_)  | |     / /___ _/ / /__  / /_
  \__ \/ / / / /   | | /| / / __ `/ / / _ \/ __/
 ___/ / /_/ / /    | |/ |/ / /_/ / / /  __/ /_
/____/\__,_/_/     |__/|__/\__,_/_/_/\___/\__/
--- sui wallet unknown-6a4a9760-dirty ---

Managed addresses : 5
Active address: 0xBD34FE428B596103CA28B5C0772B3B9758A44490
Keystore Type : File
Keystore Path : "/Users/patrick/.sui/sui_config/wallet.key"
Gateway Type : Embedded
Gateway state DB folder path : "/Users/patrick/.sui/sui_config/client_db"
Authorities : ["127.0.0.1:49960", "127.0.0.1:49964", "127.0.0.1:49968", "127.0.0.1:49972"]

Welcome to the Sui interactive shell.

sui>-$ addresses
Showing 5 results.
0xBD34FE428B596103CA28B5C0772B3B9758A44490
0x62212632C4395E9F79BC14B1199889B81472002D
0xC12C091F345209CB69DA65BAACC7F7C6D8A41CF6
0xD61877A4D5DBD05CFB7D86EB872BDA4D3C6EF6A2
0x6DE8DA38964239D3D00EFE54894B7F50D9AB2868
sui>-$ objects --address 0xBD34FE428B596103CA28B5C0772B3B9758A44490
Showing 5 results.
(0x1F2E1E1DCA679845D902FC1BAACBCDF65960CD45, SequenceNumber(1), o#3a037ded9b4119f56778b3e454fe9c415063cff1a642f0c7cabfeecc8a0c47a9)
(0x3BD96FAE70111548E11CBAC31DFDE261811BE708, SequenceNumber(1), o#c35ea1f16f16c9b8b73c62b614d9afca695b3ec6b5253d86ef609ff795cf8039)
(0x622E4580DB619CD11EDBDD938E7E68C7E08D3B38, SequenceNumber(0), o#d3e9b4e90e6282fc677acb184cd01932c184ab069442a2589fdf8e92fb7bd97a)
(0x82C68A41B50B0FECE7F9F0ACBEE0569E029ABE38, SequenceNumber(0), o#486c48675344a330084b948b3575c80d64b9fbeef5a75ced097a46187096161d)
(0x8C5577231774E09E52304319FBB63551F03B6327, SequenceNumber(0), o#34b1ac4ce378410c37bd3fc9f1aa42d29abd5a2ec47314c90b400fc26b8e72e1)
sui>-$ transfer-coin --to 0xBD34FE428B596103CA28B5C0772B3B9758A44490 --coin-object-id 0x1F2E1E1DCA679845D902FC1BAACBCDF65960CD45 --gas 0x3BD96FAE70111548E11CBAC31DFDE261811BE708 --gas-budget 1000
Transfer confirmed after 11036 us
----- Certificate ----
Transaction Hash: ZJN/3zK5SSrIF8DExYfZKIszZYPLskoRABzGoLfg9HI=
Signed Authorities : [k#b0fe865f7e31c8bf5d95b9fb9ca0c604afb7feb83beacca6ee91fce44d81d84a, k#12cded5851470aed7427a4344c006c2cb9a8ce7c163d0b8d4136626935f11b90, k#040aa08f8447f5d93ca54912baf8039b8473da4b5db9dbedc6b076c50bd8d42d]
Transaction Kind : Transfer
Recipient : 0xBD34FE428B596103CA28B5C0772B3B9758A44490
Object ID : 0x1F2E1E1DCA679845D902FC1BAACBCDF65960CD45
Sequence Number : SequenceNumber(1)
Object Digest : 0x3A037DED9B4119F56778B3E454FE9C415063CFF1A642F0C7CABFEECC8A0C47A9

----- Transaction Effects ----
Status : Success { gas_cost: GasCostSummary { computation_cost: 41, storage_cost: 30, storage_rebate: 30 } }
Mutated Objects:
  - ID: 0x1F2E1E1DCA679845D902FC1BAACBCDF65960CD45 , Owner: Account Address ( 0xBD34FE428B596103CA28B5C0772B3B9758A44490 )
  - ID: 0x3BD96FAE70111548E11CBAC31DFDE261811BE708 , Owner: Account Address ( 0xBD34FE428B596103CA28B5C0772B3B9758A44490 )
sui>-$ call --package 0x2 --module ObjectBasics --function create --args 10000 "0xBD34FE428B596103CA28B5C0772B3B9758A44490" --gas 0x1F2E1E1DCA679845D902FC1BAACBCDF65960CD45 --gas-budget 1000
----- Certificate ----
Transaction Hash: Ny0bp8+IFDlt+DyTEmznUzTJXPNypEiPoKgwxweLNKM=
Signed Authorities : [k#b0fe865f7e31c8bf5d95b9fb9ca0c604afb7feb83beacca6ee91fce44d81d84a, k#12cded5851470aed7427a4344c006c2cb9a8ce7c163d0b8d4136626935f11b90, k#48196bd7392e789913f3bc1e9a62f1e57bb37a93b5b4da2d9490db2fb94c665b]
Transaction Kind : Call
Package ID : 0x2
Module : ObjectBasics
Function : create
Arguments : [Pure([16, 39, 0, 0, 0, 0, 0, 0]), Pure([189, 52, 254, 66, 139, 89, 97, 3, 202, 40, 181, 192, 119, 43, 59, 151, 88, 164, 68, 144])]
Type Arguments : []

----- Transaction Effects ----
Status : Success { gas_cost: GasCostSummary { computation_cost: 310, storage_cost: 28, storage_rebate: 15 } }
Created Objects:
  - ID: 0xAA6CC58322A3ADBC12FFAAE3B5C968685CC3CF37 , Owner: Account Address ( 0xBD34FE428B596103CA28B5C0772B3B9758A44490 )
Mutated Objects:
  - ID: 0x1F2E1E1DCA679845D902FC1BAACBCDF65960CD45 , Owner: Account Address ( 0xBD34FE428B596103CA28B5C0772B3B9758A44490 )
sui>-$ 
```