### PR TITLE
Wallet CLI: wallet split-coin usage instruction missing --amounts

### DIFF
--- a/crates/sui/src/wallet_commands.rs
+++ b/crates/sui/src/wallet_commands.rs
@@ -192,7 +192,12 @@ pub enum WalletCommands {
         #[clap(long)]
         coin_id: ObjectID,
         /// Amount to split out from the coin
-        #[clap(long, multiple_occurrences = false, multiple_values = true)]
+        #[clap(
+            long,
+            multiple_occurrences = false,
+            multiple_values = true,
+            required = true
+        )]
         amounts: Vec<u64>,
         /// ID of the gas object for gas payment, in 20 bytes Hex string
         /// If not provided, a gas object with at least gas_budget value will be selected


### PR DESCRIPTION
this fixes #2194 

new usage instruction

```
split-coin 
Split a coin object into multiple coins

USAGE:
    split-coin [OPTIONS] --coin-id <COIN_ID> --amounts <AMOUNTS>... --gas-budget <GAS_BUDGET>

OPTIONS:
        --amounts <AMOUNTS>...       Amount to split out from the coin
        --coin-id <COIN_ID>          Coin to Split, in 20 bytes Hex string
        --gas <GAS>                  ID of the gas object for gas payment, in 20 bytes Hex string If
                                     not provided, a gas object with at least gas_budget value will
                                     be selected
        --gas-budget <GAS_BUDGET>    Gas budget for this call
    -h, --help                       Print help information
        --json                       Returns command outputs in JSON format
``` 