### PR TITLE
remove Type field from package objects

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -268,14 +268,12 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                     )}
                                 </div>
                             )}
-                            <div>
-                                <div>Type</div>
+                            {data.objType !== 'Move Package' && (
                                 <div>
-                                    {data.objType === 'Move Package'
-                                        ? 'Library'
-                                        : prepObjTypeValue(data.objType)}
+                                    <div>Type</div>
+                                    <div>{prepObjTypeValue(data.objType)}</div>
                                 </div>
-                            </div>
+                            )}
                             {data.objType !== 'Move Package' && (
                                 <div>
                                     <div>Owner</div>


### PR DESCRIPTION

per @sblackshear's suggestion in Slack, remove the Type field from package objects - it's not meaningful for them.

Here's what the stdlib package looks like now
<img width="655" alt="image" src="https://user-images.githubusercontent.com/14057748/167917991-b0daf002-8330-41f9-a735-390753c47f1c.png">


objects that aren't Move packages still display this correctly:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/14057748/167917727-5574bd8e-efcf-4b78-a43b-f1583b23dcdc.png">



to test, visit https://explorer.devnet.sui.io/objects/0000000000000000000000000000000000000002 