### PR TITLE
lint: ban lazy_static crate as a direct dependency

### DIFF
--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -7,7 +7,7 @@ use nexlint_lints::{
     content::*,
     handle_lint_results,
     package::*,
-    project::{DirectDepDups, DirectDepDupsConfig},
+    project::{BannedDeps, BannedDepsConfig, DirectDepDups, DirectDepDupsConfig},
 };
 
 static LICENSE_HEADER: &str = "Copyright (c) 2022, Mysten Labs, Inc.\n\
@@ -21,7 +21,18 @@ pub struct Args {
 
 pub fn run(args: Args) -> crate::Result<()> {
     let direct_dups_config = DirectDepDupsConfig { allow: vec![] };
-    let project_linters: &[&dyn ProjectLinter] = &[&DirectDepDups::new(&direct_dups_config)];
+    let banned_deps_config = BannedDepsConfig {
+        direct: vec![(
+            "lazy_static".to_owned(),
+            "use once_cell::sync::Lazy instead".to_owned(),
+        )]
+        .into_iter()
+        .collect(),
+    };
+    let project_linters: &[&dyn ProjectLinter] = &[
+        &DirectDepDups::new(&direct_dups_config),
+        &BannedDeps::new(&banned_deps_config),
+    ];
 
     let package_linters: &[&dyn PackageLinter] = &[
         // &CrateNamesPaths,


### PR DESCRIPTION
This adds a lint to ban the `lazy_static` crate as a direct dependency and instead suggests that you use `once_cell::sync::Lazy`.

I've been building up these lints slowly. at some point i'll need to create a uniform config that can be used across all our repos.