### PR TITLE
add enable_event_processing option in configs

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -190,6 +190,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                     metrics_address: utils::available_local_socket_address(),
                     json_rpc_address: utils::available_local_socket_address(),
                     consensus_config: Some(consensus_config),
+                    enable_event_processing: false,
                     genesis: crate::node::Genesis::new(genesis.clone()),
                 }
             })

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -33,6 +33,9 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consensus_config: Option<ConsensusConfig>,
 
+    #[serde(default)]
+    pub enable_event_processing: bool,
+
     pub genesis: Genesis,
 }
 

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -68,9 +68,8 @@ impl NetworkConfig {
             network_address: utils::new_network_address(),
             metrics_address: utils::available_local_socket_address(),
             json_rpc_address: utils::available_local_socket_address(),
-
             consensus_config: None,
-
+            enable_event_processing: true,
             genesis: validator_config.genesis.clone(),
         }
     }

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -76,6 +76,7 @@ impl ConfigurableBatchActionClient {
             None,
             None,
             &sui_config::genesis::Genesis::get_default_genesis(),
+            false,
         )
         .await;
 

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -352,6 +352,7 @@ impl LocalAuthorityClient {
             None,
             Some(Arc::new(Mutex::new(checkpoints))),
             genesis,
+            false,
         )
         .await;
         Self {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -726,6 +726,7 @@ async fn test_batch_to_checkpointing() {
         None,
         Some(checkpoints.clone()),
         &sui_config::genesis::Genesis::get_default_genesis(),
+        false,
     )
     .await;
     let authority_state = Arc::new(state);
@@ -814,6 +815,7 @@ async fn test_batch_to_checkpointing_init_crash() {
             None,
             None,
             &sui_config::genesis::Genesis::get_default_genesis(),
+            false,
         )
         .await;
         let authority_state = Arc::new(state);
@@ -894,6 +896,7 @@ async fn test_batch_to_checkpointing_init_crash() {
             None,
             Some(checkpoints.clone()),
             &sui_config::genesis::Genesis::get_default_genesis(),
+            false,
         )
         .await;
         let authority_state = Arc::new(state);
@@ -1382,6 +1385,7 @@ pub async fn checkpoint_tests_setup(num_objects: usize, batch_interval: Duration
             None,
             Some(checkpoint.clone()),
             &genesis,
+            false,
         )
         .await;
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1326,6 +1326,7 @@ pub async fn init_state() -> AuthorityState {
         None,
         None,
         &sui_config::genesis::Genesis::get_default_genesis(),
+        false,
     )
     .await
 }

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -57,6 +57,7 @@ pub(crate) async fn init_state(
         None,
         None,
         &sui_config::genesis::Genesis::get_default_genesis(),
+        false,
     )
     .await
 }
@@ -770,6 +771,7 @@ async fn test_safe_batch_stream() {
         None,
         None,
         &sui_config::genesis::Genesis::get_default_genesis(),
+        false,
     )
     .await;
 
@@ -815,6 +817,7 @@ async fn test_safe_batch_stream() {
         None,
         None,
         &sui_config::genesis::Genesis::get_default_genesis(),
+        false,
     )
     .await;
     let auth_client_from_byzantine = ByzantineAuthorityClient::new(state_b);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -69,6 +69,7 @@ impl SuiNode {
                 index_store,
                 checkpoint_store,
                 genesis,
+                config.enable_event_processing,
             )
             .await,
         );

--- a/crates/sui/src/benchmark/validator_preparer.rs
+++ b/crates/sui/src/benchmark/validator_preparer.rs
@@ -290,6 +290,7 @@ fn make_authority_state(
                 None,
                 None,
                 &sui_config::genesis::Genesis::get_default_genesis(),
+                false,
             )
             .await
         }),


### PR DESCRIPTION
Only perform event processing when the option is enabled.
1. default to false for validators
2. default to true for fullnodes