### PR TITLE
chore: rename_database, update Cargo.lock

### DIFF
--- a/sui_core/src/authority_active/gossip/mod.rs
+++ b/sui_core/src/authority_active/gossip/mod.rs
@@ -194,7 +194,7 @@ where
                         },
                         // Upon receiving a transaction digest we store it, if it is not processed already.
                         Some(Ok(BatchInfoResponseItem(UpdateItem::Transaction((_seq, _digest))))) => {
-                            if !self.state._database.effects_exists(&_digest)? {
+                            if !self.state.database.effects_exists(&_digest)? {
                                 queue.push(async move {
                                     tokio::time::sleep(Duration::from_millis(EACH_ITEM_DELAY_MS)).await;
                                     _digest
@@ -223,7 +223,7 @@ where
 
                 digest = &mut queue.next() , if !queue.is_empty() => {
                     let digest = digest.unwrap();
-                    if !self.state._database.effects_exists(&digest)? {
+                    if !self.state.database.effects_exists(&digest)? {
                         // We still do not have a transaction others have after some time
 
                         // Download the certificate

--- a/sui_storage/src/lock_service.rs
+++ b/sui_storage/src/lock_service.rs
@@ -193,13 +193,7 @@ impl LockServiceImpl {
         let existing_locks: Vec<ObjectRef> = locks
             .iter()
             .zip(objects)
-            .filter_map(|(lock_opt, objref)| {
-                if let Some(Some(_tx_digest)) = lock_opt {
-                    Some(*objref)
-                } else {
-                    None
-                }
-            })
+            .filter_map(|(lock_opt, objref)| lock_opt.flatten().map(|_tx_digest| *objref))
             .collect();
         if !existing_locks.is_empty() {
             info!(


### PR DESCRIPTION
While reading other stuff, and noticing a stale `Cargo.lock`.
Fixes https://github.com/MystenLabs/sui/issues/1497