### PR TITLE
[messages] Split out objects into their own enum

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -18,7 +18,7 @@ use sui_types::{
     event::{Event, TransferType},
     gas::SuiGasStatus,
     id::VersionedID,
-    messages::{CallArg, InputObjectKind},
+    messages::{CallArg, InputObjectKind, ObjectArg},
     object::{self, Data, MoveObject, Object, Owner},
     storage::{DeleteKind, Storage},
 };
@@ -72,7 +72,8 @@ pub fn execute<E: Debug, S: ResourceResolver<Error = E> + ModuleResolver<Error =
         .iter()
         .filter_map(|arg| match arg {
             CallArg::Pure(_) => None,
-            CallArg::ImmOrOwnedObject((id, _, _)) | CallArg::SharedObject(id) => {
+            CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _)))
+            | CallArg::Object(ObjectArg::SharedObject(id)) => {
                 Some((*id, state_view.read_object(id)?))
             }
         })
@@ -746,8 +747,12 @@ pub fn resolve_and_type_check(
                     }
                     return Ok(arg);
                 }
-                CallArg::ImmOrOwnedObject(ref_) => InputObjectKind::ImmOrOwnedMoveObject(ref_),
-                CallArg::SharedObject(id) => InputObjectKind::SharedMoveObject(id),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(ref_)) => {
+                    InputObjectKind::ImmOrOwnedMoveObject(ref_)
+                }
+                CallArg::Object(ObjectArg::SharedObject(id)) => {
+                    InputObjectKind::SharedMoveObject(id)
+                }
             };
 
             let id = object_kind.object_id();

--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -11,6 +11,7 @@ use sui_types::committee::EpochId;
 use sui_types::error::ExecutionError;
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
+use sui_types::messages::ObjectArg;
 use sui_types::object::{MoveObject, Owner, OBJECT_START_VERSION};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest, TxContext},
@@ -175,7 +176,7 @@ fn execute_transaction<S: BackingPackageStore>(
                         &function,
                         vec![],
                         vec![
-                            CallArg::SharedObject(SUI_SYSTEM_STATE_OBJECT_ID),
+                            CallArg::Object(ObjectArg::SharedObject(SUI_SYSTEM_STATE_OBJECT_ID)),
                             CallArg::Pure(bcs::to_bytes(&epoch).unwrap()),
                             CallArg::Pure(bcs::to_bytes(&storage_charge).unwrap()),
                             CallArg::Pure(bcs::to_bytes(&computation_charge).unwrap()),

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -694,7 +694,9 @@ where
         let signer = certificate.data.signer();
         let (gas_payment, _, _) = certificate.data.gas();
         let (coin_object_id, split_arg) = match call.arguments.as_slice() {
-            [CallArg::ImmOrOwnedObject((id, _, _)), CallArg::Pure(arg)] => (id, arg),
+            [CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))), CallArg::Pure(arg)] => {
+                (id, arg)
+            }
             _ => {
                 return Err(SuiError::InconsistentGatewayResult {
                     error: "Malformed transaction data".to_string(),
@@ -747,7 +749,7 @@ where
     ) -> Result<TransactionResponse, anyhow::Error> {
         let call = Self::try_get_move_call(&certificate)?;
         let primary_coin = match call.arguments.first() {
-            Some(CallArg::ImmOrOwnedObject((id, _, _))) => id,
+            Some(CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _)))) => id,
             _ => {
                 return Err(SuiError::InconsistentGatewayResult {
                     error: "Malformed transaction data".to_string(),
@@ -883,9 +885,9 @@ where
                 SuiJsonCallArg::Object(id) => {
                     let obj = self.get_object_internal(&id).await?;
                     let arg = if obj.is_shared() {
-                        CallArg::SharedObject(id)
+                        CallArg::Object(ObjectArg::SharedObject(id))
                     } else {
-                        CallArg::ImmOrOwnedObject(obj.compute_object_reference())
+                        CallArg::Object(ObjectArg::ImmOrOwnedObject(obj.compute_object_reference()))
                     };
                     objects.insert(id, obj);
                     arg
@@ -1205,7 +1207,7 @@ where
             vec![coin_type],
             gas,
             vec![
-                CallArg::ImmOrOwnedObject(coin_object_ref),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_object_ref)),
                 CallArg::Pure(bcs::to_bytes(&split_amounts)?),
             ],
             gas_budget,
@@ -1243,8 +1245,8 @@ where
             vec![coin_type],
             gas,
             vec![
-                CallArg::ImmOrOwnedObject(primary_coin_ref),
-                CallArg::ImmOrOwnedObject(coin_to_merge_ref),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(primary_coin_ref)),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_to_merge_ref)),
             ],
             gas_budget,
         );

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -16,7 +16,7 @@ use sui_types::{
     batch::UpdateItem,
     crypto::{get_key_pair, AuthoritySignature, Signature},
     messages::{
-        CallArg, ExecutionFailureStatus, ExecutionStatus, ObjectInfoRequestKind,
+        CallArg, ExecutionFailureStatus, ExecutionStatus, ObjectArg, ObjectInfoRequestKind,
         SingleTransactionKind, TransactionKind,
     },
     object::{Data, Owner},
@@ -64,6 +64,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<ExecutionFailureStatus>(&samples)?;
     tracer.trace_type::<AbortLocation>(&samples)?;
     tracer.trace_type::<CallArg>(&samples)?;
+    tracer.trace_type::<ObjectArg>(&samples)?;
     tracer.trace_type::<Data>(&samples)?;
     tracer.trace_type::<TypeTag>(&samples)?;
     tracer.trace_type::<TypedStoreError>(&samples)?;

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -124,7 +124,7 @@ fn transfer_object_move_transaction(
     gas_object_ref: ObjectRef,
 ) -> Transaction {
     let args = vec![
-        CallArg::ImmOrOwnedObject(object_ref),
+        CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref)),
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(dest)).unwrap()),
     ];
 
