### PR TITLE
Cleanup authority tests

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -791,6 +791,14 @@ impl AuthorityState {
         self.database.get_object(object_id)
     }
 
+    pub async fn get_framework_object_ref(&self) -> SuiResult<ObjectRef> {
+        Ok(self
+            .get_object(&SUI_FRAMEWORK_ADDRESS.into())
+            .await?
+            .expect("framework object should always exist")
+            .compute_object_reference())
+    }
+
     pub async fn get_object_info(&self, object_id: &ObjectID) -> Result<ObjectRead, SuiError> {
         match self.database.get_latest_parent_entry(*object_id)? {
             None => Ok(ObjectRead::NotExists(*object_id)),

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -4,12 +4,9 @@
 use super::*;
 use bcs;
 
-use authority_tests::{
-    get_genesis_package_by_module, init_state_with_ids, send_and_confirm_transaction,
-};
+use authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use move_binary_format::file_format;
 use move_core_types::{account_address::AccountAddress, ident_str};
-use sui_adapter::genesis;
 use sui_types::{
     crypto::{get_key_pair, Signature},
     messages::Transaction,
@@ -38,9 +35,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
                 .compute_object_reference(),
         }));
     }
-    let genesis_package_objects = genesis::clone_genesis_packages();
-    let package_object_ref =
-        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+    let package_object_ref = authority_state.get_framework_object_ref().await?;
     for _ in 0..N {
         transactions.push(SingleTransactionKind::Call(MoveCall {
             package: package_object_ref,
@@ -108,9 +103,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
                 .compute_object_reference(),
         }));
     }
