### PR TITLE
[tests] Reduce the re-generation of genesis in tests

### DIFF
--- a/sui_core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/sui_core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1323,6 +1323,7 @@ async fn checkpoint_tests_setup() -> TestSetup {
     let mut authorities = Vec::new();
 
     // Make all authorities and their services.
+    let genesis = sui_config::genesis::Genesis::get_default_genesis();
     for k in &keys {
         let dir = env::temp_dir();
         let path = dir.join(format!("SC_{:?}", ObjectID::random()));
@@ -1357,7 +1358,6 @@ async fn checkpoint_tests_setup() -> TestSetup {
             .set_consensus(Box::new(sender.clone()))
             .expect("No issues");
         let checkpoint = Arc::new(Mutex::new(checkpoint));
-
         let authority = AuthorityState::new(
             committee.clone(),
             *secret.public_key_bytes(),
@@ -1365,7 +1365,7 @@ async fn checkpoint_tests_setup() -> TestSetup {
             store.clone(),
             None,
             Some(checkpoint.clone()),
-            &sui_config::genesis::Genesis::get_default_genesis(),
+            &genesis,
         )
         .await;
 

--- a/test_utils/src/authority.rs
+++ b/test_utils/src/authority.rs
@@ -51,6 +51,7 @@ where
     I: IntoIterator<Item = Object> + Clone,
 {
     let mut handles = Vec::new();
+    let genesis = sui_config::genesis::Genesis::get_default_genesis();
     for validator in config.validator_configs() {
         let state = AuthorityState::new(
             validator.committee_config().committee(),
@@ -59,7 +60,7 @@ where
             Arc::new(test_authority_store()),
             None,
             None,
-            &sui_config::genesis::Genesis::get_default_genesis(),
+            &genesis,
         )
         .await;
 


### PR DESCRIPTION
In many places we keep re-reading, re-compiling and re-verifying genesis when we make authorities. In this PR I try to generate genesis once in each test and re-use it as many times as possible. This reduced the running time of sui_core tests from 300sec to 179sec on my feeble linux box.