### PR TITLE
add staging option to network, use full node for local and staging

### DIFF
--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -40,7 +40,7 @@
         "bn.js": "^5.2.0"
     },
     "scripts": {
-        "start": "react-scripts start",
+        "start": "REACT_APP_DATA=staging react-scripts start",
         "start:static": "REACT_APP_DATA=static PORT=8080 react-scripts start",
         "start:local": "REACT_APP_DATA=local PORT=8080 react-scripts start",
         "test": "npx start-server-and-test 'yarn start:static' 8080 'react-scripts test --detectOpenHandles --watchAll=false'",

--- a/explorer/client/src/components/network/Network.tsx
+++ b/explorer/client/src/components/network/Network.tsx
@@ -84,6 +84,12 @@ export default function NetworkSelect() {
                             Devnet
                         </div>
                         <div
+                            onClick={chooseNetwork(Network.Staging)}
+                            className={networkStyle(Network.Staging)}
+                        >
+                            Staging
+                        </div>
+                        <div
                             onClick={chooseNetwork(Network.Local)}
                             className={networkStyle(Network.Local)}
                         >

--- a/explorer/client/src/utils/api/rpcSetting.ts
+++ b/explorer/client/src/utils/api/rpcSetting.ts
@@ -3,11 +3,14 @@
 
 export enum Network {
     Local = 'Local',
+    Staging = 'Staging',
     Devnet = 'Devnet',
 }
 
 const ENDPOINTS = {
-    [Network.Local]: 'http://127.0.0.1:5001',
+    [Network.Local]: 'http://127.0.0.1:9000',
+    [Network.Staging]: 'https://full-node.staging.sui.io/',
+    // NOTE - no full node in devnet yet
     [Network.Devnet]: 'https://gateway.devnet.sui.io:443',
 };
 


### PR DESCRIPTION
Does 2 related things:
1) add a 'Staging' option to our network tab
2) switch the explorer to using full nodes in local and staging environments (no full node in devnet yet)

<img width="505" alt="image" src="https://user-images.githubusercontent.com/14057748/171476081-8e6010b9-903a-455a-8176-a304cd3010e6.png">

should close #1951 