### PR TITLE
Explorer demo cleanup

### DIFF
--- a/explorer/client/src/components/displaybox/DisplayBox.tsx
+++ b/explorer/client/src/components/displaybox/DisplayBox.tsx
@@ -3,11 +3,11 @@
 
 import { useState, useCallback, useEffect } from 'react';
 
-import { processDisplayValue } from '../../utils/stringUtils';
+import { transformURL } from '../../utils/stringUtils';
 
 import styles from './DisplayBox.module.css';
 
-function DisplayBox({ display }: { display: string | { bytes: number[] } }) {
+function DisplayBox({ display }: { display: string }) {
     const [hasDisplayLoaded, setHasDisplayLoaded] = useState(false);
     const [hasFailedToLoad, setHasFailedToLoad] = useState(false);
 
@@ -47,7 +47,7 @@ function DisplayBox({ display }: { display: string | { bytes: number[] } }) {
                     className={styles.imagebox}
                     style={imageStyle}
                     alt="NFT"
-                    src={processDisplayValue(display)}
+                    src={transformURL(display)}
                     onLoad={handleImageLoad}
                     onError={handleImageFail}
                 />

--- a/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../utils/static/searchUtil';
 import {
     handleCoinType,
-    processDisplayValue,
+    transformURL,
     trimStdLibPrefix,
 } from '../../utils/stringUtils';
 import DisplayBox from '../displaybox/DisplayBox';
@@ -136,7 +136,7 @@ function OwnedObjectAPI({ id, byAddress }: { id: string; byAddress: boolean }) {
                                         Type: objType,
                                         _isCoin: Coin.isCoin(resp),
                                         display: url
-                                            ? processDisplayValue(url)
+                                            ? transformURL(url)
                                             : undefined,
                                         balance: balanceValue,
                                     };

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -9,10 +9,7 @@ import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 import theme from '../../styles/theme.module.css';
 import { type AddressOwner } from '../../utils/api/DefaultRpcClient';
 import { parseImageURL } from '../../utils/objectUtils';
-import {
-    asciiFromNumberBytes,
-    trimStdLibPrefix,
-} from '../../utils/stringUtils';
+import { trimStdLibPrefix } from '../../utils/stringUtils';
 import { type DataType } from './ObjectResultType';
 
 import styles from './ObjectResult.module.css';
@@ -67,12 +64,6 @@ function ObjectLoaded({ data }: { data: DataType }) {
                 const singleOwnerPattern = /SingleOwner\(k#(.*)\)/;
                 const result = singleOwnerPattern.exec(owner);
                 return result ? result[1] : '';
-            case 'object':
-                if ('AddressOwner' in owner) {
-                    let ownerId = extractAddressOwner(owner.AddressOwner);
-                    return ownerId ? ownerId : '';
-                }
-                return '';
             default:
                 return '';
         }
@@ -88,43 +79,12 @@ function ObjectLoaded({ data }: { data: DataType }) {
         return str.replace(endParensPattern, '');
     };
 
-    const extractAddressOwner = (addrOwner: number[]): string | null => {
-        if (addrOwner.length !== 20) {
-            console.log('address owner byte length must be 20');
-            return null;
-        }
-
-        return asciiFromNumberBytes(addrOwner);
-    };
-
-    function toHexString(byteArray: number[]): string {
-        return (
-            '0x' +
-            Array.prototype.map
-                .call(byteArray, (byte) => {
-                    return ('0' + (byte & 0xff).toString(16)).slice(-2);
-                })
-                .join('')
-        );
-    }
-
-    function processOwner(owner: any) {
-        if (typeof owner === 'object' && 'AddressOwner' in owner) {
-            return toHexString(owner.AddressOwner);
-        }
-
-        return owner;
-    }
-
     const viewedData = {
         ...data,
         objType: trimStdLibPrefix(data.objType),
         name: data.name,
-        tx_digest:
-            data.data.tx_digest && typeof data.data.tx_digest === 'object'
-                ? toHexString(data.data.tx_digest as number[])
-                : data.data.tx_digest,
-        owner: processOwner(data.owner),
+        tx_digest: data.data.tx_digest,
+        owner: data.owner,
         url: parseImageURL(data.data.contents),
     };
 

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -96,39 +96,6 @@ function ObjectLoaded({ data }: { data: DataType }) {
 
         return asciiFromNumberBytes(addrOwner);
     };
-    type SuiIdBytes = { bytes: number[] };
-
-    function handleSpecialDemoNameArrays(data: {
-        name?: string;
-        player_name?: SuiIdBytes | string;
-        monster_name?: SuiIdBytes | string;
-        farm_name?: SuiIdBytes | string;
-    }): string {
-        let bytesObj: SuiIdBytes = { bytes: [] };
-
-        if ('player_name' in data) {
-            bytesObj = data.player_name as SuiIdBytes;
-            const ascii = asciiFromNumberBytes(bytesObj.bytes);
-            delete data.player_name;
-            return ascii;
-        } else if ('monster_name' in data) {
-            bytesObj = data.monster_name as SuiIdBytes;
-            const ascii = asciiFromNumberBytes(bytesObj.bytes);
-            delete data.monster_name;
-            return ascii;
-        } else if ('farm_name' in data) {
-            bytesObj = data.farm_name as SuiIdBytes;
-            const ascii = asciiFromNumberBytes(bytesObj.bytes);
-            delete data.farm_name;
-            return ascii;
-        } else if ('name' in data) {
-            return data['name'] as string;
-        } else {
-            bytesObj = { bytes: [] };
-        }
-
-        return asciiFromNumberBytes(bytesObj.bytes);
-    }
 
     function toHexString(byteArray: number[]): string {
         return (
@@ -139,18 +106,6 @@ function ObjectLoaded({ data }: { data: DataType }) {
                 })
                 .join('')
         );
-    }
-
-    function processName(name: string | undefined) {
-        // hardcode a friendly name for gas for now
-        const gasTokenTypeStr = 'Coin::Coin<0x2::GAS::GAS>';
-        const gasTokenId = '0000000000000000000000000000000000000003';
-        if (data.objType === gasTokenTypeStr && data.id === gasTokenId)
-            return 'GAS';
-
-        if (!name) {
-            return handleSpecialDemoNameArrays(data.data.contents);
-        }
     }
 
     function processOwner(owner: any) {
@@ -164,7 +119,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
     const viewedData = {
         ...data,
         objType: trimStdLibPrefix(data.objType),
-        name: processName(data.name),
+        name: data.name,
         tx_digest:
             data.data.tx_digest && typeof data.data.tx_digest === 'object'
                 ? toHexString(data.data.tx_digest as number[])
@@ -175,12 +130,12 @@ function ObjectLoaded({ data }: { data: DataType }) {
 
     //TO DO remove when have distinct name field under Description
     const nameKeyValue = Object.entries(viewedData.data?.contents)
-        .filter(([key, _]) => /name/i.test(key))
+        .filter(([key, _]) => key === 'name')
         .map(([_, value]) => value);
 
     const properties = Object.entries(viewedData.data?.contents)
         //TO DO: remove when have distinct 'name' field in Description
-        .filter(([key, _]) => !/name/i.test(key))
+        .filter(([key, _]) => key !== 'name')
         .filter(([_, value]) => checkIsPropertyType(value));
 
     const descriptionTitle =

--- a/explorer/client/src/utils/api/DefaultRpcClient.ts
+++ b/explorer/client/src/utils/api/DefaultRpcClient.ts
@@ -6,11 +6,9 @@ import { JsonRpcProvider } from '@mysten/sui.js';
 import { getEndpoint, Network } from './rpcSetting';
 
 // TODO: Remove these types with SDK types
-export type AddressBytes = number[];
-export type AddressOwner = { AddressOwner: AddressBytes };
+export type AddressOwner = { AddressOwner: string };
 
 export type AnyVec = { vec: any[] };
-export type JsonBytes = { bytes: number[] };
 
 export { Network, getEndpoint };
 

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -1,9 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export function asciiFromNumberBytes(bytes: number[]) {
-    return bytes.map((n) => String.fromCharCode(n)).join('');
-}
 
 export function hexToAscii(hex: string) {
     if (!hex || typeof hex != 'string') return;
@@ -24,15 +21,7 @@ export const handleCoinType = (str: string): string =>
         ? 'SUI'
         : str.match(/^([a-zA-Z0-9:]*)<([a-zA-Z0-9:]*)>$/)?.[2] || str;
 
-export const processDisplayValue = (display: { bytes: number[] } | string) => {
-    const url =
-        typeof display === 'object' && 'bytes' in display
-            ? asciiFromNumberBytes(display.bytes)
-            : display;
-    return typeof url === 'string' ? transformURL(url) : url;
-};
-
-function transformURL(url: string) {
+export function transformURL(url: string) {
     const found = url.match(/^ipfs:\/\/(.*)/);
     if (!found) {
         return url;

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-
 export function hexToAscii(hex: string) {
     if (!hex || typeof hex != 'string') return;
     hex = hex.replace(/^0x/, '');


### PR DESCRIPTION
Removes code left over from special-casing things for March's milestone.

* handling properties with `name` in them as the title
* handling the `number[]` encodings of bytes