### PR TITLE
[gateway] Reset transaction locks upon last retry failure

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -493,7 +493,7 @@ impl<
             .insert(&object_ref, &object.previous_transaction)?;
 
         self.lock_service
-            .initialize_locks(&[object_ref], false /* force_reset */)
+            .initialize_locks(&[object_ref], false /* is_force_reset */)
             .await?;
 
         Ok(())
@@ -533,7 +533,7 @@ impl<
 
         let refs: Vec<_> = ref_and_objects.iter().map(|(oref, _)| *oref).collect();
         self.lock_service
-            .initialize_locks(&refs, false /* force_reset */)
+            .initialize_locks(&refs, false /* is_force_reset */)
             .await?;
 
         Ok(())
@@ -568,7 +568,7 @@ impl<
     /// and have to roll back.
     pub async fn reset_transaction_lock(&self, owned_input_objects: &[ObjectRef]) -> SuiResult {
         self.lock_service
-            .initialize_locks(owned_input_objects, true /* force_reset */)
+            .initialize_locks(owned_input_objects, true /* is_force_reset */)
             .await?;
         Ok(())
     }
@@ -830,7 +830,7 @@ impl<
                     })
                     .collect();
                 self.lock_service
-                    .initialize_locks(&new_locks_to_init, false /* force_reset */)
+                    .initialize_locks(&new_locks_to_init, false /* is_force_reset */)
                     .await?;
 
                 // Remove the old lock - timing of this matters less

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -559,6 +559,19 @@ impl<
         Ok(())
     }
 
+    /// This function should only be used by the gateway.
+    /// It's called when we could not get a transaction to successfully execute,
+    /// and have to roll back.
+    pub fn reset_transaction_lock(&self, owned_input_objects: &[ObjectRef]) -> SuiResult {
+        let lock_batch = self.transaction_lock.batch().insert_batch(
+            &self.transaction_lock,
+            owned_input_objects.iter().map(|obj_ref| (obj_ref, None)),
+        )?;
+
+        lock_batch.write()?;
+        Ok(())
+    }
+
     /// Updates the state resulting from the execution of a certificate.
     ///
     /// Internally it checks that all locks for active inputs are at the correct

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -492,7 +492,9 @@ impl<
         self.parent_sync
             .insert(&object_ref, &object.previous_transaction)?;
 
-        self.lock_service.initialize_locks(vec![object_ref]).await?;
+        self.lock_service
+            .initialize_locks(&[object_ref], false /* force_reset */)
+            .await?;
 
         Ok(())
     }
@@ -530,7 +532,9 @@ impl<
             .write()?;
 
         let refs: Vec<_> = ref_and_objects.iter().map(|(oref, _)| *oref).collect();
-        self.lock_service.initialize_locks(refs).await?;
+        self.lock_service
+            .initialize_locks(&refs, false /* force_reset */)
+            .await?;
 
         Ok(())
     }
@@ -562,13 +566,10 @@ impl<
     /// This function should only be used by the gateway.
     /// It's called when we could not get a transaction to successfully execute,
     /// and have to roll back.
-    pub fn reset_transaction_lock(&self, owned_input_objects: &[ObjectRef]) -> SuiResult {
-        let lock_batch = self.transaction_lock.batch().insert_batch(
-            &self.transaction_lock,
-            owned_input_objects.iter().map(|obj_ref| (obj_ref, None)),
-        )?;
-
-        lock_batch.write()?;
+    pub async fn reset_transaction_lock(&self, owned_input_objects: &[ObjectRef]) -> SuiResult {
+        self.lock_service
+            .initialize_locks(owned_input_objects, true /* force_reset */)
+            .await?;
         Ok(())
     }
 
@@ -829,7 +830,7 @@ impl<
                     })
                     .collect();
                 self.lock_service
-                    .initialize_locks(new_locks_to_init)
+                    .initialize_locks(&new_locks_to_init, false /* force_reset */)
                     .await?;
 
                 // Remove the old lock - timing of this matters less

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -508,7 +508,7 @@ where
         if exec_result.is_err() && is_last_retry {
             // If we cannot successfully execute this transaction, even after all the retries,
             // we have to give up. Here we reset all transaction locks for each input object.
-            self.store.reset_transaction_lock(&owned_objects)?;
+            self.store.reset_transaction_lock(&owned_objects).await?;
         }
         exec_result
     }

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -417,28 +417,11 @@ where
         Ok(())
     }
 
