### PR TITLE
[gas] Delay charging gas for object read

### DIFF
--- a/sui_core/src/unit_tests/gas_tests.rs
+++ b/sui_core/src/unit_tests/gas_tests.rs
@@ -122,10 +122,11 @@ async fn test_native_transfer_insufficient_gas_reading_objects() {
     // the minimum budget requirement, but not enough to even read the objects from db.
     // This will lead to failure in lock check step during handle transaction phase.
     let balance = *MIN_GAS_BUDGET + 1;
-    let result = execute_transfer(balance, balance, false).await;
-    let err = result.response.unwrap_err();
+    let result = execute_transfer(balance, balance, true).await;
+    // The transaction should still execute to effects, but with execution status as failure.
+    let effects = result.response.unwrap().signed_effects.unwrap().effects;
     assert_eq!(
-        err,
+        effects.status.unwrap_err().1,
         SuiError::InsufficientGas {
             error: "Ran out of gas while deducting computation cost".to_owned()
         }

--- a/sui_core/src/unit_tests/gateway_state_tests.rs
+++ b/sui_core/src/unit_tests/gateway_state_tests.rs
@@ -232,7 +232,7 @@ async fn test_coin_split_insufficient_gas() {
             coin_object.id(),
             split_amounts.clone(),
             Some(gas_object.id()),
-            20, /* Insufficient gas */
+            9, /* Insufficient gas */
         )
         .await
         .unwrap();


### PR DESCRIPTION
Currently we charge gas for object reads very early, during transaction input checking. This creates a problem when there are shared objects: we may successfully deduct gas for reading shared object during transaction handling phase, but then when we process the certificate, the shared object may have changed and become much larger, and at that point we may fail  before execution, which would leave all objects locked.
This PR delays the gas charge for object read until in the execution. This ensures that we always increment shared object version number in gas charging failures.