### PR TITLE
[explorer] Standardizes the Group and NFT Views in Owned Objects

### DIFF
--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -484,28 +484,28 @@ describe('End-to-end Tests', () => {
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(1) > div:nth-child(1)',
+                    '#groupCollection > div:nth-child(1) > div > div:nth-child(1)',
                     (el: any) => el.textContent
                 )
             ).toBe('TypeCoin::Coin<0x2::USD::USD>');
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(1) > div:nth-child(2)',
+                    '#groupCollection > div:nth-child(1) > div > div:nth-child(2)',
                     (el: any) => el.textContent
                 )
             ).toBe('Balance300');
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(2) > div:nth-child(1)',
+                    '#groupCollection > div:nth-child(2) > div > div:nth-child(1)',
                     (el: any) => el.textContent
                 )
             ).toBe('TypeCoin::Coin<0x2::SUI::SUI>');
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(2) > div:nth-child(2)',
+                    '#groupCollection > div:nth-child(2) > div > div:nth-child(2)',
                     (el: any) => el.textContent
                 )
             ).toBe('Balance200');

--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -64,6 +64,8 @@ const coinGroup = (num: number) => {
     };
 };
 
+const nftObject = (num: number) => `div#ownedObjects > div:nth-child(${num})`;
+
 describe('End-to-end Tests', () => {
     beforeAll(async () => {
         browser = await puppeteer.launch();
@@ -286,9 +288,7 @@ describe('End-to-end Tests', () => {
             await page.goto(`${BASE_URL}/${parentIsA}/${parentValue}`);
 
             //Click on child in Owned Objects List:
-            const objectLink = await page.$(
-                `div#ownedObjects > div:nth-child(${parentToChildNo})`
-            );
+            const objectLink = await page.$(nftObject(parentToChildNo));
             await objectLink.click();
 
             //Check ID of child object:
@@ -332,9 +332,7 @@ describe('End-to-end Tests', () => {
             await page.goto(`${BASE_URL}/objects/${parentValue}`);
 
             //Click on child in Owned Objects List:
-            const objectLink = await page.$(
-                `div#ownedObjects > div:nth-child(1)`
-            );
+            const objectLink = await page.$(nftObject(1));
             await objectLink.click();
 
             // First see Please Wait Message:
@@ -380,9 +378,7 @@ describe('End-to-end Tests', () => {
             await page.goto(`${BASE_URL}/addresses/${address}`);
             const btn = await page.$('#nextBtn');
             await btn.click();
-            const objectLink = await page.$(
-                'div#ownedObjects > div:nth-child(1)'
-            );
+            const objectLink = await page.$(nftObject(1));
             await objectLink.click();
 
             const objectIDEl = await page.$('#objectID');
@@ -399,9 +395,7 @@ describe('End-to-end Tests', () => {
 
             const btn = await page.$('#lastBtn');
             await btn.click();
-            const objectLink = await page.$(
-                'div#ownedObjects > div:nth-child(1)'
-            );
+            const objectLink = await page.$(nftObject(1));
             await objectLink.click();
 
             const objectIDEl = await page.$('#objectID');
@@ -437,9 +431,7 @@ describe('End-to-end Tests', () => {
 
             await page.$('#backBtn').then((btn: any) => btn.click());
 
-            const objectLink = await page.$(
-                'div#ownedObjects > div:nth-child(1)'
-            );
+            const objectLink = await page.$(nftObject(1));
             await objectLink.click();
 
             const objectIDEl = await page.$('#objectID');
@@ -461,9 +453,7 @@ describe('End-to-end Tests', () => {
 
             await page.$('#firstBtn').then((btn: any) => btn.click());
 
-            const objectLink = await page.$(
-                'div#ownedObjects > div:nth-child(1)'
-            );
+            const objectLink = await page.$(nftObject(1));
             await objectLink.click();
 
             const objectIDEl = await page.$('#objectID');

--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -53,6 +53,17 @@ const searchText = async (page: any, text: string) => {
     await page.click('#searchBtn');
 };
 
+//Standardized CSS Selectors
+
+const coinGroup = (num: number) => {
+    const trunk = `#groupCollection > div:nth-child(${num})`;
+    return {
+        base: () => trunk,
+        field: (numField: number) =>
+            `${trunk} > div > div:nth-child(${numField})`,
+    };
+};
+
 describe('End-to-end Tests', () => {
     beforeAll(async () => {
         browser = await puppeteer.launch();
@@ -466,7 +477,7 @@ describe('End-to-end Tests', () => {
         it('where first and back disappear in first page', async () => {
             const address = 'ownsAllAddress';
             await page.goto(`${BASE_URL}/addresses/${address}`);
-            const btn1 = await page.$('#groupCollection > div:nth-child(1)');
+            const btn1 = await page.$(coinGroup(1).base());
             await btn1.click();
 
             //Next and Last buttons are not disabled:
@@ -484,28 +495,28 @@ describe('End-to-end Tests', () => {
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(1) > div > div:nth-child(1)',
+                    coinGroup(1).field(1),
                     (el: any) => el.textContent
                 )
             ).toBe('Type0x2::USD::USD');
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(1) > div > div:nth-child(2)',
+                    coinGroup(1).field(2),
                     (el: any) => el.textContent
                 )
             ).toBe('Balance300');
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(2) > div > div:nth-child(1)',
+                    coinGroup(2).field(1),
                     (el: any) => el.textContent
                 )
             ).toBe('TypeSUI');
 
             expect(
                 await page.$eval(
-                    '#groupCollection > div:nth-child(2) > div > div:nth-child(2)',
+                    coinGroup(2).field(2),
                     (el: any) => el.textContent
                 )
             ).toBe('Balance200');

--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -487,7 +487,7 @@ describe('End-to-end Tests', () => {
                     '#groupCollection > div:nth-child(1) > div > div:nth-child(1)',
                     (el: any) => el.textContent
                 )
-            ).toBe('TypeCoin::Coin<0x2::USD::USD>');
+            ).toBe('Type0x2::USD::USD');
 
             expect(
                 await page.$eval(
@@ -501,7 +501,7 @@ describe('End-to-end Tests', () => {
                     '#groupCollection > div:nth-child(2) > div > div:nth-child(1)',
                     (el: any) => el.textContent
                 )
-            ).toBe('TypeCoin::Coin<0x2::SUI::SUI>');
+            ).toBe('TypeSUI');
 
             expect(
                 await page.$eval(

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -8,10 +8,6 @@
     @apply w-[100%] lg:flex lg:flex-wrap lg:justify-between;
 }
 
-.groupcollection > div {
-    @apply border-solid border-stone-300 rounded-lg my-2 p-2 cursor-pointer hover:shadow-md;
-}
-
 .fillerbox {
     @apply invisible;
 }
@@ -28,8 +24,7 @@
     @apply border-none;
 }
 
-.objectbox > div > div > span:first-child,
-.groupcollection > div > div > span:first-child {
+.objectbox > div > div > span:first-child {
     @apply mr-[1rem] uppercase font-sans font-semibold block xl:inline;
 }
 

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -13,7 +13,7 @@
 }
 
 .objectbox {
-    @apply border-solid border-stone-300 rounded-lg my-2 lg:self-center hover:shadow-md cursor-pointer break-all lg:w-[20vw];
+    @apply border-solid border-stone-300 rounded-lg my-2 lg:self-center hover:shadow-md cursor-pointer break-all lg:w-[25vw];
 }
 
 .objectbox > div {

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -13,11 +13,11 @@
 }
 
 .objectbox {
-    @apply border-solid border-stone-300 rounded-lg my-2 lg:self-center hover:shadow-md cursor-pointer break-all lg:w-[25vw];
+    @apply border-solid border-stone-300 rounded-lg my-2 lg:self-center hover:shadow-md cursor-pointer break-all lg:w-[21.8vw];
 }
 
 .objectbox > div {
-    @apply pt-2 pl-2 pr-1;
+    @apply py-1 px-1;
 }
 
 .objectbox > div:first-child > div {
@@ -25,7 +25,7 @@
 }
 
 .objectbox > div > div > span:first-child {
-    @apply mr-[1rem] uppercase font-sans font-semibold block xl:inline;
+    @apply mr-[0.25vw] uppercase font-sans font-bold block xl:inline;
 }
 
 .previewimage > div > img {

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -38,6 +38,9 @@ const DATATYPE_DEFAULT: resultType = [
 
 const IS_COIN_TYPE = (typeDesc: string): boolean => /::Coin::/.test(typeDesc);
 
+const lastRowHas2Elements = (itemList: any[]): boolean =>
+    itemList.length % 3 === 2;
+
 function OwnedObject({ id }: { id: string }) {
     if (process.env.REACT_APP_DATA === 'static') {
         return <OwnedObjectStatic id={id} />;
@@ -205,7 +208,7 @@ function GroupView({ results }: { results: resultType }) {
                         </div>
                     );
                 })}
-                {uniqueTypes.length % 3 === 2 && (
+                {lastRowHas2Elements(uniqueTypes) && (
                     <div
                         className={`${styles.objectbox} ${styles.fillerbox}`}
                     />
@@ -407,7 +410,7 @@ function OwnedObjectView({ results }: { results: resultType }) {
                     ))}
                 </div>
             ))}
-            {results.length % 3 === 2 && (
+            {lastRowHas2Elements(results) && (
                 <div className={`${styles.objectbox} ${styles.fillerbox}`} />
             )}
         </div>

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -162,19 +162,22 @@ function GroupView({ results }: { results: resultType }) {
 
     const goBack = useCallback(() => setIsGroup(true), []);
 
+    const uniqueTypes = Array.from(new Set(results.map(({ Type }) => Type)));
+
     if (isGroup) {
         return (
-            <div id="groupCollection" className={styles.groupcollection}>
-                {Array.from(new Set(results.map(({ Type }) => Type))).map(
-                    (typeV) => {
-                        const subObjList = results.filter(
-                            ({ Type }) => Type === typeV
-                        );
-                        return (
-                            <div
-                                key={typeV}
-                                onClick={shrinkObjList(subObjList)}
-                            >
+            <div id="groupCollection" className={styles.ownedobjects}>
+                {uniqueTypes.map((typeV) => {
+                    const subObjList = results.filter(
+                        ({ Type }) => Type === typeV
+                    );
+                    return (
+                        <div
+                            key={typeV}
+                            onClick={shrinkObjList(subObjList)}
+                            className={styles.objectbox}
+                        >
+                            <div>
                                 <div>
                                     <span>Type</span>
                                     <span>{trimStdLibPrefix(typeV)}</span>
@@ -195,8 +198,13 @@ function GroupView({ results }: { results: resultType }) {
                                     </span>
                                 </div>
                             </div>
-                        );
-                    }
+                        </div>
+                    );
+                })}
+                {uniqueTypes.length % 3 === 2 && (
+                    <div
+                        className={`${styles.objectbox} ${styles.fillerbox}`}
+                    />
                 )}
             </div>
         );

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -12,7 +12,11 @@ import {
     findDataFromID,
     findOwnedObjectsfromID,
 } from '../../utils/static/searchUtil';
-import { processDisplayValue, trimStdLibPrefix } from '../../utils/stringUtils';
+import {
+    handleCoinType,
+    processDisplayValue,
+    trimStdLibPrefix,
+} from '../../utils/stringUtils';
 import DisplayBox from '../displaybox/DisplayBox';
 
 import styles from './OwnedObjects.module.css';
@@ -180,7 +184,7 @@ function GroupView({ results }: { results: resultType }) {
                             <div>
                                 <div>
                                     <span>Type</span>
-                                    <span>{trimStdLibPrefix(typeV)}</span>
+                                    <span>{handleCoinType(typeV)}</span>
                                 </div>
                                 <div>
                                     <span>Balance</span>
@@ -213,7 +217,7 @@ function GroupView({ results }: { results: resultType }) {
             <div>
                 <div className={styles.paginationheading}>
                     <button onClick={goBack}>&#60; Back</button>
-                    <h2>{trimStdLibPrefix(subObjs[0].Type)}</h2>
+                    <h2>{handleCoinType(subObjs[0].Type)}</h2>
                 </div>
                 <OwnedObjectSection results={subObjs} />
             </div>

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -19,6 +19,11 @@ export function hexToAscii(hex: string) {
 export const trimStdLibPrefix = (str: string): string =>
     str.replace(/^0x2::/, '');
 
+export const handleCoinType = (str: string): string =>
+    str === '0x2::Coin::Coin<0x2::SUI::SUI>'
+        ? 'SUI'
+        : str.match(/(?<=<)[a-zA-Z0-9:]+(?=>)/)?.[0] || str;
+
 export const processDisplayValue = (display: { bytes: number[] } | string) => {
     const url =
         typeof display === 'object' && 'bytes' in display


### PR DESCRIPTION
Standardizes the Group and NFT Views in Owned Objects and widens the boxes to reduce horizontal space


Before:

![image](https://user-images.githubusercontent.com/11377188/167133944-e02592a1-b918-429a-b454-4795f457758c.png)


After:

![image](https://user-images.githubusercontent.com/11377188/167133706-78b29697-8db3-476d-89b1-1a8a55f674da.png)
