### PR TITLE
make transaction package link to an object

### DIFF
--- a/explorer/client/src/components/transaction-card/TransactionCard.tsx
+++ b/explorer/client/src/components/transaction-card/TransactionCard.tsx
@@ -143,6 +143,7 @@ function formatByTransactionKind(
                 },
                 {
                     label: 'Package',
+                    category: 'objects',
                     value: moveCall.package[0],
                     link: true,
                 },


### PR DESCRIPTION
packages are objects, not addresses - change the link to reflect that

To test, compare the effect of clicking the "Package" link on page:
https://explorer.devnet.sui.io/transactions/0h0%2BnhqW7Kvp6XCDTzQ3I9f2XxV13i2QOUSf%2BxCrR2I%3D