@@ -187,7 +187,7 @@ pub fn delete_object_move_transaction(
             ident_str!("delete").to_owned(),
             Vec::new(),
             gas_object_ref,
-            vec![CallArg::ImmOrOwnedObject(object_ref)],
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref))],
             GAS_VALUE_FOR_TESTING / 2,
         ),
         secret,
@@ -203,7 +203,7 @@ pub fn set_object_move_transaction(
     gas_object_ref: ObjectRef,
 ) -> Transaction {
     let args = vec![
-        CallArg::ImmOrOwnedObject(object_ref),
+        CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref)),
         CallArg::Pure(bcs::to_bytes(&value).unwrap()),
     ];
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -39,9 +39,11 @@ impl TestCallArg {
             Self::Object(object_id) => {
                 let object = state.get_object(&object_id).await.unwrap().unwrap();
                 if object.is_shared() {
-                    CallArg::SharedObject(object_id)
+                    CallArg::Object(ObjectArg::SharedObject(object_id))
                 } else {
-                    CallArg::ImmOrOwnedObject(object.compute_object_reference())
+                    CallArg::Object(ObjectArg::ImmOrOwnedObject(
+                        object.compute_object_reference(),
+                    ))
                 }
             }
             Self::U64(value) => CallArg::Pure(bcs::to_bytes(&value).unwrap()),
@@ -220,7 +222,7 @@ async fn test_handle_shared_object_with_max_sequence_number() {
         gas_object_ref,
         /* args */
         vec![
-            CallArg::SharedObject(shared_object_id),
+            CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
             CallArg::Pure(16u64.to_le_bytes().to_vec()),
             CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
         ],
@@ -1739,7 +1741,7 @@ async fn shared_object() {
         gas_object_ref,
         /* args */
         vec![
-            CallArg::SharedObject(shared_object_id),
+            CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
             CallArg::Pure(16u64.to_le_bytes().to_vec()),
             CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
         ],

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -12,7 +12,9 @@ use sui_types::{
     base_types::{ObjectID, TransactionDigest},
     crypto::Signature,
     gas_coin::GasCoin,
-    messages::{CallArg, CertifiedTransaction, SignatureAggregator, Transaction, TransactionData},
+    messages::{
+        CallArg, CertifiedTransaction, ObjectArg, SignatureAggregator, Transaction, TransactionData,
+    },
     object::{MoveObject, Object, Owner, OBJECT_START_VERSION},
 };
 use test_utils::test_keys;
@@ -60,7 +62,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
             gas_object.compute_object_reference(),
             /* args */
             vec![
-                CallArg::SharedObject(shared_object_id),
+                CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
                 CallArg::Pure(16u64.to_le_bytes().to_vec()),
                 CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
             ],

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -412,7 +412,9 @@ async fn test_move_call_gas() -> SuiResult {
         ident_str!("delete").to_owned(),
         vec![],
         gas_object.compute_object_reference(),
-        vec![CallArg::ImmOrOwnedObject(created_object_ref)],
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+            created_object_ref,
+        ))],
         expected_gas_balance,
     );
     let signature = Signature::new(&data, &sender_key);

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -38,16 +38,9 @@ CallArg:
         NEWTYPE:
           SEQ: U8
     1:
