### PR TITLE
[governance] implement locked coin and delegation with it

### DIFF
--- a/crates/sui-framework/sources/Coin.move
+++ b/crates/sui-framework/sources/Coin.move
@@ -212,4 +212,12 @@ module Sui::Coin {
     public fun mint_for_testing<T>(value: u64, ctx: &mut TxContext): Coin<T> {
         Coin { id: TxContext::new_id(ctx), balance: Balance::create_with_value(value) }
     }
+
+    #[test_only]
+    /// Destroy a `Coin` with any value in it for testing purposes.
+    public fun destroy_for_testing<T>(self: Coin<T>): u64 {
+        let Coin { id, balance } = self;
+        ID::delete(id);
+        Balance::destroy_for_testing(balance)
+    }
 }

--- a/crates/sui-framework/sources/EpochTimeLock.move
+++ b/crates/sui-framework/sources/EpochTimeLock.move
@@ -1,0 +1,29 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module Sui::EpochTimeLock {
+    use Sui::TxContext::{Self, TxContext};
+
+    /// The epoch passed into the creation of a lock has already passed.
+    const EEPOCH_ALREADY_PASSED: u64 = 0;
+    /// Attempt is made to unlock a lock that cannot be unlocked yet.
+    const EEPOCH_STILL_LOCKED: u64 = 1;
+
+    /// Holder of an epoch number that can only be discarded in the epoch or
+    /// after the epoch has passed.
+    struct EpochTimeLock has store {
+        epoch: u64
+    }
+
+    /// Create a new epoch time lock with `epoch`. Aborts if the current epoch is less than the input epoch.
+    public fun new(epoch: u64, ctx: &mut TxContext) : EpochTimeLock {
+        assert!(TxContext::epoch(ctx) < epoch, EEPOCH_ALREADY_PASSED);
+        EpochTimeLock { epoch }
+    }
+
+    /// Destroys an epoch time lock. Aborts if the current epoch is less than the locked epoch.
+    public fun destroy(lock: EpochTimeLock, ctx: &mut TxContext) {
+        let EpochTimeLock { epoch } = lock;
+        assert!(TxContext::epoch(ctx) >= epoch, EEPOCH_STILL_LOCKED);
+    }
+}

