### PR TITLE
[explorer] Applying constants to tx tables

### DIFF
--- a/explorer/client/src/components/longtext/Longtext.tsx
+++ b/explorer/client/src/components/longtext/Longtext.tsx
@@ -16,6 +16,7 @@ function Longtext({
     category = 'unknown',
     isLink = true,
     alttext = '',
+    isCopyButton = true,
 }: {
     text: string;
     category:
@@ -26,8 +27,10 @@ function Longtext({
         | 'unknown';
     isLink?: boolean;
     alttext?: string;
+    isCopyButton?: boolean;
 }) {
     const [isCopyIcon, setCopyIcon] = useState(true);
+
     const [pleaseWait, setPleaseWait] = useState(false);
     const [network] = useContext(NetworkContext);
     const navigate = useNavigate();
@@ -40,16 +43,20 @@ function Longtext({
 
     let icon;
 
-    if (pleaseWait) {
-        icon = <span className={styles.copied}>&#8987; Please Wait</span>;
-    } else if (isCopyIcon) {
-        icon = (
-            <span className={styles.copy} onClick={handleCopyEvent}>
-                <ContentCopyIcon />
-            </span>
-        );
+    if (isCopyButton) {
+        if (pleaseWait) {
+            icon = <span className={styles.copied}>&#8987; Please Wait</span>;
+        } else if (isCopyIcon) {
+            icon = (
+                <span className={styles.copy} onClick={handleCopyEvent}>
+                    <ContentCopyIcon />
+                </span>
+            );
+        } else {
+            icon = <span className={styles.copied}>&#10003; Copied</span>;
+        }
     } else {
-        icon = <span className={styles.copied}>&#10003; Copied</span>;
+        icon = <></>;
     }
 
     const navigateUnknown = useCallback(() => {

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -1,7 +1,3 @@
-div.txcardgrid a {
-    @apply no-underline text-sky-600 hover:text-sky-900 cursor-pointer break-all;
-}
-
 div.txcardgrid h3 {
     @apply font-normal leading-3 font-mono text-center;
 }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -3,7 +3,7 @@
 
 import cl from 'classnames';
 import { useEffect, useState, useContext } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import Longtext from '../../components/longtext/Longtext';
 import { NetworkContext } from '../../context';
@@ -127,17 +127,12 @@ function LatestTxView({
                             className={cl(styles.txcardgrid, styles.txcard)}
                         >
                             <div className={styles.txcardgridlarge}>
-                                <div className={styles.txlink}>
-                                    <Longtext
-                                        text={tx.txId}
-                                        category="transactions"
-                                        isLink={true}
-                                        alttext={truncate(
-                                            tx.txId,
-                                            TRUNCATE_LENGTH
-                                        )}
-                                    />
-                                </div>
+                                <Longtext
+                                    text={tx.txId}
+                                    category="transactions"
+                                    isLink={true}
+                                    alttext={truncate(tx.txId, TRUNCATE_LENGTH)}
+                                />
                             </div>
                             <div className={styles.txtype}> {tx.kind}</div>
                             <div
@@ -152,22 +147,30 @@ function LatestTxView({
                             <div className={styles.txadd}>
                                 <div>
                                     From:
-                                    <Link
-                                        className={styles.txlink}
-                                        to={'addresses/' + tx.From}
-                                    >
-                                        {truncate(tx.From, TRUNCATE_LENGTH)}
-                                    </Link>
+                                    <Longtext
+                                        text={tx.From}
+                                        category="addresses"
+                                        isLink={true}
+                                        isCopyButton={false}
+                                        alttext={truncate(
+                                            tx.From,
+                                            TRUNCATE_LENGTH
+                                        )}
+                                    />
                                 </div>
                                 {tx.To && (
                                     <div>
                                         To :
-                                        <Link
-                                            className={styles.txlink}
-                                            to={'addresses/' + tx.To}
-                                        >
-                                            {truncate(tx.To, TRUNCATE_LENGTH)}
-                                        </Link>
+                                        <Longtext
+                                            text={tx.To}
+                                            category="addresses"
+                                            isLink={true}
+                                            isCopyButton={false}
+                                            alttext={truncate(
+                                                tx.To,
+                                                TRUNCATE_LENGTH
+                                            )}
+                                        />
                                     </div>
                                 )}
                             </div>

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -27,6 +27,8 @@ import type {
 
 import styles from './RecentTxCard.module.css';
 
+const TRUNCATE_LENGTH = 25;
+
 const initState: { loadState: string; latestTx: TxnData[] } = {
     loadState: 'pending',
     latestTx: [],
@@ -130,7 +132,10 @@ function LatestTxView({
                                         text={tx.txId}
                                         category="transactions"
                                         isLink={true}
-                                        alttext={truncate(tx.txId, 26, '...')}
+                                        alttext={truncate(
+                                            tx.txId,
+                                            TRUNCATE_LENGTH
+                                        )}
                                     />
                                 </div>
                             </div>
@@ -151,7 +156,7 @@ function LatestTxView({
                                         className={styles.txlink}
                                         to={'addresses/' + tx.From}
                                     >
-                                        {truncate(tx.From, 25, '...')}
+                                        {truncate(tx.From, TRUNCATE_LENGTH)}
                                     </Link>
                                 </div>
                                 {tx.To && (
@@ -161,7 +166,7 @@ function LatestTxView({
                                             className={styles.txlink}
                                             to={'addresses/' + tx.To}
                                         >
-                                            {truncate(tx.To, 25, '...')}
+                                            {truncate(tx.To, TRUNCATE_LENGTH)}
                                         </Link>
                                     </div>
                                 )}

--- a/explorer/client/src/components/transactions-for-id/TxForID.module.css
+++ b/explorer/client/src/components/transactions-for-id/TxForID.module.css
@@ -28,10 +28,6 @@
     @apply col-span-2;
 }
 
-.txadd a {
-    @apply no-underline text-sky-600 hover:text-sky-900 cursor-pointer break-all;
-}
-
 .failure {
     @apply text-red-300;
 }

--- a/explorer/client/src/components/transactions-for-id/TxForID.tsx
+++ b/explorer/client/src/components/transactions-for-id/TxForID.tsx
@@ -25,6 +25,8 @@ import PaginationWrapper from '../pagination/PaginationWrapper';
 
 import styles from './TxForID.module.css';
 
+const TRUNCATE_LENGTH = 14;
+
 const DATATYPE_DEFAULT = {
     loadState: 'pending',
 };
@@ -88,7 +90,7 @@ function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
                                 className={styles.txlink}
                                 to={'addresses/' + x.From}
                             >
-                                {truncate(x.From, 14, '...')}
+                                {truncate(x.From, TRUNCATE_LENGTH)}
                             </Link>
                         </div>
                         {x.To && (
@@ -98,7 +100,7 @@ function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
                                     className={styles.txlink}
                                     to={'addresses/' + x.To}
                                 >
-                                    {truncate(x.To, 14, '...')}
+                                    {truncate(x.To, TRUNCATE_LENGTH)}
                                 </Link>
                             </div>
                         )}

--- a/explorer/client/src/components/transactions-for-id/TxForID.tsx
+++ b/explorer/client/src/components/transactions-for-id/TxForID.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mysten/sui.js';
 import cl from 'classnames';
 import { useState, useEffect, useContext } from 'react';
-import { Link } from 'react-router-dom';
 
 import { NetworkContext } from '../../context';
 import {
@@ -86,22 +85,24 @@ function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
                     <div className={styles.txadd}>
                         <div>
                             From:
-                            <Link
-                                className={styles.txlink}
-                                to={'addresses/' + x.From}
-                            >
-                                {truncate(x.From, TRUNCATE_LENGTH)}
-                            </Link>
+                            <Longtext
+                                text={x.From}
+                                category="addresses"
+                                isLink={true}
+                                isCopyButton={false}
+                                alttext={truncate(x.From, TRUNCATE_LENGTH)}
+                            />
                         </div>
                         {x.To && (
                             <div>
                                 To :
-                                <Link
-                                    className={styles.txlink}
-                                    to={'addresses/' + x.To}
-                                >
-                                    {truncate(x.To, TRUNCATE_LENGTH)}
-                                </Link>
+                                <Longtext
+                                    text={x.To}
+                                    category="addresses"
+                                    isLink={true}
+                                    isCopyButton={false}
+                                    alttext={truncate(x.To, TRUNCATE_LENGTH)}
+                                />
                             </div>
                         )}
                     </div>

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -40,7 +40,7 @@ function transformURL(url: string) {
     return `https://ipfs.io/ipfs/${found[1]}`;
 }
 
-export function truncate(fullStr: string, strLen: number, separator: string) {
+export function truncate(fullStr: string, strLen: number, separator?: string) {
     if (fullStr.length <= strLen) return fullStr;
 
     separator = separator || '...';


### PR DESCRIPTION
Following feedback ( see https://github.com/MystenLabs/sui/pull/2485), constants have been applied to refactor the transaction table code. These are applied to the length to which values are truncated as well as to the CSS for addresses. This hardcodes consistency in the look of addresses across the website.

The UI should look the same as before. Here is what the UI looks like after the changes:
![image](https://user-images.githubusercontent.com/11377188/174358568-c4f75f2a-0aae-4fb6-a4cf-ae5863184fe8.png)
