### PR TITLE
Make sure CertifiedTranaction always has valid epoch

### DIFF
--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1150,7 +1150,7 @@ impl<'a> SignatureAggregator<'a> {
             committee,
             weight: 0,
             used_authorities: HashSet::new(),
-            partial: CertifiedTransaction::new(transaction),
+            partial: CertifiedTransaction::new(committee.epoch, transaction),
         }
     }
 
@@ -1188,17 +1188,8 @@ impl<'a> SignatureAggregator<'a> {
 }
 
 impl CertifiedTransaction {
-    pub fn new(transaction: Transaction) -> CertifiedTransaction {
-        CertifiedTransaction {
-            transaction_digest: transaction.transaction_digest,
-            is_verified: false,
-            data: transaction.data,
-            tx_signature: transaction.tx_signature,
-            auth_sign_info: AuthorityQuorumSignInfo {
-                epoch: 0,
-                signatures: Vec::new(),
-            },
-        }
+    pub fn new(epoch: EpochId, transaction: Transaction) -> CertifiedTransaction {
+        Self::new_with_signatures(epoch, transaction, vec![])
     }
 
     pub fn new_with_signatures(

--- a/crates/sui/src/benchmark/transaction_creator.rs
+++ b/crates/sui/src/benchmark/transaction_creator.rs
@@ -56,8 +56,8 @@ fn create_gas_object(object_id: ObjectID, owner: SuiAddress) -> Object {
 /// This builds, signs a cert
 fn make_cert(network_config: &NetworkConfig, tx: &Transaction) -> CertifiedTransaction {
     // Make certificate
-    let mut certificate = CertifiedTransaction::new(tx.clone());
     let committee = network_config.committee();
+    let mut certificate = CertifiedTransaction::new(committee.epoch(), tx.clone());
     certificate.auth_sign_info.epoch = committee.epoch();
     // TODO: Why iterating from 0 to quorum_threshold??
     for i in 0..committee.quorum_threshold() {


### PR DESCRIPTION
There is code path where epoch is not set according to the committee when creating a CertifiedTranaction.
Thus PR ensures we always set the epoch correctly.