### PR TITLE
sui: generate a fullnode config when 'sui genesis' is run

### DIFF
--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -216,6 +216,8 @@ impl NetworkConfig {
         Self::generate_with_rng(config_dir, quorum_size, OsRng)
     }
 
+    /// Generate a fullnode config based on this `NetworkConfig`. This is useful if you want to run
+    /// a fullnode and have it connect to a network defined by this `NetworkConfig`.
     pub fn generate_fullnode_config(&self) -> NodeConfig {
         let key_pair = get_key_pair_from_rng(&mut OsRng).1;
         let validator_config = &self.validator_configs[0];
@@ -247,6 +249,7 @@ fn new_network_address() -> Multiaddr {
 const SUI_DIR: &str = ".sui";
 const SUI_CONFIG_DIR: &str = "sui_config";
 pub const SUI_NETWORK_CONFIG: &str = "network.conf";
+pub const SUI_FULLNODE_CONFIG: &str = "fullnode.conf";
 pub const SUI_WALLET_CONFIG: &str = "wallet.conf";
 pub const SUI_GATEWAY_CONFIG: &str = "gateway.conf";
 pub const SUI_DEV_NET_URL: &str = "https://gateway.devnet.sui.io:443";

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -215,6 +215,27 @@ impl NetworkConfig {
     pub fn generate(config_dir: &Path, quorum_size: usize) -> Self {
         Self::generate_with_rng(config_dir, quorum_size, OsRng)
     }
+
+    pub fn generate_fullnode_config(&self) -> NodeConfig {
+        let key_pair = get_key_pair_from_rng(&mut OsRng).1;
+        let validator_config = &self.validator_configs[0];
+
+        let mut db_path = validator_config.db_path.clone();
+        db_path.pop();
+
+        NodeConfig {
+            key_pair,
+            db_path: db_path.join("fullnode"),
+            network_address: new_network_address(),
+            metrics_address: new_network_address(),
+            json_rpc_address: validator_config.json_rpc_address,
+
+            consensus_config: None,
+            committee_config: validator_config.committee_config.clone(),
+
+            genesis: validator_config.genesis.clone(),
+        }
+    }
 }
 
 fn new_network_address() -> Multiaddr {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -242,6 +242,11 @@ impl SuiCommand {
                 wallet_config.save()?;
                 info!("Wallet config file is stored in {:?}.", wallet_path);
 
+                let fullnode_config = network_config
+                    .generate_fullnode_config()
+                    .persisted(&sui_config_dir.join("fullnode.conf"));
+                fullnode_config.save()?;
+
                 for (i, validator) in network_config
                     .into_inner()
                     .into_validator_configs()

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -14,8 +14,8 @@ use clap::*;
 use std::fs;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use sui_config::GenesisConfig;
 use sui_config::{builder::ConfigBuilder, NetworkConfig};
+use sui_config::{GenesisConfig, SUI_FULLNODE_CONFIG};
 use sui_types::base_types::decode_bytes_hex;
 use sui_types::base_types::SuiAddress;
 use tracing::info;
@@ -244,7 +244,7 @@ impl SuiCommand {
 
                 let fullnode_config = network_config
                     .generate_fullnode_config()
-                    .persisted(&sui_config_dir.join("fullnode.conf"));
+                    .persisted(&sui_config_dir.join(SUI_FULLNODE_CONFIG));
                 fullnode_config.save()?;
 
                 for (i, validator) in network_config

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -74,7 +74,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         .flat_map(|r| r.map(|file| file.file_name().to_str().unwrap().to_owned()))
         .collect::<Vec<_>>();
 
-    assert_eq!(8, files.len());
+    assert_eq!(9, files.len());
     assert!(files.contains(&SUI_WALLET_CONFIG.to_string()));
     assert!(files.contains(&SUI_GATEWAY_CONFIG.to_string()));
     assert!(files.contains(&SUI_NETWORK_CONFIG.to_string()));

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -17,7 +17,7 @@ use sui::{
     sui_commands::SuiCommand,
     wallet_commands::{WalletCommandResult, WalletCommands, WalletContext},
 };
-use sui_config::{AccountConfig, GenesisConfig, NetworkConfig, ObjectConfig};
+use sui_config::{AccountConfig, GenesisConfig, NetworkConfig, ObjectConfig, SUI_FULLNODE_CONFIG};
 use sui_core::gateway_types::{GetObjectInfoResponse, SuiObject, SuiTransactionEffects};
 use sui_json::SuiJsonValue;
 use sui_types::{
@@ -78,6 +78,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     assert!(files.contains(&SUI_WALLET_CONFIG.to_string()));
     assert!(files.contains(&SUI_GATEWAY_CONFIG.to_string()));
     assert!(files.contains(&SUI_NETWORK_CONFIG.to_string()));
+    assert!(files.contains(&SUI_FULLNODE_CONFIG.to_string()));
 
     assert!(files.contains(&"wallet.key".to_string()));
 


### PR DESCRIPTION
This teaches `sui genesis` to also generate a fullnode.conf file which
can be used to run a fullnode which will connect to a local network
started with `sui start`. E.g.

    $ sui genesis
    $ sui start
    $ sui-node --config-path ~/.sui/sui_config/fullnode.conf