### PR TITLE
[chore] Use Rust syntax highlighting for mvir

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Best-effort syntax highlighting for Move: just use Rust
 *.move linguist-language=Rust
+*.mvir linguist-language=Rust
 
-# This file is used in "porcelain" file comparison, 
+# This file is used in "porcelain" file comparison,
 # we don't want an equality to fail because of line endings.
 sui_core/tests/staged/sui.yaml text eol=lf


### PR DESCRIPTION
Should make tests using mvir slightly easier to review in GitHub.