### PR TITLE
fixed seq and digest out of sync

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -52,11 +52,16 @@ async function getRecentTransactions(txNum: number): Promise<TxnData[]> {
             .then((res: GetTxnDigestsResponse) => res);
 
         const digests = transactions.map((tx) => tx[1]);
+
         const txLatest = await rpc
             .getTransactionWithEffectsBatch(digests)
             .then((txEffs: TransactionEffectsResponse[]) => {
                 return txEffs.map((txEff, i) => {
-                    const [seq, digest] = transactions[i];
+                    const [seq, digest] = transactions.filter(
+                        (transactionId) =>
+                            transactionId[1] ===
+                            txEff.effects.transaction_digest
+                    )[0];
                     const res: CertifiedTransaction = txEff.certificate;
                     const singleTransaction = getSingleTransactionKind(
                         res.data


### PR DESCRIPTION
The sequence number and the digest are out of sync `[seq, digest]` so the TxType Status and address next to the transaction ID is not accurate.

Before
<img width="969" alt="Screen Shot 2022-05-12 at 1 39 29 PM" src="https://user-images.githubusercontent.com/8676844/168135797-88a4d6c2-6d08-470e-8c54-d84e4f03ac02.png">

After
<img width="932" alt="Screen Shot 2022-05-12 at 1 39 16 PM" src="https://user-images.githubusercontent.com/8676844/168135833-8e794e0b-5755-40aa-aaac-5130bfa720db.png">
 