### PR TITLE
[Move] Fix a bug in adapter `check_child_object_of_shared_object`

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -67,6 +67,11 @@ pub enum SuiError {
     SharedObjectLockNotSetObject,
     #[error("Invalid Batch Transaction: {}", error)]
     InvalidBatchTransaction { error: String },
+    #[error("Object {child_id:?} is owned by object {parent_id:?}, which is not in the input")]
+    MissingObjectOwner {
+        child_id: ObjectID,
+        parent_id: ObjectID,
+    },
 
     // Signature verification
     #[error("Signature is not valid: {}", error)]

--- a/sui/open_rpc/samples/objects.json
+++ b/sui/open_rpc/samples/objects.json
@@ -8,7 +8,7 @@
         "fields": {
           "description": "An NFT created by the wallet Command Line Tool",
           "id": {
-            "id": "0x1c74cc69c2d29290068640d31bdc962307f3d40f",
+            "id": "0xf629b4e82581c3ce0ae206ece9d1098be27a8cd9",
             "version": 1
           },
           "name": "Example NFT",
@@ -16,14 +16,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+        "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
       },
-      "previousTransaction": "LUDHv1wjF0wzjXy4IjM6SphtxZTPhyWKpO8DxKC0lUA=",
+      "previousTransaction": "mg847TeFyfixtmgwRBbNxNDKYLCGOBPsqG2Z3HyYepk=",
       "storageRebate": 25,
       "reference": {
-        "objectId": "0x1c74cc69c2d29290068640d31bdc962307f3d40f",
+        "objectId": "0xf629b4e82581c3ce0ae206ece9d1098be27a8cd9",
         "version": 1,
-        "digest": "49mvgcmdgKUGyYLNXEfc8QzunG78WEwUgXEUcX+4vRk="
+        "digest": "tnbJkEPpw+9ISzhHekVGVTRzDgTROPMakj4/FmLSFuE="
       }
     }
   },
@@ -36,20 +36,20 @@
         "fields": {
           "balance": 100000,
           "id": {
-            "id": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+            "id": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
             "version": 0
           }
         }
       },
       "owner": {
-        "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+        "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
       },
       "previousTransaction": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+        "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
         "version": 0,
-        "digest": "jwS+ob/YuS7Wk9CFYeFjotp8ng8aFLjZ5t+PkEbMJVU="
+        "digest": "Pno7fbEapNe5vJEDfqyC0GTHsFxPad1UxpLjahFY1sM="
       }
     }
   },
@@ -59,16 +59,16 @@
       "data": {
         "dataType": "package",
         "disassembled": {
-          "M1": "// Move bytecode v5\nmodule 751e16da8f2c8b88b55ee991b9684f652618af41.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
+          "M1": "// Move bytecode v5\nmodule e5779cbe095584b7472c8fd429bc99d6fc3d093f.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
         }
       },
       "owner": "Immutable",
-      "previousTransaction": "uU+jtdAwIAgJceyYtTXPKlZst4xkz9bE6lyPnY/if/s=",
+      "previousTransaction": "YHzOMYP1rJ/bP4aOlmarBH1S6h5lEWpVHTBHCKchLFY=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x751e16da8f2c8b88b55ee991b9684f652618af41",
+        "objectId": "0xe5779cbe095584b7472c8fd429bc99d6fc3d093f",
         "version": 1,
-        "digest": "2GzYF8fL6ipLfxNn2bbMTy2N4ZzJCa9DhHxSVqsqamU="
+        "digest": "o4aZje81FxtrqqUpNtFQw6PqUZeUn7CnnD0HHGpPQxo="
       }
     }
   },