--- a/crates/sui-framework/sources/Governance/SuiSystem.move
+++ b/crates/sui-framework/sources/Governance/SuiSystem.move
@@ -7,6 +7,7 @@ module Sui::SuiSystem {
     use Sui::Delegation::{Self, Delegation};
     use Sui::EpochRewardRecord::{Self, EpochRewardRecord};
     use Sui::ID::{Self, VersionedID};
+    use Sui::LockedCoin::{Self, LockedCoin};
     use Sui::SUI::SUI;
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
@@ -167,6 +168,20 @@ module Sui::SuiSystem {
         // Delegation starts from the next epoch.
         let starting_epoch = self.epoch + 1;
         Delegation::create(starting_epoch, validator_address, delegate_stake, ctx);
+    }
+
+    public entry fun request_add_delegation_with_locked_coin(
+        self: &mut SuiSystemState,
+        delegate_stake: LockedCoin<SUI>,
+        validator_address: address,
+        ctx: &mut TxContext,
+    ) {
+        let amount = LockedCoin::value(&delegate_stake);
+        ValidatorSet::request_add_delegation(&mut self.validators, validator_address, amount);
+
+        // Delegation starts from the next epoch.
+        let starting_epoch = self.epoch + 1;
+        Delegation::create_from_locked_coin(starting_epoch, validator_address, delegate_stake, ctx);
     }
 
     public entry fun request_remove_delegation(

--- a/crates/sui-framework/sources/LockedCoin.move
+++ b/crates/sui-framework/sources/LockedCoin.move
@@ -4,38 +4,35 @@
 module Sui::LockedCoin {
     use Sui::Balance::{Self, Balance};
     use Sui::Coin::{Self, Coin};
-    use Std::Errors;
     use Sui::ID::{Self, VersionedID};
     use Sui::Transfer;
     use Sui::TxContext::{Self, TxContext};
+    use Sui::EpochTimeLock::{Self, EpochTimeLock};
 
-    /// The locked_until time passed into the creation of a locked coin is invalid.
-    const EINVALID_LOCK_UNTIL: u64 = 0;
-    /// Attempt is made to unlock a locked coin that has not been unlocked yet.
-    const ECOIN_STILL_LOCKED: u64 = 1;
+    friend Sui::Delegation;
 
     /// A coin of type `T` locked until `locked_until_epoch`.
     struct LockedCoin<phantom T> has key, store {
         id: VersionedID,
         balance: Balance<T>,
-        locked_until_epoch: u64
+        locked_until_epoch: EpochTimeLock
     }
 
-    /// Returns the epoch until which the coin is locked.
-    public fun locked_until_epoch<T>(locked_coin: &LockedCoin<T>) : u64 {
-        locked_coin.locked_until_epoch
-    }
-
-    /// Wrap a balance into a LockedCoin.
-    public fun from_balance<T>(balance: Balance<T>, locked_until_epoch: u64, ctx: &mut TxContext): LockedCoin<T> {
-        LockedCoin { id: TxContext::new_id(ctx), balance, locked_until_epoch }
+    /// Create a LockedCoin from `balance` and transfer it to `owner`.
+    public fun new_from_balance<T>(balance: Balance<T>, locked_until_epoch: EpochTimeLock, owner: address, ctx: &mut TxContext) {
+        let locked_coin = LockedCoin {
+            id: TxContext::new_id(ctx),
+            balance,
+            locked_until_epoch
+        };
+        Transfer::transfer(locked_coin, owner);
     }
 
     /// Destruct a LockedCoin wrapper and keep the balance.
-    public fun into_balance<T>(coin: LockedCoin<T>): Balance<T> {
-        let LockedCoin { id, locked_until_epoch: _, balance } = coin;
+    public(friend) fun into_balance<T>(coin: LockedCoin<T>): (Balance<T>, EpochTimeLock) {
+        let LockedCoin { id, locked_until_epoch, balance } = coin;
         ID::delete(id);
-        balance
+        (balance, locked_until_epoch)
     }
 
     /// Public getter for the locked coin's value
@@ -49,10 +46,8 @@ module Sui::LockedCoin {
     public entry fun lock_coin<T>(
         coin: Coin<T>, recipient: address, locked_until_epoch: u64, ctx: &mut TxContext
     ) {
-        assert!(TxContext::epoch(ctx) < locked_until_epoch, Errors::invalid_argument(EINVALID_LOCK_UNTIL));
         let balance = Coin::into_balance(coin);
-        let locked_coin = LockedCoin { id: TxContext::new_id(ctx), balance, locked_until_epoch };
-        Transfer::transfer(locked_coin, recipient);
+        new_from_balance(balance, EpochTimeLock::new(locked_until_epoch, ctx), recipient, ctx);
     }
 
     /// Unlock a locked coin. The function aborts if the current epoch is less than the `locked_until_epoch`
@@ -60,8 +55,8 @@ module Sui::LockedCoin {
     /// to the sender.
     public entry fun unlock_coin<T>(locked_coin: LockedCoin<T>, ctx: &mut TxContext) {
         let LockedCoin { id, balance, locked_until_epoch } = locked_coin;
-        assert!(TxContext::epoch(ctx) >= locked_until_epoch, Errors::invalid_argument(ECOIN_STILL_LOCKED));
         ID::delete(id);
+        EpochTimeLock::destroy(locked_until_epoch, ctx);
         let coin = Coin::from_balance(balance, ctx);
         Transfer::transfer(coin, TxContext::sender(ctx));
     }

--- a/crates/sui-framework/sources/LockedCoin.move
+++ b/crates/sui-framework/sources/LockedCoin.move
@@ -1,0 +1,68 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module Sui::LockedCoin {
+    use Sui::Balance::{Self, Balance};
+    use Sui::Coin::{Self, Coin};
+    use Std::Errors;
+    use Sui::ID::{Self, VersionedID};
+    use Sui::Transfer;
+    use Sui::TxContext::{Self, TxContext};
+
+    /// The locked_until time passed into the creation of a locked coin is invalid.
+    const EINVALID_LOCK_UNTIL: u64 = 0;
+    /// Attempt is made to unlock a locked coin that has not been unlocked yet.
+    const ECOIN_STILL_LOCKED: u64 = 1;
+
+    /// A coin of type `T` locked until `locked_until_epoch`.
+    struct LockedCoin<phantom T> has key, store {
+        id: VersionedID,
+        balance: Balance<T>,
+        locked_until_epoch: u64
+    }
+
+    /// Returns the epoch until which the coin is locked.
+    public fun locked_until_epoch<T>(locked_coin: &LockedCoin<T>) : u64 {
+        locked_coin.locked_until_epoch
+    }
+
+    /// Wrap a balance into a LockedCoin.
+    public fun from_balance<T>(balance: Balance<T>, locked_until_epoch: u64, ctx: &mut TxContext): LockedCoin<T> {
+        LockedCoin { id: TxContext::new_id(ctx), balance, locked_until_epoch }
+    }
+
+    /// Destruct a LockedCoin wrapper and keep the balance.
+    public fun into_balance<T>(coin: LockedCoin<T>): Balance<T> {
+        let LockedCoin { id, locked_until_epoch: _, balance } = coin;
+        ID::delete(id);
+        balance
+    }
+
+    /// Public getter for the locked coin's value
+    public fun value<T>(self: &LockedCoin<T>): u64 {
+        Balance::value(&self.balance)
+    }
+
+    /// Lock a coin up until `locked_until_epoch`. The input Coin<T> is deleted and a LockedCoin<T>
+    /// is transferred to the `recipient`. This function aborts if the `locked_until_epoch` is less than
+    /// or equal to the current epoch.
+    public entry fun lock_coin<T>(
+        coin: Coin<T>, recipient: address, locked_until_epoch: u64, ctx: &mut TxContext
+    ) {
+        assert!(TxContext::epoch(ctx) < locked_until_epoch, Errors::invalid_argument(EINVALID_LOCK_UNTIL));
+        let balance = Coin::into_balance(coin);
+        let locked_coin = LockedCoin { id: TxContext::new_id(ctx), balance, locked_until_epoch };
+        Transfer::transfer(locked_coin, recipient);
+    }
+
+    /// Unlock a locked coin. The function aborts if the current epoch is less than the `locked_until_epoch`
+    /// of the coin. If the check is successful, the locked coin is deleted and a Coin<T> is transferred back
+    /// to the sender.
+    public entry fun unlock_coin<T>(locked_coin: LockedCoin<T>, ctx: &mut TxContext) {
+        let LockedCoin { id, balance, locked_until_epoch } = locked_coin;
+        assert!(TxContext::epoch(ctx) >= locked_until_epoch, Errors::invalid_argument(ECOIN_STILL_LOCKED));
+        ID::delete(id);
+        let coin = Coin::from_balance(balance, ctx);
+        Transfer::transfer(coin, TxContext::sender(ctx));
+    }
+}

--- a/crates/sui-framework/sources/TestScenario.move
+++ b/crates/sui-framework/sources/TestScenario.move
@@ -110,7 +110,13 @@ module Sui::TestScenario {
         // create a seed for new transaction digest to ensure that this tx has a different
         // digest (and consequently, different object ID's) than the previous tx
         let new_tx_digest_seed = (vector::length(&scenario.event_start_indexes) as u8);
-        scenario.ctx = TxContext::new_from_address(*sender, new_tx_digest_seed);
+        let epoch = TxContext::epoch(&scenario.ctx);
+        scenario.ctx = TxContext::new_with_epoch(*sender, epoch, new_tx_digest_seed);
+    }
+
+    /// Advance the scenario to a new epoch.
+    public fun next_epoch(scenario: &mut Scenario) {
+        TxContext::advance_epoch(&mut scenario.ctx);
     }
 
     /// Remove the object of type `T` from the inventory of the current tx sender in `scenario`.

--- a/crates/sui-framework/sources/TestScenario.move
+++ b/crates/sui-framework/sources/TestScenario.move
@@ -81,7 +81,7 @@ module Sui::TestScenario {
     /// Begin a new multi-transaction test scenario in a context where `sender` is the tx sender
     public fun begin(sender: &address): Scenario {
         Scenario {
-            ctx: TxContext::new_from_address(*sender, 0),
+            ctx: TxContext::new_from_hint(*sender, 0, 0, 0),
             removed: vector::empty(),
             event_start_indexes: vector[0],
         }
@@ -111,12 +111,12 @@ module Sui::TestScenario {
         // digest (and consequently, different object ID's) than the previous tx
         let new_tx_digest_seed = (vector::length(&scenario.event_start_indexes) as u8);
         let epoch = TxContext::epoch(&scenario.ctx);
-        scenario.ctx = TxContext::new_with_epoch(*sender, epoch, new_tx_digest_seed);
+        scenario.ctx = TxContext::new_from_hint(*sender, new_tx_digest_seed, epoch, 0);
     }
 
     /// Advance the scenario to a new epoch.
     public fun next_epoch(scenario: &mut Scenario) {
-        TxContext::advance_epoch(&mut scenario.ctx);
+        TxContext::increment_epoch_number(&mut scenario.ctx);
     }
 
     /// Remove the object of type `T` from the inventory of the current tx sender in `scenario`.

--- a/crates/sui-framework/sources/TxContext.move
+++ b/crates/sui-framework/sources/TxContext.move
@@ -73,31 +73,25 @@ module Sui::TxContext {
 
     #[test_only]
     /// Create a `TxContext` for testing
-    public fun new(signer: signer, tx_hash: vector<u8>, epoch: u64, ids_created: u64): TxContext {
+    public fun new(addr: address, tx_hash: vector<u8>, epoch: u64, ids_created: u64): TxContext {
         assert!(
             vector::length(&tx_hash) == TX_HASH_LENGTH,
             errors::invalid_argument(EBadTxHashLength)
         );
-        TxContext { signer, tx_hash, epoch, ids_created }
+        TxContext { signer: new_signer_from_address(addr), tx_hash, epoch, ids_created }
     }
 
     #[test_only]
     /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
-    public fun new_with_epoch(a: address, epoch: u64, hint: u8): TxContext {
-        new(new_signer_from_address(a), dummy_tx_hash_with_hint(hint), epoch, 0)
-    }
-
-    #[test_only]
-    /// Create a `TxContext` with sender `a` for testing, and a tx hash derived from `hint`
-    public fun new_from_address(a: address, hint: u8): TxContext {
-        new(new_signer_from_address(a), dummy_tx_hash_with_hint(hint), 0, 0)
+    public fun new_from_hint(addr: address, hint: u8, epoch: u64, ids_created: u64): TxContext {
+        new(addr, dummy_tx_hash_with_hint(hint), epoch, ids_created)
     }
 
     #[test_only]
     /// Create a dummy `TxContext` for testing
     public fun dummy(): TxContext {
         let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
-        new(new_signer_from_address(@0x0), tx_hash, 0, 0)
+        new(@0x0, tx_hash, 0, 0)
     }
 
     #[test_only]
@@ -127,7 +121,7 @@ module Sui::TxContext {
     }
 
     #[test_only]
-    public fun advance_epoch(self: &mut TxContext) {
+    public fun increment_epoch_number(self: &mut TxContext) {
         self.epoch = self.epoch + 1
     }
 

--- a/crates/sui-framework/sources/TxContext.move
+++ b/crates/sui-framework/sources/TxContext.move
@@ -73,17 +73,7 @@ module Sui::TxContext {
 
     #[test_only]
     /// Create a `TxContext` for testing
-    public fun new(signer: signer, tx_hash: vector<u8>, ids_created: u64): TxContext {
-        assert!(
-            vector::length(&tx_hash) == TX_HASH_LENGTH,
-            errors::invalid_argument(EBadTxHashLength)
-        );
-        TxContext { signer, tx_hash, epoch: 0, ids_created }
-    }
-
-    #[test_only]
-    /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
-    public fun new_with_epoch(signer: signer, tx_hash: vector<u8>, epoch: u64, ids_created: u64): TxContext {
+    public fun new(signer: signer, tx_hash: vector<u8>, epoch: u64, ids_created: u64): TxContext {
         assert!(
             vector::length(&tx_hash) == TX_HASH_LENGTH,
             errors::invalid_argument(EBadTxHashLength)
@@ -92,16 +82,22 @@ module Sui::TxContext {
     }
 
     #[test_only]
+    /// Create a `TxContext` for testing, with a potentially non-zero epoch number.
+    public fun new_with_epoch(a: address, epoch: u64, hint: u8): TxContext {
+        new(new_signer_from_address(a), dummy_tx_hash_with_hint(hint), epoch, 0)
+    }
+
+    #[test_only]
     /// Create a `TxContext` with sender `a` for testing, and a tx hash derived from `hint`
     public fun new_from_address(a: address, hint: u8): TxContext {
-        new(new_signer_from_address(a), dummy_tx_hash_with_hint(hint), 0)
+        new(new_signer_from_address(a), dummy_tx_hash_with_hint(hint), 0, 0)
     }
 
     #[test_only]
     /// Create a dummy `TxContext` for testing
     public fun dummy(): TxContext {
         let tx_hash = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
-        new(new_signer_from_address(@0x0), tx_hash, 0)
+        new(new_signer_from_address(@0x0), tx_hash, 0, 0)
     }
 
     #[test_only]
@@ -128,6 +124,11 @@ module Sui::TxContext {
         let ids_created = self.ids_created;
         assert!(ids_created > 0, ENoIDsCreated);
         ID::new(derive_id(*&self.tx_hash, ids_created - 1))
+    }
+
+    #[test_only]
+    public fun advance_epoch(self: &mut TxContext) {
+        self.epoch = self.epoch + 1
     }
 
     #[test_only]

--- a/crates/sui-framework/tests/CoinBalanceTests.move
+++ b/crates/sui-framework/tests/CoinBalanceTests.move
@@ -8,7 +8,6 @@ module Sui::TestCoin {
     use Sui::Balance;
     use Sui::SUI::SUI;
     use Sui::LockedCoin::LockedCoin;
-    use Std::Errors;
     use Sui::TxContext;
     use Sui::LockedCoin;
     use Sui::Coin::Coin;
@@ -43,7 +42,7 @@ module Sui::TestCoin {
     const TEST_RECIPIENT_ADDR: address = @0xB0B;
 
     #[test]
-    public(script) fun test_locked_coin_valid() {
+    public entry fun test_locked_coin_valid() {
         let scenario = &mut TestScenario::begin(&TEST_SENDER_ADDR);
         let ctx = TestScenario::ctx(scenario);
         let coin = Coin::mint_for_testing<SUI>(42, ctx);
@@ -55,7 +54,7 @@ module Sui::TestCoin {
         // Advance the epoch by 2.
         TestScenario::next_epoch(scenario);
         TestScenario::next_epoch(scenario);
-        assert!(TxContext::epoch(TestScenario::ctx(scenario)) == 2, Errors::invalid_state(1));
+        assert!(TxContext::epoch(TestScenario::ctx(scenario)) == 2, 1);
 
         TestScenario::next_tx(scenario, &TEST_RECIPIENT_ADDR);
         let locked_coin = TestScenario::take_owned<LockedCoin<SUI>>(scenario);
@@ -64,13 +63,13 @@ module Sui::TestCoin {
 
         TestScenario::next_tx(scenario, &TEST_RECIPIENT_ADDR);
         let unlocked_coin = TestScenario::take_owned<Coin<SUI>>(scenario);
-        assert!(Coin::value(&unlocked_coin) == 42, Errors::invalid_state(2));
+        assert!(Coin::value(&unlocked_coin) == 42, 2);
         Coin::destroy_for_testing(unlocked_coin);
     }
 
     #[test]
-    #[expected_failure(abort_code = 263)]
-    public(script) fun test_locked_coin_invalid() {
+    #[expected_failure(abort_code = 1)]
+    public entry fun test_locked_coin_invalid() {
         let scenario = &mut TestScenario::begin(&TEST_SENDER_ADDR);
         let ctx = TestScenario::ctx(scenario);
         let coin = Coin::mint_for_testing<SUI>(42, ctx);
@@ -81,7 +80,7 @@ module Sui::TestCoin {
 
         // Advance the epoch by 1.
         TestScenario::next_epoch(scenario);
-        assert!(TxContext::epoch(TestScenario::ctx(scenario)) == 1, Errors::invalid_state(1));
+        assert!(TxContext::epoch(TestScenario::ctx(scenario)) == 1, 1);
 
         TestScenario::next_tx(scenario, &TEST_RECIPIENT_ADDR);
         let locked_coin = TestScenario::take_owned<LockedCoin<SUI>>(scenario);

--- a/crates/sui-framework/tests/ValidatorSetTests.move
+++ b/crates/sui-framework/tests/ValidatorSetTests.move
@@ -81,7 +81,7 @@ module Sui::ValidatorSetTests {
 
     fun create_validator(addr: address, hint: u8): (TxContext, Validator) {
         let stake_value = (hint as u64) * 100;
-        let ctx = TxContext::new_from_address(addr, hint);
+        let ctx = TxContext::new_from_hint(addr, hint, 0, 0);
         let init_stake = Coin::mint_for_testing(stake_value, &mut ctx);
         let init_stake = Coin::into_balance(init_stake);
         let validator = Validator::new(


### PR DESCRIPTION
This PR
- adds a generic Move module for `LockedCoin` providing functionalities to lock a `Coin<T>` and unlock a `LockedCoin<T>`.
- modifies other modules including `Delegation` and `SuiSystem` so that locked SUI holders can delegate and undelegate as well.
- adds tests for locked coins and adds some test only methods in other modules.