### PR TITLE
Add proposal struct for validator voting 

### DIFF
--- a/crates/sui-framework/sources/Governance/Proposal.move
+++ b/crates/sui-framework/sources/Governance/Proposal.move
@@ -1,0 +1,72 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module Sui::Proposal{
+    use Std::Vector;
+
+    struct Proposal has store {
+
+        // the epoch this proposal is about
+        epoch: u64,
+
+        // minum weighted votes to reach quorum
+        quorum_threshold: u64,
+
+        // allowed voters
+        allowed_voters: vector<address>,
+
+        // voted voter
+        voted: vector<address>,
+    
+        total_weighted_vote: u64,
+    }
+
+    public fun new(epoch: u64, quorum_threshold: u64, allowed_voters: vector<address>): Proposal {
+        Proposal {
+            epoch,
+            quorum_threshold,
+            allowed_voters: allowed_voters,
+            voted: Vector::empty(),
+            total_weighted_vote: 0,
+        }
+    }
+
+    public fun vote(self: &mut Proposal, weight: u64, voter: address) {
+        // is allowed voter
+        assert!(cotains_address(&self.allowed_voters, voter), 0);
+
+        // has not voted
+        assert!(!cotains_address(&self.voted, voter), 0);
+
+        Vector::push_back(&mut self.voted, voter);
+        self.total_weighted_vote = self.total_weighted_vote + weight;
+    }
+
+    public fun has_reach_quorum(self: &Proposal): bool {
+        self.total_weighted_vote >= self.quorum_threshold
+    }
+
+    public fun destroy(self: Proposal) {
+        let Proposal {
+            epoch:_,
+            quorum_threshold: _,
+            allowed_voters: _,
+            voted: _,
+            total_weighted_vote: _,
+        } = self;
+    }
+
+    fun cotains_address(v: &vector<address>, target: address): bool {
+        let length = Vector::length(v);
+        let i = 0;
+        while (i < length) {
+            let candidate = Vector::borrow(v, i);
+            if (*candidate == target) {
+                return true
+            };
+            i = i + 1;
+        };
+        return false
+    }
+
+}

--- a/crates/sui-framework/sources/Governance/Proposal.move
+++ b/crates/sui-framework/sources/Governance/Proposal.move
@@ -4,6 +4,9 @@
 module Sui::Proposal{
     use Std::Vector;
 
+
+
+    /// Generic data structure to collect vote and check on quorum
     struct Proposal has store {
 
         // the epoch this proposal is about

--- a/crates/sui-framework/tests/ProposalTests.move
+++ b/crates/sui-framework/tests/ProposalTests.move
@@ -1,0 +1,33 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module Sui::ProposalTests {
+    use Sui::Proposal;
+
+    #[test]
+    #[expected_failure]
+    public(script) fun test_not_allowed_vote() {
+        let proposal = Proposal::new(0, 100, vector<address>[@0x42, @0x100]);
+        Proposal::vote(&mut proposal, 1, @0x1);
+        Proposal::destroy(proposal);
+    }
+
+    #[test]
+    #[expected_failure]
+    public(script) fun test_not_already_voted() {
+        let proposal = Proposal::new(0, 100, vector<address>[@0x42, @0x100]);
+        Proposal::vote(&mut proposal, 1, @0x42);
+        Proposal::vote(&mut proposal, 1, @0x42);
+        Proposal::destroy(proposal);
+        
+    }
+
+    #[test]
+    public(script) fun test_reach_quorum() {
+        let proposal = Proposal::new(0, 50, vector<address>[@0x42, @0x100]);
+        Proposal::vote(&mut proposal, 50, @0x42);
+        assert!(Proposal::has_reach_quorum(&proposal), 1);
+        Proposal::destroy(proposal);
+    }
+}

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -55,6 +55,15 @@ pub struct ValidatorSet {
     pub pending_removals: Vec<u64>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct Proposal {
+    pub epoch: u64,
+    pub quorum_threshold: u64,
+    pub allowed_voters: Vec<AccountAddress>,
+    pub voted: Vec<AccountAddress>,
+    pub total_weighted_vote: u64,
+}
+
 /// Rust version of the Move Sui::SuiSystem::SuiSystemState type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SuiSystemState {
@@ -65,6 +74,7 @@ pub struct SuiSystemState {
     pub storage_fund: Balance,
     pub parameters: SystemParameters,
     pub delegation_reward: Balance,
+    pub active_proposal_for_x: MoveOption<Proposal>,
     // TODO: Use getters instead of all pub.
 }
 


### PR DESCRIPTION
We can parameterize "x" in `create_proposal_for_x` and `vote_for_x` once we settle on the actual content of proposal.
With lacking of Map like struct in Move, I still haven't figure out a more extensible way to group and track different proposal type.  