### PR TITLE
Fix concurrency

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -656,7 +656,7 @@ impl AuthorityState {
         // If we already assigned locks to this transaction, we can try to execute it immediately.
         // This can happen to transaction previously submitted to consensus that failed execution
         // due to missing dependencies.
-        if self.shared_locks_exist(&certificate).await? {
+        if self.transaction_locks_exist(&certificate).await? {
             // Attempt to execute the transaction. This will only succeed if the authority
             // already executed all its dependencies and if the locks are correctly attributed to
             // the transaction (ie. this transaction is the next to be executed).
@@ -1226,7 +1226,7 @@ impl AuthorityState {
     }
 
     /// Check whether a shared-object certificate has already been given shared-locks.
-    async fn shared_locks_exist(&self, certificate: &CertifiedTransaction) -> SuiResult<bool> {
+    async fn transaction_locks_exist(&self, certificate: &CertifiedTransaction) -> SuiResult<bool> {
         let digest = certificate.digest();
         let shared_inputs = certificate.shared_input_objects();
         let shared_locks = self.database.sequenced(digest, shared_inputs)?;
@@ -1303,6 +1303,9 @@ impl ExecutionState for AuthorityState {
                     SuiError::NotASharedObjectTransaction
                 );
 
+                // Check if we already assigned locks to the shared objects.
+                let shared_locks = self.transaction_locks_exist(&certificate).await?;
+
                 // If we already executed this transaction, return the signed effects.
                 let digest = certificate.digest();
                 if self.database.effects_exists(digest)? {
@@ -1312,7 +1315,7 @@ impl ExecutionState for AuthorityState {
                 }
 
                 // If we didn't already assigned shared-locks to this transaction, we do it now.
-                if !self.shared_locks_exist(&certificate).await? {
+                if !shared_locks {
                     // Check the certificate. Remember that Byzantine authorities may input anything into
                     // consensus.
                     certificate.verify(&self.committee.load())?;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -656,7 +656,7 @@ impl AuthorityState {
         // If we already assigned locks to this transaction, we can try to execute it immediately.
         // This can happen to transaction previously submitted to consensus that failed execution
         // due to missing dependencies.
-        if self.transaction_locks_exist(&certificate).await? {
+        if self.transaction_shared_locks_exist(&certificate).await? {
             // Attempt to execute the transaction. This will only succeed if the authority
             // already executed all its dependencies and if the locks are correctly attributed to
             // the transaction (ie. this transaction is the next to be executed).
@@ -1226,7 +1226,10 @@ impl AuthorityState {
     }
 
     /// Check whether a shared-object certificate has already been given shared-locks.
-    async fn transaction_locks_exist(&self, certificate: &CertifiedTransaction) -> SuiResult<bool> {
+    async fn transaction_shared_locks_exist(
+        &self,
+        certificate: &CertifiedTransaction,
+    ) -> SuiResult<bool> {
         let digest = certificate.digest();
         let shared_inputs = certificate.shared_input_objects();
         let shared_locks = self.database.sequenced(digest, shared_inputs)?;
@@ -1304,7 +1307,7 @@ impl ExecutionState for AuthorityState {
                 );
 
                 // Check if we already assigned locks to the shared objects.
-                let shared_locks = self.transaction_locks_exist(&certificate).await?;
+                let shared_locks = self.transaction_shared_locks_exist(&certificate).await?;
 
                 // If we already executed this transaction, return the signed effects.
                 let digest = certificate.digest();

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -846,7 +846,7 @@ impl<const ALL_OBJ_VER: bool, S: Eq + Serialize + for<'de> Deserialize<'de>>
         }))
     }
 
-    /// Remove the shared objects locks. This function is not safety-critical and is only need to cleanup the store.
+    /// Remove the shared objects locks.
     pub fn remove_shared_objects_locks(
         &self,
         mut write_batch: DBBatch,


### PR DESCRIPTION
Let's say there are two identical transactions TX1 and TX2 that are sequenced one after the other.

Authority A does the following:
1. Ensure there are no effects for TX1: the check pass
2. Ensure the shared-locks for TX1 do not exist: the check pass
3. Assign shared-locks to TX1
4. Ensure there are no effects for TX2: the check pass
5. **Atomically execute TX1 and removes the locks**
6. Ensure the shared-locks for TX2 do not exist: the check pass
7. Assign shared-locks to TX2

Authority B does the following:
1. Ensure there are no effects for TX1: the check pass
2. Ensure the shared-locks for TX1 do not exist: the check pass
3. Assign shared-locks to TX1
4. Ensure there are no effects for TX2: the check pass
5. Ensure the shared-locks for TX2 do not exist: the check fail
6. **Atomically execute TX1 and removes the locks**

So there is an inconsistency between Authority A (who has assigned locks for TX2) and authority B (who dropped TX2). Remember that execution happens in a separate thread.