@@ -77,21 +77,21 @@
     "details": {
       "data": {
         "dataType": "moveObject",
-        "type": "0x956623467646212cdcbd75399e6e329c50758abe::Hero::Hero",
+        "type": "0x335c6759f2c294136562068f589015577f63a5b7::Hero::Hero",
         "fields": {
           "experience": 0,
-          "game_id": "0x0b7c9628de0b02b0c5309377595ae78d916805c0",
+          "game_id": "0x34ba632dec641789edf9e4bb1a0734a7f665dc43",
           "hp": 100,
           "id": {
-            "id": "0x8907ad9f4c84f55b0ad38ec672c645aa84cc7654",
+            "id": "0xd0d122e384dfb635e22c870edab5a0a5f5aa4eff",
             "version": 1
           },
           "sword": {
-            "type": "0x956623467646212cdcbd75399e6e329c50758abe::Hero::Sword",
+            "type": "0x335c6759f2c294136562068f589015577f63a5b7::Hero::Sword",
             "fields": {
-              "game_id": "0x0b7c9628de0b02b0c5309377595ae78d916805c0",
+              "game_id": "0x34ba632dec641789edf9e4bb1a0734a7f665dc43",
               "id": {
-                "id": "0x07aaed5a79f8a7456516e31dfce3084e642ffeb1",
+                "id": "0x5b4d5642d8051815961837aaac0806734e73e984",
                 "version": 0
               },
               "magic": 10,
@@ -101,14 +101,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+        "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
       },
-      "previousTransaction": "O6Lqe/CPhFVYH8b7ASBx+DsLzaUlWt7TQARAX2ktBLY=",
+      "previousTransaction": "y/jg8HSpqaJfU2IwxxGVlw7MPmtKW6YgFkbKDueIyFg=",
       "storageRebate": 22,
       "reference": {
-        "objectId": "0x8907ad9f4c84f55b0ad38ec672c645aa84cc7654",
+        "objectId": "0xd0d122e384dfb635e22c870edab5a0a5f5aa4eff",
         "version": 1,
-        "digest": "iR1+VKjftUzM3R6elyPpjoKZypZQJTCWhMxC1DFERV0="
+        "digest": "bpn3xEBMftbfmKHaJMm0Eba/V0doebXxws/mH0iyNOs="
       }
     }
   }

--- a/sui/open_rpc/samples/transactions.json
+++ b/sui/open_rpc/samples/transactions.json
@@ -2,7 +2,7 @@
   "move_call": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "LUDHv1wjF0wzjXy4IjM6SphtxZTPhyWKpO8DxKC0lUA=",
+        "transactionDigest": "mg847TeFyfixtmgwRBbNxNDKYLCGOBPsqG2Z3HyYepk=",
         "data": {
           "transactions": [
             {
@@ -10,7 +10,7 @@
                 "package": {
                   "objectId": "0x0000000000000000000000000000000000000002",
                   "version": 1,
-                  "digest": "XDC70TFubqTPjdB9oDkxGwqYa7oXmN6Rk0RwagmlVPs="
+                  "digest": "kr2zPqqWdlrIahQ6OShj8JP6gfLFr0Jtu16UBchzHqg="
                 },
                 "module": "DevNetNFT",
                 "function": "mint",
@@ -22,29 +22,29 @@
               }
             }
           ],
-          "sender": "0xeeaf68795523eda4b29ca1d95826e1111c854c21",
+          "sender": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec",
           "gasPayment": {
-            "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+            "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
             "version": 0,
-            "digest": "jwS+ob/YuS7Wk9CFYeFjotp8ng8aFLjZ5t+PkEbMJVU="
+            "digest": "Pno7fbEapNe5vJEDfqyC0GTHsFxPad1UxpLjahFY1sM="
           },
           "gasBudget": 10000
         },
-        "txSignature": "GEYZcewOKeD8J8dIRe2nNuA7Yj5rAlR88tvWakYmtIBdaHG2yweCq8p9NzOAPcYtiVfdouXaKO17WQ26Jlq1A0CX8MOtBw5CCae4fuvknYsGiRIzRNHXj1IGJ+1PWwbJ",
+        "txSignature": "nYvwmZ3QWrQn1SR+4KfMmcuebSC44We94BozM6Q8ZY2csTInsxZPV+YsozGNK2dRoO7jzVItYyumMjZNP9cFDmS/f5jJiuAmuVzCPM7NPpsdFI9gUr+bLT0+PralngGk",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "drK5ZiJpkTX1i1LXKluMURUXKQbmbqo37ShQJ0QWHcs=",
-              "rwdf0mG+c13aRw/dmmZ0FHMs3ey0SeyrFuZKnqDb9QeTtVVjuMxqqabSMyxEg6DvWLMhCglR4tMq+6OFdeweAA=="
+              "f3WhWq6lkM+IsmHqXgp5/Ye39A8JJfjFPEeHuLwrgiw=",
+              "Xb9INyabExSQK7QpJpueiAVRSI5dHw4eddor81axcfMoSVYex7k38AGGfLrvzADwO7liw3sRXzyDeYG9qaEdCg=="
             ],
             [
-              "dyxkrnJZ1unLzo6IPCCivkiaJlc8Wo/dyTVRoFz2ZJA=",
-              "fLb/g5vIS+mBH/yudgaM9txHDiU+ZCnb24njpB5DYiSeg0a6faL7aavqVvz/N+/55gph7ONbQQylhAB+GJDWAw=="
+              "NLFQ4dW3Ui6IkzKFAIC+y9cVuXmGx6ouwQUruoepI6k=",
+              "25cBGXYbj75GyilQs/2MMzLpCClkr5aKct7uTQ6OIR/p3v02wcnPYdUPXep3vrFMXF8AYXTNG1Qrq8K7Tp2bBQ=="
             ],
             [
-              "wu4eaZsCnEWvOwsM67WdWSnm2RC90xnOz++1HqWlgaM=",
-              "Bt3x1uy+LV4p+Y6Q/KQxLa0sqRQxzt/BZ9v3Q6pC0LrFtmMB8njbAiUrEMMG0oRPmkhALKwlgngjyukfsAL8DQ=="
+              "JQLS415wB1E6P/aoc79dduvi0EIbpAx4wF3jg5HMFXM=",
+              "TVjbaY9J8J6is84mxVcMSMfvkR/DwwN1wXRCmddawEch/gqOKqtxvlBG88MqZZK/a7BXSvzFpYaOCJbD40jYBg=="
             ]
           ]
         }
