### PR TITLE
Update Move Contract Display

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useCallback } from 'react';
 
 import DisplayBox from '../../components/displaybox/DisplayBox';
 import Longtext from '../../components/longtext/Longtext';
+import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 import theme from '../../styles/theme.module.css';
 import { type AddressOwner } from '../../utils/api/DefaultRpcClient';
 import { parseImageURL } from '../../utils/objectUtils';
@@ -15,7 +16,6 @@ import {
 import { type DataType } from './ObjectResultType';
 
 import styles from './ObjectResult.module.css';
-import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 
 function ObjectLoaded({ data }: { data: DataType }) {
     // TODO - restore or remove this functionality

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 import DisplayBox from '../../components/displaybox/DisplayBox';
 import Longtext from '../../components/longtext/Longtext';
-import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 import theme from '../../styles/theme.module.css';
 import { type AddressOwner } from '../../utils/api/DefaultRpcClient';
 import { parseImageURL } from '../../utils/objectUtils';
@@ -283,17 +282,17 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                 <div>
                                     <div>Owner</div>
                                     <div id="owner">
-                                    <Longtext
-                                        text={extractOwnerData(data.owner)}
-                                        category="unknown"
-                                        // TODO: make this more elegant
-                                        isLink={
-                                            extractOwnerData(data.owner) !==
-                                                'Immutable' &&
-                                            extractOwnerData(data.owner) !==
-                                                'Shared'
-                                        }
-                                    />
+                                        <Longtext
+                                            text={extractOwnerData(data.owner)}
+                                            category="unknown"
+                                            // TODO: make this more elegant
+                                            isLink={
+                                                extractOwnerData(data.owner) !==
+                                                    'Immutable' &&
+                                                extractOwnerData(data.owner) !==
+                                                    'Shared'
+                                            }
+                                        />
                                     </div>
                                 </div>
                             )}

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -23,6 +23,9 @@ function ObjectLoaded({ data }: { data: DataType }) {
     const [showProperties, setShowProperties] = useState(false);
     const [showConnectedEntities, setShowConnectedEntities] = useState(false);
 
+    console.log(data);
+    const IS_LIBRARY = data.objType === 'Move Package';
+
     useEffect(() => {
         setShowDescription(true);
         setShowProperties(true);
@@ -270,11 +273,16 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             )}
                             <div>
                                 <div>Type</div>
-                                <div>{prepObjTypeValue(data.objType)}</div>
+                                <div>
+                                    {IS_LIBRARY
+                                        ? 'Library'
+                                        : prepObjTypeValue(data.objType)}
+                                </div>
                             </div>
-                            <div>
-                                <div>Owner</div>
-                                <div id="owner">
+                            {!IS_LIBRARY && (
+                                <div>
+                                    <div>Owner</div>
+                                    <div id="owner">
                                     <Longtext
                                         text={extractOwnerData(data.owner)}
                                         category="unknown"
@@ -286,8 +294,9 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                                 'Shared'
                                         }
                                     />
+                                    </div>
                                 </div>
-                            </div>
+                            )}
                             {data.contract_id && (
                                 <div>
                                     <div>Contract ID</div>
@@ -324,7 +333,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             )}
                         </div>
                     )}
-                    {properties.length > 0 && (
+                    {properties.length > 0 && !IS_LIBRARY && (
                         <>
                             <h2
                                 className={styles.clickableheader}
@@ -353,9 +362,25 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             Child Objects {showConnectedEntities ? '' : '+'}
                         </h2>
                     ) : (
-                        <></>
+                        <div>
+                            <h2
+                                className={styles.clickableheader}
+                                onClick={clickSetShowProperties}
+                            >
+                                Modules {showProperties ? '' : '+'}
+                            </h2>
+                            {showProperties && (
+                                <div className={styles.bytecodebox}>
+                                    {properties.map(([key, value], index) => (
+                                        <div key={`property-${index}`}>
+                                            <div>{prepLabel(key)}</div>
+                                            <div>{value}</div>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
                     )}
-                    {showConnectedEntities && <OwnedObjects id={data.id} />}
                 </div>
             </div>
         </>

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -15,6 +15,7 @@ import {
 import { type DataType } from './ObjectResultType';
 
 import styles from './ObjectResult.module.css';
+import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 
 function ObjectLoaded({ data }: { data: DataType }) {
     // TODO - restore or remove this functionality
@@ -377,6 +378,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             )}
                         </div>
                     )}
+                    {showConnectedEntities && <OwnedObjects id={data.id} />}
                 </div>
             </div>
         </>

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -22,9 +22,6 @@ function ObjectLoaded({ data }: { data: DataType }) {
     const [showProperties, setShowProperties] = useState(false);
     const [showConnectedEntities, setShowConnectedEntities] = useState(false);
 
-    console.log(data);
-    const IS_LIBRARY = data.objType === 'Move Package';
-
     useEffect(() => {
         setShowDescription(true);
         setShowProperties(true);
@@ -273,12 +270,12 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             <div>
                                 <div>Type</div>
                                 <div>
-                                    {IS_LIBRARY
+                                    {data.objType === 'Move Package'
                                         ? 'Library'
                                         : prepObjTypeValue(data.objType)}
                                 </div>
                             </div>
-                            {!IS_LIBRARY && (
+                            {data.objType !== 'Move Package' && (
                                 <div>
                                     <div>Owner</div>
                                     <div id="owner">
@@ -332,7 +329,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             )}
                         </div>
                     )}
-                    {properties.length > 0 && !IS_LIBRARY && (
+                    {properties.length > 0 && data.objType !== 'Move Package' && (
                         <>
                             <h2
                                 className={styles.clickableheader}

--- a/explorer/client/src/pages/object-result/ObjectResult.module.css
+++ b/explorer/client/src/pages/object-result/ObjectResult.module.css
@@ -77,3 +77,18 @@ h2.clickableheader {
 div.accommodate > h2.clickableheader {
     @apply lg:w-[50vw];
 }
+
+/* Bytecode Styling */
+
+div.bytecodebox > div {
+    @apply ml-[5vw];
+}
+
+div.bytecodebox > div > div:first-child {
+    @apply font-sans tracking-tight font-semibold block;
+}
+
+div.bytecodebox > div > div:nth-child(2) {
+    @apply overflow-auto h-[30vh] w-[65vw] 
+  border-solid border-stone-300 mt-[2vh] mb-[5vh] p-2 whitespace-pre text-sm;
+}


### PR DESCRIPTION
This is a merge of current `main` with @Andrew47 's draft PR for issue #1043 .

Now, Move contracts should display like this:
![image](https://user-images.githubusercontent.com/14057748/166857848-2b709885-5baf-4e28-8d9e-dfc5cdbbb0aa.png)


To test, start the explorer and visit the stdlib:
http://localhost:3000/objects/0000000000000000000000000000000000000002