### PR TITLE
chore: Add wallet.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ storage/
 
 # Python
 .pyc
+
+# logs
+wallet.log.*


### PR DESCRIPTION
I have the following change in my repo whenever I the `wallet` or `/target/debug/wallet` run into some error

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	wallet.log.2022-05-26
```

I guess having `wallet.log.*` show up in the current directory is convenient, but not sure if we want to move it to `~/.sui`