### PR TITLE
generate-json-rpc-spec: move into own crate and fix when run at repo …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "generate-json-rpc-spec"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap 3.1.18",
+ "pretty_assertions",
+ "serde 1.0.137",
+ "serde_json",
+ "sui",
+ "sui-core",
+ "sui-gateway",
+ "sui-json",
+ "sui-types",
+ "tempfile",
+ "test-utils",
+ "tokio",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/generate-json-rpc-spec",
     "crates/sui",
     "crates/sui-adapter",
     "crates/sui-adapter-transactional-tests",

--- a/crates/generate-json-rpc-spec/Cargo.toml
+++ b/crates/generate-json-rpc-spec/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "generate-json-rpc-spec"
+version = "0.0.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+anyhow = { version = "1.0.57", features = ["backtrace"] }
+clap = { version = "3.1.17", features = ["derive"] }
+pretty_assertions = "1.2.0"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.80"
+tempfile = "3.3.0"
+tokio = { version = "1.18.2", features = ["full"] }
+
+sui = { path = "../sui" }
+sui-core = { path = "../sui-core" }
+sui-gateway = { path = "../sui-gateway" }
+sui-json = { path = "../sui-json" }
+sui-types = { path = "../sui-types" }
+test-utils = { path = "../test-utils" }

--- a/crates/generate-json-rpc-spec/src/main.rs
+++ b/crates/generate-json-rpc-spec/src/main.rs
@@ -37,13 +37,23 @@ struct Options {
     action: Action,
 }
 
-const FILE_PATH: &str = "sui-open-rpc/spec/openrpc.json";
-const OBJECT_SAMPLE_FILE_PATH: &str = "sui-open-rpc/samples/objects.json";
-const TRANSACTION_SAMPLE_FILE_PATH: &str = "sui-open-rpc/samples/transactions.json";
+const FILE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../sui-open-rpc/spec/openrpc.json",
+);
+
+const OBJECT_SAMPLE_FILE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../sui-open-rpc/samples/objects.json",
+);
+
+const TRANSACTION_SAMPLE_FILE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../sui-open-rpc/samples/transactions.json",
+);
 
 #[tokio::main]
 async fn main() {
-    println!("{}", std::env::current_dir().unwrap().display());
     let options = Options::parse();
     let open_rpc = RpcGatewayOpenRpc::open_rpc();
     match options.action {

--- a/crates/generate-json-rpc-spec/tests/generate-spec.rs
+++ b/crates/generate-json-rpc-spec/tests/generate-spec.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+const GENERATE_JSON_RPC_SPEC_BIN: &str = env!("CARGO_BIN_EXE_generate-json-rpc-spec");
+
 #[test]
 fn test_json_rpc_spec() {
     // If this test breaks and you intended a json rpc schema change, you need to run to get the fresh schema:
-    // # cargo -q run --example generate-json-rpc-spec -- record
-    let status = std::process::Command::new("cargo")
-        .current_dir("..")
-        .args(&["run", "--example", "generate-json-rpc-spec", "--"])
+    // # cargo -q run --bin generate-json-rpc-spec -- record
+    let status = std::process::Command::new(GENERATE_JSON_RPC_SPEC_BIN)
         .arg("test")
         .status()
         .expect("failed to execute process");

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -83,8 +83,3 @@ test-utils = { path = "../test-utils" }
 
 [features]
 benchmark = ["narwhal-node/benchmark"]
-
-[[example]]
-name = "generate-json-rpc-spec"
-path = "src/generate_json_rpc_spec.rs"
-test = false


### PR DESCRIPTION
…root

This PR does 4 things:
1. Move generate-json-rpc-spec functionality into its own crate
2. Makes generate-json-rpc-spec a binary instead of an example
3. Changes the integration test which ensures the checked-in format has been updated to use the binary pre-compiled by cargo before the test is invoked. This eliminates the odd extra compile that occurred when running this test
4. Fixes the binary to not be depended on the directory it's run from in order to function properly.