### PR TITLE
[Sui CLI / UX] - Improved wallet object command

### DIFF
--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -148,7 +148,7 @@ where
 }
 
 pub trait Encoding {
-    fn decode(s: &String) -> Result<Vec<u8>, anyhow::Error>;
+    fn decode(s: &str) -> Result<Vec<u8>, anyhow::Error>;
     fn encode<T: AsRef<[u8]>>(data: T) -> String;
 }
 
@@ -178,7 +178,7 @@ impl Base64 {
 }
 
 impl Encoding for Hex {
-    fn decode(s: &String) -> Result<Vec<u8>, anyhow::Error> {
+    fn decode(s: &str) -> Result<Vec<u8>, anyhow::Error> {
         decode_bytes_hex(s)
     }
 
@@ -187,7 +187,7 @@ impl Encoding for Hex {
     }
 }
 impl Encoding for Base64 {
-    fn decode(s: &String) -> Result<Vec<u8>, anyhow::Error> {
+    fn decode(s: &str) -> Result<Vec<u8>, anyhow::Error> {
         base64ct::Base64::decode_vec(s).map_err(|e| anyhow!(e))
     }
 

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -72,6 +72,13 @@ where
     {
         if deserializer.is_human_readable() {
             let value = E::deserialize_as(deserializer)?;
+            if value.len() != N {
+                return Err(D::Error::custom(anyhow!(
+                    "invalid array length {}, expecting {}",
+                    value.len(),
+                    N
+                )));
+            }
             let mut array = [0u8; N];
             array.copy_from_slice(&value[..N]);
             Ok(array)
@@ -141,18 +148,28 @@ where
 }
 
 pub trait Encoding {
-    fn decode(s: String) -> Result<Vec<u8>, anyhow::Error>;
+    fn decode(s: &String) -> Result<Vec<u8>, anyhow::Error>;
     fn encode<T: AsRef<[u8]>>(data: T) -> String;
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
-pub struct Hex(pub String);
+pub struct Hex(String);
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
-pub struct Base64(pub String);
+#[serde(try_from = "String")]
+pub struct Base64(String);
+
+impl TryFrom<String> for Base64 {
+    type Error = anyhow::Error;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        // Make sure the value is valid base64 string.
+        Base64::decode(&value)?;
+        Ok(Self(value))
+    }
+}
 
 impl Base64 {
     pub fn to_vec(self) -> Result<Vec<u8>, anyhow::Error> {
-        Self::decode(self.0)
+        Self::decode(&self.0)
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Self {
@@ -161,8 +178,8 @@ impl Base64 {
 }
 
 impl Encoding for Hex {
-    fn decode(s: String) -> Result<Vec<u8>, anyhow::Error> {
-        decode_bytes_hex(&s)
+    fn decode(s: &String) -> Result<Vec<u8>, anyhow::Error> {
+        decode_bytes_hex(s)
     }
 
     fn encode<T: AsRef<[u8]>>(data: T) -> String {
@@ -170,8 +187,8 @@ impl Encoding for Hex {
     }
 }
 impl Encoding for Base64 {
-    fn decode(s: String) -> Result<Vec<u8>, anyhow::Error> {
-        base64ct::Base64::decode_vec(&s).map_err(|e| anyhow!(e))
+    fn decode(s: &String) -> Result<Vec<u8>, anyhow::Error> {
+        base64ct::Base64::decode_vec(s).map_err(|e| anyhow!(e))
     }
 
     fn encode<T: AsRef<[u8]>>(data: T) -> String {
@@ -185,7 +202,7 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Base64 {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Self::decode(s).map_err(to_custom_error::<'de, D, _>)
+        Self::decode(&s).map_err(to_custom_error::<'de, D, _>)
     }
 }
 
@@ -207,7 +224,7 @@ impl<'de> DeserializeAs<'de, Vec<u8>> for Hex {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Self::decode(s).map_err(to_custom_error::<'de, D, _>)
+        Self::decode(&s).map_err(to_custom_error::<'de, D, _>)
     }
 }
 

--- a/sui/open_rpc/spec/openrpc.json
+++ b/sui/open_rpc/spec/openrpc.json
@@ -842,12 +842,6 @@
           },
           {
             "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/MoveValue"
-            }
-          },
-          {
-            "type": "object",
             "required": [
               "fields",
               "type"
@@ -862,6 +856,12 @@
               "type": {
                 "type": "string"
               }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MoveValue"
             }
           }
         ]
@@ -884,6 +884,9 @@
             "items": {
               "$ref": "#/components/schemas/MoveValue"
             }
+          },
+          {
+            "$ref": "#/components/schemas/Base64"
           },
           {
             "type": "string"

--- a/sui/src/wallet_commands.rs
+++ b/sui/src/wallet_commands.rs
@@ -684,7 +684,7 @@ impl Display for WalletCommandResult {
                 writeln!(writer, "{}", object)?;
             }
         }
-        write!(f, "{}", writer)
+        write!(f, "{}", writer.trim_end_matches('\n'))
     }
 }
 

--- a/sui_core/src/gateway_types.rs
+++ b/sui_core/src/gateway_types.rs
@@ -9,6 +9,8 @@ use std::fmt;
 use std::fmt::Write;
 use std::fmt::{Display, Formatter};
 
+use colored::Colorize;
+use itertools::Itertools;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
 use move_core_types::value::{MoveStruct, MoveStructLayout, MoveValue};
@@ -18,7 +20,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value;
 
-use colored::Colorize;
 use sui_types::base_types::{
     ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
 };
@@ -193,19 +194,44 @@ impl From<ObjectRef> for SuiObjectRef {
 
 impl Display for SuiObject {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let type_string = self
-            .data
-            .type_()
-            .map_or("Move Package".to_owned(), |type_| type_.to_string());
-
-        write!(
-            f,
-            "ID: {:?}\nVersion: {:?}\nOwner: {}\nType: {}",
-            self.id(),
-            self.version().value(),
-            self.owner,
-            type_string
-        )
+        let type_ = if self.data.type_().is_some() {
+            "Move Object"
+        } else {
+            "Move Package"
+        };
+        let mut writer = String::new();
+        writeln!(
+            writer,
+            "{}",
+            format!(
+                "----- {type_} ({}[{}]) -----",
+                self.id(),
+                self.version().value()
+            )
+            .bold()
+        )?;
+        writeln!(writer, "{}: {}", "Owner".bold().bright_black(), self.owner)?;
+        writeln!(
+            writer,
+            "{}: {}",
+            "Version".bold().bright_black(),
+            self.version().value()
+        )?;
+        writeln!(
+            writer,
+            "{}: {}",
+            "Storage Rebate".bold().bright_black(),
+            self.storage_rebate
+        )?;
+        writeln!(
+            writer,
+            "{}: {:?}",
+            "Previous Transaction".bold().bright_black(),
+            self.previous_transaction
+        )?;
+        writeln!(writer, "{}", "----- Data -----".bold())?;
+        write!(writer, "{}", &self.data)?;
+        write!(f, "{}", writer)
     }
 }
 
@@ -258,6 +284,34 @@ impl SuiObject {
 pub enum SuiData {
     MoveObject(SuiMoveObject),
     Package(SuiMovePackage),
+}
+
+impl Display for SuiData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = String::new();
+        match self {
+            SuiData::MoveObject(o) => {
+                writeln!(writer, "{}: {}", "type".bold().bright_black(), o.type_)?;
+                write!(writer, "{}", &o.fields)?;
+            }
+            SuiData::Package(p) => {
+                write!(
+                    writer,
+                    "{}: {:?}",
+                    "Modules".bold().bright_black(),
+                    p.disassembled.keys()
+                )?;
+            }
+        }
+        write!(f, "{}", writer)
+    }
+}
+
+fn indent<T: Display>(d: &T, indent: usize) -> String {
+    d.to_string()
+        .lines()
+        .map(|line| format!("{:indent$}{}", "", line))
+        .join("\n")
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Eq, PartialEq)]
@@ -339,9 +393,9 @@ pub struct PublishResponse {
 impl Display for PublishResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
-        writeln!(writer, "----- Certificate ----")?;
+        writeln!(writer, "{}", "----- Certificate ----".bold())?;
         write!(writer, "{}", self.certificate)?;
-        writeln!(writer, "----- Publish Results ----")?;
+        writeln!(writer, "{}", "----- Publish Results ----".bold())?;
         writeln!(
             writer,
             "The newly published package object ID: {:?}",
@@ -423,6 +477,38 @@ pub enum SuiMoveValue {
     Option(Box<Option<SuiMoveValue>>),
 }
 
+impl Display for SuiMoveValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = String::new();
+        match self {
+            SuiMoveValue::Number(value) => {
+                write!(writer, "{}", value)?;
+            }
+            SuiMoveValue::Bool(value) => {
+                write!(writer, "{}", value)?;
+            }
+            SuiMoveValue::Address(value) => {
+                write!(writer, "{}", value)?;
+            }
+            SuiMoveValue::Vector(_) => {}
+            SuiMoveValue::String(value) => {
+                write!(writer, "{}", value)?;
+            }
+            SuiMoveValue::VersionedID { id, version } => {
+                write!(writer, "{id}[{version}]")?;
+            }
+            SuiMoveValue::Struct(value) => {
+                write!(writer, "{}", value)?;
+            }
+            SuiMoveValue::Option(value) => {
+                write!(writer, "{:?}", value)?;
+            }
+        }
+
+        write!(f, "{}", writer)
+    }
+}
+
 impl From<MoveValue> for SuiMoveValue {
     fn from(value: MoveValue) -> Self {
         match value {
@@ -467,12 +553,40 @@ impl From<MoveValue> for SuiMoveValue {
 #[serde(untagged, rename = "MoveStruct")]
 pub enum SuiMoveStruct {
     Runtime(Vec<SuiMoveValue>),
-    WithFields(BTreeMap<String, SuiMoveValue>),
     WithTypes {
         #[serde(rename = "type")]
         type_: String,
         fields: BTreeMap<String, SuiMoveValue>,
     },
+    WithFields(BTreeMap<String, SuiMoveValue>),
+}
+
+impl Display for SuiMoveStruct {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = String::new();
+        match self {
+            SuiMoveStruct::Runtime(_) => {}
+            SuiMoveStruct::WithFields(fields) => {
+                for (name, value) in fields {
+                    writeln!(writer, "{}: {value}", name.bold().bright_black())?;
+                }
+            }
+            SuiMoveStruct::WithTypes { type_, fields } => {
+                writeln!(writer)?;
+                writeln!(writer, "  {}: {type_}", "type".bold().bright_black())?;
+                for (name, value) in fields {
+                    let value = format!("{}", value);
+                    let value = if value.starts_with('\n') {
+                        indent(&value, 2)
+                    } else {
+                        value
+                    };
+                    writeln!(writer, "  {}: {value}", name.bold().bright_black())?;
+                }
+            }
+        }
+        write!(f, "{}", writer.trim_end_matches('\n'))
+    }
 }
 
 fn try_convert_type(type_: &StructTag, fields: &[(Identifier, MoveValue)]) -> Option<SuiMoveValue> {

--- a/sui_core/src/unit_tests/gateway_types_tests.rs
+++ b/sui_core/src/unit_tests/gateway_types_tests.rs
@@ -26,8 +26,8 @@ fn test_move_value_to_sui_bytearray() {
         MoveValue::U8(4),
     ]);
     let sui_value = SuiMoveValue::from(move_value);
-    let bytes_base64 = Base64::encode(&[0, 1, 2, 3, 4]);
-    assert!(matches!(sui_value, SuiMoveValue::String(bytes) if bytes == bytes_base64))
+    let bytes_base64 = Base64::from_bytes(&[0, 1, 2, 3, 4]);
+    assert!(matches!(sui_value, SuiMoveValue::Bytearray(bytes) if bytes == bytes_base64))
 }
 
 #[test]
@@ -117,6 +117,7 @@ fn test_serde() {
         SuiMoveValue::Address(SuiAddress::random_for_testing_only()),
         SuiMoveValue::Bool(true),
         SuiMoveValue::Option(Box::new(None)),
+        SuiMoveValue::Bytearray(Base64::from_bytes(&[10u8; 20])),
     ];
 
     for value in test_values {

--- a/sui_core/src/unit_tests/gateway_types_tests.rs
+++ b/sui_core/src/unit_tests/gateway_types_tests.rs
@@ -11,7 +11,6 @@ use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::MoveObject;
 use sui_types::sui_serde::Base64;
-use sui_types::sui_serde::Encoding;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 
 use crate::gateway_types::{SuiMoveStruct, SuiMoveValue};


### PR DESCRIPTION
impl display for `SuiObject`, improve wallet cli object command output

also added some bugfixs:
* `Readable` serde panic when trying to convert a non ObjectId Vec to ObjectID due to array size different, it should return Err instead.
* Added Bytearray SuiMoveValue instead of converting it to string.

Results:
object (coin) :
<img width="948" alt="image" src="https://user-images.githubusercontent.com/1888654/168832295-07efd870-55d6-4883-9d59-9b95b0d71eab.png">

object (package) :
<img width="948" alt="image" src="https://user-images.githubusercontent.com/1888654/168832467-d3a40d4a-1388-40de-a721-e3d0b0d46de0.png">

publish:
<img width="1588" alt="image" src="https://user-images.githubusercontent.com/1888654/168831977-1a2b2bd2-deeb-4c1d-b440-b7cc9af46a09.png">