@@ -53,44 +53,44 @@
         "status": {
           "status": "success",
           "gas_cost": {
-            "computationCost": 719,
+            "computationCost": 708,
             "storageCost": 40,
             "storageRebate": 0
           }
         },
-        "transactionDigest": "LUDHv1wjF0wzjXy4IjM6SphtxZTPhyWKpO8DxKC0lUA=",
+        "transactionDigest": "mg847TeFyfixtmgwRBbNxNDKYLCGOBPsqG2Z3HyYepk=",
         "created": [
           {
             "owner": {
-              "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+              "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
             },
             "reference": {
-              "objectId": "0x1c74cc69c2d29290068640d31bdc962307f3d40f",
+              "objectId": "0xf629b4e82581c3ce0ae206ece9d1098be27a8cd9",
               "version": 1,
-              "digest": "49mvgcmdgKUGyYLNXEfc8QzunG78WEwUgXEUcX+4vRk="
+              "digest": "tnbJkEPpw+9ISzhHekVGVTRzDgTROPMakj4/FmLSFuE="
             }
           }
         ],
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+              "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
             },
             "reference": {
-              "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+              "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
               "version": 1,
-              "digest": "CridvOzqeE6uCYghp9/gyBtBJA/1Y4SLG9sQpykjGKQ="
+              "digest": "M860JH3T7XZ0CZmGOraq5hFRD17DmcXRi7NMoJoj3p0="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
           "reference": {
-            "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+            "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
             "version": 1,
-            "digest": "CridvOzqeE6uCYghp9/gyBtBJA/1Y4SLG9sQpykjGKQ="
+            "digest": "M860JH3T7XZ0CZmGOraq5hFRD17DmcXRi7NMoJoj3p0="
           }
         }
       }
@@ -99,43 +99,43 @@
   "transfer": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "DpVXAnekzdJcOerD/FORk1XNofhbuMlHo2YRQeh4uWc=",
+        "transactionDigest": "GnAwms1/2wN6qwOBpkThTyuxFyL85buxmrzVzi0YRko=",
         "data": {
           "transactions": [
             {
               "TransferCoin": {
-                "recipient": "0xeeaf68795523eda4b29ca1d95826e1111c854c21",
+                "recipient": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec",
                 "objectRef": {
-                  "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+                  "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
                   "version": 4,
-                  "digest": "BtY4eun9rmiDXM4CH8lSemtUQelQd2L7jWxjJ/O35EM="
+                  "digest": "fMHxFPQbuiz8ctiKSpSVLB3IVqzIlAjkokLR8ZRFUvs="
                 }
               }
             }
           ],
-          "sender": "0xeeaf68795523eda4b29ca1d95826e1111c854c21",
+          "sender": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec",
           "gasPayment": {
-            "objectId": "0x4d50103188cc5d27ff07dddd57f0955cebe06456",
+            "objectId": "0x2d6b435b2ea82eac86f69ef292d17a22bb639e55",
             "version": 1,
-            "digest": "OHXuqc6LO602zI+v6E1UecQW53HIGyvxhN851F5FEpA="
+            "digest": "a0xaCY1bYeL3bIZI0UFRukxb52EapqGo7ij2Coz5bNM="
           },
           "gasBudget": 1000
         },
-        "txSignature": "OsipCsIFRnCWGrQw5BL9+lRUIjAw/0Qe8I2JNAH+iv0RsrO/xpy15UVsV8mEMAXIYQCQ3HoPl3QOHQwM5Lw+AkCX8MOtBw5CCae4fuvknYsGiRIzRNHXj1IGJ+1PWwbJ",
+        "txSignature": "FnjZtsr5bAK6IPC3PkszO2yhvyf+4oVcoBpWDAZae5ny8U+oSa5aD0aYDYRfNxPjeK1GsDoMA/VVGzPpUxNwCWS/f5jJiuAmuVzCPM7NPpsdFI9gUr+bLT0+PralngGk",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "drK5ZiJpkTX1i1LXKluMURUXKQbmbqo37ShQJ0QWHcs=",
-              "RCspUoICIvRmNFdaX4/fvEqDJv49aAU2A2aV9bskvZ78FbLkKNxrcm8GKHvuVH6rKEaVNHyAcOLi5j8WIxakCg=="
+              "NLFQ4dW3Ui6IkzKFAIC+y9cVuXmGx6ouwQUruoepI6k=",
+              "ULlQLT7ZS8lXHRgyJmwaGVqvNApnyru0QcvS4+5QGl+0WseXw+z3ubsN+bMRoqlYNhyTZceTHLRb0kyr+a2LCA=="
             ],
             [
-              "bs8O4FsKXAg2jgHNjleDzZJiMTHBb8lc8eWqpqD39ik=",
-              "XLR54OWEhxrdp003o9s0T3I332XgfI58DhcEGPJRMTjCTUmkp1Ra/2IE9lZ/SArFP4S8oK+yvbpjan8KryVwDQ=="
+              "JQLS415wB1E6P/aoc79dduvi0EIbpAx4wF3jg5HMFXM=",
+              "H/yAh+SftzGXlQE6sMPolfxcXI4c7N+mdbqj4td8oDvU9JJJpApdXfLdsCih81Iyu3NCQwKm9wYNNMUhBSvqAA=="
             ],
             [
-              "wu4eaZsCnEWvOwsM67WdWSnm2RC90xnOz++1HqWlgaM=",
-              "An9AGEijPbIFwwa+RKZ9e8LpAfg4rPmQbVr+ZZj62I01uuHWPGoYVNCg20T6Oe1dXSOhMtiz65qHM3gjW7laDQ=="
+              "79KKiGxX+cHdI5j+lzOy4051Fhri+qhCp5dTgENvxtY=",
+              "ihDshvZRqhXoA2KbgZgsvlLpPDOI5GJHBX+oYMpD2+r8h0jRk3gJF5aia3G/DhjfWGKbmh+N3BUFDruT91M9Ag=="
             ]
           ]
         }
