### PR TITLE
[genesis] Init genesis in db, not in authority state

### DIFF
--- a/sui_core/src/authority/authority_store.rs
+++ b/sui_core/src/authority/authority_store.rs
@@ -1137,3 +1137,121 @@ impl From<&ObjectRef> for ObjectKey {
         Self(object_ref.0, object_ref.1)
     }
 }
+
+/// Persist the Genesis package to DB along with the side effects for module initialization
+pub async fn store_package_and_init_modules_for_genesis<
+    const A: bool,
+    const B: bool,
+    S: Eq + Serialize + for<'de> Deserialize<'de>,
+>(
+    store: &Arc<SuiDataStore<A, B, S>>,
+    native_functions: &NativeFunctionTable,
+    ctx: &mut TxContext,
+    modules: Vec<CompiledModule>,
+) -> SuiResult {
+    let inputs = Transaction::input_objects_in_compiled_modules(&modules);
+    let ids: Vec<_> = inputs.iter().map(|kind| kind.object_id()).collect();
+    let input_objects = store.get_objects(&ids[..])?;
+    // When publishing genesis packages, since the std framework packages all have
+    // non-zero addresses, [`Transaction::input_objects_in_compiled_modules`] will consider
+    // them as dependencies even though they are not. Hence input_objects contain objects
+    // that don't exist on-chain because they are yet to be published.
+    #[cfg(debug_assertions)]
+    {
+        let to_be_published_addresses: HashSet<_> = modules
+            .iter()
+            .map(|module| *module.self_id().address())
+            .collect();
+        assert!(
+            // An object either exists on-chain, or is one of the packages to be published.
+            inputs
+                .iter()
+                .zip(input_objects.iter())
+                .all(|(kind, obj_opt)| obj_opt.is_some()
+                    || to_be_published_addresses.contains(&kind.object_id()))
+        );
+    }
+    let filtered = inputs
+        .into_iter()
+        .zip(input_objects.into_iter())
+        .filter_map(|(input, object_opt)| object_opt.map(|object| (input, object)))
+        .collect::<Vec<_>>();
+
+    debug_assert!(ctx.digest() == TransactionDigest::genesis());
+    let mut temporary_store = AuthorityTemporaryStore::new(store.clone(), filtered, ctx.digest());
+    let package_id = ObjectID::from(*modules[0].self_id().address());
+    let natives = native_functions.clone();
+    let mut gas_status = SuiGasStatus::new_unmetered();
+    let vm = adapter::verify_and_link(
+        &temporary_store,
+        &modules,
+        package_id,
+        natives,
+        &mut gas_status,
+    )?;
+    adapter::store_package_and_init_modules(
+        &mut temporary_store,
+        &vm,
+        modules,
+        ctx,
+        &mut gas_status,
+    )?;
+    store
+        .update_objects_state_for_genesis(temporary_store, ctx.digest())
+        .await
+}
+
+pub async fn generate_genesis_system_object<
+    const A: bool,
+    const B: bool,
+    S: Eq + Serialize + for<'de> Deserialize<'de>,
+>(
+    store: &Arc<SuiDataStore<A, B, S>>,
+    move_vm: &Arc<MoveVM>,
+    committee: &Committee,
+    genesis_ctx: &mut TxContext,
+) -> SuiResult {
+    let genesis_digest = genesis_ctx.digest();
+    let mut temporary_store = AuthorityTemporaryStore::new(store.clone(), vec![], genesis_digest);
+    let pubkeys: Vec<Vec<u8>> = committee
+        .expanded_keys
+        .values()
+        .map(|pk| pk.to_bytes().to_vec())
+        .collect();
+    // TODO: May use separate sui address than derived from pubkey.
+    let sui_addresses: Vec<AccountAddress> = committee
+        .voting_rights
+        .keys()
+        .map(|pk| SuiAddress::from(pk).into())
+        .collect();
+    // TODO: Allow config to specify human readable validator names.
+    let names: Vec<Vec<u8>> = (0..sui_addresses.len())
+        .map(|i| Vec::from(format!("Validator{}", i).as_bytes()))
+        .collect();
+    // TODO: Change voting_rights to use u64 instead of usize.
+    let stakes: Vec<u64> = committee
+        .voting_rights
+        .values()
+        .map(|v| *v as u64)
+        .collect();
+    adapter::execute(
+        move_vm,
+        &mut temporary_store,
+        ModuleId::new(SUI_FRAMEWORK_ADDRESS, ident_str!("Genesis").to_owned()),
+        &ident_str!("create").to_owned(),
+        vec![],
+        vec![
+            CallArg::Pure(bcs::to_bytes(&pubkeys).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&sui_addresses).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&names).unwrap()),
+            // TODO: below is netaddress, for now just use names as we don't yet want to expose them.
+            CallArg::Pure(bcs::to_bytes(&names).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&stakes).unwrap()),
+        ],
+        &mut SuiGasStatus::new_unmetered(),
+        genesis_ctx,
+    )?;
+    store
+        .update_objects_state_for_genesis(temporary_store, genesis_digest)
+        .await
+}


### PR DESCRIPTION
All the genesis packages, objects are directly initialized to the db, and has nothing to do with AuthorityState. Initializing them in the state is confusing and prevents from sharing the code with other type of nodes when it comes to genesis.
This PR moves all the logic to the store file, and each directly operates on Arc<SuiDataStore>.