### PR TITLE
Use dyn AuthorityAPI for authority clients

### DIFF
--- a/sui_core/src/authority_active.rs
+++ b/sui_core/src/authority_active.rs
@@ -39,7 +39,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     authority::AuthorityState, authority_aggregator::AuthorityAggregator,
-    authority_client::AuthorityAPI,
+    authority_client::AuthorityClient,
 };
 use tokio::time::Instant;
 
@@ -89,19 +89,19 @@ impl AuthorityHealth {
     }
 }
 
-pub struct ActiveAuthority<A> {
+pub struct ActiveAuthority {
     // The local authority state
     pub state: Arc<AuthorityState>,
     // The network interfaces to other authorities
-    pub net: Arc<AuthorityAggregator<A>>,
+    pub net: Arc<AuthorityAggregator>,
     // Network health
     pub health: Arc<Mutex<HashMap<AuthorityName, AuthorityHealth>>>,
 }
 
-impl<A> ActiveAuthority<A> {
+impl ActiveAuthority {
     pub fn new(
         authority: Arc<AuthorityState>,
-        authority_clients: BTreeMap<AuthorityName, A>,
+        authority_clients: BTreeMap<AuthorityName, AuthorityClient>,
     ) -> SuiResult<Self> {
         let committee = authority.committee.clone();
 
@@ -164,10 +164,7 @@ impl<A> ActiveAuthority<A> {
     }
 }
 
-impl<A> ActiveAuthority<A>
-where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
-{
+impl ActiveAuthority {
     // TODO: Active tasks go here + logic to spawn them all
     pub async fn spawn_all_active_processes(self) -> Option<()> {
         // Spawn a task to take care of gossip

--- a/sui_core/src/authority_active/gossip/mod.rs
+++ b/sui_core/src/authority_active/gossip/mod.rs
@@ -23,12 +23,12 @@ use tracing::{debug, error, info};
 #[cfg(test)]
 mod tests;
 
-struct PeerGossip<A> {
+struct PeerGossip {
     peer_name: AuthorityName,
-    client: SafeClient<A>,
+    client: SafeClient,
     state: Arc<AuthorityState>,
     max_seq: Option<TxSequenceNumber>,
-    aggregator: Arc<AuthorityAggregator<A>>,
+    aggregator: Arc<AuthorityAggregator>,
 }
 
 const EACH_ITEM_DELAY_MS: u64 = 1_000;
@@ -37,10 +37,7 @@ const REFRESH_FOLLOWER_PERIOD_SECS: u64 = 60;
 
 use super::ActiveAuthority;
 
-pub async fn gossip_process<A>(active_authority: &ActiveAuthority<A>, degree: usize)
-where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
-{
+pub async fn gossip_process(active_authority: &ActiveAuthority, degree: usize) {
     // A copy of the committee
     let committee = &active_authority.net.committee;
 
@@ -130,11 +127,8 @@ where
     }
 }
 
-impl<A> PeerGossip<A>
-where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
-{
-    pub fn new(peer_name: AuthorityName, active_authority: &ActiveAuthority<A>) -> PeerGossip<A> {
+impl PeerGossip {
+    pub fn new(peer_name: AuthorityName, active_authority: &ActiveAuthority) -> PeerGossip {
         PeerGossip {
             peer_name,
             client: active_authority.net.authority_clients[&peer_name].clone(),

--- a/sui_core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/sui_core/src/checkpoints/tests/checkpoint_tests.rs
@@ -8,7 +8,7 @@ use crate::{
         authority_aggregator_tests::transfer_coin_transaction, AuthorityAggregator,
     },
     authority_batch::batch_tests::init_state_parameters_from_rng,
-    authority_client::LocalAuthorityClient,
+    authority_client::{AuthorityClient, LocalAuthorityClient},
 };
 use rand::prelude::StdRng;
 use rand::SeedableRng;
@@ -1283,7 +1283,7 @@ struct TestSetup {
     committee: Committee,
     authorities: Vec<TestAuthority>,
     transactions: Vec<sui_types::messages::Transaction>,
-    aggregator: AuthorityAggregator<LocalAuthorityClient>,
+    aggregator: AuthorityAggregator,
 }
 
 async fn checkpoint_tests_setup() -> TestSetup {
@@ -1407,10 +1407,10 @@ async fn checkpoint_tests_setup() -> TestSetup {
         authorities
             .iter()
             .map(|a| {
-                (
-                    a.authority.name,
-                    LocalAuthorityClient::new_from_authority(a.authority.clone()),
-                )
+                let client: AuthorityClient = Arc::new(LocalAuthorityClient::new_from_authority(
+                    a.authority.clone(),
+                ));
+                (a.authority.name, client)
             })
             .collect(),
     );

--- a/sui_core/src/make.rs
+++ b/sui_core/src/make.rs
@@ -3,7 +3,7 @@
 
 use crate::authority::{AuthorityState, AuthorityStore};
 use crate::authority_active::ActiveAuthority;
-use crate::authority_client::NetworkAuthorityClient;
+use crate::authority_client::{AuthorityClient, NetworkAuthorityClient};
 use crate::authority_server::AuthorityServer;
 use crate::authority_server::AuthorityServerHandle;
 use crate::checkpoints::CheckpointStore;
@@ -158,13 +158,13 @@ pub async fn make_authority(
     // If we have network information make authority clients
     // to all authorities in the system.
     let _active_authority: Option<()> = {
-        let mut authority_clients = BTreeMap::new();
+        let mut authority_clients: BTreeMap<_, AuthorityClient> = BTreeMap::new();
         let mut config = mysten_network::config::Config::new();
         config.connect_timeout = Some(Duration::from_secs(5));
         config.request_timeout = Some(Duration::from_secs(5));
         for validator in validator_config.committee_config().validator_set() {
             let channel = config.connect_lazy(validator.network_address()).unwrap();
-            let client = NetworkAuthorityClient::new(channel);
+            let client = Arc::new(NetworkAuthorityClient::new(channel));
             authority_clients.insert(validator.public_key(), client);
         }
 

--- a/sui_core/src/unit_tests/batch_tests.rs
+++ b/sui_core/src/unit_tests/batch_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use rand::{prelude::StdRng, SeedableRng};
+use std::any::Any;
 use sui_types::committee::Committee;
 use sui_types::crypto::get_key_pair;
 use sui_types::crypto::get_key_pair_from_rng;
@@ -612,6 +613,11 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         });
         Ok(Box::pin(stream))
     }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl TrustworthyAuthorityClient {
@@ -745,6 +751,11 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         });
         Ok(Box::pin(stream))
     }
+
+    #[cfg(test)]
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl ByzantineAuthorityClient {
@@ -782,7 +793,7 @@ async fn test_safe_batch_stream() {
     .await;
 
     // Happy path:
-    let auth_client = TrustworthyAuthorityClient::new(state);
+    let auth_client = Arc::new(TrustworthyAuthorityClient::new(state));
     let safe_client = SafeClient::new(auth_client, committee.clone(), public_key_bytes);
 
     let request = BatchInfoRequest {
@@ -824,7 +835,7 @@ async fn test_safe_batch_stream() {
         &sui_config::genesis::Genesis::get_default_genesis(),
     )
     .await;
-    let auth_client_from_byzantine = ByzantineAuthorityClient::new(state_b);
+    let auth_client_from_byzantine = Arc::new(ByzantineAuthorityClient::new(state_b));
     let safe_client_from_byzantine = SafeClient::new(
         auth_client_from_byzantine,
         committee.clone(),

--- a/sui_core/src/unit_tests/gateway_state_tests.rs
+++ b/sui_core/src/unit_tests/gateway_state_tests.rs
@@ -20,12 +20,9 @@ use crate::authority_aggregator::authority_aggregator_tests::{
     authority_genesis_objects, crate_object_move_transaction, get_local_client,
     init_local_authorities,
 };
-use crate::authority_client::LocalAuthorityClient;
 use crate::gateway_state::{GatewayAPI, GatewayState};
 
-async fn create_gateway_state(
-    genesis_objects: Vec<Vec<Object>>,
-) -> GatewayState<LocalAuthorityClient> {
+async fn create_gateway_state(genesis_objects: Vec<Vec<Object>>) -> GatewayState {
     let all_owners: HashSet<_> = genesis_objects
         .iter()
         .flat_map(|v| v.iter().map(|o| o.get_single_owner().unwrap()))
@@ -40,7 +37,7 @@ async fn create_gateway_state(
 }
 
 async fn transfer_coin(
-    gateway: &GatewayState<LocalAuthorityClient>,
+    gateway: &GatewayState,
     signer: SuiAddress,
     key: &KeyPair,
     coin_object_id: ObjectID,

--- a/sui_core/src/unit_tests/server_tests.rs
+++ b/sui_core/src/unit_tests/server_tests.rs
@@ -293,10 +293,10 @@ async fn test_subscription_safe_client() {
     let db3 = server.state.db().clone();
 
     let _master_safe_client = SafeClient::new(
-        LocalAuthorityClient {
+        Arc::new(LocalAuthorityClient {
             state: state.clone(),
             fault_config: LocalAuthorityClientFaultConfig::default(),
-        },
+        }),
         state.committee.clone(),
         state.name,
     );


### PR DESCRIPTION
This removes a lot of generic boilerplate and simplifies many types.

The motivation for this is to be able to use a LocalAuthorityClient in AuthorityAggregator to sync remote authorities to the local full node. (see: https://github.com/MystenLabs/sui/blob/main/sui_core/src/authority_aggregator.rs#L77).

