### PR TITLE
Revert "avoid using locked gas objects (#1768)"

### DIFF
--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -609,23 +609,6 @@
           "$ref": "#/components/schemas/ObjectRead"
         }
       }
-    },
-    {
-      "name": "sui_getLockedObjects",
-      "description": "",
-      "params": [],
-      "result": {
-        "name": "BTreeMap < ObjectRef, TransactionDigest >",
-        "summary": "",
-        "description": "",
-        "required": true,
-        "schema": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          }
-        }
-      }
     }
   ],
   "components": {

--- a/sui/src/rpc_gateway.rs
+++ b/sui/src/rpc_gateway.rs
@@ -15,7 +15,6 @@ use move_core_types::identifier::Identifier;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64, serde_as};
-use std::collections::BTreeMap;
 use std::path::Path;
 use sui_core::gateway_state::{
     gateway_responses::{TransactionEffectsResponse, TransactionResponse},
@@ -23,7 +22,6 @@ use sui_core::gateway_state::{
 };
 use sui_core::sui_json::SuiJsonValue;
 use sui_open_rpc_macros::open_rpc;
-use sui_types::base_types::ObjectRef;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     crypto,
@@ -156,9 +154,6 @@ pub trait RpcGateway {
     /// `get_object_typed_info` instead.
     #[method(name = "getObjectInfoRaw")]
     async fn get_object_info(&self, object_id: ObjectID) -> RpcResult<ObjectRead>;
-
-    #[method(name = "getLockedObjects")]
-    fn get_locked_objects(&self) -> RpcResult<BTreeMap<ObjectRef, TransactionDigest>>;
 }
 
 pub struct RpcGatewayImpl {
@@ -388,10 +383,6 @@ impl RpcGatewayServer for RpcGatewayImpl {
         digest: TransactionDigest,
     ) -> RpcResult<TransactionEffectsResponse> {
         Ok(self.gateway.get_transaction(digest).await?)
-    }
-
-    fn get_locked_objects(&self) -> RpcResult<BTreeMap<ObjectRef, TransactionDigest>> {
-        Ok(self.gateway.get_locked_objects()?)
     }
 }
 

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use anyhow::Error;
 use async_trait::async_trait;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -196,14 +194,5 @@ impl GatewayAPI for RpcGatewayClient {
         digest: TransactionDigest,
     ) -> Result<TransactionEffectsResponse, Error> {
         Ok(self.client.get_transaction(digest).await?)
-    }
-
-    /// Return locked objects and digests of TX they're locked on
-    fn get_locked_objects(&self) -> Result<BTreeMap<ObjectRef, TransactionDigest>, Error> {
-        let handle = Handle::current();
-        let _ = handle.enter();
-        Ok(futures::executor::block_on(
-            self.client.get_locked_objects(),
-        )?)
     }
 }

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -641,17 +641,13 @@ impl WalletContext {
         budget: u64,
         forbidden_gas_objects: BTreeSet<ObjectID>,
     ) -> Result<(u64, Object), anyhow::Error> {
-        // Make sure we don't use locked gas objects
-        let mut forbidden_gas_objects = forbidden_gas_objects.clone();
-        forbidden_gas_objects.extend(self.gateway.get_locked_objects()?.iter().map(|w| w.0 .0));
-
         for o in self.gas_objects(address).await.unwrap() {
             if o.0 >= budget && !forbidden_gas_objects.contains(&o.1.id()) {
                 return Ok(o);
             }
         }
         return Err(anyhow!(
-            "No available gas objects found with value >= budget {}",
+            "No non-argument gas objects found with value >= budget {}",
             budget
         ));
     }

--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -321,14 +321,6 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
         }
     }
 
-    /// Read all locks.
-    pub fn get_locked_objects(&self) -> BTreeMap<ObjectRef, TransactionDigest> {
-        self.transaction_lock
-            .iter()
-            .filter_map(|lck| lck.1.map(|t| (lck.0, t)))
-            .collect()
-    }
-
     /// Read a certificate and return an option with None if it does not exist.
     pub fn read_certificate(
         &self,

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -211,14 +211,11 @@ pub trait GatewayAPI {
         count: u64,
     ) -> Result<Vec<(GatewayTxSeqNumber, TransactionDigest)>, anyhow::Error>;
 
-    /// Return transaction details by digest
+    // return transaction details by digest
     async fn get_transaction(
         &self,
         digest: TransactionDigest,
     ) -> Result<TransactionEffectsResponse, anyhow::Error>;
-
-    /// Return locked objects and digests of TX they're locked on
-    fn get_locked_objects(&self) -> Result<BTreeMap<ObjectRef, TransactionDigest>, anyhow::Error>;
 }
 
 impl<A> GatewayState<A>
@@ -956,11 +953,5 @@ where
             }),
             None => Err(anyhow!(SuiError::TransactionNotFound { digest })),
         }
-    }
-
-    /// Return locked objects and digests of TX they're locked on
-    /// This function never fails, but is wrapped in Ok for compat with rpc
-    fn get_locked_objects(&self) -> Result<BTreeMap<ObjectRef, TransactionDigest>, anyhow::Error> {
-        Ok(self.store.get_locked_objects())
     }
 }


### PR DESCRIPTION
This will resolve https://github.com/MystenLabs/sui/issues/1804

This reverts commit 1ee582ca4f7e896fffa6ea1b82c89aafc10e5302.

The issue is that it tries to read all transaction locks in the gateway to pick gas objects, but that basically means walking through every single object in the gateway, which would time out.