### PR TITLE
remove 'ID' from Last Transaction label

### DIFF
--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -181,7 +181,7 @@ describe('End-to-end Tests', () => {
             expect(value.trim()).toBe(objectID);
 
             //Go back to Transaction
-            const lastTransactionLink = await page.$('#lasttxID > a');
+            const lastTransactionLink = await page.$('#lasttx > a');
             await lastTransactionLink.click();
             const el2 = await page.$('#transactionID');
             const value2 = await page.evaluate((x: any) => x.textContent, el2);

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -233,8 +233,8 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             </div>
                             {data.data?.tx_digest && (
                                 <div>
-                                    <div>Last Transaction ID</div>
-                                    <div id="lasttxID">
+                                    <div>Last Transaction</div>
+                                    <div id="lasttx">
                                         <Longtext
                                             text={data.data?.tx_digest}
                                             category="transactions"


### PR DESCRIPTION
The label fits & reads better without "ID" - i think users understand that the hash text is an identifier implicitly.

screenshot comparison:

## 650px width

### now
<img width="632" alt="image" src="https://user-images.githubusercontent.com/14057748/167920554-17ddb883-e622-4b26-8869-fd553815b40c.png">


### previously
<img width="636" alt="image" src="https://user-images.githubusercontent.com/14057748/167920816-f8af456a-914b-4ebd-a07c-4f85b29dfedb.png">

