### PR TITLE
[sdk] Adds experimental section to sdk

### DIFF
--- a/sdk/typescript/src/experimental/README.md
+++ b/sdk/typescript/src/experimental/README.md
@@ -1,3 +1,6 @@
+> *WARNING* This part of the SDK contains experimental APIs for dapps.
+> It is not exported with SDK by default and should be used with caution.
+
 # Move BCS
 
 This library implements [Binary Canonical Serialization (BCS)](https://github.com/diem/bcs) in JavaScript, making BCS available in both Browser and NodeJS environments.
@@ -12,7 +15,7 @@ This library implements [Binary Canonical Serialization (BCS)](https://github.co
 
 ### Working with primitive types
 
-To deserialize data, use a `MoveBCS.de(type: string, data: string)`. Type parameter is a name of the type; data is a BCS encoded as hex. 
+To deserialize data, use a `MoveBCS.de(type: string, data: string)`. Type parameter is a name of the type; data is a BCS encoded as hex.
 
 ```js
 // MoveBCS has a set of built ins:
@@ -69,7 +72,7 @@ MoveBCS.registerStructType('Coin', {
 
 
 
-// Created in Rust with diem/bcs 
+// Created in Rust with diem/bcs
 let rust_bcs_str = '80d1b105600000000e4269672057616c6c65742047757900';
 
 console.log(MoveBCS.de('Coin', MoveBCS.util.fromHex(rust_bcs_str)));
@@ -84,10 +87,3 @@ let test_ser = MoveBCS.ser('Coin', {
 console.log(test_ser.toBytes());
 console.assert(MoveBCS.util.toHex(test_ser.toBytes()) === rust_bcs_str, 'Whoopsie, result mismatch');
 ```
-
-## TODO
-
-- [ ] Add support for `u128` serialization (deserialization is ready)
-- [ ] Improve frontend wrapper for better DevEx based on usage
-- [ ] Figure out an obvious way to add support for addresses
-<!-- Addresses differ on different platforms -->

--- a/sdk/typescript/src/experimental/b64.ts
+++ b/sdk/typescript/src/experimental/b64.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*\
+|*|  Base64 / binary data / UTF-8 strings utilities
+|*|  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Base64_encoding_and_decoding
+\*/
+
+/* Array of bytes to Base64 string decoding */
+
+function b64ToUint6(nChr: number) {
+  return nChr > 64 && nChr < 91 ?
+      nChr - 65
+    : nChr > 96 && nChr < 123 ?
+      nChr - 71
+    : nChr > 47 && nChr < 58 ?
+      nChr + 4
+    : nChr === 43 ?
+      62
+    : nChr === 47 ?
+      63
+    :
+      0;
+}
+
+export function fromB64(sBase64: string, nBlocksSize?: number): Uint8Array {
+  var
+    sB64Enc = sBase64.replace(/[^A-Za-z0-9\+\/]/g, ""), nInLen = sB64Enc.length,
+    nOutLen = nBlocksSize ? Math.ceil((nInLen * 3 + 1 >> 2) / nBlocksSize) * nBlocksSize : nInLen * 3 + 1 >> 2, taBytes = new Uint8Array(nOutLen);
+
+  for (var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx++) {
+    nMod4 = nInIdx & 3;
+    nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << 6 * (3 - nMod4);
+    if (nMod4 === 3 || nInLen - nInIdx === 1) {
+      for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
+        taBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
+      }
+      nUint24 = 0;
+
+    }
+  }
+
+  return taBytes;
+}
+
+/* Base64 string to array encoding */
+
+function uint6ToB64(nUint6: number) {
+  return nUint6 < 26
+    ? nUint6 + 65
+    : nUint6 < 52
+        ? nUint6 + 71
+        : nUint6 < 62
+            ? nUint6 - 4
+            : nUint6 === 62
+                ? 43
+                : nUint6 === 63
+                    ? 47
+                    : 65;
+}
+
+export function toB64(aBytes: Uint8Array): string {
+  var nMod3 = 2, sB64Enc = "";
+
+  for (var nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx < nLen; nIdx++) {
+    nMod3 = nIdx % 3;
+    if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0) { sB64Enc += "\r\n"; }
+    nUint24 |= aBytes[nIdx] << (16 >>> nMod3 & 24);
+    if (nMod3 === 2 || aBytes.length - nIdx === 1) {
+      sB64Enc += String.fromCodePoint(uint6ToB64(nUint24 >>> 18 & 63), uint6ToB64(nUint24 >>> 12 & 63), uint6ToB64(nUint24 >>> 6 & 63), uint6ToB64(nUint24 & 63));
+      nUint24 = 0;
+    }
+  }
+
+  return sB64Enc.slice(0, sB64Enc.length - 2 + nMod3) + (nMod3 === 2 ? '' : nMod3 === 1 ? '=' : '==');
+}

