### PR TITLE
[wallet] Enable shared object by default

### DIFF
--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -26,8 +26,6 @@ use sui_core::sui_json::SuiJsonValue;
 use sui_framework::build_move_package_to_bytes;
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
-    error::SuiError,
-    fp_ensure,
     gas_coin::GasCoin,
     messages::{CertifiedTransaction, ExecutionStatus, Transaction, TransactionEffects},
     object::{Object, ObjectRead, ObjectRead::Exists},
@@ -717,15 +715,6 @@ async fn call_move(
         .unwrap()
         .sign(&sender, &data.to_bytes())?;
     let transaction = Transaction::new(data, signature);
-    // Shared objects are not yet supported end-to-end.
-    // Disabling it by default at the moment. However we could still use it
-    // if we pass environment variable SHARED to the wallet.
-    if std::env::var("SHARED").is_err() {
-        fp_ensure!(
-            !transaction.contains_shared_object(),
-            SuiError::UnsupportedSharedObjectError.into()
-        );
-    }
     let (cert, effects) = context
         .gateway
         .execute_transaction(transaction)


### PR DESCRIPTION
Shared object should now work end to end. Enable it from wallet.