-      ImmOrOwnedObject:
+      Object:
         NEWTYPE:
-          TUPLE:
-            - TYPENAME: ObjectID
-            - TYPENAME: SequenceNumber
-            - TYPENAME: ObjectDigest
-    2:
-      SharedObject:
-        NEWTYPE:
-          TYPENAME: ObjectID
+          TYPENAME: ObjectArg
 ChangeEpoch:
   STRUCT:
     - epoch: U64
@@ -179,6 +172,19 @@ MoveTypeLayout:
           TYPENAME: MoveStructLayout
     7:
       signer: UNIT
+ObjectArg:
+  ENUM:
+    0:
+      ImmOrOwnedObject:
+        NEWTYPE:
+          TUPLE:
+            - TYPENAME: ObjectID
+            - TYPENAME: SequenceNumber
+            - TYPENAME: ObjectDigest
+    1:
+      SharedObject:
+        NEWTYPE:
+          TYPENAME: ObjectID
 ObjectDigest:
   NEWTYPESTRUCT: BYTES
 ObjectFormatOptions:

--- a/crates/sui-json-rpc-api/src/rpc_types.rs
+++ b/crates/sui-json-rpc-api/src/rpc_types.rs
@@ -35,7 +35,7 @@ use sui_types::event::{Event, TransferType};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
-    CallArg, CertifiedTransaction, ExecutionStatus, InputObjectKind, MoveModulePublish,
+    CallArg, CertifiedTransaction, ExecutionStatus, InputObjectKind, MoveModulePublish, ObjectArg,
     SingleTransactionKind, TransactionData, TransactionEffects, TransactionKind,
 };
 use sui_types::move_package::disassemble_modules;
@@ -914,10 +914,10 @@ impl TryFrom<SingleTransactionKind> for SuiTransactionKind {
                     .into_iter()
                     .map(|arg| match arg {
                         CallArg::Pure(p) => SuiJsonValue::from_bcs_bytes(&p),
-                        CallArg::ImmOrOwnedObject((id, _, _)) => {
+                        CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => {
                             SuiJsonValue::new(Value::String(id.to_hex_literal()))
                         }
-                        CallArg::SharedObject(id) => {
+                        CallArg::Object(ObjectArg::SharedObject(id)) => {
                             SuiJsonValue::new(Value::String(id.to_hex_literal()))
                         }
                     })

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -8,7 +8,7 @@ use move_command_line_common::{parser::Parser as MoveCLParser, values::ValueToke
 use move_compiler::shared::parse_u128;
 use move_core_types::identifier::Identifier;
 use move_core_types::value::{MoveStruct, MoveValue};
-use sui_types::messages::CallArg;
+use sui_types::messages::{CallArg, ObjectArg};
 
 use crate::test_adapter::SuiTestAdapter;
 
@@ -92,10 +92,10 @@ impl SuiValue {
                     None => bail!("INVALID TEST. Could not load object argument {}", id),
                 };
                 if obj.is_shared() {
-                    CallArg::SharedObject(id)
+                    CallArg::Object(ObjectArg::SharedObject(id))
                 } else {
                     let obj_ref = obj.compute_object_reference();
-                    CallArg::ImmOrOwnedObject(obj_ref)
+                    CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref))
                 }
             }
             SuiValue::MoveValue(v) => CallArg::Pure(v.simple_serialize().unwrap()),

--- a/crates/sui/src/benchmark/transaction_creator.rs
+++ b/crates/sui/src/benchmark/transaction_creator.rs
@@ -36,7 +36,7 @@ fn make_transfer_transaction(
             function: ident_str!("transfer").to_owned(),
             type_arguments: Vec::new(),
             arguments: vec![
-                CallArg::ImmOrOwnedObject(object_ref),
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref)),
                 CallArg::Pure(bcs::to_bytes(&AccountAddress::from(recipient)).unwrap()),
             ],
         })

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -9,7 +9,7 @@ use sui_core::{
 use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest},
     crypto::get_key_pair_from_rng,
