### PR TITLE
Support Transfer coin and pays with same coin

### DIFF
--- a/doc/src/build/wallet.md
+++ b/doc/src/build/wallet.md
@@ -19,16 +19,16 @@ connect the wallet  client to the DevNet, run the following command:
 ```shell
 $ wallet
 ```
-The wallet will print the following line if the wallet is starting up the 
+The wallet will print the following line if the wallet is starting up the
 first time.
 ```shell
 Config file ["/Users/dir/.sui/sui_config/wallet.conf"] doesn't exist, do you want to connect to a Sui Gateway [y/n]?
 ```
 Type 'y' and then press 'Enter'. You should see the following output:
 ```shell
-Sui Gateway Url (Default to Sui DevNet if not specified) : 
+Sui Gateway Url (Default to Sui DevNet if not specified) :
 ```
-The wallet will prompt for the Gateway URL, press 'Enter' and it will default to the DevNet, 
+The wallet will prompt for the Gateway URL, press 'Enter' and it will default to the DevNet,
 or enter the URL if you want to connect to a Gateway hosted elsewhere.
 
 If you have used the wallet before with a local network, follow the next section to
@@ -360,12 +360,12 @@ When not specified, the active address is used.
 
 ```
 sui>-$ objects
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x0b8a4620426e526fa42995cf26eb610bfe6bf063 |     0      | o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221
 
 sui>-$ objects --address 0x913cf36f370613ed131868ac6f9da2420166062e
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x0b8a4620426e526fa42995cf26eb610bfe6bf063 |     0      | o#6ea7e2d4bf47b3cc219fdc44bf15530244d3b3d1838d59586c0bb41d3db92221
 ```
@@ -477,7 +477,7 @@ $ wallet objects --address 0x66af3898e7558b79e115ab61184a958497d1905a
 The result should resemble the following, which shows the object in the format of (`object_id`, `sequence_number`, `object_hash`).
 
 ```shell
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x00a0a5211f6edcf4ba09d23b8a7250072be1edb6 |     0      | o#fbb33b6524d4a648fd5fff8dc93f3d6858945959b710a0893c2b86504b38f731
  0x054c8263c73abd697a0f5aa8990d6d7668ce3d0d |     0      | o#cb99c4b8bb83a0b0111583cd2671f27d6eaeb89f89fd7ae822dc335f1a09e187
@@ -570,7 +570,7 @@ If you inspect a newly created account, you would expect the account does not ow
 
 ```shell
 $ wallet objects --address 0xc72cf3adcc4d11c03079cef2c8992aea5268677a
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
 Showing 0 results.
 ```
@@ -591,8 +591,8 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-        --gas <gas>                             ID of the coin object for gas payment, in 20 bytes Hex string If not provided, a coin
-                                                object with at least gas_budget value will be selected
+        --gas <gas>                             ID of the gas object for gas payment, in 20 bytes Hex string. If not provided, gas will
+                                                be deducted from the to-be-transferred coin itself
         --gas-budget <gas-budget>               Gas budget for this transfer
         --coin-object-id <coin-object-id>       Coin to transfer, in 20 bytes Hex string
         --to <to>                               Recipient address
@@ -600,8 +600,8 @@ OPTIONS:
 
 To transfer a coin object to a recipient, you will need the recipient's address,
 the object ID of the coin that you want to transfer,
-and optionally the coin object ID for the transaction fee payment. If a gas 
-coin is not specified, one that meets the budget is picked. Gas budget sets a
+and optionally the coin object ID for the transaction fee payment. If a gas
+coin is not specified, gas will be deducted from the to-be-transferred coin itself. Gas budget sets a
 cap for how much gas you want to spend. We are still finalizing our gas metering
 mechanisms. For now, just set something large enough.
 
@@ -617,16 +617,14 @@ With output like:
 Transfer confirmed after 4412 us
 ----- Certificate ----
 Signed Authorities : [k#21d89c3a12409b7aeadf36a9753417ead5fa9ea607ccb666e83b739b8a73c5e8, k#8d86bef2f8ae835d4763c9a697ad5c458130907996d59adc4ea5be37f2e0fab2, k#f9664056f3cc46b03e86beeb3febf99af1c9ec3f6aa709a1dbd101c9e9a79c3a]
+Gas Object ID : 0xda2237a9890bccebeeeae0d23ec739f00d2ce2b1
 Transaction Kind : Transfer
 Recipient : 0xc72cf3adcc4d11c03079cef2c8992aea5268677a
 Object ID : 0xda2237a9890bccebeeeae0d23ec739f00d2ce2b1
-Sequence Number : SequenceNumber(0)
-Object Digest : db58b72bd45fb8331558a01baec42ad1575c5870bee882be5bae29c91856fe74
 
 ----- Transaction Effects ----
 Status : Success { gas_used: 18, results: [] }
 Mutated Objects:
-0x00a0a5211f6edcf4ba09d23b8a7250072be1edb6 SequenceNumber(1) o#0a4be8bae4e4ea4d8e3a9f5d4ff8533aa36bff247238ab668edc1e5369843c64
 0xda2237a9890bccebeeeae0d23ec739f00d2ce2b1 SequenceNumber(1) o#f77edd77f5c154a850078b81b320870890bbb4f06d18f80fd512b1cc26bc3297
 ```
 