--- a/sdk/typescript/src/experimental/b64.ts
+++ b/sdk/typescript/src/experimental/b64.ts
@@ -64,7 +64,7 @@ export function toB64(aBytes: Uint8Array): string {
 
   for (var nLen = aBytes.length, nUint24 = 0, nIdx = 0; nIdx < nLen; nIdx++) {
     nMod3 = nIdx % 3;
-    if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0) { sB64Enc += "\r\n"; }
+    if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0) { sB64Enc += ""; } // sB64Enc = "\r\n";
     nUint24 |= aBytes[nIdx] << (16 >>> nMod3 & 24);
     if (nMod3 === 2 || aBytes.length - nIdx === 1) {
       sB64Enc += String.fromCodePoint(uint6ToB64(nUint24 >>> 18 & 63), uint6ToB64(nUint24 >>> 12 & 63), uint6ToB64(nUint24 >>> 6 & 63), uint6ToB64(nUint24 & 63));

--- a/sdk/typescript/src/experimental/bcs.ts
+++ b/sdk/typescript/src/experimental/bcs.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
+/*
  * BCS implementation {@see https://github.com/diem/bcs } for JavaScript.
  * Intended to be used for Move applications; supports both NodeJS and browser.
  *
@@ -11,9 +11,9 @@
  * @property {BcsReader}
  */
 
-import * as BN from 'bn.js';
-import { HexDataBuffer as HEX } from '../serialization/hex';
-import { Base64DataBuffer as B64 } from '../serialization/base64';
+import * as BN from "bn.js";
+import { toB64, fromB64 } from "./b64";
+import { toHEX, fromHEX } from "./hex";
 
 /**
  * Class used for reading BCS data chunk by chunk. Meant to be used
@@ -99,7 +99,7 @@ export class BcsReader {
   read64(): BN {
     let value1 = this.read32();
     let value2 = this.read32();
-    let result = value2.toString(16) + value1.toString(16).padStart(8, '0');
+    let result = value2.toString(16) + value1.toString(16).padStart(8, "0");
 
     return new BN.BN(result, 16);
   }
@@ -110,7 +110,7 @@ export class BcsReader {
   read128(): BN {
     let value1 = this.read64();
     let value2 = this.read64();
-    let result = value2.toString(16) + value1.toString(16).padStart(8, '0');
+    let result = value2.toString(16) + value1.toString(16).padStart(8, "0");
 
     return new BN.BN(result, 16);
   }
@@ -186,7 +186,10 @@ export class BcsWriter {
    */
   static toBN(number: number | BN | bigint | string): BN {
     switch (typeof number) {
-      case 'bigint':
+      case "boolean":
+        number = +number;
+        return new BN.BN(number.toString());
+      case "bigint":
         return new BN.BN(number.toString());
       default:
         return new BN.BN(number);
@@ -237,8 +240,8 @@ export class BcsWriter {
    */
   write64(value: bigint | BN): this {
     BcsWriter.toBN(value)
-      .toArray('le', 8)
-      .forEach(el => this.write8(el));
+      .toArray("le", 8)
+      .forEach((el) => this.write8(el));
 
     return this;
   }
@@ -251,8 +254,8 @@ export class BcsWriter {
    */
   write128(value: bigint | BN): this {
     BcsWriter.toBN(value)
-      .toArray('le', 16)
-      .forEach(el => this.write8(el));
+      .toArray("le", 16)
+      .forEach((el) => this.write8(el));
 
     return this;
   }
@@ -263,7 +266,7 @@ export class BcsWriter {
    * @returns {this}
    */
   writeULEB(value: number): this {
-    ulebEncode(value).forEach(el => this.write8(el));
+    ulebEncode(value).forEach((el) => this.write8(el));
     return this;
   }
   /**
@@ -275,7 +278,7 @@ export class BcsWriter {
    * @returns {this}
    */
   writeVec(
-    vector: Array<any>,
+    vector: any[],
     cb: (writer: BcsWriter, el: any, i: number, len: number) => {}
   ): this {
     this.writeULEB(vector.length);
@@ -284,10 +287,21 @@ export class BcsWriter {
   }
 
   /**
+   * Adds support for iterations over the object.
+   * @returns {Uint8Array}
+   */
+  *[Symbol.iterator](): Iterator<number, Iterable<number>> {
+    for (let i = 0; i < this.bytePosition; i++) {
+      yield this.dataView.getUint8(i);
+    }
+    return this.toBytes();
+  }
+
+  /**
    * Get underlying buffer taking only value bytes (in case initial buffer size was bigger).
    * @returns {Uint8Array} Resulting BCS.
    */
-  toBytes() {
+  toBytes(): Uint8Array {
     return new Uint8Array(this.dataView.buffer.slice(0, this.bytePosition));
   }
 
@@ -296,22 +310,13 @@ export class BcsWriter {
    * @param encoding Encoding to use: 'base64' or 'hex'
    */
   toString(encoding: string): string {
-    switch (encoding) {
-      case 'base64':
-        return new B64(this.toBytes()).toString();
-      case 'hex':
-        return new HEX(this.toBytes()).toString();
-      default:
-        throw new Error(
-          'Unsupported encoding, supported values are: base64, hex'
-        );
-    }
+    return encodeStr(this.toBytes(), encoding);
   }
 }
 
 // Helper utility: write number as an ULEB array.
 // Original code is taken from: https://www.npmjs.com/package/uleb128 (no longer exists)
-function ulebEncode(num: number): Array<number> {
+function ulebEncode(num: number): number[] {
   let arr = [];
   let len = 0;
 
@@ -332,9 +337,10 @@ function ulebEncode(num: number): Array<number> {
 
 // Helper utility: decode ULEB as an array of numbers.
 // Original code is taken from: https://www.npmjs.com/package/uleb128 (no longer exists)
-function ulebDecode(
-  arr: Array<number> | Uint8Array
-): { value: number; length: number } {
+function ulebDecode(arr: number[] | Uint8Array): {
+  value: number;
+  length: number;
+} {
   let total = 0;
   let shift = 0;
   let len = 0;
@@ -372,14 +378,14 @@ interface TypeInterface {
  */
 export class BCS {
   // Prefefined types constants
-  static readonly U8: string = 'u8';
-  static readonly U32: string = 'u32';
-  static readonly U64: string = 'u64';
-  static readonly U128: string = 'u128';
-  static readonly BOOL: string = 'bool';
-  static readonly VECTOR: string = 'vector';
-  static readonly ADDRESS: string = 'address';
-  static readonly STRING: string = 'string';
+  static readonly U8: string = "u8";
+  static readonly U32: string = "u32";
+  static readonly U64: string = "u64";
+  static readonly U128: string = "u128";
+  static readonly BOOL: string = "bool";
+  static readonly VECTOR: string = "vector";
+  static readonly ADDRESS: string = "address";
+  static readonly STRING: string = "string";
 
   private static types: Map<string, TypeInterface> = new Map();
 
@@ -400,7 +406,7 @@ export class BCS {
    * @param size Serialization buffer size. Default 1024 = 1KB.
    * @return A BCS reader instance. Usually you'd want to call `.toBytes()`
    */
-  public static set(type: string, data: any, size: number = 1024): BcsWriter {
+  public static ser(type: string, data: any, size: number = 1024): BcsWriter {
     return this.getTypeInterface(type).encode(data, size);
   }
 
@@ -490,17 +496,34 @@ export class BCS {
    *
    * @param name Name of the address type.
    * @param length Byte length of the address.
+   * @param encoding Encoding to use for the address type
    * @returns
    */
-  public static registerAddressType(name: string, length: number): typeof BCS {
-    return this.registerType(
-      name,
-      (writer, data) =>
-        new HEX(data)
-          .getData()
-          .reduce((writer, el) => writer.write8(el), writer),
-      reader => new HEX(reader.readBytes(length)).toString()
-    );
+  public static registerAddressType(
+    name: string,
+    length: number,
+    encoding: string | void = "hex"
+  ): typeof BCS {
+    // todo: create a common interface?
+    // @ts-ignore
+    let proxyClass;
+
+    switch (encoding) {
+      case "base64":
+        return this.registerType(
+          name,
+          (writer, data) => fromB64(data).reduce((writer, el) => writer.write8(el), writer),
+          (reader) => toB64(reader.readBytes(length))
+        );
+      case "hex":
+        return this.registerType(
+          name,
+          (writer, data) => fromHEX(data).reduce((writer, el) => writer.write8(el), writer),
+          (reader) => toHEX(reader.readBytes(length))
+        );
+      default:
+        throw new Error("Unsupported encoding! Use either hex or base64");
+    }
   }
 
   /**
@@ -511,27 +534,26 @@ export class BCS {
    * let array = BCS.de('vector<u8>', new Uint8Array([6,1,2,3,4,5,6])); // [1,2,3,4,5,6];
    * let again = BCS.set('vector<u8>', [1,2,3,4,5,6]).toBytes();
    *
+   * BCS.registerVectorType('vector<u8>', 'u8', 'hex');
+   * let array =
+   *
    * @param name Name of the type to register.
    * @param elementType Name of the inner type of the vector.
+   * @param encoding Either 'base64' or 'hex' to enable string<->vector conversions
    * @return Returns self for chaining.
    */
   public static registerVectorType(
     name: string,
     elementType: string
   ): typeof BCS {
-    // OMITTING SAFETY CHECK TO ALLOW RECURSIVE DEFINITIONS
-    // if (!BCS.hasType(elementType)) {
-    //     throw new Error(`Type ${elementType} is not registered`);
-    // }
-
     return this.registerType(
       name,
       (writer, data) =>
         writer.writeVec(data, (writer, el) => {
           return BCS.getTypeInterface(elementType)._encodeRaw(writer, el);
         }),
-      reader =>
-        reader.readVec(reader => {
+      (reader) =>
+        reader.readVec((reader) => {
           return BCS.getTypeInterface(elementType)._decodeRaw(reader);
         })
     );
@@ -594,21 +616,21 @@ export class BCS {
 
     // Make sure all the types in the fields description are already known
     // and that all the field types are strings.
-    // OMITTING this check to allow recursive definitions and dynamic typing.
-    // for (let type of Object.values(struct)) {
-    //         throw new Error(`Type ${type} is not registered`);
-    //     }
-    // }
-
     return this.registerType(
       name,
       (writer, data) => {
         for (let key of canonicalOrder) {
-          BCS.getTypeInterface(struct[key])._encodeRaw(writer, data[key]);
+          if (key in data) {
+            BCS.getTypeInterface(struct[key])._encodeRaw(writer, data[key]);
+          } else {
+            throw new Error(
+              `Struct ${name} requires field ${key}:${struct[key]}`
+            );
+          }
         }
         return writer;
       },
-      reader => {
+      (reader) => {
         let result: { [key: string]: any } = {};
         for (let key of canonicalOrder) {
           result[key] = BCS.getTypeInterface(struct[key])._decodeRaw(reader);
@@ -655,6 +677,9 @@ export class BCS {
     return this.registerType(
       name,
       (writer, data) => {
+        if (data === undefined) {
+          throw new Error(`Unable to write enum ${name}, missing data`);
+        }
         let key = Object.keys(data)[0];
         if (key === undefined) {
           throw new Error(`Unknown invariant of the enum ${name}`);
@@ -676,7 +701,7 @@ export class BCS {
           ? BCS.getTypeInterface(invariantType)._encodeRaw(writer, data[key])
           : writer;
       },
-      reader => {
+      (reader) => {
         let orderByte = reader.readULEB();
         let invariant = canonicalOrder[orderByte];
         let invariantType = struct[invariant];
@@ -706,39 +731,79 @@ export class BCS {
   }
 }
 
+/**
+ * Encode data with either `hex` or `base64`.
+ *
+ * @param {Uint8Array} data Data to encode.
+ * @param {String} encoding Encoding to use: base64 or hex
+ * @return {String} Encoded value.
+ */
+export function encodeStr(data: Uint8Array, encoding: string): string {
+  switch (encoding) {
+    case "base64":
+      return toB64(data);
+    case "hex":
+      return toHEX(data);
+    default:
+      throw new Error(
+        "Unsupported encoding, supported values are: base64, hex"
+      );
+  }
+}
+
+/**
+ * Decode either `base64` or `hex` data.
+ *
+ * @param {String} data Data to encode.
+ * @param {String} encoding Encoding to use: base64 or hex
+ * @return {Uint8Array} Encoded value.
+ */
+export function decodeStr(data: string, encoding: string): Uint8Array {
+  switch (encoding) {
+    case "base64":
+      return fromB64(data);
+    case "hex":
+      return fromHEX(data);
+    default:
+      throw new Error(
+        "Unsupported encoding, supported values are: base64, hex"
+      );
+  }
+}
+
 (function registerPrimitives(): void {
   BCS.registerType(
     BCS.U8,
     (writer, data) => writer.write8(data),
-    reader => reader.read8(),
-    u8 => u8 < 256
+    (reader) => reader.read8(),
+    (u8) => u8 < 256
   );
 
   BCS.registerType(
     BCS.U32,
     (writer, data) => writer.write32(data),
-    reader => reader.read32(),
-    u32 => u32 < 4294967296
+    (reader) => reader.read32(),
+    (u32) => u32 < 4294967296
   );
 
   BCS.registerType(
     BCS.U64,
     (writer, data) => writer.write64(data),
-    reader => reader.read64(),
-    _u64 => true
+    (reader) => reader.read64(),
+    (_u64) => true
   );
 
   BCS.registerType(
     BCS.U128,
     (writer, data) => writer.write128(data),
-    reader => reader.read128(),
-    _u128 => true
+    (reader) => reader.read128(),
+    (_u128) => true
   );
 
   BCS.registerType(
     BCS.BOOL,
     (writer, data) => writer.write8(data),
-    reader => reader.read8().toString(10) == '1',
+    (reader) => reader.read8().toString(10) == "1",
     (_bool: boolean) => true
   );
 
@@ -748,11 +813,11 @@ export class BCS {
       writer.writeVec(Array.from(data), (writer, el) =>
         writer.write8(el.charCodeAt(0))
       ),
-    reader => {
+    (reader) => {
       return reader
-        .readVec(reader => reader.read8())
-        .map(el => String.fromCharCode(el))
-        .join('');
+        .readVec((reader) => reader.read8())
+        .map((el) => String.fromCharCode(el))
+        .join("");
     },
     (str: string) => /^[\x00-\x7F]*$/.test(str)
   );

--- a/sdk/typescript/src/experimental/hex.ts
+++ b/sdk/typescript/src/experimental/hex.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export function fromHEX(hexStr: string): Uint8Array {
+    // @ts-ignore
+    let intArr = hexStr
+        .replace('0x', '')
+        .match(/.{1,2}/g).map((byte) => parseInt(byte, 16));
+
+    if (intArr === null) {
+        throw new Error(`Unable to parse HEX: ${hexStr}`);
+    }
+
+    return Uint8Array.from(intArr);
+}
+
+export function toHEX(bytes: Uint8Array): string {
+    return bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
+}

--- a/sdk/typescript/src/experimental/index.ts
+++ b/sdk/typescript/src/experimental/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * as bcs from './bcs';
+export * from './b64';
+export * from './hex';
+export * from './module';
+export * from './types';

--- a/sdk/typescript/src/experimental/module.ts
+++ b/sdk/typescript/src/experimental/module.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    SuiObjectRef,
+    CallArg,
+    TypeTag,
+    MoveCallTx,
+} from './types';
+
+export class MoveModule {
+    constructor(public pkg: SuiObjectRef, public name: string) {}
+
+    public call(
+        method: string,
+        type_args: TypeTag[],
+        args: CallArg[]
+    ): MoveCallTx {
+        return {
+            Call: {
+                package: this.pkg,
+                module: this.name,
+                function: method,
+                typeArguments: type_args,
+                arguments: args,
+            },
+        };
+    }
+}

--- a/sdk/typescript/src/experimental/types.ts
+++ b/sdk/typescript/src/experimental/types.ts
@@ -1,0 +1,253 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Types and Interface definitions for the SDK.
+ *
+ * They provide the foundation for the TypeScript system which mimics
+ * the underlying BCS structs.
+ *
+ * @module sui-types
+ */
+
+import { BCS, decodeStr, encodeStr } from "./bcs";
+
+// This buddy collects definitions for BCS.
+const initializers: Function[] = [];
+
+initializers.push((b: typeof BCS) =>
+  b
+    .registerVectorType("vector<u8>", "u8")
+    .registerVectorType("vector<vector<u8>>", "vector<u8>")
+    .registerAddressType("ObjectID", 20)
+    .registerAddressType("SuiAddress", 20)
+    .registerType(
+      "ObjectDigest",
+      (writer, str) => {
+        let bytes = Array.from(decodeStr(str, 'base64'));
+        return writer.writeVec(bytes, (writer, el) => writer.write8(el));
+      },
+      (reader) => {
+        let bytes = reader.readVec((reader) => reader.read8());
+        return encodeStr(new Uint8Array(bytes), 'base64');
+      }
+    )
+);
+
+export type SuiObjectRef = {
+  objectId: string;
+  version: number;
+  digest: string;
+}
+
+initializers.push((b: typeof BCS) =>
+  b.registerStructType("SuiObjectRef", {
+    objectId: "ObjectID",
+    version: "u64",
+    digest: "ObjectDigest",
+  })
+);
+
+/**
+ * Transaction type used for transfering Coin objects between accounts.
+ * For this transaction to be executed, and `SuiObjectRef` should be queried
+ * upfront and used as a parameter.
+ */
+export type TransferCoinTx = {
+  TransferCoin: {
+    recipient: string;
+    object_ref: SuiObjectRef;
+  };
+}
+
+initializers.push((b: typeof BCS) =>
+  b.registerStructType("TransferCoinTx", {
+    recipient: "SuiAddress",
+    object_ref: "SuiObjectRef",
+  })
+);
+
+/**
+ * Transaction type used for publishing Move modules to the Sui.
+ * Should be already compiled using `sui-move`, example:
+ * ```
+ * $ sui-move build
+ * $ cat build/project_name/bytecode_modules/module.mv
+ * ```
+ * In JS:
+ * ```
+ * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv');
+ * let bytes = Array.from(bytes);
+ * let modules = [ bytes ];
+ *
+ * // ... publish logic ...
+ * ```
+ *
+ * Each module should be represented as a sequence of bytes.
+ */
+export type PublishTx = {
+  Publish: {
+    modules: Iterable<Iterable<number>>;
+  };
+}
+
+initializers.push((b: typeof BCS) =>
+  b.registerStructType("PublishTx", {
+    modules: "vector<vector<u8>>",
+  })
+);
+
+// ========== Move Call Tx ===========
+
+/**
+ * An argument for the transaction. It is a 'meant' enum which expects to have
+ * one of the optional properties. If not, the BCS error will be thrown while
+ * attempting to form a transaction.
+ *
+ * Example:
+ * ```js
+ * let arg1: CallArg = { SharedObject: '5460cf92b5e3e7067aaace60d88324095fd22944' };
+ * let arg2: CallArg = { Pure: bcs.ser('u64', 100000) };
+ * let arg3: CallArg = { ImmOrOwnedObject: {
+ *   ObjectID: '4047d2e25211d87922b6650233bd0503a6734279',
+ *   SequenceNumber: 1,
+ *   ObjectDigest: Buffer.from('bCiANCht4O9MEUhuYjdRCqRPZjr2rJ8MfqNiwyhmRgA=', 'base64')
+ * } };
+ * ```
+ *
+ * For `Pure` arguments BCS is required. You must encode the values with BCS according
+ * to the type required by the called function. Pure accepts only serialized values
+ */
+export type CallArg =
+  | { SharedObject: string }
+  | { Pure: Iterable<number> }
+  | { ImmOrOwnedObject: SuiObjectRef }
+
+initializers.push((b: typeof BCS) =>
+  b.registerEnumType("CallArg", {
+    Pure: "vector<u8>",
+    ImmOrOwnedObject: "SuiObjectRef",
+    SharedObject: "ObjectID",
+  })
+);
+
+export type StructTag = {
+  address: string,
+  module: string,
+  name: string,
+  typeParams: TypeTag[]
+};
+
+export type TypeTag =
+  | { bool: null }
+  | { u8: null }
+  | { u64: null }
+  | { u128: null }
+  | { address: null }
+  | { signer: null }
+  | { vector: TypeTag }
+  | { struct: StructTag }
+
+initializers.push((b: typeof BCS) => b
+  .registerEnumType('TypeTag', {
+    bool: null,
+    u8: null,
+    u64: null,
+    u128: null,
+    address: null,
+    signer: null,
+    vector: 'TypeTag',
+    struct: 'StructTag'
+  })
+  .registerVectorType('vector<TypeTag>', 'TypeTag')
+  .registerStructType('StructTag', {
+    address: 'string',
+    module: 'string',
+    name: 'string',
+    typeParams: 'vector<TypeTag>'
+  })
+);
+
+/**
+ * Transaction type used for calling Move modules' functions.
+ * Should be crafted carefully, because the order of type parameters and
+ * arguments matters.
+ */
+export type MoveCallTx = {
+  Call: {
+    package: SuiObjectRef;
+    module: string;
+    function: string;
+    typeArguments: TypeTag[];
+    arguments: CallArg[];
+  };
+}
+
+initializers.push((b: typeof BCS) =>
+  b
+    .registerVectorType("vector<CallArg>", "CallArg")
+    .registerStructType("MoveCallTx", {
+      package: "SuiObjectRef",
+      module: "string",
+      function: "string",
+      typeArguments: "vector<TypeTag>",
+      arguments: "vector<CallArg>",
+    })
+);
+
+// ========== TransactionData ===========
+
+export type Transaction = MoveCallTx | PublishTx | TransferCoinTx;
+
+initializers.push((b: typeof BCS) =>
+  b.registerEnumType("Transaction", {
+    TransferCoin: "TransferCoinTx",
+    Publish: "PublishTx",
+    Call: "MoveCallTx",
+  })
+);
+
+export type TransactionKind =
+  | { Single: Transaction }
+  | { Batch: Transaction[] };
+
+initializers.push((b: typeof BCS) =>
+  b
+    .registerVectorType("vector<Transaction>", "Transaction")
+    .registerEnumType("TransactionKind", {
+      Single: "Transaction",
+      Batch: "vector<Transaction>",
+    })
+);
+
+/**
+ * The TransactionData to be signed and sent to the Gateway service.
+ *
+ * Field `sender` is made optional as it can be added during the signing
+ * process and there's no need to define it sooner.
+ */
+export type TransactionData = {
+  sender?: string; //
+  gasBudget: number;
+  kind: TransactionKind;
+  gasPayment: SuiObjectRef;
+}
+
+initializers.push((b: typeof BCS) =>
+  b.registerStructType("TransactionData", {
+    kind: "TransactionKind",
+    sender: "SuiAddress",
+    gasPayment: "SuiObjectRef",
+    gasBudget: "u64",
+  })
+);
+
+/**
+ * Initialize BCS definitions.
+ * @param {BCS} bcs
+ */
+export function registerTypes(bcs: typeof BCS) {
+  for (let init of initializers) {
+    init(bcs);
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -21,4 +21,4 @@ export * from './signers/signer-with-provider';
 export * from './types';
 export * from './index.guard';
 
-export * as BCS from './bcs';
+export * as experimental from './experimental';

--- a/sdk/typescript/test/bcs/bcs.test.ts
+++ b/sdk/typescript/test/bcs/bcs.test.ts
@@ -1,9 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { BCS } from '../../src/experimental/bcs';
+import { bcs } from '../../src/experimental';
 import { Base64DataBuffer as B64 } from '../../src';
 import { BN } from 'bn.js';
+
+const { BCS } = bcs;
 
 describe('Move BCS', () => {
   beforeEach(() => {

--- a/sdk/typescript/test/bcs/bcs.test.ts
+++ b/sdk/typescript/test/bcs/bcs.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { BCS } from '../../src/bcs';
+import { BCS } from '../../src/experimental/bcs';
 import { Base64DataBuffer as B64 } from '../../src';
 import { BN } from 'bn.js';
 
@@ -18,7 +18,7 @@ describe('Move BCS', () => {
   it('should ser/de u64', () => {
     const exp = 'AO/Nq3hWNBI=';
     const num = BigInt('1311768467750121216');
-    const set = BCS.set('u64', num).toBytes();
+    const set = BCS.ser('u64', num).toBytes();
 
     expect(new B64(set).toString()).toEqual(exp);
     expect(BCS.de('u64', new B64(exp).getData())).toEqual(
@@ -33,7 +33,7 @@ describe('Move BCS', () => {
     expect(BCS.de('u128', sample.getData()).toString(10)).toEqual(
       '1111311768467750121216'
     );
-    expect(new B64(BCS.set('u128', num).toBytes()).toString()).toEqual(
+    expect(new B64(BCS.ser('u128', num).toBytes()).toString()).toEqual(
       sample.toString()
     );
   });
@@ -52,7 +52,7 @@ describe('Move BCS', () => {
       is_locked: false,
     };
 
-    const setBytes = BCS.set('Coin', expected);
+    const setBytes = BCS.ser('Coin', expected);
 
     expect(BCS.de('Coin', rustBcs.getData())).toEqual(expected);
     expect(setBytes.toString('base64')).toEqual(rustBcs.toString());
@@ -69,7 +69,7 @@ describe('Move BCS', () => {
 
     // create the same vec with 1000 elements
     let arr = Array.from(Array(1000)).map(() => 255);
-    const serialized = BCS.set('vector<u8>', arr);
+    const serialized = BCS.ser('vector<u8>', arr);
 
     expect(deserialized.length).toEqual(1000);
     expect(serialized.toString('base64')).toEqual(largeBCSVec());
@@ -88,8 +88,8 @@ describe('Move BCS', () => {
     let example2 = new B64('AQIBAAAAAAAAAAIAAAAAAAAA');
 
     // serialize 2 objects with the same data and signature
-    let set1 = BCS.set('Enum', { single: { value: 10000000 } }).toBytes();
-    let set2 = BCS.set('Enum', {
+    let set1 = BCS.ser('Enum', { single: { value: 10000000 } }).toBytes();
+    let set2 = BCS.ser('Enum', {
       multi: [{ value: 1 }, { value: 2 }],
     }).toBytes();
 
@@ -124,7 +124,7 @@ describe('Move BCS', () => {
     // Test Transfer tx
     let sample = transactionData().transfer;
     let de = BCS.de('TransactionData', sample.getData());
-    expect(BCS.set('TransactionData', de).toString('base64')).toEqual(
+    expect(BCS.ser('TransactionData', de).toString('base64')).toEqual(
       sample.toString()
     );
   });
@@ -133,7 +133,7 @@ describe('Move BCS', () => {
     // Test Module publish tx
     let sample = transactionData().module_publish;
     let de = BCS.de('TransactionData', sample.getData());
-    expect(BCS.set('TransactionData', de).toString('base64')).toEqual(
+    expect(BCS.ser('TransactionData', de).toString('base64')).toEqual(
       sample.toString()
     );
   });
@@ -144,9 +144,9 @@ describe('Move BCS', () => {
     let de = BCS.de('TransactionData', sample.getData());
 
     // Buffer size in this example is increased to 20KB
-    // @see BCS.set(type, data, [SIZE=1024]);
+    // @see BCS.ser(type, data, [SIZE=1024]);
     expect(
-      BCS.set('TransactionData', de, 1024 * 20).toString('base64')
+      BCS.ser('TransactionData', de, 1024 * 20).toString('base64')
     ).toEqual(sample.toString());
   });
 });


### PR DESCRIPTION
This PR isolates BCS and libraries for it in the `experimental` section. If it is required, we could even remove it from SDK's default imports.