### PR TITLE
[sui framework] eliminate polymorphic delete in Transfer::delete_chil…

### DIFF
--- a/crates/sui-core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
+++ b/crates/sui-core/src/unit_tests/data/object_owner/sources/ObjectOwner.move
@@ -74,7 +74,8 @@ module ObjectOwner::ObjectOwner {
         let Parent { id, child: child_ref_opt } = parent;
         let child_ref = Option::extract(&mut child_ref_opt);
         Option::destroy_none(child_ref_opt);
-        Transfer::delete_child_object(child, child_ref);
+        let Child { id: child_id } = child;
+        Transfer::delete_child_object(child_id, child_ref);
         ID::delete(id);
     }
 }

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -99,7 +99,6 @@ async fn test_object_wrapping_unwrapping() {
     assert_eq!(parent_object_ref.1, OBJECT_START_VERSION);
 
     // Extract the child out of the parent.
-    println!("before this call");
     let effects = call_move(
         &authority,
         &gas,

--- a/crates/sui-framework/src/natives/transfer.rs
+++ b/crates/sui-framework/src/natives/transfer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{natives::get_object_id, EventType};
+use crate::EventType;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::native_functions::NativeContext;
@@ -100,12 +100,13 @@ pub fn delete_child_object_internal(
     ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    debug_assert!(ty_args.len() == 1);
-    debug_assert!(args.len() == 1);
+    debug_assert!(ty_args.is_empty());
+    // first args is an object ID that we will emit in a DeleteChildObject event
+    // second arg is VersionedID that we want to ignore
+    debug_assert!(args.len() == 2);
 
-    let obj = args.pop_back().unwrap();
+    let obj_id = args.pop_front().unwrap();
     let event_type = EventType::DeleteChildObject;
-    let obj_id = get_object_id(obj)?;
     // TODO: Decide the cost.
     let cost = native_gas(context.cost_table(), NativeCostIndex::EMIT_EVENT, 1);
     if context.save_event(vec![], event_type as u64, Type::Address, obj_id)? {


### PR DESCRIPTION
…d_object

- Get rid of `Transfer::delete_child_object_internal`, which allowed deletion of a Move object without the `drop` ability (bad)
- Adjust `Transfer::delete_child_object` to take the `VersionedID` of the child object rather than the object itself. This allows a Move programmer to delete a child object and `ChildRef` in the same transaction, but without exposing a polymorphic delete.
- Refactored test of this function. This was the only call site
- Changed the dynamic checks for dangling reference detection in the adapter. This is the biggest change here--please review carefully. The dynamic check previously complained if a child was deleted in the same tx as its parent, but that is too strict for the new implementation of `Transfer::delete_child_object`.