### PR TITLE
gossip: use an http keepalive to keep idle connections open

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -80,6 +80,7 @@ impl SuiNode {
             let mut net_config = mysten_network::config::Config::new();
             net_config.connect_timeout = Some(Duration::from_secs(5));
             net_config.request_timeout = Some(Duration::from_secs(5));
+            net_config.http2_keepalive_interval = Some(Duration::from_secs(5));
 
             let mut authority_clients = BTreeMap::new();
             for validator in genesis.validator_set() {


### PR DESCRIPTION
Due to a network not being super active we may run into the follow log being emitted: 
```
2022-06-08T18:23:04.299025Z ERROR sui_core::authority_active::gossip: Peer k#839e99f8b03f0f5563d6cd9cc39e10a8cf483ad2775aecbb927031370925ef4e returned error: RpcError("error reading a body from connection: broken pipe")
```

This is due to the HTTP2 idle timeout of 20s being hit. This can be addressed by issuing an HTTP2 keepalive roughly ever 5 seconds to ensure the connection is kept open.