@@ -149,41 +149,41 @@
             "storageRebate": 30
           }
         },
-        "transactionDigest": "DpVXAnekzdJcOerD/FORk1XNofhbuMlHo2YRQeh4uWc=",
+        "transactionDigest": "GnAwms1/2wN6qwOBpkThTyuxFyL85buxmrzVzi0YRko=",
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+              "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
             },
             "reference": {
-              "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+              "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
               "version": 5,
-              "digest": "lwOpHxFfWGsS7pmO/8Fx4Arwl2OEQdJ9BQuSv/a8oF8="
+              "digest": "Ox0voIPRGuiY/4bCMHVswCLKOyhN8C6/86eHt7Qrpwg="
             }
           },
           {
             "owner": {
-              "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+              "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
             },
             "reference": {
-              "objectId": "0x4d50103188cc5d27ff07dddd57f0955cebe06456",
+              "objectId": "0x2d6b435b2ea82eac86f69ef292d17a22bb639e55",
               "version": 2,
-              "digest": "AIwPLqYM+jsH39RT9PNIKW9NZi010drTPwEsRPYG+fQ="
+              "digest": "tifEb2VP9kyNhRO1S2VNPB2E624RO7n08ou+WdouFS4="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
           "reference": {
-            "objectId": "0x4d50103188cc5d27ff07dddd57f0955cebe06456",
+            "objectId": "0x2d6b435b2ea82eac86f69ef292d17a22bb639e55",
             "version": 2,
-            "digest": "AIwPLqYM+jsH39RT9PNIKW9NZi010drTPwEsRPYG+fQ="
+            "digest": "tifEb2VP9kyNhRO1S2VNPB2E624RO7n08ou+WdouFS4="
           }
         },
         "dependencies": [
-          "O6Lqe/CPhFVYH8b7ASBx+DsLzaUlWt7TQARAX2ktBLY="
+          "y/jg8HSpqaJfU2IwxxGVlw7MPmtKW6YgFkbKDueIyFg="
         ]
       }
     }
