### PR TITLE
Owned Object Display Improvements

### DIFF
--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -5,11 +5,7 @@
 }
 
 .ownedobjects {
-    @apply w-[100%] lg:flex lg:justify-items-center lg:flex-wrap;
-}
-
-.ownedobjects > div {
-    @apply mx-auto break-all lg:w-[20vw];
+    @apply w-[100%] lg:flex lg:flex-wrap lg:justify-between;
 }
 
 .groupcollection > div {
@@ -17,7 +13,7 @@
 }
 
 .objectbox {
-    @apply border-solid border-stone-300 rounded-lg my-2 p-[0.25vw] lg:w-[23vw] lg:self-center hover:shadow-md cursor-pointer;
+    @apply border-solid border-stone-300 rounded-lg my-2 lg:self-center hover:shadow-md cursor-pointer break-all lg:w-[20vw];
 }
 
 .objectbox > div {

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -21,7 +21,7 @@
 }
 
 .objectbox > div {
-    @apply pt-2 pl-2;
+    @apply pt-2 pl-2 pr-1;
 }
 
 .objectbox > div:first-child > div {

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -12,6 +12,10 @@
     @apply border-solid border-stone-300 rounded-lg my-2 p-2 cursor-pointer hover:shadow-md;
 }
 
+.fillerbox {
+    @apply invisible;
+}
+
 .objectbox {
     @apply border-solid border-stone-300 rounded-lg my-2 lg:self-center hover:shadow-md cursor-pointer break-all lg:w-[20vw];
 }

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -83,6 +83,7 @@ function OwnedObjectAPI({ id }: { id: string }) {
                             (resp) => {
                                 const info = getObjectExistsResponse(resp)!;
                                 const contents = getObjectContent(resp);
+                                console.log(info.object);
                                 const url = parseImageURL(info.object);
                                 const balanceValue = (
                                     typeof contents?.fields.balance === 'number'

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -83,7 +83,6 @@ function OwnedObjectAPI({ id }: { id: string }) {
                             (resp) => {
                                 const info = getObjectExistsResponse(resp)!;
                                 const contents = getObjectContent(resp);
-                                console.log(info.object);
                                 const url = parseImageURL(info.object);
                                 const balanceValue = (
                                     typeof contents?.fields.balance === 'number'

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -388,6 +388,9 @@ function OwnedObjectView({ results }: { results: resultType }) {
                     ))}
                 </div>
             ))}
+            {results.length % 3 === 2 && (
+                <div className={`${styles.objectbox} ${styles.fillerbox}`} />
+            )}
         </div>
     );
 }

--- a/explorer/client/src/utils/objectUtils.ts
+++ b/explorer/client/src/utils/objectUtils.ts
@@ -4,14 +4,15 @@
 import type { ObjectExistsInfo } from 'sui.js';
 
 export function parseImageURL(data: any): string {
-    if (data?.contents?.url?.fields) {
-        return data.contents.url.fields['url'];
-    }
-    // TODO: Remove Legacy format
-    if (data?.contents?.display) {
-        return data.contents.display;
-    }
-    return '';
+    return (
+        //Render Image for Preview Cards
+        data?.contents?.fields?.url?.fields?.url ||
+        //Render Image for Object Results
+        data?.contents?.url?.fields?.url ||
+        // TODO: Remove Legacy format
+        data?.contents?.display ||
+        ''
+    );
 }
 
 export function parseObjectType(data: ObjectExistsInfo): string {


### PR DESCRIPTION
This improves the display of Owned Objects in three ways:

1. Images now display in the Preview Cards
2. Preview Cards are now vertically aligned
3. When a row has two Preview Cards these align with the first two cards above

Before:
![image](https://user-images.githubusercontent.com/11377188/166901970-9987bd4b-ef52-4fbd-9692-3a60edbbc2af.png)

After:
![image](https://user-images.githubusercontent.com/11377188/166901831-4ac15bb0-1b37-4858-8f79-c78667774c66.png)

Without compromising on small screen appearance:
![image](https://user-images.githubusercontent.com/11377188/166902900-5315ba1f-5d25-4770-976e-aa1ab4fe3922.png)

