### PR TITLE
Wallet transaction tab

### DIFF
--- a/wallet/src/ui/app/ApiProvider.ts
+++ b/wallet/src/ui/app/ApiProvider.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// import { JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 import { RawSigner, JsonRpcProvider } from '@mysten/sui.js';
 
 import type { Ed25519Keypair } from '@mysten/sui.js';
@@ -55,12 +54,8 @@ export default class ApiProvider {
         this._apiProvider = new JsonRpcProvider(DEFAULT_API_ENDPOINT);
     }
 
-    public setNewJsonRpcProvider(apiEnv: string) {
-        if (apiEnv) {
-            this._apiProvider = new JsonRpcProvider(
-                getDefaultAPI(API_ENV[apiEnv as keyof typeof API_ENV])
-            );
-        }
+    public setNewJsonRpcProvider(apiEnv: API_ENV) {
+        this._apiProvider = new JsonRpcProvider(getDefaultAPI(apiEnv));
     }
 
     public get instance() {

--- a/wallet/src/ui/app/ApiProvider.ts
+++ b/wallet/src/ui/app/ApiProvider.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+// import { JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import { RawSigner, JsonRpcProvider } from '@mysten/sui.js';
 
 import type { Ed25519Keypair } from '@mysten/sui.js';
 
@@ -16,9 +17,9 @@ type EnvInfo = {
     color: string;
 };
 export const API_ENV_TO_INFO: Record<API_ENV, EnvInfo> = {
-    [API_ENV.local]: { name: 'Local', color: '#000' },
-    [API_ENV.devNet]: { name: 'DevNet', color: '#666' },
-    [API_ENV.staging]: { name: 'Staging', color: '#999' },
+    [API_ENV.local]: { name: 'Local', color: '#9064ff' },
+    [API_ENV.devNet]: { name: 'DevNet', color: '#29b6af' },
+    [API_ENV.staging]: { name: 'Staging', color: '#ff4a8d' },
 };
 
 export const ENV_TO_API: Record<API_ENV, string | undefined> = {
@@ -52,6 +53,14 @@ export default class ApiProvider {
 
     constructor() {
         this._apiProvider = new JsonRpcProvider(DEFAULT_API_ENDPOINT);
+    }
+
+    public setNewJsonRpcProvider(apiEnv: string) {
+        if (apiEnv) {
+            this._apiProvider = new JsonRpcProvider(
+                getDefaultAPI(API_ENV[apiEnv as keyof typeof API_ENV])
+            );
+        }
     }
 
     public get instance() {

--- a/wallet/src/ui/app/components/account-address/index.tsx
+++ b/wallet/src/ui/app/components/account-address/index.tsx
@@ -12,7 +12,7 @@ function AccountAddress() {
     const address = useAppSelector(
         ({ account: { address } }) => address && `0x${address}`
     );
-    const shortenAddress = useMiddleEllipsis(address || '');
+    const shortenAddress = useMiddleEllipsis(address || '', 20);
     return address ? (
         <span className={st['address-container']}>
             <CopyToClipboard txt={address}>

--- a/wallet/src/ui/app/components/header/index.tsx
+++ b/wallet/src/ui/app/components/header/index.tsx
@@ -22,6 +22,13 @@ function Header() {
             <NavLink to="./nfts" className={makeLinkCls} title="NFTs">
                 <BsIcon className={st.icon} icon="collection" />
             </NavLink>
+            <NavLink
+                to="./transactions"
+                className={makeLinkCls}
+                title="Transactions"
+            >
+                <BsIcon className={st.icon} icon="arrow-left-right" />
+            </NavLink>
             <NavLink to="./settings" className={makeLinkCls} title="Settings">
                 <BsIcon className={st.icon} icon="gear" />
             </NavLink>

--- a/wallet/src/ui/app/components/network-switch/Network.module.scss
+++ b/wallet/src/ui/app/components/network-switch/Network.module.scss
@@ -1,0 +1,111 @@
+.network {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    margin-left: 10px;
+    width: 100%;
+    justify-content: space-between;
+    font-family: 'Space Mono', monospace;
+}
+
+.network-container {
+    max-width: 180px;
+    height: 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 100px;
+    border: 1px solid #d1d9e1;
+    padding: 8px 16px;
+    width: 100%;
+    background-color: #f8f8f8;
+    cursor: pointer;
+}
+
+.network-icon {
+    font-size: 13px;
+}
+
+.network-name {
+    color: #000;
+    font-weight: 500;
+    margin-left: 4px;
+}
+
+.network-dropdown {
+    color: #000;
+    font-weight: bold;
+}
+
+.network-options {
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    background-color: #fff;
+    position: absolute;
+    z-index: 100;
+    min-height: 100px;
+    width: 250px;
+    border-radius: 10px;
+    margin-right: 23px;
+    top: 56px;
+    box-shadow: 1px 1px 3px 0 #d1d9e1;
+    cursor: auto;
+    font-family: 'Space Mono', monospace;
+    padding: 16px 0 0;
+
+    .network-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        width: 100%;
+        line-height: 150%;
+        font-size: 1rem;
+        text-align: center;
+        border-bottom: 1px solid #d1d9e1;
+        padding-bottom: 10px;
+    }
+
+    .network-lists {
+        list-style: none;
+        padding: 0;
+        overflow-y: auto;
+        margin-bottom: 0;
+        margin-top: 0;
+        width: 100%;
+    }
+
+    .network-item {
+        list-style: none;
+        padding: 16px;
+        font-size: 16px;
+        font-style: normal;
+        cursor: pointer;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        line-height: 20px;
+
+        &:hover {
+            background-color: #e6effe;
+        }
+
+        .network-icon {
+            margin-right: 15px;
+        }
+
+        .selected-network {
+            margin-right: 15px;
+            font-weight: bold;
+            font-size: 20px;
+            opacity: 0;
+        }
+
+        .network-active {
+            opacity: 1;
+            color: #6fbcf0;
+        }
+    }
+}

--- a/wallet/src/ui/app/components/network-switch/Network.module.scss
+++ b/wallet/src/ui/app/components/network-switch/Network.module.scss
@@ -9,7 +9,7 @@
 }
 
 .network-container {
-    max-width: 180px;
+    max-width: 150px;
     height: 25px;
     display: flex;
     align-items: center;

--- a/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
+++ b/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
@@ -31,13 +31,15 @@ const NetworkSelector = () => {
         []
     );
 
+    // TODO move the dispatch to combinereducer
     const changeNetwork = useCallback(
-        (networkName: string) => () => {
+        (e: React.MouseEvent<HTMLLIElement>) => {
+            const networkName = e.currentTarget.dataset.network;
             const apiEnv = API_ENV[networkName as keyof typeof API_ENV];
             dispatch(setNetworkSelector(true));
             dispatch(setApiEnv(apiEnv));
             dispatch(changeRPCNetwork());
-            dispatch(getTransactionsByAddress()).unwrap();
+            dispatch(getTransactionsByAddress());
         },
         [dispatch]
     );
@@ -46,11 +48,12 @@ const NetworkSelector = () => {
         <div className={st['network-options']}>
             <div className={st['network-header']}>RPC NETWORK</div>
             <ul className={st['network-lists']}>
-                {netWorks.map((apiEnv, index) => (
+                {netWorks.map((apiEnv) => (
                     <li
                         className={st['network-item']}
-                        key={`networkid-${index}`}
-                        onClick={changeNetwork(apiEnv.networkName)}
+                        key={apiEnv.networkName}
+                        data-network={apiEnv.networkName}
+                        onClick={changeNetwork}
                     >
                         <BsIcon
                             icon="check2"
@@ -69,15 +72,6 @@ const NetworkSelector = () => {
                         {apiEnv.name}
                     </li>
                 ))}
-
-                <li className={st['network-item']}>
-                    <BsIcon
-                        icon="check2"
-                        className={cl(st['selected-network'])}
-                    />
-                    <BsIcon icon="circle-fill" className={st['network-icon']} />
-                    Custom
-                </li>
             </ul>
         </div>
     );

--- a/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
+++ b/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
@@ -12,6 +12,7 @@ import {
     changeRPCNetwork,
     setNetworkSelector,
 } from '_redux/slices/app';
+import { getTransactionsByAddress } from '_redux/slices/txresults';
 import store from '_store';
 
 import st from './Network.module.scss';
@@ -36,8 +37,9 @@ const NetworkSelector = () => {
             dispatch(setNetworkSelector(true));
             store.dispatch(setApiEnv(apiEnv));
             dispatch(changeRPCNetwork()).unwrap();
+            dispatch(getTransactionsByAddress()).unwrap();
         },
-        []
+        [dispatch]
     );
 
     return (

--- a/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
+++ b/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
@@ -13,30 +13,30 @@ import {
     setNetworkSelector,
 } from '_redux/slices/app';
 import { getTransactionsByAddress } from '_redux/slices/txresults';
-import store from '_store';
 
 import st from './Network.module.scss';
 
 const NetworkSelector = () => {
     const selectedApiEnv = useAppSelector(({ app }) => app.apiEnv);
     const dispatch = useAppDispatch();
-    const networkList: any = API_ENV_TO_INFO;
     const netWorks = useMemo(
         () =>
-            Object.keys(networkList).map((itm: string) => ({
-                style: { color: networkList[itm].color },
-                ...networkList[itm],
+            Object.keys(API_ENV).map((itm) => ({
+                style: {
+                    color: API_ENV_TO_INFO[itm as keyof typeof API_ENV].color,
+                },
+                ...API_ENV_TO_INFO[itm as keyof typeof API_ENV],
                 networkName: itm,
             })),
-        [networkList]
+        []
     );
 
     const changeNetwork = useCallback(
         (networkName: string) => () => {
             const apiEnv = API_ENV[networkName as keyof typeof API_ENV];
             dispatch(setNetworkSelector(true));
-            store.dispatch(setApiEnv(apiEnv));
-            dispatch(changeRPCNetwork()).unwrap();
+            dispatch(setApiEnv(apiEnv));
+            dispatch(changeRPCNetwork());
             dispatch(getTransactionsByAddress()).unwrap();
         },
         [dispatch]
@@ -56,9 +56,8 @@ const NetworkSelector = () => {
                             icon="check2"
                             className={cl(
                                 st['selected-network'],
-                                selectedApiEnv === apiEnv.networkName
-                                    ? st['network-active']
-                                    : ''
+                                selectedApiEnv === apiEnv.networkName &&
+                                    st['network-active']
                             )}
                         />
                         <div style={apiEnv.style}>

--- a/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
+++ b/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
@@ -36,12 +36,12 @@ const NetworkSelector = () => {
     );
 
     return (
-        <div className={st['network-options']}>
-            <div className={st['network-header']}>RPC NETWORK</div>
-            <ul className={st['network-lists']}>
+        <div className={st.networkOptions}>
+            <div className={st.networkHeader}>RPC NETWORK</div>
+            <ul className={st.networkLists}>
                 {netWorks.map((apiEnv) => (
                     <li
-                        className={st['network-item']}
+                        className={st.networkItem}
                         key={apiEnv.networkName}
                         data-network={apiEnv.networkName}
                         onClick={changeNetwork}
@@ -49,15 +49,15 @@ const NetworkSelector = () => {
                         <BsIcon
                             icon="check2"
                             className={cl(
-                                st['selected-network'],
+                                st.selectedNetwork,
                                 selectedApiEnv === apiEnv.networkName &&
-                                    st['network-active']
+                                    st.networkActive
                             )}
                         />
                         <div style={apiEnv.style}>
                             <BsIcon
                                 icon="circle-fill"
-                                className={st['network-icon']}
+                                className={st.networkIcon}
                             />
                         </div>
                         {apiEnv.name}

--- a/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
+++ b/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import cl from 'classnames';
+import { useMemo, useCallback } from 'react';
+
+import { API_ENV_TO_INFO, API_ENV } from '_app/ApiProvider';
+import BsIcon from '_components/bs-icon';
+import { useAppSelector, useAppDispatch } from '_hooks';
+import {
+    setApiEnv,
+    changeRPCNetwork,
+    setNetworkSelector,
+} from '_redux/slices/app';
+import store from '_store';
+
+import st from './Network.module.scss';
+
+const NetworkSelector = () => {
+    const selectedApiEnv = useAppSelector(({ app }) => app.apiEnv);
+    const dispatch = useAppDispatch();
+    const networkList: any = API_ENV_TO_INFO;
+    const netWorks = useMemo(
+        () =>
+            Object.keys(networkList).map((itm: string) => ({
+                style: { color: networkList[itm].color },
+                ...networkList[itm],
+                networkName: itm,
+            })),
+        [networkList]
+    );
+
+    const changeNetwork = useCallback(
+        (networkName: string) => () => {
+            const apiEnv = API_ENV[networkName as keyof typeof API_ENV];
+            dispatch(setNetworkSelector(true));
+            store.dispatch(setApiEnv(apiEnv));
+            dispatch(changeRPCNetwork()).unwrap();
+        },
+        []
+    );
+
+    return (
+        <div className={st['network-options']}>
+            <div className={st['network-header']}>RPC NETWORK</div>
+            <ul className={st['network-lists']}>
+                {netWorks.map((apiEnv, index) => (
+                    <li
+                        className={st['network-item']}
+                        key={`networkid-${index}`}
+                        onClick={changeNetwork(apiEnv.networkName)}
+                    >
+                        <BsIcon
+                            icon="check2"
+                            className={cl(
+                                st['selected-network'],
+                                selectedApiEnv === apiEnv.networkName
+                                    ? st['network-active']
+                                    : ''
+                            )}
+                        />
+                        <div style={apiEnv.style}>
+                            <BsIcon
+                                icon="circle-fill"
+                                className={st['network-icon']}
+                            />
+                        </div>
+                        {apiEnv.name}
+                    </li>
+                ))}
+
+                <li className={st['network-item']}>
+                    <BsIcon
+                        icon="check2"
+                        className={cl(st['selected-network'])}
+                    />
+                    <BsIcon icon="circle-fill" className={st['network-icon']} />
+                    Custom
+                </li>
+            </ul>
+        </div>
+    );
+};
+
+export default NetworkSelector;

--- a/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
+++ b/wallet/src/ui/app/components/network-switch/NetworkSelector.tsx
@@ -7,12 +7,7 @@ import { useMemo, useCallback } from 'react';
 import { API_ENV_TO_INFO, API_ENV } from '_app/ApiProvider';
 import BsIcon from '_components/bs-icon';
 import { useAppSelector, useAppDispatch } from '_hooks';
-import {
-    setApiEnv,
-    changeRPCNetwork,
-    setNetworkSelector,
-} from '_redux/slices/app';
-import { getTransactionsByAddress } from '_redux/slices/txresults';
+import { changeRPCNetwork } from '_redux/slices/app';
 
 import st from './Network.module.scss';
 
@@ -31,15 +26,11 @@ const NetworkSelector = () => {
         []
     );
 
-    // TODO move the dispatch to combinereducer
     const changeNetwork = useCallback(
-        (e: React.MouseEvent<HTMLLIElement>) => {
+        (e: React.MouseEvent<HTMLElement>) => {
             const networkName = e.currentTarget.dataset.network;
             const apiEnv = API_ENV[networkName as keyof typeof API_ENV];
-            dispatch(setNetworkSelector(true));
-            dispatch(setApiEnv(apiEnv));
-            dispatch(changeRPCNetwork());
-            dispatch(getTransactionsByAddress());
+            dispatch(changeRPCNetwork(apiEnv));
         },
         [dispatch]
     );

--- a/wallet/src/ui/app/components/network-switch/index.tsx
+++ b/wallet/src/ui/app/components/network-switch/index.tsx
@@ -37,22 +37,19 @@ const Network = () => {
 
     return (
         <div
-            className={st['network-container']}
+            className={st.networkContainer}
             ref={ref}
             onClick={openNetworkSelector}
         >
             {selectedApiEnv ? (
                 <div className={st.network} style={netColor}>
-                    <BsIcon icon="circle-fill" className={st['network-icon']} />
-                    <span className={st['network-name']}>
+                    <BsIcon icon="circle-fill" className={st.networkIcon} />
+                    <span className={st.networkName}>
                         {API_ENV_TO_INFO[selectedApiEnv].name}
                     </span>
                     <BsIcon
                         icon={showNetworkSelect ? 'chevron-up' : 'chevron-down'}
-                        className={cl(
-                            st['network-icon'],
-                            st['network-dropdown']
-                        )}
+                        className={cl(st.networkIcon, st.networkDropdown)}
                     />
                 </div>
             ) : null}

--- a/wallet/src/ui/app/components/network-switch/index.tsx
+++ b/wallet/src/ui/app/components/network-switch/index.tsx
@@ -36,19 +36,19 @@ const Network = () => {
     useOnClickOutside(ref, clickOutsidehandler);
 
     return (
-        <div className={st['network-container']} ref={ref}>
+        <div
+            className={st['network-container']}
+            ref={ref}
+            onClick={openNetworkSelector}
+        >
             {selectedApiEnv ? (
-                <div
-                    className={st.network}
-                    style={netColor}
-                    onClick={openNetworkSelector}
-                >
+                <div className={st.network} style={netColor}>
                     <BsIcon icon="circle-fill" className={st['network-icon']} />
                     <span className={st['network-name']}>
                         {API_ENV_TO_INFO[selectedApiEnv].name}
                     </span>
                     <BsIcon
-                        icon="chevron-down"
+                        icon={showNetworkSelect ? 'chevron-up' : 'chevron-down'}
                         className={cl(
                             st['network-icon'],
                             st['network-dropdown']

--- a/wallet/src/ui/app/components/network-switch/index.tsx
+++ b/wallet/src/ui/app/components/network-switch/index.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import cl from 'classnames';
+import { useMemo, useCallback, useEffect, useRef } from 'react';
+
+import NetworkSelector from './NetworkSelector';
+import { API_ENV_TO_INFO } from '_app/ApiProvider';
+import BsIcon from '_components/bs-icon';
+import { useAppSelector, useAppDispatch } from '_hooks';
+import { setNetworkSelector } from '_redux/slices/app';
+
+import st from './Network.module.scss';
+
+const Network = () => {
+    const selectedApiEnv = useAppSelector(({ app }) => app.apiEnv);
+    const showNetworkSelect = useAppSelector(({ app }) => app.showHideNetwork);
+    const dispatch = useAppDispatch();
+
+    const openNetworkSelector = useCallback(
+        () => () => {
+            dispatch(setNetworkSelector(showNetworkSelect));
+        },
+        [dispatch, showNetworkSelect]
+    );
+
+    const netColor = useMemo(
+        () =>
+            selectedApiEnv
+                ? { color: API_ENV_TO_INFO[selectedApiEnv].color }
+                : {},
+        [selectedApiEnv]
+    );
+    const ref = useRef<HTMLHeadingElement>(null);
+
+    useEffect(() => {
+        const handleClickOutside = (
+            event: React.ChangeEvent<HTMLInputElement> | any
+        ) => {
+            if (ref.current && !ref.current.contains(event.target)) {
+                showNetworkSelect && dispatch(setNetworkSelector(true));
+            }
+        };
+        document.addEventListener('click', handleClickOutside, true);
+        return () => {
+            document.removeEventListener('click', handleClickOutside, true);
+        };
+    }, [dispatch, showNetworkSelect]);
+
+    return (
+        <div className={st['network-container']} ref={ref}>
+            {selectedApiEnv ? (
+                <div
+                    className={st.network}
+                    style={netColor}
+                    onClick={openNetworkSelector()}
+                >
+                    <BsIcon icon="circle-fill" className={st['network-icon']} />
+                    <span className={st['network-name']}>
+                        {API_ENV_TO_INFO[selectedApiEnv].name}
+                    </span>
+                    <BsIcon
+                        icon="chevron-down"
+                        className={cl(
+                            st['network-icon'],
+                            st['network-dropdown']
+                        )}
+                    />
+                </div>
+            ) : null}
+
+            {showNetworkSelect && <NetworkSelector />}
+        </div>
+    );
+};
+
+export default Network;

--- a/wallet/src/ui/app/components/network-switch/index.tsx
+++ b/wallet/src/ui/app/components/network-switch/index.tsx
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { useMemo, useCallback, useEffect, useRef } from 'react';
+import { useMemo, useCallback, useRef } from 'react';
 
 import NetworkSelector from './NetworkSelector';
 import { API_ENV_TO_INFO } from '_app/ApiProvider';
 import BsIcon from '_components/bs-icon';
-import { useAppSelector, useAppDispatch } from '_hooks';
+import { useAppSelector, useAppDispatch, useOnClickOutside } from '_hooks';
 import { setNetworkSelector } from '_redux/slices/app';
 
 import st from './Network.module.scss';
@@ -17,12 +17,9 @@ const Network = () => {
     const showNetworkSelect = useAppSelector(({ app }) => app.showHideNetwork);
     const dispatch = useAppDispatch();
 
-    const openNetworkSelector = useCallback(
-        () => () => {
-            dispatch(setNetworkSelector(showNetworkSelect));
-        },
-        [dispatch, showNetworkSelect]
-    );
+    const openNetworkSelector = useCallback(() => {
+        dispatch(setNetworkSelector(showNetworkSelect));
+    }, [dispatch, showNetworkSelect]);
 
     const netColor = useMemo(
         () =>
@@ -33,19 +30,10 @@ const Network = () => {
     );
     const ref = useRef<HTMLHeadingElement>(null);
 
-    useEffect(() => {
-        const handleClickOutside = (
-            event: React.ChangeEvent<HTMLInputElement> | any
-        ) => {
-            if (ref.current && !ref.current.contains(event.target)) {
-                showNetworkSelect && dispatch(setNetworkSelector(true));
-            }
-        };
-        document.addEventListener('click', handleClickOutside, true);
-        return () => {
-            document.removeEventListener('click', handleClickOutside, true);
-        };
-    }, [dispatch, showNetworkSelect]);
+    const clickOutsidehandler = () => {
+        return showNetworkSelect && dispatch(setNetworkSelector(true));
+    };
+    useOnClickOutside(ref, clickOutsidehandler);
 
     return (
         <div className={st['network-container']} ref={ref}>
@@ -53,7 +41,7 @@ const Network = () => {
                 <div
                     className={st.network}
                     style={netColor}
-                    onClick={openNetworkSelector()}
+                    onClick={openNetworkSelector}
                 >
                     <BsIcon icon="circle-fill" className={st['network-icon']} />
                     <span className={st['network-name']}>

--- a/wallet/src/ui/app/components/transactions-card/TransactionsCard.module.scss
+++ b/wallet/src/ui/app/components/transactions-card/TransactionsCard.module.scss
@@ -1,34 +1,30 @@
-.tx-container {
+.title {
     font-size: 15px;
+    font-weight: 700;
+    color: #404040;
+}
 
-    .title {
-        font-size: 15px;
-        font-weight: 700;
-        color: #404040;
+.card {
+    box-shadow: 0 1px 2px 0 #0000000d;
+    background-color: #fff;
+    display: grid;
+    height: auto;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    padding: 0.8rem;
+    text-align: left;
+    font-family: 'Space Mono', ui-monospace, monospace;
+
+    a {
+        color: #4caad8;
+        text-decoration: none;
     }
+}
 
-    .card {
-        box-shadow: 0 1px 2px 0 #0000000d;
-        background-color: #fff;
-        display: grid;
-        height: auto;
-        margin-bottom: 1rem;
-        margin-top: 1rem;
-        padding: 0.8rem;
-        text-align: left;
-        font-family: 'Space Mono', ui-monospace, monospace;
+.failure {
+    color: #fca5a5;
+}
 
-        a {
-            color: #4caad8;
-            text-decoration: none;
-        }
-    }
-
-    .failure {
-        color: #fca5a5;
-    }
-
-    .success {
-        color: #4ade80;
-    }
+.success {
+    color: #4ade80;
 }

--- a/wallet/src/ui/app/components/transactions-card/TransactionsCard.module.scss
+++ b/wallet/src/ui/app/components/transactions-card/TransactionsCard.module.scss
@@ -1,0 +1,34 @@
+.tx-container {
+    font-size: 15px;
+
+    .title {
+        font-size: 15px;
+        font-weight: 700;
+        color: #404040;
+    }
+
+    .card {
+        box-shadow: 0 1px 2px 0 #0000000d;
+        background-color: #fff;
+        display: grid;
+        height: auto;
+        margin-bottom: 1rem;
+        margin-top: 1rem;
+        padding: 0.8rem;
+        text-align: left;
+        font-family: 'Space Mono', ui-monospace, monospace;
+
+        a {
+            color: #4caad8;
+            text-decoration: none;
+        }
+    }
+
+    .failure {
+        color: #fca5a5;
+    }
+
+    .success {
+        color: #4ade80;
+    }
+}

--- a/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -2,95 +2,67 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
+import { memo } from 'react';
 
-import AccountAddress from '_components/account-address';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
+import { useMiddleEllipsis } from '_hooks';
 
-import type { ExecutionStatusType, TransactionKindName } from '@mysten/sui.js';
+import type { TxResultState } from '_redux/slices/txresults';
 
 import st from './TransactionsCard.module.scss';
 
-type TxnData = {
-    To?: string;
-    seq: number;
-    txId: string;
-    status: ExecutionStatusType;
-    txGas: number;
-    kind: TransactionKindName | undefined;
-    From: string;
-};
-const truncate = (txt: string, maxLength: number) => {
-    if (txt.length < maxLength + 3) {
-        return txt;
-    }
-    const beginningLength = Math.ceil(maxLength / 2);
-    const endingLength = maxLength - beginningLength;
-    return `${txt.substring(0, beginningLength)}...${txt.substring(
-        txt.length - endingLength
-    )}`;
-};
+function TransactionCard({ txn }: { txn: TxResultState }) {
+    // can't use react hooks conditionaly so rendering the txn.To as with ellipsis or an empty string or if it is null
+    const toAddrStr = useMiddleEllipsis(txn.To || '', 20);
 
-function TransactionResult({ txresults }: { txresults: TxnData[] }) {
     return (
-        <div className={st['tx-container']}>
-            <h4>
-                Last 5 transaction for <AccountAddress />
-            </h4>
-            {txresults.map((txn) => (
-                <div className={st['card']} key={txn.txId}>
-                    <div>
-                        Tx:{' '}
-                        <ExplorerLink
-                            type={ExplorerLinkType.transaction}
-                            transactionID={txn.txId}
-                            title="View on Sui Explorer"
-                            className={st['explorer-link']}
-                        >
-                            {truncate(txn.txId || '', 20)}
-                        </ExplorerLink>
-                    </div>
-                    <div>TxType: Call </div>
-                    <div>
-                        {' '}
-                        Gas : {txn.txGas} | Status:{' '}
-                        <span
-                            className={cl(
-                                st[txn.status.toLowerCase()],
-                                st.txstatus
-                            )}
-                        >
-                            {txn.status === 'success' ? '\u2714' : '\u2716'}{' '}
-                        </span>
-                    </div>
-                    <div>
-                        From:
-                        <ExplorerLink
-                            type={ExplorerLinkType.address}
-                            address={txn.From}
-                            title="View on Sui Explorer"
-                            className={st['explorer-link']}
-                        >
-                            {truncate(txn.From || '', 20)}
-                        </ExplorerLink>
-                    </div>
-                    {txn.To && (
-                        <div>
-                            To:
-                            <ExplorerLink
-                                type={ExplorerLinkType.address}
-                                address={txn.From}
-                                title="View on Sui Explorer"
-                                className={st['explorer-link']}
-                            >
-                                {truncate(txn.To || '', 20)}
-                            </ExplorerLink>
-                        </div>
-                    )}
+        <div className={st['card']} key={txn.txId}>
+            <div>
+                Tx:{' '}
+                <ExplorerLink
+                    type={ExplorerLinkType.transaction}
+                    transactionID={txn.txId}
+                    title="View on Sui Explorer"
+                    className={st['explorer-link']}
+                >
+                    {useMiddleEllipsis(txn.txId || '', 20)}
+                </ExplorerLink>
+            </div>
+            <div>TxType: Call </div>
+            <div>
+                {' '}
+                Gas : {txn.txGas} | Status:{' '}
+                <span className={cl(st[txn.status.toLowerCase()], st.txstatus)}>
+                    {txn.status === 'success' ? '\u2714' : '\u2716'}{' '}
+                </span>
+            </div>
+            <div>
+                From:
+                <ExplorerLink
+                    type={ExplorerLinkType.address}
+                    address={txn.From}
+                    title="View on Sui Explorer"
+                    className={st['explorer-link']}
+                >
+                    {useMiddleEllipsis(txn.From || '', 20)}
+                </ExplorerLink>
+            </div>
+            {txn?.To && (
+                <div>
+                    To:
+                    <ExplorerLink
+                        type={ExplorerLinkType.address}
+                        address={txn.To}
+                        title="View on Sui Explorer"
+                        className={st['explorer-link']}
+                    >
+                        {toAddrStr}
+                    </ExplorerLink>
                 </div>
-            ))}
+            )}
         </div>
     );
 }
 
-export default TransactionResult;
+export default memo(TransactionCard);

--- a/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -13,11 +13,10 @@ import type { TxResultState } from '_redux/slices/txresults';
 import st from './TransactionsCard.module.scss';
 
 function TransactionCard({ txn }: { txn: TxResultState }) {
-    // can't use react hooks conditionaly so rendering the txn.To as with ellipsis or an empty string or if it is null
     const toAddrStr = useMiddleEllipsis(txn.To || '', 20);
 
     return (
-        <div className={st['card']} key={txn.txId}>
+        <div className={st.card} key={txn.txId}>
             <div>
                 Tx:{' '}
                 <ExplorerLink
@@ -55,7 +54,7 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
                         type={ExplorerLinkType.address}
                         address={txn.To}
                         title="View on Sui Explorer"
-                        className={st['explorer-link']}
+                        className={st.explorerLink}
                     >
                         {toAddrStr}
                     </ExplorerLink>

--- a/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import cl from 'classnames';
+
+import AccountAddress from '_components/account-address';
+import ExplorerLink from '_components/explorer-link';
+import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
+
+import type { ExecutionStatusType, TransactionKindName } from '@mysten/sui.js';
+
+import st from './TransactionsCard.module.scss';
+
+type TxnData = {
+    To?: string;
+    seq: number;
+    txId: string;
+    status: ExecutionStatusType;
+    txGas: number;
+    kind: TransactionKindName | undefined;
+    From: string;
+};
+const truncate = (txt: string, maxLength: number) => {
+    if (txt.length < maxLength + 3) {
+        return txt;
+    }
+    const beginningLength = Math.ceil(maxLength / 2);
+    const endingLength = maxLength - beginningLength;
+    return `${txt.substring(0, beginningLength)}...${txt.substring(
+        txt.length - endingLength
+    )}`;
+};
+
+function TransactionResult({ txresults }: { txresults: TxnData[] }) {
+    return (
+        <div className={st['tx-container']}>
+            <h4>
+                Last 5 transaction for <AccountAddress />
+            </h4>
+            {txresults.map((txn) => (
+                <div className={st['card']} key={txn.txId}>
+                    <div>
+                        Tx:{' '}
+                        <ExplorerLink
+                            type={ExplorerLinkType.transaction}
+                            transactionID={txn.txId}
+                            title="View on Sui Explorer"
+                            className={st['explorer-link']}
+                        >
+                            {truncate(txn.txId || '', 20)}
+                        </ExplorerLink>
+                    </div>
+                    <div>TxType: Call </div>
+                    <div>
+                        {' '}
+                        Gas : {txn.txGas} | Status:{' '}
+                        <span
+                            className={cl(
+                                st[txn.status.toLowerCase()],
+                                st.txstatus
+                            )}
+                        >
+                            {txn.status === 'success' ? '\u2714' : '\u2716'}{' '}
+                        </span>
+                    </div>
+                    <div>
+                        From:
+                        <ExplorerLink
+                            type={ExplorerLinkType.address}
+                            address={txn.From}
+                            title="View on Sui Explorer"
+                            className={st['explorer-link']}
+                        >
+                            {truncate(txn.From || '', 20)}
+                        </ExplorerLink>
+                    </div>
+                    {txn.To && (
+                        <div>
+                            To:
+                            <ExplorerLink
+                                type={ExplorerLinkType.address}
+                                address={txn.From}
+                                title="View on Sui Explorer"
+                                className={st['explorer-link']}
+                            >
+                                {truncate(txn.To || '', 20)}
+                            </ExplorerLink>
+                        </div>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export default TransactionResult;

--- a/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -42,7 +42,7 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
                     type={ExplorerLinkType.address}
                     address={txn.From}
                     title="View on Sui Explorer"
-                    className={st['explorer-link']}
+                    className={st.explorerLink}
                 >
                     {useMiddleEllipsis(txn.From || '', 20)}
                 </ExplorerLink>

--- a/wallet/src/ui/app/hooks/index.ts
+++ b/wallet/src/ui/app/hooks/index.ts
@@ -9,3 +9,4 @@ export { default as useMiddleEllipsis } from './useMiddleEllipsis';
 export { default as useMediaUrl } from './useMediaUrl';
 export { default as useSuiObjectFields } from './useSuiObjectFields';
 export { default as useNumberDelimiters } from './useNumberDelimiters';
+export { default as useOnClickOutside } from './useOnClickOutside';

--- a/wallet/src/ui/app/hooks/useOnClickOutside.ts
+++ b/wallet/src/ui/app/hooks/useOnClickOutside.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+
+import type { RefObject } from 'react';
+
+type Event = MouseEvent | TouchEvent;
+
+const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
+    ref: RefObject<T>,
+    handler: (event: Event) => void
+) => {
+    useEffect(() => {
+        const listener = (event: Event) => {
+            const el = ref?.current;
+            if (!el || el.contains((event?.target as Node) || null)) {
+                return;
+            }
+
+            handler(event); // Call the handler only if the click is outside of the element passed.
+        };
+
+        document.addEventListener('mousedown', listener);
+        document.addEventListener('touchstart', listener);
+
+        return () => {
+            document.removeEventListener('mousedown', listener);
+            document.removeEventListener('touchstart', listener);
+        };
+    }, [ref, handler]); // Reload only if ref or handler changes
+};
+
+export default useOnClickOutside;

--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -8,6 +8,7 @@ import HomePage from './pages/home';
 import NftsPage from './pages/home/nfts';
 import SettingsPage from './pages/home/settings';
 import TokensPage from './pages/home/tokens';
+import TransactionsPage from './pages/home/transactions';
 import InitializePage from './pages/initialize';
 import BackupPage from './pages/initialize/backup';
 import CreatePage from './pages/initialize/create';
@@ -40,6 +41,7 @@ const App = () => {
                 />
                 <Route path="tokens" element={<TokensPage />} />
                 <Route path="nfts" element={<NftsPage />} />
+                <Route path="transactions" element={<TransactionsPage />} />
                 <Route path="settings" element={<SettingsPage />} />
                 <Route path="send" element={<TransferCoinPage />} />
                 <Route

--- a/wallet/src/ui/app/pages/home/index.tsx
+++ b/wallet/src/ui/app/pages/home/index.tsx
@@ -1,16 +1,15 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { of, filter, switchMap, from, defer, repeat } from 'rxjs';
 
-import { API_ENV_TO_INFO } from '_app/ApiProvider';
-import BsIcon from '_components/bs-icon';
 import Header from '_components/header';
 import Loading from '_components/loading';
 import Logo from '_components/logo';
-import { useInitializedGuard, useAppDispatch, useAppSelector } from '_hooks';
+import NetworkSwitch from '_components/network-switch';
+import { useInitializedGuard, useAppDispatch } from '_hooks';
 import { fetchAllOwnedObjects } from '_redux/slices/sui-objects';
 
 import st from './Home.module.scss';
@@ -33,30 +32,13 @@ const HomePage = () => {
             .subscribe();
         return () => sub.unsubscribe();
     }, [guardChecking, dispatch]);
-    const selectedApiEnv = useAppSelector(({ app }) => app.apiEnv);
-    const netColor = useMemo(
-        () =>
-            selectedApiEnv
-                ? { color: API_ENV_TO_INFO[selectedApiEnv].color }
-                : {},
-        [selectedApiEnv]
-    );
+
     return (
         <Loading loading={guardChecking}>
             <div className={st.container}>
                 <div className={st['outer-container']}>
                     <Logo txt={true} />
-                    {selectedApiEnv ? (
-                        <div className={st.network} style={netColor}>
-                            <BsIcon
-                                icon="circle-fill"
-                                className={st['network-icon']}
-                            />
-                            <span className={st['network-name']}>
-                                {API_ENV_TO_INFO[selectedApiEnv].name}
-                            </span>
-                        </div>
-                    ) : null}
+                    <NetworkSwitch />
                 </div>
                 <div className={st['inner-container']}>
                     <Header />

--- a/wallet/src/ui/app/pages/home/transactions/Transactions.module.scss
+++ b/wallet/src/ui/app/pages/home/transactions/Transactions.module.scss
@@ -1,0 +1,3 @@
+.tx-container {
+    font-size: 15px;
+}

--- a/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -22,7 +22,7 @@ function TransactionPage() {
     }, [dispatch]);
 
     return txByAddress && txByAddress.length ? (
-        <div className={st['tx-container']}>
+        <div className={st.txContainer}>
             <h4>
                 Last 5 transaction for <AccountAddress />
             </h4>

--- a/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -1,33 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import { memo, useEffect } from 'react';
 
-import { useMemo } from 'react';
-
-import CoinBalance from '_components/coin-balance';
-import ObjectsLayout from '_components/objects-layout';
-import { useAppSelector } from '_hooks';
-import { accountAggregateBalancesSelector } from '_redux/slices/account';
+import TransactionResult from '_components/transactions-card';
+import { useAppSelector, useAppDispatch } from '_hooks';
+import { getTransactionsByAddress } from '_redux/slices/txresults';
 
 function TransactionPage() {
-    const balances = useAppSelector(accountAggregateBalancesSelector);
-    const coinTypes = useMemo(() => Object.keys(balances), [balances]);
-    return (
-        <ObjectsLayout
-            totalItems={coinTypes?.length}
-            emptyMsg="No tokens found"
-        >
-            {coinTypes.map((aCoinType) => {
-                const aCoinBalance = balances[aCoinType];
-                return (
-                    <CoinBalance
-                        type={aCoinType}
-                        balance={aCoinBalance}
-                        key={aCoinType}
-                    />
-                );
-            })}
-        </ObjectsLayout>
-    );
+    const dispatch = useAppDispatch();
+    const txByAddress = useAppSelector(({ txresults }) => txresults.latestTx);
+
+    useEffect(() => {
+        dispatch(getTransactionsByAddress()).unwrap();
+    }, [dispatch]);
+
+    return txByAddress && txByAddress.length ? (
+        <TransactionResult
+            txresults={txByAddress.filter((_, index: number) => index <= 4)}
+        />
+    ) : null;
 }
 
-export default TransactionPage;
+export default memo(TransactionPage);

--- a/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -2,22 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 import { memo, useEffect } from 'react';
 
-import TransactionResult from '_components/transactions-card';
+import AccountAddress from '_components/account-address';
+import TransactionCard from '_components/transactions-card';
 import { useAppSelector, useAppDispatch } from '_hooks';
 import { getTransactionsByAddress } from '_redux/slices/txresults';
 
+import type { TxResultState } from '_redux/slices/txresults';
+
+import st from './Transactions.module.scss';
+
 function TransactionPage() {
     const dispatch = useAppDispatch();
-    const txByAddress = useAppSelector(({ txresults }) => txresults.latestTx);
+    const txByAddress: TxResultState[] = useAppSelector(
+        ({ txresults }) => txresults.latestTx
+    );
 
     useEffect(() => {
         dispatch(getTransactionsByAddress()).unwrap();
     }, [dispatch]);
 
     return txByAddress && txByAddress.length ? (
-        <TransactionResult
-            txresults={txByAddress.filter((_, index: number) => index <= 4)}
-        />
+        <div className={st['tx-container']}>
+            <h4>
+                Last 5 transaction for <AccountAddress />
+            </h4>
+            {txByAddress.slice(0, 5).map((txn) => (
+                <TransactionCard txn={txn} key={txn.txId} />
+            ))}
+        </div>
     ) : null;
 }
 

--- a/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import CoinBalance from '_components/coin-balance';
+import ObjectsLayout from '_components/objects-layout';
+import { useAppSelector } from '_hooks';
+import { accountAggregateBalancesSelector } from '_redux/slices/account';
+
+function TransactionPage() {
+    const balances = useAppSelector(accountAggregateBalancesSelector);
+    const coinTypes = useMemo(() => Object.keys(balances), [balances]);
+    return (
+        <ObjectsLayout
+            totalItems={coinTypes?.length}
+            emptyMsg="No tokens found"
+        >
+            {coinTypes.map((aCoinType) => {
+                const aCoinBalance = balances[aCoinType];
+                return (
+                    <CoinBalance
+                        type={aCoinType}
+                        balance={aCoinBalance}
+                        key={aCoinType}
+                    />
+                );
+            })}
+        </ObjectsLayout>
+    );
+}
+
+export default TransactionPage;

--- a/wallet/src/ui/app/redux/RootReducer.ts
+++ b/wallet/src/ui/app/redux/RootReducer.ts
@@ -7,8 +7,16 @@ import account from './slices/account';
 import app from './slices/app';
 import suiObjects from './slices/sui-objects';
 import transactions from './slices/transactions';
+// TODO add to transactions slice
+import txresults from './slices/txresults';
 
-const rootReducer = combineReducers({ account, app, suiObjects, transactions });
+const rootReducer = combineReducers({
+    account,
+    app,
+    suiObjects,
+    transactions,
+    txresults,
+});
 
 export type RootState = ReturnType<typeof rootReducer>;
 

--- a/wallet/src/ui/app/redux/RootReducer.ts
+++ b/wallet/src/ui/app/redux/RootReducer.ts
@@ -7,7 +7,6 @@ import account from './slices/account';
 import app from './slices/app';
 import suiObjects from './slices/sui-objects';
 import transactions from './slices/transactions';
-// TODO add to transactions slice
 import txresults from './slices/txresults';
 
 const rootReducer = combineReducers({

--- a/wallet/src/ui/app/redux/slices/app/index.ts
+++ b/wallet/src/ui/app/redux/slices/app/index.ts
@@ -5,6 +5,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppType } from './AppType';
 import { DEFAULT_API_ENV } from '_app/ApiProvider';
+// import { getTransactionsByAddress } from '_redux/slices/txresults';
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { API_ENV } from '_app/ApiProvider';
@@ -12,7 +13,7 @@ import type { AppThunkConfig } from '_store/thunk-extras';
 
 type AppState = {
     appType: AppType;
-    apiEnv: API_ENV | null;
+    apiEnv: API_ENV;
     showHideNetwork: boolean;
 };
 
@@ -44,6 +45,7 @@ const slice = createSlice({
             state.showHideNetwork = !payload;
         },
     },
+
     initialState,
 });
 

--- a/wallet/src/ui/app/redux/slices/app/index.ts
+++ b/wallet/src/ui/app/redux/slices/app/index.ts
@@ -25,11 +25,12 @@ const initialState: AppState = {
 };
 
 // On network change, set setNewJsonRpcProvider, fetch all owned objects, and fetch all transactions
+// TODO: add clear Object state because edge cases where use state stays in cache
 export const changeRPCNetwork = createAsyncThunk<void, API_ENV, AppThunkConfig>(
     'changeRPCNetwork',
-    async (networkName, { extra: { api }, dispatch }) => {
+    (networkName, { extra: { api }, dispatch }) => {
         dispatch(setApiEnv(networkName));
-        api.setNewJsonRpcProvider(networkName || 'devNet');
+        api.setNewJsonRpcProvider(networkName);
         dispatch(setNetworkSelector(true));
         dispatch(getTransactionsByAddress());
         dispatch(fetchAllOwnedObjects());

--- a/wallet/src/ui/app/redux/slices/app/index.ts
+++ b/wallet/src/ui/app/redux/slices/app/index.ts
@@ -5,7 +5,8 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppType } from './AppType';
 import { DEFAULT_API_ENV } from '_app/ApiProvider';
-// import { getTransactionsByAddress } from '_redux/slices/txresults';
+import { fetchAllOwnedObjects } from '_redux/slices/sui-objects';
+import { getTransactionsByAddress } from '_redux/slices/txresults';
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { API_ENV } from '_app/ApiProvider';
@@ -23,11 +24,15 @@ const initialState: AppState = {
     showHideNetwork: false,
 };
 
-export const changeRPCNetwork = createAsyncThunk<void, void, AppThunkConfig>(
+// On network change, set setNewJsonRpcProvider, fetch all owned objects, and fetch all transactions
+export const changeRPCNetwork = createAsyncThunk<void, API_ENV, AppThunkConfig>(
     'changeRPCNetwork',
-    async (_, { extra: { api }, getState }) => {
-        const newApiEnv = getState().app.apiEnv;
-        api.setNewJsonRpcProvider(newApiEnv || 'devNet');
+    async (networkName, { extra: { api }, dispatch }) => {
+        dispatch(setApiEnv(networkName));
+        api.setNewJsonRpcProvider(networkName || 'devNet');
+        dispatch(setNetworkSelector(true));
+        dispatch(getTransactionsByAddress());
+        dispatch(fetchAllOwnedObjects());
     }
 );
 

--- a/wallet/src/ui/app/redux/slices/app/index.ts
+++ b/wallet/src/ui/app/redux/slices/app/index.ts
@@ -1,23 +1,34 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppType } from './AppType';
 import { DEFAULT_API_ENV } from '_app/ApiProvider';
 
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { API_ENV } from '_app/ApiProvider';
+import type { AppThunkConfig } from '_store/thunk-extras';
 
 type AppState = {
     appType: AppType;
     apiEnv: API_ENV | null;
+    showHideNetwork: boolean;
 };
 
 const initialState: AppState = {
     appType: AppType.unknown,
     apiEnv: DEFAULT_API_ENV,
+    showHideNetwork: false,
 };
+
+export const changeRPCNetwork = createAsyncThunk<void, void, AppThunkConfig>(
+    'changeRPCNetwork',
+    async (_, { extra: { api }, getState }) => {
+        const newApiEnv = getState().app.apiEnv;
+        api.setNewJsonRpcProvider(newApiEnv || 'devNet');
+    }
+);
 
 const slice = createSlice({
     name: 'app',
@@ -28,10 +39,14 @@ const slice = createSlice({
         setApiEnv: (state, { payload }: PayloadAction<API_ENV>) => {
             state.apiEnv = payload;
         },
+        // TODO: move to a separate slice
+        setNetworkSelector: (state, { payload }: PayloadAction<boolean>) => {
+            state.showHideNetwork = !payload;
+        },
     },
     initialState,
 });
 
-export const { initAppType, setApiEnv } = slice.actions;
+export const { initAppType, setApiEnv, setNetworkSelector } = slice.actions;
 
 export default slice.reducer;

--- a/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -1,7 +1,15 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isSuiMoveObject } from '@mysten/sui.js';
+import {
+    isSuiMoveObject,
+    getTransactionDigest,
+    getTransactions,
+    getTransactionKindName,
+    getTransferCoinTransaction,
+    getExecutionStatusType,
+    getTotalGasUsed,
+} from '@mysten/sui.js';
 import {
     createAsyncThunk,
     createEntityAdapter,
@@ -18,6 +26,8 @@ import type {
     SuiAddress,
     SuiMoveObject,
     TransactionEffectsResponse,
+    GetTxnDigestsResponse,
+    CertifiedTransaction,
 } from '@mysten/sui.js';
 import type { RootState } from '_redux/RootReducer';
 import type { AppThunkConfig } from '_store/thunk-extras';
@@ -28,6 +38,7 @@ type SendTokensTXArgs = {
     recipientAddress: SuiAddress;
 };
 type TransactionResult = { EffectResponse: TransactionEffectsResponse };
+type TxResultByAddress = [];
 
 export const sendTokens = createAsyncThunk<
     TransactionResult,
@@ -54,12 +65,78 @@ export const sendTokens = createAsyncThunk<
             amount,
             recipientAddress
         );
+
         // TODO: better way to sync latest objects
         dispatch(fetchAllOwnedObjects());
         // TODO: is this correct? Find a better way to do it
         return response as TransactionResult;
     }
 );
+
+const deduplicate = (results: [number, string][] | undefined) =>
+    results
+        ? results
+              .map((result) => result[1])
+              .filter((value, index, self) => self.indexOf(value) === index)
+        : [];
+
+export const getTransactionsByAddress = createAsyncThunk<
+    TxResultByAddress,
+    GetTxnDigestsResponse,
+    AppThunkConfig
+>('sui-transactions/fetch-txData', async (_, { getState, extra: { api } }) => {
+    const address = getState().account.address;
+
+    if (address) {
+        // Get all transactions txId for address
+        const transactions: GetTxnDigestsResponse =
+            await api.instance.getTransactionsForAddress(address);
+        //getTransactionWithEffectsBatch
+
+        const resp = await api.instance
+            .getTransactionWithEffectsBatch(deduplicate(transactions))
+            .then((txEffs: TransactionEffectsResponse[]) => {
+                return (
+                    txEffs
+                        .map((txEff, i) => {
+                            const [seq, digest] = transactions.filter(
+                                (transactionId) =>
+                                    transactionId[1] ===
+                                    getTransactionDigest(txEff.certificate)
+                            )[0];
+                            const res: CertifiedTransaction = txEff.certificate;
+                            // TODO: handle multiple transactions
+                            const txns = getTransactions(res);
+                            if (txns.length > 1) {
+                                return null;
+                            }
+                            const txn = txns[0];
+                            const txKind = getTransactionKindName(txn);
+                            const recipient =
+                                getTransferCoinTransaction(txn)?.recipient;
+
+                            return {
+                                seq,
+                                txId: digest,
+                                status: getExecutionStatusType(txEff),
+                                txGas: getTotalGasUsed(txEff),
+                                kind: txKind,
+                                From: res.data.sender,
+                                ...(recipient
+                                    ? {
+                                          To: recipient,
+                                      }
+                                    : {}),
+                            };
+                        })
+                        // Remove failed transactions and sort by sequence number
+                        .filter((itm) => itm)
+                        .sort((a, b) => b!.seq - a!.seq)
+                );
+            });
+        return resp as any;
+    }
+});
 
 const txAdapter = createEntityAdapter<TransactionResult>({
     selectId: (tx) => tx.EffectResponse.certificate.transactionDigest,

--- a/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -1,15 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    isSuiMoveObject,
-    getTransactionDigest,
-    getTransactions,
-    getTransactionKindName,
-    getTransferCoinTransaction,
-    getExecutionStatusType,
-    getTotalGasUsed,
-} from '@mysten/sui.js';
+import { isSuiMoveObject } from '@mysten/sui.js';
 import {
     createAsyncThunk,
     createEntityAdapter,
@@ -26,8 +18,6 @@ import type {
     SuiAddress,
     SuiMoveObject,
     TransactionEffectsResponse,
-    GetTxnDigestsResponse,
-    CertifiedTransaction,
 } from '@mysten/sui.js';
 import type { RootState } from '_redux/RootReducer';
 import type { AppThunkConfig } from '_store/thunk-extras';
@@ -38,7 +28,6 @@ type SendTokensTXArgs = {
     recipientAddress: SuiAddress;
 };
 type TransactionResult = { EffectResponse: TransactionEffectsResponse };
-type TxResultByAddress = [];
 
 export const sendTokens = createAsyncThunk<
     TransactionResult,
@@ -72,71 +61,6 @@ export const sendTokens = createAsyncThunk<
         return response as TransactionResult;
     }
 );
-
-const deduplicate = (results: [number, string][] | undefined) =>
-    results
-        ? results
-              .map((result) => result[1])
-              .filter((value, index, self) => self.indexOf(value) === index)
-        : [];
-
-export const getTransactionsByAddress = createAsyncThunk<
-    TxResultByAddress,
-    GetTxnDigestsResponse,
-    AppThunkConfig
->('sui-transactions/fetch-txData', async (_, { getState, extra: { api } }) => {
-    const address = getState().account.address;
-
-    if (address) {
-        // Get all transactions txId for address
-        const transactions: GetTxnDigestsResponse =
-            await api.instance.getTransactionsForAddress(address);
-        //getTransactionWithEffectsBatch
-
-        const resp = await api.instance
-            .getTransactionWithEffectsBatch(deduplicate(transactions))
-            .then((txEffs: TransactionEffectsResponse[]) => {
-                return (
-                    txEffs
-                        .map((txEff, i) => {
-                            const [seq, digest] = transactions.filter(
-                                (transactionId) =>
-                                    transactionId[1] ===
-                                    getTransactionDigest(txEff.certificate)
-                            )[0];
-                            const res: CertifiedTransaction = txEff.certificate;
-                            // TODO: handle multiple transactions
-                            const txns = getTransactions(res);
-                            if (txns.length > 1) {
-                                return null;
-                            }
-                            const txn = txns[0];
-                            const txKind = getTransactionKindName(txn);
-                            const recipient =
-                                getTransferCoinTransaction(txn)?.recipient;
-
-                            return {
-                                seq,
-                                txId: digest,
-                                status: getExecutionStatusType(txEff),
-                                txGas: getTotalGasUsed(txEff),
-                                kind: txKind,
-                                From: res.data.sender,
-                                ...(recipient
-                                    ? {
-                                          To: recipient,
-                                      }
-                                    : {}),
-                            };
-                        })
-                        // Remove failed transactions and sort by sequence number
-                        .filter((itm) => itm)
-                        .sort((a, b) => b!.seq - a!.seq)
-                );
-            });
-        return resp as any;
-    }
-});
 
 const txAdapter = createEntityAdapter<TransactionResult>({
     selectId: (tx) => tx.EffectResponse.certificate.transactionDigest,

--- a/wallet/src/ui/app/redux/slices/txresults/index.ts
+++ b/wallet/src/ui/app/redux/slices/txresults/index.ts
@@ -24,7 +24,7 @@ import type {
 } from '@mysten/sui.js';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
-type TxResultState = {
+export type TxResultState = {
     To?: string;
     seq: number;
     txId: string;
@@ -51,6 +51,7 @@ const initialState = Txdapter.getInitialState<TransactionManualState>({
 });
 type TxResultByAddress = TxResultState[];
 
+// Remove duplicate transactionsId, reduces the number of RPC calls
 const deduplicate = (results: [number, string][] | undefined) =>
     results
         ? results

--- a/wallet/src/ui/app/redux/slices/txresults/index.ts
+++ b/wallet/src/ui/app/redux/slices/txresults/index.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    getTransactionDigest,
+    getTransactions,
+    getTransactionKindName,
+    getTransferCoinTransaction,
+    getExecutionStatusType,
+    getTotalGasUsed,
+} from '@mysten/sui.js';
+import {
+    createSlice,
+    createAsyncThunk,
+    createEntityAdapter,
+} from '@reduxjs/toolkit';
+
+import type {
+    TransactionEffectsResponse,
+    GetTxnDigestsResponse,
+    CertifiedTransaction,
+    TransactionKindName,
+    ExecutionStatusType,
+} from '@mysten/sui.js';
+import type { AppThunkConfig } from '_store/thunk-extras';
+
+type TxResultState = {
+    To?: string;
+    seq: number;
+    txId: string;
+    status: ExecutionStatusType;
+    txGas: number;
+    kind: TransactionKindName | undefined;
+    From: string;
+};
+
+const Txdapter = createEntityAdapter<TxResultState>({
+    selectId: ({ txId }) => txId,
+});
+
+interface TransactionManualState {
+    loading: boolean;
+    error: false | { code?: string; message?: string; name?: string };
+    latestTx: TxResultState[];
+}
+
+const initialState = Txdapter.getInitialState<TransactionManualState>({
+    loading: true,
+    latestTx: [],
+    error: false,
+});
+type TxResultByAddress = TxResultState[];
+
+const deduplicate = (results: [number, string][] | undefined) =>
+    results
+        ? results
+              .map((result) => result[1])
+              .filter((value, index, self) => self.indexOf(value) === index)
+        : [];
+
+export const getTransactionsByAddress = createAsyncThunk<
+    TxResultByAddress,
+    void,
+    AppThunkConfig
+>(
+    'sui-transactions/get-transactions-by-address',
+    async (_, { getState, extra: { api } }): Promise<TxResultByAddress> => {
+        const address = getState().account.address;
+
+        if (!address) {
+            return [];
+        }
+        // Get all transactions txId for address
+        const transactions: GetTxnDigestsResponse = (
+            await api.instance.getTransactionsForAddress(address)
+        ).filter((tx) => tx);
+
+        if (!transactions || !transactions.length) {
+            return [];
+        }
+        //getTransactionWithEffectsBatch
+        const resp = await api.instance
+            .getTransactionWithEffectsBatch(deduplicate(transactions))
+            .then((txEffs: TransactionEffectsResponse[]) => {
+                return (
+                    txEffs
+                        .map((txEff, i) => {
+                            const [seq, digest] = transactions.filter(
+                                (transactionId) =>
+                                    transactionId[1] ===
+                                    getTransactionDigest(txEff.certificate)
+                            )[0];
+                            const res: CertifiedTransaction = txEff.certificate;
+                            // TODO: handle multiple transactions
+                            const txns = getTransactions(res);
+                            if (txns.length > 1) {
+                                return null;
+                            }
+                            const txn = txns[0];
+                            const txKind = getTransactionKindName(txn);
+                            const recipient =
+                                getTransferCoinTransaction(txn)?.recipient;
+
+                            return {
+                                seq,
+                                txId: digest,
+                                status: getExecutionStatusType(txEff),
+                                txGas: getTotalGasUsed(txEff),
+                                kind: txKind,
+                                From: res.data.sender,
+                                ...(recipient
+                                    ? {
+                                          To: recipient,
+                                      }
+                                    : {}),
+                            };
+                        })
+                        // Remove failed transactions and sort by sequence number
+                        .filter((itm) => itm)
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        .sort((a, b) => b!.seq - a!.seq)
+                );
+            });
+        return resp as TxResultByAddress;
+    }
+);
+const txSlice = createSlice({
+    name: 'txresult',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(getTransactionsByAddress.fulfilled, (state, action) => {
+                Txdapter.setAll(state, action.payload);
+                state.loading = false;
+                state.error = false;
+                state.latestTx = action.payload;
+            })
+            .addCase(getTransactionsByAddress.pending, (state, action) => {
+                state.loading = true;
+                state.latestTx = [];
+            })
+            .addCase(
+                getTransactionsByAddress.rejected,
+                (state, { error: { code, name, message } }) => {
+                    state.loading = false;
+                    state.error = { code, message, name };
+                    state.latestTx = [];
+                }
+            );
+    },
+});
+
+export default txSlice.reducer;

--- a/wallet/src/ui/app/redux/slices/txresults/index.ts
+++ b/wallet/src/ui/app/redux/slices/txresults/index.ts
@@ -9,11 +9,7 @@ import {
     getExecutionStatusType,
     getTotalGasUsed,
 } from '@mysten/sui.js';
-import {
-    createSlice,
-    createAsyncThunk,
-    createEntityAdapter,
-} from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import type {
     TransactionEffectsResponse,
@@ -34,21 +30,17 @@ export type TxResultState = {
     From: string;
 };
 
-const Txdapter = createEntityAdapter<TxResultState>({
-    selectId: ({ txId }) => txId,
-});
-
 interface TransactionManualState {
     loading: boolean;
     error: false | { code?: string; message?: string; name?: string };
     latestTx: TxResultState[];
 }
 
-const initialState = Txdapter.getInitialState<TransactionManualState>({
+const initialState: TransactionManualState = {
     loading: true,
     latestTx: [],
     error: false,
-});
+};
 type TxResultByAddress = TxResultState[];
 
 // Remove duplicate transactionsId, reduces the number of RPC calls
@@ -132,7 +124,6 @@ const txSlice = createSlice({
     extraReducers: (builder) => {
         builder
             .addCase(getTransactionsByAddress.fulfilled, (state, action) => {
-                Txdapter.setAll(state, action.payload);
                 state.loading = false;
                 state.error = false;
                 state.latestTx = action.payload;

--- a/wallet/src/ui/styles/global.scss
+++ b/wallet/src/ui/styles/global.scss
@@ -1,4 +1,5 @@
 @import url('bootstrap-icons');
+@import url('https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap');
 
 html,
 body {


### PR DESCRIPTION
@pchrysochoidis please review.  

- Added Network selector
- Transactions section added. 

RPC endpoints configured in `.env` file
Transaction for a specific address is fetched either on network change or on-page tab switch. Not part of the polling.


https://user-images.githubusercontent.com/8676844/173327388-6c0791db-a325-4b2e-959b-c26e1d13088e.mov



