### PR TITLE
Fix shared_object_sync test

### DIFF
--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -28,6 +28,10 @@ pub fn test_authority_configs() -> NetworkConfig {
     let rng = StdRng::from_seed([0; 32]);
     let mut configs = NetworkConfig::generate_with_rng(&config_dir, TEST_COMMITTEE_SIZE, rng);
     for config in configs.validator_configs.iter_mut() {
+        // Disable gossip by default to reduce non-determinism.
+        // TODO: Once this library is more broadly used, we can make this a config argument.
+        config.enable_gossip = false;
+
         let parameters = &mut config.consensus_config.as_mut().unwrap().narwhal_config;
         // NOTE: the following parameters are important to ensure tests run fast. Using the default
         // Narwhal parameters may result in tests taking >60 seconds.


### PR DESCRIPTION
The test has been flaky because of gossip, which was introducing non-deterministic behavior.
Disable gossip by default in these tests.
This fixes https://github.com/MystenLabs/sui/issues/2530