### PR TITLE
disable fetching owned objects for packages

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -378,7 +378,10 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             )}
                         </div>
                     )}
-                    {showConnectedEntities && <OwnedObjects id={data.id} />}
+                    {showConnectedEntities &&
+                        data.objType !== 'Move Package' && (
+                            <OwnedObjects id={data.id} />
+                        )}
                 </div>
             </div>
         </>


### PR DESCRIPTION
Move packages can't own objects, so let's disable the display and fetching of them.