### PR TITLE
Sadhan/object-sequence-overflow

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -222,7 +222,7 @@ fn check_one_lock(
                 SuiError::MovePackageAsObject { object_id }
             );
             fp_ensure!(
-                sequence_number <= SequenceNumber::MAX,
+                sequence_number < SequenceNumber::MAX,
                 SuiError::InvalidSequenceNumber
             );
 
@@ -278,6 +278,10 @@ fn check_one_lock(
             };
         }
         InputObjectKind::SharedMoveObject(..) => {
+            fp_ensure!(
+                object.version() < SequenceNumber::MAX,
+                SuiError::InvalidSequenceNumber
+            );
             // When someone locks an object as shared it must be shared already.
             fp_ensure!(object.is_shared(), SuiError::NotSharedObjectError);
         }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -144,8 +144,8 @@ pub enum SuiError {
     CertificateAuthorityReuse,
     #[error("Sequence numbers above the maximal value are not usable for transfers.")]
     InvalidSequenceNumber,
-    #[error("Sequence number overflow.")]
-    SequenceOverflow,
+    #[error("Sequence number overflow for object: {object_id}")]
+    SequenceOverflow { object_id: ObjectID },
     #[error("Sequence number underflow.")]
     SequenceUnderflow,
     #[error("Wrong shard used.")]

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -465,6 +465,23 @@ impl Object {
         Self::with_id_owner_gas_for_testing(id, owner, GAS_VALUE_FOR_TESTING)
     }
 
+    pub fn with_id_owner_version_for_testing(
+        id: ObjectID,
+        version: SequenceNumber,
+        owner: SuiAddress,
+    ) -> Self {
+        let data = Data::Move(MoveObject {
+            type_: GasCoin::type_(),
+            contents: GasCoin::new(id, version, GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
+        });
+        Self {
+            owner: Owner::AddressOwner(owner),
+            data,
+            previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
+        }
+    }
+
     pub fn with_owner_for_testing(owner: SuiAddress) -> Self {
         Self::with_id_owner_for_testing(ObjectID::random(), owner)
     }


### PR DESCRIPTION
This diff handles objects with max sequence number by returning an error early on during transaction processing. This is for #182