### PR TITLE
[adapter][verifier] allow option and ID arguments in entry points

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -212,6 +212,9 @@ pub struct TransactionEffectsDigest(
     pub [u8; TRANSACTION_DIGEST_LENGTH],
 );
 
+pub const STD_OPTION_MODULE_NAME: &IdentStr = ident_str!("Option");
+pub const STD_OPTION_STRUCT_NAME: &IdentStr = STD_OPTION_MODULE_NAME;
+
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("TxContext");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = TX_CONTEXT_MODULE_NAME;
 

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_invalid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_invalid.exp
@@ -1,0 +1,7 @@
+processed 2 tasks
+
+task 0 'publish'. lines 6-16:
+Error: Failed to verify the Move module, reason: "Invalid entry point parameter type. Expected primitive or object type. Got: Std::Option::Option<T0>".
+
+task 1 'publish'. lines 18-28:
+Error: Failed to verify the Move module, reason: "Invalid entry point parameter type. Expected primitive or object type. Got: vector<Std::Option::Option<T0>>".

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_invalid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_invalid.mvir
@@ -1,0 +1,28 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, type parameters with key are not valid when nested as no primitive has key
+
+//# publish
+module 0x0.M {
+    import 0x2.TxContext;
+    import 0x1.Option;
+
+    public(script) no<T:key>(l0: Option.Option<T>, ctx: &mut TxContext.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}
+
+//# publish
+module 0x0.M {
+    import 0x2.TxContext;
+    import 0x1.Option;
+
+    public(script) no<T:key>(l0: vector<Option.Option<T>>, ctx: &mut TxContext.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_valid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_valid.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
-task 0 'publish'. lines 6-23:
+task 0 'publish'. lines 6-16:
 created: object(103)
 written: object(102)

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_valid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_valid.mvir
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// valid, type parameters with key are valid as long as they are not nested
+
+//# publish
+module 0x0.M {
+    import 0x2.TxContext;
+    import 0x1.Option;
+
+    public(script) yes<T:key>(l0: T, l1: &T, l2: &mut T, ctx: &mut TxContext.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/id.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/id.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
-task 0 'publish'. lines 6-23:
+task 0 'publish'. lines 6-21:
 created: object(103)
 written: object(102)

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/id.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/id.mvir
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// valid, ID is allowed
+
+//# publish
+module 0x0.M {
+    import 0x2.TxContext;
+    import 0x2.ID;
+
+    public(script) yes<T>(
+        l0: ID.ID,
+        l1: vector<ID.ID>,
+        l2: vector<vector<ID.ID>>,
+        ctx: &mut TxContext.TxContext,
+    ) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/option.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/option.mvir
@@ -1,14 +1,21 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// invalid, non key structs are not supported
+// valid, option of primitives is allowed
 
 //# publish
 module 0x0.M {
     import 0x2.TxContext;
     import 0x1.Option;
 
-    public(script) no(s: Option.Option<u64>, ctx: &mut TxContext.TxContext) {
+    public(script) yes<T>(
+        l0: Option.Option<u64>,
+        l1: Option.Option<Option.Option<u64>>,
+        l2: Option.Option<vector<u64>>,
+        l3: vector<Option.Option<u64>>,
+        l4: Option.Option<Option.Option<T>>,
+        ctx: &mut TxContext.TxContext
+    ) {
         label l0:
         abort 0;
     }


### PR DESCRIPTION
- This seemed easy to fix so I gave it a shot, I think it fits in nicely but
  - I wish this wasn't so special cased. Could be interesting to have some system in the future to automagically allow certain types
  - I think the general solution here is probably public constructors.... but that is a long long ways off IMO 
- #2049
- Allow options of "pure" values
- Allow ID as a "pure" value

- As discussed on the issue, I don't think string is a good fit right here due to the complexities around validation 