### PR TITLE
Fix named anchor manually change the Gateway URL in DevNet guide

### DIFF
--- a/doc/src/explore/devnet.md
+++ b/doc/src/explore/devnet.md
@@ -48,7 +48,7 @@ In addition, to conduct advanced work such as publishing a Move module or making
 
 ### Set up wallet, connect to gateway
 
-Now [set up your wallet and connect to DevNet](../build/wallet.md#connect-to-devnet) in a single step. Note you can [manually change the Gateway URL](../build/wallet.md#manually-changing-the-gateway-url) if you have already configured a Sui wallet.
+Now [set up your wallet and connect to DevNet](../build/wallet.md#connect-to-devnet) in a single step. Note you can [manually change the Gateway URL](../build/wallet.md#manually-change-the-gateway-url) if you have already configured a Sui wallet.
 
 > **Tip:** If you run into issues, reset the Sui configuration by removing its directory, by default located at `~/.sui/sui_config`. Then reinstall [Sui binaries](../build/install.md#binaries).
 


### PR DESCRIPTION
Fix named anchor link to manually change the Gateway URL from DevNet guide