### PR TITLE
[Epoch] Create Sui System State object at genesis by calling Move

### DIFF
--- a/sui/tests/shared_objects_tests.rs
+++ b/sui/tests/shared_objects_tests.rs
@@ -163,7 +163,6 @@ async fn call_shared_object_contract() {
     // the handles (or the authorities will stop).
     let configs = test_authority_configs();
     let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
-
     // Publish the move package to all authorities and get the new package ref.
     tokio::task::yield_now().await;
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;


### PR DESCRIPTION
Previously we relied upon the Move module initializer called automatically when initializing the Genesis Move module in the Sui Framework, to create the singleton Sui System State Object.
That approach requires hardcoding the validator information in Move, which will make it very difficult for us to test or to run the network locally.
This PR makes the system object creation no longer part of the initializer. Instead, during genesis creation of the AuthorityState, we call a Move function explicitly to create the object based on the validator config.

For now, we only care about the sui address and public key, so they are set properly.
The rest (human-readable name, net address andetc.) are not important to be on-chain right now so I added a few TODOs there.