### PR TITLE
change default local rpc port to 9000

### DIFF
--- a/explorer/client/src/utils/api/rpcSetting.ts
+++ b/explorer/client/src/utils/api/rpcSetting.ts
@@ -7,7 +7,7 @@ export enum Network {
 }
 
 const ENDPOINTS = {
-    [Network.Local]: 'http://127.0.0.1:5001',
+    [Network.Local]: 'http://127.0.0.1:9000',
     [Network.Devnet]: 'https://gateway.devnet.sui.io:443',
 };
 


### PR DESCRIPTION
this uses the full node by default instead of the gateway