### PR TITLE
[sdk] Minor updates in JS BCS

### DIFF
--- a/sdk/typescript/src/bcs/README.md
+++ b/sdk/typescript/src/bcs/README.md
@@ -12,7 +12,7 @@ This library implements [Binary Canonical Serialization (BCS)](https://github.co
 
 ### Working with primitive types
 
-To deserialize data, use a `MoveBCS.de(type: string, data: string)`. Type parameter is a name of the type; data is a BCS encoded as hex. 
+To deserialize data, use a `MoveBCS.de(type: string, data: string)`. Type parameter is a name of the type; data is a BCS encoded as hex.
 
 ```js
 // MoveBCS has a set of built ins:
@@ -62,27 +62,28 @@ TBD
 // }
 
 MoveBCS.registerStructType('Coin', {
-    value: MoveBCS.U64,
-    owner: MoveBCS.STRING,
-    is_locked: MoveBCS.BOOL
+  value: MoveBCS.U64,
+  owner: MoveBCS.STRING,
+  is_locked: MoveBCS.BOOL,
 });
 
-
-
-// Created in Rust with diem/bcs 
+// Created in Rust with diem/bcs
 let rust_bcs_str = '80d1b105600000000e4269672057616c6c65742047757900';
 
 console.log(MoveBCS.de('Coin', MoveBCS.util.fromHex(rust_bcs_str)));
 
 // Let's encode the value as well
 let test_ser = MoveBCS.ser('Coin', {
-    owner: 'Big Wallet Guy',
-    value: '412412400000',
-    is_locked: false
+  owner: 'Big Wallet Guy',
+  value: '412412400000',
+  is_locked: false,
 });
 
 console.log(test_ser.toBytes());
-console.assert(MoveBCS.util.toHex(test_ser.toBytes()) === rust_bcs_str, 'Whoopsie, result mismatch');
+console.assert(
+  MoveBCS.util.toHex(test_ser.toBytes()) === rust_bcs_str,
+  'Whoopsie, result mismatch'
+);
 ```
 
 ## TODO

--- a/sdk/typescript/src/bcs/index.ts
+++ b/sdk/typescript/src/bcs/index.ts
@@ -522,7 +522,6 @@ export class BCS {
    *
    * @param name Name of the type to register.
    * @param elementType Name of the inner type of the vector.
-   * @param encoding Either 'base64' or 'hex' to enable string<->vector conversions
    * @return Returns self for chaining.
    */
   public static registerVectorType(

--- a/sdk/typescript/src/bcs/index.ts
+++ b/sdk/typescript/src/bcs/index.ts
@@ -238,7 +238,7 @@ export class BcsWriter {
   write64(value: bigint | BN): this {
     BcsWriter.toBN(value)
       .toArray('le', 8)
-      .forEach(el => this.write8(el));
+      .forEach((el) => this.write8(el));
 
     return this;
   }
@@ -252,7 +252,7 @@ export class BcsWriter {
   write128(value: bigint | BN): this {
     BcsWriter.toBN(value)
       .toArray('le', 16)
-      .forEach(el => this.write8(el));
+      .forEach((el) => this.write8(el));
 
     return this;
   }
@@ -263,7 +263,7 @@ export class BcsWriter {
    * @returns {this}
    */
   writeULEB(value: number): this {
-    ulebEncode(value).forEach(el => this.write8(el));
+    ulebEncode(value).forEach((el) => this.write8(el));
     return this;
   }
   /**
@@ -275,7 +275,7 @@ export class BcsWriter {
    * @returns {this}
    */
   writeVec(
-    vector: Array<any>,
+    vector: any[],
     cb: (writer: BcsWriter, el: any, i: number, len: number) => {}
   ): this {
     this.writeULEB(vector.length);
@@ -284,10 +284,21 @@ export class BcsWriter {
   }
 
   /**
+   * Adds support for iterations over the object.
+   * @returns {Uint8Array}
+   */
+  *[Symbol.iterator](): Iterator<number, Iterable<number>> {
+    for (let i = 0; i < this.bytePosition; i++) {
+      yield this.dataView.getUint8(i);
+    }
+    return this.toBytes();
+  }
+
+  /**
    * Get underlying buffer taking only value bytes (in case initial buffer size was bigger).
    * @returns {Uint8Array} Resulting BCS.
    */
-  toBytes() {
+  toBytes(): Uint8Array {
     return new Uint8Array(this.dataView.buffer.slice(0, this.bytePosition));
   }
 
@@ -296,22 +307,13 @@ export class BcsWriter {
    * @param encoding Encoding to use: 'base64' or 'hex'
    */
   toString(encoding: string): string {
-    switch (encoding) {
-      case 'base64':
-        return new B64(this.toBytes()).toString();
-      case 'hex':
-        return new HEX(this.toBytes()).toString();
-      default:
-        throw new Error(
-          'Unsupported encoding, supported values are: base64, hex'
-        );
-    }
+    return encodeStr(this.toBytes(), encoding);
   }
 }
 
 // Helper utility: write number as an ULEB array.
 // Original code is taken from: https://www.npmjs.com/package/uleb128 (no longer exists)
-function ulebEncode(num: number): Array<number> {
+function ulebEncode(num: number): number[] {
   let arr = [];
   let len = 0;
 
@@ -332,9 +334,10 @@ function ulebEncode(num: number): Array<number> {
 
 // Helper utility: decode ULEB as an array of numbers.
 // Original code is taken from: https://www.npmjs.com/package/uleb128 (no longer exists)
-function ulebDecode(
-  arr: Array<number> | Uint8Array
-): { value: number; length: number } {
+function ulebDecode(arr: number[] | Uint8Array): {
+  value: number;
+  length: number;
+} {
   let total = 0;
   let shift = 0;
   let len = 0;
@@ -400,7 +403,7 @@ export class BCS {
    * @param size Serialization buffer size. Default 1024 = 1KB.
    * @return A BCS reader instance. Usually you'd want to call `.toBytes()`
    */
-  public static set(type: string, data: any, size: number = 1024): BcsWriter {
+  public static ser(type: string, data: any, size: number = 1024): BcsWriter {
     return this.getTypeInterface(type).encode(data, size);
   }
 
@@ -490,17 +493,40 @@ export class BCS {
    *
    * @param name Name of the address type.
    * @param length Byte length of the address.
+   * @param encoding Encoding to use for the address type
    * @returns
    */
-  public static registerAddressType(name: string, length: number): typeof BCS {
-    return this.registerType(
-      name,
-      (writer, data) =>
-        new HEX(data)
-          .getData()
-          .reduce((writer, el) => writer.write8(el), writer),
-      reader => new HEX(reader.readBytes(length)).toString()
-    );
+  public static registerAddressType(
+    name: string,
+    length: number,
+    encoding: string | void = 'hex'
+  ): typeof BCS {
+    // todo: create a common interface?
+    // @ts-ignore
+    let proxyClass;
+
+    switch (encoding) {
+      case 'base64':
+        return this.registerType(
+          name,
+          (writer, data) =>
+            new B64(data)
+              .getData()
+              .reduce((writer, el) => writer.write8(el), writer),
+          (reader) => new B64(reader.readBytes(length)).toString()
+        );
+      case 'hex':
+        return this.registerType(
+          name,
+          (writer, data) =>
+            new HEX(data)
+              .getData()
+              .reduce((writer, el) => writer.write8(el), writer),
+          (reader) => new HEX(reader.readBytes(length)).toString()
+        );
+      default:
+        throw new Error('Unsupported encoding! Use either hex or base64');
+    }
   }
 
   /**
@@ -511,27 +537,26 @@ export class BCS {
    * let array = BCS.de('vector<u8>', new Uint8Array([6,1,2,3,4,5,6])); // [1,2,3,4,5,6];
    * let again = BCS.set('vector<u8>', [1,2,3,4,5,6]).toBytes();
    *
+   * BCS.registerVectorType('vector<u8>', 'u8', 'hex');
+   * let array =
+   *
    * @param name Name of the type to register.
    * @param elementType Name of the inner type of the vector.
+   * @param encoding Either 'base64' or 'hex' to enable string<->vector conversions
    * @return Returns self for chaining.
    */
   public static registerVectorType(
     name: string,
     elementType: string
   ): typeof BCS {
-    // OMITTING SAFETY CHECK TO ALLOW RECURSIVE DEFINITIONS
-    // if (!BCS.hasType(elementType)) {
-    //     throw new Error(`Type ${elementType} is not registered`);
-    // }
-
     return this.registerType(
       name,
       (writer, data) =>
         writer.writeVec(data, (writer, el) => {
           return BCS.getTypeInterface(elementType)._encodeRaw(writer, el);
         }),
-      reader =>
-        reader.readVec(reader => {
+      (reader) =>
+        reader.readVec((reader) => {
           return BCS.getTypeInterface(elementType)._decodeRaw(reader);
         })
     );
@@ -594,21 +619,21 @@ export class BCS {
 
     // Make sure all the types in the fields description are already known
     // and that all the field types are strings.
-    // OMITTING this check to allow recursive definitions and dynamic typing.
-    // for (let type of Object.values(struct)) {
-    //         throw new Error(`Type ${type} is not registered`);
-    //     }
-    // }
-
     return this.registerType(
       name,
       (writer, data) => {
         for (let key of canonicalOrder) {
-          BCS.getTypeInterface(struct[key])._encodeRaw(writer, data[key]);
+          if (key in data) {
+            BCS.getTypeInterface(struct[key])._encodeRaw(writer, data[key]);
+          } else {
+            throw new Error(
+              `Struct ${name} requires field ${key}:${struct[key]}`
+            );
+          }
         }
         return writer;
       },
-      reader => {
+      (reader) => {
         let result: { [key: string]: any } = {};
         for (let key of canonicalOrder) {
           result[key] = BCS.getTypeInterface(struct[key])._decodeRaw(reader);
@@ -655,6 +680,9 @@ export class BCS {
     return this.registerType(
       name,
       (writer, data) => {
+        if (data === undefined) {
+          throw new Error(`Unable to write enum ${name}, missing data`);
+        }
         let key = Object.keys(data)[0];
         if (key === undefined) {
           throw new Error(`Unknown invariant of the enum ${name}`);
@@ -676,7 +704,7 @@ export class BCS {
           ? BCS.getTypeInterface(invariantType)._encodeRaw(writer, data[key])
           : writer;
       },
-      reader => {
+      (reader) => {
         let orderByte = reader.readULEB();
         let invariant = canonicalOrder[orderByte];
         let invariantType = struct[invariant];
@@ -706,39 +734,79 @@ export class BCS {
   }
 }
 
+/**
+ * Encode data with either `hex` or `base64`.
+ *
+ * @param {Uint8Array} data Data to encode.
+ * @param {String} encoding Encoding to use: base64 or hex
+ * @return {String} Encoded value.
+ */
+export function encodeStr(data: Uint8Array, encoding: string): string {
+  switch (encoding) {
+    case 'base64':
+      return new B64(data).toString();
+    case 'hex':
+      return new HEX(data).toString();
+    default:
+      throw new Error(
+        'Unsupported encoding, supported values are: base64, hex'
+      );
+  }
+}
+
+/**
+ * Decode either `base64` or `hex` data.
+ *
+ * @param {String} data Data to encode.
+ * @param {String} encoding Encoding to use: base64 or hex
+ * @return {Uint8Array} Encoded value.
+ */
+export function decodeStr(data: string, encoding: string): Uint8Array {
+  switch (encoding) {
+    case 'base64':
+      return new B64(data).getData();
+    case 'hex':
+      return new HEX(data).getData();
+    default:
+      throw new Error(
+        'Unsupported encoding, supported values are: base64, hex'
+      );
+  }
+}
+
 (function registerPrimitives(): void {
   BCS.registerType(
     BCS.U8,
     (writer, data) => writer.write8(data),
-    reader => reader.read8(),
-    u8 => u8 < 256
+    (reader) => reader.read8(),
+    (u8) => u8 < 256
   );
 
   BCS.registerType(
     BCS.U32,
     (writer, data) => writer.write32(data),
-    reader => reader.read32(),
-    u32 => u32 < 4294967296
+    (reader) => reader.read32(),
+    (u32) => u32 < 4294967296
   );
 
   BCS.registerType(
     BCS.U64,
     (writer, data) => writer.write64(data),
-    reader => reader.read64(),
-    _u64 => true
+    (reader) => reader.read64(),
+    (_u64) => true
   );
 
   BCS.registerType(
     BCS.U128,
     (writer, data) => writer.write128(data),
-    reader => reader.read128(),
-    _u128 => true
+    (reader) => reader.read128(),
+    (_u128) => true
   );
 
   BCS.registerType(
     BCS.BOOL,
     (writer, data) => writer.write8(data),
-    reader => reader.read8().toString(10) == '1',
+    (reader) => reader.read8().toString(10) == '1',
     (_bool: boolean) => true
   );
 
@@ -748,10 +816,10 @@ export class BCS {
       writer.writeVec(Array.from(data), (writer, el) =>
         writer.write8(el.charCodeAt(0))
       ),
-    reader => {
+    (reader) => {
       return reader
-        .readVec(reader => reader.read8())
-        .map(el => String.fromCharCode(el))
+        .readVec((reader) => reader.read8())
+        .map((el) => String.fromCharCode(el))
         .join('');
     },
     (str: string) => /^[\x00-\x7F]*$/.test(str)

--- a/sdk/typescript/src/serialization/hex.ts
+++ b/sdk/typescript/src/serialization/hex.ts
@@ -8,7 +8,7 @@ export class HexDataBuffer {
 
   constructor(data: Uint8Array | string) {
     if (typeof data === 'string') {
-      this._data = new Uint8Array(Buffer.from(data, 'hex'));
+      this._data = new Uint8Array(Buffer.from(data.replace('0x', ''), 'hex'));
     } else {
       this._data = data;
     }

--- a/sdk/typescript/test/bcs/bcs.test.ts
+++ b/sdk/typescript/test/bcs/bcs.test.ts
@@ -18,7 +18,7 @@ describe('Move BCS', () => {
   it('should ser/de u64', () => {
     const exp = 'AO/Nq3hWNBI=';
     const num = BigInt('1311768467750121216');
-    const set = BCS.set('u64', num).toBytes();
+    const set = BCS.ser('u64', num).toBytes();
 
     expect(new B64(set).toString()).toEqual(exp);
     expect(BCS.de('u64', new B64(exp).getData())).toEqual(
@@ -33,7 +33,7 @@ describe('Move BCS', () => {
     expect(BCS.de('u128', sample.getData()).toString(10)).toEqual(
       '1111311768467750121216'
     );
-    expect(new B64(BCS.set('u128', num).toBytes()).toString()).toEqual(
+    expect(new B64(BCS.ser('u128', num).toBytes()).toString()).toEqual(
       sample.toString()
     );
   });
@@ -52,7 +52,7 @@ describe('Move BCS', () => {
       is_locked: false,
     };
 
-    const setBytes = BCS.set('Coin', expected);
+    const setBytes = BCS.ser('Coin', expected);
 
     expect(BCS.de('Coin', rustBcs.getData())).toEqual(expected);
     expect(setBytes.toString('base64')).toEqual(rustBcs.toString());
@@ -69,7 +69,7 @@ describe('Move BCS', () => {
 
     // create the same vec with 1000 elements
     let arr = Array.from(Array(1000)).map(() => 255);
-    const serialized = BCS.set('vector<u8>', arr);
+    const serialized = BCS.ser('vector<u8>', arr);
 
     expect(deserialized.length).toEqual(1000);
     expect(serialized.toString('base64')).toEqual(largeBCSVec());
@@ -88,8 +88,8 @@ describe('Move BCS', () => {
     let example2 = new B64('AQIBAAAAAAAAAAIAAAAAAAAA');
 
     // serialize 2 objects with the same data and signature
-    let set1 = BCS.set('Enum', { single: { value: 10000000 } }).toBytes();
-    let set2 = BCS.set('Enum', {
+    let set1 = BCS.ser('Enum', { single: { value: 10000000 } }).toBytes();
+    let set2 = BCS.ser('Enum', {
       multi: [{ value: 1 }, { value: 2 }],
     }).toBytes();
 
@@ -124,7 +124,7 @@ describe('Move BCS', () => {
     // Test Transfer tx
     let sample = transactionData().transfer;
     let de = BCS.de('TransactionData', sample.getData());
-    expect(BCS.set('TransactionData', de).toString('base64')).toEqual(
+    expect(BCS.ser('TransactionData', de).toString('base64')).toEqual(
       sample.toString()
     );
   });
@@ -133,7 +133,7 @@ describe('Move BCS', () => {
     // Test Module publish tx
     let sample = transactionData().module_publish;
     let de = BCS.de('TransactionData', sample.getData());
-    expect(BCS.set('TransactionData', de).toString('base64')).toEqual(
+    expect(BCS.ser('TransactionData', de).toString('base64')).toEqual(
       sample.toString()
     );
   });
@@ -144,9 +144,9 @@ describe('Move BCS', () => {
     let de = BCS.de('TransactionData', sample.getData());
 
     // Buffer size in this example is increased to 20KB
-    // @see BCS.set(type, data, [SIZE=1024]);
+    // @see BCS.ser(type, data, [SIZE=1024]);
     expect(
-      BCS.set('TransactionData', de, 1024 * 20).toString('base64')
+      BCS.ser('TransactionData', de, 1024 * 20).toString('base64')
     ).toEqual(sample.toString());
   });
 });


### PR DESCRIPTION
- unifies `B64` and `HEX` text encodings for easier removal/updates
- removes `0x` prefix in `HexDataBuffer` for easier address reads/writes
- makes `BcsWriter` iterable, so `toBytes()` method can be omitted in `CallArg::Pure()`
- better Error handling in BCS, giving more user friendly experience in building interfaces
- minor type improvements: `Array<number>` -> `number[]`