### PR TITLE
[store] Consolidate default db options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5581,7 +5581,6 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "executor",
- "fdlimit",
  "futures",
  "hex",
  "itertools",
@@ -5794,6 +5793,7 @@ name = "sui-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fdlimit",
  "futures",
  "pretty_assertions",
  "rocksdb",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -30,7 +30,6 @@ ed25519-dalek = "1.0.1"
 scopeguard = "1.1.0"
 clap = { version = "3.1.17", features = ["derive"] }
 bincode = "1.3.3"
-fdlimit = "0.2.1"
 schemars = "0.8.10"
 multiaddr = "0.14.0"
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "7c247967e5a5abd59ecaa75bc62b05bcdf4503fe" }

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -219,17 +219,13 @@ mod tests {
     use std::time::Duration;
     use tokio::time::timeout;
 
-    use crate::authority::authority_tests::max_files_authority_tests;
-
     #[tokio::test]
     async fn test_notifier() {
         let dir = env::temp_dir();
         let path = dir.join(format!("DB_{:?}", ObjectID::random()));
         fs::create_dir(&path).unwrap();
 
-        let mut opts = rocksdb::Options::default();
-        opts.set_max_open_files(max_files_authority_tests());
-        let store = Arc::new(AuthorityStore::open(path, Some(opts)));
+        let store = Arc::new(AuthorityStore::open(path, None));
 
         let notifier = Arc::new(TransactionNotifier::new(store.clone()).unwrap());
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -12,6 +12,7 @@ use std::{collections::HashSet, path::Path, sync::Arc};
 
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
+use sui_storage::default_db_options;
 use sui_types::{
     base_types::{AuthorityName, TransactionDigest},
     batch::TxSequenceNumber,
@@ -205,19 +206,7 @@ impl CheckpointStore {
         committee: Committee,
         secret: StableSyncAuthoritySigner,
     ) -> Result<CheckpointStore, SuiError> {
-        let mut options = db_options.unwrap_or_default();
-
-        /* The table cache is locked for updates and this determines the number
-           of shards, ie 2^10. Increase in case of lock contentions.
-        */
-        let row_cache = rocksdb::Cache::new_lru_cache(1_000_000).expect("Cache is ok");
-        options.set_row_cache(&row_cache);
-        options.set_table_cache_num_shard_bits(10);
-        options.set_compression_type(rocksdb::DBCompressionType::None);
-
-        let mut point_lookup = options.clone();
-        point_lookup.optimize_for_point_lookup(1024 * 1024);
-        point_lookup.set_memtable_whole_key_filtering(true);
+        let (options, point_lookup) = default_db_options(db_options);
 
         let db = open_cf_opts(
             &path,
@@ -527,7 +516,7 @@ impl CheckpointStore {
         } else {
             // Maybe the fragment we received allows us to complete the current checkpoint?
             // Since we seem to be missing information to complete it (ie there is a checkpoint
-            // but we are not inlcuded in it.)
+            // but we are not included in it.)
             loop {
                 let construct = self.attempt_to_construct_checkpoint();
                 // Exit if checkpoint construction leads to an error or returns false
@@ -693,8 +682,8 @@ impl CheckpointStore {
             }
 
             // TODO: here define what we do if we do not have enough info
-            //       to reconstruct the checkpoint. We can stroe the global waypoints
-            //       and activelly wait for someone else to give us the data?
+            //       to reconstruct the checkpoint. We can store the global waypoints
+            //       and actively wait for someone else to give us the data?
 
             let locals = self.get_locals();
             let mut new_locals = locals.as_ref().clone();
@@ -1066,7 +1055,7 @@ impl CheckpointStore {
         )?;
 
         // If the transactions processed did not belong to a checkpoint yet, we add them to the list
-        // of `extra` transactions, that we should be activelly propagating to others.
+        // of `extra` transactions, that we should be actively propagating to others.
         let batch = batch.insert_batch(
             &self.extra_transactions,
             transactions

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{
-    authority::{authority_tests::max_files_authority_tests, AuthorityState, AuthorityStore},
+    authority::{AuthorityState, AuthorityStore},
     authority_aggregator::{
         authority_aggregator_tests::transfer_coin_transaction, AuthorityAggregator,
     },
@@ -38,12 +38,9 @@ fn random_ckpoint_store_num(num: usize) -> Vec<(PathBuf, CheckpointStore)> {
             fs::create_dir(&path).unwrap();
 
             // Create an authority
-            let mut opts = rocksdb::Options::default();
-            opts.set_max_open_files(max_files_authority_tests());
-
             let cps = CheckpointStore::open(
                 path.clone(),
-                Some(opts),
+                None,
                 *k.public_key_bytes(),
                 committee.clone(),
                 Arc::pin(k.copy()),
@@ -66,14 +63,11 @@ fn crash_recovery() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-
     // Open store first time
 
     let mut cps = CheckpointStore::open(
         path.clone(),
-        Some(opts.clone()),
+        None,
         *k.public_key_bytes(),
         committee.clone(),
         Arc::pin(k.copy()),
@@ -117,7 +111,7 @@ fn crash_recovery() {
 
     let mut cps_new = CheckpointStore::open(
         path,
-        Some(opts),
+        None,
         *k.public_key_bytes(),
         committee,
         Arc::pin(k.copy()),
@@ -633,14 +627,11 @@ fn checkpoint_integration() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-
     // Make a checkpoint store:
 
     let mut cps = CheckpointStore::open(
         path,
-        Some(opts.clone()),
+        None,
         *k.public_key_bytes(),
         committee,
         Arc::pin(k.copy()),
@@ -714,9 +705,6 @@ async fn test_batch_to_checkpointing() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-
     // Make a test key pair
     let seed = [1u8; 32];
     let (committee, _, authority_key) =
@@ -724,7 +712,7 @@ async fn test_batch_to_checkpointing() {
 
     let mut store_path = path.clone();
     store_path.push("store");
-    let store = Arc::new(AuthorityStore::open(&store_path, Some(opts)));
+    let store = Arc::new(AuthorityStore::open(&store_path, None));
 
     let mut checkpoints_path = path.clone();
     checkpoints_path.push("checkpoints");
@@ -812,10 +800,6 @@ async fn test_batch_to_checkpointing_init_crash() {
     let path = dir.join(format!("DB_{:?}", ObjectID::random()));
     fs::create_dir(&path).unwrap();
 
-    // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-
     // Make a test key pair
     let seed = [1u8; 32];
     let (committee, _, authority_key) =
@@ -831,7 +815,7 @@ async fn test_batch_to_checkpointing_init_crash() {
 
     // Scope to ensure all variables are dropped
     {
-        let store = Arc::new(AuthorityStore::open(&store_path, Some(opts.clone())));
+        let store = Arc::new(AuthorityStore::open(&store_path, None));
 
         let state = AuthorityState::new(
             committee.clone(),
@@ -898,7 +882,7 @@ async fn test_batch_to_checkpointing_init_crash() {
 
     // Scope to ensure all variables are dropped
     {
-        let store = Arc::new(AuthorityStore::open(&store_path, Some(opts)));
+        let store = Arc::new(AuthorityStore::open(&store_path, None));
 
         let checkpoints = Arc::new(Mutex::new(
             CheckpointStore::open(
@@ -1337,17 +1321,13 @@ async fn checkpoint_tests_setup() -> TestSetup {
 
         let secret = Arc::pin(k.copy());
 
-        // Create an authority
-        let mut opts = rocksdb::Options::default();
-        opts.set_max_open_files(max_files_authority_tests());
-
         // Make a checkpoint store:
 
-        let store = Arc::new(AuthorityStore::open(&store_path, Some(opts.clone())));
+        let store = Arc::new(AuthorityStore::open(&store_path, None));
 
         let mut checkpoint = CheckpointStore::open(
             &checkpoints_path,
-            Some(opts.clone()),
+            None,
             *secret.public_key_bytes(),
             committee.clone(),
             secret.clone(),

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -76,9 +76,7 @@ async fn test_open_manager() {
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     {
         // Create an authority
-        let mut opts = rocksdb::Options::default();
-        opts.set_max_open_files(max_files_authority_tests());
-        let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+        let store = Arc::new(AuthorityStore::open(&path, None));
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
         // TEST 1: init from an empty database should return to a zero block
@@ -101,9 +99,7 @@ async fn test_open_manager() {
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     {
         // Create an authority
-        let mut opts = rocksdb::Options::default();
-        opts.set_max_open_files(max_files_authority_tests());
-        let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+        let store = Arc::new(AuthorityStore::open(&path, None));
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
         let last_block = authority_state
@@ -123,9 +119,7 @@ async fn test_open_manager() {
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     {
         // Create an authority
-        let mut opts = rocksdb::Options::default();
-        opts.set_max_open_files(max_files_authority_tests());
-        let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+        let store = Arc::new(AuthorityStore::open(&path, None));
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
         let last_block = authority_state.init_batches_from_database().unwrap();
@@ -144,9 +138,7 @@ async fn test_batch_manager_happy_path() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-    let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+    let store = Arc::new(AuthorityStore::open(&path, None));
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -205,9 +197,7 @@ async fn test_batch_manager_out_of_order() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-    let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+    let store = Arc::new(AuthorityStore::open(&path, None));
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -272,9 +262,7 @@ async fn test_batch_manager_drop_out_of_order() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-    let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+    let store = Arc::new(AuthorityStore::open(&path, None));
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -390,9 +378,7 @@ async fn test_batch_store_retrieval() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-    let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+    let store = Arc::new(AuthorityStore::open(&path, None));
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -769,9 +755,7 @@ async fn test_safe_batch_stream() {
     authorities.insert(public_key_bytes, 1);
     let committee = Committee::new(0, authorities);
     // Create an authority
-    let mut opts = rocksdb::Options::default();
-    opts.set_max_open_files(max_files_authority_tests());
-    let store = Arc::new(AuthorityStore::open(&path, Some(opts)));
+    let store = Arc::new(AuthorityStore::open(&path, None));
     let state = AuthorityState::new(
         committee.clone(),
         public_key_bytes,

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.55"
+fdlimit = "0.2.1"
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -6,3 +6,28 @@ pub use lock_service::LockService;
 
 pub mod indexes;
 pub use indexes::IndexStore;
+use rocksdb::Options;
+
+/// Given a provided `db_options`, add a few default options.
+/// Returns the default option and the point lookup option.
+pub fn default_db_options(db_options: Option<Options>) -> (Options, Options) {
+    let mut options = db_options.unwrap_or_default();
+
+    // One common issue when running tests on Mac is that the default ulimit is too low,
+    // leading to I/O errors such as "Too many open files". Raising fdlimit to bypass it.
+    options.set_max_open_files((fdlimit::raise_fd_limit().unwrap() / 8) as i32);
+
+    /* The table cache is locked for updates and this determines the number
+        of shareds, ie 2^10. Increase in case of lock contentions.
+    */
+    let row_cache = rocksdb::Cache::new_lru_cache(300_000).expect("Cache is ok");
+    options.set_row_cache(&row_cache);
+    options.set_table_cache_num_shard_bits(10);
+    options.set_compression_type(rocksdb::DBCompressionType::None);
+
+    let mut point_lookup = options.clone();
+    point_lookup.optimize_for_point_lookup(1024 * 1024);
+    point_lookup.set_memtable_whole_key_filtering(true);
+
+    (options, point_lookup)
+}

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -26,6 +26,8 @@ use typed_store::{reopen, traits::Map};
 use sui_types::base_types::{ObjectRef, TransactionDigest};
 use sui_types::error::{SuiError, SuiResult};
 
+use crate::default_db_options;
+
 /// Commands to send to the LockService (for mutating lock state)
 // TODO: use smallvec as an optimization
 #[derive(Debug)]
@@ -78,27 +80,11 @@ struct LockServiceImpl {
 impl LockServiceImpl {
     /// Open or create a new LockService database
     fn try_open_db<P: AsRef<Path>>(path: P, db_options: Option<Options>) -> Result<Self, SuiError> {
-        let mut options = db_options.unwrap_or_default();
-
-        /* The table cache is locked for updates and this determines the number
-           of shareds, ie 2^10. Increase in case of lock contentions.
-        */
-        let row_cache = rocksdb::Cache::new_lru_cache(300_000).expect("Cache is ok");
-        options.set_row_cache(&row_cache);
-        options.set_table_cache_num_shard_bits(10);
-        options.set_compression_type(rocksdb::DBCompressionType::None);
-
-        let mut point_lookup = options.clone();
-        point_lookup.optimize_for_point_lookup(1024 * 1024);
-        point_lookup.set_memtable_whole_key_filtering(true);
-
-        let transform = rocksdb::SliceTransform::create("bytes_8_to_16", |key| &key[8..16], None);
-        point_lookup.set_prefix_extractor(transform);
-        point_lookup.set_memtable_prefix_bloom_ratio(0.2);
+        let (options, point_lookup) = default_db_options(db_options);
 
         let db = {
             let path = &path;
-            let db_options = Some(options.clone());
+            let db_options = Some(options);
             let opt_cfs: &[(&str, &rocksdb::Options)] = &[("transaction_lock", &point_lookup)];
             typed_store::rocks::open_cf_opts(path, db_options, opt_cfs)
         }


### PR DESCRIPTION
All db store creations can share the same default options.

Note that I removed
```
 let transform = rocksdb::SliceTransform::create("bytes_8_to_16", |key| &key[8..16], None);
 point_lookup.set_prefix_extractor(transform);
 point_lookup.set_memtable_prefix_bloom_ratio(0.2);
```
Not sure if this matters. It seems that this can not be turned on for different stores at the same time.