### PR TITLE
[checkpoints] Added a previous hash to the checkpoint

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -14,8 +14,8 @@ use sui_types::{
     messages::{CertifiedTransaction, ConfirmationTransaction, TransactionInfoRequest},
     messages_checkpoint::{
         AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpoint, CheckpointContents,
-        CheckpointFragment, CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
-        SignedCheckpoint, SignedCheckpointProposal,
+        CheckpointDigest, CheckpointFragment, CheckpointRequest, CheckpointResponse,
+        CheckpointSequenceNumber, SignedCheckpoint, SignedCheckpointProposal,
     },
 };
 use tokio::time::timeout;
@@ -325,7 +325,7 @@ where
     // Attempt to construct a newer checkpoint from signed summaries.
     #[allow(clippy::type_complexity)]
     let mut partial_checkpoints: BTreeMap<
-        (CheckpointSequenceNumber, [u8; 32]),
+        (CheckpointSequenceNumber, CheckpointDigest),
         Vec<(AuthorityName, SignedCheckpoint)>,
     > = BTreeMap::new();
     final_state
@@ -550,7 +550,7 @@ where
                 detail: Some(contents),
             }) => {
                 // TODO: check here that the digest of contents matches
-                if contents.digest() != checkpoint.checkpoint.digest {
+                if contents.digest() != checkpoint.checkpoint.content_digest {
                     // A byzantine authority!
                     // TODO: Report Byzantine authority
                     warn!("Sync Error: Incorrect contents returned");

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -390,7 +390,7 @@ fn latest_proposal() {
         .collect();
 
     let transactions = CheckpointContents::new(ckp_items.clone().into_iter());
-    let summary = CheckpointSummary::new(0, &transactions);
+    let summary = CheckpointSummary::new(0, &transactions, None);
 
     cps1.handle_internal_set_checkpoint(summary.clone(), &transactions)
         .unwrap();
@@ -529,7 +529,7 @@ fn set_get_checkpoint() {
         .cloned();
 
     let transactions = CheckpointContents::new(ckp_items);
-    let summary = CheckpointSummary::new(0, &transactions);
+    let summary = CheckpointSummary::new(0, &transactions, None);
 
     cps1.handle_internal_set_checkpoint(summary.clone(), &transactions)
         .unwrap();
@@ -673,7 +673,13 @@ fn checkpoint_integration() {
             .chain(some_fresh_transactions.iter().cloned().map(|(_, d)| d))
             .collect();
         let transactions = CheckpointContents::new(unprocessed.clone().into_iter());
-        let summary = CheckpointSummary::new(cps.get_locals().next_checkpoint, &transactions);
+        let next_checkpoint = cps.get_locals().next_checkpoint;
+        let summary = CheckpointSummary::new(
+            next_checkpoint,
+            &transactions,
+            cps.get_prev_checkpoint_digest(next_checkpoint)
+                .expect("previous checkpoint should exist"),
+        );
 
         cps.handle_internal_set_checkpoint(summary.clone(), &transactions)
             .unwrap();


### PR DESCRIPTION
Addresses partially #2039 by adding the hash of the previous checkpoint to a checkpoint, thus creating a hash chain of checkpoints that can be authenticated from the latest one.