### PR TITLE
[core] Add effects digest to follower API + checkpoints

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -860,7 +860,7 @@ impl AuthorityState {
                 .skip_to(&next_expected_tx)
                 .expect("Seeking batches should never fail at this point")
             {
-                let transactions: Vec<(TxSequenceNumber, TransactionDigest)> = state
+                let transactions: Vec<(TxSequenceNumber, ExecutionDigests)> = state
                     .database
                     .executed_sequence
                     .iter()

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -77,7 +77,7 @@ impl TransactionNotifier {
     pub fn iter_from(
         self: &Arc<Self>,
         next_seq: u64,
-    ) -> SuiResult<impl futures::Stream<Item = (TxSequenceNumber, TransactionDigest)> + Unpin> {
+    ) -> SuiResult<impl futures::Stream<Item = (TxSequenceNumber, ExecutionDigests)> + Unpin> {
         if self
             .has_stream
             .compare_exchange(
@@ -93,7 +93,7 @@ impl TransactionNotifier {
 
         // The state we inject in the async stream
         let transaction_notifier = self.clone();
-        let temp_buffer: VecDeque<(TxSequenceNumber, TransactionDigest)> = VecDeque::new();
+        let temp_buffer: VecDeque<(TxSequenceNumber, ExecutionDigests)> = VecDeque::new();
         let uniquess_guard = IterUniquenessGuard(transaction_notifier.clone());
         let initial_state = (transaction_notifier, temp_buffer, next_seq, uniquess_guard);
 
@@ -238,17 +238,17 @@ mod tests {
 
         {
             let t0 = &notifier.ticket().expect("ok");
-            store.side_sequence(t0.seq(), &TransactionDigest::random());
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
         }
 
         {
             let t0 = &notifier.ticket().expect("ok");
-            store.side_sequence(t0.seq(), &TransactionDigest::random());
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
         }
 
         {
             let t0 = &notifier.ticket().expect("ok");
-            store.side_sequence(t0.seq(), &TransactionDigest::random());
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
         }
 
         let mut iter = notifier.iter_from(0).unwrap();
@@ -276,7 +276,7 @@ mod tests {
 
         {
             let t0 = &notifier.ticket().expect("ok");
-            store.side_sequence(t0.seq(), &TransactionDigest::random());
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
         }
 
         let x = iter.next().await;
@@ -293,15 +293,15 @@ mod tests {
         let t7 = notifier.ticket().expect("ok");
         let t8 = notifier.ticket().expect("ok");
 
-        store.side_sequence(t6.seq(), &TransactionDigest::random());
+        store.side_sequence(t6.seq(), &ExecutionDigests::random());
         drop(t6);
 
-        store.side_sequence(t5.seq(), &TransactionDigest::random());
+        store.side_sequence(t5.seq(), &ExecutionDigests::random());
         drop(t5);
 
         drop(t7);
 
-        store.side_sequence(t8.seq(), &TransactionDigest::random());
+        store.side_sequence(t8.seq(), &ExecutionDigests::random());
         drop(t8);
 
         assert!(matches!(iter.next().await, Some((5, _))));

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -238,7 +238,7 @@ where
 
                         // Upon receiving a transaction digest, store it if it is not processed already.
                         Some(Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digest))))) => {
-                            if !self.state.database.effects_exists(&digest)? {
+                            if !self.state.database.effects_exists(&digest.transaction)? {
                                 queue.push(async move {
                                     tokio::time::sleep(Duration::from_millis(EACH_ITEM_DELAY_MS)).await;
                                     digest
@@ -267,9 +267,9 @@ where
                 },
                 digest = &mut queue.next() , if !queue.is_empty() => {
                     let digest = digest.unwrap();
-                    if !self.state.database.effects_exists(&digest)? {
+                    if !self.state.database.effects_exists(&digest.transaction)? {
                         // Download the certificate
-                        let response = self.client.handle_transaction_info_request(TransactionInfoRequest::from(digest)).await?;
+                        let response = self.client.handle_transaction_info_request(TransactionInfoRequest::from(digest.transaction)).await?;
                         self.process_response(response).await?;
                     }
                 }

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -39,7 +39,7 @@ pub async fn test_gossip() {
         for digest in &digests {
             let result1 = client
                 .handle_transaction_info_request(TransactionInfoRequest {
-                    transaction_digest: *digest,
+                    transaction_digest: digest.transaction,
                 })
                 .await;
 
@@ -78,7 +78,7 @@ pub async fn test_gossip_error() {
         for digest in &digests {
             let result1 = client
                 .handle_transaction_info_request(TransactionInfoRequest {
-                    transaction_digest: *digest,
+                    transaction_digest: digest.transaction,
                 })
                 .await;
 

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -146,7 +146,7 @@ impl crate::authority::AuthorityState {
         // The structures we use to build the next batch. The current_batch holds the sequence
         // of transactions in order, following the last batch. The loose transactions holds
         // transactions we may have received out of order.
-        let mut current_batch: Vec<(TxSequenceNumber, TransactionDigest)> = Vec::new();
+        let mut current_batch: Vec<(TxSequenceNumber, ExecutionDigests)> = Vec::new();
 
         while !exit {
             // Reset the flags.

--- a/crates/sui-core/src/checkpoints/proposal.rs
+++ b/crates/sui-core/src/checkpoints/proposal.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use sui_types::{
-    base_types::{AuthorityName, TransactionDigest},
+    base_types::{AuthorityName, ExecutionDigests},
     messages_checkpoint::{
         CheckpointContents, CheckpointFragment, CheckpointSequenceNumber, CheckpointSummary,
         SignedCheckpointProposal,
@@ -40,8 +40,8 @@ impl CheckpointProposal {
         self.proposal.0.checkpoint.sequence_number()
     }
 
-    // Iterate over all transactions
-    pub fn transactions(&self) -> impl Iterator<Item = &TransactionDigest> {
+    // Iterate over all transaction/effects
+    pub fn transactions(&self) -> impl Iterator<Item = &ExecutionDigests> {
         self.transactions.transactions.iter()
     }
 

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -3,9 +3,10 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
+use sui_types::base_types::ExecutionDigests;
 use sui_types::committee::StakeUnit;
 use sui_types::{
-    base_types::{AuthorityName, TransactionDigest},
+    base_types::AuthorityName,
     committee::Committee,
     error::SuiError,
     messages::CertifiedTransaction,
@@ -15,8 +16,8 @@ use sui_types::{
 
 pub struct FragmentReconstruction {
     pub committee: Committee,
-    pub global: GlobalCheckpoint<AuthorityName, TransactionDigest>,
-    pub extra_transactions: BTreeMap<TransactionDigest, CertifiedTransaction>,
+    pub global: GlobalCheckpoint<AuthorityName, ExecutionDigests>,
+    pub extra_transactions: BTreeMap<ExecutionDigests, CertifiedTransaction>,
 }
 
 impl FragmentReconstruction {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -89,12 +89,12 @@ fn crash_recovery() {
 
     // Do stuff
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
-    let t6 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
+    let t6 = ExecutionDigests::random();
 
     cps.handle_internal_batch(4, &[(1, t1), (2, t2), (3, t3)])
         .unwrap();
@@ -141,12 +141,12 @@ fn make_checkpoint_db() {
     let (_committee, _keys, mut stores) = random_ckpoint_store();
     let (_, mut cps) = stores.pop().unwrap();
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
-    let t6 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
+    let t6 = ExecutionDigests::random();
 
     cps.update_processed_transactions(&[(1, t1), (2, t2), (3, t3)])
         .unwrap();
@@ -188,11 +188,11 @@ fn make_proposals() {
     let (_, mut cps3) = stores.pop().unwrap();
     let (_, mut cps4) = stores.pop().unwrap();
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     cps1.update_processed_transactions(&[(1, t2), (2, t3)])
@@ -242,11 +242,11 @@ fn make_diffs() {
     let (_, mut cps3) = stores.pop().unwrap();
     let (_, mut cps4) = stores.pop().unwrap();
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     cps1.update_processed_transactions(&[(1, t2), (2, t3)])
@@ -269,7 +269,7 @@ fn make_diffs() {
     let diff12 = p1.fragment_with(&p2);
     let diff23 = p2.fragment_with(&p3);
 
-    let mut global = GlobalCheckpoint::<AuthorityName, TransactionDigest>::new();
+    let mut global = GlobalCheckpoint::<AuthorityName, ExecutionDigests>::new();
     global.insert(diff12.diff.clone()).unwrap();
     global.insert(diff23.diff).unwrap();
 
@@ -296,12 +296,12 @@ fn latest_proposal() {
     let (_, mut cps3) = stores.pop().unwrap();
     let (_, mut cps4) = stores.pop().unwrap();
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
-    let t6 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
+    let t6 = ExecutionDigests::random();
 
     cps1.update_processed_transactions(&[(1, t2), (2, t3)])
         .unwrap();
@@ -479,11 +479,11 @@ fn set_get_checkpoint() {
     let (_, mut cps3) = stores.pop().unwrap();
     let (_, mut cps4) = stores.pop().unwrap();
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     cps1.update_processed_transactions(&[(1, t2), (2, t3)])
@@ -634,7 +634,7 @@ fn checkpoint_integration() {
         let old_checkpoint = cps.get_locals().next_checkpoint;
 
         let some_fresh_transactions: Vec<_> = (0..7)
-            .map(|_| TransactionDigest::random())
+            .map(|_| ExecutionDigests::random())
             .chain(unprocessed.clone().into_iter())
             .enumerate()
             .map(|(i, d)| (i as u64 + next_tx_num, d))
@@ -655,7 +655,7 @@ fn checkpoint_integration() {
 
         // Step 2. Continue to process transactions while a proposal is out.
         let some_fresh_transactions: Vec<_> = (0..7)
-            .map(|_| TransactionDigest::random())
+            .map(|_| ExecutionDigests::random())
             .enumerate()
             .map(|(i, d)| (i as u64 + next_tx_num, d))
             .collect();
@@ -668,7 +668,7 @@ fn checkpoint_integration() {
 
         // Step 3. Receive a Checkpoint
         unprocessed = (0..5)
-            .map(|_| TransactionDigest::random())
+            .map(|_| ExecutionDigests::random())
             .into_iter()
             .chain(some_fresh_transactions.iter().cloned().map(|(_, d)| d))
             .collect();
@@ -745,10 +745,10 @@ async fn test_batch_to_checkpointing() {
         let t2 = &authority_state.batch_notifier.ticket().expect("ok");
         let t3 = &authority_state.batch_notifier.ticket().expect("ok");
 
-        store.side_sequence(t1.seq(), &TransactionDigest::random());
-        store.side_sequence(t3.seq(), &TransactionDigest::random());
-        store.side_sequence(t2.seq(), &TransactionDigest::random());
-        store.side_sequence(t0.seq(), &TransactionDigest::random());
+        store.side_sequence(t1.seq(), &ExecutionDigests::random());
+        store.side_sequence(t3.seq(), &ExecutionDigests::random());
+        store.side_sequence(t2.seq(), &ExecutionDigests::random());
+        store.side_sequence(t0.seq(), &ExecutionDigests::random());
     }
 
     // Get transactions in order then batch.
@@ -837,10 +837,10 @@ async fn test_batch_to_checkpointing_init_crash() {
             let t2 = &authority_state.batch_notifier.ticket().expect("ok");
             let t3 = &authority_state.batch_notifier.ticket().expect("ok");
 
-            store.side_sequence(t1.seq(), &TransactionDigest::random());
-            store.side_sequence(t3.seq(), &TransactionDigest::random());
-            store.side_sequence(t2.seq(), &TransactionDigest::random());
-            store.side_sequence(t0.seq(), &TransactionDigest::random());
+            store.side_sequence(t1.seq(), &ExecutionDigests::random());
+            store.side_sequence(t3.seq(), &ExecutionDigests::random());
+            store.side_sequence(t2.seq(), &ExecutionDigests::random());
+            store.side_sequence(t0.seq(), &ExecutionDigests::random());
         }
 
         // Get transactions in order then batch.
@@ -924,11 +924,11 @@ fn set_fragment_external() {
     cps4.set_consensus(Box::new(test_tx))
         .expect("No issues setting the consensus");
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     cps1.update_processed_transactions(&[(1, t2), (2, t3)])
@@ -972,11 +972,11 @@ fn set_fragment_reconstruct() {
     let (_, mut cps3) = test_objects.pop().unwrap();
     let (_, mut cps4) = test_objects.pop().unwrap();
 
-    let t1 = TransactionDigest::random();
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
-    let t4 = TransactionDigest::random();
-    let t5 = TransactionDigest::random();
+    let t1 = ExecutionDigests::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
+    let t4 = ExecutionDigests::random();
+    let t5 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     cps1.update_processed_transactions(&[(1, t2), (2, t3)])
@@ -1019,8 +1019,8 @@ fn set_fragment_reconstruct() {
 fn set_fragment_reconstruct_two_components() {
     let (committee, _keys, mut test_objects) = random_ckpoint_store_num(2 * 3 + 1);
 
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     for (_, cps) in &mut test_objects {
@@ -1071,8 +1071,8 @@ fn set_fragment_reconstruct_two_components() {
 fn set_fragment_reconstruct_two_mutual() {
     let (committee, _, mut test_objects) = random_ckpoint_store_num(4);
 
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     for (_, cps) in &mut test_objects {
@@ -1130,8 +1130,8 @@ fn test_fragment_full_flow() {
 
     let (test_tx, rx) = TestConsensus::new();
 
-    let t2 = TransactionDigest::random();
-    let t3 = TransactionDigest::random();
+    let t2 = ExecutionDigests::random();
+    let t3 = ExecutionDigests::random();
     // let t6 = TransactionDigest::random();
 
     for (_, cps) in &mut test_objects {

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -11,7 +11,7 @@ use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use signature::Signer;
 use std::{fs::File, io::Write};
 use sui_types::{
-    base_types::{self, ObjectDigest, ObjectID, TransactionDigest},
+    base_types::{self, ObjectDigest, ObjectID, TransactionDigest, TransactionEffectsDigest},
     batch::UpdateItem,
     crypto::{get_key_pair, AuthoritySignature, Signature},
     error::SuiError,
@@ -53,6 +53,9 @@ fn get_registry() -> Result<Registry> {
     let td = TransactionDigest::random();
     tracer.trace_value(&mut samples, &od)?;
     tracer.trace_value(&mut samples, &td)?;
+
+    let teff = TransactionEffectsDigest::random();
+    tracer.trace_value(&mut samples, &teff)?;
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<SuiError>(&samples)?;

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -183,7 +183,7 @@ impl<C> SafeClient<C> {
         _request: BatchInfoRequest,
         signed_batch: &SignedBatch,
         transactions_and_last_batch: &Option<(
-            Vec<(TxSequenceNumber, TransactionDigest)>,
+            Vec<(TxSequenceNumber, ExecutionDigests)>,
             AuthorityBatch,
         )>,
     ) -> SuiResult {
@@ -263,7 +263,8 @@ where
                         Ok(BatchInfoResponseItem(UpdateItem::Batch(_signed_batch))) => None,
                         Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digest)))) => {
                             // Download the full transaction info
-                            let transaction_info_request = TransactionInfoRequest::from(*digest);
+                            let transaction_info_request =
+                                TransactionInfoRequest::from(digest.transaction);
                             let res = _client
                                 .handle_transaction_info_request(transaction_info_request)
                                 .await

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -11,7 +11,7 @@ use crate::{
 use futures::StreamExt;
 use std::sync::Arc;
 use sui_types::{
-    base_types::{dbg_addr, dbg_object_id, TransactionDigest},
+    base_types::{dbg_addr, dbg_object_id, ExecutionDigests},
     batch::UpdateItem,
     object::ObjectFormatOptions,
 };
@@ -118,7 +118,7 @@ async fn test_subscription() {
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    let tx_zero = TransactionDigest::new([0; 32]);
+    let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
         let ticket = state.batch_notifier.ticket().expect("all good");
         db.executed_sequence
@@ -313,7 +313,7 @@ async fn test_subscription_safe_client() {
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    let tx_zero = TransactionDigest::new([0; 32]);
+    let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
         let ticket = server.state.batch_notifier.ticket().expect("all good");
         db.executed_sequence

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -55,6 +55,12 @@ Data:
       Package:
         NEWTYPE:
           TYPENAME: MovePackage
+ExecutionDigests:
+  STRUCT:
+    - transaction:
+        TYPENAME: TransactionDigest
+    - effects:
+        TYPENAME: TransactionEffectsDigest
 ExecutionStatus:
   ENUM:
     0:
@@ -648,6 +654,8 @@ SuiError:
           - error: STR
 TransactionDigest:
   NEWTYPESTRUCT: BYTES
+TransactionEffectsDigest:
+  NEWTYPESTRUCT: BYTES
 TransactionKind:
   ENUM:
     0:
@@ -710,7 +718,7 @@ UpdateItem:
         NEWTYPE:
           TUPLE:
             - U64
-            - TYPENAME: TransactionDigest
+            - TYPENAME: ExecutionDigests
     1:
       Batch:
         NEWTYPE:

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -12,6 +12,7 @@ use anyhow::anyhow;
 use base64ct::Encoding;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use digest::Digest;
+use ed25519_dalek::Sha512;
 use hex::FromHex;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
@@ -226,6 +227,18 @@ pub struct TransactionDigest(
     [u8; TRANSACTION_DIGEST_LENGTH],
 );
 
+impl From<TransactionDigest> for RistrettoPoint {
+    fn from(other: TransactionDigest) -> RistrettoPoint {
+        RistrettoPoint::hash_from_bytes::<Sha512>(&other.0)
+    }
+}
+
+impl From<&TransactionDigest> for RistrettoPoint {
+    fn from(other: &TransactionDigest) -> RistrettoPoint {
+        RistrettoPoint::hash_from_bytes::<Sha512>(&other.0)
+    }
+}
+
 // Each object has a unique digest
 #[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
@@ -250,11 +263,20 @@ pub struct ExecutionDigests {
 }
 
 impl ExecutionDigests {
-    pub fn new(transaction : TransactionDigest, effects: TransactionEffectsDigest) -> Self {
+    pub fn new(transaction: TransactionDigest, effects: TransactionEffectsDigest) -> Self {
         Self {
             transaction,
-            effects
+            effects,
         }
+    }
+}
+
+impl From<&ExecutionDigests> for RistrettoPoint {
+    fn from(other: &ExecutionDigests) -> RistrettoPoint {
+        let mut data = [0; 64];
+        data[0..32].clone_from_slice(&other.transaction.0);
+        data[32..64].clone_from_slice(&other.effects.0);
+        RistrettoPoint::from_uniform_bytes(&data)
     }
 }
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -250,7 +250,7 @@ pub struct ObjectDigest(
 pub struct TransactionEffectsDigest(
     #[schemars(with = "Base64")]
     #[serde_as(as = "Readable<Base64, Bytes>")]
-    pub [u8; 32],
+    pub [u8; TRANSACTION_DIGEST_LENGTH],
 );
 
 impl TransactionEffectsDigest {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -244,14 +244,26 @@ pub struct ObjectDigest(
 ); // We use SHA3-256 hence 32 bytes here
 
 #[serde_as]
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema, Debug,
+)]
 pub struct TransactionEffectsDigest(
     #[schemars(with = "Base64")]
     #[serde_as(as = "Readable<Base64, Bytes>")]
     pub [u8; 32],
 );
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
+impl TransactionEffectsDigest {
+    // for testing
+    pub fn random() -> Self {
+        let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
+        Self(random_bytes)
+    }
+}
+
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema, Debug,
+)]
 pub struct ExecutionDigests {
     pub transaction: TransactionDigest,
     pub effects: TransactionEffectsDigest,
@@ -262,6 +274,13 @@ impl ExecutionDigests {
         Self {
             transaction,
             effects,
+        }
+    }
+
+    pub fn random() -> Self {
+        Self {
+            transaction: TransactionDigest::random(),
+            effects: TransactionEffectsDigest::random(),
         }
     }
 }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -32,6 +32,7 @@ use crate::object::{Object, Owner};
 use crate::sui_serde::Base64;
 use crate::sui_serde::Hex;
 use crate::sui_serde::Readable;
+use crate::waypoint::IntoPoint;
 
 #[cfg(test)]
 #[path = "unit_tests/base_types_tests.rs"]
@@ -239,6 +240,12 @@ impl From<&TransactionDigest> for RistrettoPoint {
     }
 }
 
+impl IntoPoint for TransactionDigest {
+    fn into_point(&self) -> RistrettoPoint {
+        RistrettoPoint::hash_from_bytes::<Sha512>(&self.0)
+    }
+}
+
 // Each object has a unique digest
 #[serde_as]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, JsonSchema)]
@@ -285,6 +292,15 @@ impl From<ExecutionDigests> for RistrettoPoint {
         let mut data = [0; 64];
         data[0..32].clone_from_slice(&other.transaction.0);
         data[32..64].clone_from_slice(&other.effects.0);
+        RistrettoPoint::from_uniform_bytes(&data)
+    }
+}
+
+impl IntoPoint for ExecutionDigests {
+    fn into_point(&self) -> RistrettoPoint {
+        let mut data = [0; 64];
+        data[0..32].clone_from_slice(&self.transaction.0);
+        data[32..64].clone_from_slice(&self.effects.0);
         RistrettoPoint::from_uniform_bytes(&data)
     }
 }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -228,18 +228,6 @@ pub struct TransactionDigest(
     [u8; TRANSACTION_DIGEST_LENGTH],
 );
 
-impl From<TransactionDigest> for RistrettoPoint {
-    fn from(other: TransactionDigest) -> RistrettoPoint {
-        RistrettoPoint::hash_from_bytes::<Sha512>(&other.0)
-    }
-}
-
-impl From<&TransactionDigest> for RistrettoPoint {
-    fn from(other: &TransactionDigest) -> RistrettoPoint {
-        RistrettoPoint::hash_from_bytes::<Sha512>(&other.0)
-    }
-}
-
 impl IntoPoint for TransactionDigest {
     fn into_point(&self) -> RistrettoPoint {
         RistrettoPoint::hash_from_bytes::<Sha512>(&self.0)
@@ -275,24 +263,6 @@ impl ExecutionDigests {
             transaction,
             effects,
         }
-    }
-}
-
-impl From<&ExecutionDigests> for RistrettoPoint {
-    fn from(other: &ExecutionDigests) -> RistrettoPoint {
-        let mut data = [0; 64];
-        data[0..32].clone_from_slice(&other.transaction.0);
-        data[32..64].clone_from_slice(&other.effects.0);
-        RistrettoPoint::from_uniform_bytes(&data)
-    }
-}
-
-impl From<ExecutionDigests> for RistrettoPoint {
-    fn from(other: ExecutionDigests) -> RistrettoPoint {
-        let mut data = [0; 64];
-        data[0..32].clone_from_slice(&other.transaction.0);
-        data[32..64].clone_from_slice(&other.effects.0);
-        RistrettoPoint::from_uniform_bytes(&data)
     }
 }
 

--- a/crates/sui-types/src/batch.rs
+++ b/crates/sui-types/src/batch.rs
@@ -1,24 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::base_types::{AuthorityName, TransactionDigest};
+use crate::base_types::{AuthorityName, ExecutionDigests};
 use crate::crypto::{sha3_hash, AuthoritySignature, BcsSignable};
 use crate::error::SuiError;
 use serde::{Deserialize, Serialize};
 
 pub type TxSequenceNumber = u64;
 
-/// Either a freshly sequenced transaction hash or a batch
+/// Either a freshly sequenced transaction/effects tuple of hashes or a batch
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum UpdateItem {
-    Transaction((TxSequenceNumber, TransactionDigest)),
+    Transaction((TxSequenceNumber, ExecutionDigests)),
     Batch(SignedBatch),
 }
 
 pub type BatchDigest = [u8; 32];
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
-pub struct TransactionBatch(pub Vec<(TxSequenceNumber, TransactionDigest)>);
+pub struct TransactionBatch(pub Vec<(TxSequenceNumber, ExecutionDigests)>);
 impl BcsSignable for TransactionBatch {}
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Default, Debug, Serialize, Deserialize)]
@@ -62,11 +62,11 @@ impl AuthorityBatch {
         }
     }
 
-    /// Make a batch, containing some transactions, and following the previous
+    /// Make a batch, containing some transaction/effects, and following the previous
     /// batch.
     pub fn make_next(
         previous_batch: &AuthorityBatch,
-        transactions: &[(TxSequenceNumber, TransactionDigest)],
+        transactions: &[(TxSequenceNumber, ExecutionDigests)],
     ) -> Result<AuthorityBatch, SuiError> {
         let transaction_vec = transactions.to_vec();
         if transaction_vec.is_empty() {

--- a/crates/sui-types/src/unit_tests/waypoint_tests.rs
+++ b/crates/sui-types/src/unit_tests/waypoint_tests.rs
@@ -19,6 +19,12 @@ fn make_item() -> Item {
     Item(item)
 }
 
+impl From<&Item> for RistrettoPoint {
+    fn from(other: &Item) -> RistrettoPoint {
+        RistrettoPoint::hash_from_bytes::<Sha512>(&other.0)
+    }
+}
+
 #[test]
 fn test_diff() {
     let mut first = Waypoint::default();
@@ -29,11 +35,11 @@ fn test_diff() {
     let v3 = make_item();
     let v4 = make_item();
 
-    first.insert(&v1);
+    first.insertx(&v1);
     first.insert(&v2);
     first.insert(&v3);
 
-    second.insert(&v1);
+    second.insertx(&v1);
     second.insert(&v2);
     second.insert(&v4);
 
@@ -45,7 +51,7 @@ fn test_diff() {
         second,
         vec![v3].into_iter(),
     );
-    assert!(diff.check());
+    assert!(diff.checkx());
 }
 
 #[test]

--- a/crates/sui-types/src/unit_tests/waypoint_tests.rs
+++ b/crates/sui-types/src/unit_tests/waypoint_tests.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use rand::Rng;
+use ed25519_dalek::Sha512;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Item([u8; 8]);
@@ -25,6 +26,12 @@ impl From<&Item> for RistrettoPoint {
     }
 }
 
+impl IntoPoint for Item {
+    fn into_point(&self) -> RistrettoPoint {
+        RistrettoPoint::hash_from_bytes::<Sha512>(&self.0)
+    }
+}
+
 #[test]
 fn test_diff() {
     let mut first = Waypoint::default();
@@ -35,11 +42,11 @@ fn test_diff() {
     let v3 = make_item();
     let v4 = make_item();
 
-    first.insertx(&v1);
+    first.insert(&v1);
     first.insert(&v2);
     first.insert(&v3);
 
-    second.insertx(&v1);
+    second.insert(&v1);
     second.insert(&v2);
     second.insert(&v4);
 
@@ -51,7 +58,7 @@ fn test_diff() {
         second,
         vec![v3].into_iter(),
     );
-    assert!(diff.checkx());
+    assert!(diff.check());
 }
 
 #[test]

--- a/crates/sui-types/src/unit_tests/waypoint_tests.rs
+++ b/crates/sui-types/src/unit_tests/waypoint_tests.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use rand::Rng;
 use ed25519_dalek::Sha512;
+use rand::Rng;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Item([u8; 8]);

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -78,7 +78,7 @@ async fn wait_for_tx(wait_digest: TransactionDigest, state: Arc<AuthorityState>)
                     // Upon receiving a transaction digest we store it, if it is not processed already.
                     Some(Ok(BatchInfoResponseItem(UpdateItem::Transaction((_seq, digest))))) => {
                         info!(?digest, "Received Transaction");
-                        if wait_digest == digest {
+                        if wait_digest == digest.transaction {
                             info!(?digest, "Digest found");
                             break;
                         }


### PR DESCRIPTION
This PR extends the information in `UpdateItems` sent by the follower API, as well as the information stored in checkpoints from only containing a `TransactionDigest` to also containing the `TransactionEffectsDigest`, in a new structure that we call `ExecutionDigest`.