### PR TITLE
[store] Do not store transaction lock for shared objects

### DIFF
--- a/sui_core/src/authority.rs
+++ b/sui_core/src/authority.rs
@@ -535,8 +535,8 @@ impl AuthorityState {
             ObjectInfoRequestKind::LatestObjectInfo(request_layout) => {
                 match self.get_object(&request.object_id).await {
                     Ok(Some(object)) => {
-                        let lock = if object.is_immutable() {
-                            // Read only objects have no locks.
+                        let lock = if !object.is_owned() {
+                            // Unowned obejcts have no locks.
                             None
                         } else {
                             self.get_transaction_lock(&object.compute_object_reference())


### PR DESCRIPTION
We don't need or want to add entries in transaction locks for shared objects.
First of all we don't need it, as we only need to lock owned objects. 
Secondly when updating the store it checks that the transaction lock for every active input exists. This is problematic for the gateway when there are shared objects, because most likely the transaction lock doesn't exists since the gateway is always out of dated with shared objects.