### PR TITLE
sui: limit when the build script needs to be run

### DIFF
--- a/sui/build.rs
+++ b/sui/build.rs
@@ -33,5 +33,6 @@ fn main() {
         }
 
         println!("cargo:rustc-env=GIT_REV={}", git_rev);
+        println!("cargo:rerun-if-changed=build.rs");
     }
 }


### PR DESCRIPTION
Support for embedding the git revision inside the wallet cli was added
back in 96611e00 (wallet: log git revision on start, 2022-04-22). This
was done by using a build.rs file to run a few git commands to query for
the git revision of HEAD and if the working directory was dirty or not.

The addition of this feature had the unintended consequence of causing
a ton of code to be re-build anytime any file in the `sui` crate was
changed. This is due to the fact that, by default, a build.rs file is
re-run anytime any file anywhere in the crate (integration tests and
examples included) [1].

This patch fixes this by only having cargo re-run the build script when
the build.rs file is changed.

[1] https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath