### PR TITLE
[GatewayAPI] - Make gas input optional in Gateway + Gateway refactoring

### DIFF
--- a/faucet/src/faucet/simple_faucet.rs
+++ b/faucet/src/faucet/simple_faucet.rs
@@ -116,7 +116,7 @@ impl SimpleFaucet {
                 signer,
                 coin_id,
                 amounts.to_vec().clone(),
-                gas_object_id,
+                Some(gas_object_id),
                 budget,
             )
             .await?;
@@ -146,7 +146,7 @@ impl SimpleFaucet {
 
         let data = context
             .gateway
-            .transfer_coin(signer, coin_id, gas_object_id, budget, recipient)
+            .transfer_coin(signer, coin_id, Some(gas_object_id), budget, recipient)
             .await?;
         let signature = context
             .keystore

--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -62,10 +62,9 @@
           }
         },
         {
-          "name": "gas_payment",
+          "name": "gas",
           "summary": "",
           "description": "",
-          "required": true,
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
@@ -166,10 +165,9 @@
           }
         },
         {
-          "name": "gas_object_id",
+          "name": "gas",
           "summary": "",
           "description": "",
-          "required": true,
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
@@ -222,10 +220,9 @@
           }
         },
         {
-          "name": "gas_object_id",
+          "name": "gas",
           "summary": "",
           "description": "",
-          "required": true,
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
@@ -289,10 +286,9 @@
           }
         },
         {
-          "name": "gas_payment",
+          "name": "gas",
           "summary": "",
           "description": "",
-          "required": true,
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
@@ -351,10 +347,9 @@
           }
         },
         {
-          "name": "gas_payment",
+          "name": "gas",
           "summary": "",
           "description": "",
-          "required": true,
           "schema": {
             "$ref": "#/components/schemas/ObjectID"
           }
@@ -899,6 +894,59 @@
       },
       "Identifier": {
         "type": "string"
+      },
+      "InputObjectKind": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "MovePackage"
+            ],
+            "properties": {
+              "MovePackage": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "ImmOrOwnedMoveObject"
+            ],
+            "properties": {
+              "ImmOrOwnedMoveObject": {
+                "type": "array",
+                "items": [
+                  {
+                    "$ref": "#/components/schemas/ObjectID"
+                  },
+                  {
+                    "$ref": "#/components/schemas/SequenceNumber"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ObjectDigest"
+                  }
+                ],
+                "maxItems": 3,
+                "minItems": 3
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "SharedMoveObject"
+            ],
+            "properties": {
+              "SharedMoveObject": {
+                "$ref": "#/components/schemas/ObjectID"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "MergeCoinResponse": {
         "type": "object",
@@ -1602,9 +1650,33 @@
       "TransactionBytes": {
         "type": "object",
         "required": [
+          "gas",
+          "input_objects",
           "tx_bytes"
         ],
         "properties": {
+          "gas": {
+            "type": "array",
+            "items": [
+              {
+                "$ref": "#/components/schemas/ObjectID"
+              },
+              {
+                "$ref": "#/components/schemas/SequenceNumber"
+              },
+              {
+                "$ref": "#/components/schemas/ObjectDigest"
+              }
+            ],
+            "maxItems": 3,
+            "minItems": 3
+          },
+          "input_objects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InputObjectKind"
+            }
+          },
           "tx_bytes": {
             "$ref": "#/components/schemas/Base64"
           }

--- a/sui/src/rpc_gateway_client.rs
+++ b/sui/src/rpc_gateway_client.rs
@@ -47,13 +47,13 @@ impl GatewayAPI for RpcGatewayClient {
         &self,
         signer: SuiAddress,
         object_id: ObjectID,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
         recipient: SuiAddress,
     ) -> Result<TransactionData, Error> {
         let bytes: TransactionBytes = self
             .client
-            .transfer_coin(signer, object_id, gas_payment, gas_budget, recipient)
+            .transfer_coin(signer, object_id, gas, gas_budget, recipient)
             .await?;
         bytes.to_data()
     }
@@ -66,19 +66,19 @@ impl GatewayAPI for RpcGatewayClient {
     async fn move_call(
         &self,
         signer: SuiAddress,
-        package_object_ref: ObjectRef,
+        package_object_id: ObjectID,
         module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
         arguments: Vec<SuiJsonValue>,
-        gas_object_ref: ObjectRef,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, Error> {
         let bytes: TransactionBytes = self
             .client
             .move_call(
                 signer,
-                package_object_ref.0,
+                package_object_id,
                 module,
                 function,
                 type_arguments
@@ -86,7 +86,7 @@ impl GatewayAPI for RpcGatewayClient {
                     .map(|tag| tag.try_into())
                     .collect::<Result<Vec<_>, _>>()?,
                 arguments,
-                gas_object_ref.0,
+                gas,
                 gas_budget,
             )
             .await?;
@@ -97,13 +97,13 @@ impl GatewayAPI for RpcGatewayClient {
         &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
-        gas_object_ref: ObjectRef,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, Error> {
         let package_bytes = package_bytes.into_iter().map(Base64).collect();
         let bytes: TransactionBytes = self
             .client
-            .publish(signer, package_bytes, gas_object_ref.0, gas_budget)
+            .publish(signer, package_bytes, gas, gas_budget)
             .await?;
         bytes.to_data()
     }
@@ -113,18 +113,12 @@ impl GatewayAPI for RpcGatewayClient {
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, Error> {
         let bytes: TransactionBytes = self
             .client
-            .split_coin(
-                signer,
-                coin_object_id,
-                split_amounts,
-                gas_payment,
-                gas_budget,
-            )
+            .split_coin(signer, coin_object_id, split_amounts, gas, gas_budget)
             .await?;
         bytes.to_data()
     }
@@ -134,12 +128,12 @@ impl GatewayAPI for RpcGatewayClient {
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, Error> {
         let bytes: TransactionBytes = self
             .client
-            .merge_coin(signer, primary_coin, coin_to_merge, gas_payment, gas_budget)
+            .merge_coin(signer, primary_coin, coin_to_merge, gas, gas_budget)
             .await?;
         bytes.to_data()
     }

--- a/sui/src/unit_tests/rpc_server_tests.rs
+++ b/sui/src/unit_tests/rpc_server_tests.rs
@@ -72,7 +72,7 @@ async fn test_transfer_coin() -> Result<(), anyhow::Error> {
         .transfer_coin(
             *address,
             objects.first().unwrap().0,
-            objects.last().unwrap().0,
+            Some(objects.last().unwrap().0),
             1000,
             *address,
         )
@@ -115,7 +115,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     .collect::<Vec<_>>();
 
     let tx_data: TransactionBytes = http_client
-        .publish(*address, compiled_modules, gas.0, 10000)
+        .publish(*address, compiled_modules, Some(gas.0), 10000)
         .await?;
 
     let keystore = SuiKeystore::load_or_create(&test_network.working_dir.join("wallet.key"))?;
@@ -162,7 +162,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
             function,
             vec![],
             json_args,
-            gas.0,
+            Some(gas.0),
             1000,
         )
         .await?;
@@ -222,7 +222,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     let mut tx_responses = Vec::new();
     for (id, _, _) in &objects[..objects.len() - 1] {
         let tx_data: TransactionBytes = http_client
-            .transfer_coin(*address, *id, *gas_id, 1000, *address)
+            .transfer_coin(*address, *id, Some(*gas_id), 1000, *address)
             .await?;
 
         let keystore = SuiKeystore::load_or_create(&test_network.working_dir.join("wallet.key"))?;

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -13,9 +13,10 @@ use async_trait::async_trait;
 use futures::future;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
-use sui_adapter::adapter::resolve_and_type_check;
 use tracing::{debug, error, Instrument};
 
+use sui_adapter::adapter::resolve_and_type_check;
+use sui_types::gas_coin::GasCoin;
 use sui_types::{
     base_types::*,
     coin,
@@ -121,7 +122,7 @@ pub trait GatewayAPI {
         &self,
         signer: SuiAddress,
         object_id: ObjectID,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
         recipient: SuiAddress,
     ) -> Result<TransactionData, anyhow::Error>;
@@ -135,12 +136,12 @@ pub trait GatewayAPI {
     async fn move_call(
         &self,
         signer: SuiAddress,
-        package_object_ref: ObjectRef,
+        package_object_id: ObjectID,
         module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
         arguments: Vec<SuiJsonValue>,
-        gas_object_ref: ObjectRef,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error>;
 
@@ -149,7 +150,7 @@ pub trait GatewayAPI {
         &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
-        gas_object_ref: ObjectRef,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error>;
 
@@ -164,7 +165,7 @@ pub trait GatewayAPI {
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error>;
 
@@ -181,7 +182,7 @@ pub trait GatewayAPI {
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error>;
 
@@ -233,14 +234,20 @@ where
     }
 
     async fn get_object(&self, object_id: &ObjectID) -> SuiResult<Object> {
-        let object = self
-            .store
-            .get_object(object_id)?
-            .ok_or(SuiError::ObjectNotFound {
-                object_id: *object_id,
-            })?;
-        debug!(?object_id, ?object, "Fetched object from local store");
-        Ok(object)
+        Ok(if let Some(object) = self.store.get_object(object_id)? {
+            debug!(?object_id, ?object, "Fetched object from local store");
+            object
+        } else {
+            let object = self
+                .get_object_info(*object_id)
+                .await
+                .map_err(|_| SuiError::ObjectNotFound {
+                    object_id: *object_id,
+                })?
+                .into_object()?;
+            debug!(?object_id, ?object, "Fetched object from validators");
+            object
+        })
     }
 
     async fn set_transaction_lock(
@@ -583,6 +590,45 @@ where
         }
     }
 
+    async fn choose_gas_for_address(
+        &self,
+        address: SuiAddress,
+        budget: u64,
+        gas: Option<ObjectID>,
+        used_coins: Vec<ObjectID>,
+    ) -> Result<ObjectRef, anyhow::Error> {
+        if let Some(id) = gas {
+            Ok(self.get_object(&id).await?.compute_object_reference())
+        } else {
+            let used_coins = used_coins.into_iter().collect::<BTreeSet<_>>();
+            for (id, balance) in self.get_owned_coins(address).await.unwrap() {
+                if balance >= budget && !used_coins.contains(&id.0) {
+                    return Ok(id);
+                }
+            }
+            return Err(anyhow!(
+                "No non-argument gas objects found with value >= budget {}",
+                budget
+            ));
+        }
+    }
+
+    // TODO: expose this in GatewayAPI?
+    async fn get_owned_coins(
+        &self,
+        address: SuiAddress,
+    ) -> Result<Vec<(ObjectRef, u64)>, anyhow::Error> {
+        let mut coins = Vec::new();
+        for (id, _, _) in self.store.get_account_objects(address)? {
+            let object = self.get_object(&id).await?;
+            if matches!(object.data.type_(), Some(ty)  if *ty == GasCoin::type_()) {
+                let gas_coin = GasCoin::try_from(object.data.try_as_move().unwrap())?;
+                coins.push((object.compute_object_reference(), gas_coin.value()));
+            }
+        }
+        Ok(coins)
+    }
+
     #[cfg(test)]
     pub fn highest_known_version(&self, object_id: &ObjectID) -> Result<SequenceNumber, SuiError> {
         self.latest_object_ref(object_id)
@@ -689,24 +735,17 @@ where
         &self,
         signer: SuiAddress,
         object_id: ObjectID,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
         recipient: SuiAddress,
     ) -> Result<TransactionData, anyhow::Error> {
-        // TODO: We should be passing in object_ref directly instead of object_id.
+        let gas_payment = self
+            .choose_gas_for_address(signer, gas_budget, gas, vec![object_id])
+            .await?;
         let object = self.get_object(&object_id).await?;
         let object_ref = object.compute_object_reference();
-        let gas_payment = self.get_object(&gas_payment).await?;
-        let gas_payment_ref = gas_payment.compute_object_reference();
-
-        let data = TransactionData::new_transfer(
-            recipient,
-            object_ref,
-            signer,
-            gas_payment_ref,
-            gas_budget,
-        );
-
+        let data =
+            TransactionData::new_transfer(recipient, object_ref, signer, gas_payment, gas_budget);
         Ok(data)
     }
 
@@ -736,15 +775,16 @@ where
     async fn move_call(
         &self,
         signer: SuiAddress,
-        package_object_ref: ObjectRef,
+        package_object_id: ObjectID,
         module: Identifier,
         function: Identifier,
         type_arguments: Vec<TypeTag>,
         arguments: Vec<SuiJsonValue>,
-        gas_object_ref: ObjectRef,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error> {
-        let package_obj = self.get_object(&package_object_ref.0).await?;
+        let package_obj = self.get_object(&package_object_id).await?;
+        let package_obj_ref = package_obj.compute_object_reference();
         let json_args =
             resolve_move_function_args(&package_obj, module.clone(), function.clone(), arguments)?;
 
@@ -768,6 +808,11 @@ where
             })
         }
 
+        let forbidden_gas_objects = objects.keys().copied().collect();
+        let gas = self
+            .choose_gas_for_address(signer, gas_budget, gas, forbidden_gas_objects)
+            .await?;
+
         // Pass in the objects for a deeper check
         let compiled_module = package_obj
             .data
@@ -784,11 +829,11 @@ where
 
         let data = TransactionData::new_move_call(
             signer,
-            package_object_ref,
+            package_obj_ref,
             module,
             function,
             type_arguments,
-            gas_object_ref,
+            gas,
             args,
             gas_budget,
         );
@@ -801,10 +846,13 @@ where
         &self,
         signer: SuiAddress,
         package_bytes: Vec<Vec<u8>>,
-        gas_object_ref: ObjectRef,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error> {
-        let data = TransactionData::new_module(signer, gas_object_ref, package_bytes, gas_budget);
+        let gas = self
+            .choose_gas_for_address(signer, gas_budget, gas, vec![])
+            .await?;
+        let data = TransactionData::new_module(signer, gas, package_bytes, gas_budget);
         Ok(data)
     }
 
@@ -813,23 +861,22 @@ where
         signer: SuiAddress,
         coin_object_id: ObjectID,
         split_amounts: Vec<u64>,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error> {
-        // TODO: We should be passing in object_refs directly instead of object_ids.
+        let gas = self
+            .choose_gas_for_address(signer, gas_budget, gas, vec![coin_object_id])
+            .await?;
         let coin_object = self.get_object(&coin_object_id).await?;
         let coin_object_ref = coin_object.compute_object_reference();
-        let gas_payment = self.get_object(&gas_payment).await?;
-        let gas_payment_ref = gas_payment.compute_object_reference();
         let coin_type = coin_object.get_move_template_type()?;
-
         let data = TransactionData::new_move_call(
             signer,
             self.get_framework_object_ref().await?,
             coin::COIN_MODULE_NAME.to_owned(),
             coin::COIN_SPLIT_VEC_FUNC_NAME.to_owned(),
             vec![coin_type],
-            gas_payment_ref,
+            gas,
             vec![
                 CallArg::ImmOrOwnedObject(coin_object_ref),
                 CallArg::Pure(bcs::to_bytes(&split_amounts)?),
@@ -845,26 +892,25 @@ where
         signer: SuiAddress,
         primary_coin: ObjectID,
         coin_to_merge: ObjectID,
-        gas_payment: ObjectID,
+        gas: Option<ObjectID>,
         gas_budget: u64,
     ) -> Result<TransactionData, anyhow::Error> {
-        // TODO: We should be passing in object_refs directly instead of object_ids.
+        let gas = self
+            .choose_gas_for_address(signer, gas_budget, gas, vec![coin_to_merge, primary_coin])
+            .await?;
         let primary_coin = self.get_object(&primary_coin).await?;
         let primary_coin_ref = primary_coin.compute_object_reference();
         let coin_to_merge = self.get_object(&coin_to_merge).await?;
         let coin_to_merge_ref = coin_to_merge.compute_object_reference();
-        let gas_payment = self.get_object(&gas_payment).await?;
-        let gas_payment_ref = gas_payment.compute_object_reference();
 
         let coin_type = coin_to_merge.get_move_template_type()?;
-
         let data = TransactionData::new_move_call(
             signer,
             self.get_framework_object_ref().await?,
             coin::COIN_MODULE_NAME.to_owned(),
             coin::COIN_JOIN_FUNC_NAME.to_owned(),
             vec![coin_type],
-            gas_payment_ref,
+            gas,
             vec![
                 CallArg::ImmOrOwnedObject(primary_coin_ref),
                 CallArg::ImmOrOwnedObject(coin_to_merge_ref),

--- a/sui_core/src/gateway_state.rs
+++ b/sui_core/src/gateway_state.rs
@@ -613,7 +613,6 @@ where
         }
     }
 
-    // TODO: expose this in GatewayAPI?
     async fn get_owned_coins(
         &self,
         address: SuiAddress,

--- a/sui_core/src/unit_tests/gateway_state_tests.rs
+++ b/sui_core/src/unit_tests/gateway_state_tests.rs
@@ -51,7 +51,7 @@ async fn transfer_coin(
         .transfer_coin(
             signer,
             coin_object_id,
-            gas_object_id,
+            Some(gas_object_id),
             GAS_VALUE_FOR_TESTING,
             recipient,
         )
@@ -140,7 +140,7 @@ async fn test_publish() {
         .publish(
             addr1,
             compiled_modules,
-            gas_object.compute_object_reference(),
+            Some(gas_object.id()),
             GAS_VALUE_FOR_TESTING,
         )
         .await
@@ -174,7 +174,7 @@ async fn test_coin_split() {
             addr1,
             coin_object.id(),
             split_amounts.clone(),
-            gas_object.id(),
+            Some(gas_object.id()),
             GAS_VALUE_FOR_TESTING,
         )
         .await
@@ -231,7 +231,7 @@ async fn test_coin_split_insufficient_gas() {
             addr1,
             coin_object.id(),
             split_amounts.clone(),
-            gas_object.id(),
+            Some(gas_object.id()),
             20, /* Insufficient gas */
         )
         .await
@@ -276,7 +276,7 @@ async fn test_coin_merge() {
             addr1,
             coin_object1.id(),
             coin_object2.id(),
-            gas_object.id(),
+            Some(gas_object.id()),
             GAS_VALUE_FOR_TESTING,
         )
         .await
@@ -327,7 +327,7 @@ async fn test_recent_transactions() -> Result<(), anyhow::Error> {
     let mut digests = vec![];
     for obj_id in [object1.id(), object2.id(), object3.id()] {
         let data = gateway
-            .transfer_coin(addr1, obj_id, gas_object.id(), 50000, addr2)
+            .transfer_coin(addr1, obj_id, Some(gas_object.id()), 50000, addr2)
             .await
             .unwrap();
         let signature = key1.sign(&data.to_bytes());
@@ -371,7 +371,7 @@ async fn test_equivocation_resilient() {
             .transfer_coin(
                 addr1,
                 coin_object.id(),
-                gas_object.id(),
+                Some(gas_object.id()),
                 GAS_VALUE_FOR_TESTING,
                 recipient,
             )

--- a/sui_types/src/messages.rs
+++ b/sui_types/src/messages.rs
@@ -984,7 +984,7 @@ impl PartialEq for SignedTransactionEffects {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum InputObjectKind {
     // A Move package, must be immutable.
     MovePackage(ObjectID),


### PR DESCRIPTION
This PR moved gas selection logic from wallet to gateway, this is to remove the dependence of accessing raw `MovePackage` in `ObjectRead` in the client, this is needed to enable Gateway to return a "parsed"/structured move object data instead of bytes. It also improve performance of the wallet cli as now it don't need to retrieve the whole package object from the gateway to process the call args.

Notable Changes:
* moved coin selection to gateway 
* gas is now optional, the gateway will choose one from the signer's possession (feature migrated from wallet)
* transaction creation endpoints (sui_transferCoin, sui_moveCall etc) now accepts ObjectID instead of reference. To make sure the client know which version of the object they are using, the TransactionByte response now contains the gas object ref and input objects for client to verify the object and version used are correct.
* Refactoring to make naming consistent in GatewayAPI