-    messages::{CallArg, ExecutionStatus},
+    messages::{CallArg, ExecutionStatus, ObjectArg},
 };
 use test_utils::transaction::publish_counter_package;
 use test_utils::{
@@ -269,7 +269,7 @@ async fn checkpoint_with_shared_objects() {
         "counter",
         "increment",
         package_ref,
-        vec![CallArg::SharedObject(counter_id)],
+        vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
     );
     let replies = submit_shared_object_transaction(
         increment_counter_transaction.clone(),

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -4,7 +4,9 @@
 use std::sync::Arc;
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::gateway_state::{GatewayAPI, GatewayState};
-use sui_types::messages::{CallArg, ExecutionStatus, ObjectInfoRequest, ObjectInfoRequestKind};
+use sui_types::messages::{
+    CallArg, ExecutionStatus, ObjectArg, ObjectInfoRequest, ObjectInfoRequestKind,
+};
 use sui_types::object::OBJECT_START_VERSION;
 use test_utils::authority::{get_client, test_authority_aggregator};
 use test_utils::transaction::{
@@ -98,7 +100,7 @@ async fn call_shared_object_contract() {
         "assert_value",
         package_ref,
         vec![
-            CallArg::SharedObject(counter_id),
+            CallArg::Object(ObjectArg::SharedObject(counter_id)),
             CallArg::Pure(0u64.to_le_bytes().to_vec()),
         ],
     );
@@ -114,7 +116,7 @@ async fn call_shared_object_contract() {
         "counter",
         "increment",
         package_ref,
-        vec![CallArg::SharedObject(counter_id)],
+        vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
     );
     let effects = submit_shared_object_transaction(transaction, &configs.validator_set()[0..1])
         .await
@@ -129,7 +131,7 @@ async fn call_shared_object_contract() {
         "assert_value",
         package_ref,
         vec![
-            CallArg::SharedObject(counter_id),
+            CallArg::Object(ObjectArg::SharedObject(counter_id)),
             CallArg::Pure(1u64.to_le_bytes().to_vec()),
         ],
     );
@@ -177,7 +179,7 @@ async fn shared_object_flood() {
         "assert_value",
         package_ref,
         vec![
-            CallArg::SharedObject(counter_id),
+            CallArg::Object(ObjectArg::SharedObject(counter_id)),
             CallArg::Pure(0u64.to_le_bytes().to_vec()),
         ],
     );
@@ -193,7 +195,7 @@ async fn shared_object_flood() {
         "counter",
         "increment",
         package_ref,
-        vec![CallArg::SharedObject(counter_id)],
+        vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
     );
     let effects = submit_shared_object_transaction(transaction, configs.validator_set())
         .await
@@ -208,7 +210,7 @@ async fn shared_object_flood() {
         "assert_value",
         package_ref,
         vec![
-            CallArg::SharedObject(counter_id),
+            CallArg::Object(ObjectArg::SharedObject(counter_id)),
             CallArg::Pure(1u64.to_le_bytes().to_vec()),
         ],
     );
@@ -278,7 +280,7 @@ async fn shared_object_sync() {
         "counter",
         "increment",
         package_ref,
-        vec![CallArg::SharedObject(counter_id)],
+        vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
     );
 
     // Let's submit the transaction to the first authority (the only one up-to-date).
@@ -409,7 +411,8 @@ async fn shared_object_on_gateway() {
                     "counter",
                     "increment",
                     package_ref,
-                    /* arguments */ vec![CallArg::SharedObject(shared_object_id)],
+                    /* arguments */
+                    vec![CallArg::Object(ObjectArg::SharedObject(shared_object_id))],
                 );
                 async move { g.execute_transaction(increment_counter_transaction).await }
             })
@@ -431,7 +434,7 @@ async fn shared_object_on_gateway() {
         "assert_value",
         package_ref,
         vec![
-            CallArg::SharedObject(shared_object_id),
+            CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
             CallArg::Pure((increment_amount as u64).to_le_bytes().to_vec()),
         ],
     );

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -10,7 +10,8 @@ use std::path::PathBuf;
 use sui_adapter::genesis;
 use sui_types::base_types::ObjectRef;
 use sui_types::messages::{
-    CertifiedTransaction, SignatureAggregator, SignedTransaction, Transaction, TransactionData,
+    CertifiedTransaction, ObjectArg, SignatureAggregator, SignedTransaction, Transaction,
+    TransactionData,
 };
 use sui_types::object::Object;
 use sui_types::{base_types::SuiAddress, crypto::Signature};
@@ -100,7 +101,7 @@ pub fn test_shared_object_transactions() -> Vec<Transaction> {
             gas_object.compute_object_reference(),
             /* args */
             vec![
-                CallArg::SharedObject(shared_object_id),
+                CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
                 CallArg::Pure(16u64.to_le_bytes().to_vec()),
                 CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
             ],


### PR DESCRIPTION
- To make room for vectors of objects, object args should be a nested enum
- First step for #1521