@@ -634,7 +632,7 @@ The account will now have one object:
 
 ```shell
 $ wallet objects --address 0xc72cf3adcc4d11c03079cef2c8992aea5268677a
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0xda2237a9890bccebeeeae0d23ec739f00d2ce2b1 |     0      | o#f77edd77f5c154a850078b81b320870890bbb4f06d18f80fd512b1cc26bc3297
 ```
@@ -721,7 +719,7 @@ $ wallet objects --address 0xef999dbdb19ccca504eef5432cec69ea8a1d4a1b
 And its output:
 
 ```
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x149a3493c97fafc696526052fe08e77043d4be0b |     0      | o#2d50f098c913e1863ece507dcdcd5a291252f6c1df89ec8f16c62b542ac723b5
  0x1b19f74ad77a95d7562432f6991ac9ec1ea2c57c |     0      | o#d390dc554759f892a714b2659046f3f47830cd789b3ec1df9d40bd876c3e1352
@@ -786,7 +784,7 @@ $ wallet objects --address 0x45cda12e3bafe3017b4b3cd62c493e5fbaad7fb0
 
 With output resembling:
 
-```                 Object ID                  |  Version   |                                Digest                               
+```                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x13347bd461e8a2b9ee5de7f6131063a3050a45c4 |     0      | o#4ca351cbf507cac8162cb8278a38c1c9cdf4c6d2be05f2bee405da02ce8a4aa1
  0xb402f52ba6216a770939e6d4922ae6d6d05c2256 |     0      | o#b95d120c36fab571c2389bccf507530a39e0055cdd9e9793aaf4ef691b1b8c96
@@ -826,7 +824,7 @@ New Coins : Coin { id: 0x72129fbf3168c37a4dd8ec7ee69da28d0d4d4636, value: 5000 }
 Updated Gas : Coin { id: 0xb402f52ba6216a770939e6d4922ae6d6d05c2256, value: 99780 }
 
 $ wallet objects --address 0x45cda12e3bafe3017b4b3cd62c493e5fbaad7fb0
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x13347bd461e8a2b9ee5de7f6131063a3050a45c4 |     1      | o#4f86a454ed9aa482adcbfece78cdd77d491d4e768aa8034af78a237d18e09f9f
  0x72129fbf3168c37a4dd8ec7ee69da28d0d4d4636 |     1      | o#247905d1c8eee09b4d3bd02f4229376cd7482705e28ef7ff4ca86774d09c72b8
@@ -864,7 +862,7 @@ Let us examine objects owned by address `0xae6fb6036570fec1df71599740c132cdf5b45
 
 ```shell
 $ wallet objects --address ae6fb6036570fec1df71599740c132cdf5b45b9d
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x5044dc15d3c71d500116eb026e8b70d0a180f3ac |     0      | o#748fabf1f7f92c8d00b54f5b431fd4e28d9dfd642cc0bc5c48b16dc0efdc58c1
  0x749e3ee0e0ac93bfc06ed58972efe87717a428da |     0      | o#05efb7971ec89b78fd512913fb6f9bfbd0b5ffd2e99775493f9703ff153b3998
@@ -946,7 +944,7 @@ the sender:
 
 ```shell
 $ wallet objects --address 0xae6fb6036570fec1df71599740c132cdf5b45b9d
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x749e3ee0e0ac93bfc06ed58972efe87717a428da |     0      | o#05efb7971ec89b78fd512913fb6f9bfbd0b5ffd2e99775493f9703ff153b3998
  0x98765d1cbc66bdfc443aa60b614427470b266b28 |     0      | o#5f1696a263b9c97ba2e50175db0af1052a70943148b697fca98f98781482eba5