@@ -191,7 +191,7 @@
   "coin_split": {
     "SplitCoinResponse": {
       "certificate": {
-        "transactionDigest": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+        "transactionDigest": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
         "data": {
           "transactions": [
             {
@@ -199,7 +199,7 @@
                 "package": {
                   "objectId": "0x0000000000000000000000000000000000000002",
                   "version": 1,
-                  "digest": "XDC70TFubqTPjdB9oDkxGwqYa7oXmN6Rk0RwagmlVPs="
+                  "digest": "kr2zPqqWdlrIahQ6OShj8JP6gfLFr0Jtu16UBchzHqg="
                 },
                 "module": "Coin",
                 "function": "split_vec",
@@ -207,7 +207,7 @@
                   "0x2::SUI::SUI"
                 ],
                 "arguments": [
-                  "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+                  "0x696c90985cbe53cbf96ca1a827eea89e6618238",
                   [
                     20,
                     20,
@@ -219,29 +219,29 @@
               }
             }
           ],
-          "sender": "0xeeaf68795523eda4b29ca1d95826e1111c854c21",
+          "sender": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec",
           "gasPayment": {
-            "objectId": "0x4d50103188cc5d27ff07dddd57f0955cebe06456",
+            "objectId": "0x2d6b435b2ea82eac86f69ef292d17a22bb639e55",
             "version": 2,
-            "digest": "AIwPLqYM+jsH39RT9PNIKW9NZi010drTPwEsRPYG+fQ="
+            "digest": "tifEb2VP9kyNhRO1S2VNPB2E624RO7n08ou+WdouFS4="
           },
           "gasBudget": 1000
         },
-        "txSignature": "K93WfH54W13wu6x5ziYhuga3WWH0o/COoEAltecPC66XmYXDL9rrBXEK/SRLCkbDwk8XxHEMB8bmjzm+F6FKBECX8MOtBw5CCae4fuvknYsGiRIzRNHXj1IGJ+1PWwbJ",
+        "txSignature": "GWLCZGEH+fBH90102uIWBWBR3HwnkO9oVYFv0geGkUZQCIaeCNDIBbfOdlzGoaXMckwnTWjp3g88lDup8FvQBWS/f5jJiuAmuVzCPM7NPpsdFI9gUr+bLT0+PralngGk",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "drK5ZiJpkTX1i1LXKluMURUXKQbmbqo37ShQJ0QWHcs=",
-              "/aLHBbotSMtzZnyOAgBlxE7A2UjwfOtt2pSu8RSABTISYMwVWtKz9hax0udgvttRhgtVn7KAdRUc7oHCxaGQDA=="
+              "79KKiGxX+cHdI5j+lzOy4051Fhri+qhCp5dTgENvxtY=",
+              "lP/LYFUewDrfDriw8JAINzDCBVxC3h/U435FOzzu3MXVoHu2zZboRv5ZwJsUaicW3OfvIJdUk+vRNCePirbQBw=="
             ],
             [
-              "dyxkrnJZ1unLzo6IPCCivkiaJlc8Wo/dyTVRoFz2ZJA=",
-              "Vz31BHsB4/5XqIDrv75PYnul89UJGS7XxWqgbYzKuNSVETqDyF43E6fjScOgssPXihJY/a6aK1hoysnw7U5kDg=="
+              "f3WhWq6lkM+IsmHqXgp5/Ye39A8JJfjFPEeHuLwrgiw=",
+              "v2lySrl8N2XxrR78Cumaf/x+W061yC1kmtQK42x19ca0SnMOKY0zqDqTKv9oXYfMPtv4kiiQ3MH4Z9wfQGf7Dw=="
             ],
             [
-              "bs8O4FsKXAg2jgHNjleDzZJiMTHBb8lc8eWqpqD39ik=",
-              "GpwlKd1PoiLlmq3zdcj/NKmlk6KS4Cstv9DminmH2yEq/1hGC0q6OLicVDlDi4C3R1aONHMk2VdujBAE2RseDQ=="
+              "JQLS415wB1E6P/aoc79dduvi0EIbpAx4wF3jg5HMFXM=",
+              "sh1IZAOM5anwnoAGnmLpyrnLw8obHfWLFhmhLNQIpzntvTZDEttW+PaZE6YA53xjclIVOSNrwDnBcuU1b3r2Aw=="
             ]
           ]
         }
@@ -251,22 +251,22 @@
           "dataType": "moveObject",
           "type": "0x2::Coin::Coin<0x2::SUI::SUI>",
           "fields": {
-            "balance": 95648,
+            "balance": 95681,
             "id": {
-              "id": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+              "id": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
               "version": 6
             }
           }
         },
         "owner": {
-          "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+          "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
         },
-        "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+        "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x2fd9e6245b774f54c28090911c3a804789d990f0",
+          "objectId": "0x0696c90985cbe53cbf96ca1a827eea89e6618238",
           "version": 6,
-          "digest": "omUGjJkGoQtehcSwBqvf1IIG0jpudQZ16WzQjGuhCtU="
+          "digest": "DcxjiVs7M9iWisfC7sm7LhbHQZVqyJHz/jd9YSNcBqM="
         }
       },
       "newCoins": [
@@ -277,20 +277,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x1a04d6c704542a87f06c8bb3d7439ded4df55cce",
+                "id": "0x0d4d4b7b21fe6a67c5a8ee46d761d977670eb682",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
-          "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+          "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x1a04d6c704542a87f06c8bb3d7439ded4df55cce",
+            "objectId": "0x0d4d4b7b21fe6a67c5a8ee46d761d977670eb682",
             "version": 1,
-            "digest": "LfgnOKNSMjrtLVoe6EnazMqmB0vQOLDHe0R3UEjawf8="
+            "digest": "Hhblw47wUb8o9fNhm29qufrepR6KhheYG3ddt5Xcw9Y="
           }
         },
         {
@@ -300,20 +300,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x38bfbe3f602bb65bb4c6950933bec3e955686de8",
+                "id": "0xbd3f34302943c99cc7ce479cb357069a55988cd1",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
-          "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+          "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x38bfbe3f602bb65bb4c6950933bec3e955686de8",
+            "objectId": "0xbd3f34302943c99cc7ce479cb357069a55988cd1",
             "version": 1,
-            "digest": "kMtbQM+PR1DBebZpmMfwZ/tnvOcO//R3bbn5P3S4SYA="
+            "digest": "MLz/n7kxXvFbcjKrYM2AWhxCKNcKU+37tOKOiAvBhPw="
           }
         },
         {
@@ -323,20 +323,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x70367d6d46ff858aa3481ffbf73c30d4e73616d6",
+                "id": "0xe2b4c29580c8f43f3b4c666ffce54085fa8c9396",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
-          "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+          "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x70367d6d46ff858aa3481ffbf73c30d4e73616d6",
+            "objectId": "0xe2b4c29580c8f43f3b4c666ffce54085fa8c9396",
             "version": 1,
-            "digest": "IJ4S2lskK6G88Y/8Wcw4eamLABoUcmicC9DNJheVHuE="
+            "digest": "vqF8GUmSWM2axKMjUrisMPyL8fqBus5mP1lUDDDYF4E="
           }
         },
         {
@@ -346,20 +346,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x8b8b5ff6d0099ca8c0118724e2c8b0d766757fee",
+                "id": "0xeb06ee6ecbc0f15dcc19046cf68ff16d4a6a67a7",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
-          "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+          "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x8b8b5ff6d0099ca8c0118724e2c8b0d766757fee",
+            "objectId": "0xeb06ee6ecbc0f15dcc19046cf68ff16d4a6a67a7",
             "version": 1,
-            "digest": "FqXkIsfXhxQWeMnLneFvkAEKBWvjIC0JVKa37AG9hpM="
+            "digest": "ux3KHVUx6ZI7gRlShFrQudAXPpBRsGdolEVSXR5j6QY="
           }
         },
         {
@@ -369,20 +369,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x8cc09205df122aff87cc0b128196aca766cf25ef",
+                "id": "0xf390bf1d23776b2cb1ed27f79494c1e9069b4590",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+            "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
           },
