### PR TITLE
Add epoch ID to TxContext

### DIFF
--- a/crates/sui-adapter/src/genesis.rs
+++ b/crates/sui-adapter/src/genesis.rs
@@ -32,7 +32,7 @@ pub fn get_framework_object_ref() -> ObjectRef {
 }
 
 pub fn get_genesis_context() -> TxContext {
-    TxContext::new(&SuiAddress::default(), &TransactionDigest::genesis())
+    TxContext::new(&SuiAddress::default(), &TransactionDigest::genesis(), 0)
 }
 
 /// Create and return objects wrapping the genesis modules for sui

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -471,6 +471,7 @@ impl AuthorityState {
             &self.move_vm,
             &self._native_functions,
             gas_status,
+            self.committee.epoch,
         )?;
 
         self.metrics.total_effects.inc();

--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -7,6 +7,7 @@ use crate::authority::AuthorityTemporaryStore;
 use move_core_types::language_storage::ModuleId;
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
 use sui_adapter::adapter;
+use sui_types::committee::EpochId;
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, TxContext},
     error::SuiResult,
@@ -30,8 +31,9 @@ pub fn execute_transaction_to_effects<S: BackingPackageStore>(
     move_vm: &Arc<MoveVM>,
     native_functions: &NativeFunctionTable,
     gas_status: SuiGasStatus,
+    epoch: EpochId,
 ) -> SuiResult<TransactionEffects> {
-    let mut tx_ctx = TxContext::new(&transaction_data.signer(), &transaction_digest);
+    let mut tx_ctx = TxContext::new(&transaction_data.signer(), &transaction_digest, epoch);
 
     let gas_object_id = transaction_data.gas_payment_object_ref().0;
     let status = execute_transaction(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -436,7 +436,7 @@ async fn test_publish_dependent_module_ok() {
     let signature = Signature::new(&data, &sender_key);
     let transaction = Transaction::new(data, signature);
 
-    let dependent_module_id = TxContext::new(&sender, transaction.digest()).fresh_id();
+    let dependent_module_id = TxContext::new(&sender, transaction.digest(), 0).fresh_id();
 
     // Object does not exist
     assert!(authority
@@ -472,7 +472,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let data = TransactionData::new_module(sender, gas_payment_object_ref, module_bytes, MAX_GAS);
     let signature = Signature::new(&data, &sender_key);
     let transaction = Transaction::new(data, signature);
-    let _module_object_id = TxContext::new(&sender, transaction.digest()).fresh_id();
+    let _module_object_id = TxContext::new(&sender, transaction.digest(), 0).fresh_id();
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap();

--- a/crates/sui-framework/sources/TxContext.move
+++ b/crates/sui-framework/sources/TxContext.move
@@ -30,6 +30,8 @@ module Sui::TxContext {
         signer: signer,
         /// Hash of the current transaction
         tx_hash: vector<u8>,
+        /// The current epoch number.
+        epoch: u64,
         /// Counter recording the number of fresh id's created while executing
         /// this transaction. Always 0 at the start of a transaction
         ids_created: u64
@@ -44,6 +46,10 @@ module Sui::TxContext {
     /// Return a `signer` for the user that signed the current transaction
     public fun signer_(self: &TxContext): &signer {
         &self.signer
+    }
+
+    public fun epoch(self: &TxContext): u64 {
+        self.epoch
     }
 
     /// Generate a new, globally unique object ID with version 0
@@ -72,7 +78,17 @@ module Sui::TxContext {
             Vector::length(&tx_hash) == TX_HASH_LENGTH,
             Errors::invalid_argument(EBadTxHashLength)
         );
-        TxContext { signer, tx_hash, ids_created }
+        TxContext { signer, tx_hash, epoch: 0, ids_created }
+    }
+
+    #[test_only]
+    /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
+    public fun new_with_epoch(signer: signer, tx_hash: vector<u8>, epoch: u64, ids_created: u64): TxContext {
+        assert!(
+            Vector::length(&tx_hash) == TX_HASH_LENGTH,
+            Errors::invalid_argument(EBadTxHashLength)
+        );
+        TxContext { signer, tx_hash, epoch, ids_created }
     }
 
     #[test_only]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -476,6 +476,8 @@ impl<'a> SuiTestAdapter<'a> {
             &self.vm,
             &self.native_functions,
             gas_status,
+            // TODO: Support different epochs in transactional tests.
+            0,
         )?;
         let (_objects, _active_inputs, written, deleted, _events) = temporary_store.into_inner();
         let created_set: BTreeSet<_> = created.iter().map(|((id, _, _), _)| *id).collect();

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -34,6 +34,7 @@ use schemars::JsonSchema;
 use serde_with::serde_as;
 use serde_with::Bytes;
 
+use crate::committee::EpochId;
 use sha3::Sha3_256;
 
 #[cfg(test)]
@@ -224,15 +225,18 @@ pub struct TxContext {
     sender: AccountAddress,
     /// Digest of the current transaction
     digest: Vec<u8>,
+    /// The current epoch number
+    epoch: EpochId,
     /// Number of `ObjectID`'s generated during execution of the current transaction
     ids_created: u64,
 }
 
 impl TxContext {
-    pub fn new(sender: &SuiAddress, digest: &TransactionDigest) -> Self {
+    pub fn new(sender: &SuiAddress, digest: &TransactionDigest, epoch: EpochId) -> Self {
         Self {
             sender: AccountAddress::new(sender.0),
             digest: digest.0.to_vec(),
+            epoch,
             ids_created: 0,
         }
     }
@@ -274,6 +278,7 @@ impl TxContext {
         Self::new(
             &SuiAddress::random_for_testing_only(),
             &TransactionDigest::random(),
+            0,
         )
     }
 


### PR DESCRIPTION
Move code should be able to access the current epoch through TxContext.