### PR TITLE
loading notice on Address page

### DIFF
--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -51,7 +51,7 @@
 }
 
 button.btncontainer {
-    @apply inline-block px-0 cursor-pointer border-none bg-inherit hover:bg-sui 
+    @apply inline-block px-0 cursor-pointer border-none bg-inherit hover:bg-sui
   py-2
   text-offblack stroke-offblack
   hover:text-white hover:stroke-white
@@ -72,4 +72,8 @@ button.btncontainer {
 
 .paginationheading > h2 {
     @apply inline lg:ml-5;
+}
+
+.gray {
+    color: gray;
 }

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -109,7 +109,11 @@ function OwnedObjectAPI({ id }: { id: string }) {
     if (isLoaded) {
         return <OwnedObjectLayout results={results} />;
     } else {
-        return <div />;
+        return results.length > 0 ? (
+            <div className={styles.gray}>loading...</div>
+        ) : (
+            <div />
+        );
     }
 }
 


### PR DESCRIPTION
Since we added coin aggregation, there can be significant loading time on Address pages.

This adds a very simple `loading...` notice in the Owned Objects header, instead of leaving it empty until load.

The loading notice won't display if the address owns no objects.

## before (while loading)
<img width="622" alt="image" src="https://user-images.githubusercontent.com/14057748/166863804-9da68702-9669-4210-8e7b-62353c7936bb.png">

## after (while loading)
<img width="554" alt="image" src="https://user-images.githubusercontent.com/14057748/166863852-ae8f0e8c-e265-423a-9462-59b9e94496f9.png">



you can test this on this object page if you start a local instance:
http://localhost:3000/addresses/813ec1ab1e1797c79d1e1fcbebebc27a1fd21f07