-          "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+          "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x8cc09205df122aff87cc0b128196aca766cf25ef",
+            "objectId": "0xf390bf1d23776b2cb1ed27f79494c1e9069b4590",
             "version": 1,
-            "digest": "/8GRDlm0df/94Rsegh3WNgVC/Iv4mX22qQrs5QiGjjM="
+            "digest": "idoB0iARX/lIdpWt6sWFJC/A+I7O9olPOEb0MbQ7O90="
           }
         }
       ],
@@ -391,22 +391,22 @@
           "dataType": "moveObject",
           "type": "0x2::Coin::Coin<0x2::SUI::SUI>",
           "fields": {
-            "balance": 98958,
+            "balance": 98969,
             "id": {
-              "id": "0x4d50103188cc5d27ff07dddd57f0955cebe06456",
+              "id": "0x2d6b435b2ea82eac86f69ef292d17a22bb639e55",
               "version": 3
             }
           }
         },
         "owner": {
-          "AddressOwner": "0xeeaf68795523eda4b29ca1d95826e1111c854c21"
+          "AddressOwner": "0x0f08fbeeabaf8a58a6f1fdffe3d8485ba745aeec"
         },
-        "previousTransaction": "8DU/9llewLEI+98936RRh8PkkTmYTO4KmypbIE4Xf7o=",
+        "previousTransaction": "Kjdn2vn7LSG5XbyPGQxyxsSJnKmzSxmO1fbMlefy6n0=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x4d50103188cc5d27ff07dddd57f0955cebe06456",
+          "objectId": "0x2d6b435b2ea82eac86f69ef292d17a22bb639e55",
           "version": 3,
-          "digest": "Y9BBf1tFcQuBFjVfTEB5+e26SBQbnXgUAsvKT1I3GbE="
+          "digest": "bB4qHncDaxNxTpEfJVraU8lMWpm1F43qC+3U5r0XBpg="
         }
       }
     }

