### PR TITLE
Transfer becomes TransferCoin in typescript type check

### DIFF
--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn install; yarn build
       - name: Install yarn dependencies
         working-directory: ./explorer/client
-        run: yarn install
+        run: yarn install --force
       - name: Lint
         working-directory: ./explorer/client
         run: yarn lint

--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -173,7 +173,7 @@ describe('End-to-end Tests', () => {
 
             //Go to Object
             const objectLink = await page.$(
-                'div#txview > div:nth-child(4) > div:nth-child(2)'
+                'div#txview > div:nth-child(5) > div:nth-child(2) > ul > li:first-child > a'
             );
             await objectLink.click();
             const el = await page.$('#objectID');

--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -173,7 +173,7 @@ describe('End-to-end Tests', () => {
 
             //Go to Object
             const objectLink = await page.$(
-                'div#txview > div:nth-child(5) > div:nth-child(2) > ul > li:first-child > a'
+                'div#txview > div:nth-child(4) > div:nth-child(2)'
             );
             await objectLink.click();
             const el = await page.$('#objectID');

--- a/explorer/client/src/pages/transaction-result/TransactionResult.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionResult.tsx
@@ -45,7 +45,7 @@ const initState: TxnState = {
     data: {
         kind: {
             Single: {
-                Transfer: {
+                TransferCoin: {
                     recipient: '',
                     object_ref: ['', 0, ''],
                 },

--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -112,7 +112,7 @@ function formatByTransactionKind(
     data: TransactionData
 ) {
     switch (kind) {
-        case 'Transfer':
+        case 'TransferCoin':
             const transfer = getTransferTransaction(data)!;
             return [
                 {

--- a/explorer/client/src/utils/static/mock_data.json
+++ b/explorer/client/src/utils/static/mock_data.json
@@ -861,7 +861,7 @@
                 "data": {
                     "kind": {
                         "Single": {
-                            "Transfer": {
+                            "TransferCoin": {
                                 "recipient": "receiverAddress",
                                 "object_ref": [
                                     "7bc832ec31709638cd8d9323e90edf332gff4389",
@@ -961,7 +961,7 @@
                 "data": {
                     "kind": {
                         "Single": {
-                            "Transfer": {
+                            "TransferCoin": {
                                 "recipient": "receiverAddress",
                                 "object_ref": [
                                     "7bc832ec31709638cd8d9323e90edf332gff4389",

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -279,8 +279,7 @@ export function isRawAuthoritySignInfo(obj: any, _argumentName?: string): obj is
 
 export function isTransactionKindName(obj: any, _argumentName?: string): obj is TransactionKindName {
     return (
-        (obj === "Transfer" ||
-            obj === "TransferCoin" ||
+        (obj === "TransferCoin" ||
             obj === "Publish" ||
             obj === "Call")
     )
@@ -292,10 +291,6 @@ export function isSingleTransactionKind(obj: any, _argumentName?: string): obj i
             typeof obj === "object" ||
             typeof obj === "function") &&
             isTransferCoin(obj.TransferCoin) as boolean ||
-            (obj !== null &&
-                typeof obj === "object" ||
-                typeof obj === "function") &&
-            isTransferCoin(obj.Transfer) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, TransferCoinTransaction, TxnDataSerializer, TransactionDigest, SuiAddress, ObjectOwner, ObjectRef, ObjectContentField, ObjectContentFields, ObjectContent, MovePackageContent, SuiObject, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, ObjectType, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, Transfer, RawAuthoritySignInfo, TransactionKindName, SingleTransactionKind, TransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, ExecutionStatusDetail, OwnedObjectRef, TransactionEffects, TransactionEffectsResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, Event, StructTag, MoveTypeTag, MoveCall, MoveCallArg, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, TransactionResponse, SignedTransaction } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, TransferCoinTransaction, TxnDataSerializer, TransactionDigest, SuiAddress, ObjectOwner, ObjectRef, ObjectContentField, ObjectContentFields, ObjectContent, MovePackageContent, SuiObject, ObjectExistsInfo, ObjectNotExistsInfo, ObjectStatus, ObjectType, GetOwnedObjectRefsResponse, GetObjectInfoResponse, ObjectDigest, ObjectId, SequenceNumber, RawObjectRef, TransferCoin, RawAuthoritySignInfo, TransactionKindName, SingleTransactionKind, TransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, ExecutionStatusDetail, OwnedObjectRef, TransactionEffects, TransactionEffectsResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveModulePublish, Event, StructTag, MoveTypeTag, MoveCall, MoveCallArg, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, TransactionResponse, SignedTransaction } from "./index";
 import { BN } from "bn.js";
 
 export function isEd25519KeypairData(obj: any, _argumentName?: string): obj is Ed25519KeypairData {
@@ -259,7 +259,7 @@ export function isRawObjectRef(obj: any, _argumentName?: string): obj is RawObje
     )
 }
 
-export function isTransfer(obj: any, _argumentName?: string): obj is Transfer {
+export function isTransferCoin(obj: any, _argumentName?: string): obj is TransferCoin {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -280,6 +280,7 @@ export function isRawAuthoritySignInfo(obj: any, _argumentName?: string): obj is
 export function isTransactionKindName(obj: any, _argumentName?: string): obj is TransactionKindName {
     return (
         (obj === "Transfer" ||
+            obj === "TransferCoin" ||
             obj === "Publish" ||
             obj === "Call")
     )
@@ -290,7 +291,11 @@ export function isSingleTransactionKind(obj: any, _argumentName?: string): obj i
         ((obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
-            isTransfer(obj.Transfer) as boolean ||
+            isTransferCoin(obj.TransferCoin) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isTransferCoin(obj.Transfer) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -148,9 +148,7 @@ export function getTransferTransaction(
   data: TransactionData
 ): TransferCoin | undefined {
   const tx = getSingleTransactionKind(data);
-  if (!tx) return undefined;
-  if ('TransferCoin' in tx) return tx.TransferCoin;
-  return undefined;
+  return tx && 'TransferCoin' in tx ? tx.TransferCoin : undefined;
 }
 
 export function getPublishTransaction(

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -4,15 +4,16 @@
 import { ObjectOwner, SuiAddress, TransactionDigest } from './common';
 import { ObjectId, RawObjectRef } from './objects';
 
-export type Transfer = {
+export type TransferCoin = {
   recipient: string;
   object_ref: RawObjectRef;
 };
 export type RawAuthoritySignInfo = [AuthorityName, AuthoritySignature];
 
-export type TransactionKindName = 'Transfer' | 'Publish' | 'Call';
+export type TransactionKindName = 'Transfer' | 'TransferCoin' | 'Publish' | 'Call';
 export type SingleTransactionKind =
-  | { Transfer: Transfer }
+  | { TransferCoin: TransferCoin }
+  | { Transfer: TransferCoin }
   | { Publish: MoveModulePublish }
   | { Call: MoveCall };
 export type TransactionKind =
@@ -146,9 +147,12 @@ export function getSingleTransactionKind(
 
 export function getTransferTransaction(
   data: TransactionData
-): Transfer | undefined {
+): TransferCoin | undefined {
   const tx = getSingleTransactionKind(data);
-  return tx && 'Transfer' in tx ? tx.Transfer : undefined;
+  if (!tx) return undefined;
+  if ('Transfer' in tx) return tx.Transfer;
+  if ('TransferCoin' in tx) return tx.TransferCoin;
+  return undefined;
 }
 
 export function getPublishTransaction(

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -10,10 +10,9 @@ export type TransferCoin = {
 };
 export type RawAuthoritySignInfo = [AuthorityName, AuthoritySignature];
 
-export type TransactionKindName = 'Transfer' | 'TransferCoin' | 'Publish' | 'Call';
+export type TransactionKindName = 'TransferCoin' | 'Publish' | 'Call';
 export type SingleTransactionKind =
   | { TransferCoin: TransferCoin }
-  | { Transfer: TransferCoin }
   | { Publish: MoveModulePublish }
   | { Call: MoveCall };
 export type TransactionKind =
@@ -150,7 +149,6 @@ export function getTransferTransaction(
 ): TransferCoin | undefined {
   const tx = getSingleTransactionKind(data);
   if (!tx) return undefined;
-  if ('Transfer' in tx) return tx.Transfer;
   if ('TransferCoin' in tx) return tx.TransferCoin;
   return undefined;
 }


### PR DESCRIPTION
Explorer frontend broke because of this name change, this adds more flexibility to the type check.


To test, `npm start` the explorer and navigate to:
http://localhost:3000/transactions/NoDwmf3WZfUfjLugQwQ7FHq%2F6KgawS9935zND%2FhA3as%3D/?rpc=http%3A%2F%2Fade208279c6c444e5bf8b852fca5411d-1692910544.us-west-2.elb.amazonaws.com%3A9000%2F

this was previously broken.

This was also causing issues with only showing a few recent transactions on the home page, which should show 15 again.
http://localhost:3000/?rpc=http%3A%2F%2Fade208279c6c444e5bf8b852fca5411d-1692910544.us-west-2.elb.amazonaws.com%3A9000%2F