### PR TITLE
ci: run cargo-udeps on nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,3 +58,35 @@ jobs:
         with:
           command: build
           args: --all-targets --all-features --release --profile=release
+
+  cargo-udeps:
+    needs: diff
+    runs-on: [self-hosted, ubuntu]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+      # 'librocksdb-sys' src directory which is managed by cargo
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/librocksdb-sys-*
+      - name: Install cargo-udeps, and cache the binary
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-udeps
+          locked: true
+      - name: Install cargo-hakari, and cache the binary
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-hakari
+          locked: true
+      # Normally running cargo-udeps requires use of a nightly compiler
+      # In order to have a more stable and less noisy experience, lets instead
+      # opt to use the stable toolchain specified via the 'rust-toolchain' file
+      # and instead enable nightly features via 'RUSTC_BOOTSTRAP'
+      - name: run cargo-udeps
+        run: |
+          # First we need to disable the workspace-hack package
+          cargo hakari disable
+          cargo hakari remove-deps -y
+          RUSTC_BOOTSTRAP=1 cargo udeps


### PR DESCRIPTION
This commit deleted the udeps job because it was taking too much time:
https://github.com/MystenLabs/sui/commit/e5bf59cf2528d7d02cd35378e21e820163e6f11d

This re-establishes it on a nightly basis.