-    /// Execute (or retry) a transaction and execute the Confirmation Transaction.
-    /// Update local object states using newly created certificate and ObjectInfoResponse from the Confirmation step.
-    async fn execute_transaction_impl(
+    async fn execute_transaction_impl_inner(
         &self,
+        all_objects: Vec<(InputObjectKind, Object)>,
         transaction: Transaction,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        transaction.verify_signature()?;
-
-        self.sync_input_objects_with_authorities(&transaction)
-            .await?;
-
-        let (_gas_status, all_objects) = transaction_input_checker::check_transaction_input(
-            &self.store,
-            &transaction,
-            &self.metrics.shared_obj_tx,
-        )
-        .await?;
-
-        let owned_objects = transaction_input_checker::filter_owned_objects(&all_objects);
-        self.set_transaction_lock(&owned_objects, transaction.clone())
-            .instrument(tracing::trace_span!("db_set_transaction_lock"))
-            .await?;
         // If execute_transaction ever fails due to panic, we should fix the panic and make sure it doesn't.
         // If execute_transaction fails, we should retry the same transaction, and it will
         // properly unlock the objects used in this transaction. In the short term, we will ask the wallet to retry failed transactions.
@@ -493,6 +476,41 @@ where
             .await?;
 
         Ok((new_certificate, effects))
+    }
+
+    /// Execute (or retry) a transaction and execute the Confirmation Transaction.
+    /// Update local object states using newly created certificate and ObjectInfoResponse from the Confirmation step.
+    async fn execute_transaction_impl(
+        &self,
+        transaction: Transaction,
+        is_last_retry: bool,
+    ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
+        transaction.verify_signature()?;
+
+        self.sync_input_objects_with_authorities(&transaction)
+            .await?;
+
+        let (_gas_status, all_objects) = transaction_input_checker::check_transaction_input(
+            &self.store,
+            &transaction,
+            &self.metrics.shared_obj_tx,
+        )
+        .await?;
+
+        let owned_objects = transaction_input_checker::filter_owned_objects(&all_objects);
+        self.set_transaction_lock(&owned_objects, transaction.clone())
+            .instrument(tracing::trace_span!("db_set_transaction_lock"))
+            .await?;
+
+        let exec_result = self
+            .execute_transaction_impl_inner(all_objects, transaction)
+            .await;
+        if exec_result.is_err() && is_last_retry {
+            // If we cannot successfully execute this transaction, even after all the retries,
+            // we have to give up. Here we reset all transaction locks for each input object.
+            self.store.reset_transaction_lock(&owned_objects)?;
+        }
+        exec_result
     }
 
     async fn download_object_from_authorities(&self, object_id: ObjectID) -> SuiResult<ObjectRead> {
@@ -811,7 +829,7 @@ where
         // Use start_coarse_time() if the below turns out to have a perf impact
         let timer = self.metrics.transaction_latency.start_timer();
         let mut res = self
-            .execute_transaction_impl(tx.clone())
+            .execute_transaction_impl(tx.clone(), false)
             .instrument(span.clone())
             .await;
         // NOTE: below only records latency if this completes.
@@ -839,7 +857,7 @@ where
             );
 
             res = self
-                .execute_transaction_impl(tx.clone())
+                .execute_transaction_impl(tx.clone(), remaining_retries == 0)
                 .instrument(span.clone())
                 .await;
         }

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -37,6 +37,7 @@ enum LockServiceCommands {
     },
     Initialize {
         refs: Vec<ObjectRef>,
+        force_reset: bool,
         resp: oneshot::Sender<SuiResult>,
     },
     RemoveLocks {
@@ -184,33 +185,31 @@ impl LockServiceImpl {
 
     /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
     /// If the lock already exists and is locked to a transaction, then return TransactionLockExists
-    fn initialize_locks(&self, objects: &[ObjectRef]) -> SuiResult {
+    fn initialize_locks(&self, objects: &[ObjectRef], force_reset: bool) -> SuiResult {
         debug!(?objects, "initialize_locks");
         // Use a multiget for efficiency
         let locks = self.transaction_lock.multi_get(objects)?;
 
-        // If any locks exist and are not None, return errors for them
-        let existing_locks: Vec<ObjectRef> = locks
-            .iter()
-            .zip(objects)
-            .filter_map(|(lock_opt, objref)| lock_opt.flatten().map(|_tx_digest| *objref))
-            .collect();
-        if !existing_locks.is_empty() {
-            info!(
-                ?existing_locks,
-                "Cannot initialize locks because some exist already"
-            );
-            return Err(SuiError::TransactionLockExists {
-                refs: existing_locks,
-            });
+        if !force_reset {
+            // If any locks exist and are not None, return errors for them
+            let existing_locks: Vec<ObjectRef> = locks
+                .iter()
+                .zip(objects)
+                .filter_map(|(lock_opt, objref)| lock_opt.flatten().map(|_tx_digest| *objref))
+                .collect();
+            if !existing_locks.is_empty() {
+                info!(
+                    ?existing_locks,
+                    "Cannot initialize locks because some exist already"
+                );
+                return Err(SuiError::TransactionLockExists {
+                    refs: existing_locks,
+                });
+            }
         }
 
-        // Insert where locks don't exist already
-        let refs_to_insert = locks
-            .iter()
-            .zip(objects)
-            .filter_map(|(lock_opt, objref)| lock_opt.is_none().then(|| (objref, None)));
-        self.transaction_lock.multi_insert(refs_to_insert)?;
+        self.transaction_lock
+            .multi_insert(objects.iter().map(|obj_ref| (obj_ref, None)))?;
 
         Ok(())
     }
@@ -239,8 +238,12 @@ impl LockServiceImpl {
                         warn!("Could not respond to sender, sender dropped!");
                     }
                 }
-                LockServiceCommands::Initialize { refs, resp } => {
-                    if let Err(_e) = resp.send(self.initialize_locks(&refs)) {
+                LockServiceCommands::Initialize {
+                    refs,
+                    force_reset,
+                    resp,
+                } => {
+                    if let Err(_e) = resp.send(self.initialize_locks(&refs, force_reset)) {
                         warn!("Could not respond to sender, sender dropped!");
                     }
                 }
@@ -336,12 +339,15 @@ impl LockService {
     }
 
     /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
-    /// If the lock already exists and is locked to a transaction, then return TransactionLockExists
-    pub async fn initialize_locks(&self, refs: Vec<ObjectRef>) -> SuiResult {
+    /// If `force_reset` is true, we initialize them regardless of their existing state.
+    /// Otherwise, if the lock already exists and is locked to a transaction, then return TransactionLockExists
+    /// Only the gateway could set force_reset to true.
+    pub async fn initialize_locks(&self, refs: &[ObjectRef], force_reset: bool) -> SuiResult {
         let (os_sender, os_receiver) = oneshot::channel::<SuiResult>();
         self.sender
             .send(LockServiceCommands::Initialize {
-                refs,
+                refs: Vec::from(refs),
+                force_reset,
                 resp: os_sender,
             })
             .await
@@ -446,7 +452,8 @@ mod tests {
         assert_eq!(ls.get_lock(ref1), Ok(None));
 
         // Initialize 2 locks
-        ls.initialize_locks(&[ref1, ref2]).unwrap();
+        ls.initialize_locks(&[ref1, ref2], false /* force_reset */)
+            .unwrap();
         assert_eq!(ls.get_lock(ref2), Ok(Some(None)));
         assert_eq!(ls.locks_exist(&[ref1, ref2]), Ok(()));
 
@@ -469,12 +476,13 @@ mod tests {
 
         // Should get TransactionLockExists if try to initialize already locked object
         assert!(matches!(
-            ls.initialize_locks(&[ref2, ref3]),
+            ls.initialize_locks(&[ref2, ref3], false /* force_reset */),
             Err(SuiError::TransactionLockExists { .. })
         ));
 
         // Should not be able to acquire lock for diff tx if already locked
-        ls.initialize_locks(&[ref3]).unwrap();
+        ls.initialize_locks(&[ref3], false /* force_reset */)
+            .unwrap();
         assert!(matches!(
             ls.acquire_locks(&[ref2, ref3], tx2),
             Err(SuiError::ConflictingTransaction { .. })
@@ -491,7 +499,8 @@ mod tests {
         let tx1 = TransactionDigest::random();
 
         // Initialize 2 locks
-        ls.initialize_locks(&[ref1, ref2]).unwrap();
+        ls.initialize_locks(&[ref1, ref2], false /* force_reset */)
+            .unwrap();
 
         // Should be able to acquire lock if all objects initialized
         ls.acquire_locks(&[ref1, ref2], tx1).unwrap();
@@ -499,7 +508,7 @@ mod tests {
 
         // Cannot initialize them again since they are locked already
         assert!(matches!(
-            ls.initialize_locks(&[ref1, ref2]),
+            ls.initialize_locks(&[ref1, ref2], false /* force_reset */),
             Err(SuiError::TransactionLockExists { .. })
         ));
 
@@ -508,7 +517,8 @@ mod tests {
         assert_eq!(ls.get_lock(ref2), Ok(None));
 
         // Now initialization should succeed
-        ls.initialize_locks(&[ref1, ref2]).unwrap();
+        ls.initialize_locks(&[ref1, ref2], false /* force_reset */)
+            .unwrap();
     }
 
     #[tokio::test]
@@ -524,7 +534,10 @@ mod tests {
         // Should be able to concurrently initialize locks for same objects, all should succeed
         let futures = (0..10).map(|_n| {
             let ls = ls.clone();
-            tokio::spawn(async move { ls.initialize_locks(vec![ref1, ref2]).await })
+            tokio::spawn(async move {
+                ls.initialize_locks(&[ref1, ref2], false /* force_reset */)
+                    .await
+            })
         });
         let results = join_all(futures).await;
         assert!(results.iter().all(|res| res.is_ok()));


### PR DESCRIPTION
When we have multiple gateways, it can happen when the object version in one gateway is out-of-dated. When this happens, a transaction might pass all local transaction lock checks on the gateway, but then fail to execute in authorities. We don't want to keep objects locked forever on the gateway.
This PR resets the transaction locks on the objects upon the last retry failure.

Sorry @velvia , this PR is adding one more function that will need to be copied into the lock service.