--- a/sui_core/src/transaction_input_checker.rs
+++ b/sui_core/src/transaction_input_checker.rs
@@ -269,12 +269,9 @@ fn check_one_lock(
                     // Check that the object owner is another mutable object in the input.
                     fp_ensure!(
                         owned_object_authenticators.contains(&owner),
-                        SuiError::IncorrectSigner {
-                            error: format!(
-                                "Object {:?} is owned by object {:?}, which is not in the input",
-                                object.id(),
-                                owner
-                            ),
+                        SuiError::MissingObjectOwner {
+                            child_id: object.id(),
+                            parent_id: owner.into(),
                         }
                     );
                 }

--- a/sui_core/tests/staged/sui.yaml
+++ b/sui_core/tests/staged/sui.yaml
@@ -267,22 +267,29 @@ SuiError:
         STRUCT:
           - error: STR
     11:
+      MissingObjectOwner:
+        STRUCT:
+          - child_id:
+              TYPENAME: ObjectID
+          - parent_id:
+              TYPENAME: ObjectID
+    12:
       InvalidSignature:
         STRUCT:
           - error: STR
-    12:
+    13:
       IncorrectSigner:
         STRUCT:
           - error: STR
-    13:
-      UnknownSigner: UNIT
     14:
+      UnknownSigner: UNIT
+    15:
       WrongEpoch:
         STRUCT:
           - expected_epoch: U64
-    15:
-      CertificateRequiresQuorum: UNIT
     16:
+      CertificateRequiresQuorum: UNIT
+    17:
       UnexpectedSequenceNumber:
         STRUCT:
           - object_id:
@@ -291,177 +298,177 @@ SuiError:
               TYPENAME: SequenceNumber
           - given_sequence:
               TYPENAME: SequenceNumber
-    17:
+    18:
       ConflictingTransaction:
         STRUCT:
           - pending_transaction:
               TYPENAME: TransactionDigest
-    18:
-      ErrorWhileProcessingTransaction: UNIT
     19:
+      ErrorWhileProcessingTransaction: UNIT
+    20:
       ErrorWhileProcessingTransactionTransaction:
         STRUCT:
           - err: STR
-    20:
+    21:
       ErrorWhileProcessingConfirmationTransaction:
         STRUCT:
           - err: STR
-    21:
-      ErrorWhileRequestingCertificate: UNIT
     22:
+      ErrorWhileRequestingCertificate: UNIT
+    23:
       ErrorWhileProcessingPublish:
         STRUCT:
           - err: STR
-    23:
+    24:
       ErrorWhileProcessingMoveCall:
         STRUCT:
           - err: STR
-    24:
-      ErrorWhileRequestingInformation: UNIT
     25:
+      ErrorWhileRequestingInformation: UNIT
+    26:
       ObjectFetchFailed:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - err: STR
-    26:
+    27:
       MissingEarlierConfirmations:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - current_sequence_number:
               TYPENAME: SequenceNumber
-    27:
-      UnexpectedTransactionIndex: UNIT
     28:
-      ConcurrentIteratorError: UNIT
+      UnexpectedTransactionIndex: UNIT
     29:
-      ClosedNotifierError: UNIT
+      ConcurrentIteratorError: UNIT
     30:
+      ClosedNotifierError: UNIT
+    31:
       CertificateNotfound:
         STRUCT:
           - certificate_digest:
               TYPENAME: TransactionDigest
-    31:
+    32:
       ParentNotfound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - sequence:
               TYPENAME: SequenceNumber
-    32:
-      UnknownSenderAccount: UNIT
     33:
-      CertificateAuthorityReuse: UNIT
+      UnknownSenderAccount: UNIT
     34:
-      InvalidSequenceNumber: UNIT
+      CertificateAuthorityReuse: UNIT
     35:
-      SequenceOverflow: UNIT
+      InvalidSequenceNumber: UNIT
     36:
-      SequenceUnderflow: UNIT
+      SequenceOverflow: UNIT
     37:
-      WrongShard: UNIT
+      SequenceUnderflow: UNIT
     38:
-      InvalidCrossShardUpdate: UNIT
+      WrongShard: UNIT
     39:
-      InvalidAuthenticator: UNIT
+      InvalidCrossShardUpdate: UNIT
     40:
-      InvalidAddress: UNIT
+      InvalidAuthenticator: UNIT
     41:
-      InvalidTransactionDigest: UNIT
+      InvalidAddress: UNIT
     42:
+      InvalidTransactionDigest: UNIT
+    43:
       InvalidObjectDigest:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
           - expected_digest:
               TYPENAME: ObjectDigest
-    43:
-      InvalidDecoding: UNIT
     44:
-      UnexpectedMessage: UNIT
+      InvalidDecoding: UNIT
     45:
-      DuplicateObjectRefInput: UNIT
+      UnexpectedMessage: UNIT
     46:
+      DuplicateObjectRefInput: UNIT
+    47:
       ClientIoError:
         STRUCT:
           - error: STR
-    47:
-      TransferImmutableError: UNIT
     48:
+      TransferImmutableError: UNIT
+    49:
       TooManyItemsError:
         NEWTYPE: U64
-    49:
-      InvalidSequenceRangeError: UNIT
     50:
-      NoBatchesFoundError: UNIT
+      InvalidSequenceRangeError: UNIT
     51:
-      CannotSendClientMessageError: UNIT
+      NoBatchesFoundError: UNIT
     52:
+      CannotSendClientMessageError: UNIT
+    53:
       SubscriptionItemsDroppedError:
         NEWTYPE: U64
-    53:
-      SubscriptionServiceClosed: UNIT
     54:
+      SubscriptionServiceClosed: UNIT
+    55:
       CheckpointingError:
         STRUCT:
           - error: STR
-    55:
+    56:
       ModuleLoadFailure:
         STRUCT:
           - error: STR
-    56:
+    57:
       ModuleVerificationFailure:
         STRUCT:
           - error: STR
-    57:
+    58:
       ModuleDeserializationFailure:
         STRUCT:
           - error: STR
-    58:
+    59:
       ModulePublishFailure:
         STRUCT:
           - error: STR
-    59:
+    60:
       ModuleBuildFailure:
         STRUCT:
           - error: STR
-    60:
+    61:
       DependentPackageNotFound:
         STRUCT:
           - package_id:
               TYPENAME: ObjectID
-    61:
+    62:
       MoveUnitTestFailure:
         STRUCT:
           - error: STR
-    62:
+    63:
       FunctionNotFound:
         STRUCT:
           - error: STR
-    63:
+    64:
       ModuleNotFound:
         STRUCT:
           - module_name: STR
-    64:
+    65:
       InvalidFunctionSignature:
         STRUCT:
           - error: STR
-    65:
+    66:
       TypeError:
         STRUCT:
           - error: STR
-    66:
+    67:
       AbortedExecution:
         STRUCT:
           - error: STR
-    67:
+    68:
       InvalidMoveEvent:
         STRUCT:
           - error: STR
-    68:
-      CircularObjectOwnership: UNIT
     69:
+      CircularObjectOwnership: UNIT
+    70:
       InvalidSharedChildUse:
         STRUCT:
           - child:
@@ -471,17 +478,17 @@ SuiError:
               TYPENAME: ObjectID
           - ancestor_module: STR
           - current_module: STR
-    70:
+    71:
       GasBudgetTooHigh:
         STRUCT:
           - error: STR
-    71:
+    72:
       InsufficientGas:
         STRUCT:
           - error: STR
-    72:
-      InvalidTxUpdate: UNIT
     73:
+      InvalidTxUpdate: UNIT
+    74:
       TransactionLockExists:
         STRUCT:
           - refs:
@@ -490,21 +497,21 @@ SuiError:
                   - TYPENAME: ObjectID
                   - TYPENAME: SequenceNumber
                   - TYPENAME: ObjectDigest
-    74:
-      TransactionLockDoesNotExist: UNIT
     75:
-      TransactionLockReset: UNIT
+      TransactionLockDoesNotExist: UNIT
     76:
+      TransactionLockReset: UNIT
+    77:
       TransactionNotFound:
         STRUCT:
           - digest:
               TYPENAME: TransactionDigest
-    77:
+    78:
       ObjectNotFound:
         STRUCT:
           - object_id:
               TYPENAME: ObjectID
-    78:
+    79:
       ObjectDeleted:
         STRUCT:
           - object_ref:
@@ -512,26 +519,26 @@ SuiError:
                 - TYPENAME: ObjectID
                 - TYPENAME: SequenceNumber
                 - TYPENAME: ObjectDigest
-    79:
+    80:
       BadObjectType:
         STRUCT:
           - error: STR
-    80:
-      MoveExecutionFailure: UNIT
     81:
-      ObjectInputArityViolation: UNIT
+      MoveExecutionFailure: UNIT
     82:
-      ExecutionInvariantViolation: UNIT
+      ObjectInputArityViolation: UNIT
     83:
-      AuthorityInformationUnavailable: UNIT
+      ExecutionInvariantViolation: UNIT
     84:
-      AuthorityUpdateFailure: UNIT
+      AuthorityInformationUnavailable: UNIT
     85:
+      AuthorityUpdateFailure: UNIT
+    86:
       ByzantineAuthoritySuspicion:
         STRUCT:
           - authority:
               TYPENAME: PublicKeyBytes
-    86:
+    87:
       PairwiseSyncFailed:
         STRUCT:
           - xsource:
@@ -542,31 +549,31 @@ SuiError:
               TYPENAME: TransactionDigest
           - error:
               TYPENAME: SuiError
-    87:
+    88:
       StorageError:
         NEWTYPE:
           TYPENAME: TypedStoreError
-    88:
-      BatchErrorSender: UNIT
     89:
+      BatchErrorSender: UNIT
+    90:
       GenericAuthorityError:
         STRUCT:
           - error: STR
-    90:
+    91:
       QuorumNotReached:
         STRUCT:
           - errors:
               SEQ:
                 TYPENAME: SuiError
-    91:
+    92:
       ObjectSerializationError:
         STRUCT:
           - error: STR
-    92:
-      ConcurrentTransactionError: UNIT
     93:
-      IncorrectRecipientError: UNIT
+      ConcurrentTransactionError: UNIT
     94:
+      IncorrectRecipientError: UNIT
+    95:
       TooManyIncorrectAuthorities:
         STRUCT:
           - errors:
@@ -574,42 +581,42 @@ SuiError:
                 TUPLE:
                   - TYPENAME: PublicKeyBytes
                   - TYPENAME: SuiError
-    95:
+    96:
       InconsistentGatewayResult:
         STRUCT:
           - error: STR
-    96:
+    97:
       GatewayInvalidTxRangeQuery:
         STRUCT:
           - error: STR
-    97:
-      OnlyOneConsensusClientPermitted: UNIT
     98:
+      OnlyOneConsensusClientPermitted: UNIT
+    99:
       ConsensusConnectionBroken:
         NEWTYPE: STR
-    99:
+    100:
       FailedToHearBackFromConsensus:
         NEWTYPE: STR
-    100:
+    101:
       SharedObjectLockingFailure:
         NEWTYPE: STR
-    101:
-      ListenerCapacityExceeded: UNIT
     102:
+      ListenerCapacityExceeded: UNIT
+    103:
       ConsensusSuiSerializationError:
         NEWTYPE: STR
-    103:
-      NotASharedObjectTransaction: UNIT
     104:
+      NotASharedObjectTransaction: UNIT
+    105:
       SignatureSeedInvalidLength:
         NEWTYPE: U64
-    105:
+    106:
       HkdfError:
         NEWTYPE: STR
-    106:
+    107:
       SignatureKeyGenError:
         NEWTYPE: STR
-    107:
+    108:
       RpcError:
         NEWTYPE: STR
 TransactionDigest:


### PR DESCRIPTION
I was under the wrong assumption that `resolve_and_type_check` can only be called in the transaction execution path where we guarantee every object is properly authenticated.
However it turns out we also call this function when constructing a transaction. And if an owner object is not around at that time, this function will crash because of unwrap.
This PR removes the unwrap.
Also noticed we are using a confusing error for this case. Add a new error for it.