### PR TITLE
Add rustdoc output to Contribute to Sui

### DIFF
--- a/doc/src/contribute/index.md
+++ b/doc/src/contribute/index.md
@@ -36,7 +36,7 @@ at [Install Sui](../build/install.md#source-code).
 
 And see the Rust [Crates](https://doc.rust-lang.org/rust-by-example/crates.html) in use at:
 * https://mystenlabs.github.io/sui/ - the Sui blockchain
-* https://mystenlabs.github.io/narwhal/ - The Narwhal and Tusk consensus engine
+* https://mystenlabs.github.io/narwhal/ - the Narwhal and Tusk consensus engine
 * https://mystenlabs.github.io/mysten-infra/ - Mysten Labs infrastructure
 
 ## Send pull requests


### PR DESCRIPTION
Integrating work from:
https://github.com/MystenLabs/mysten-infra/pull/71
https://github.com/MystenLabs/sui/pull/1878

Into docs.sui.io Dev Portal.