### PR TITLE
[Move] Allow publishing modules with warnings (update Move version)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3131,12 +3131,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3175,7 +3175,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3192,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "difference",
@@ -3248,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3330,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "hex",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "hex",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3523,7 +3523,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3551,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3577,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -3622,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "log",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "once_cell",
  "serde 1.0.137",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3670,7 +3670,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "better_any",
  "fail",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4e15a34ecf155b7e2d9729d3b07f83c146149f02#4e15a34ecf155b7e2d9729d3b07f83c146149f02"
+source = "git+https://github.com/move-language/move?rev=a86f31415b9a18867b5edaed6f915a39b8c2ef40#a86f31415b9a18867b5edaed6f915a39b8c2ef40"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -13,13 +13,13 @@ bcs = "0.1.3"
 once_cell = "1.11.0"
 parking_lot = "0.12.1"
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-cli = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-cli = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 sui-framework = { path = "../sui-framework" }
 sui-verifier = { path = "../sui-verifier" }
@@ -27,4 +27,4 @@ sui-types = { path = "../sui-types" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -21,8 +21,8 @@ tracing = "0.1.34"
 
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "2c5e8236c0702a3ff47dd769c2bbc94b029bf4a9", package = "config" }
 narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "2c5e8236c0702a3ff47dd769c2bbc94b029bf4a9", package = "crypto" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 sui-framework = { path = "../sui-framework" }
 

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -50,12 +50,12 @@ sui-storage = { path = "../sui-storage" }
 sui-config = { path = "../sui-config" }
 sui-json = { path = "../sui-json" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "ff5c1d69057fe93be658377462ca2875a57a0223"}
 

--- a/crates/sui-framework-build/Cargo.toml
+++ b/crates/sui-framework-build/Cargo.toml
@@ -12,9 +12,9 @@ publish = false
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../../crates/sui-verifier" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-framework-build/src/lib.rs
+++ b/crates/sui-framework-build/src/lib.rs
@@ -60,7 +60,7 @@ pub fn build_move_package(
     build_config: BuildConfig,
     is_framework: bool,
 ) -> SuiResult<Vec<CompiledModule>> {
-    match build_config.compile_package(path, &mut Vec::new()) {
+    match build_config.compile_package_no_exit(path, &mut Vec::new()) {
         Err(error) => Err(SuiError::ModuleBuildFailure {
             error: error.to_string(),
         }),

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -18,22 +18,22 @@ once_cell = "1.11.0"
 sui-types = { path = "../sui-types" }
 sui-framework-build = { path = "../sui-framework-build" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-cli = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-cli = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 workspace-hack = { path = "../workspace-hack"}
 
 [build-dependencies]
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 bcs = "0.1.3"
 sui-framework-build = { path = "../sui-framework-build" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["move-cli", "move-unit-test"]

--- a/crates/sui-gateway/Cargo.toml
+++ b/crates/sui-gateway/Cargo.toml
@@ -30,6 +30,6 @@ sui-json = { path = "../sui-json" }
 sui-open-rpc = { path = "../sui-open-rpc" }
 sui-open-rpc-macros = { path = "../sui-open-rpc-macros" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "ff5c1d69057fe93be658377462ca2875a57a0223" }
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -17,8 +17,8 @@ schemars = "0.8.8"
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../sui-verifier" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -23,7 +23,7 @@ sui-types = { path = "../sui-types" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "ff5c1d69057fe93be658377462ca2875a57a0223"}
 workspace-hack = { path = "../workspace-hack"}
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -20,18 +20,18 @@ rand = "0.7.3"
 rayon = "1.5.3"
 tempfile = "3.2.0"
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-cli = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-cli = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 
 sui-framework = { path = "../sui-framework" }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -39,12 +39,12 @@ strum_macros = "^0.24"
 name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "ff5c1d69057fe93be658377462ca2875a57a0223" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "ff5c1d69057fe93be658377462ca2875a57a0223" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "2c5e8236c0702a3ff47dd769c2bbc94b029bf4a9", package = "executor" }
 narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "2c5e8236c0702a3ff47dd769c2bbc94b029bf4a9", package = "crypto" }

--- a/crates/sui-verifier/Cargo.toml
+++ b/crates/sui-verifier/Cargo.toml
@@ -8,11 +8,11 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 sui-types = { path = "../sui-types" }
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -60,12 +60,12 @@ rustyline-derive = "0.6.0"
 colored = "2.0.0"
 unescape = "0.1.0"
 
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 
 narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "2c5e8236c0702a3ff47dd769c2bbc94b029bf4a9", package = "node" }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -24,8 +24,8 @@ jsonrpsee-http-client = "0.13.1"
 sui-adapter = { path = "../sui-adapter" }
 sui-framework = { path = "../sui-framework" }
 sui-gateway = { path = "../sui-gateway" }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev ="ff5c1d69057fe93be658377462ca2875a57a0223"}
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "2c5e8236c0702a3ff47dd769c2bbc94b029bf4a9", package = "config" }
 

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -62,7 +62,7 @@ bls-crypto = { git = "https://github.com/huitseeker/celo-bls-snark-rs", branch =
 blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["fiat"] }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
@@ -243,41 +243,41 @@ mime = { version = "0.3", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
-move-abigen = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-cli = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-cli = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 mysten-network-9da6af2c8f03eecf = { package = "mysten-network", git = "https://github.com/MystenLabs/mysten-infra", rev = "7c247967e5a5abd59ecaa75bc62b05bcdf4503fe", default-features = false }
@@ -349,8 +349,8 @@ rand_pcg = { version = "0.2", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-read-write-set = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -556,7 +556,7 @@ blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bumpalo = { version = "3" }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["fiat"] }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
@@ -764,41 +764,41 @@ mime = { version = "0.3", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
-move-abigen = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-cli = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-cli = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
@@ -891,8 +891,8 @@ rand_pcg = { version = "0.2", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-read-write-set = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "4e15a34ecf155b7e2d9729d3b07f83c146149f02", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "a86f31415b9a18867b5edaed6f915a39b8c2ef40", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
For a long time, compilation warnings in Move code were preventing module publishing which is arguably not-ideal and has been reported by our users as a nuisance (https://github.com/MystenLabs/sui/issues/2088).

This PR fixes https://github.com/MystenLabs/sui/issues/2088 by (largely) providing necessary support on the core Move side.