### PR TITLE
updated sad path test resilience to errors

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -51,7 +51,7 @@ use gossip::gossip_process;
 const MAX_RETRIES_RECORDED: u32 = 10;
 const DELAY_FOR_1_RETRY_MS: u64 = 2_000;
 const EXPONENTIAL_DELAY_BASIS: u64 = 2;
-const MAX_RETRY_DELAY_MS: u64 = 30_000;
+pub const MAX_RETRY_DELAY_MS: u64 = 30_000;
 
 pub struct AuthorityHealth {
     // Records the number of retries

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -391,8 +391,8 @@ where
         let address = self.address;
         let count: u64 = 0;
         let stream = Box::pin(batch_info_items.scan(
-            (0u64, None, count),
-            move |(seq, txs_and_last_batch, count), batch_info_item| {
+            (None, count),
+            move |(txs_and_last_batch, count), batch_info_item| {
                 let req_clone = request.clone();
                 let client = client.clone();
 
@@ -412,8 +412,6 @@ where
                             client.report_client_error(err.clone());
                             Some(Err(err))
                         } else {
-                            // Save the sequence number of this batch
-                            *seq = signed_batch.batch.next_sequence_number;
                             // Insert a fresh vector for the new batch of transactions
                             let _ =
                                 txs_and_last_batch.insert((Vec::new(), signed_batch.batch.clone()));


### PR DESCRIPTION
This updates the sad path test to show that after an error, after waiting the backoff duration, we continue normal processing. 