### PR TITLE
consensus: create new config for each authority

### DIFF
--- a/sui/src/sui_commands.rs
+++ b/sui/src/sui_commands.rs
@@ -320,7 +320,6 @@ impl SuiNetwork {
         );
 
         let consensus_committee = make_default_narwhal_committee(&config.authorities)?;
-        let consensus_parameters = ConsensusParameters::default();
 
         // Pass in the newtwork parameters of all authorities
         let net = config.get_authority_infos();
@@ -328,6 +327,7 @@ impl SuiNetwork {
         let mut spawned_authorities = Vec::new();
 
         for authority in &config.authorities {
+            let consensus_parameters = ConsensusParameters::default();
             let key_pair = key_pairs.get(&authority.public_key).unwrap_or_else(|| {
                 panic!(
                     "Can't find key pair for authority {:?}",

--- a/test_utils/src/authority.rs
+++ b/test_utils/src/authority.rs
@@ -91,17 +91,17 @@ where
 {
     let states = test_authority_states(objects).await;
     let consensus_committee = make_default_narwhal_committee(authorities).unwrap();
-    let consensus_parameters = ConsensusParameters {
-        max_header_delay: std::time::Duration::from_millis(200),
-        header_size: 1,
-        ..ConsensusParameters::default()
-    };
     let mut handles = Vec::new();
     for ((state, config), key_pair) in states
         .into_iter()
         .zip(authorities.iter())
         .zip(key_pairs.iter())
     {
+        let consensus_parameters = ConsensusParameters {
+            max_header_delay: std::time::Duration::from_millis(200),
+            header_size: 1,
+            ..ConsensusParameters::default()
+        };
         let handle = make_authority(
             /* authority */ config,
             key_pair,


### PR DESCRIPTION
Create a new Narwhal configuration for each authority we want to start
in order to avoid binding to the exact same ports. Eventaully we'll want
this config to be a part of a larger ValidatorConfig.