@@ -999,7 +997,7 @@ $ wallet objects --address 0xae6fb6036570fec1df71599740c132cdf5b45b9d
 Outputting:
 
 ```
-                 Object ID                  |  Version   |                                Digest                               
+                 Object ID                  |  Version   |                                Digest
 ------------------------------------------------------------------------------------------------------------------------------
  0x749e3ee0e0ac93bfc06ed58972efe87717a428da |     0      | o#05efb7971ec89b78fd512913fb6f9bfbd0b5ffd2e99775493f9703ff153b3998
  0x98765d1cbc66bdfc443aa60b614427470b266b28 |     0      | o#5f1696a263b9c97ba2e50175db0af1052a70943148b697fca98f98781482eba5

--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -2070,12 +2070,15 @@
       "TransferCoin": {
         "type": "object",
         "required": [
-          "object_ref",
           "recipient"
         ],
         "properties": {
           "object_ref": {
-            "type": "array",
+            "description": "The coin object to be transferred. If it's None, the gas object will be transferred. This cannot be None when in a batch transaction.",
+            "type": [
+              "array",
+              "null"
+            ],
             "items": [
               {
                 "$ref": "#/components/schemas/ObjectID"

--- a/sui/src/benchmark/transaction_creator.rs
+++ b/sui/src/benchmark/transaction_creator.rs
@@ -43,7 +43,7 @@ fn make_transfer_transaction(
     } else {
         SingleTransactionKind::TransferCoin(TransferCoin {
             recipient,
-            object_ref,
+            object_ref: Some(object_ref),
         })
     }
 }

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -143,8 +143,8 @@ pub enum WalletCommands {
         #[clap(long)]
         coin_object_id: ObjectID,
 
-        /// ID of the gas object for gas payment, in 20 bytes Hex string
-        /// If not provided, a gas object with at least gas_budget value will be selected
+        /// ID of the gas object for gas payment, in 20 bytes Hex string.
+        /// If not provided, gas will be deducted from the to-be-transferred coin itself.
         #[clap(long)]
         gas: Option<ObjectID>,
 

--- a/sui_core/src/unit_tests/batch_transaction_tests.rs
+++ b/sui_core/src/unit_tests/batch_transaction_tests.rs
@@ -31,11 +31,13 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
     for obj_id in all_ids.iter().take(N) {
         transactions.push(SingleTransactionKind::TransferCoin(TransferCoin {
             recipient,
-            object_ref: authority_state
-                .get_object(obj_id)
-                .await?
-                .unwrap()
-                .compute_object_reference(),
+            object_ref: Some(
+                authority_state
+                    .get_object(obj_id)
+                    .await?
+                    .unwrap()
+                    .compute_object_reference(),
+            ),
         }));
     }
     let genesis_package_objects = genesis::clone_genesis_packages();
@@ -101,11 +103,13 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
     for obj_id in all_ids.iter().take(N) {
         transactions.push(SingleTransactionKind::TransferCoin(TransferCoin {
             recipient,
-            object_ref: authority_state
-                .get_object(obj_id)
-                .await?
-                .unwrap()
-                .compute_object_reference(),
+            object_ref: Some(
+                authority_state
+                    .get_object(obj_id)
+                    .await?
+                    .unwrap()
+                    .compute_object_reference(),
+            ),
         }));
     }
     let genesis_package_objects = genesis::clone_genesis_packages();

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -611,10 +611,11 @@ TransferCoin:
     - recipient:
         TYPENAME: SuiAddress
     - object_ref:
-        TUPLE:
-          - TYPENAME: ObjectID
-          - TYPENAME: SequenceNumber
-          - TYPENAME: ObjectDigest
+        OPTION:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
 TypeTag:
   ENUM:
     0:


### PR DESCRIPTION
This PR adds the ability to transfer a coin object and also pays gas with the same object.
Specifically it does the following:
1. In wallet, when gas is not specified, it will automatically pay with the transfer object, instead of trying to pick a gas object. We will need to update docs to reflect this.
2. The object_ref field in TransferCoin transaction kind is now option, and when it's none, we will be transferring the gas object.
3. Make sure that this type of transfer can not happen in a batch transaction
4. Added the ability to deduct and change owner of the gas object at the same time
5. Added a test.
6. Updated docs.