### PR TITLE
Remove committee from CheckpointStore

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -82,6 +82,9 @@ mod authority_store;
 pub use authority_store::{
     AuthorityStore, AuthorityStoreWrapper, GatewayStore, ReplicaStore, SuiDataStore,
 };
+use sui_types::messages_checkpoint::{
+    CheckpointRequest, CheckpointRequestType, CheckpointResponse,
+};
 use sui_types::object::Owner;
 use sui_types::sui_system_state::SuiSystemState;
 
@@ -730,6 +733,32 @@ impl AuthorityState {
         Ok((items, (should_subscribe, start, end)))
     }
 
+    pub fn handle_checkpoint_request(
+        &self,
+        request: &CheckpointRequest,
+    ) -> Result<CheckpointResponse, SuiError> {
+        let mut checkpoint_store = self
+            .checkpoints
+            .as_ref()
+            .ok_or(SuiError::UnsupportedFeatureError {
+                error: "Checkpoint not supported".to_owned(),
+            })?
+            .lock();
+        match &request.request_type {
+            CheckpointRequestType::LatestCheckpointProposal => {
+                checkpoint_store.handle_latest_proposal(request)
+            }
+            CheckpointRequestType::PastCheckpoint(seq) => {
+                checkpoint_store.handle_past_checkpoint(request.detail, *seq)
+            }
+            CheckpointRequestType::SetCertificate(cert, opt_contents) => checkpoint_store
+                .handle_checkpoint_certificate(cert, opt_contents, &self.committee.load()),
+            CheckpointRequestType::SetFragment(fragment) => {
+                checkpoint_store.handle_receive_fragment(fragment, &self.committee.load())
+            }
+        }
+    }
+
     pub async fn new(
         committee: Committee,
         name: AuthorityName,
@@ -871,10 +900,6 @@ impl AuthorityState {
         })?;
         self.halted.store(false, Ordering::SeqCst);
         Ok(())
-    }
-
-    pub(crate) fn checkpoints(&self) -> Option<Arc<Mutex<CheckpointStore>>> {
-        self.checkpoints.clone()
     }
 
     pub(crate) fn db(&self) -> Arc<AuthorityStore> {
@@ -1251,7 +1276,7 @@ impl ExecutionState for AuthorityState {
                 if let Some(checkpoint) = &self.checkpoints {
                     checkpoint
                         .lock()
-                        .handle_internal_fragment(seq, *fragment)
+                        .handle_internal_fragment(seq, *fragment, &self.committee.load())
                         .map_err(|e| SuiError::from(&e.to_string()[..]))?;
 
                     // NOTE: The method `handle_internal_fragment` is idempotent, so we don't need

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -312,13 +312,7 @@ impl AuthorityAPI for LocalAuthorityClient {
     ) -> Result<CheckpointResponse, SuiError> {
         let state = self.state.clone();
 
-        let result = state
-            .checkpoints
-            .as_ref()
-            .unwrap()
-            .lock()
-            .handle_checkpoint_request(&request);
-        result
+        state.handle_checkpoint_request(&request)
     }
 }
 
@@ -347,14 +341,8 @@ impl LocalAuthorityClient {
         let store = Arc::new(AuthorityStore::open(&store_path, None));
         let mut checkpoints_path = path.clone();
         checkpoints_path.push("checkpoints");
-        let checkpoints = CheckpointStore::open(
-            &checkpoints_path,
-            None,
-            address,
-            committee.clone(),
-            secret.clone(),
-        )
-        .expect("Should not fail to open local checkpoint DB");
+        let checkpoints = CheckpointStore::open(&checkpoints_path, None, address, secret.clone())
+            .expect("Should not fail to open local checkpoint DB");
 
         let state = AuthorityState::new(
             committee.clone(),

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -379,17 +379,13 @@ impl Validator for ValidatorService {
         &self,
         request: tonic::Request<CheckpointRequest>,
     ) -> Result<tonic::Response<CheckpointResponse>, tonic::Status> {
-        if let Some(checkpoint) = &self.state.checkpoints() {
-            let request = request.into_inner();
+        let request = request.into_inner();
 
-            let response = checkpoint
-                .lock()
-                .handle_checkpoint_request(&request)
-                .map_err(|e| tonic::Status::internal(e.to_string()))?;
+        let response = self
+            .state
+            .handle_checkpoint_request(&request)
+            .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-            return Ok(tonic::Response::new(response));
-        }
-
-        Err(tonic::Status::internal("Unsupported".to_string()))
+        return Ok(tonic::Response::new(response));
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -42,7 +42,6 @@ impl SuiNode {
                 config.db_path().join("checkpoints"),
                 None,
                 config.public_key(),
-                genesis.committee(),
                 secret.clone(),
             )?)))
         } else {


### PR DESCRIPTION
The checkpoint store can get committee either from the state, if it's called from the state; or from active_authority.net if it's called from the active authority.
This reduce yet one committee that we need to worry about at epoch boundaries.