### PR TITLE
[Move] Return error instead of panicking on primitive type event

### DIFF
--- a/crates/sui-framework/src/natives/event.rs
+++ b/crates/sui-framework/src/natives/event.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::EventType;
-use move_binary_format::errors::PartialVMResult;
-use move_core_types::gas_schedule::GasAlgebra;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{gas_schedule::GasAlgebra, vm_status::StatusCode};
 use move_vm_runtime::native_functions::NativeContext;
 use move_vm_types::{
     gas_schedule::NativeCostIndex,
@@ -33,8 +33,9 @@ pub fn emit(
     match ty {
         Type::Struct(..) | Type::StructInstantiation(..) => (),
         ty => {
-            // TODO: // TODO(https://github.com/MystenLabs/sui/issues/19): enforce this in the ability system
-            panic!("Unsupported event type {:?}--struct expected", ty)
+            // TODO (https://github.com/MystenLabs/sui/issues/19): ideally enforce this in the ability system
+            return Err(PartialVMError::new(StatusCode::DATA_FORMAT_ERROR)
+                .with_message(format!("Unsupported event type {:?} (struct expected)", ty)));
         }
     }
 


### PR DESCRIPTION
This fixes https://github.com/MystenLabs/sui/issues/2232. This is how the problem was being reported to the user when trying to execute a function generating a primitive type event (via wallet CLI):

```
Failed to execute certificate on a quorum of validators, cause by : [
    "Confirmation transaction processing failed: previous attempt of transaction resulted in an error - transaction will be retried offline",
    "Confirmation transaction processing failed: previous attempt of transaction resulted in an error - transaction will be retried offline",
    "Confirmation transaction processing failed: previous attempt of transaction resulted in an error - transaction will be retried offline",
]
```

And this is what we will have after this PR lands, which is arguably more informative:
```
Execution aborted: "VMError with status DATA_FORMAT_ERROR at location Module ModuleId { address: 0000000000000000000000000000000000000002, name: Identifier(\"event\") } and message Unsupported event type Bool (struct expected) at code offset 0 in function definition 0".
```