### PR TITLE
[framework] Adds copy to Sui::Url::Url

### DIFF
--- a/crates/sui-framework/sources/Url.move
+++ b/crates/sui-framework/sources/Url.move
@@ -16,14 +16,14 @@ module Sui::Url {
     const EHashLengthMismatch: u64 = 0;
 
     /// Represents an arbitrary URL. Clients rendering values of this type should fetch the resource at `url` and render it using a to-be-defined Sui standard.
-    struct Url has store, drop {
+    struct Url has store, copy, drop {
         // TODO: validate URL format
         url: String,
     }
 
     /// Represents an arbitrary URL plus an immutable commitment to the underlying
     /// resource hash. Clients rendering values of this type should fetch the resource at `url`, and then compare it against `resource_hash` using a to-be-defined Sui standard, and (if the two match) render the value using the `Url` standard.
-    struct UrlCommitment has store, drop {
+    struct UrlCommitment has store, copy, drop {
         url: Url,
         resource_hash: vector<u8>,
     }


### PR DESCRIPTION
I don't see a reason not to have `copy` on the `Url` type. To make it "emittable" in events we need this type to have `copy`.

Example:
```rs
module 0x0::shop {
  struct Item has key {
    id: Sui::ID::VersionedID,
    meta: ItemMeta
  }

  /// used both to describe an item (eg in explorer and a website)
  struct ItemMeta has copy, drop {
    name: Sui::UTF8::String,
    url: Sui::Url::Url
  }
  
  /// event that helps discover listed items 
  struct ItemListed has copy, drop {
    by: address,
    meta: ItemMeta
  }
}
```