-    let genesis_package_objects = genesis::clone_genesis_packages();
-    let package_object_ref =
-        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+    let package_object_ref = authority_state.get_framework_object_ref().await?;
     transactions.push(SingleTransactionKind::Call(MoveCall {
         package: package_object_ref,
         module: ident_str!("ObjectBasics").to_owned(),
@@ -188,9 +181,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
         .insert_genesis_object(gas_object.clone())
         .await;
 
-    let genesis_package_objects = genesis::clone_genesis_packages();
-    let package_object_ref =
-        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
+    let package_object_ref = authority_state.get_framework_object_ref().await?;
     const N: usize = 100;
     let mut transactions = vec![];
     for _ in 0..N {

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -1,16 +1,12 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use crate::authority::{
-    authority_tests::{get_genesis_package_by_module, init_state_with_objects},
-    AuthorityState,
-};
+use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use move_core_types::{account_address::AccountAddress, ident_str};
 use narwhal_executor::{ExecutionIndices, ExecutionState};
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
-use sui_adapter::genesis;
 use sui_network::tonic;
 use sui_types::{
     base_types::{ObjectID, TransactionDigest},
@@ -53,8 +49,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         // Make a sample transaction.
         let module = "ObjectBasics";
         let function = "create";
-        let genesis_package_objects = genesis::clone_genesis_packages();
-        let package_object_ref = get_genesis_package_by_module(&genesis_package_objects, module);
+        let package_object_ref = authority.get_framework_object_ref().await.unwrap();
 
         let data = TransactionData::new_move_call(
             sender,

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_tests::get_genesis_package_by_module;
-
 use super::*;
 
 use super::authority_tests::{init_state_with_ids, send_and_confirm_transaction};
@@ -312,12 +310,8 @@ async fn test_publish_gas() -> SuiResult {
 async fn test_move_call_gas() -> SuiResult {
     let (sender, sender_key) = get_key_pair();
     let gas_object_id = ObjectID::random();
-    // find the function Object::create and call it to create a new object
-    let genesis_package_objects = genesis::clone_genesis_packages();
-    let package_object_ref =
-        get_genesis_package_by_module(&genesis_package_objects, "ObjectBasics");
-
     let authority_state = init_state_with_ids(vec![(sender, gas_object_id)]).await;
+    let package_object_ref = authority_state.get_framework_object_ref().await?;
     let gas_object = authority_state.get_object(&gas_object_id).await?.unwrap();
 
     let module = ident_str!("ObjectBasics").to_owned();

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 use crate::authority::authority_tests::{
-    call_move, init_state_with_ids, send_and_confirm_transaction,
+    call_move, init_state_with_ids, send_and_confirm_transaction, TestCallArg,
 };
 
 use move_package::BuildConfig;
@@ -41,8 +41,6 @@ async fn test_object_wrapping_unwrapping() {
         "create_child",
         vec![],
         vec![],
-        vec![],
-        vec![],
     )
     .await
     .unwrap();
@@ -64,9 +62,7 @@ async fn test_object_wrapping_unwrapping() {
         "ObjectWrapping",
         "create_parent",
         vec![],
-        vec![child_object_ref.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(child_object_ref.0)],
     )
     .await
     .unwrap();
@@ -108,9 +104,7 @@ async fn test_object_wrapping_unwrapping() {
         "ObjectWrapping",
         "extract_child",
         vec![],
-        vec![parent_object_ref.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(parent_object_ref.0)],
     )
     .await
     .unwrap();
@@ -144,9 +138,10 @@ async fn test_object_wrapping_unwrapping() {
         "ObjectWrapping",
         "set_child",
         vec![],
-        vec![parent_object_ref.0, child_object_ref.0],
-        vec![],
-        vec![],
+        vec![
+            TestCallArg::Object(parent_object_ref.0),
+            TestCallArg::Object(child_object_ref.0),
+        ],
     )
     .await
     .unwrap();
@@ -178,9 +173,7 @@ async fn test_object_wrapping_unwrapping() {
         "ObjectWrapping",
         "delete_parent",
         vec![],
-        vec![parent_object_ref.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(parent_object_ref.0)],
     )
     .await
     .unwrap();
@@ -228,8 +221,6 @@ async fn test_object_owning_another_object() {
         "create_parent",
         vec![],
         vec![],
-        vec![],
-        vec![],
     )
     .await
     .unwrap();
@@ -245,8 +236,6 @@ async fn test_object_owning_another_object() {
         &package,
         "ObjectOwner",
         "create_child",
-        vec![],
-        vec![],
         vec![],
         vec![],
     )
@@ -265,9 +254,7 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "mutate_child",
         vec![],
-        vec![child.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(child.0)],
     )
     .await
     .unwrap();
@@ -283,9 +270,7 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "add_child",
         vec![],
-        vec![parent.0, child.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(parent.0), TestCallArg::Object(child.0)],
     )
     .await
     .unwrap();
@@ -308,9 +293,7 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "mutate_child",
         vec![],
-        vec![child.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(child.0)],
     )
     .await;
     assert!(result.is_err());
@@ -325,9 +308,7 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "mutate_child_with_parent",
         vec![],
-        vec![child.0, parent.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(child.0), TestCallArg::Object(parent.0)],
     )
     .await
     .unwrap();
@@ -342,8 +323,6 @@ async fn test_object_owning_another_object() {
         &package,
         "ObjectOwner",
         "create_parent",
-        vec![],
-        vec![],
         vec![],
         vec![],
     )
@@ -362,9 +341,11 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "transfer_child",
         vec![],
-        vec![parent.0, child.0, new_parent.0],
-        vec![],
-        vec![],
+        vec![
+            TestCallArg::Object(parent.0),
+            TestCallArg::Object(child.0),
+            TestCallArg::Object(new_parent.0),
+        ],
     )
     .await
     .unwrap();
@@ -388,9 +369,10 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "delete_child",
         vec![],
-        vec![child.0, new_parent.0],
-        vec![],
-        vec![],
+        vec![
+            TestCallArg::Object(child.0),
+            TestCallArg::Object(new_parent.0),
+        ],
     )
     .await
     .unwrap();
@@ -409,9 +391,10 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "remove_child",
         vec![],
-        vec![new_parent.0, child.0],
-        vec![],
-        vec![],
+        vec![
+            TestCallArg::Object(new_parent.0),
+            TestCallArg::Object(child.0),
+        ],
     )
     .await
     .unwrap();
@@ -427,9 +410,10 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "delete_child",
         vec![],
-        vec![child.0, new_parent.0],
-        vec![],
-        vec![],
+        vec![
+            TestCallArg::Object(child.0),
+            TestCallArg::Object(new_parent.0),
+        ],
     )
     .await
     .unwrap();
@@ -445,8 +429,6 @@ async fn test_object_owning_another_object() {
         &package,
         "ObjectOwner",
         "create_parent_and_child",
-        vec![],
-        vec![],
         vec![],
         vec![],
     )
@@ -473,9 +455,7 @@ async fn test_object_owning_another_object() {
         "ObjectOwner",
         "delete_parent_and_child",
         vec![],
-        vec![parent.0, child.0],
-        vec![],
-        vec![],
+        vec![TestCallArg::Object(parent.0), TestCallArg::Object(child.0)],
     )
     .await
     .unwrap();


### PR DESCRIPTION
This PR cleans up two things:
1. We have removed the Move argument order constraints. This PR makes the testing code not rely on the order, but can specify arguments in arbitrary order. Added a TestCallArg layer to make it easier to write.
2. Removed unnecessary complication when looking up framework package.