### PR TITLE
Various crypto cleanups

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -333,7 +333,7 @@ impl AuthorityState {
     ) -> Result<TransactionInfoResponse, SuiError> {
         self.metrics.tx_orders.inc();
         // Check the sender's signature.
-        transaction.verify_signature().map_err(|e| {
+        transaction.verify().map_err(|e| {
             self.metrics.signature_errors.inc();
             e
         })?;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1243,11 +1243,10 @@ pub async fn generate_genesis_system_object<
     let genesis_digest = genesis_ctx.digest();
     let mut temporary_store =
         AuthorityTemporaryStore::new(store.clone(), InputObjects::new(vec![]), genesis_digest);
-    let pubkeys: Vec<Vec<u8>> = committee
-        .expanded_keys
-        .values()
-        .map(|pk| pk.to_bytes().to_vec())
-        .collect();
+    let mut pubkeys = Vec::new();
+    for name in committee.voting_rights.keys() {
+        pubkeys.push(committee.public_key(name)?.to_bytes().to_vec());
+    }
     // TODO: May use separate sui address than derived from pubkey.
     let sui_addresses: Vec<AccountAddress> = committee
         .voting_rights

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -245,7 +245,7 @@ impl Validator for ValidatorService {
         let mut transaction = request.into_inner();
 
         transaction
-            .verify_signature()
+            .verify()
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         //TODO This is really really bad, we should have different types for signature-verified transactions
         transaction.is_verified = true;

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -21,7 +21,7 @@ use sui_network::{
     tonic,
 };
 
-use sui_types::{crypto::VerificationObligation, error::*, messages::*};
+use sui_types::{error::*, messages::*};
 use tokio::{
     sync::mpsc::{channel, Sender},
     task::JoinHandle,
@@ -244,12 +244,8 @@ impl Validator for ValidatorService {
     ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
         let mut transaction = request.into_inner();
 
-        let mut obligation = VerificationObligation::default();
         transaction
-            .add_sender_sig_to_verification_obligation(&mut obligation)
-            .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
-        obligation
-            .verify_all()
+            .verify_signature()
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         //TODO This is really really bad, we should have different types for signature-verified transactions
         transaction.is_verified = true;
@@ -279,12 +275,8 @@ impl Validator for ValidatorService {
     ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
         let mut transaction = request.into_inner();
 
-        let mut obligation = VerificationObligation::default();
         transaction
-            .add_to_verification_obligation(&self.state.committee.load(), &mut obligation)
-            .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
-        obligation
-            .verify_all()
+            .verify(&self.state.committee.load())
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         //TODO This is really really bad, we should have different types for signature verified transactions
         transaction.is_verified = true;

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -246,7 +246,7 @@ impl Validator for ValidatorService {
 
         let mut obligation = VerificationObligation::default();
         transaction
-            .add_tx_sig_to_verification_obligation(&mut obligation)
+            .add_sender_sig_to_verification_obligation(&mut obligation)
             .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
         obligation
             .verify_all()

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -517,7 +517,7 @@ where
         transaction: Transaction,
         is_last_retry: bool,
     ) -> Result<(CertifiedTransaction, CertifiedTransactionEffects), anyhow::Error> {
-        transaction.verify_signature()?;
+        transaction.verify()?;
 
         self.sync_input_objects_with_authorities(&transaction)
             .await?;

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -31,7 +31,8 @@ impl Committee {
         let total_votes = voting_rights.iter().map(|(_, votes)| votes).sum();
         let expanded_keys: HashMap<_, _> = voting_rights
             .iter()
-            // TODO: How do we guarantee the unwrap is safe?
+            // TODO: Verify all code path to make sure we always have valid public keys.
+            // e.g. when a new validator is registering themself on-chain.
             .map(|(addr, _)| (*addr, (*addr).try_into().expect("Invalid Authority Key")))
             .collect();
         Committee {
@@ -47,8 +48,6 @@ impl Committee {
     }
 
     pub fn public_key(&self, authority: &AuthorityName) -> SuiResult<PublicKey> {
-        // do we know, or can we build a valid public key?
-        // TODO: We could also update expanded_keys here if we like.
         match self.expanded_keys.get(authority) {
             Some(v) => Ok(*v),
             None => (*authority).try_into(),

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -560,7 +560,7 @@ pub fn sha3_hash<S: Signable<Sha3_256>>(signable: &S) -> [u8; 32] {
 #[derive(Default)]
 pub struct VerificationObligation {
     lookup: PubKeyLookup,
-    pub messages: Vec<Vec<u8>>,
+    messages: Vec<Vec<u8>>,
     pub message_index: Vec<usize>,
     pub signatures: Vec<dalek::Signature>,
     pub public_keys: Vec<dalek::PublicKey>,
@@ -586,6 +586,14 @@ impl VerificationObligation {
                 Ok(public_key)
             }
         }
+    }
+
+    /// Add a new message to the list of messages to be verified.
+    /// Returns the index of the message.
+    pub fn add_message(&mut self, message: Vec<u8>) -> usize {
+        let idx = self.messages.len();
+        self.messages.push(message);
+        idx
     }
 
     pub fn verify_all(self) -> SuiResult<PubKeyLookup> {

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -481,6 +481,22 @@ impl PartialEq for AuthoritySignInfo {
     }
 }
 
+impl AuthoritySignInfo {
+    pub fn add_to_verification_obligation(
+        &self,
+        committee: &Committee,
+        obligation: &mut VerificationObligation,
+        message_index: usize,
+    ) -> SuiResult<()> {
+        obligation
+            .public_keys
+            .push(committee.public_key(&self.authority)?);
+        obligation.signatures.push(self.signature.0);
+        obligation.message_index.push(message_index);
+        Ok(())
+    }
+}
+
 /// Represents at least a quorum (could be more) of authority signatures.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AuthorityQuorumSignInfo {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -487,8 +487,7 @@ impl<S> TransactionEnvelope<S> {
         let (message, signature, public_key) = self
             .tx_signature
             .get_verification_inputs(&self.data, self.data.sender)?;
-        let idx = obligation.messages.len();
-        obligation.messages.push(message);
+        let idx = obligation.add_message(message);
         let key = obligation.lookup_public_key(&public_key)?;
         obligation.public_keys.push(key);
         obligation.signatures.push(signature);
@@ -1283,8 +1282,7 @@ impl CertifiedTransaction {
         let mut message = Vec::new();
         self.data.write(&mut message);
 
-        let idx = obligation.messages.len();
-        obligation.messages.push(message);
+        let idx = obligation.add_message(message);
 
         for tuple in self.auth_sign_info.signatures.iter() {
             let (authority, signature) = tuple;

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -468,11 +468,11 @@ pub struct TransactionEnvelope<S> {
 impl<S> TransactionEnvelope<S> {
     pub fn verify_signature(&self) -> Result<(), SuiError> {
         let mut obligation = VerificationObligation::default();
-        self.add_tx_sig_to_verification_obligation(&mut obligation)?;
+        self.add_sender_sig_to_verification_obligation(&mut obligation)?;
         obligation.verify_all().map(|_| ())
     }
 
-    pub fn add_tx_sig_to_verification_obligation(
+    pub fn add_sender_sig_to_verification_obligation(
         &self,
         obligation: &mut VerificationObligation,
     ) -> SuiResult<()> {
@@ -1246,7 +1246,7 @@ impl CertifiedTransaction {
         obligation: &mut VerificationObligation,
     ) -> SuiResult<()> {
         // Add the obligation of the sender signature verification.
-        self.add_tx_sig_to_verification_obligation(obligation)?;
+        self.add_sender_sig_to_verification_obligation(obligation)?;
 
         // Add the obligation of the authority signature verifications.
         let mut message = Vec::new();

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -468,7 +468,7 @@ pub struct TransactionEnvelope<S> {
 }
 
 impl<S> TransactionEnvelope<S> {
-    pub fn add_sender_sig_to_verification_obligation(
+    fn add_sender_sig_to_verification_obligation(
         &self,
         obligation: &mut VerificationObligation,
     ) -> SuiResult<()> {
@@ -1249,7 +1249,7 @@ impl CertifiedTransaction {
         obligation.verify_all().map(|_| ())
     }
 
-    pub fn add_to_verification_obligation(
+    fn add_to_verification_obligation(
         &self,
         committee: &Committee,
         obligation: &mut VerificationObligation,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -452,6 +452,8 @@ pub struct TransactionEnvelope<S> {
     #[serde(skip)]
     transaction_digest: OnceCell<TransactionDigest>,
     // Deserialization sets this to "false"
+    // TODO: is_verified is only set to true in some callsites after verification.
+    // Hence it's not optimal.
     #[serde(skip)]
     pub is_verified: bool,
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -685,11 +685,9 @@ impl SignedTransaction {
         let mut message = Vec::new();
         self.data.write(&mut message);
         let idx = obligation.add_message(message);
-        obligation
-            .public_keys
-            .push(committee.public_key(&self.auth_sign_info.authority)?);
-        obligation.signatures.push(self.auth_sign_info.signature.0);
-        obligation.message_index.push(idx);
+        self.auth_sign_info
+            .add_to_verification_obligation(committee, &mut obligation, idx)?;
+
         obligation.verify_all()?;
         Ok(weight)
     }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -468,12 +468,6 @@ pub struct TransactionEnvelope<S> {
 }
 
 impl<S> TransactionEnvelope<S> {
-    pub fn verify_signature(&self) -> Result<(), SuiError> {
-        let mut obligation = VerificationObligation::default();
-        self.add_sender_sig_to_verification_obligation(&mut obligation)?;
-        obligation.verify_all().map(|_| ())
-    }
-
     pub fn add_sender_sig_to_verification_obligation(
         &self,
         obligation: &mut VerificationObligation,
@@ -602,6 +596,12 @@ impl Transaction {
             tx_signature: signature,
             auth_sign_info: EmptySignInfo {},
         }
+    }
+
+    pub fn verify(&self) -> Result<(), SuiError> {
+        let mut obligation = VerificationObligation::default();
+        self.add_sender_sig_to_verification_obligation(&mut obligation)?;
+        obligation.verify_all().map(|_| ())
     }
 }
 
@@ -1164,7 +1164,7 @@ pub struct SignatureAggregator<'a> {
 impl<'a> SignatureAggregator<'a> {
     /// Start aggregating signatures for the given value into a certificate.
     pub fn try_new(transaction: Transaction, committee: &'a Committee) -> Result<Self, SuiError> {
-        transaction.verify_signature()?;
+        transaction.verify()?;
         Ok(Self::new_unsafe(transaction, committee))
     }
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -361,14 +361,9 @@ impl CertifiedCheckpoint {
 
         for tuple in self.signatures.iter() {
             let (authority, signature) = tuple;
-            // do we know, or can we build a valid public key?
-            match committee.expanded_keys.get(authority) {
-                Some(v) => obligation.public_keys.push(*v),
-                None => {
-                    let public_key = (*authority).try_into()?;
-                    obligation.public_keys.push(public_key);
-                }
-            }
+            obligation
+                .public_keys
+                .push(committee.public_key(authority)?);
 
             // build a signature
             obligation.signatures.push(signature.0);

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -357,8 +357,7 @@ impl CertifiedCheckpoint {
         let mut message = Vec::new();
         self.checkpoint.write(&mut message);
 
-        let idx = obligation.messages.len();
-        obligation.messages.push(message);
+        let idx = obligation.add_message(message);
 
         for tuple in self.signatures.iter() {
             let (authority, signature) = tuple;


### PR DESCRIPTION
This PR does some cleanups on crypto. Please review carefully since there are lots of changes and this is crypto library.
1. A helper function in `VerificationObligation` to add a new message and return the message index. This allows us to keep `messages` private, to make sure we use it correctly.
2. Move the quorum signature obligation functionality to crypto.rs into `AuthorityQuorumSignInfo`. This will allow us to reuse it for other certified data structure (such as checkpoint) down the road.
3. Rename `add_tx_sig_to_verification_obligation` to `add_sender_sig_to_verification_obligation` to make it clearer.
4. When verifying SignedTransaction, also use obligation instead of manual verify calls.
5. Make `Committee::expanded_keys` private, and add a helper function to query public keys. This also allows me to discover a bug in authority code where we are using `expanded_keys` directly and rely on it being set.
6. Validator always calls into `verify` functions instead of manually adding things to obligations. This helps reduce code duplication and chances to make mistakes.
7. Move the `verify` function of `Transaction` to its own struct implementation out of the generic implementation, to avoid misuse.
8. Make the obligation adding functions private, as we expect callers to always call the verify function.

There are more rooms for code cleanups:
1. In every case the verification obligation is always verifying signatures around the same message. Maybe the obligation object doesn't have to keep a vector of messages and message_index, but instead to have a 1:1 mapping from message to obligation
2. We can then turn all checkpoint related structures into the same envelope style to reuse some of the code in crypto.rs.