### PR TITLE
Enable write-ahead log, recover in-progress TXes at startup.

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -60,7 +60,7 @@ use sui_types::{
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use tokio::sync::broadcast::error::RecvError;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, warn};
 use typed_store::Map;
 
 #[cfg(test)]
@@ -1345,10 +1345,14 @@ impl AuthorityState {
         let notifier_ticket = self.batch_notifier.ticket()?;
         let seq = notifier_ticket.seq();
 
-        let update_type = UpdateType::Transaction(seq, signed_effects.effects.digest());
-
         self.database
-            .update_state(temporary_store, certificate, signed_effects, update_type)
+            .update_state(
+                temporary_store,
+                certificate,
+                seq,
+                signed_effects,
+                &signed_effects.effects.digest(),
+            )
             .await
 
         // implicitly we drop the ticket here and that notifies the batch manager

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -910,6 +910,10 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
             })
             .unzip();
 
+        trace!(digest = ?transaction_digest,
+               ?sequenced_to_write, ?schedule_to_write,
+               "locking shared objects");
+
         // Make an iterator to update the last consensus index.
         let index_to_write = std::iter::once((LAST_CONSENSUS_INDEX_ADDR, consensus_index));
 

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -157,7 +157,7 @@ async fn test_start_epoch_change() {
     let signed_effects = effects.to_sign_effects(0, &state.name, &*state.secret);
     assert_eq!(
         state
-            .update_state(temporary_store, &certificate, &signed_effects)
+            .commit_certificate(temporary_store, &certificate, &signed_effects)
             .await
             .unwrap_err(),
         SuiError::ValidatorHaltedAtEpochEnd

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -509,18 +509,17 @@ where
         let mutated_objects = self
             .download_objects_from_authorities(mutated_object_refs)
             .await?;
-        let update_type = UpdateType::Transaction(
-            self.next_tx_seq_number
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
-            effects.effects.digest(),
-        );
+        let seq = self
+            .next_tx_seq_number
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         self.store
             .update_gateway_state(
                 input_objects,
                 mutated_objects,
                 new_certificate.clone(),
+                seq,
                 effects.clone().to_unsigned_effects(),
-                update_type,
+                &effects.effects.digest(),
             )
             .await?;
 

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -36,10 +36,8 @@ use sui_types::{
 use crate::authority::ResolverWrapper;
 use crate::transaction_input_checker;
 use crate::{
-    authority::{GatewayStore, UpdateType},
-    authority_aggregator::AuthorityAggregator,
-    authority_client::AuthorityAPI,
-    query_helpers::QueryHelpers,
+    authority::GatewayStore, authority_aggregator::AuthorityAggregator,
+    authority_client::AuthorityAPI, query_helpers::QueryHelpers,
 };
 use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
 use sui_json_rpc_api::rpc_types::{

--- a/crates/sui-storage/benches/write_ahead_log.rs
+++ b/crates/sui-storage/benches/write_ahead_log.rs
@@ -35,7 +35,7 @@ fn main() {
 
                     if let Some(g) = g {
                         sleep(Duration::from_millis(1)).await;
-                        g.commit_tx().unwrap();
+                        g.commit_tx();
                     }
                 }
             }));

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -164,7 +164,7 @@ where
             let db_options = Some(options.clone());
             let opt_cfs: &[(&str, &rocksdb::Options)] = &[
                 ("tx_write_ahead_log", &options),
-                ("tx_retry_count", &options)
+                ("tx_retry_count", &options),
             ];
             typed_store::rocks::open_cf_opts(path, db_options, opt_cfs)
         }

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -143,6 +143,7 @@ async fn call_shared_object_contract() {
 /// transaction (one copy per authority).
 #[tokio::test]
 async fn shared_object_flood() {
+    telemetry_subscribers::init_for_testing();
     let mut gas_objects = test_gas_objects();
 
     // Get the authority configs and spawn them. Note that it is important to not drop


### PR DESCRIPTION
A few items are still TODO:

- Tests (coming soon, want to make sure there's consensus on the approach before I work on this)
- Offline retries - right now we only process the log at startup. The main motivation is for crash recovery, so that's ok. But we'd also like to attempt recovery periodically while running in case txes fail transiently due to db write errors.
- After tests are done I will:
   - Remove object critical section.
   - Break up the big atomic batch write for better performance.