### PR TITLE
Batch calls for recent transactions

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -49,7 +49,7 @@ async function getRecentTransactions(txNum: number): Promise<TxnData[]> {
             .getRecentTransactions(txNum)
             .then((res: GetTxnDigestsResponse) => res);
 
-        const digests = transactions.map((tx: any[]) => tx[1]);
+        const digests = transactions.map((tx) => tx[1]);
         const txLatest = await rpc
             .getTransactionWithEffectsBatch(digests)
             .then((txEffs: TransactionEffectsResponse[]) => {

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -149,8 +149,8 @@ function LatestTxCard() {
     if (!isLoaded && results.loadState === 'fail') {
         return (
             <ErrorResult
-                id="latestTx"
-                errorMsg="There was an issue getting the latest transaction"
+                id=""
+                errorMsg="There was an issue getting the latest transactions"
             />
         );
     }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -46,7 +46,7 @@ async function getRecentTransactions(txNum: number): Promise<TxnData[]> {
     try {
         // Get the latest transactions
         // TODO sui.js to get the latest transactions meta data
-        const transactions: GetTxnDigestsResponse = await rpc
+        const transactions = await rpc
             .getRecentTransactions(txNum)
             .then((res: GetTxnDigestsResponse) => res);
 

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -45,7 +45,6 @@ type TxnData = {
 async function getRecentTransactions(txNum: number): Promise<TxnData[]> {
     try {
         // Get the latest transactions
-        // TODO sui.js to get the latest transactions meta data
         const transactions = await rpc
             .getRecentTransactions(txNum)
             .then((res: GetTxnDigestsResponse) => res);
@@ -132,6 +131,7 @@ function LatestTxCard() {
                     ...initState,
                     loadState: 'fail',
                 });
+                setIsLoaded(false);
             });
 
         return () => {

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -45,58 +45,47 @@ type TxnData = {
 async function getRecentTransactions(txNum: number): Promise<TxnData[]> {
     try {
         // Get the latest transactions
-        // TODO add batch transaction kind TransactionDigest
         // TODO sui.js to get the latest transactions meta data
-        const transactions = await rpc
+        const transactions: GetTxnDigestsResponse = await rpc
             .getRecentTransactions(txNum)
             .then((res: GetTxnDigestsResponse) => res);
 
-        const txLatest = await Promise.all(
-            transactions.map(async (tx) => {
-                const [seq, digest] = tx;
-                return await rpc
-                    .getTransactionWithEffects(digest)
-                    .then((txEff: TransactionEffectsResponse) => {
-                        const res: CertifiedTransaction = txEff.certificate;
-                        const singleTransaction = getSingleTransactionKind(
-                            res.data
+        const digests = transactions.map((tx: any[]) => tx[1]);
+        const txLatest = await rpc
+            .getTransactionWithEffectsBatch(digests)
+            .then((txEffs: TransactionEffectsResponse[]) => {
+                return txEffs.map((txEff, i) => {
+                    const [seq, digest] = transactions[i];
+                    const res: CertifiedTransaction = txEff.certificate;
+                    const singleTransaction = getSingleTransactionKind(
+                        res.data
+                    );
+                    if (!singleTransaction) {
+                        throw new Error(
+                            `Transaction kind not supported yet ${res.data.kind}`
                         );
-                        if (!singleTransaction) {
-                            throw new Error(
-                                `Transaction kind not supported yet ${res.data.kind}`
-                            );
-                        }
-                        const txKind = getTransactionKind(res.data);
-                        const recipient = getTransferTransaction(
-                            res.data
-                        )?.recipient;
+                    }
+                    const txKind = getTransactionKind(res.data);
+                    const recipient = getTransferTransaction(
+                        res.data
+                    )?.recipient;
 
-                        return {
-                            seq,
-                            txId: digest,
-                            status: getExecutionStatusType(
-                                txEff.effects.status
-                            ),
-                            txGas: getTotalGasUsed(txEff.effects.status),
-                            kind: txKind,
-                            From: res.data.sender,
-                            ...(recipient
-                                ? {
-                                      To: recipient,
-                                  }
-                                : {}),
-                        };
-                    })
-                    .catch((err) => {
-                        console.error(
-                            'Failed to get transaction details for txn digest',
-                            digest,
-                            err
-                        );
-                        return null;
-                    });
-            })
-        );
+                    return {
+                        seq,
+                        txId: digest,
+                        status: getExecutionStatusType(txEff.effects.status),
+                        txGas: getTotalGasUsed(txEff.effects.status),
+                        kind: txKind,
+                        From: res.data.sender,
+                        ...(recipient
+                            ? {
+                                  To: recipient,
+                              }
+                            : {}),
+                    };
+                });
+            });
+
         // Remove failed transactions and sort by sequence number
         return txLatest
             .filter((itm) => itm)

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -170,7 +170,6 @@ export class JsonRpcProvider extends Provider {
   }
 
   async getRecentTransactions(count: number): Promise<GetTxnDigestsResponse> {
-
     try {
       return await this.client.requestWithType(
         'sui_getRecentTransactions',

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -100,6 +100,24 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
+  async getTransactionWithEffectsBatch(
+    digests: TransactionDigest[]
+  ): Promise<TransactionEffectsResponse[]> {
+    const requests = digests.map(d => ({
+      method: 'sui_getTransaction',
+      args: [d],
+    }));
+    try {
+      return await this.client.batchRequestWithType(
+        requests,
+        isTransactionEffectsResponse
+      );
+    } catch (err) {
+      const list = digests.join(', ').substring(0, -2);
+      throw new Error(`Error getting transaction effects: ${err} for digests [${list}]`);
+    }
+  }
+
   async getTransaction(
     digest: TransactionDigest
   ): Promise<CertifiedTransaction> {
@@ -152,6 +170,7 @@ export class JsonRpcProvider extends Provider {
   }
 
   async getRecentTransactions(count: number): Promise<GetTxnDigestsResponse> {
+
     try {
       return await this.client.requestWithType(
         'sui_getRecentTransactions',


### PR DESCRIPTION
add batched calls for `sui_getTransaction`, which speeds up the homepage's list of recent transactions significantly.

works just like the batched `getObjectInfo` calls.