### PR TITLE
[Sui Framework] Expose getter for current epoch number

### DIFF
--- a/sui_programmability/framework/sources/Governance/SuiSystem.move
+++ b/sui_programmability/framework/sources/Governance/SuiSystem.move
@@ -256,4 +256,15 @@ module Sui::SuiSystem {
         // remaining balance in `computation_reward`. All of these go to the storage fund.
         Balance::join(&mut self.storage_fund, computation_reward)
     }
+
+    /// Return the current epoch number. Useful for applications that need a coarse-grained concept of time,
+    /// since epochs are ever-increasing and epoch changes are intended to happen every 24 hours.
+    public fun epoch(self: &SuiSystemState): u64 {
+        self.epoch
+    }
+
+    #[test_only]
+    public fun set_epoch_for_testing(self: &mut SuiSystemState, epoch_num: u64) {
+        self.epoch = epoch_num
+    }
 }


### PR DESCRIPTION
Also expose a test-only function for advancing the epoch number. This is useful for contracts that need time, at least until we have a more fine-grained timestamping scheme.