### PR TITLE
gateway port 9000 -> 443

### DIFF
--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -228,7 +228,7 @@ const SUI_CONFIG_DIR: &str = "sui_config";
 pub const SUI_NETWORK_CONFIG: &str = "network.conf";
 pub const SUI_WALLET_CONFIG: &str = "wallet.conf";
 pub const SUI_GATEWAY_CONFIG: &str = "gateway.conf";
-pub const SUI_DEV_NET_URL: &str = "https://gateway.devnet.sui.io:9000";
+pub const SUI_DEV_NET_URL: &str = "https://gateway.devnet.sui.io:443";
 
 pub const AUTHORITIES_DB_NAME: &str = "authorities_db";
 pub const DEFAULT_STARTING_PORT: u16 = 10000;

--- a/crates/sui/src/config/mod.rs
+++ b/crates/sui/src/config/mod.rs
@@ -27,7 +27,7 @@ pub const SUI_WALLET_CONFIG: &str = "wallet.conf";
 pub const SUI_GATEWAY_CONFIG: &str = "gateway.conf";
 pub const FULL_NODE_DB_PATH: &str = "full_node_db";
 
-pub const SUI_DEV_NET_URL: &str = "https://gateway.devnet.sui.io:9000";
+pub const SUI_DEV_NET_URL: &str = "https://gateway.devnet.sui.io:443";
 
 pub fn sui_config_dir() -> Result<PathBuf, anyhow::Error> {
     match std::env::var_os("SUI_CONFIG_DIR") {

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -22,7 +22,7 @@ Fetch objects owned by the address `0xbff6ccc8707aa517b4f1b95750a2a8c666012df3`
 
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:9000/');
+const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:443');
 const objects = await provider.getOwnedObjectRefs(
   '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3'
 );
@@ -32,7 +32,7 @@ Fetch transaction details from a transaction digest:
 
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:9000/');
+const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:443');
 const txn = await provider.getTransaction(
   '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME='
 );
@@ -48,7 +48,7 @@ import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 const keypair = new Ed25519Keypair();
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:9000/')
+  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
 );
 const txn = await signer.transferCoin({
   signer: keypair.getPublicKey().toSuiAddress(),

--- a/sdk/typescript/test/types/framework.test.ts
+++ b/sdk/typescript/test/types/framework.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import mockObjectData from '../../../../sui/open_rpc/samples/objects.json';
+import mockObjectData from '../../../../crates/sui-open-rpc/samples/objects.json';
 import { Coin, GetObjectInfoResponse } from '../../src';
 
 import BN from 'bn.js';

--- a/sdk/typescript/test/types/objects.test.ts
+++ b/sdk/typescript/test/types/objects.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import mockObjectData from '../../../../sui/open_rpc/samples/objects.json';
+import mockObjectData from '../../../../crates/sui-open-rpc/samples/objects.json';
 
 import { isGetObjectInfoResponse } from '../../src/index.guard';
 

--- a/sdk/typescript/test/types/transactions.test.ts
+++ b/sdk/typescript/test/types/transactions.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import mockTransactionData from '../../../../sui/open_rpc/samples/transactions.json';
+import mockTransactionData from '../../../../crates/sui-open-rpc/samples/transactions.json';
 
 import { isTransactionResponse } from '../../src/index.guard';
 


### PR DESCRIPTION
As title. Since CF tunnel enabled, our production (devnet) exposes 443 rather than 9000.
This will fix the problem that wallet become stuck when using default gateway url