### PR TITLE
Record sequence number assignments in lock service.

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -80,9 +80,7 @@ mod temporary_store;
 pub use temporary_store::AuthorityTemporaryStore;
 
 mod authority_store;
-pub use authority_store::{
-    AuthorityStore, AuthorityStoreWrapper, GatewayStore, ReplicaStore, SuiDataStore,
-};
+pub use authority_store::{AuthorityStore, AuthorityStoreWrapper, GatewayStore, SuiDataStore};
 use sui_types::messages_checkpoint::{
     CheckpointRequest, CheckpointRequestType, CheckpointResponse,
 };

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1143,7 +1143,8 @@ impl AuthorityState {
 
         let update_type = UpdateType::Transaction(seq, signed_effects.effects.digest());
 
-        let res = self.database
+        let res = self
+            .database
             .update_state(temporary_store, certificate, signed_effects, update_type)
             .await;
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -80,7 +80,9 @@ mod temporary_store;
 pub use temporary_store::AuthorityTemporaryStore;
 
 mod authority_store;
-pub use authority_store::{AuthorityStore, AuthorityStoreWrapper, GatewayStore, SuiDataStore};
+pub use authority_store::{
+    AuthorityStore, AuthorityStoreWrapper, GatewayStore, SuiDataStore, UpdateType,
+};
 use sui_types::messages_checkpoint::{
     CheckpointRequest, CheckpointRequestType, CheckpointResponse,
 };
@@ -1139,9 +1141,10 @@ impl AuthorityState {
             (None, None)
         };
 
-        let res = self
-            .database
-            .update_state(temporary_store, certificate, signed_effects, Some(seq))
+        let update_type = UpdateType::Transaction(seq, signed_effects.effects.digest());
+
+        let res = self.database
+            .update_state(temporary_store, certificate, signed_effects, update_type)
             .await;
 
         if let Some(indexes) = &self.indexes {

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -85,6 +85,9 @@ async fn checkpoint_active_flow_happy_path() {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn checkpoint_active_flow_crash_client_with_gossip() {
+    use telemetry_subscribers::init_for_testing;
+    init_for_testing();
+
     let setup = checkpoint_tests_setup(20, Duration::from_millis(200)).await;
 
     let TestSetup {

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -36,7 +36,7 @@ use sui_types::{
 
 use crate::transaction_input_checker;
 use crate::{
-    authority::GatewayStore, authority_aggregator::AuthorityAggregator,
+    authority::{GatewayStore, UpdateType}, authority_aggregator::AuthorityAggregator,
     authority_client::AuthorityAPI, query_helpers::QueryHelpers,
 };
 use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
@@ -478,14 +478,18 @@ where
         let mutated_objects = self
             .download_objects_from_authorities(mutated_object_refs)
             .await?;
+        let update_type = UpdateType::Transaction(
+            self.next_tx_seq_number
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+            effects.digest(),
+        );
         self.store
             .update_gateway_state(
                 all_objects,
                 mutated_objects,
                 new_certificate.clone(),
                 effects.clone().to_unsigned_effects(),
-                self.next_tx_seq_number
-                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+                update_type,
             )
             .await?;
 

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -36,8 +36,10 @@ use sui_types::{
 
 use crate::transaction_input_checker;
 use crate::{
-    authority::{GatewayStore, UpdateType}, authority_aggregator::AuthorityAggregator,
-    authority_client::AuthorityAPI, query_helpers::QueryHelpers,
+    authority::{GatewayStore, UpdateType},
+    authority_aggregator::AuthorityAggregator,
+    authority_client::AuthorityAPI,
+    query_helpers::QueryHelpers,
 };
 use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
 

--- a/crates/sui-core/src/query_helpers.rs
+++ b/crates/sui-core/src/query_helpers.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 const MAX_TX_RANGE_SIZE: u64 = 4096;
 
-pub struct QueryHelpers<const ALL_OBJ_VER: bool, const USE_LOCKS: bool, S> {
+pub struct QueryHelpers<const ALL_OBJ_VER: bool, S> {
     _s: std::marker::PhantomData<S>,
 }
 
@@ -17,20 +17,17 @@ pub struct QueryHelpers<const ALL_OBJ_VER: bool, const USE_LOCKS: bool, S> {
 // be duplicated between AuthorityState and GatewayState. The gateway read API will be removed
 // soon, since nodes will be handling that. At that point we should delete this struct and move the
 // code back to AuthorityState.
-impl<
-        const ALL_OBJ_VER: bool,
-        const USE_LOCKS: bool,
-        S: Eq + Serialize + for<'de> Deserialize<'de>,
-    > QueryHelpers<ALL_OBJ_VER, USE_LOCKS, S>
+impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
+    QueryHelpers<ALL_OBJ_VER, S>
 {
     pub fn get_total_transaction_number(
-        database: &SuiDataStore<ALL_OBJ_VER, USE_LOCKS, S>,
+        database: &SuiDataStore<ALL_OBJ_VER, S>,
     ) -> Result<u64, anyhow::Error> {
         Ok(database.next_sequence_number()?)
     }
 
     pub fn get_transactions_in_range(
-        database: &SuiDataStore<ALL_OBJ_VER, USE_LOCKS, S>,
+        database: &SuiDataStore<ALL_OBJ_VER, S>,
         start: TxSequenceNumber,
         end: TxSequenceNumber,
     ) -> Result<Vec<(TxSequenceNumber, TransactionDigest)>, anyhow::Error> {
@@ -61,7 +58,7 @@ impl<
     }
 
     pub fn get_recent_transactions(
-        database: &SuiDataStore<ALL_OBJ_VER, USE_LOCKS, S>,
+        database: &SuiDataStore<ALL_OBJ_VER, S>,
         count: u64,
     ) -> Result<Vec<(TxSequenceNumber, TransactionDigest)>, anyhow::Error> {
         fp_ensure!(
@@ -80,7 +77,7 @@ impl<
     }
 
     pub fn get_transaction(
-        database: &SuiDataStore<ALL_OBJ_VER, USE_LOCKS, S>,
+        database: &SuiDataStore<ALL_OBJ_VER, S>,
         digest: TransactionDigest,
     ) -> Result<TransactionEffectsResponse, anyhow::Error> {
         let opt = database.get_certified_transaction(&digest)?;

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -18,8 +18,8 @@ use tracing::{debug, instrument};
 use crate::authority::SuiDataStore;
 
 #[instrument(level = "trace", skip_all)]
-pub async fn check_transaction_input<const A: bool, const B: bool, S, T>(
-    store: &SuiDataStore<A, B, S>,
+pub async fn check_transaction_input<const A: bool, S, T>(
+    store: &SuiDataStore<A, S>,
     transaction: &TransactionEnvelope<T>,
     shared_obj_metric: &IntCounter,
 ) -> Result<(SuiGasStatus<'static>, Vec<(InputObjectKind, Object)>), SuiError>
@@ -52,8 +52,8 @@ where
 /// Returns the gas object (to be able to reuse it latter) and a gas status
 /// that will be used in the entire lifecycle of the transaction execution.
 #[instrument(level = "trace", skip_all)]
-async fn check_gas<const A: bool, const B: bool, S>(
-    store: &SuiDataStore<A, B, S>,
+async fn check_gas<const A: bool, S>(
+    store: &SuiDataStore<A, S>,
     gas_payment_id: ObjectID,
     gas_budget: u64,
     is_system_tx: bool,
@@ -76,8 +76,8 @@ where
 }
 
 #[instrument(level = "trace", skip_all, fields(num_objects = input_objects.len()))]
-async fn fetch_objects<const A: bool, const B: bool, S>(
-    store: &SuiDataStore<A, B, S>,
+async fn fetch_objects<const A: bool, S>(
+    store: &SuiDataStore<A, S>,
     input_objects: &[InputObjectKind],
 ) -> Result<Vec<Option<Object>>, SuiError>
 where
@@ -90,8 +90,8 @@ where
 /// Check all the objects used in the transaction against the database, and ensure
 /// that they are all the correct version and number.
 #[instrument(level = "trace", skip_all)]
-async fn check_locks<const A: bool, const B: bool, S>(
-    store: &SuiDataStore<A, B, S>,
+async fn check_locks<const A: bool, S>(
+    store: &SuiDataStore<A, S>,
     transaction: &TransactionData,
 ) -> Result<Vec<(InputObjectKind, Object)>, SuiError>
 where


### PR DESCRIPTION
- unifies sequencing and lock initialization, which I believe are essentially the same concept. locks enforce correct partial ordering of txes - sequence numbers embed that partial order in a total ordering that is local to the validator.
- categorically prevents sequencing the same tx under two sequence numbers
- provides an idempotent lock_service.sequence_transaction call which is critical for safe recovery of interrupted tx writes.