### PR TITLE
[sui-core] Infra to restart and stop active services

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -217,14 +217,13 @@ where
 
         // Run concurrently and wait for both to quit.
         let (res_gossip, res_checkpoint) = join!(gossip_join, checkpoint_join);
-        
+
         if let Err(err) = res_gossip {
             error!("Gossip exit: {}", err);
-        }        
+        }
         if let Err(err) = res_checkpoint {
             error!("Checkpoint exit: {}", err);
         }
-
     }
 }
 
@@ -393,7 +392,6 @@ mod test {
         assert!(*arc_int.lock().unwrap() == 2);
     }
 
-
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_signal_complete() {
         let (sender, receiver) = LifecycleSignalSender::new();
@@ -426,5 +424,4 @@ mod test {
         // .. the restart does nothing.
         assert!(*arc_int.lock().unwrap() == 1);
     }
-
 }

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -41,7 +41,7 @@ use sui_types::{
     error::{SuiError, SuiResult},
 };
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::debug;
 
 use crate::{
     authority::AuthorityState, authority_aggregator::AuthorityAggregator,
@@ -219,15 +219,12 @@ where
     }
 }
 
-/*
-    The active authority start-update-shutdown facilities.
+// The active authority start-update-shutdown facilities.
 
-    The active authority runs in a separate task, and manages the tasks of separate active
-    processes, with one sub-task per active process. These subtasks internally listen to a
-    watch channel on which others may send a start, shutdown, or update signal. When this
-    is received the tasks are restarted, or shut down.
-
-*/
+// The active authority runs in a separate task, and manages the tasks of separate active
+// processes, with one sub-task per active process. These subtasks internally listen to a
+// watch channel on which others may send a start, shutdown, or update signal. When this
+// is received the tasks are restarted, or shut down.
 
 use tokio::sync::watch;
 
@@ -279,7 +276,7 @@ impl LifecycleTaskHandler {
             let signal = self.receiver.changed().await;
             match signal {
                 Err(_err) => {
-                    info!("Closing active tasks, command channel was dropped.");
+                    debug!("Closing active tasks, command channel was dropped.");
                     abort = true;
                     exit = true;
                 }
@@ -287,16 +284,16 @@ impl LifecycleTaskHandler {
                     // We have actually received a new signal.
                     match *self.receiver.borrow() {
                         LifecycleSignal::Start => {
-                            info!("Starting task: {}", description);
+                            debug!("Starting task: {}", description);
                             start = true;
                         }
                         LifecycleSignal::Restart => {
-                            info!("Restarting task: {}", description);
+                            debug!("Restarting task: {}", description);
                             abort = true;
                             start = true;
                         }
                         LifecycleSignal::Exit => {
-                            info!("Exit task: {}", description);
+                            debug!("Exit task: {}", description);
                             abort = true;
                             exit = true;
                         }

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -338,9 +338,7 @@ impl LifecycleTaskHandler {
             // Second potentially restart task
             if start {
                 let fut = fun();
-                handle = Some(tokio::task::spawn(
-                    async move { fut.await },
-                ));
+                handle = Some(tokio::task::spawn(async move { fut.await }));
             }
 
             // Third exit the loop.

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -31,7 +31,6 @@
 
 use futures::{join, Future};
 use std::{
-    borrow::Borrow,
     collections::{BTreeMap, HashMap},
     sync::Arc,
     time::Duration,
@@ -270,8 +269,8 @@ impl LifecycleTaskHandler {
     pub async fn spawn<F, T>(mut self, description: String, fun: F) -> Result<(), SuiError>
     where
         F: Fn() -> T,
-        T: Future + Send + 'static,
-        <T as Future>::Output: Borrow<Result<(), SuiError>> + Send + 'static,
+        T: Future<Output = Result<(), SuiError>> + Send + 'static,
+        <T as Future>::Output: Send + 'static,
     {
         let mut handle: Option<tokio::task::JoinHandle<Result<(), SuiError>>> = None;
         loop {
@@ -340,7 +339,7 @@ impl LifecycleTaskHandler {
             if start {
                 let fut = fun();
                 handle = Some(tokio::task::spawn(
-                    async move { fut.await.borrow().clone() },
+                    async move { fut.await },
                 ));
             }
 

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    authority_active::ActiveAuthority, authority_client::LocalAuthorityClient,
-    checkpoints::checkpoint_tests::TestSetup, safe_client::SafeClient,
+    authority_active::{ActiveAuthority, LifecycleSignal, LifecycleSignalSender},
+    authority_client::LocalAuthorityClient,
+    checkpoints::checkpoint_tests::TestSetup,
+    safe_client::SafeClient,
 };
 
 use std::{collections::BTreeSet, time::Duration};
@@ -26,13 +28,18 @@ async fn checkpoint_active_flow_happy_path() {
     } = setup;
 
     // Start active part of authority.
+    let mut control_channel_senders = Vec::new();
     for inner_state in authorities.clone() {
         let clients = aggregator.clone_inner_clients();
+        let (_sender, receiver) = LifecycleSignalSender::new();
         let _active_handle = tokio::task::spawn(async move {
             let active_state =
                 ActiveAuthority::new(inner_state.authority.clone(), clients).unwrap();
-            active_state.spawn_all_active_processes().await
+
+            active_state.spawn_all_active_processes(receiver).await;
         });
+        _sender.signal(LifecycleSignal::Start).await;
+        control_channel_senders.push(_sender);
     }
 
     let sender_aggregator = aggregator.clone();
@@ -92,14 +99,20 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
     } = setup;
 
     // Start active part of authority.
+    let mut control_channel_senders = Vec::new();
     for inner_state in authorities.clone() {
         let clients = aggregator.clone_inner_clients();
+        let (_sender, receiver) = LifecycleSignalSender::new();
         let _active_handle = tokio::task::spawn(async move {
             let active_state =
                 ActiveAuthority::new(inner_state.authority.clone(), clients).unwrap();
             // Spin the gossip service.
-            active_state.spawn_active_processes(true, true).await;
+            active_state
+                .spawn_active_processes(receiver, true, true)
+                .await;
         });
+        _sender.signal(LifecycleSignal::Start).await;
+        control_channel_senders.push(_sender);
     }
 
     let sender_aggregator = aggregator.clone();
@@ -175,14 +188,20 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
     } = setup;
 
     // Start active part of authority.
+    let mut control_channel_senders = Vec::new();
     for inner_state in authorities.clone() {
         let clients = aggregator.clone_inner_clients();
+        let (_sender, receiver) = LifecycleSignalSender::new();
         let _active_handle = tokio::task::spawn(async move {
             let active_state =
                 ActiveAuthority::new(inner_state.authority.clone(), clients).unwrap();
             // Spin the gossip service.
-            active_state.spawn_active_processes(false, true).await;
+            active_state
+                .spawn_active_processes(receiver, false, true)
+                .await;
         });
+        _sender.signal(LifecycleSignal::Start).await;
+        control_channel_senders.push(_sender);
     }
 
     let sender_aggregator = aggregator.clone();


### PR DESCRIPTION
Initial infrastructure that allows starting, restarting and exiting active components, for two key purposes:
- clean shutdown.
- reloading the config / committee upon epoch change.