### PR TITLE
restore explorer search padding

### DIFF
--- a/explorer/client/src/components/search/Search.module.css
+++ b/explorer/client/src/components/search/Search.module.css
@@ -17,8 +17,10 @@ select.categorydropdown > option {
 }
 
 .searchtext {
-    @apply border-r-2 border-y-0 border-l-0 rounded-l-md 
-    font-mono leading-8 
+    @apply border-r-2 border-y-0 border-l-0 rounded-l-md
+    font-mono leading-8
     flex-1 ml-[1vw] sm:ml-[5vw] w-[5rem]
     text-xs mr-0 bg-offwhite;
+
+    padding-left: 1rem;
 }

--- a/explorer/client/src/components/search/Search.tsx
+++ b/explorer/client/src/components/search/Search.tsx
@@ -14,7 +14,7 @@ function getPlaceholderText(category: SearchCategory) {
         case 'addresses':
             return 'Search by address';
         case 'transactions':
-            return 'Search by digest';
+            return 'Search by tx ID';
         case 'objects':
         case 'all':
             return 'Search by ID';


### PR DESCRIPTION
we have tweaked this previously, but somewhere along the way a change removed the left padding from the placeholder text.

also changes transaction terminology

looks like this on main
<img width="264" alt="image" src="https://user-images.githubusercontent.com/14057748/168376136-68a5dece-e49b-470c-8804-588db836212a.png">


looks like this after adding padding here
<img width="278" alt="image" src="https://user-images.githubusercontent.com/14057748/168376183-1ac2b041-607b-46dc-aa95-e8302862edac.png">
