### PR TITLE
make genesis transaction display friendlier

### DIFF
--- a/explorer/client/src/components/longtext/Longtext.tsx
+++ b/explorer/client/src/components/longtext/Longtext.tsx
@@ -55,6 +55,15 @@ function Longtext({
         navigateWithUnknown(text, navigate).then(() => setPleaseWait(false));
     }, [text, navigate]);
 
+    // temporary hack to make display of the genesis transaction clearer
+    if (
+        category === 'transactions' &&
+        text === 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+    ) {
+        text = 'Genesis';
+        isLink = false;
+    }
+
     let textComponent;
     if (isLink) {
         if (category === 'unknown') {


### PR DESCRIPTION
turns the 0 transaction ID into "Genesis" to make it easier to understand.

Eventually we may want this functionality to be in the backend instead.

## before
<img width="431" alt="image" src="https://user-images.githubusercontent.com/14057748/166872520-8bfdbf5b-f6f9-4b2f-88b7-43869a98ede3.png">


## after
<img width="739" alt="image" src="https://user-images.githubusercontent.com/14057748/166872400-99057035-9401-41f4-9cf2-f54ce7b2bfe8.png">
