### PR TITLE
Explorer: move transactions below the owned objects section

### DIFF
--- a/explorer/client/src/pages/address-result/AddressResult.tsx
+++ b/explorer/client/src/pages/address-result/AddressResult.tsx
@@ -39,13 +39,13 @@ function AddressResult() {
                         />
                     </div>
                 </div>
-                <TxForID id={addressID} category="address" />
                 <div>
                     <div>Owned Objects</div>
                     <div>
                         {<OwnedObjects id={addressID} byAddress={true} />}
                     </div>
                 </div>
+                <TxForID id={addressID} category="address" />
             </div>
         );
     } else {


### PR DESCRIPTION
Before
<img width="1367" alt="CleanShot 2022-06-10 at 17 57 24@2x" src="https://user-images.githubusercontent.com/76067158/173166435-82ec1d0b-7a27-4f95-87fe-3544bcaab501.png">

After
<img width="1573" alt="CleanShot 2022-06-10 at 17 56 53@2x" src="https://user-images.githubusercontent.com/76067158/173166444-3d0472e7-a22b-486f-994c-22b745c6ac3b.png">

Per conversation with @bwann52 , we would like to put owned objects in a more prominent position than transactions
closing https://github.com/MystenLabs/sui/issues/2517