### PR TITLE
Epoch reconfiguration library

### DIFF
--- a/crates/sui-config/src/genesis_config.rs
+++ b/crates/sui-config/src/genesis_config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use sui_types::base_types::{ObjectID, SuiAddress, TxContext};
+use sui_types::committee::StakeUnit;
 use sui_types::crypto::{get_key_pair_from_rng, KeyPair};
 use sui_types::object::Object;
 use tracing::info;
@@ -122,7 +123,7 @@ impl GenesisConfig {
 pub struct ValidatorGenesisInfo {
     pub key_pair: KeyPair,
     pub network_address: Multiaddr,
-    pub stake: usize,
+    pub stake: StakeUnit,
     pub narwhal_primary_to_primary: Multiaddr,
     pub narwhal_worker_to_primary: Multiaddr,
     pub narwhal_primary_to_worker: Multiaddr,

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
+use sui_types::committee::StakeUnit;
 use tracing::trace;
 
 pub mod builder;
@@ -32,7 +33,7 @@ pub const AUTHORITIES_DB_NAME: &str = "authorities_db";
 pub const CONSENSUS_DB_NAME: &str = "consensus_db";
 pub const FULL_NODE_DB_PATH: &str = "full_node_db";
 
-const DEFAULT_STAKE: usize = 1;
+const DEFAULT_STAKE: StakeUnit = 1;
 
 pub fn sui_config_dir() -> Result<PathBuf, anyhow::Error> {
     match std::env::var_os("SUI_CONFIG_DIR") {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use sui_types::base_types::SuiAddress;
+use sui_types::committee::StakeUnit;
 use sui_types::crypto::{KeyPair, PublicKeyBytes};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -123,7 +124,7 @@ impl ConsensusConfig {
 #[serde(rename_all = "kebab-case")]
 pub struct ValidatorInfo {
     pub public_key: PublicKeyBytes,
-    pub stake: usize,
+    pub stake: StakeUnit,
     pub network_address: Multiaddr,
 }
 
@@ -136,7 +137,7 @@ impl ValidatorInfo {
         self.public_key
     }
 
-    pub fn stake(&self) -> usize {
+    pub fn stake(&self) -> StakeUnit {
         self.stake
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -12,6 +12,7 @@ use crate::{
     transaction_input_checker,
 };
 use anyhow::anyhow;
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
@@ -30,6 +31,7 @@ use parking_lot::Mutex;
 use prometheus_exporter::prometheus::{
     register_histogram, register_int_counter, Histogram, IntCounter,
 };
+use std::ops::Deref;
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     pin::Pin,
@@ -52,7 +54,7 @@ use sui_types::{
     messages::*,
     object::{Data, Object, ObjectFormatOptions, ObjectRead},
     storage::{BackingPackageStore, DeleteKind, Storage},
-    MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
+    MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use tracing::{debug, error, instrument};
 use typed_store::Map;
@@ -79,6 +81,7 @@ pub use temporary_store::AuthorityTemporaryStore;
 mod authority_store;
 pub use authority_store::{AuthorityStore, GatewayStore, ReplicaStore, SuiDataStore};
 use sui_types::object::Owner;
+use sui_types::sui_system_state::SuiSystemState;
 
 use self::authority_store::{
     generate_genesis_system_object, store_package_and_init_modules_for_genesis,
@@ -219,10 +222,11 @@ pub struct AuthorityState {
     pub secret: StableSyncAuthoritySigner,
 
     /// Committee of this Sui instance.
-    pub committee: Committee,
+    pub committee: ArcSwap<Committee>,
     /// A global lock to halt all transaction/cert processing.
     #[allow(dead_code)]
-    halted: AtomicBool,
+    pub(crate) halted: AtomicBool,
+    pub(crate) change_epoch_tx: Mutex<BTreeMap<AuthorityName, SignedTransaction>>,
 
     /// Move native functions that are available to invoke
     _native_functions: NativeFunctionTable,
@@ -281,6 +285,10 @@ impl AuthorityState {
             return Ok(transaction_info);
         }
 
+        if self.halted.load(Ordering::SeqCst) {
+            return Err(SuiError::ValidatorHaltedAtEpochEnd);
+        }
+
         let (_gas_status, all_objects) = transaction_input_checker::check_transaction_input(
             &self.database,
             &transaction,
@@ -290,8 +298,12 @@ impl AuthorityState {
 
         let owned_objects = transaction_input_checker::filter_owned_objects(&all_objects);
 
-        let signed_transaction =
-            SignedTransaction::new(self.committee.epoch, transaction, self.name, &*self.secret);
+        let signed_transaction = SignedTransaction::new(
+            self.committee.load().epoch,
+            transaction,
+            self.name,
+            &*self.secret,
+        );
 
         // Check and write locks, to signed transaction, into the database
         // The call to self.set_transaction_lock checks the lock is not conflicting,
@@ -348,9 +360,17 @@ impl AuthorityState {
             return Ok(info);
         }
 
+        if self.halted.load(Ordering::SeqCst) {
+            return Err(SuiError::ValidatorHaltedAtEpochEnd);
+        }
+
         // Check the certificate and retrieve the transfer data.
         tracing::trace_span!("cert_check_signature")
-            .in_scope(|| confirmation_transaction.certificate.verify(&self.committee))
+            .in_scope(|| {
+                confirmation_transaction
+                    .certificate
+                    .verify(&self.committee.load())
+            })
             .map_err(|e| {
                 self.metrics.signature_errors.inc();
                 e
@@ -481,7 +501,7 @@ impl AuthorityState {
             &self.move_vm,
             &self._native_functions,
             gas_status,
-            self.committee.epoch,
+            self.committee.load().epoch,
         )?;
 
         self.metrics.total_effects.inc();
@@ -491,7 +511,7 @@ impl AuthorityState {
 
         // TODO: Distribute gas charge and rebate, which can be retrieved from effects.
         let signed_effects =
-            effects.to_sign_effects(self.committee.epoch, &self.name, &*self.secret);
+            effects.to_sign_effects(self.committee.load().epoch, &self.name, &*self.secret);
 
         // Update the database in an atomic manner
         self.update_state(temporary_store, &certificate, &signed_effects)
@@ -762,8 +782,9 @@ impl AuthorityState {
         let mut state = AuthorityState {
             name,
             secret,
-            committee: current_epoch_info.committee,
+            committee: ArcSwap::from(Arc::new(current_epoch_info.committee)),
             halted: AtomicBool::new(current_epoch_info.validator_halted),
+            change_epoch_tx: Mutex::new(BTreeMap::new()),
             _native_functions: native_functions,
             move_vm,
             database: store.clone(),
@@ -817,12 +838,50 @@ impl AuthorityState {
         state
     }
 
+    pub(crate) fn insert_new_epoch_info(&self, new_committee: &Committee) -> SuiResult {
+        let current_epoch_info = self.database.get_last_epoch_info()?;
+        fp_ensure!(
+            current_epoch_info.committee.epoch <= new_committee.epoch,
+            SuiError::InconsistentEpochState {
+                error: "Trying to insert an old epoch entry".to_owned()
+            }
+        );
+        self.database.insert_new_epoch_info(EpochInfoLocals {
+            committee: new_committee.clone(),
+            validator_halted: true,
+        })?;
+        self.committee.store(Arc::new(new_committee.clone()));
+        Ok(())
+    }
+
+    pub(crate) fn begin_new_epoch(&self) -> SuiResult {
+        let epoch_info = self.database.get_last_epoch_info()?;
+        fp_ensure!(
+            &epoch_info.committee == self.committee.load().clone().deref(),
+            SuiError::InconsistentEpochState {
+                error:
+                    "About to being new epoch, however current committee differs from epoch store"
+                        .to_owned()
+            }
+        );
+        self.database.insert_new_epoch_info(EpochInfoLocals {
+            committee: self.clone_committee(),
+            validator_halted: false,
+        })?;
+        self.halted.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
     pub(crate) fn checkpoints(&self) -> Option<Arc<Mutex<CheckpointStore>>> {
         self.checkpoints.clone()
     }
 
     pub(crate) fn db(&self) -> Arc<AuthorityStore> {
         self.database.clone()
+    }
+
+    pub fn clone_committee(&self) -> Committee {
+        self.committee.load().clone().deref().clone()
     }
 
     async fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
@@ -835,6 +894,20 @@ impl AuthorityState {
             .await?
             .expect("framework object should always exist")
             .compute_object_reference())
+    }
+
+    pub async fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState> {
+        let sui_system_object = self
+            .get_object(&SUI_SYSTEM_STATE_OBJECT_ID)
+            .await?
+            .expect("Sui System State object must always exist");
+        let move_object = sui_system_object
+            .data
+            .try_as_move()
+            .expect("Sui System State object must be a Move object");
+        let result = bcs::from_bytes::<SuiSystemState>(move_object.contents())
+            .expect("Sui System State object deserialization cannot fail");
+        Ok(result)
     }
 
     pub async fn get_object_read(&self, object_id: &ObjectID) -> Result<ObjectRead, SuiError> {
@@ -1031,6 +1104,11 @@ impl AuthorityState {
         certificate: &CertifiedTransaction,
         signed_effects: &SignedTransactionEffects,
     ) -> SuiResult {
+        if self.halted.load(Ordering::SeqCst) {
+            // TODO: Here we should allow consensus transaction to continue.
+            return Err(SuiError::ValidatorHaltedAtEpochEnd);
+        }
+
         let notifier_ticket = self.batch_notifier.ticket()?;
         let seq = notifier_ticket.seq();
 
@@ -1157,7 +1235,7 @@ impl ExecutionState for AuthorityState {
                 if !self.shared_locks_exist(&certificate).await? {
                     // Check the certificate. Remember that Byzantine authorities may input anything into
                     // consensus.
-                    certificate.verify(&self.committee)?;
+                    certificate.verify(&self.committee.load())?;
 
                     // Persist the certificate since we are about to lock one or more shared object.
                     // We thus need to make sure someone (if not the client) can continue the protocol.

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -286,6 +286,7 @@ impl AuthorityState {
         }
 
         if self.halted.load(Ordering::SeqCst) {
+            // TODO: Do we want to include the new validator set?
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 
@@ -361,6 +362,7 @@ impl AuthorityState {
         }
 
         if self.halted.load(Ordering::SeqCst) {
+            // TODO: Do we want to include the new validator set?
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 
@@ -856,13 +858,10 @@ impl AuthorityState {
 
     pub(crate) fn begin_new_epoch(&self) -> SuiResult {
         let epoch_info = self.database.get_last_epoch_info()?;
-        fp_ensure!(
-            &epoch_info.committee == self.committee.load().clone().deref(),
-            SuiError::InconsistentEpochState {
-                error:
-                    "About to being new epoch, however current committee differs from epoch store"
-                        .to_owned()
-            }
+        assert_eq!(
+            &epoch_info.committee,
+            self.committee.load().clone().deref(),
+            "About to being new epoch, however current committee differs from epoch store"
         );
         self.database.insert_new_epoch_info(EpochInfoLocals {
             committee: self.clone_committee(),
@@ -1106,6 +1105,7 @@ impl AuthorityState {
     ) -> SuiResult {
         if self.halted.load(Ordering::SeqCst) {
             // TODO: Here we should allow consensus transaction to continue.
+            // TODO: Do we want to include the new validator set?
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -48,16 +48,17 @@ impl TransactionNotifier {
     }
 
     pub fn low_watermark(&self) -> TxSequenceNumber {
-        self.low_watermark.load(std::sync::atomic::Ordering::SeqCst)
+        self.low_watermark.load(Ordering::SeqCst)
     }
 
+    // TODO: Return a future instead so that the caller can await for.
     pub fn ticket_drained(&self) -> bool {
         self.inner.lock().high_watermark == self.low_watermark.load(Ordering::SeqCst)
     }
 
     /// Get a ticket with a sequence number
     pub fn ticket(self: &Arc<Self>) -> SuiResult<TransactionNotifierTicket> {
-        if self.is_closed.load(std::sync::atomic::Ordering::SeqCst) {
+        if self.is_closed.load(Ordering::SeqCst) {
             return Err(SuiError::ClosedNotifierError);
         }
 

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -51,6 +51,10 @@ impl TransactionNotifier {
         self.low_watermark.load(std::sync::atomic::Ordering::SeqCst)
     }
 
+    pub fn ticket_drained(&self) -> bool {
+        self.inner.lock().high_watermark == self.low_watermark.load(Ordering::SeqCst)
+    }
+
     /// Get a ticket with a sequence number
     pub fn ticket(self: &Arc<Self>) -> SuiResult<TransactionNotifierTicket> {
         if self.is_closed.load(std::sync::atomic::Ordering::SeqCst) {

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -111,7 +111,7 @@ impl<A> ActiveAuthority<A> {
         authority: Arc<AuthorityState>,
         authority_clients: BTreeMap<AuthorityName, A>,
     ) -> SuiResult<Self> {
-        let committee = authority.committee.clone();
+        let committee = authority.clone_committee();
 
         Ok(ActiveAuthority {
             health: Arc::new(Mutex::new(

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -258,7 +258,11 @@ pub async fn init_configurable_authorities(
             let transaction =
                 crate_object_move_transaction(addr1, &key1, addr1, 100, framework_obj_ref, gas_ref);
 
-            for tx_client in clients.iter_mut().take(committee.quorum_threshold()) {
+            // TODO: `take` here only works when each validator has equal stake.
+            for tx_client in clients
+                .iter_mut()
+                .take(committee.quorum_threshold() as usize)
+            {
                 // Do transactions.
                 do_transaction(tx_client, &transaction).await;
             }
@@ -290,7 +294,8 @@ pub async fn init_configurable_authorities(
         // Submit the cert to 2f+1 authorities.
         for (_, cert_client) in authority_clients
             .iter_mut()
-            .take(committee.quorum_threshold())
+            // TODO: This only works when every validator has equal stake
+            .take(committee.quorum_threshold() as usize)
         {
             _ = do_cert(cert_client, &cert1).await;
 

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -61,10 +61,7 @@ pub async fn gossip_process_with_start_seq<A>(
     let committee = &active_authority.net.committee;
 
     // Number of tasks at most "degree" and no more than committee - 1
-    let target_num_tasks: usize = usize::min(
-        active_authority.state.committee.load().voting_rights.len() - 1,
-        degree,
-    );
+    let target_num_tasks: usize = usize::min(committee.voting_rights.len() - 1, degree);
 
     // If we do not expect to connect to anyone
     if target_num_tasks == 0 {

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use futures::stream::FuturesOrdered;
 use futures::{stream::FuturesUnordered, StreamExt};
 use std::{collections::HashSet, sync::Arc, time::Duration};
+use sui_types::committee::StakeUnit;
 use sui_types::{
     base_types::AuthorityName,
     batch::{TxSequenceNumber, UpdateItem},
@@ -117,7 +118,7 @@ pub async fn gossip_process_with_start_seq<A>(
             let total_stake_used = peer_names
                 .iter()
                 .map(|name| committee.weight(name))
-                .sum::<u64>()
+                .sum::<StakeUnit>()
                 + committee.weight(&active_authority.state.name);
             if total_stake_used >= committee.quorum_threshold() {
                 break;

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -389,7 +389,7 @@ where
         FReduce: Fn(
             S,
             AuthorityName,
-            usize,
+            u64,
             Result<V, SuiError>,
         ) -> AsyncResult<'a, ReduceOutput<S>, SuiError>,
     {
@@ -466,8 +466,8 @@ where
     > {
         #[derive(Default)]
         struct GetObjectByIDRequestState {
-            good_weight: usize,
-            bad_weight: usize,
+            good_weight: u64,
+            bad_weight: u64,
             responses: Vec<(AuthorityName, SuiResult<ObjectInfoResponse>)>,
         }
         let initial_state = GetObjectByIDRequestState::default();
@@ -613,8 +613,8 @@ where
     ) -> Result<(BTreeMap<ObjectRef, Vec<AuthorityName>>, Vec<AuthorityName>), SuiError> {
         #[derive(Default)]
         struct OwnedObjectQueryState {
-            good_weight: usize,
-            bad_weight: usize,
+            good_weight: u64,
+            bad_weight: u64,
             object_map: BTreeMap<ObjectRef, Vec<AuthorityName>>,
             responded_authorities: Vec<AuthorityName>,
             errors: Vec<(AuthorityName, SuiError)>,
@@ -877,8 +877,8 @@ where
             // The list of errors gathered at any point
             errors: Vec<SuiError>,
             // Tally of stake for good vs bad responses.
-            good_stake: usize,
-            bad_stake: usize,
+            good_stake: u64,
+            bad_stake: u64,
         }
 
         let state = ProcessTransactionState {
@@ -1034,8 +1034,8 @@ where
             // Different authorities could return different effects.  We want at least one effect to come
             // from 2f+1 authorities, which meets quorum and can be considered the approved effect.
             // The map here allows us to count the stake for each unique effect.
-            effects_map: HashMap<[u8; 32], (usize, TransactionEffects)>,
-            bad_stake: usize,
+            effects_map: HashMap<[u8; 32], (u64, TransactionEffects)>,
+            bad_stake: u64,
         }
 
         let state = ProcessCertificateState {
@@ -1125,7 +1125,7 @@ where
                             let entry = state
                                 .effects_map
                                 .entry(inner_effects.digest())
-                                .or_insert((0usize, inner_effects.effects));
+                                .or_insert((0, inner_effects.effects));
                             entry.0 += weight;
 
                             if entry.0 >= threshold {
@@ -1221,7 +1221,7 @@ where
         while let Some(((obj_ref, tx_digest), (obj_option, layout_option, authorities))) =
             object_ref_stack.pop()
         {
-            let stake: usize = authorities
+            let stake: u64 = authorities
                 .iter()
                 .map(|(name, _)| self.committee.weight(name))
                 .sum();

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -22,6 +22,7 @@ use tracing::{debug, info, instrument, trace, Instrument};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::string::ToString;
 use std::time::Duration;
+use sui_types::committee::StakeUnit;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
 
@@ -389,7 +390,7 @@ where
         FReduce: Fn(
             S,
             AuthorityName,
-            u64,
+            StakeUnit,
             Result<V, SuiError>,
         ) -> AsyncResult<'a, ReduceOutput<S>, SuiError>,
     {
@@ -466,8 +467,8 @@ where
     > {
         #[derive(Default)]
         struct GetObjectByIDRequestState {
-            good_weight: u64,
-            bad_weight: u64,
+            good_weight: StakeUnit,
+            bad_weight: StakeUnit,
             responses: Vec<(AuthorityName, SuiResult<ObjectInfoResponse>)>,
         }
         let initial_state = GetObjectByIDRequestState::default();
@@ -613,8 +614,8 @@ where
     ) -> Result<(BTreeMap<ObjectRef, Vec<AuthorityName>>, Vec<AuthorityName>), SuiError> {
         #[derive(Default)]
         struct OwnedObjectQueryState {
-            good_weight: u64,
-            bad_weight: u64,
+            good_weight: StakeUnit,
+            bad_weight: StakeUnit,
             object_map: BTreeMap<ObjectRef, Vec<AuthorityName>>,
             responded_authorities: Vec<AuthorityName>,
             errors: Vec<(AuthorityName, SuiError)>,
@@ -877,8 +878,8 @@ where
             // The list of errors gathered at any point
             errors: Vec<SuiError>,
             // Tally of stake for good vs bad responses.
-            good_stake: u64,
-            bad_stake: u64,
+            good_stake: StakeUnit,
+            bad_stake: StakeUnit,
         }
 
         let state = ProcessTransactionState {
@@ -1034,8 +1035,8 @@ where
             // Different authorities could return different effects.  We want at least one effect to come
             // from 2f+1 authorities, which meets quorum and can be considered the approved effect.
             // The map here allows us to count the stake for each unique effect.
-            effects_map: HashMap<[u8; 32], (u64, TransactionEffects)>,
-            bad_stake: u64,
+            effects_map: HashMap<[u8; 32], (StakeUnit, TransactionEffects)>,
+            bad_stake: StakeUnit,
         }
 
         let state = ProcessCertificateState {
@@ -1221,7 +1222,7 @@ where
         while let Some(((obj_ref, tx_digest), (obj_option, layout_option, authorities))) =
             object_ref_stack.pop()
         {
-            let stake: u64 = authorities
+            let stake: StakeUnit = authorities
                 .iter()
                 .map(|(name, _)| self.committee.weight(name))
                 .sum();

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -79,7 +79,7 @@ impl AuthorityServer {
         let consensus_adapter = ConsensusAdapter::new(
             state.clone(),
             consensus_address,
-            state.committee.clone(),
+            state.clone_committee(),
             tx_consensus_listener,
             /* max_delay */ Duration::from_millis(5_000),
         );
@@ -192,7 +192,7 @@ impl ValidatorService {
         let consensus_adapter = ConsensusAdapter::new(
             state.clone(),
             consensus_config.address().to_owned(),
-            state.committee.clone(),
+            state.clone_committee(),
             tx_sui_to_consensus,
             /* max_delay */ Duration::from_millis(5_000),
         );
@@ -249,7 +249,7 @@ impl Validator for ValidatorService {
 
         let mut obligation = VerificationObligation::default();
         transaction
-            .add_to_verification_obligation(&self.state.committee, &mut obligation)
+            .add_to_verification_obligation(&self.state.committee.load(), &mut obligation)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         obligation
             .verify_all()

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -182,13 +182,18 @@ impl CheckpointStore {
 
     /// Set the local variables in memory and store
     fn set_locals(
-        &mut self,
+        &self,
         _previous: Arc<CheckpointLocals>,
         locals: CheckpointLocals,
     ) -> Result<(), SuiError> {
         self.locals.insert(&LOCALS, &locals)?;
         self.memory_locals.store(Some(Arc::new(locals)));
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn set_locals_for_testing(&self, locals: CheckpointLocals) -> Result<(), SuiError> {
+        self.set_locals(Arc::new(locals.clone()), locals)
     }
 
     /// Read the local variables

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -182,7 +182,7 @@ impl CheckpointStore {
 
     /// Set the local variables in memory and store
     fn set_locals(
-        &self,
+        &mut self,
         _previous: Arc<CheckpointLocals>,
         locals: CheckpointLocals,
     ) -> Result<(), SuiError> {
@@ -192,12 +192,12 @@ impl CheckpointStore {
     }
 
     #[cfg(test)]
-    pub fn set_locals_for_testing(&self, locals: CheckpointLocals) -> Result<(), SuiError> {
+    pub fn set_locals_for_testing(&mut self, locals: CheckpointLocals) -> Result<(), SuiError> {
         self.set_locals(Arc::new(locals.clone()), locals)
     }
 
     /// Read the local variables
-    pub fn get_locals(&self) -> Arc<CheckpointLocals> {
+    pub fn get_locals(&mut self) -> Arc<CheckpointLocals> {
         self.memory_locals.load().clone().unwrap()
     }
 
@@ -816,13 +816,13 @@ impl CheckpointStore {
     // Helper read functions
 
     /// Return the seq number of the last checkpoint we have recorded.
-    pub fn next_checkpoint(&self) -> CheckpointSequenceNumber {
+    pub fn next_checkpoint(&mut self) -> CheckpointSequenceNumber {
         self.get_locals().next_checkpoint
     }
 
     /// Returns the lowest checkpoint sequence number with unprocessed transactions
     /// if any, otherwise the next checkpoint (not seen).
-    pub fn lowest_unprocessed_checkpoint(&self) -> CheckpointSequenceNumber {
+    pub fn lowest_unprocessed_checkpoint(&mut self) -> CheckpointSequenceNumber {
         self.unprocessed_transactions
             .iter()
             .map(|(_, chk_seq)| chk_seq)

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -192,7 +192,7 @@ impl CheckpointStore {
     }
 
     /// Read the local variables
-    pub fn get_locals(&mut self) -> Arc<CheckpointLocals> {
+    pub fn get_locals(&self) -> Arc<CheckpointLocals> {
         self.memory_locals.load().clone().unwrap()
     }
 
@@ -811,13 +811,13 @@ impl CheckpointStore {
     // Helper read functions
 
     /// Return the seq number of the last checkpoint we have recorded.
-    pub fn next_checkpoint(&mut self) -> CheckpointSequenceNumber {
+    pub fn next_checkpoint(&self) -> CheckpointSequenceNumber {
         self.get_locals().next_checkpoint
     }
 
     /// Returns the lowest checkpoint sequence number with unprocessed transactions
     /// if any, otherwise the next checkpoint (not seen).
-    pub fn lowest_unprocessed_checkpoint(&mut self) -> CheckpointSequenceNumber {
+    pub fn lowest_unprocessed_checkpoint(&self) -> CheckpointSequenceNumber {
         self.unprocessed_transactions
             .iter()
             .map(|(_, chk_seq)| chk_seq)

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -117,13 +117,13 @@ impl FragmentReconstruction {
 // A structure that stores a set of spanning trees, and that supports addition
 // of links to merge them, and construct ever growing components.
 struct SpanGraph {
-    nodes: HashMap<AuthorityName, (AuthorityName, usize)>,
+    nodes: HashMap<AuthorityName, (AuthorityName, u64)>,
 }
 
 impl SpanGraph {
     /// Initialize the graph with each authority just pointing to itself.
     pub fn new(committee: &Committee) -> SpanGraph {
-        let nodes: HashMap<AuthorityName, (AuthorityName, usize)> = committee
+        let nodes: HashMap<AuthorityName, (AuthorityName, u64)> = committee
             .voting_rights
             .iter()
             .map(|(n, w)| (*n, (*n, *w)))
@@ -135,7 +135,7 @@ impl SpanGraph {
     /// Follow pointer until you get to a node that only point to itself
     /// and return the node name, and the weight of the tree that points
     /// indirectly to it.
-    pub fn top_node(&self, name: &AuthorityName) -> (AuthorityName, usize) {
+    pub fn top_node(&self, name: &AuthorityName) -> (AuthorityName, u64) {
         let mut next_name = name;
         while self.nodes[next_name].0 != *next_name {
             next_name = &self.nodes[next_name].0
@@ -147,11 +147,7 @@ impl SpanGraph {
     /// connected components. This is done by take the top node of the
     /// first and making it point to the top node of the second, and
     /// updating the total weight of the second.
-    pub fn merge(
-        &mut self,
-        name1: &AuthorityName,
-        name2: &AuthorityName,
-    ) -> (AuthorityName, usize) {
+    pub fn merge(&mut self, name1: &AuthorityName, name2: &AuthorityName) -> (AuthorityName, u64) {
         let top1 = self.top_node(name1).0;
         let top2 = self.top_node(name2).0;
         if top1 == top2 {

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
+use sui_types::committee::StakeUnit;
 use sui_types::{
     base_types::{AuthorityName, TransactionDigest},
     committee::Committee,
@@ -117,13 +118,13 @@ impl FragmentReconstruction {
 // A structure that stores a set of spanning trees, and that supports addition
 // of links to merge them, and construct ever growing components.
 struct SpanGraph {
-    nodes: HashMap<AuthorityName, (AuthorityName, u64)>,
+    nodes: HashMap<AuthorityName, (AuthorityName, StakeUnit)>,
 }
 
 impl SpanGraph {
     /// Initialize the graph with each authority just pointing to itself.
     pub fn new(committee: &Committee) -> SpanGraph {
-        let nodes: HashMap<AuthorityName, (AuthorityName, u64)> = committee
+        let nodes: HashMap<AuthorityName, (AuthorityName, StakeUnit)> = committee
             .voting_rights
             .iter()
             .map(|(n, w)| (*n, (*n, *w)))
@@ -135,7 +136,7 @@ impl SpanGraph {
     /// Follow pointer until you get to a node that only point to itself
     /// and return the node name, and the weight of the tree that points
     /// indirectly to it.
-    pub fn top_node(&self, name: &AuthorityName) -> (AuthorityName, u64) {
+    pub fn top_node(&self, name: &AuthorityName) -> (AuthorityName, StakeUnit) {
         let mut next_name = name;
         while self.nodes[next_name].0 != *next_name {
             next_name = &self.nodes[next_name].0
@@ -147,7 +148,11 @@ impl SpanGraph {
     /// connected components. This is done by take the top node of the
     /// first and making it point to the top node of the second, and
     /// updating the total weight of the second.
-    pub fn merge(&mut self, name1: &AuthorityName, name2: &AuthorityName) -> (AuthorityName, u64) {
+    pub fn merge(
+        &mut self,
+        name1: &AuthorityName,
+        name2: &AuthorityName,
+    ) -> (AuthorityName, StakeUnit) {
         let top1 = self.top_node(name1).0;
         let top2 = self.top_node(name2).0;
         if top1 == top2 {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -111,7 +111,7 @@ fn crash_recovery() {
     // Delete and re-open DB
     drop(cps);
 
-    let cps_new = CheckpointStore::open(
+    let mut cps_new = CheckpointStore::open(
         path,
         None,
         *k.public_key_bytes(),

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -111,7 +111,7 @@ fn crash_recovery() {
     // Delete and re-open DB
     drop(cps);
 
-    let mut cps_new = CheckpointStore::open(
+    let cps_new = CheckpointStore::open(
         path,
         None,
         *k.public_key_bytes(),

--- a/crates/sui-core/src/epoch/mod.rs
+++ b/crates/sui-core/src/epoch/mod.rs
@@ -4,6 +4,12 @@
 use serde::{Deserialize, Serialize};
 use sui_types::committee::Committee;
 
+pub mod reconfiguration;
+
+#[cfg(test)]
+#[path = "./tests/reconfiguration_tests.rs"]
+mod reconfiguration_tests;
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct EpochInfoLocals {
     pub committee: Committee,

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -102,8 +102,9 @@ impl<A> ActiveAuthority<A> {
             .collect();
         let new_committee = Committee::new(next_epoch, votes);
         self.state.insert_new_epoch_info(&new_committee)?;
-        self.state.checkpoints.as_ref().unwrap().lock().committee = new_committee;
-        // TODO: Update all committee in all components, potentially restart some authority clients.
+        //self.state.checkpoints.as_ref().unwrap().lock().committee = new_committee;
+        // TODO: Update all committee in all components safely,
+        // potentially restart some authority clients.
         // Including: self.net, narwhal committee, anything else?
         // We should also reduce the amount of committee passed around.
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority_active::ActiveAuthority;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use sui_types::committee::Committee;
+use sui_types::crypto::PublicKeyBytes;
+use sui_types::error::{SuiResult, SuiError};
+use sui_types::fp_ensure;
+use sui_types::messages::SignedTransaction;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use tokio::time::Instant;
+use typed_store::Map;
+
+// TODO: Make last checkpoint number of each epoch more flexible.
+const CHECKPOINT_COUNT_PER_EPOCH: u64 = 200;
+
+const MAX_START_EPOCH_WAIT_SECONDS: Duration = Duration::from_secs(5);
+
+impl<A> ActiveAuthority<A> {
+    pub async fn start_epoch_change(&mut self) -> SuiResult {
+        {
+            let checkpoints = self.state.checkpoints.as_ref().unwrap().lock();
+            let next_cp = checkpoints.get_locals().next_checkpoint;
+            fp_ensure!(
+                Self::is_second_last_checkpoint_epoch(next_cp),
+                SuiError::InconsistentEpochState {
+                    error: "start_epoch_change called at the wrong checkpoint".to_owned(),
+                }
+            );
+            fp_ensure!(
+                checkpoints.lowest_unprocessed_checkpoint() == next_cp,
+                SuiError::InconsistentEpochState {
+                    error: "start_epoch_change called when there are still unprocessed transactions".to_owned(),
+                }
+            );
+            // drop checkpoints lock
+        }
+        
+        self.state.halted.store(true, Ordering::SeqCst);
+        let instant = Instant::now();
+        while !self.state.batch_notifier.ticket_drained() {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            fp_ensure!(
+                instant.elapsed() <= MAX_START_EPOCH_WAIT_SECONDS,
+                SuiError::InconsistentEpochState {
+                    error: "Waiting for batch_notifier ticket to drain timed out in start_epoch_change".to_owned(),
+                }
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn finish_epoch_change(&mut self) -> SuiResult {
+        fp_ensure!(
+            self.state.halted.load(Ordering::SeqCst),
+            SuiError::InconsistentEpochState {
+                error: "finish_epoch_change called when validator is not halted".to_owned(),
+            }
+        );
+        {
+            let checkpoints = self.state.checkpoints.as_ref().unwrap().lock();
+            let next_cp = checkpoints.get_locals().next_checkpoint;
+            fp_ensure!(
+                Self::is_last_checkpoint_epoch(next_cp),
+                SuiError::InconsistentEpochState {
+                    error: "finish_epoch_change called at the wrong checkpoint".to_owned(),
+                }
+            );
+            fp_ensure!(
+                checkpoints.lowest_unprocessed_checkpoint() == next_cp,
+                SuiError::InconsistentEpochState {
+                    error: "finish_epoch_change called when there are still unprocessed transactions".to_owned(),
+                }
+            );
+            if checkpoints.extra_transactions.iter().next().is_some() {
+                // TODO: Revert any tx that's executed but not in the checkpoint.
+            }
+            // drop checkpoints lock
+        }
+
+        let sui_system_state = self.state.get_sui_system_state_object().await?;
+        let next_epoch = sui_system_state.epoch + 1;
+        let next_epoch_validators = &sui_system_state.validators.next_epoch_validators;
+        let votes = next_epoch_validators
+            .iter()
+            .map(|metadata| {
+                (
+                    PublicKeyBytes::try_from(metadata.pubkey_bytes.as_ref())
+                        .expect("Validity of public key bytes should be verified on-chain"),
+                    metadata.next_epoch_stake,
+                )
+            })
+            .collect();
+        let new_committee = Committee::new(next_epoch, votes);
+        self.state.insert_new_epoch_info(&new_committee)?;
+        self.state.checkpoints.as_ref().unwrap().lock().committee = new_committee;
+        // TODO: Update all committee in all components, potentially restart some authority clients.
+        // Including: self.net, narwhal committee, anything else?
+        // We should also reduce the amount of committee passed around.
+
+        let advance_epoch_tx = SignedTransaction::new_change_epoch(
+            next_epoch,
+            0, // TODO: fill in storage_charge
+            0, // TODO: fill in computation_charge
+            self.state.name,
+            &*self.state.secret,
+        );
+        self.state
+            .change_epoch_tx
+            .lock()
+            .insert(self.state.name, advance_epoch_tx);
+
+        // TODO: Now ask every validator in the committee for this signed tx.
+        // Aggregate them to obtain a cert, execute the cert, and then start the new epoch.
+
+        self.state.begin_new_epoch()?;
+        Ok(())
+    }
+
+    fn is_last_checkpoint_epoch(checkpoint: CheckpointSequenceNumber) -> bool {
+        checkpoint > 0 && checkpoint % CHECKPOINT_COUNT_PER_EPOCH == 0
+    }
+
+    fn is_second_last_checkpoint_epoch(checkpoint: CheckpointSequenceNumber) -> bool {
+        (checkpoint + 1) % CHECKPOINT_COUNT_PER_EPOCH == 0
+    }
+}

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -7,11 +7,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_types::committee::Committee;
 use sui_types::crypto::PublicKeyBytes;
-use sui_types::error::{SuiError, SuiResult};
-use sui_types::fp_ensure;
+use sui_types::error::SuiResult;
 use sui_types::messages::SignedTransaction;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use tokio::time::Instant;
 use typed_store::Map;
 
 // TODO: Make last checkpoint number of each epoch more flexible.

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[tokio::test]
+async fn test_validator_halt() {}

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -185,19 +185,9 @@ async fn test_finish_epoch_change() {
         .unwrap();
     // Create an active authority for the first authority state.
     let active = ActiveAuthority::new(state.clone(), net.authority_clients).unwrap();
-    // Cannot call finish_epoch_change if validator is not yet halted.
-    assert!(matches!(
-        active.finish_epoch_change().await.unwrap_err(),
-        SuiError::InconsistentEpochState { .. }
-    ));
 
     active.start_epoch_change().await.unwrap();
 
-    // Still cannot call finish_epoch_change if not at the last checkpoint.
-    assert!(matches!(
-        active.finish_epoch_change().await.unwrap_err(),
-        SuiError::InconsistentEpochState { .. }
-    ));
     locals.next_checkpoint += 1;
     state
         .checkpoints

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -1,5 +1,226 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::BTreeSet,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    crypto::{get_key_pair, AuthoritySignature, Signature},
+    error::SuiError,
+    gas::SuiGasStatus,
+    messages::{ConfirmationTransaction, SignatureAggregator, Transaction, TransactionData},
+    object::Object,
+};
+
+use crate::{
+    authority::AuthorityTemporaryStore, authority_active::ActiveAuthority,
+    authority_aggregator::authority_aggregator_tests::init_local_authorities,
+    checkpoints::CheckpointLocals, epoch::reconfiguration::CHECKPOINT_COUNT_PER_EPOCH,
+    execution_engine,
+};
+
 #[tokio::test]
-async fn test_validator_halt() {}
+async fn test_start_epoch_change() {
+    // Create a sender, owning an object and a gas object.
+    let (sender, sender_key) = get_key_pair();
+    let object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+    let gas_object = Object::with_id_owner_for_testing(ObjectID::random(), sender);
+    let genesis_objects = vec![object.clone(), gas_object.clone()];
+    // Create authority_aggregator and authority states.
+    let (net, states) = init_local_authorities(vec![
+        genesis_objects.clone(),
+        genesis_objects.clone(),
+        genesis_objects.clone(),
+        genesis_objects.clone(),
+    ])
+    .await;
+    let state = states[0].clone();
+    // Set the checkpoint number to be near the end of epoch.
+    state
+        .checkpoints
+        .as_ref()
+        .unwrap()
+        .lock()
+        .set_locals_for_testing(CheckpointLocals {
+            next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH - 1,
+            proposal_next_transaction: None,
+            next_transaction_sequence: 0,
+            no_more_fragments: true,
+            current_proposal: None,
+        })
+        .unwrap();
+    // Create an active authority for the first authority state.
+    let active = ActiveAuthority::new(state.clone(), net.authority_clients).unwrap();
+    // Make the high watermark differ from low watermark.
+    let ticket = state.batch_notifier.ticket().unwrap();
+
+    // Invoke start_epoch_change on the active authority.
+    let epoch_change_started = Arc::new(AtomicBool::new(false));
+    let epoch_change_started_copy = epoch_change_started.clone();
+    let handle = tokio::spawn(async move {
+        active.start_epoch_change().await.unwrap();
+        epoch_change_started_copy.store(true, Ordering::SeqCst);
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Validator should now be halted, but epoch change hasn't finished.
+    assert!(state.halted.load(Ordering::SeqCst));
+    assert!(!epoch_change_started.load(Ordering::SeqCst));
+
+    // Drain ticket.
+    drop(ticket);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // After we drained ticket, epoch change started.
+    assert!(epoch_change_started.load(Ordering::SeqCst));
+    handle.await.unwrap();
+
+    // Test that when validator is halted, we cannot send any transaction.
+    let tx_data = TransactionData::new_transfer(
+        SuiAddress::default(),
+        object.compute_object_reference(),
+        sender,
+        gas_object.compute_object_reference(),
+        1000,
+    );
+    let signature = Signature::new(&tx_data, &sender_key);
+    let transaction = Transaction::new(tx_data, signature);
+    assert_eq!(
+        state
+            .handle_transaction(transaction.clone())
+            .await
+            .unwrap_err(),
+        SuiError::ValidatorHaltedAtEpochEnd
+    );
+
+    // Test that when validator is halted, we cannot send any certificate.
+    let mut sigs = SignatureAggregator::try_new(transaction.clone(), &net.committee).unwrap();
+    let mut cert = None;
+    for state in &states {
+        cert = sigs
+            .append(
+                state.name,
+                AuthoritySignature::new(&transaction.data, &*state.secret),
+            )
+            .unwrap();
+    }
+    let certificate = cert.unwrap();
+    assert_eq!(
+        state
+            .handle_confirmation_transaction(ConfirmationTransaction {
+                certificate: certificate.clone()
+            })
+            .await
+            .unwrap_err(),
+        SuiError::ValidatorHaltedAtEpochEnd
+    );
+
+    // Test that for certificates that have finished execution and is about to write effects,
+    // they will also fail to get a ticket for the commit.
+    let tx_digest = *transaction.digest();
+    let mut temporary_store = AuthorityTemporaryStore::new(
+        state.database.clone(),
+        transaction
+            .data
+            .input_objects()
+            .unwrap()
+            .into_iter()
+            .zip(genesis_objects)
+            .collect(),
+        tx_digest,
+    );
+    let effects = execution_engine::execute_transaction_to_effects(
+        vec![],
+        &mut temporary_store,
+        transaction.data.clone(),
+        tx_digest,
+        BTreeSet::new(),
+        &state.move_vm,
+        &state._native_functions,
+        SuiGasStatus::new_with_budget(1000, 1, 1),
+        state.committee.load().epoch,
+    )
+    .unwrap();
+    let signed_effects = effects.to_sign_effects(0, &state.name, &*state.secret);
+    assert_eq!(
+        state
+            .update_state(temporary_store, &certificate, &signed_effects)
+            .await
+            .unwrap_err(),
+        SuiError::ValidatorHaltedAtEpochEnd
+    );
+}
+
+#[tokio::test]
+async fn test_finish_epoch_change() {
+    // Create authority_aggregator and authority states.
+    let genesis_objects = vec![];
+    let (net, states) = init_local_authorities(vec![
+        genesis_objects.clone(),
+        genesis_objects.clone(),
+        genesis_objects.clone(),
+        genesis_objects.clone(),
+    ])
+    .await;
+    let state = states[0].clone();
+    // Set the checkpoint number to be near the end of epoch.
+    let mut locals = CheckpointLocals {
+        next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH - 1,
+        proposal_next_transaction: None,
+        next_transaction_sequence: 0,
+        no_more_fragments: true,
+        current_proposal: None,
+    };
+    state
+        .checkpoints
+        .as_ref()
+        .unwrap()
+        .lock()
+        .set_locals_for_testing(locals.clone())
+        .unwrap();
+    // Create an active authority for the first authority state.
+    let active = ActiveAuthority::new(state.clone(), net.authority_clients).unwrap();
+    // Cannot call finish_epoch_change if validator is not yet halted.
+    assert!(matches!(
+        active.finish_epoch_change().await.unwrap_err(),
+        SuiError::InconsistentEpochState { .. }
+    ));
+
+    active.start_epoch_change().await.unwrap();
+
+    // Still cannot call finish_epoch_change if not at the last checkpoint.
+    assert!(matches!(
+        active.finish_epoch_change().await.unwrap_err(),
+        SuiError::InconsistentEpochState { .. }
+    ));
+    locals.next_checkpoint += 1;
+    state
+        .checkpoints
+        .as_ref()
+        .unwrap()
+        .lock()
+        .set_locals_for_testing(locals.clone())
+        .unwrap();
+    active.finish_epoch_change().await.unwrap();
+    // Verify that epoch changed in authority state.
+    assert_eq!(active.state.committee.load().epoch, 1);
+    assert_eq!(
+        active
+            .state
+            .db()
+            .get_last_epoch_info()
+            .unwrap()
+            .committee
+            .epoch,
+        1
+    );
+    // Verify that validator is no longer halted.
+    assert!(!active.state.halted.load(Ordering::SeqCst));
+    // Verify that the special system tx is set.
+    assert!(active.state.change_epoch_tx.load().is_some());
+}

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -256,7 +256,7 @@ pub async fn extract_cert<A: AuthorityAPI>(
         }
     }
 
-    let stake: u64 = votes.iter().map(|(name, _)| committee.weight(name)).sum();
+    let stake: StakeUnit = votes.iter().map(|(name, _)| committee.weight(name)).sum();
     let quorum_threshold = committee.quorum_threshold();
     assert!(stake >= quorum_threshold);
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -256,7 +256,7 @@ pub async fn extract_cert<A: AuthorityAPI>(
         }
     }
 
-    let stake: usize = votes.iter().map(|(name, _)| committee.weight(name)).sum();
+    let stake: u64 = votes.iter().map(|(name, _)| committee.weight(name)).sum();
     let quorum_threshold = committee.quorum_threshold();
     assert!(stake >= quorum_threshold);
 

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -75,7 +75,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
             .await
             .unwrap();
         let vote = response.signed_transaction.unwrap();
-        let certificate = SignatureAggregator::try_new(transaction, &authority.committee)
+        let certificate = SignatureAggregator::try_new(transaction, &authority.committee.load())
             .unwrap()
             .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
             .unwrap()
@@ -144,7 +144,7 @@ async fn submit_transaction_to_consensus() {
     let certificate = test_certificates(&state).await.pop().unwrap();
     let expected_transaction = certificate.clone().to_transaction();
 
-    let committee = state.committee.clone();
+    let committee = state.clone_committee();
     let state_guard = Arc::new(state);
 
     // Make a new consensus submitter instance.

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -302,7 +302,7 @@ async fn test_subscription_safe_client() {
             state: state.clone(),
             fault_config: LocalAuthorityClientFaultConfig::default(),
         },
-        state.committee.clone(),
+        state.clone_committee(),
         state.name,
     );
 

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -629,23 +629,16 @@ SuiError:
     108:
       SignatureKeyGenError:
         NEWTYPE: STR
-<<<<<<< HEAD
     109:
-      RpcError:
-        NEWTYPE: STR
-    110:
-=======
-    110:
       ValidatorHaltedAtEpochEnd: UNIT
-    111:
+    110:
       InconsistentEpochState:
         STRUCT:
           - error: STR
-    112:
+    111:
       RpcError:
         NEWTYPE: STR
-    113:
->>>>>>> 8e71b892 ([epoch] Add reconfiguration logic)
+    112:
       UnsupportedFeatureError:
         STRUCT:
           - error: STR

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -629,10 +629,23 @@ SuiError:
     108:
       SignatureKeyGenError:
         NEWTYPE: STR
+<<<<<<< HEAD
     109:
       RpcError:
         NEWTYPE: STR
     110:
+=======
+    110:
+      ValidatorHaltedAtEpochEnd: UNIT
+    111:
+      InconsistentEpochState:
+        STRUCT:
+          - error: STR
+    112:
+      RpcError:
+        NEWTYPE: STR
+    113:
+>>>>>>> 8e71b892 ([epoch] Add reconfiguration logic)
       UnsupportedFeatureError:
         STRUCT:
           - error: STR

--- a/crates/sui-framework/sources/Governance/Genesis.move
+++ b/crates/sui-framework/sources/Governance/Genesis.move
@@ -17,9 +17,6 @@ module Sui::Genesis {
     /// Initial value of the lower-bound on the amount of stake required to become a validator.
     const INIT_MIN_VALIDATOR_STAKE: u64 = 100000000000000;
 
-    /// Initial value of the upper-bound on the amount of stake allowed to become a validator.
-    const INIT_MAX_VALIDATOR_STAKE: u64 = 100000000000000000;
-
     /// Initial value of the upper-bound on the number of validators.
     const INIT_MAX_VALIDATOR_COUNT: u64 = 100;
 
@@ -67,7 +64,6 @@ module Sui::Genesis {
             storage_fund,
             INIT_MAX_VALIDATOR_COUNT,
             INIT_MIN_VALIDATOR_STAKE,
-            INIT_MAX_VALIDATOR_STAKE,
         );
     }
 }

--- a/crates/sui-framework/sources/Governance/SuiSystem.move
+++ b/crates/sui-framework/sources/Governance/SuiSystem.move
@@ -24,8 +24,6 @@ module Sui::SuiSystem {
     struct SystemParameters has store {
         /// Lower-bound on the amount of stake required to become a validator.
         min_validator_stake: u64,
-        /// Upper-bound on the amount of stake allowed to become a validator.
-        max_validator_stake: u64,
         /// Maximum number of validator candidates at any moment.
         /// We do not allow the number of validators in any epoch to go above this.
         max_validator_candidate_count: u64,
@@ -59,9 +57,7 @@ module Sui::SuiSystem {
         storage_fund: Balance<SUI>,
         max_validator_candidate_count: u64,
         min_validator_stake: u64,
-        max_validator_stake: u64,
     ) {
-        assert!(min_validator_stake < max_validator_stake, 0);
         let state = SuiSystemState {
             // Use a hardcoded ID.
             id: ID::get_sui_system_state_object_id(),
@@ -71,7 +67,6 @@ module Sui::SuiSystem {
             storage_fund,
             parameters: SystemParameters {
                 min_validator_stake,
-                max_validator_stake,
                 max_validator_candidate_count,
             },
             delegation_reward: Balance::zero(),
@@ -100,8 +95,7 @@ module Sui::SuiSystem {
         );
         let stake_amount = Coin::value(&stake);
         assert!(
-            stake_amount >= self.parameters.min_validator_stake
-                && stake_amount <= self.parameters.max_validator_stake,
+            stake_amount >= self.parameters.min_validator_stake,
             0
         );
         let validator = Validator::new(
@@ -139,7 +133,6 @@ module Sui::SuiSystem {
         ValidatorSet::request_add_stake(
             &mut self.validators,
             Coin::into_balance(new_stake),
-            self.parameters.max_validator_stake,
             ctx,
         )
     }

--- a/crates/sui-framework/sources/Governance/ValidatorSet.move
+++ b/crates/sui-framework/sources/Governance/ValidatorSet.move
@@ -383,6 +383,7 @@ module Sui::ValidatorSet {
     }
 
     /// Upon any change to the validator set, derive and update the metadata of the validators for the new epoch.
+    /// TODO: If we want to enforce a % on stake threshold, this is the function to do it.
     fun derive_next_epoch_validators(self: &ValidatorSet): vector<ValidatorMetadata> {
         let active_count = Vector::length(&self.active_validators);
         let removal_count = Vector::length(&self.pending_removals);

--- a/crates/sui-framework/sources/Governance/ValidatorSet.move
+++ b/crates/sui-framework/sources/Governance/ValidatorSet.move
@@ -9,7 +9,7 @@ module Sui::ValidatorSet {
     use Sui::EpochRewardRecord;
     use Sui::SUI::SUI;
     use Sui::TxContext::{Self, TxContext};
-    use Sui::Validator::{Self, Validator};
+    use Sui::Validator::{Self, Validator, ValidatorMetadata};
 
     friend Sui::SuiSystem;
 
@@ -39,18 +39,25 @@ module Sui::ValidatorSet {
         /// Removal requests from the validators. Each element is an index
         /// pointing to `active_validators`.
         pending_removals: vector<u64>,
+
+        /// The metadata of the validator set for the next epoch. This is kept up-to-dated.
+        /// Everytime a change request is received, this set is updated.
+        next_epoch_validators: vector<ValidatorMetadata>,
     }
 
     public(friend) fun new(init_active_validators: vector<Validator>): ValidatorSet {
         let (validator_stake, delegation_stake, quorum_stake_threshold) = calculate_total_stake_and_quorum_threshold(&init_active_validators);
-        ValidatorSet {
+        let validators = ValidatorSet {
             validator_stake,
             delegation_stake,
             quorum_stake_threshold,
             active_validators: init_active_validators,
             pending_validators: Vector::empty(),
             pending_removals: Vector::empty(),
-        }
+            next_epoch_validators: Vector::empty(),
+        };
+        validators.next_epoch_validators = derive_next_epoch_validators(&validators);
+        validators
     }
 
     /// Get the total number of candidates that might become validators in the next epoch.
@@ -97,12 +104,11 @@ module Sui::ValidatorSet {
     public(friend) fun request_add_stake(
         self: &mut ValidatorSet,
         new_stake: Balance<SUI>,
-        max_validator_stake: u64,
         ctx: &TxContext,
     ) {
         let validator_address = TxContext::sender(ctx);
         let validator = get_validator_mut(&mut self.active_validators, validator_address);
-        Validator::request_add_stake(validator, new_stake, max_validator_stake);
+        Validator::request_add_stake(validator, new_stake);
     }
 
     /// Called by `SuiSystem`, to withdraw stake from a validator.
@@ -184,15 +190,25 @@ module Sui::ValidatorSet {
         computation_reward: &mut Balance<SUI>,
         ctx: &mut TxContext,
     ) {
-        distribute_reward(&mut self.active_validators, self.validator_stake, computation_reward);
+        // `compute_reward_distribution` must be called before `adjust_stake` to make sure we are using the current
+        // epoch's stake information to compute reward distribution.
+        let rewards = compute_reward_distribution(
+            &self.active_validators,
+            self.validator_stake,
+            Balance::value(computation_reward),
+        );
 
-        // This needs to come before adjust_stake since some of the
-        // pending validators may also have pending deposits.
-        process_pending_validators(&mut self.active_validators, &mut self.pending_validators);
-
+        // `adjust_stake` must be called before `distribute_reward`, because reward distribution goes to
+        // each validator's pending stake, and that shouldn't be available in the next epoch.
         adjust_stake(&mut self.active_validators, ctx);
 
+        distribute_reward(&mut self.active_validators, &rewards, computation_reward);
+
+        process_pending_validators(&mut self.active_validators, &mut self.pending_validators);
+
         process_pending_removals(&mut self.active_validators, &mut self.pending_removals, ctx);
+
+        self.next_epoch_validators = derive_next_epoch_validators(self);
 
         let (validator_stake, delegation_stake, quorum_stake_threshold) = calculate_total_stake_and_quorum_threshold(&self.active_validators);
         self.validator_stake = validator_stake;
@@ -327,20 +343,67 @@ module Sui::ValidatorSet {
         }
     }
 
+    /// Given the current list of active validators, the total stake and total reward,
+    /// calculate the amount of reward each validator should get.
+    /// Returns the amount of reward for each validator, as well as a remaining reward
+    /// due to integer division loss.
+    fun compute_reward_distribution(
+        validators: &vector<Validator>,
+        total_stake: u64,
+        total_reward: u64,
+    ): vector<u64> {
+        let results = Vector::empty();
+        let length = Vector::length(validators);
+        let i = 0;
+        while (i < length) {
+            let validator = Vector::borrow(validators, i);
+            // Integer divisions will truncate the results. Because of this, we expect that at the end
+            // there will be some reward remaining in `total_reward`.
+            // Use u128 to avoid multiplication overflow.
+            let stake_amount: u128 = (Validator::stake_amount(validator) as u128);
+            let reward_amount = stake_amount * (total_reward as u128) / (total_stake as u128);
+            Vector::push_back(&mut results, (reward_amount as u64));
+            i = i + 1;
+        };
+        results
+    }
+
     // TODO: Allow reward compunding for delegators.
-    fun distribute_reward(validators: &mut vector<Validator>, total_stake: u64, reward: &mut Balance<SUI>) {
-        let total_reward_amount = Balance::value(reward);
+    fun distribute_reward(validators: &mut vector<Validator>, rewards: &vector<u64>, reward: &mut Balance<SUI>) {
         let length = Vector::length(validators);
         let i = 0;
         while (i < length) {
             let validator = Vector::borrow_mut(validators, i);
-            // Integer divisions will truncate the results. Because of this, we expect that at the end
-            // there will be some reward remaining in `reward`.
-            let reward_amount = Validator::stake_amount(validator) * total_reward_amount / total_stake;
+            let reward_amount = *Vector::borrow(rewards, i);
             let reward = Balance::split(reward, reward_amount);
-            Validator::deposit_reward(validator, reward);
+            // Because reward goes to pending stake, it's the same as calling `request_add_stake`.
+            Validator::request_add_stake(validator, reward);
             i = i + 1;
         }
+    }
+
+    /// Upon any change to the validator set, derive and update the metadata of the validators for the new epoch.
+    fun derive_next_epoch_validators(self: &ValidatorSet): vector<ValidatorMetadata> {
+        let active_count = Vector::length(&self.active_validators);
+        let removal_count = Vector::length(&self.pending_removals);
+        let result = Vector::empty();
+        while (active_count > 0) {
+            if (removal_count > 0) {
+                let removal_index = *Vector::borrow(&self.pending_removals, removal_count - 1);
+                if (removal_index == active_count - 1) {
+                    // This validator will be removed, and hence we won't add it to the new validator set.
+                    removal_count = removal_count - 1;
+                    active_count = active_count - 1;
+                    continue
+                };
+            };
+            let metadata = Validator::metadata(
+                Vector::borrow(&self.active_validators, active_count - 1),
+            );
+            Vector::push_back(&mut result, *metadata);
+            active_count = active_count - 1;
+        };
+        result
     }
 
     #[test_only]
@@ -355,6 +418,7 @@ module Sui::ValidatorSet {
             active_validators,
             pending_validators,
             pending_removals: _,
+            next_epoch_validators: _,
         } = self;
         while (!Vector::is_empty(&active_validators)) {
             let v = Vector::pop_back(&mut active_validators);

--- a/crates/sui-framework/tests/ValidatorSetTests.move
+++ b/crates/sui-framework/tests/ValidatorSetTests.move
@@ -39,7 +39,6 @@ module Sui::ValidatorSetTests {
         ValidatorSet::request_add_stake(
             &mut validator_set,
             Coin::into_balance(Coin::mint_for_testing(500, &mut ctx1)),
-            600 /* max_validator_stake */,
             &ctx1,
         );
         // Adding stake to existing active validator during the epoch

--- a/crates/sui-framework/tests/ValidatorTests.move
+++ b/crates/sui-framework/tests/ValidatorTests.move
@@ -53,7 +53,7 @@ module Sui::ValidatorTests {
         );
 
         let new_stake = Coin::into_balance(Coin::mint_for_testing(30, ctx));
-        Validator::request_add_stake(&mut validator, new_stake, 100);
+        Validator::request_add_stake(&mut validator, new_stake);
 
         assert!(Validator::stake_amount(&validator) == 10, 0);
         assert!(Validator::pending_stake_amount(&validator) == 30, 0);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -94,7 +94,7 @@ impl SuiNode {
                 gossip_process_with_start_seq(
                     &active_authority,
                     // listen to all authorities (note that gossip_process caps this to total minus 1.)
-                    active_authority.state.committee.voting_rights.len(),
+                    active_authority.state.committee.load().voting_rights.len(),
                     // start receiving the earliest TXes the validator has.
                     Some(0),
                 )

--- a/crates/sui-open-rpc/samples/objects.json
+++ b/crates/sui-open-rpc/samples/objects.json
@@ -8,7 +8,7 @@
         "fields": {
           "description": "An NFT created by the wallet Command Line Tool",
           "id": {
-            "id": "0xf46a9c1f71bac2a11ae41153edbf3870f1806522",
+            "id": "0x52d6f5e5a8b25acd42a17f0f371649d05be94fed",
             "version": 1
           },
           "name": "Example NFT",
@@ -16,14 +16,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+        "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
       },
-      "previousTransaction": "Zwlbw1HboiIyYI/PWP569dmy326Q7mmWiZK2/5zBOTU=",
+      "previousTransaction": "Dk5VQI5yFhxmmn1qHgZN7Y7qMod1iV7l1al9gQRAsp4=",
       "storageRebate": 25,
       "reference": {
-        "objectId": "0xf46a9c1f71bac2a11ae41153edbf3870f1806522",
+        "objectId": "0x52d6f5e5a8b25acd42a17f0f371649d05be94fed",
         "version": 1,
-        "digest": "gHRdLwFUxQzY3uOXRgxZFtjQkOEGn4aUGMQ4dfIA+hY="
+        "digest": "g+WOG9VarXk3ksEod2zsXiMf6qDDRiKtoaSCL82q1gc="
       }
     }
   },
@@ -36,20 +36,20 @@
         "fields": {
           "balance": 100000,
           "id": {
-            "id": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+            "id": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
             "version": 0
           }
         }
       },
       "owner": {
-        "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+        "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
       },
       "previousTransaction": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+        "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
         "version": 0,
-        "digest": "s5DP1I7tW3rFQ8sgk2fqoZoC15+2Amn+H9yksQknoYw="
+        "digest": "nUDXjVtM4s161uovLAD/k9lkfViahX6MQA+HqjVqNHA="
       }
     }
   },
@@ -59,16 +59,16 @@
       "data": {
         "dataType": "package",
         "disassembled": {
-          "M1": "// Move bytecode v5\nmodule 16c21936128845700a729e130b2da1770ccb0a40.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
+          "M1": "// Move bytecode v5\nmodule 54f0307451e360800515cef3e550037b821de423.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
         }
       },
       "owner": "Immutable",
-      "previousTransaction": "1mfNLeyzwuV7Y7+u8FXK4j+2h9ua4jik40s/uaXwUdw=",
+      "previousTransaction": "O3BJ05Qy66tWL9tuHmC/ouGPp5qK1p1Shs8eCzibAG0=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x16c21936128845700a729e130b2da1770ccb0a40",
+        "objectId": "0x54f0307451e360800515cef3e550037b821de423",
         "version": 1,
-        "digest": "qHhAaabSzF2VcVfY2HpFXU8748dqkBTskUdnEq1rlJE="
+        "digest": "KtpPkUgdnByKXKRYUgyDp/yCELUmD0DBJTn0R+dOssw="
       }
     }
   },
@@ -77,21 +77,21 @@
     "details": {
       "data": {
         "dataType": "moveObject",
-        "type": "0xdae900dab646dc065232d6ede6b3aa566769dd7c::Hero::Hero",
+        "type": "0x8f7c336a73b3f3f03b402a16f827e9433b40eb8c::Hero::Hero",
         "fields": {
           "experience": 0,
-          "game_id": "0x4955ac9f1c1113ff44834bd31b659edb457d3ef9",
+          "game_id": "0x954ff3cfb0f687e32cd02103b3404454c8f661a1",
           "hp": 100,
           "id": {
-            "id": "0xbd046912c4f022450f54becc2816ab549fd8a864",
+            "id": "0x5dce1f6aecdfe1f71efa2a59612923bb9cbd8af7",
             "version": 1
           },
           "sword": {
-            "type": "0xdae900dab646dc065232d6ede6b3aa566769dd7c::Hero::Sword",
+            "type": "0x8f7c336a73b3f3f03b402a16f827e9433b40eb8c::Hero::Sword",
             "fields": {
-              "game_id": "0x4955ac9f1c1113ff44834bd31b659edb457d3ef9",
+              "game_id": "0x954ff3cfb0f687e32cd02103b3404454c8f661a1",
               "id": {
-                "id": "0xe660bb5a634d0d648f8f3437ab18b26b3c67e8cb",
+                "id": "0xeb66499fd24782e3ecd4175188bab976add60654",
                 "version": 0
               },
               "magic": 10,
@@ -101,14 +101,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+        "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
       },
-      "previousTransaction": "AcQpy99nCvjG8L1U2HQWwxRvFlFcZZ1kjuVBz/rTBAI=",
+      "previousTransaction": "qdA6WxlhoDge0Mgcx539sjk4QEtZs7a5NK9g0bLZ0zM=",
       "storageRebate": 22,
       "reference": {
-        "objectId": "0xbd046912c4f022450f54becc2816ab549fd8a864",
+        "objectId": "0x5dce1f6aecdfe1f71efa2a59612923bb9cbd8af7",
         "version": 1,
-        "digest": "Sm3O+1kcXEjvVkl3NtLaWoFK9PiT6A5V6kPvPHpV6L4="
+        "digest": "WEC6Ve/yE+FqHtVRM5JYPovU4tBDZPHs7GaA0e8G0AY="
       }
     }
   }

--- a/crates/sui-open-rpc/samples/objects.json
+++ b/crates/sui-open-rpc/samples/objects.json
@@ -8,7 +8,7 @@
         "fields": {
           "description": "An NFT created by the wallet Command Line Tool",
           "id": {
-            "id": "0xc7619788abec20bd698d301d60461001396259a5",
+            "id": "0x2ead2173bc84026d126e2a58a1cfd3b48380417c",
             "version": 1
           },
           "name": "Example NFT",
@@ -16,14 +16,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+        "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
       },
-      "previousTransaction": "XzaoA9oTgeW7cjKHbMsma4a4Oxn6lE8qB1rHYn0Ssz8=",
+      "previousTransaction": "UvCLC/D3ykGCUQ5mZEZEBUh+D0zw5RV3RtS1cOxP588=",
       "storageRebate": 25,
       "reference": {
-        "objectId": "0xc7619788abec20bd698d301d60461001396259a5",
+        "objectId": "0x2ead2173bc84026d126e2a58a1cfd3b48380417c",
         "version": 1,
-        "digest": "6VqFCPYlKh3LruU1UfD2V98AJcyMURY+4K38UCV0PoI="
+        "digest": "eQhn479Tmtk5a18+iGIkrxRHWiNjg9keuUh7Mh8oh8I="
       }
     }
   },
@@ -36,20 +36,20 @@
         "fields": {
           "balance": 100000,
           "id": {
-            "id": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+            "id": "0x06028375fc3506e7f66618167e3de1f896ec8783",
             "version": 0
           }
         }
       },
       "owner": {
-        "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+        "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
       },
       "previousTransaction": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+        "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
         "version": 0,
-        "digest": "qPh5rxDZL0+8iAPpOYm+MKA1kb4u2Oz/ggOYzk1+ypc="
+        "digest": "ChEV3TbRjBxrhOrFJPpwDeB/qIRNQj0OU/zJlublZLc="
       }
     }
   },
@@ -59,16 +59,16 @@
       "data": {
         "dataType": "package",
         "disassembled": {
-          "M1": "// Move bytecode v5\nmodule 1373663d46fa4ec26a7a434825c72dbe9c1c7145.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
+          "M1": "// Move bytecode v5\nmodule 2da3bbe895d1bea45e499805cc1de83f2a8f95e7.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
         }
       },
       "owner": "Immutable",
-      "previousTransaction": "7YHe5fURQLuk5Xq11j6XMBUqOJkXn4vBE/poS/+bHNc=",
+      "previousTransaction": "nOXrlcSqOD/DCpYGaWmXK413s+zeO2cL/R94zcJGLzg=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x1373663d46fa4ec26a7a434825c72dbe9c1c7145",
+        "objectId": "0x2da3bbe895d1bea45e499805cc1de83f2a8f95e7",
         "version": 1,
-        "digest": "R+bc5vA6D4BBElukzvcOi0C3UYS59b3SeuyWVXlSsh4="
+        "digest": "qbiPulMlmh0T37gMbGp3WJJiQJ3sm7vlbIi/3U5+k58="
       }
     }
   },
@@ -77,21 +77,21 @@
     "details": {
       "data": {
         "dataType": "moveObject",
-        "type": "0xe62268a2843b18a12e8e33d910772f4dfc50e7b6::Hero::Hero",
+        "type": "0x8afc38966cb8185ae0aeec08ce387a71bd1cbaa0::Hero::Hero",
         "fields": {
           "experience": 0,
-          "game_id": "0x75759a6308618eb807c41b1cf17dca8dbd928fe5",
+          "game_id": "0x9e4d02dbd4c83a68655a57d68f0c649730940342",
           "hp": 100,
           "id": {
-            "id": "0x7993eb2c32a78548faed550102b0001504cda649",
+            "id": "0xa5842d14c3ada2f6722cb62aedfc876840ed5520",
             "version": 1
           },
           "sword": {
-            "type": "0xe62268a2843b18a12e8e33d910772f4dfc50e7b6::Hero::Sword",
+            "type": "0x8afc38966cb8185ae0aeec08ce387a71bd1cbaa0::Hero::Sword",
             "fields": {
-              "game_id": "0x75759a6308618eb807c41b1cf17dca8dbd928fe5",
+              "game_id": "0x9e4d02dbd4c83a68655a57d68f0c649730940342",
               "id": {
-                "id": "0x1f2786131fd0911fd8e95a1489088b569eb4a343",
+                "id": "0xed5999563d0a06f630dfd3d47bb6d53231457093",
                 "version": 0
               },
               "magic": 10,
@@ -101,14 +101,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+        "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
       },
-      "previousTransaction": "brtqfhPIP5lgMOlTKqAhsS2rNdzDQ0EwsYoEs0adKDM=",
+      "previousTransaction": "m6Z/zbUiai23IvcqHAqhSAf/YKu9IJ4/3r7PlBmUcjM=",
       "storageRebate": 22,
       "reference": {
-        "objectId": "0x7993eb2c32a78548faed550102b0001504cda649",
+        "objectId": "0xa5842d14c3ada2f6722cb62aedfc876840ed5520",
         "version": 1,
-        "digest": "Z/aJJbHLcblffUjOXy+lMPoTt+p8PWXo2vZ6168jT54="
+        "digest": "vWEueSZHwQoehl6vmLBOe21SUy51q/LrV2cI+P61Ozw="
       }
     }
   }

--- a/crates/sui-open-rpc/samples/objects.json
+++ b/crates/sui-open-rpc/samples/objects.json
@@ -8,7 +8,7 @@
         "fields": {
           "description": "An NFT created by the wallet Command Line Tool",
           "id": {
-            "id": "0x2ead2173bc84026d126e2a58a1cfd3b48380417c",
+            "id": "0xf46a9c1f71bac2a11ae41153edbf3870f1806522",
             "version": 1
           },
           "name": "Example NFT",
@@ -16,14 +16,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+        "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
       },
-      "previousTransaction": "UvCLC/D3ykGCUQ5mZEZEBUh+D0zw5RV3RtS1cOxP588=",
+      "previousTransaction": "Zwlbw1HboiIyYI/PWP569dmy326Q7mmWiZK2/5zBOTU=",
       "storageRebate": 25,
       "reference": {
-        "objectId": "0x2ead2173bc84026d126e2a58a1cfd3b48380417c",
+        "objectId": "0xf46a9c1f71bac2a11ae41153edbf3870f1806522",
         "version": 1,
-        "digest": "eQhn479Tmtk5a18+iGIkrxRHWiNjg9keuUh7Mh8oh8I="
+        "digest": "gHRdLwFUxQzY3uOXRgxZFtjQkOEGn4aUGMQ4dfIA+hY="
       }
     }
   },
@@ -36,20 +36,20 @@
         "fields": {
           "balance": 100000,
           "id": {
-            "id": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+            "id": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
             "version": 0
           }
         }
       },
       "owner": {
-        "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+        "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
       },
       "previousTransaction": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+        "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
         "version": 0,
-        "digest": "ChEV3TbRjBxrhOrFJPpwDeB/qIRNQj0OU/zJlublZLc="
+        "digest": "s5DP1I7tW3rFQ8sgk2fqoZoC15+2Amn+H9yksQknoYw="
       }
     }
   },
@@ -59,16 +59,16 @@
       "data": {
         "dataType": "package",
         "disassembled": {
-          "M1": "// Move bytecode v5\nmodule 2da3bbe895d1bea45e499805cc1de83f2a8f95e7.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
+          "M1": "// Move bytecode v5\nmodule 16c21936128845700a729e130b2da1770ccb0a40.M1 {\nstruct Forge has store, key {\n\tid: VersionedID,\n\tswords_created: u64\n}\nstruct Sword has store, key {\n\tid: VersionedID,\n\tmagic: u64,\n\tstrength: u64\n}\n\ninit(Arg0: &mut TxContext) {\nB0:\n\t0: CopyLoc[0](Arg0: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: LdU64(0)\n\t3: Pack[0](Forge)\n\t4: StLoc[1](loc0: Forge)\n\t5: MoveLoc[1](loc0: Forge)\n\t6: MoveLoc[0](Arg0: &mut TxContext)\n\t7: FreezeRef\n\t8: Call[7](sender(&TxContext): address)\n\t9: Call[0](transfer<Forge>(Forge, address))\n\t10: Ret\n}\npublic magic(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[0](Sword.magic: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic strength(Arg0: &Sword): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Sword)\n\t1: ImmBorrowField[1](Sword.strength: u64)\n\t2: ReadRef\n\t3: Ret\n}\npublic(script) sword_create(Arg0: &mut Forge, Arg1: u64, Arg2: u64, Arg3: address, Arg4: &mut TxContext) {\nB0:\n\t0: MoveLoc[4](Arg4: &mut TxContext)\n\t1: Call[6](new_id(&mut TxContext): VersionedID)\n\t2: MoveLoc[1](Arg1: u64)\n\t3: MoveLoc[2](Arg2: u64)\n\t4: Pack[1](Sword)\n\t5: StLoc[5](loc0: Sword)\n\t6: MoveLoc[5](loc0: Sword)\n\t7: MoveLoc[3](Arg3: address)\n\t8: Call[1](transfer<Sword>(Sword, address))\n\t9: CopyLoc[0](Arg0: &mut Forge)\n\t10: ImmBorrowField[2](Forge.swords_created: u64)\n\t11: ReadRef\n\t12: LdU64(1)\n\t13: Add\n\t14: MoveLoc[0](Arg0: &mut Forge)\n\t15: MutBorrowField[2](Forge.swords_created: u64)\n\t16: WriteRef\n\t17: Ret\n}\npublic(script) sword_transfer(Arg0: Sword, Arg1: address, Arg2: &mut TxContext) {\nB0:\n\t0: MoveLoc[0](Arg0: Sword)\n\t1: MoveLoc[1](Arg1: address)\n\t2: Call[1](transfer<Sword>(Sword, address))\n\t3: Ret\n}\npublic swords_created(Arg0: &Forge): u64 {\nB0:\n\t0: MoveLoc[0](Arg0: &Forge)\n\t1: ImmBorrowField[2](Forge.swords_created: u64)\n\t2: ReadRef\n\t3: Ret\n}\n}"
         }
       },
       "owner": "Immutable",
-      "previousTransaction": "nOXrlcSqOD/DCpYGaWmXK413s+zeO2cL/R94zcJGLzg=",
+      "previousTransaction": "1mfNLeyzwuV7Y7+u8FXK4j+2h9ua4jik40s/uaXwUdw=",
       "storageRebate": 0,
       "reference": {
-        "objectId": "0x2da3bbe895d1bea45e499805cc1de83f2a8f95e7",
+        "objectId": "0x16c21936128845700a729e130b2da1770ccb0a40",
         "version": 1,
-        "digest": "qbiPulMlmh0T37gMbGp3WJJiQJ3sm7vlbIi/3U5+k58="
+        "digest": "qHhAaabSzF2VcVfY2HpFXU8748dqkBTskUdnEq1rlJE="
       }
     }
   },
@@ -77,21 +77,21 @@
     "details": {
       "data": {
         "dataType": "moveObject",
-        "type": "0x8afc38966cb8185ae0aeec08ce387a71bd1cbaa0::Hero::Hero",
+        "type": "0xdae900dab646dc065232d6ede6b3aa566769dd7c::Hero::Hero",
         "fields": {
           "experience": 0,
-          "game_id": "0x9e4d02dbd4c83a68655a57d68f0c649730940342",
+          "game_id": "0x4955ac9f1c1113ff44834bd31b659edb457d3ef9",
           "hp": 100,
           "id": {
-            "id": "0xa5842d14c3ada2f6722cb62aedfc876840ed5520",
+            "id": "0xbd046912c4f022450f54becc2816ab549fd8a864",
             "version": 1
           },
           "sword": {
-            "type": "0x8afc38966cb8185ae0aeec08ce387a71bd1cbaa0::Hero::Sword",
+            "type": "0xdae900dab646dc065232d6ede6b3aa566769dd7c::Hero::Sword",
             "fields": {
-              "game_id": "0x9e4d02dbd4c83a68655a57d68f0c649730940342",
+              "game_id": "0x4955ac9f1c1113ff44834bd31b659edb457d3ef9",
               "id": {
-                "id": "0xed5999563d0a06f630dfd3d47bb6d53231457093",
+                "id": "0xe660bb5a634d0d648f8f3437ab18b26b3c67e8cb",
                 "version": 0
               },
               "magic": 10,
@@ -101,14 +101,14 @@
         }
       },
       "owner": {
-        "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+        "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
       },
-      "previousTransaction": "m6Z/zbUiai23IvcqHAqhSAf/YKu9IJ4/3r7PlBmUcjM=",
+      "previousTransaction": "AcQpy99nCvjG8L1U2HQWwxRvFlFcZZ1kjuVBz/rTBAI=",
       "storageRebate": 22,
       "reference": {
-        "objectId": "0xa5842d14c3ada2f6722cb62aedfc876840ed5520",
+        "objectId": "0xbd046912c4f022450f54becc2816ab549fd8a864",
         "version": 1,
-        "digest": "vWEueSZHwQoehl6vmLBOe21SUy51q/LrV2cI+P61Ozw="
+        "digest": "Sm3O+1kcXEjvVkl3NtLaWoFK9PiT6A5V6kPvPHpV6L4="
       }
     }
   }

--- a/crates/sui-open-rpc/samples/transactions.json
+++ b/crates/sui-open-rpc/samples/transactions.json
@@ -2,7 +2,7 @@
   "move_call": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "XzaoA9oTgeW7cjKHbMsma4a4Oxn6lE8qB1rHYn0Ssz8=",
+        "transactionDigest": "UvCLC/D3ykGCUQ5mZEZEBUh+D0zw5RV3RtS1cOxP588=",
         "data": {
           "transactions": [
             {
@@ -10,7 +10,7 @@
                 "package": {
                   "objectId": "0x0000000000000000000000000000000000000002",
                   "version": 1,
-                  "digest": "faGXBqbeg7QrbM02bplusUTwaATxw4gro+QZOkmehfU="
+                  "digest": "DlyqSfycSa8RPKn9KshawEFozlgbfkRXTGhcSKgWolI="
                 },
                 "module": "DevNetNFT",
                 "function": "mint",
@@ -22,29 +22,29 @@
               }
             }
           ],
-          "sender": "0xc8507421face4ab67dac23c9295e6eaa0d44d977",
+          "sender": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
           "gasPayment": {
-            "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+            "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
             "version": 0,
-            "digest": "qPh5rxDZL0+8iAPpOYm+MKA1kb4u2Oz/ggOYzk1+ypc="
+            "digest": "ChEV3TbRjBxrhOrFJPpwDeB/qIRNQj0OU/zJlublZLc="
           },
           "gasBudget": 10000
         },
-        "txSignature": "ve7SSIj9cu/HoCN0C4IoJMY1qxko6XtC7J4X/s/wLyXjXjs0yvWt7YON2UOUyMjYYJrgHgxxiRMixnWvb87/BgGrrCrtyO8uCxryrgPNFiqiCFkAitbGVvGxaxXrht0Z",
+        "txSignature": "MaCw+BaqZyNw8Z9YQbpDnAi9og/ZvQ1ChPbz6GDCZQqST3nvveEgvQjgzhmOjfEcRsl9i41iIHvUo3Kg4PzXDciPT/ULc4LROUiSsCkb2IXtWrEEF60oJjPrs5njcb6w",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "OwIHxzZW4z+pZ+8BdE3CfShhfP562+PYWKkAEOlzifQ=",
-              "ETBAJaVMiZs2AZE+zZ+jEmm7F+WrokTsEPOJikpDliUWhYS7us0WEaMqUCy3U0zrPbJUvYVuifZqD+H20Ev+DA=="
+              "9ElPJH8yyV4877PlUecP6AaALwBzxnrs+MQqVh0IKno=",
+              "7mkaR5JwxHQKxF57HOGjkCID/sUje7Jii8MtXPo8hO0S5oPIq1Aq+l+a1aXJzc2eGe+P/fTAjrNFftOZKKoWAg=="
             ],
             [
-              "2PFDMHzs06bcc5NyvD35PNZdVUN3OrpL2HQQZdltq8A=",
-              "KC8mgUigWg0qdT8UGAx32FOWUzafYDtCPMKYel1jyCz3TxTNh66dFLasBWt9AnM3Z+TcGtw482y2xd8yb+g9CQ=="
+              "HA68/0emwiWZPm/ULlUeC947vM/IyfNfv7GXEz6Q+Tc=",
+              "vNzJ7cSpUsrxKp1z+1ZQRdythr1kP/DDIpwMZcg13n3APHX9T1hAOyJcHbG9QViGtq4/whqr0dZUb1PbEDQUCA=="
             ],
             [
-              "uq+MQgMi/MD7G/AmKDQj920/Izb/l8ZDGvFVXqw8aFY=",
-              "rtIt0BvJCXFOIEmnsfnGO99F8hPV9vkTjDoLpaBhyyyTp4SGGedr4FgaS2GXD+mhJzGHFYGL3t6Nfvw587HvDA=="
+              "kBKf7Pj/609sv1kJoO8BZkeYv5m/itWWz0gNSvHX29s=",
+              "TX1nTH67qGAtlnpXRoUIB+ADQQo3b725EKBD1WFKib9RwkqdAA6VbMu1a+i2MdRHkWor1i4PHzOw13MdGWXPBQ=="
             ]
           ]
         }
@@ -53,89 +53,148 @@
         "status": {
           "status": "success",
           "gas_cost": {
-            "computationCost": 708,
+            "computationCost": 722,
             "storageCost": 40,
             "storageRebate": 0
           }
         },
-        "transactionDigest": "XzaoA9oTgeW7cjKHbMsma4a4Oxn6lE8qB1rHYn0Ssz8=",
+        "transactionDigest": "UvCLC/D3ykGCUQ5mZEZEBUh+D0zw5RV3RtS1cOxP588=",
         "created": [
           {
             "owner": {
-              "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
             },
             "reference": {
-              "objectId": "0xc7619788abec20bd698d301d60461001396259a5",
+              "objectId": "0x2ead2173bc84026d126e2a58a1cfd3b48380417c",
               "version": 1,
-              "digest": "6VqFCPYlKh3LruU1UfD2V98AJcyMURY+4K38UCV0PoI="
+              "digest": "eQhn479Tmtk5a18+iGIkrxRHWiNjg9keuUh7Mh8oh8I="
             }
           }
         ],
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
             },
             "reference": {
-              "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+              "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
               "version": 1,
-              "digest": "IX9/I/WUo5yWh9xcljLR5UXV5LOLoKdh4mUMOw9cKv0="
+              "digest": "TKjT/WJk51DE+4+AAB2O00Dka8+BOun+if0FfsDGiLA="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
           "reference": {
-            "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+            "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
             "version": 1,
-            "digest": "IX9/I/WUo5yWh9xcljLR5UXV5LOLoKdh4mUMOw9cKv0="
+            "digest": "TKjT/WJk51DE+4+AAB2O00Dka8+BOun+if0FfsDGiLA="
           }
-        }
+        },
+        "events": [
+          {
+            "type_": "0x2::DevNetNFT::MintNFTEvent",
+            "contents": [
+              46,
+              173,
+              33,
+              115,
+              188,
+              132,
+              2,
+              109,
+              18,
+              110,
+              42,
+              88,
+              161,
+              207,
+              211,
+              180,
+              131,
+              128,
+              65,
+              124,
+              178,
+              132,
+              63,
+              40,
+              179,
+              211,
+              96,
+              151,
+              177,
+              112,
+              240,
+              38,
+              201,
+              155,
+              219,
+              172,
+              49,
+              212,
+              251,
+              199,
+              11,
+              69,
+              120,
+              97,
+              109,
+              112,
+              108,
+              101,
+              32,
+              78,
+              70,
+              84
+            ]
+          }
+        ]
       }
     }
   },
   "transfer": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "AiY+cCKq5VB8P9aEcZEJBp3goZahgl9jMkpksYUyimY=",
+        "transactionDigest": "f+TTxzx/VUdDElTzcH+XPM5gKrQW4MRsh/jCFfP4t2A=",
         "data": {
           "transactions": [
             {
               "TransferCoin": {
-                "recipient": "0xc8507421face4ab67dac23c9295e6eaa0d44d977",
+                "recipient": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
                 "objectRef": {
-                  "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+                  "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
                   "version": 4,
-                  "digest": "vDR8qSCCPtbDYJ0ZKn5FBc/ZpgiuMnENr0PJT8oKqro="
+                  "digest": "wFIsyyHfKOZ+LBxGN4BUwAhVPulX5j14PHLSJNDfF38="
                 }
               }
             }
           ],
-          "sender": "0xc8507421face4ab67dac23c9295e6eaa0d44d977",
+          "sender": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
           "gasPayment": {
-            "objectId": "0x44116984c6e384738f9abe08554a2df82bf7f81a",
+            "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
             "version": 1,
-            "digest": "mFrWOvLVMJ4BPTnEHNLFlHceYNQFaJ7ndkde44nJXl8="
+            "digest": "hus/FD/jCqRH6u930P9AzSLeANED4X486hCv31d5qOA="
           },
           "gasBudget": 1000
         },
-        "txSignature": "rbgmGg3Z0fEGE6JZ6FGvDWWffExw22yL0yJhaZWK1XQV7hBrgRKQN6oaW8DoXuLGuOwNGz4EvkYVZkPw0jcKAQGrrCrtyO8uCxryrgPNFiqiCFkAitbGVvGxaxXrht0Z",
+        "txSignature": "nzXVH3z4AjrMM2r0qyOWecLOnnJAB67rEdjlW2fAoFLQzk/mKB1FtCB5BJtgnrQxoyRNQG+aRz1soySIWmH4B8iPT/ULc4LROUiSsCkb2IXtWrEEF60oJjPrs5njcb6w",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "2PFDMHzs06bcc5NyvD35PNZdVUN3OrpL2HQQZdltq8A=",
-              "DLai1/aIiTHRgSELqvQQP2//QcwcC7HICiWo9ivdq3RKWU9Ojy9mNk5RzjtYeJpDknrV2EpFBfXtcxsHPU6fAA=="
+              "3cb6GkCsFh4Hb5/iNx6nU+2H0be+t572ahAFBCftwFA=",
+              "2+izoMm+iQm1DErp2WWbE424d6yMHMRDKvRjTY/0j3rB+elT7R/vQqgfEBu+n3iO5xPt5V0DHDQz92M6g+NUDA=="
             ],
             [
-              "kFejcuHXsZ8hOE9Di2LWnHqsUPJswXtakWBSNXr3h1w=",
-              "R/jJcDM7/RrCOs5QB99ewjrp4pjL0w+BBL60ae1dfMzrC+MnX91PV7/w/eWgZzZzOTt5GZJ6D+9Xrdafa5SgBg=="
+              "kBKf7Pj/609sv1kJoO8BZkeYv5m/itWWz0gNSvHX29s=",
+              "8UsAoshlrllH4eMRp/iRc77QwrLd3foE0GYgknHbX8qFtGcOUehlTW7IAY2+Z0C7j9kH65iEaIizpSNmPtVvDg=="
             ],
             [
-              "OwIHxzZW4z+pZ+8BdE3CfShhfP562+PYWKkAEOlzifQ=",
-              "PoZAizZuUBOh3nxL7zkdoDzXUOUd2KDAMBxc2uNpThp2znb2YF5iYLa3q6R5WMUZV445EQkY+iX7BOTod67HAQ=="
+              "HA68/0emwiWZPm/ULlUeC947vM/IyfNfv7GXEz6Q+Tc=",
+              "95yj60g4wSFF/GrkBVX39eJcMnzsOxG1IWqEwdxxjzyIggijKh2qcO3l3cz1GgPqQcnfue5LMb02EcH2t8VaAw=="
             ]
           ]
         }
@@ -149,41 +208,41 @@
             "storageRebate": 30
           }
         },
-        "transactionDigest": "AiY+cCKq5VB8P9aEcZEJBp3goZahgl9jMkpksYUyimY=",
+        "transactionDigest": "f+TTxzx/VUdDElTzcH+XPM5gKrQW4MRsh/jCFfP4t2A=",
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
             },
             "reference": {
-              "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+              "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
               "version": 5,
-              "digest": "dlCKhiTYu0E+6WZtPVh/VmaiNIN3Ddm2VS13G2CKCg8="
+              "digest": "biVtZZ/t+O+34WChpnZFXG8k/3c6riR93EdYIzcV21Y="
             }
           },
           {
             "owner": {
-              "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
             },
             "reference": {
-              "objectId": "0x44116984c6e384738f9abe08554a2df82bf7f81a",
+              "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
               "version": 2,
-              "digest": "aBnjtKhgx2o9VRZw4bOR6dQHLZVgEIWV/zVUdkLRJqU="
+              "digest": "20IeFiZPv89kRMg+Vk+RpiSerEuWb+jif9OJXB660Sk="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
           "reference": {
-            "objectId": "0x44116984c6e384738f9abe08554a2df82bf7f81a",
+            "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
             "version": 2,
-            "digest": "aBnjtKhgx2o9VRZw4bOR6dQHLZVgEIWV/zVUdkLRJqU="
+            "digest": "20IeFiZPv89kRMg+Vk+RpiSerEuWb+jif9OJXB660Sk="
           }
         },
         "dependencies": [
-          "brtqfhPIP5lgMOlTKqAhsS2rNdzDQ0EwsYoEs0adKDM="
+          "m6Z/zbUiai23IvcqHAqhSAf/YKu9IJ4/3r7PlBmUcjM="
         ]
       }
     }
@@ -191,7 +250,7 @@
   "coin_split": {
     "SplitCoinResponse": {
       "certificate": {
-        "transactionDigest": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+        "transactionDigest": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
         "data": {
           "transactions": [
             {
@@ -199,7 +258,7 @@
                 "package": {
                   "objectId": "0x0000000000000000000000000000000000000002",
                   "version": 1,
-                  "digest": "faGXBqbeg7QrbM02bplusUTwaATxw4gro+QZOkmehfU="
+                  "digest": "DlyqSfycSa8RPKn9KshawEFozlgbfkRXTGhcSKgWolI="
                 },
                 "module": "Coin",
                 "function": "split_vec",
@@ -207,7 +266,7 @@
                   "0x2::SUI::SUI"
                 ],
                 "arguments": [
-                  "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+                  "0x6028375fc3506e7f66618167e3de1f896ec8783",
                   [
                     20,
                     20,
@@ -219,29 +278,29 @@
               }
             }
           ],
-          "sender": "0xc8507421face4ab67dac23c9295e6eaa0d44d977",
+          "sender": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
           "gasPayment": {
-            "objectId": "0x44116984c6e384738f9abe08554a2df82bf7f81a",
+            "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
             "version": 2,
-            "digest": "aBnjtKhgx2o9VRZw4bOR6dQHLZVgEIWV/zVUdkLRJqU="
+            "digest": "20IeFiZPv89kRMg+Vk+RpiSerEuWb+jif9OJXB660Sk="
           },
           "gasBudget": 1000
         },
-        "txSignature": "USwotv5HY28EEGXuw+M2Qcc4FyjTlo+bYzT12PBeFlcpZqrs/WCjUrY2UozXPPPN6PBW3E4UD6vPe+unlat/AAGrrCrtyO8uCxryrgPNFiqiCFkAitbGVvGxaxXrht0Z",
+        "txSignature": "6bm2fnpaEwMMIde40pH00bBLhZDUnVD3G5y9A2kW6IAZ9FAaWpB73LDs/o9p8/AcHjrDQ26DZLOUgxwaBWzGDsiPT/ULc4LROUiSsCkb2IXtWrEEF60oJjPrs5njcb6w",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "uq+MQgMi/MD7G/AmKDQj920/Izb/l8ZDGvFVXqw8aFY=",
-              "6cX6z3TDJpW9NHbgBo02SjdAK0cEZTgPaHH0vdK8gdacVkeqdkOCGGsmV/x5rhR8YcZyEGSJoB737PAKgEmyAA=="
+              "3cb6GkCsFh4Hb5/iNx6nU+2H0be+t572ahAFBCftwFA=",
+              "vJ0gXKF2FMPdJfYhl3hU8N4I1W/mKcZE9VUsFhbuIl8S727ksSMfkbCXcFaY1sNQJYSdfjXIw8KP62aGZC7UCA=="
             ],
             [
-              "OwIHxzZW4z+pZ+8BdE3CfShhfP562+PYWKkAEOlzifQ=",
-              "zwLrxSmMJcVIijM4Nz/wBWtFsMe/E6YOv8JaZnV+02P5wKu1Fvf1EMoI2xQgM9BXCIIMxyMzSbOnXY8G8c6yBg=="
+              "HA68/0emwiWZPm/ULlUeC947vM/IyfNfv7GXEz6Q+Tc=",
+              "WTrs0ZCylvLeOWx6fpfitLO4NtqGSWlzW5/KpjwYG0zQQs6dFluhjso/U2fvBDyB09mIYnoaTKuA1PhLIQBjBQ=="
             ],
             [
-              "kFejcuHXsZ8hOE9Di2LWnHqsUPJswXtakWBSNXr3h1w=",
-              "BI9ROm+/DAmzMtMze1zCK1y+M2/dPfw6qAJkc3yAq3pgvIHwv84kUQhFWxIdrhhqs+jo9ufPB5z1sTUAM0miBA=="
+              "kBKf7Pj/609sv1kJoO8BZkeYv5m/itWWz0gNSvHX29s=",
+              "6HMldSphA8cU4+oH60UdY1frsIzs+4aks3+pdOzzxciGNOOq+qH/ytPcppDvTXJBIOo+Rl4cd1Yx1ztdMP3BAw=="
             ]
           ]
         }
@@ -251,22 +310,22 @@
           "dataType": "moveObject",
           "type": "0x2::Coin::Coin<0x2::SUI::SUI>",
           "fields": {
-            "balance": 95681,
+            "balance": 95650,
             "id": {
-              "id": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+              "id": "0x06028375fc3506e7f66618167e3de1f896ec8783",
               "version": 6
             }
           }
         },
         "owner": {
-          "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+          "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
         },
-        "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+        "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x3818c35255ad136f52e0fd23667e16e3c0cc4860",
+          "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
           "version": 6,
-          "digest": "mjjEIWYdjwEGdWvjuuofQv8h7UoyNzeIuB/jmS3b/t4="
+          "digest": "bkpD7syeQG98JZJLct9oln284deogc0IEXYDkIuKWwA="
         }
       },
       "newCoins": [
@@ -277,20 +336,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x06958d434af8a52c36b7da24414f8ec9acec40cb",
+                "id": "0x69a710e15104cb6df719fd4f406710d6fc1a91de",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
-          "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x06958d434af8a52c36b7da24414f8ec9acec40cb",
+            "objectId": "0x69a710e15104cb6df719fd4f406710d6fc1a91de",
             "version": 1,
-            "digest": "Hs5rGAG8MSEVGYoBP9Gqzs6FF/exPFBnf7fGgkjOOr4="
+            "digest": "Kns1/nG8J2nJnexXI61PHHXj127OqdcyEHCzA8dbOxI="
           }
         },
         {
@@ -300,20 +359,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x2920ae9b8cbc28f98ca5f0b65b6db88ecc176c02",
+                "id": "0x93cf651468ac83e28e2789d1d8b94d890de5d6b4",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
-          "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x2920ae9b8cbc28f98ca5f0b65b6db88ecc176c02",
+            "objectId": "0x93cf651468ac83e28e2789d1d8b94d890de5d6b4",
             "version": 1,
-            "digest": "bRR3Vn0oEZ1mmM27TkXgAxeOIgOE25iiUxSy2FPkXUY="
+            "digest": "XlemfCVVwp7napyh/aws5anjSoXxQ/m8jFMgPKeiJUw="
           }
         },
         {
@@ -323,20 +382,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x7ea7a5f255a828458c49988f171f298051ec36ce",
+                "id": "0xc8f70ae9332866d5b1e22c5b3b44061476727059",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
-          "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x7ea7a5f255a828458c49988f171f298051ec36ce",
+            "objectId": "0xc8f70ae9332866d5b1e22c5b3b44061476727059",
             "version": 1,
-            "digest": "C2OSTZYh+wPhCScON0n2+g2fS9TQA15MsyhvslBOf+c="
+            "digest": "cQhD5w7LOyrlF2VB07jVE1h9gEZBUMJmBH/Xef7xOtU="
           }
         },
         {
@@ -346,20 +405,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x969213935861f7abc02072ba9de1bf420db3c2de",
+                "id": "0xdd22d51d0ced9895fe5a9d973a6af7a2d104ec60",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
-          "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x969213935861f7abc02072ba9de1bf420db3c2de",
+            "objectId": "0xdd22d51d0ced9895fe5a9d973a6af7a2d104ec60",
             "version": 1,
-            "digest": "O37OLUmNAd+EefJUb0eiDNbYrNKSmaCqEQkeO5gfUZw="
+            "digest": "b+c7GzUHgiMcUoI8HJ4gXG7u4OUjy8Cqg1WQWV/WPSA="
           }
         },
         {
@@ -369,20 +428,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0xb252dec7c0fff07ab8515d5b3c832636c4ddf80a",
+                "id": "0xf9ce6bbcba48c3d2756954cb5e6ca9038942c903",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
           },
-          "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0xb252dec7c0fff07ab8515d5b3c832636c4ddf80a",
+            "objectId": "0xf9ce6bbcba48c3d2756954cb5e6ca9038942c903",
             "version": 1,
-            "digest": "+9JPMpAZWUUvW7ZfkjQTX6SPNLCSDNsE046C97PZDME="
+            "digest": "3eg11cwHQ3MdMT63HAqEtITGa0DD7wMAjksZQ+JlzL4="
           }
         }
       ],
@@ -391,22 +450,22 @@
           "dataType": "moveObject",
           "type": "0x2::Coin::Coin<0x2::SUI::SUI>",
           "fields": {
-            "balance": 98969,
+            "balance": 98960,
             "id": {
-              "id": "0x44116984c6e384738f9abe08554a2df82bf7f81a",
+              "id": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
               "version": 3
             }
           }
         },
         "owner": {
-          "AddressOwner": "0xc8507421face4ab67dac23c9295e6eaa0d44d977"
+          "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
         },
-        "previousTransaction": "yLPmNAteC/bDESd72yKNdRF4/xTIYn0a1qA1MqfpEDM=",
+        "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x44116984c6e384738f9abe08554a2df82bf7f81a",
+          "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
           "version": 3,
-          "digest": "jpWDZHVNvcfBBEr9aSGVH2V+hAjuiP6Wtg0Yf9EmNO4="
+          "digest": "t8QF9rH41McU58KDWcT0Zo0hEEtjBIM8uqOTJRkLcUs="
         }
       }
     }

--- a/crates/sui-open-rpc/samples/transactions.json
+++ b/crates/sui-open-rpc/samples/transactions.json
@@ -2,7 +2,7 @@
   "move_call": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "Zwlbw1HboiIyYI/PWP569dmy326Q7mmWiZK2/5zBOTU=",
+        "transactionDigest": "Dk5VQI5yFhxmmn1qHgZN7Y7qMod1iV7l1al9gQRAsp4=",
         "data": {
           "transactions": [
             {
@@ -22,29 +22,29 @@
               }
             }
           ],
-          "sender": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
+          "sender": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067",
           "gasPayment": {
-            "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+            "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
             "version": 0,
-            "digest": "s5DP1I7tW3rFQ8sgk2fqoZoC15+2Amn+H9yksQknoYw="
+            "digest": "nUDXjVtM4s161uovLAD/k9lkfViahX6MQA+HqjVqNHA="
           },
           "gasBudget": 10000
         },
-        "txSignature": "br48z1aispXhYTaR7vmipD9bXFED1PARf+6I3za95+UjF2imH76CA/D5cLDdhnxRLz7XwuUjJb9MGG/+KGMQDAQLyzwt66TsjrROzVdjtsc7mz06Gui1lH2o6jgDErkz",
+        "txSignature": "3n4A0YKSkqvFCXs14fOrDsU4BTTeoytC9a9xYWmEHz4n+3xgdFkDMZ+4DYjYquGNsxy/18b7n35HcBgq5wgJAmyMSy5cB0b8E9HsNxwphUjnjSYUGXVxKBNtzNm09OXm",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "rodi2Y0amgrRFduSoYppdYPLjsmXdOlPJ+a175A2M2o=",
-              "ZWR0eB++w7tWOkInDvwIUfBcFPElBOyp1/ouOlxFZzyyhaK2MsRV5iscZD2irLMBAh6ybfymcyziQfBLllFLCQ=="
+              "WuOn0un1hl99zkNMwVwexPvSWMbjIc9QS/FAC1O9t6U=",
+              "1lgVhrg+dtxzAHmWuBNS2UHjnyALUCiNeIAHo0KPh5pNx/nt6FkdU8DDqZ8MzpuN7ShyV0EgkXUt0K9IytO7Bw=="
             ],
             [
-              "CqO5NAkCfdwL15ucJA4x9dql6q3PeLhdJ5nMdIFMkzQ=",
-              "N3tA9bj/SuVOEjBy4mRN1ICUON+M3gZATwJdzhMlG8erMSkXVRVHcPJK/kHAgEo9+vKWpZWIZgPi5TVvKExfDQ=="
+              "Zvn9oco3ekdKabJ85hTwFC1dYwzn49cOXE5y9HdQS00=",
+              "rAzGmFrRJzgPOR//SnVv3JWMjhlpdKZIEJrLHC3vfNreqpOgXEIliJp9JGRb1U7TE513rLKWultbrOBhiHCiDQ=="
             ],
             [
-              "G8zk24V5+zaaksnSI54RLAtiVEd1wm+8NUjNgz6/Vl4=",
-              "QM+7/KJj0F25jrMbqLFHSgmzxguh47Uo9dejCwK2X0LrXUU0C5gyPZO4cI5fDjG2GS6NOy6MW2UQUbJMoph0Dg=="
+              "4tEDRCCGr2VPMX2WWRBVZxEjws65Bm2d/Q52d452clM=",
+              "MIK2v5ulqg688GQvojoBZE3PZYo+wWE4yj2erq/tf3s4hRGK/GMN0xLi7m+R7pIdlzy5DsGNupb/quSwErSHBQ=="
             ]
           ]
         }
@@ -58,85 +58,85 @@
             "storageRebate": 0
           }
         },
-        "transactionDigest": "Zwlbw1HboiIyYI/PWP569dmy326Q7mmWiZK2/5zBOTU=",
+        "transactionDigest": "Dk5VQI5yFhxmmn1qHgZN7Y7qMod1iV7l1al9gQRAsp4=",
         "created": [
           {
             "owner": {
-              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+              "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
             },
             "reference": {
-              "objectId": "0xf46a9c1f71bac2a11ae41153edbf3870f1806522",
+              "objectId": "0x52d6f5e5a8b25acd42a17f0f371649d05be94fed",
               "version": 1,
-              "digest": "gHRdLwFUxQzY3uOXRgxZFtjQkOEGn4aUGMQ4dfIA+hY="
+              "digest": "g+WOG9VarXk3ksEod2zsXiMf6qDDRiKtoaSCL82q1gc="
             }
           }
         ],
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+              "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
             },
             "reference": {
-              "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+              "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
               "version": 1,
-              "digest": "u3Nwu0IDsh4oXeCE9KbvxL38GoATgwe9WQZsyQ0nmls="
+              "digest": "pVD8ODU1BfKiKJ+53hW2UQDSFgSc2mjFScDetT0/Isw="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
           "reference": {
-            "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+            "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
             "version": 1,
-            "digest": "u3Nwu0IDsh4oXeCE9KbvxL38GoATgwe9WQZsyQ0nmls="
+            "digest": "pVD8ODU1BfKiKJ+53hW2UQDSFgSc2mjFScDetT0/Isw="
           }
         },
         "events": [
           {
             "type_": "0x2::DevNetNFT::MintNFTEvent",
             "contents": [
-              244,
-              106,
-              156,
-              31,
-              113,
-              186,
-              194,
+              82,
+              214,
+              245,
+              229,
+              168,
+              178,
+              90,
+              205,
+              66,
               161,
-              26,
-              228,
-              17,
-              83,
+              127,
+              15,
+              55,
+              22,
+              73,
+              208,
+              91,
+              233,
+              79,
               237,
-              191,
-              56,
-              112,
-              241,
-              128,
-              101,
-              34,
-              87,
-              78,
-              171,
-              132,
-              152,
-              196,
-              227,
-              234,
-              27,
-              27,
-              173,
-              41,
-              44,
-              235,
-              39,
-              159,
-              213,
-              169,
+              104,
+              202,
+              108,
+              32,
+              251,
               9,
-              111,
+              67,
+              129,
+              56,
+              232,
+              182,
+              95,
+              155,
+              36,
+              106,
+              91,
+              131,
+              127,
+              96,
+              103,
               11,
               69,
               120,
@@ -158,43 +158,43 @@
   "transfer": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "Ql6ndu7o3zFPtRoXPraJqyXr/5IoIXOgr32oJj6we1E=",
+        "transactionDigest": "8LHHeUlBlyx2fnjsQCcW4110xS8xMmVHtwZhVc7/Rk0=",
         "data": {
           "transactions": [
             {
               "TransferCoin": {
-                "recipient": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
+                "recipient": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067",
                 "objectRef": {
-                  "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+                  "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
                   "version": 4,
-                  "digest": "zJe23jPTxzonJojWL7JGfHeWtUga4B7aEZzGfImHfk="
+                  "digest": "lTf5GhtTZnzack00VW6/VI0g4HU/vWRdrfrwyUXPy1w="
                 }
               }
             }
           ],
-          "sender": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
+          "sender": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067",
           "gasPayment": {
-            "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
+            "objectId": "0x709a1d6e870754424963d59c85b802b276b4570d",
             "version": 1,
-            "digest": "ZZjPoajN0vouoVem/6GLqxbS8bng9LtmPG7jynKyAtk="
+            "digest": "es9Y47NXVRQ84hSQQv9e1w3OdS5KRjmNdfMKS2N/9RM="
           },
           "gasBudget": 1000
         },
-        "txSignature": "6tRcNd6pzf6FvuAl9GrP6jGW6Y82Myed7rE4h9jl8J4Oy/aQyGROJzDvMqQAdHZU5fhoxTcVIdSX7U+N8iI8BgQLyzwt66TsjrROzVdjtsc7mz06Gui1lH2o6jgDErkz",
+        "txSignature": "HCqZLBVcF5QqcuXXgBw/0KClKrK6xF8fN8gBnnUW3t3/YrK8WfUGba4SDb7f7y6aGy7Z+4ns8S/NOkAaW+71CWyMSy5cB0b8E9HsNxwphUjnjSYUGXVxKBNtzNm09OXm",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "rodi2Y0amgrRFduSoYppdYPLjsmXdOlPJ+a175A2M2o=",
-              "KRvuWBNDuc0rWPqJIn+JSASjc67pASpB/fnznGdjC8gT/mgISlvycysQoBvjCGYVyKqVsZl7HLx0jiB21zCYCA=="
+              "Zvn9oco3ekdKabJ85hTwFC1dYwzn49cOXE5y9HdQS00=",
+              "DvpBeBXF8Ob0JzDQXTKpEPbLIA5mbudbdBqiX1BkwC/tPMusMz1teLkWQ5EcUp3mHj5xbryLwFQueL8loH63Dg=="
             ],
             [
-              "G8zk24V5+zaaksnSI54RLAtiVEd1wm+8NUjNgz6/Vl4=",
-              "a9wp+5nJkS/husx0F6oXYg4rlg8RyINk2XGGKJ3DWRwYjwfD61NUDwnowdlSsGp4INo+RRpzzh8y5zsgEEFABg=="
+              "kCV5KPUKQHT6wFnhBl6eKRzzHWlrqRDi4VhvbiLLOv8=",
+              "2ui5xpwR7vpckOqjzDEylr/TJtf61gQls2xzv2GWyVTEtevltSVvU4r0TpRXEQjmNVNxC0J4afTPRKuTTg/VDA=="
             ],
             [
-              "CqO5NAkCfdwL15ucJA4x9dql6q3PeLhdJ5nMdIFMkzQ=",
-              "mcYbsu50zSZHSMEWtslY2N/7NTRbvH4rUO6DnFcxhfn+LeABROAxSv+3DHgSghwnOjdRAlDTbdqZV9BCxhmWDA=="
+              "WuOn0un1hl99zkNMwVwexPvSWMbjIc9QS/FAC1O9t6U=",
+              "0/WvD7jh4K4dC5bvECPvhIwQ8KuTBEVBqLzyGC7LFaZaf6lPPvkEpeAQ+hQErEwCqzGPo5HUid9bnhiUHEk0BQ=="
             ]
           ]
         }
@@ -208,41 +208,41 @@
             "storageRebate": 30
           }
         },
-        "transactionDigest": "Ql6ndu7o3zFPtRoXPraJqyXr/5IoIXOgr32oJj6we1E=",
+        "transactionDigest": "8LHHeUlBlyx2fnjsQCcW4110xS8xMmVHtwZhVc7/Rk0=",
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+              "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
             },
             "reference": {
-              "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+              "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
               "version": 5,
-              "digest": "vHEsewqQX9W92Gd6cz9petkaMDIfxctCXqXOGeofc8o="
+              "digest": "PsO1vOxWaexWckbToJUNyzbH5HBsJgL4mvScOXQUFig="
             }
           },
           {
             "owner": {
-              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+              "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
             },
             "reference": {
-              "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
+              "objectId": "0x709a1d6e870754424963d59c85b802b276b4570d",
               "version": 2,
-              "digest": "luorcI3cugL3ZkdTLqFlKGkQ6alwy01F3umcAzlEg8I="
+              "digest": "rXqPVZx45PauXHeNxzB8WkiqR4mEaiykyJo9hDSRBU4="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
           "reference": {
-            "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
+            "objectId": "0x709a1d6e870754424963d59c85b802b276b4570d",
             "version": 2,
-            "digest": "luorcI3cugL3ZkdTLqFlKGkQ6alwy01F3umcAzlEg8I="
+            "digest": "rXqPVZx45PauXHeNxzB8WkiqR4mEaiykyJo9hDSRBU4="
           }
         },
         "dependencies": [
-          "AcQpy99nCvjG8L1U2HQWwxRvFlFcZZ1kjuVBz/rTBAI="
+          "qdA6WxlhoDge0Mgcx539sjk4QEtZs7a5NK9g0bLZ0zM="
         ]
       }
     }
@@ -250,7 +250,7 @@
   "coin_split": {
     "SplitCoinResponse": {
       "certificate": {
-        "transactionDigest": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+        "transactionDigest": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
         "data": {
           "transactions": [
             {
@@ -266,7 +266,7 @@
                   "0x2::SUI::SUI"
                 ],
                 "arguments": [
-                  "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+                  "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
                   [
                     20,
                     20,
@@ -278,29 +278,29 @@
               }
             }
           ],
-          "sender": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
+          "sender": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067",
           "gasPayment": {
-            "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
+            "objectId": "0x709a1d6e870754424963d59c85b802b276b4570d",
             "version": 2,
-            "digest": "luorcI3cugL3ZkdTLqFlKGkQ6alwy01F3umcAzlEg8I="
+            "digest": "rXqPVZx45PauXHeNxzB8WkiqR4mEaiykyJo9hDSRBU4="
           },
           "gasBudget": 1000
         },
-        "txSignature": "NZounzncH2cszGqS7GAgh3IDdUeKCi6LSJ39NVodsn3kKOGF/G48zFy5iwLA7xmyVYQGvJvwJSwudOvNUrUMDgQLyzwt66TsjrROzVdjtsc7mz06Gui1lH2o6jgDErkz",
+        "txSignature": "hYSnsdoYIXM4NkUx7n2q+5hvfZfd24wRjcMKAIlxB/6uZtVOrzZUDNLQMW/d6swG9s/hj4hLjrERh2vexLqMBmyMSy5cB0b8E9HsNxwphUjnjSYUGXVxKBNtzNm09OXm",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "rodi2Y0amgrRFduSoYppdYPLjsmXdOlPJ+a175A2M2o=",
-              "7Mmz0ReDb9X0EO/m5AifLPhAsiv/gAOpfTUwxL6urhod0bUOq2G6PRrmhZFUlnYATJ2Fg/CQoMpuknSlyfA7Dg=="
+              "WuOn0un1hl99zkNMwVwexPvSWMbjIc9QS/FAC1O9t6U=",
+              "AwcqgAbFVT2tKszho/JYz4A4NR1IONb5x/v/Qy+OUVqGV2koNF24xFCD81QJZbeDEs8X2MImhG++GZUmn4ZWBA=="
             ],
             [
-              "CqO5NAkCfdwL15ucJA4x9dql6q3PeLhdJ5nMdIFMkzQ=",
-              "XVEL9snJB9MrjLOY3ImAS+/eoZubQPYwqrJFAcVI3qGkb0eYUHYze3MPG5UD3dv4yaqPtjupmdTX1hm3y3R9Cg=="
+              "4tEDRCCGr2VPMX2WWRBVZxEjws65Bm2d/Q52d452clM=",
+              "idCkt0MQeje0W7dvFrvBuOc8c8+uHyNPkTCzYuZhIXcveAc79VmcXY6TytU0xhBpS01KKYfNaRu25SmIFFuuAQ=="
             ],
             [
-              "G8zk24V5+zaaksnSI54RLAtiVEd1wm+8NUjNgz6/Vl4=",
-              "fbX4Kydjgn2nJvyN8d6k7kuzJ1NbcX4GmEFLDzdeHpF/uwcLCVW1qeSpz7v5uSE6skRu4dzUEfdGNKfAgEU/CQ=="
+              "Zvn9oco3ekdKabJ85hTwFC1dYwzn49cOXE5y9HdQS00=",
+              "Nv7napeptyBRGDVEr5wEB31LF43n5yIOb6hxa+rRk0WxAeudwjuDSaZ0YZum7RRPBeu9QnUKrazLnV8PzGIwBA=="
             ]
           ]
         }
@@ -312,20 +312,20 @@
           "fields": {
             "balance": 95650,
             "id": {
-              "id": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+              "id": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
               "version": 6
             }
           }
         },
         "owner": {
-          "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+          "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
         },
-        "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+        "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
+          "objectId": "0x1a0629232a197a8cb83608b4581ed11d0ce9abe0",
           "version": 6,
-          "digest": "4C4MjkyIAWGUd8EvoJvkrYqqEXZu3RyBqb4kZ68wtiU="
+          "digest": "73WLNnsgomrXd+B5lUr69GtTQ3aJ7+6zQAlF2hGpaUY="
         }
       },
       "newCoins": [
@@ -336,20 +336,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x088a11566311fd2f9c1505f334156d1e44407abd",
+                "id": "0x20744af7f6ad0dca25158cb0281e19d782b34d8a",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
-          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+          "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x088a11566311fd2f9c1505f334156d1e44407abd",
+            "objectId": "0x20744af7f6ad0dca25158cb0281e19d782b34d8a",
             "version": 1,
-            "digest": "+l6Z1u+MTN5ejetG2rKdOj6wLHnuEzboEY/yn/L4ULo="
+            "digest": "Yy3sXriX39FZNgsah5LhWLqby2EGz6HjdInfHxtHNpU="
           }
         },
         {
@@ -359,20 +359,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x671e121c1f04763ab11a47b03165b79a99ae4349",
+                "id": "0x6e8cf4faca9193bfca39649095f61e5f11c5f200",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
-          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+          "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x671e121c1f04763ab11a47b03165b79a99ae4349",
+            "objectId": "0x6e8cf4faca9193bfca39649095f61e5f11c5f200",
             "version": 1,
-            "digest": "Xl+D5ymPe2xp+o1GldPmPSaDuswMJIQHnPpc2aB2c+w="
+            "digest": "KiVijMj5upK3Yy7krQu4aTBwFDHo/qWsd+bq7ytXI5M="
           }
         },
         {
@@ -382,20 +382,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x6b5c7cb064f3efdfd431efbfdb73d1eca47cbb5a",
+                "id": "0x7185266cd1cda1e386b19361a5be9cda9aadbf55",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
-          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+          "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x6b5c7cb064f3efdfd431efbfdb73d1eca47cbb5a",
+            "objectId": "0x7185266cd1cda1e386b19361a5be9cda9aadbf55",
             "version": 1,
-            "digest": "7sgiMTjG8/5ViUITcOSqzF4dfqGSZe2iDM0yjuJynBc="
+            "digest": "inAPFddnNNnfMCjlqKFs+c/epuDA3p12eWpAvLxvoSs="
           }
         },
         {
@@ -405,20 +405,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x77025491f613467a726a73d453c71df9584cc7de",
+                "id": "0x8003d09019b78a4d1e6b2284bdcf5e19bffd6b58",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
-          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+          "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x77025491f613467a726a73d453c71df9584cc7de",
+            "objectId": "0x8003d09019b78a4d1e6b2284bdcf5e19bffd6b58",
             "version": 1,
-            "digest": "fIUwkb4Ym2xbjtiyU7Z52s0DGCvCEKKvFFUb13CJPio="
+            "digest": "v6qxDVhvjX4X8E2nG9D/qGh3Yl5fT3Rr+gXZtoC5iPM="
           }
         },
         {
@@ -428,20 +428,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0xb2b78b1f4cd7395d7c403ec24bf6b5ef935422f6",
+                "id": "0xf9f7a1e0d990cbfb1e587d7c4ad7aee4216f480a",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+            "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
           },
-          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+          "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0xb2b78b1f4cd7395d7c403ec24bf6b5ef935422f6",
+            "objectId": "0xf9f7a1e0d990cbfb1e587d7c4ad7aee4216f480a",
             "version": 1,
-            "digest": "1yLUUzLtiIRlvIaxblN+2tooz6GvIZs8duVfIPXp2iE="
+            "digest": "IGAZJQyyF6SswqcsRSnsxpeBacoj/ijWckMuq9S6uII="
           }
         }
       ],
@@ -452,20 +452,20 @@
           "fields": {
             "balance": 98960,
             "id": {
-              "id": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
+              "id": "0x709a1d6e870754424963d59c85b802b276b4570d",
               "version": 3
             }
           }
         },
         "owner": {
-          "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
+          "AddressOwner": "0x68ca6c20fb09438138e8b65f9b246a5b837f6067"
         },
-        "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
+        "previousTransaction": "4iMjJ5413nzXV4hrTNpCDolnClOzalQsDL24vZqiL7I=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
+          "objectId": "0x709a1d6e870754424963d59c85b802b276b4570d",
           "version": 3,
-          "digest": "OmKLY3cFmYfgR+1tecRfRwqL2zVNpuYsKrZIrruktdU="
+          "digest": "ssphUUZtUmaYNkys2dtI6OciQf9VGJ+6cVD/d8ejFHk="
         }
       }
     }

--- a/crates/sui-open-rpc/samples/transactions.json
+++ b/crates/sui-open-rpc/samples/transactions.json
@@ -2,7 +2,7 @@
   "move_call": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "UvCLC/D3ykGCUQ5mZEZEBUh+D0zw5RV3RtS1cOxP588=",
+        "transactionDigest": "Zwlbw1HboiIyYI/PWP569dmy326Q7mmWiZK2/5zBOTU=",
         "data": {
           "transactions": [
             {
@@ -22,29 +22,29 @@
               }
             }
           ],
-          "sender": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
+          "sender": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
           "gasPayment": {
-            "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+            "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
             "version": 0,
-            "digest": "ChEV3TbRjBxrhOrFJPpwDeB/qIRNQj0OU/zJlublZLc="
+            "digest": "s5DP1I7tW3rFQ8sgk2fqoZoC15+2Amn+H9yksQknoYw="
           },
           "gasBudget": 10000
         },
-        "txSignature": "MaCw+BaqZyNw8Z9YQbpDnAi9og/ZvQ1ChPbz6GDCZQqST3nvveEgvQjgzhmOjfEcRsl9i41iIHvUo3Kg4PzXDciPT/ULc4LROUiSsCkb2IXtWrEEF60oJjPrs5njcb6w",
+        "txSignature": "br48z1aispXhYTaR7vmipD9bXFED1PARf+6I3za95+UjF2imH76CA/D5cLDdhnxRLz7XwuUjJb9MGG/+KGMQDAQLyzwt66TsjrROzVdjtsc7mz06Gui1lH2o6jgDErkz",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "9ElPJH8yyV4877PlUecP6AaALwBzxnrs+MQqVh0IKno=",
-              "7mkaR5JwxHQKxF57HOGjkCID/sUje7Jii8MtXPo8hO0S5oPIq1Aq+l+a1aXJzc2eGe+P/fTAjrNFftOZKKoWAg=="
+              "rodi2Y0amgrRFduSoYppdYPLjsmXdOlPJ+a175A2M2o=",
+              "ZWR0eB++w7tWOkInDvwIUfBcFPElBOyp1/ouOlxFZzyyhaK2MsRV5iscZD2irLMBAh6ybfymcyziQfBLllFLCQ=="
             ],
             [
-              "HA68/0emwiWZPm/ULlUeC947vM/IyfNfv7GXEz6Q+Tc=",
-              "vNzJ7cSpUsrxKp1z+1ZQRdythr1kP/DDIpwMZcg13n3APHX9T1hAOyJcHbG9QViGtq4/whqr0dZUb1PbEDQUCA=="
+              "CqO5NAkCfdwL15ucJA4x9dql6q3PeLhdJ5nMdIFMkzQ=",
+              "N3tA9bj/SuVOEjBy4mRN1ICUON+M3gZATwJdzhMlG8erMSkXVRVHcPJK/kHAgEo9+vKWpZWIZgPi5TVvKExfDQ=="
             ],
             [
-              "kBKf7Pj/609sv1kJoO8BZkeYv5m/itWWz0gNSvHX29s=",
-              "TX1nTH67qGAtlnpXRoUIB+ADQQo3b725EKBD1WFKib9RwkqdAA6VbMu1a+i2MdRHkWor1i4PHzOw13MdGWXPBQ=="
+              "G8zk24V5+zaaksnSI54RLAtiVEd1wm+8NUjNgz6/Vl4=",
+              "QM+7/KJj0F25jrMbqLFHSgmzxguh47Uo9dejCwK2X0LrXUU0C5gyPZO4cI5fDjG2GS6NOy6MW2UQUbJMoph0Dg=="
             ]
           ]
         }
@@ -58,85 +58,85 @@
             "storageRebate": 0
           }
         },
-        "transactionDigest": "UvCLC/D3ykGCUQ5mZEZEBUh+D0zw5RV3RtS1cOxP588=",
+        "transactionDigest": "Zwlbw1HboiIyYI/PWP569dmy326Q7mmWiZK2/5zBOTU=",
         "created": [
           {
             "owner": {
-              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
             },
             "reference": {
-              "objectId": "0x2ead2173bc84026d126e2a58a1cfd3b48380417c",
+              "objectId": "0xf46a9c1f71bac2a11ae41153edbf3870f1806522",
               "version": 1,
-              "digest": "eQhn479Tmtk5a18+iGIkrxRHWiNjg9keuUh7Mh8oh8I="
+              "digest": "gHRdLwFUxQzY3uOXRgxZFtjQkOEGn4aUGMQ4dfIA+hY="
             }
           }
         ],
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
             },
             "reference": {
-              "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+              "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
               "version": 1,
-              "digest": "TKjT/WJk51DE+4+AAB2O00Dka8+BOun+if0FfsDGiLA="
+              "digest": "u3Nwu0IDsh4oXeCE9KbvxL38GoATgwe9WQZsyQ0nmls="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
           "reference": {
-            "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+            "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
             "version": 1,
-            "digest": "TKjT/WJk51DE+4+AAB2O00Dka8+BOun+if0FfsDGiLA="
+            "digest": "u3Nwu0IDsh4oXeCE9KbvxL38GoATgwe9WQZsyQ0nmls="
           }
         },
         "events": [
           {
             "type_": "0x2::DevNetNFT::MintNFTEvent",
             "contents": [
-              46,
-              173,
-              33,
-              115,
-              188,
-              132,
-              2,
-              109,
-              18,
-              110,
-              42,
-              88,
+              244,
+              106,
+              156,
+              31,
+              113,
+              186,
+              194,
               161,
-              207,
-              211,
-              180,
-              131,
-              128,
-              65,
-              124,
-              178,
-              132,
-              63,
-              40,
-              179,
-              211,
-              96,
-              151,
-              177,
+              26,
+              228,
+              17,
+              83,
+              237,
+              191,
+              56,
               112,
-              240,
-              38,
-              201,
-              155,
-              219,
-              172,
-              49,
-              212,
-              251,
-              199,
+              241,
+              128,
+              101,
+              34,
+              87,
+              78,
+              171,
+              132,
+              152,
+              196,
+              227,
+              234,
+              27,
+              27,
+              173,
+              41,
+              44,
+              235,
+              39,
+              159,
+              213,
+              169,
+              9,
+              111,
               11,
               69,
               120,
@@ -158,43 +158,43 @@
   "transfer": {
     "EffectResponse": {
       "certificate": {
-        "transactionDigest": "f+TTxzx/VUdDElTzcH+XPM5gKrQW4MRsh/jCFfP4t2A=",
+        "transactionDigest": "Ql6ndu7o3zFPtRoXPraJqyXr/5IoIXOgr32oJj6we1E=",
         "data": {
           "transactions": [
             {
               "TransferCoin": {
-                "recipient": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
+                "recipient": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
                 "objectRef": {
-                  "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+                  "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
                   "version": 4,
-                  "digest": "wFIsyyHfKOZ+LBxGN4BUwAhVPulX5j14PHLSJNDfF38="
+                  "digest": "zJe23jPTxzonJojWL7JGfHeWtUga4B7aEZzGfImHfk="
                 }
               }
             }
           ],
-          "sender": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
+          "sender": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
           "gasPayment": {
-            "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
+            "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
             "version": 1,
-            "digest": "hus/FD/jCqRH6u930P9AzSLeANED4X486hCv31d5qOA="
+            "digest": "ZZjPoajN0vouoVem/6GLqxbS8bng9LtmPG7jynKyAtk="
           },
           "gasBudget": 1000
         },
-        "txSignature": "nzXVH3z4AjrMM2r0qyOWecLOnnJAB67rEdjlW2fAoFLQzk/mKB1FtCB5BJtgnrQxoyRNQG+aRz1soySIWmH4B8iPT/ULc4LROUiSsCkb2IXtWrEEF60oJjPrs5njcb6w",
+        "txSignature": "6tRcNd6pzf6FvuAl9GrP6jGW6Y82Myed7rE4h9jl8J4Oy/aQyGROJzDvMqQAdHZU5fhoxTcVIdSX7U+N8iI8BgQLyzwt66TsjrROzVdjtsc7mz06Gui1lH2o6jgDErkz",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "3cb6GkCsFh4Hb5/iNx6nU+2H0be+t572ahAFBCftwFA=",
-              "2+izoMm+iQm1DErp2WWbE424d6yMHMRDKvRjTY/0j3rB+elT7R/vQqgfEBu+n3iO5xPt5V0DHDQz92M6g+NUDA=="
+              "rodi2Y0amgrRFduSoYppdYPLjsmXdOlPJ+a175A2M2o=",
+              "KRvuWBNDuc0rWPqJIn+JSASjc67pASpB/fnznGdjC8gT/mgISlvycysQoBvjCGYVyKqVsZl7HLx0jiB21zCYCA=="
             ],
             [
-              "kBKf7Pj/609sv1kJoO8BZkeYv5m/itWWz0gNSvHX29s=",
-              "8UsAoshlrllH4eMRp/iRc77QwrLd3foE0GYgknHbX8qFtGcOUehlTW7IAY2+Z0C7j9kH65iEaIizpSNmPtVvDg=="
+              "G8zk24V5+zaaksnSI54RLAtiVEd1wm+8NUjNgz6/Vl4=",
+              "a9wp+5nJkS/husx0F6oXYg4rlg8RyINk2XGGKJ3DWRwYjwfD61NUDwnowdlSsGp4INo+RRpzzh8y5zsgEEFABg=="
             ],
             [
-              "HA68/0emwiWZPm/ULlUeC947vM/IyfNfv7GXEz6Q+Tc=",
-              "95yj60g4wSFF/GrkBVX39eJcMnzsOxG1IWqEwdxxjzyIggijKh2qcO3l3cz1GgPqQcnfue5LMb02EcH2t8VaAw=="
+              "CqO5NAkCfdwL15ucJA4x9dql6q3PeLhdJ5nMdIFMkzQ=",
+              "mcYbsu50zSZHSMEWtslY2N/7NTRbvH4rUO6DnFcxhfn+LeABROAxSv+3DHgSghwnOjdRAlDTbdqZV9BCxhmWDA=="
             ]
           ]
         }
@@ -208,41 +208,41 @@
             "storageRebate": 30
           }
         },
-        "transactionDigest": "f+TTxzx/VUdDElTzcH+XPM5gKrQW4MRsh/jCFfP4t2A=",
+        "transactionDigest": "Ql6ndu7o3zFPtRoXPraJqyXr/5IoIXOgr32oJj6we1E=",
         "mutated": [
           {
             "owner": {
-              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
             },
             "reference": {
-              "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+              "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
               "version": 5,
-              "digest": "biVtZZ/t+O+34WChpnZFXG8k/3c6riR93EdYIzcV21Y="
+              "digest": "vHEsewqQX9W92Gd6cz9petkaMDIfxctCXqXOGeofc8o="
             }
           },
           {
             "owner": {
-              "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+              "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
             },
             "reference": {
-              "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
+              "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
               "version": 2,
-              "digest": "20IeFiZPv89kRMg+Vk+RpiSerEuWb+jif9OJXB660Sk="
+              "digest": "luorcI3cugL3ZkdTLqFlKGkQ6alwy01F3umcAzlEg8I="
             }
           }
         ],
         "gasObject": {
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
           "reference": {
-            "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
+            "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
             "version": 2,
-            "digest": "20IeFiZPv89kRMg+Vk+RpiSerEuWb+jif9OJXB660Sk="
+            "digest": "luorcI3cugL3ZkdTLqFlKGkQ6alwy01F3umcAzlEg8I="
           }
         },
         "dependencies": [
-          "m6Z/zbUiai23IvcqHAqhSAf/YKu9IJ4/3r7PlBmUcjM="
+          "AcQpy99nCvjG8L1U2HQWwxRvFlFcZZ1kjuVBz/rTBAI="
         ]
       }
     }
@@ -250,7 +250,7 @@
   "coin_split": {
     "SplitCoinResponse": {
       "certificate": {
-        "transactionDigest": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+        "transactionDigest": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
         "data": {
           "transactions": [
             {
@@ -266,7 +266,7 @@
                   "0x2::SUI::SUI"
                 ],
                 "arguments": [
-                  "0x6028375fc3506e7f66618167e3de1f896ec8783",
+                  "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
                   [
                     20,
                     20,
@@ -278,29 +278,29 @@
               }
             }
           ],
-          "sender": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7",
+          "sender": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f",
           "gasPayment": {
-            "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
+            "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
             "version": 2,
-            "digest": "20IeFiZPv89kRMg+Vk+RpiSerEuWb+jif9OJXB660Sk="
+            "digest": "luorcI3cugL3ZkdTLqFlKGkQ6alwy01F3umcAzlEg8I="
           },
           "gasBudget": 1000
         },
-        "txSignature": "6bm2fnpaEwMMIde40pH00bBLhZDUnVD3G5y9A2kW6IAZ9FAaWpB73LDs/o9p8/AcHjrDQ26DZLOUgxwaBWzGDsiPT/ULc4LROUiSsCkb2IXtWrEEF60oJjPrs5njcb6w",
+        "txSignature": "NZounzncH2cszGqS7GAgh3IDdUeKCi6LSJ39NVodsn3kKOGF/G48zFy5iwLA7xmyVYQGvJvwJSwudOvNUrUMDgQLyzwt66TsjrROzVdjtsc7mz06Gui1lH2o6jgDErkz",
         "authSignInfo": {
           "epoch": 0,
           "signatures": [
             [
-              "3cb6GkCsFh4Hb5/iNx6nU+2H0be+t572ahAFBCftwFA=",
-              "vJ0gXKF2FMPdJfYhl3hU8N4I1W/mKcZE9VUsFhbuIl8S727ksSMfkbCXcFaY1sNQJYSdfjXIw8KP62aGZC7UCA=="
+              "rodi2Y0amgrRFduSoYppdYPLjsmXdOlPJ+a175A2M2o=",
+              "7Mmz0ReDb9X0EO/m5AifLPhAsiv/gAOpfTUwxL6urhod0bUOq2G6PRrmhZFUlnYATJ2Fg/CQoMpuknSlyfA7Dg=="
             ],
             [
-              "HA68/0emwiWZPm/ULlUeC947vM/IyfNfv7GXEz6Q+Tc=",
-              "WTrs0ZCylvLeOWx6fpfitLO4NtqGSWlzW5/KpjwYG0zQQs6dFluhjso/U2fvBDyB09mIYnoaTKuA1PhLIQBjBQ=="
+              "CqO5NAkCfdwL15ucJA4x9dql6q3PeLhdJ5nMdIFMkzQ=",
+              "XVEL9snJB9MrjLOY3ImAS+/eoZubQPYwqrJFAcVI3qGkb0eYUHYze3MPG5UD3dv4yaqPtjupmdTX1hm3y3R9Cg=="
             ],
             [
-              "kBKf7Pj/609sv1kJoO8BZkeYv5m/itWWz0gNSvHX29s=",
-              "6HMldSphA8cU4+oH60UdY1frsIzs+4aks3+pdOzzxciGNOOq+qH/ytPcppDvTXJBIOo+Rl4cd1Yx1ztdMP3BAw=="
+              "G8zk24V5+zaaksnSI54RLAtiVEd1wm+8NUjNgz6/Vl4=",
+              "fbX4Kydjgn2nJvyN8d6k7kuzJ1NbcX4GmEFLDzdeHpF/uwcLCVW1qeSpz7v5uSE6skRu4dzUEfdGNKfAgEU/CQ=="
             ]
           ]
         }
@@ -312,20 +312,20 @@
           "fields": {
             "balance": 95650,
             "id": {
-              "id": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+              "id": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
               "version": 6
             }
           }
         },
         "owner": {
-          "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+          "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
         },
-        "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+        "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x06028375fc3506e7f66618167e3de1f896ec8783",
+          "objectId": "0x7706429e7012f06ec2b908aab5b98e1412c54e47",
           "version": 6,
-          "digest": "bkpD7syeQG98JZJLct9oln284deogc0IEXYDkIuKWwA="
+          "digest": "4C4MjkyIAWGUd8EvoJvkrYqqEXZu3RyBqb4kZ68wtiU="
         }
       },
       "newCoins": [
@@ -336,20 +336,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x69a710e15104cb6df719fd4f406710d6fc1a91de",
+                "id": "0x088a11566311fd2f9c1505f334156d1e44407abd",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
-          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x69a710e15104cb6df719fd4f406710d6fc1a91de",
+            "objectId": "0x088a11566311fd2f9c1505f334156d1e44407abd",
             "version": 1,
-            "digest": "Kns1/nG8J2nJnexXI61PHHXj127OqdcyEHCzA8dbOxI="
+            "digest": "+l6Z1u+MTN5ejetG2rKdOj6wLHnuEzboEY/yn/L4ULo="
           }
         },
         {
@@ -359,20 +359,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0x93cf651468ac83e28e2789d1d8b94d890de5d6b4",
+                "id": "0x671e121c1f04763ab11a47b03165b79a99ae4349",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
-          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0x93cf651468ac83e28e2789d1d8b94d890de5d6b4",
+            "objectId": "0x671e121c1f04763ab11a47b03165b79a99ae4349",
             "version": 1,
-            "digest": "XlemfCVVwp7napyh/aws5anjSoXxQ/m8jFMgPKeiJUw="
+            "digest": "Xl+D5ymPe2xp+o1GldPmPSaDuswMJIQHnPpc2aB2c+w="
           }
         },
         {
@@ -382,20 +382,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0xc8f70ae9332866d5b1e22c5b3b44061476727059",
+                "id": "0x6b5c7cb064f3efdfd431efbfdb73d1eca47cbb5a",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
-          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0xc8f70ae9332866d5b1e22c5b3b44061476727059",
+            "objectId": "0x6b5c7cb064f3efdfd431efbfdb73d1eca47cbb5a",
             "version": 1,
-            "digest": "cQhD5w7LOyrlF2VB07jVE1h9gEZBUMJmBH/Xef7xOtU="
+            "digest": "7sgiMTjG8/5ViUITcOSqzF4dfqGSZe2iDM0yjuJynBc="
           }
         },
         {
@@ -405,20 +405,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0xdd22d51d0ced9895fe5a9d973a6af7a2d104ec60",
+                "id": "0x77025491f613467a726a73d453c71df9584cc7de",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
-          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0xdd22d51d0ced9895fe5a9d973a6af7a2d104ec60",
+            "objectId": "0x77025491f613467a726a73d453c71df9584cc7de",
             "version": 1,
-            "digest": "b+c7GzUHgiMcUoI8HJ4gXG7u4OUjy8Cqg1WQWV/WPSA="
+            "digest": "fIUwkb4Ym2xbjtiyU7Z52s0DGCvCEKKvFFUb13CJPio="
           }
         },
         {
@@ -428,20 +428,20 @@
             "fields": {
               "balance": 20,
               "id": {
-                "id": "0xf9ce6bbcba48c3d2756954cb5e6ca9038942c903",
+                "id": "0xb2b78b1f4cd7395d7c403ec24bf6b5ef935422f6",
                 "version": 1
               }
             }
           },
           "owner": {
-            "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+            "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
           },
-          "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+          "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
           "storageRebate": 15,
           "reference": {
-            "objectId": "0xf9ce6bbcba48c3d2756954cb5e6ca9038942c903",
+            "objectId": "0xb2b78b1f4cd7395d7c403ec24bf6b5ef935422f6",
             "version": 1,
-            "digest": "3eg11cwHQ3MdMT63HAqEtITGa0DD7wMAjksZQ+JlzL4="
+            "digest": "1yLUUzLtiIRlvIaxblN+2tooz6GvIZs8duVfIPXp2iE="
           }
         }
       ],
@@ -452,20 +452,20 @@
           "fields": {
             "balance": 98960,
             "id": {
-              "id": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
+              "id": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
               "version": 3
             }
           }
         },
         "owner": {
-          "AddressOwner": "0xb2843f28b3d36097b170f026c99bdbac31d4fbc7"
+          "AddressOwner": "0x574eab8498c4e3ea1b1bad292ceb279fd5a9096f"
         },
-        "previousTransaction": "FXI+YU4nYF1HdLTg/L3MPf3uEnR6vuYEJ1Ca+MxTV/I=",
+        "previousTransaction": "fVbwnKDXRTocTg/Ptt2yh9sHtRQfYZKB2omBcRJZO5I=",
         "storageRebate": 15,
         "reference": {
-          "objectId": "0x75c7af0d2575c1dc82e4880018e6eb31024da151",
+          "objectId": "0x974db647fae1402b6b8bbf3c33fead7b8d2d6d45",
           "version": 3,
-          "digest": "t8QF9rH41McU58KDWcT0Zo0hEEtjBIM8uqOTJRkLcUs="
+          "digest": "OmKLY3cFmYfgR+1tecRfRwqL2zVNpuYsKrZIrruktdU="
         }
       }
     }

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -13,18 +13,20 @@ use std::collections::{BTreeMap, HashMap};
 
 pub type EpochId = u64;
 
+pub type StakeUnit = u64;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Committee {
     pub epoch: EpochId,
-    pub voting_rights: BTreeMap<AuthorityName, u64>,
-    pub total_votes: u64,
+    pub voting_rights: BTreeMap<AuthorityName, StakeUnit>,
+    pub total_votes: StakeUnit,
     // Note: this is a derived structure, no need to store.
     #[serde(skip)]
     pub expanded_keys: HashMap<AuthorityName, PublicKey>,
 }
 
 impl Committee {
-    pub fn new(epoch: EpochId, voting_rights: BTreeMap<AuthorityName, u64>) -> Self {
+    pub fn new(epoch: EpochId, voting_rights: BTreeMap<AuthorityName, StakeUnit>) -> Self {
         let total_votes = voting_rights.iter().map(|(_, votes)| votes).sum();
         let expanded_keys: HashMap<_, _> = voting_rights
             .iter()
@@ -57,17 +59,17 @@ impl Committee {
         unreachable!();
     }
 
-    pub fn weight(&self, author: &AuthorityName) -> u64 {
+    pub fn weight(&self, author: &AuthorityName) -> StakeUnit {
         *self.voting_rights.get(author).unwrap_or(&0)
     }
 
-    pub fn quorum_threshold(&self) -> u64 {
+    pub fn quorum_threshold(&self) -> StakeUnit {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (2 N + 3) / 3 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f
         2 * self.total_votes / 3 + 1
     }
 
-    pub fn validity_threshold(&self) -> u64 {
+    pub fn validity_threshold(&self) -> StakeUnit {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1
         (self.total_votes + 2) / 3
@@ -89,7 +91,7 @@ impl Committee {
     pub fn robust_value<A, V>(
         &self,
         items: impl Iterator<Item = (A, V)>,
-        threshold: u64,
+        threshold: StakeUnit,
     ) -> (AuthorityName, V)
     where
         A: Borrow<AuthorityName> + Ord,

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashMap};
 
 pub type EpochId = u64;
 
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Committee {
     pub epoch: EpochId,
     pub voting_rights: BTreeMap<AuthorityName, u64>,
@@ -108,5 +108,13 @@ impl Committee {
             }
         }
         unreachable!();
+    }
+}
+
+impl PartialEq for Committee {
+    fn eq(&self, other: &Self) -> bool {
+        self.epoch == other.epoch
+            && self.voting_rights == other.voting_rights
+            && self.total_votes == other.total_votes
     }
 }

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -16,15 +16,15 @@ pub type EpochId = u64;
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct Committee {
     pub epoch: EpochId,
-    pub voting_rights: BTreeMap<AuthorityName, usize>,
-    pub total_votes: usize,
+    pub voting_rights: BTreeMap<AuthorityName, u64>,
+    pub total_votes: u64,
     // Note: this is a derived structure, no need to store.
     #[serde(skip)]
     pub expanded_keys: HashMap<AuthorityName, PublicKey>,
 }
 
 impl Committee {
-    pub fn new(epoch: EpochId, voting_rights: BTreeMap<AuthorityName, usize>) -> Self {
+    pub fn new(epoch: EpochId, voting_rights: BTreeMap<AuthorityName, u64>) -> Self {
         let total_votes = voting_rights.iter().map(|(_, votes)| votes).sum();
         let expanded_keys: HashMap<_, _> = voting_rights
             .iter()
@@ -57,17 +57,17 @@ impl Committee {
         unreachable!();
     }
 
-    pub fn weight(&self, author: &AuthorityName) -> usize {
+    pub fn weight(&self, author: &AuthorityName) -> u64 {
         *self.voting_rights.get(author).unwrap_or(&0)
     }
 
-    pub fn quorum_threshold(&self) -> usize {
+    pub fn quorum_threshold(&self) -> u64 {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (2 N + 3) / 3 = 2f + 1 + (2k + 2)/3 = 2f + 1 + k = N - f
         2 * self.total_votes / 3 + 1
     }
 
-    pub fn validity_threshold(&self) -> usize {
+    pub fn validity_threshold(&self) -> u64 {
         // If N = 3f + 1 + k (0 <= k < 3)
         // then (N + 2) / 3 = f + 1 + k/3 = f + 1
         (self.total_votes + 2) / 3
@@ -89,7 +89,7 @@ impl Committee {
     pub fn robust_value<A, V>(
         &self,
         items: impl Iterator<Item = (A, V)>,
-        threshold: usize,
+        threshold: u64,
     ) -> (AuthorityName, V)
     where
         A: Borrow<AuthorityName> + Ord,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -337,6 +337,12 @@ pub enum SuiError {
     #[error("Signature key generation error: {0}")]
     SignatureKeyGenError(String),
 
+    // Epoch related errors.
+    #[error("Validator temporarily stopped processing transactions due to epoch change")]
+    ValidatorHaltedAtEpochEnd,
+    #[error("Inconsistent state detected during epoch change: {:?}", error)]
+    InconsistentEpochState { error: String },
+
     // These are errors that occur when an RPC fails and is simply the utf8 message sent in a
     // Tonic::Status
     #[error("{0}")]

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -641,7 +641,7 @@ impl SignedTransaction {
     }
 
     /// Verify the signature and return the non-zero voting right of the authority.
-    pub fn verify(&self, committee: &Committee) -> Result<usize, SuiError> {
+    pub fn verify(&self, committee: &Committee) -> Result<u64, SuiError> {
         self.verify_signature()?;
         let weight = committee.weight(&self.auth_sign_info.authority);
         fp_ensure!(weight > 0, SuiError::UnknownSigner);
@@ -1098,7 +1098,7 @@ impl InputObjectKind {
 }
 pub struct SignatureAggregator<'a> {
     committee: &'a Committee,
-    weight: usize,
+    weight: u64,
     used_authorities: HashSet<AuthorityName>,
     partial: CertifiedTransaction,
 }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{base_types::*, batch::*, committee::Committee, error::*, event::Event};
-use crate::committee::EpochId;
+use crate::committee::{EpochId, StakeUnit};
 use crate::crypto::{
     sha3_hash, AuthorityQuorumSignInfo, AuthoritySignInfo, AuthoritySignature, BcsSignable,
     EmptySignInfo, Signable, Signature, VerificationObligation,
@@ -1098,7 +1098,7 @@ impl InputObjectKind {
 }
 pub struct SignatureAggregator<'a> {
     committee: &'a Committee,
-    weight: u64,
+    weight: StakeUnit,
     used_authorities: HashSet<AuthorityName>,
     partial: CertifiedTransaction,
 }

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -16,7 +16,6 @@ pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SystemParameters {
     pub min_validator_stake: u64,
-    pub max_validator_stake: u64,
     pub max_validator_candidate_count: u64,
 }
 
@@ -27,13 +26,19 @@ pub struct MoveOption<T> {
     pub vec: Vec<T>,
 }
 
-/// Rust version of the Move Sui::Validator::Validator type
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct Validator {
+pub struct ValidatorMetadata {
     pub sui_address: AccountAddress,
     pub pubkey_bytes: Vec<u8>,
     pub name: Vec<u8>,
     pub net_address: Vec<u8>,
+    pub next_epoch_stake: u64,
+}
+
+/// Rust version of the Move Sui::Validator::Validator type
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct Validator {
+    pub metadata: ValidatorMetadata,
     pub stake: Balance,
     pub delegation: u64,
     pub pending_stake: MoveOption<Balance>,
@@ -54,6 +59,7 @@ pub struct ValidatorSet {
     pub active_validators: Vec<Validator>,
     pub pending_validators: Vec<Validator>,
     pub pending_removals: Vec<u64>,
+    pub next_epoch_validators: Vec<ValidatorMetadata>,
 }
 
 /// Rust version of the Move Sui::SuiSystem::SuiSystemState type

--- a/crates/sui-types/src/waypoint.rs
+++ b/crates/sui-types/src/waypoint.rs
@@ -407,7 +407,7 @@ where
     /// In case keys are authority names we can check if the set of
     /// authorities represented in this checkpoint represent a quorum
     pub fn has_quorum(&self, committee: &Committee) -> bool {
-        let authority_weights: usize = self
+        let authority_weights: u64 = self
             .authority_waypoints
             .keys()
             .map(|name| committee.weight(name))

--- a/crates/sui-types/src/waypoint.rs
+++ b/crates/sui-types/src/waypoint.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use ed25519_dalek::Sha512;
 
+use crate::committee::StakeUnit;
 use crate::{base_types::AuthorityName, committee::Committee};
 
 #[cfg(test)]
@@ -407,7 +408,7 @@ where
     /// In case keys are authority names we can check if the set of
     /// authorities represented in this checkpoint represent a quorum
     pub fn has_quorum(&self, committee: &Committee) -> bool {
-        let authority_weights: u64 = self
+        let authority_weights: StakeUnit = self
             .authority_waypoints
             .keys()
             .map(|name| committee.weight(name))

--- a/crates/sui/src/benchmark/load_generator.rs
+++ b/crates/sui/src/benchmark/load_generator.rs
@@ -290,9 +290,9 @@ pub fn calculate_throughput(num_items: usize, elapsed_time_us: u128) -> f64 {
 async fn send_tx_chunks_for_quorum_notif(
     notif: Arc<Notify>,
     tx_chunk: Vec<Transaction>,
-    result_chann_tx: &mut MpscSender<(u128, usize)>,
+    result_chann_tx: &mut MpscSender<(u128, u64)>,
     address: Multiaddr,
-    stake: usize,
+    stake: u64,
     conn: usize,
 ) {
     notif.notified().await;
@@ -319,9 +319,9 @@ async fn send_tx_for_quorum(
     order_chunk: Vec<Transaction>,
     conf_chunk: Vec<CertifiedTransaction>,
     result_chann_tx: &mut MpscSender<u128>,
-    net_clients: Vec<(Multiaddr, usize)>,
+    net_clients: Vec<(Multiaddr, u64)>,
     conn: usize,
-    quorum_threshold: usize,
+    quorum_threshold: u64,
 ) {
     // For receiving info back from the subtasks
     let (order_chann_tx, mut order_chann_rx) = MpscChannel(net_clients.len() * 2);
@@ -451,7 +451,7 @@ impl MultiFixedRateLoadGenerator {
 
         network_cfg: &NetworkConfig,
     ) -> Self {
-        let network_clients_stake: Vec<(Multiaddr, usize)> = network_cfg
+        let network_clients_stake: Vec<(Multiaddr, u64)> = network_cfg
             .validator_set()
             .iter()
             .map(|q| (q.network_address().to_owned(), q.stake()))

--- a/crates/sui/src/benchmark/load_generator.rs
+++ b/crates/sui/src/benchmark/load_generator.rs
@@ -24,6 +24,7 @@ use tokio::{sync::Notify, time};
 use tracing::{error, info};
 
 use sui_config::NetworkConfig;
+use sui_types::committee::StakeUnit;
 
 pub fn check_transaction_response(reply_message: Result<TransactionInfoResponse, io::Error>) {
     match reply_message {
@@ -290,9 +291,9 @@ pub fn calculate_throughput(num_items: usize, elapsed_time_us: u128) -> f64 {
 async fn send_tx_chunks_for_quorum_notif(
     notif: Arc<Notify>,
     tx_chunk: Vec<Transaction>,
-    result_chann_tx: &mut MpscSender<(u128, u64)>,
+    result_chann_tx: &mut MpscSender<(u128, StakeUnit)>,
     address: Multiaddr,
-    stake: u64,
+    stake: StakeUnit,
     conn: usize,
 ) {
     notif.notified().await;
@@ -319,9 +320,9 @@ async fn send_tx_for_quorum(
     order_chunk: Vec<Transaction>,
     conf_chunk: Vec<CertifiedTransaction>,
     result_chann_tx: &mut MpscSender<u128>,
-    net_clients: Vec<(Multiaddr, u64)>,
+    net_clients: Vec<(Multiaddr, StakeUnit)>,
     conn: usize,
-    quorum_threshold: u64,
+    quorum_threshold: StakeUnit,
 ) {
     // For receiving info back from the subtasks
     let (order_chann_tx, mut order_chann_rx) = MpscChannel(net_clients.len() * 2);
@@ -451,7 +452,7 @@ impl MultiFixedRateLoadGenerator {
 
         network_cfg: &NetworkConfig,
     ) -> Self {
-        let network_clients_stake: Vec<(Multiaddr, u64)> = network_cfg
+        let network_clients_stake: Vec<(Multiaddr, StakeUnit)> = network_cfg
             .validator_set()
             .iter()
             .map(|q| (q.network_address().to_owned(), q.stake()))

--- a/crates/sui/src/benchmark/transaction_creator.rs
+++ b/crates/sui/src/benchmark/transaction_creator.rs
@@ -64,10 +64,11 @@ fn make_cert(network_config: &NetworkConfig, tx: &Transaction) -> CertifiedTrans
     let mut certificate = CertifiedTransaction::new(tx.clone());
     let committee = network_config.committee();
     certificate.auth_sign_info.epoch = committee.epoch();
+    // TODO: Why iterating from 0 to quorum_threshold??
     for i in 0..committee.quorum_threshold() {
         let secx = network_config
             .validator_configs()
-            .get(i)
+            .get(i as usize)
             .unwrap()
             .key_pair();
         let pubx = secx.public_key_bytes();


### PR DESCRIPTION
This PR adds the basic reconfiguration flow at epoch boundaries.
The core of this PR is in reconfiguration.rs, with two functions:
1. `start_epoch_change`: this function will be called when the checkpoint process finishes processing all transactions from the second last checkpoint in the epoch. It halts the validator so that it no longer processes transactions/certificates. It also waits for the tickets to drain so that no more transactions are going to commit to the effects store.
2. `finish_epoch_change`: this function will be called when the checkpoint process finishes processing all transactions from the last checkpoint in the epoch. It first obtains the new validator set for the new epoch (to do this, a lot of changes have to be made to the governance contract, which will be described latter); create a new committee, and update the validator's local epoch information with the new committee. It will also eventually reset the committee/net of all components, and process a special system transaction that advances epoch state on-chain. The last part will be done in future PRs to avoid growing this PR forever

A few other changes covered by this PR: 
1. Changed all stake type from `usize` to `StakeUnit`, which is `u64`, to be consistent with the type on-chain. This is the primary reason a lot of files were touched.
2. Step 2 above requires an easy way to obtain the validator set for the new epoch. To support this, I changed the governance contract such that each time a change is requested to the validator set, it regenerates a metadata list for the new validator set. This has some side benefits: it makes it a lot easier for a validator to know whether they will make to the next epoch, instead of waiting til the end. It will also make it easier to enforce a % threshold on validator stake.