### PR TITLE
Prometheus: Listen on 0.0.0.0

### DIFF
--- a/sui/src/bin/rpc-server.rs
+++ b/sui/src/bin/rpc-server.rs
@@ -25,7 +25,7 @@ use tracing::info;
 
 const DEFAULT_RPC_SERVER_PORT: &str = "5001";
 const DEFAULT_RPC_SERVER_ADDR_IPV4: &str = "127.0.0.1";
-const PROM_PORT_ADDR: &str = "127.0.0.1:9184";
+const PROM_PORT_ADDR: &str = "0.0.0.0:9184";
 
 #[cfg(test)]
 #[path = "../unit_tests/rpc_server_tests.rs"]

--- a/sui/src/bin/validator.rs
+++ b/sui/src/bin/validator.rs
@@ -12,7 +12,7 @@ use sui_config::{builder::ConfigBuilder, PersistedConfig};
 use sui_config::{GenesisConfig, ValidatorConfig};
 use tracing::{error, info};
 
-const PROM_PORT_ADDR: &str = "127.0.0.1:9184";
+const PROM_PORT_ADDR: &str = "0.0.0.0:9184";
 
 #[derive(Parser)]
 #[clap(


### PR DESCRIPTION
Really simple one line fixes.  The old value was 127.0.0.1 which prevents metrics from listening on external connections.

I could expand this to use ValidatorConfig for validators if @bmwill could show me how to convert `multiaddr` to `SocketAddr`, but I couldn't' find an easy way, and we're just trying to get this working quickly for observability.