### PR TITLE
[devnet] Temporarily disable shared objects on gateway

### DIFF
--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -832,6 +832,12 @@ where
             tx_kind = tx.data.kind_as_str()
         );
 
+        // TODO: Temporarily disable shared objects in transactions.
+        fp_ensure!(
+            !tx.contains_shared_object(),
+            SuiError::UnsupportedSharedObjectError.into()
+        );
+
         // Use start_coarse_time() if the below turns out to have a perf impact
         let timer = self.metrics.transaction_latency.start_timer();
         let mut res = self

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -487,7 +487,7 @@ async fn replay_shared_object_transaction() {
 }
 
 #[tokio::test]
-//#[ignore] // cargo test gateway -p sui --test shared_objects_tests -- --nocapture
+#[ignore]
 async fn shared_object_on_gateway() {
     let mut gas_objects = test_gas_objects();
 


### PR DESCRIPTION
It's easiest to disable on gateway as we can still keep all authority shared objects running.