### PR TITLE
actually utilize the in-mem module cache in validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.2.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f4ea34740bd5042b688060cbff8b010f5a324719d5e111284d648035bccc47"
+checksum = "63b40347dcad92b4dfeb9765c41c48503416daddf6dba55b74614dc035a43ed2"
 
 [[package]]
 name = "event-listener"
@@ -2153,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "hakari"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532c7a447b62879000ce0841235f85853fa3a44d4f05fc6fa504759966fc6056"
+checksum = "35cafecb693cbf0c09e3079793e65ee4b1567297c29d9fd8de2306e98feb8d61"
 dependencies = [
  "atomicwrites",
  "bimap",
@@ -2801,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2940,9 +2940,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
 ]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -79,7 +79,9 @@ mod temporary_store;
 pub use temporary_store::AuthorityTemporaryStore;
 
 mod authority_store;
-pub use authority_store::{ArcWrapper, AuthorityStore, GatewayStore, ReplicaStore, SuiDataStore};
+pub use authority_store::{
+    AuthorityStore, AuthorityStoreWrapper, GatewayStore, ReplicaStore, SuiDataStore,
+};
 use sui_types::object::Owner;
 use sui_types::sui_system_state::SuiSystemState;
 
@@ -237,7 +239,7 @@ pub struct AuthorityState {
 
     indexes: Option<Arc<IndexStore>>,
 
-    module_cache: SyncModuleCache<ArcWrapper<AuthorityStore>>, // TODO: use strategies (e.g. LRU?) to constraint memory usage
+    module_cache: SyncModuleCache<AuthorityStoreWrapper>, // TODO: use strategies (e.g. LRU?) to constraint memory usage
 
     /// The checkpoint store
     pub(crate) checkpoints: Option<Arc<Mutex<CheckpointStore>>>,
@@ -790,7 +792,7 @@ impl AuthorityState {
             move_vm,
             database: store.clone(),
             indexes,
-            module_cache: SyncModuleCache::new(ArcWrapper(store.clone())),
+            module_cache: SyncModuleCache::new(AuthorityStoreWrapper(store.clone())),
             checkpoints,
             batch_channels: tx,
             batch_notifier: Arc::new(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -16,7 +16,7 @@ use arc_swap::{ArcSwap, ArcSwapOption};
 use async_trait::async_trait;
 use itertools::Itertools;
 use move_binary_format::CompiledModule;
-use move_bytecode_utils::module_cache::ModuleCache;
+use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_core_types::{
     account_address::AccountAddress,
     ident_str,
@@ -79,7 +79,7 @@ mod temporary_store;
 pub use temporary_store::AuthorityTemporaryStore;
 
 mod authority_store;
-pub use authority_store::{AuthorityStore, GatewayStore, ReplicaStore, SuiDataStore};
+pub use authority_store::{ArcWrapper, AuthorityStore, GatewayStore, ReplicaStore, SuiDataStore};
 use sui_types::object::Owner;
 use sui_types::sui_system_state::SuiSystemState;
 
@@ -236,6 +236,8 @@ pub struct AuthorityState {
     pub(crate) database: Arc<AuthorityStore>, // TODO: remove pub
 
     indexes: Option<Arc<IndexStore>>,
+
+    module_cache: SyncModuleCache<ArcWrapper<AuthorityStore>>, // TODO: use strategies (e.g. LRU?) to constraint memory usage
 
     /// The checkpoint store
     pub(crate) checkpoints: Option<Arc<Mutex<CheckpointStore>>>,
@@ -625,10 +627,7 @@ impl AuthorityState {
                                 .await?
                         };
                         let layout = match request_layout {
-                            Some(format) => {
-                                let resolver = ModuleCache::new(&self);
-                                object.get_layout(format, &resolver)?
-                            }
+                            Some(format) => object.get_layout(format, &self.module_cache)?,
                             None => None,
                         };
 
@@ -791,6 +790,7 @@ impl AuthorityState {
             move_vm,
             database: store.clone(),
             indexes,
+            module_cache: SyncModuleCache::new(ArcWrapper(store.clone())),
             checkpoints,
             batch_channels: tx,
             batch_notifier: Arc::new(
@@ -922,9 +922,8 @@ impl AuthorityState {
                             })
                         }
                         Some(object) => {
-                            let resolver = ModuleCache::new(&self);
-                            let layout =
-                                object.get_layout(ObjectFormatOptions::default(), &resolver)?;
+                            let layout = object
+                                .get_layout(ObjectFormatOptions::default(), &self.module_cache)?;
                             Ok(ObjectRead::Exists(obj_ref, object, layout))
                         }
                     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1197,14 +1197,6 @@ impl AuthorityState {
     }
 }
 
-impl ModuleResolver for AuthorityState {
-    type Error = SuiError;
-
-    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.database.get_module(module_id)
-    }
-}
-
 #[async_trait]
 impl ExecutionState for AuthorityState {
     type Transaction = ConsensusTransaction;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1135,6 +1135,16 @@ impl<const A: bool, const B: bool, S: Eq + Serialize + for<'de> Deserialize<'de>
     }
 }
 
+/// A wrapper to make Orphan Rule happy
+pub struct ArcWrapper<T>(pub Arc<T>);
+
+impl ModuleResolver for ArcWrapper<AuthorityStore> {
+    type Error = SuiError;
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_module(module_id)
+    }
+}
+
 // The primary key type for object storage.
 #[serde_as]
 #[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1136,9 +1136,9 @@ impl<const A: bool, const B: bool, S: Eq + Serialize + for<'de> Deserialize<'de>
 }
 
 /// A wrapper to make Orphan Rule happy
-pub struct ArcWrapper<T>(pub Arc<T>);
+pub struct AuthorityStoreWrapper(pub Arc<AuthorityStore>);
 
-impl ModuleResolver for ArcWrapper<AuthorityStore> {
+impl ModuleResolver for AuthorityStoreWrapper {
     type Error = SuiError;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         self.0.get_module(module_id)


### PR DESCRIPTION
Prior to this PR, we weren't really utilizing the module cache since we always recreate one whenever we need it. 

an newly added issue to constraint the cache size in the future: https://github.com/MystenLabs/sui/issues/2325 