### PR TITLE
[gateway] Allow shared objects out-of-sync

### DIFF
--- a/sui_core/src/authority_aggregator.rs
+++ b/sui_core/src/authority_aggregator.rs
@@ -1221,8 +1221,10 @@ where
         // When we get an object back, it also might not match the digest we want
         for resp in results.into_iter().flatten().flatten() {
             match resp.object_and_lock {
-                // did the response match the digest?
-                Some(o) if o.object.digest() == object_ref.2 => {
+                // Either the object is a shared object, in which case we don't care about its content
+                // because we can never keep shared objects up-to-date.
+                // Or if it's not shared object, we check if the digest matches.
+                Some(o) if o.object.is_shared() || o.object.digest() == object_ref.2 => {
                     ret_val = Ok(o.object);
                     break;
                 }

--- a/test_utils/src/objects.rs
+++ b/test_utils/src/objects.rs
@@ -7,7 +7,7 @@ use sui_types::object::{MoveObject, Object, Owner, OBJECT_START_VERSION};
 
 /// Make a few test gas objects.
 pub fn test_gas_objects() -> Vec<Object> {
-    (0..9)
+    (0..19)
         .map(|i| {
             let seed = format!("0x555555555555555{i}");
             let gas_object_id = ObjectID::from_hex_literal(&seed).unwrap();


### PR DESCRIPTION
On the gateway, there is no way to keep shared objects always up-to-date. We need to loosen the requirement that the digest of the shared objects we downloaded does not necessarily need to match with what's in the effects.
Added a test that sends ~15 transactions to increment the same counter at the same time, and confirm that it works.