### PR TITLE
Collect change epoch system transaction cert and execute

### DIFF
--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -115,9 +115,10 @@ where
             self.state.name,
             &*self.state.secret,
         );
+        // Add the signed transaction to the store.
         self.state
-            .change_epoch_tx
-            .store(Some(Arc::new(advance_epoch_tx.clone())));
+            .set_transaction_lock(&[], advance_epoch_tx.clone())
+            .await?;
 
         // Collect a certificate for this system transaction that changes epoch,
         // and execute it locally.

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1260,7 +1260,7 @@ async fn test_genesis_sui_sysmtem_state_object() {
 async fn test_change_epoch_transaction() {
     let authority_state = init_state().await;
     let signed_tx = SignedTransaction::new_change_epoch(
-        0,
+        1,
         100,
         100,
         authority_state.name,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -608,14 +608,14 @@ impl SignedTransaction {
     }
 
     pub fn new_change_epoch(
-        cur_epoch: EpochId,
+        next_epoch: EpochId,
         storage_charge: u64,
         computation_charge: u64,
         authority: AuthorityName,
         secret: &dyn signature::Signer<AuthoritySignature>,
     ) -> Self {
         let kind = TransactionKind::Single(SingleTransactionKind::ChangeEpoch(ChangeEpoch {
-            epoch: cur_epoch + 1,
+            epoch: next_epoch,
             storage_charge,
             computation_charge,
         }));
@@ -633,7 +633,7 @@ impl SignedTransaction {
             data,
             tx_signature: Signature::new_empty(),
             auth_sign_info: AuthoritySignInfo {
-                epoch: cur_epoch,
+                epoch: next_epoch,
                 authority,
                 signature,
             },


### PR DESCRIPTION
This PR finishes a critical step in `finish_epoch_change` during epoch change, execute the system transaction that would mutate epoch information on-chain.
The way it works is for each validator to sign the special transaction locally, store it in memory, and then actively query from a quorum of validators (that are in the new committee) to collect a cert. Each validator will also serve such request through a special check in the transaction request pipeline. Once we have a cert, each validator executes it locally, and at this point, we unhalt the validator and resume the new epoch.