### PR TITLE
[bugfix] - wallet move call parsing array incorrectly 

### DIFF
--- a/sui_core/src/sui_json.rs
+++ b/sui_core/src/sui_json.rs
@@ -182,7 +182,8 @@ fn try_from_bcs_bytes(bytes: &[u8]) -> Result<JsonValue, anyhow::Error> {
 impl std::str::FromStr for SuiJsonValue {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, anyhow::Error> {
-        SuiJsonValue::new(serde_json::from_value(json!(s))?)
+        // Wrap input with json! if serde_json fails, the failure usually cause by missing quote escapes.
+        SuiJsonValue::new(serde_json::from_str(s).or_else(|_| serde_json::from_value(json!(s)))?)
     }
 }
 

--- a/sui_core/src/unit_tests/sui_json.rs
+++ b/sui_core/src/unit_tests/sui_json.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
+use std::str::FromStr;
 
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, value::MoveTypeLayout,
 };
 use serde_json::{json, Value};
+use test_fuzz::runtime::num_traits::ToPrimitive;
+
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::object::Object;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
@@ -509,4 +512,37 @@ fn test_convert_number_array_from_bcs() {
     for value in value.0.as_array().unwrap() {
         assert_eq!(50000, value.as_u64().unwrap())
     }
+}
+
+#[test]
+fn test_from_str() {
+    let test = SuiJsonValue::from_str("10000").unwrap();
+    assert!(test.0.is_number());
+    let test = SuiJsonValue::from_str("[10,10,10,10]").unwrap();
+    assert!(test.0.is_array());
+    assert_eq!(
+        vec![10, 10, 10, 10],
+        test.0
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|value| value.as_u64().unwrap().to_u8().unwrap())
+            .collect::<Vec<_>>()
+    );
+    let test = SuiJsonValue::from_str("true").unwrap();
+    assert!(test.0.is_boolean());
+    // test id without quotes
+    let object_id = ObjectID::random().to_hex_literal();
+    let test = SuiJsonValue::from_str(&object_id).unwrap();
+    assert!(test.0.is_string());
+    assert_eq!(object_id, test.0.as_str().unwrap());
+
+    // test id with quotes
+    let test = SuiJsonValue::from_str(&format!("{}", &object_id)).unwrap();
+    assert!(test.0.is_string());
+    assert_eq!(object_id, test.0.as_str().unwrap());
+
+    let test = SuiJsonValue::from_str("Some string").unwrap();
+    assert!(test.0.is_string());
+    assert_eq!("Some string", test.0.as_str().unwrap())
 }

--- a/sui_core/src/unit_tests/sui_json.rs
+++ b/sui_core/src/unit_tests/sui_json.rs
@@ -516,8 +516,10 @@ fn test_convert_number_array_from_bcs() {
 
 #[test]
 fn test_from_str() {
+    // test number
     let test = SuiJsonValue::from_str("10000").unwrap();
     assert!(test.0.is_number());
+    // Test array
     let test = SuiJsonValue::from_str("[10,10,10,10]").unwrap();
     assert!(test.0.is_array());
     assert_eq!(
@@ -529,8 +531,10 @@ fn test_from_str() {
             .map(|value| value.as_u64().unwrap().to_u8().unwrap())
             .collect::<Vec<_>>()
     );
+    // test bool
     let test = SuiJsonValue::from_str("true").unwrap();
     assert!(test.0.is_boolean());
+
     // test id without quotes
     let object_id = ObjectID::random().to_hex_literal();
     let test = SuiJsonValue::from_str(&object_id).unwrap();
@@ -538,11 +542,17 @@ fn test_from_str() {
     assert_eq!(object_id, test.0.as_str().unwrap());
 
     // test id with quotes
-    let test = SuiJsonValue::from_str(&format!("{}", &object_id)).unwrap();
+    let test = SuiJsonValue::from_str(&format!("\"{}\"", &object_id)).unwrap();
     assert!(test.0.is_string());
     assert_eq!(object_id, test.0.as_str().unwrap());
 
+    // test string without quotes
     let test = SuiJsonValue::from_str("Some string").unwrap();
+    assert!(test.0.is_string());
+    assert_eq!("Some string", test.0.as_str().unwrap());
+
+    // test string with quotes
+    let test = SuiJsonValue::from_str("\"Some string\"").unwrap();
     assert!(test.0.is_string());
     assert_eq!("Some string", test.0.as_str().unwrap())
 }


### PR DESCRIPTION
it is parsing the array as string and then converting it into u8 array in some cases.

Added unit test for SuiJsonValue `FromStr` to make sure it's covered.