### PR TITLE
Node sync waits for finality before applying TXes

### DIFF
--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -1,0 +1,435 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{DigestHandler, Follower};
+use crate::{
+    authority::AuthorityState, authority_aggregator::AuthorityAggregator,
+    authority_client::AuthorityAPI,
+};
+use async_trait::async_trait;
+
+use std::collections::{hash_map, HashMap};
+use sui_storage::node_sync_store::NodeSyncStore;
+use sui_types::{
+    base_types::{AuthorityName, ExecutionDigests, TransactionDigest},
+    committee::{Committee, StakeUnit},
+    error::{SuiError, SuiResult},
+    messages::{CertifiedTransaction, ConfirmationTransaction, SignedTransactionEffects},
+};
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use tokio::sync::{broadcast, mpsc, Mutex, Semaphore};
+use tokio::task::JoinHandle;
+
+use tracing::{error, info, trace, warn};
+
+const NODE_SYNC_QUEUE_LEN: usize = 500;
+
+// Process up to 20 digests concurrently.
+const MAX_NODE_SYNC_CONCURRENCY: usize = 100;
+
+/// EffectsStakeMap tracks which effects digests have been attested by a quorum of validators and
+/// are thus final.
+struct EffectsStakeMap {
+    /// Keep track of how much stake has voted for a given effects digest
+    /// any entry in this map with >2f+1 stake can be sequenced locally and
+    /// removed from the map.
+    effects_stake_map: HashMap<ExecutionDigests, StakeUnit>,
+    /// Keep track of stake votes per validator - needed to double check the total stored in
+    /// effects_stake_map, which can otherwise be corrupted by byzantine double-voting.
+    effects_vote_map: HashMap<(ExecutionDigests, AuthorityName), StakeUnit>,
+}
+
+impl EffectsStakeMap {
+    pub fn new() -> Self {
+        Self {
+            effects_stake_map: HashMap::new(),
+            effects_vote_map: HashMap::new(),
+        }
+    }
+
+    /// Note that a given effects digest has been attested by a validator, and return true if the
+    /// stake that has attested that effects digest has exceeded the quorum threshold.
+    pub fn note_effects_digest(
+        &mut self,
+        source: &AuthorityName,
+        stake: StakeUnit,
+        quorum_threshold: StakeUnit,
+        digests: &ExecutionDigests,
+    ) -> bool {
+        let vote_entry = self.effects_vote_map.entry((*digests, *source));
+
+        let cur_stake = if let hash_map::Entry::Occupied(_) = &vote_entry {
+            // TODO: report byzantine authority suspciion
+            warn!(peer = ?source, digest = ?digests.transaction, effects = ?digests.effects,
+                "ByzantineAuthoritySuspicion: peer double-voted for effects digest");
+            self.effects_stake_map.entry(*digests).or_insert(0)
+        } else {
+            vote_entry.or_insert(stake);
+
+            self.effects_stake_map
+                .entry(*digests)
+                .and_modify(|cur| *cur += stake)
+                .or_insert(stake)
+        };
+
+        let is_final = *cur_stake >= quorum_threshold;
+        if !is_final {
+            trace!(
+                ?digests,
+                "tx cert/effects not yet final: {} < {}",
+                *cur_stake,
+                quorum_threshold
+            );
+        }
+        is_final
+    }
+}
+
+/// Waiter is used to single-shot concurrent requests and wait for dependencies to finish.
+struct Waiter<Key, ResultT> {
+    waiters: Mutex<HashMap<Key, broadcast::Sender<ResultT>>>,
+}
+
+impl<Key: std::hash::Hash + Eq + Clone + std::fmt::Debug, ResultT: Clone> Waiter<Key, ResultT> {
+    fn new() -> Self {
+        Self {
+            waiters: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns (Some(tx), rx) if there are no other waiters yet, or else (None, rx).
+    /// All rxes can be woken by sending to the supplied tx, or by calling notify(key, result)
+    async fn wait(
+        &self,
+        key: &Key,
+    ) -> (
+        Option<broadcast::Sender<ResultT>>,
+        broadcast::Receiver<ResultT>,
+    ) {
+        let waiters = &mut self.waiters.lock().await;
+        let entry = waiters.entry(key.clone());
+
+        match entry {
+            hash_map::Entry::Occupied(e) => (None, e.get().subscribe()),
+            hash_map::Entry::Vacant(e) => {
+                let (tx, rx) = broadcast::channel(1);
+                e.insert(tx.clone());
+                (Some(tx), rx)
+            }
+        }
+    }
+
+    async fn notify(&self, key: &Key, res: ResultT) -> SuiResult {
+        if let Some(tx) = self.waiters.lock().await.remove(key) {
+            tx.send(res).map_err(|_| SuiError::GenericAuthorityError {
+                error: format!("couldn't notify waiters for key {:?}", key),
+            })?;
+        }
+        // else: no one was waiting on this key.
+        Ok(())
+    }
+}
+
+struct DigestsMessage {
+    digests: ExecutionDigests,
+    peer: AuthorityName,
+}
+
+/// NodeSyncState is shared by any number of NodeSyncDigestHandler's, and receives DigestsMessage
+/// messages from those handlers, waits for finality of TXes, and then downloads and applies those
+/// TXes locally.
+struct NodeSyncState<A> {
+    committee: Arc<Committee>,
+    effects_stake: Mutex<EffectsStakeMap>,
+    state: Arc<AuthorityState>,
+    node_sync_store: Arc<NodeSyncStore>,
+    aggregator: Arc<AuthorityAggregator<A>>,
+
+    // Used to single-shot multiple concurrent downloads.
+    pending_downloads: Waiter<TransactionDigest, SuiResult>,
+
+    // Used to wait for parent transactions to be applied locally
+    pending_txes: Waiter<TransactionDigest, ()>,
+}
+
+impl<A> NodeSyncState<A>
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    fn start(self_: Arc<Self>, mut receiver: mpsc::Receiver<DigestsMessage>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            // this pattern for limiting concurrency is from
+            // https://github.com/tokio-rs/tokio/discussions/2648
+            let limit = Arc::new(Semaphore::new(MAX_NODE_SYNC_CONCURRENCY));
+
+            while let Some(DigestsMessage { digests, peer }) = receiver.recv().await {
+                let permit = Arc::clone(&limit).acquire_owned().await;
+                let self_ = self_.clone();
+                tokio::spawn(async move {
+                    let _permit = permit; // hold semaphore permit until task completes
+                                          // TODO: must send status back to follower so that it knows whether to advance
+                                          // the watermark.
+                    if let Err(error) = self_.process_digest(peer, digests).await {
+                        error!(?digests, ?peer, "process_digest failed: {}", error);
+                    }
+                });
+            }
+        })
+    }
+
+    async fn process_digest(&self, peer: AuthorityName, digests: ExecutionDigests) -> SuiResult {
+        // check if we the tx is already locally final
+        if self.state.database.effects_exists(&digests.transaction)? {
+            return Ok(());
+        }
+
+        // TODO: We could kick off the cert download now, as an optimization. For simplicity
+        // we wait until we have the final effects digest and download them both at once, after the
+        // is_final check. We can't download the effects yet because a SignedEffects is signed
+        // only by the originating validator and so can't be trusted until we have seen at least
+        // f+1 identical effects digests.
+        //
+        // There is a further optimization which is that we could start downloading the effects
+        // earlier than we do as well, after f+1 instead of 2f+1. Then when we reach 2f+1 we might
+        // already have everything stored locally.
+        //
+        // These optimizations may well be worth it at some point if we are trying to get latency
+        // down.
+
+        // Check if the tx is final.
+        let stake = self.committee.weight(&peer);
+        let quorum_threshold = self.committee.quorum_threshold();
+        let is_final = self.effects_stake.lock().await.note_effects_digest(
+            &peer,
+            stake,
+            quorum_threshold,
+            &digests,
+        );
+
+        if !is_final {
+            return Ok(());
+        }
+
+        // Download the cert and effects now that we have established finality and we know that the
+        // effects digest is correct.
+        let (cert, effects) = self.download_cert_and_effects(&peer, &digests).await?;
+
+        for parent in effects.effects.dependencies.iter() {
+            if self.state.database.effects_exists(parent)? {
+                continue;
+            }
+
+            let (_, mut rx) = self.pending_txes.wait(parent).await;
+
+            // because we process digests in causal order, we can be sure that all of our parents
+            // have already started processing, therefore we will eventually be notified that each
+            // parent is complete.
+            rx.recv()
+                .await
+                .map_err(|e| SuiError::GenericAuthorityError {
+                    error: format!("{:?}", e),
+                })?;
+        }
+
+        if cfg!(debug_assertions) {
+            for parent in effects.effects.dependencies.iter() {
+                debug_assert!(self.state.database.effects_exists(parent).unwrap());
+            }
+        }
+
+        // TODO: support shared object TXes via something like:
+        // self.state.sequence_shared_locks_from_effects(effects).await
+        self.state
+            .handle_confirmation_transaction(ConfirmationTransaction { certificate: cert })
+            .await?;
+        self.node_sync_store
+            .delete_cert_and_effects(&digests.transaction)?;
+
+        self.pending_txes.notify(&digests.transaction, ()).await?;
+        Ok(())
+    }
+
+    // Download the certificate and effects specified in digests.
+    async fn download_cert_and_effects(
+        &self,
+        peer: &AuthorityName,
+        digests: &ExecutionDigests,
+    ) -> SuiResult<(CertifiedTransaction, SignedTransactionEffects)> {
+        let digest = digests.transaction;
+        if let Some(c) = self.node_sync_store.get_cert_and_effects(&digest)? {
+            return Ok(c);
+        }
+
+        let (tx, mut rx) = self.pending_downloads.wait(&digest).await;
+        // Only start the download if there are no other concurrent downloads.
+        if let Some(tx) = tx {
+            let aggregator = self.aggregator.clone();
+            let digests = *digests;
+            let peer = *peer;
+            let node_sync_store = self.node_sync_store.clone();
+            tokio::task::spawn(async move {
+                if let Err(error) =
+                    tx.send(Self::download_impl(peer, aggregator, &digests, node_sync_store).await)
+                {
+                    error!(?digest, ?peer, ?error, "Could not broadcast cert response");
+                }
+            });
+        }
+
+        let _ = rx
+            .recv()
+            .await
+            .map_err(|e| SuiError::GenericAuthorityError {
+                error: format!("{:?}", e),
+            })??;
+
+        self.node_sync_store
+            .get_cert_and_effects(&digest)?
+            .ok_or_else(|| SuiError::GenericAuthorityError {
+                error: format!(
+                    "cert/effects for {:?} should have been in the node_sync_store",
+                    digest
+                ),
+            })
+    }
+
+    async fn download_impl(
+        peer: AuthorityName,
+        aggregator: Arc<AuthorityAggregator<A>>,
+        digests: &ExecutionDigests,
+        node_sync_store: Arc<NodeSyncStore>,
+    ) -> SuiResult {
+        let digest = digests.transaction;
+
+        // TODO: Add a function to AuthorityAggregator to try multiple validators - even
+        // though we are fetching the cert/effects from the same validator that sent us the tx
+        // digest, and even though we know the cert is final, any given validator may be byzantine
+        // and refuse to give us the cert and effects.
+        let client = aggregator.clone_client(&peer);
+        let resp = client
+            .handle_transaction_and_effects_info_request(digests)
+            .await
+            .expect("TODO: need to use authority aggregator to download cert");
+
+        let cert = resp.certified_transaction.ok_or_else(|| {
+            info!(?digest, ?peer, "validator did not return cert");
+            SuiError::GenericAuthorityError {
+                error: format!("validator did not return cert for {:?}", digest),
+            }
+        })?;
+
+        let effects = resp.signed_effects.ok_or_else(|| {
+            info!(?digest, ?peer, "validator did not return effects");
+            SuiError::ByzantineAuthoritySuspicion { authority: peer }
+        })?;
+
+        node_sync_store.store_cert_and_effects(&digest, &(cert, effects))?;
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct NodeSyncDigestHandler {
+    _sync_join_handle: Arc<JoinHandle<()>>,
+    sender: mpsc::Sender<DigestsMessage>,
+}
+
+impl NodeSyncDigestHandler {
+    pub fn new<A>(
+        state: Arc<AuthorityState>,
+        aggregator: Arc<AuthorityAggregator<A>>,
+        node_sync_store: Arc<NodeSyncStore>,
+    ) -> Self
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        let (sender, receiver) = mpsc::channel(NODE_SYNC_QUEUE_LEN);
+
+        let committee = state.committee.load().deref().clone();
+        let sync_state = Arc::new(NodeSyncState {
+            committee,
+            effects_stake: Mutex::new(EffectsStakeMap::new()),
+            state,
+            aggregator,
+            node_sync_store,
+            pending_downloads: Waiter::new(),
+            pending_txes: Waiter::new(),
+        });
+
+        let _sync_join_handle = Arc::new(NodeSyncState::start(sync_state, receiver));
+
+        Self {
+            _sync_join_handle,
+            sender,
+        }
+    }
+}
+
+#[async_trait]
+impl<A> DigestHandler<A> for NodeSyncDigestHandler
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    async fn handle_digest(&self, follower: &Follower<A>, digests: ExecutionDigests) -> SuiResult {
+        self.sender
+            .send(DigestsMessage {
+                digests,
+                peer: follower.peer_name,
+            })
+            .await
+            .map_err(|e| SuiError::GenericAuthorityError {
+                error: e.to_string(),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Note: this code is tested end-to-end in full_node_tests.rs
+
+    use sui_types::{
+        base_types::{
+            AuthorityName, ExecutionDigests, TransactionDigest, TransactionEffectsDigest,
+        },
+        crypto::get_key_pair,
+    };
+
+    use super::EffectsStakeMap;
+
+    fn random_authority_name() -> AuthorityName {
+        let key = get_key_pair();
+        *key.1.public_key_bytes()
+    }
+
+    #[test]
+    fn test_effects_stake() {
+        let mut map = EffectsStakeMap::new();
+
+        let threshold = 3;
+
+        let byzantine = random_authority_name();
+        let validator2 = random_authority_name();
+        let validator3 = random_authority_name();
+
+        let digests = ExecutionDigests {
+            transaction: TransactionDigest::random(),
+            effects: TransactionEffectsDigest::random(),
+        };
+
+        assert!(!map.note_effects_digest(&byzantine, 1, threshold, &digests));
+        assert!(!map.note_effects_digest(&validator2, 1, threshold, &digests));
+
+        // double voting is rejected
+        assert!(!map.note_effects_digest(&byzantine, 1, threshold, &digests));
+
+        // final vote pushes us over.
+        assert!(map.note_effects_digest(&validator3, 1, threshold, &digests));
+
+        // double vote doesn't result in false if we already exceeded threshold.
+        assert!(map.note_effects_digest(&byzantine, 1, threshold, &digests));
+    }
+}

--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -102,7 +102,11 @@ struct Waiter<Key, ResultT> {
     waiters: Mutex<HashMap<Key, broadcast::Sender<ResultT>>>,
 }
 
-impl<Key: std::hash::Hash + Eq + Clone + std::fmt::Debug, ResultT: Clone> Waiter<Key, ResultT> {
+impl<Key, ResultT> Waiter<Key, ResultT>
+where
+    Key: std::hash::Hash + Eq + Clone + std::fmt::Debug,
+    ResultT: Clone,
+{
     fn new() -> Self {
         Self {
             waiters: Mutex::new(HashMap::new()),

--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -28,7 +28,7 @@ use tracing::{error, info, trace, warn};
 const NODE_SYNC_QUEUE_LEN: usize = 500;
 
 // Process up to 20 digests concurrently.
-const MAX_NODE_SYNC_CONCURRENCY: usize = 100;
+const MAX_NODE_SYNC_CONCURRENCY: usize = 20;
 
 /// EffectsStakeMap tracks which effects digests have been attested by a quorum of validators and
 /// are thus final.

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -161,6 +161,7 @@ where
         source_authority: AuthorityName,
         cert_handler: CertHandler,
     ) -> Result<(), SuiError> {
+        // TODO(panic): this panics
         let source_client = self.authority_clients[&source_authority].clone();
 
         // This represents a stack of certificates that we need to register with the

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -10,6 +10,7 @@ pub use indexes::IndexStore;
 pub mod event_store;
 pub mod follower_store;
 pub mod mutex_table;
+pub mod node_sync_store;
 pub mod write_ahead_log;
 
 use rocksdb::Options;

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::default_db_options;
+use std::path::Path;
+
+use sui_types::{
+    base_types::TransactionDigest,
+    error::{SuiError, SuiResult},
+    messages::{CertifiedTransaction, SignedTransactionEffects},
+};
+
+use typed_store::rocks::DBMap;
+use typed_store::{reopen, traits::Map};
+
+/// NodeSyncStore store is used by nodes to store downloaded objects (certs, etc) that have
+/// not yet been applied to the node's SuiDataStore.
+pub struct NodeSyncStore {
+    /// Certificates/Effects that have been fetched from remote validators, but not sequenced.
+    certs_and_fx: DBMap<TransactionDigest, (CertifiedTransaction, SignedTransactionEffects)>,
+}
+
+impl NodeSyncStore {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, SuiError> {
+        let (options, _) = default_db_options(None, None);
+
+        let db = {
+            let path = &path;
+            let db_options = Some(options.clone());
+            let opt_cfs: &[(&str, &rocksdb::Options)] = &[("certs_and_fx", &options)];
+            typed_store::rocks::open_cf_opts(path, db_options, opt_cfs)
+        }
+        .map_err(SuiError::StorageError)?;
+
+        let certs_and_fx = reopen!(&db, "certs_and_fx";<TransactionDigest, (CertifiedTransaction, SignedTransactionEffects)>);
+
+        Ok(Self { certs_and_fx })
+    }
+
+    pub fn has_cert_and_effects(&self, tx: &TransactionDigest) -> SuiResult<bool> {
+        Ok(self.certs_and_fx.contains_key(tx)?)
+    }
+
+    pub fn store_cert_and_effects(
+        &self,
+        tx: &TransactionDigest,
+        val: &(CertifiedTransaction, SignedTransactionEffects),
+    ) -> SuiResult {
+        Ok(self.certs_and_fx.insert(tx, val)?)
+    }
+
+    pub fn get_cert_and_effects(
+        &self,
+        tx: &TransactionDigest,
+    ) -> SuiResult<Option<(CertifiedTransaction, SignedTransactionEffects)>> {
+        Ok(self.certs_and_fx.get(tx)?)
+    }
+
+    pub fn delete_cert_and_effects(&self, tx: &TransactionDigest) -> SuiResult {
+        Ok(self.certs_and_fx.remove(tx)?)
+    }
+}

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -139,6 +139,9 @@ pub struct PublicKeyBytes(
 );
 
 impl PublicKeyBytes {
+    pub const MIN: Self = PublicKeyBytes([u8::MIN; dalek::PUBLIC_KEY_LENGTH]);
+    pub const MAX: Self = PublicKeyBytes([u8::MAX; dalek::PUBLIC_KEY_LENGTH]);
+
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -139,9 +139,6 @@ pub struct PublicKeyBytes(
 );
 
 impl PublicKeyBytes {
-    pub const MIN: Self = PublicKeyBytes([u8::MIN; dalek::PUBLIC_KEY_LENGTH]);
-    pub const MAX: Self = PublicKeyBytes([u8::MAX; dalek::PUBLIC_KEY_LENGTH]);
-
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
     }


### PR DESCRIPTION
Node sync process now waits for finality.
- Certificates are not processed locally in the node until finality has
  been established.
- Trustworthy TransactionEffects are downloaded, so we can easily add
  shared object support after this commit.

This also supports much higher concurrency in the syncing process, which should help us sync much faster - the old process was mostly serialized.