### PR TITLE
[events] Remove MoveObject from events

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
@@ -23,7 +23,7 @@ created: object(108)
 written: object(107)
 
 task 6 'run'. lines 18-18:
-events: MoveEvent(MoveObject { type_: StructTag { address: sui, module: Identifier("object_basics"), name: Identifier("NewValueEvent"), type_params: [] }, contents: [20, 0, 0, 0, 0, 0, 0, 0] })
+events: MoveEvent { type_: StructTag { address: sui, module: Identifier("object_basics"), name: Identifier("NewValueEvent"), type_params: [] }, contents: [20, 0, 0, 0, 0, 0, 0, 0] }
 written: object(105), object(108), object(109)
 
 task 7 'run'. lines 20-20:

--- a/crates/sui-core/src/event_filter.rs
+++ b/crates/sui-core/src/event_filter.rs
@@ -25,7 +25,7 @@ impl EventFilter {
     fn try_matches(&self, item: &EventEnvelope) -> Result<bool, anyhow::Error> {
         Ok(match self {
             EventFilter::ByMoveEventType(event_type) => match &item.event {
-                Event::MoveEvent(event_obj) => &event_obj.type_ == event_type,
+                Event::MoveEvent { type_, .. } => type_ == event_type,
                 // TODO: impl for non-move event
                 _ => false,
             },

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -47,7 +47,7 @@ impl EventHandler {
             Event::MoveEvent { type_, contents } => {
                 debug!(event =? event, "Process MoveEvent.");
                 let move_struct =
-                    Event::move_event_to_move_struct(&type_, &contents, &self.module_cache)?;
+                    Event::move_event_to_move_struct(type_, contents, &self.module_cache)?;
                 Some(serde_json::to_value(&move_struct).map_err(|e| {
                     SuiError::ObjectSerializationError {
                         error: e.to_string(),

--- a/crates/sui-storage/src/event_store/sql.rs
+++ b/crates/sui-storage/src/event_store/sql.rs
@@ -361,7 +361,6 @@ mod tests {
     use serde_json::json;
     use std::collections::BTreeMap;
 
-    use sui_types::object::MoveObject;
     use sui_types::{
         base_types::SuiAddress,
         event::{Event, EventEnvelope, TransferType},
@@ -431,7 +430,7 @@ mod tests {
         };
         let event_bytes = bcs::to_bytes(&move_event).unwrap();
         (
-            Event::MoveEvent(MoveObject::new(TestEvent::struct_tag(), event_bytes)),
+            Event::move_event(TestEvent::struct_tag(), event_bytes),
             move_event.move_struct(),
         )
     }

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -137,7 +137,15 @@ impl MoveObject {
         format: ObjectFormatOptions,
         resolver: &impl GetModule,
     ) -> Result<MoveStructLayout, SuiError> {
-        let type_ = TypeTag::Struct(self.type_.clone());
+        Self::get_layout_from_struct_tag(self.type_.clone(), format, resolver)
+    }
+
+    pub fn get_layout_from_struct_tag(
+        struct_tag: StructTag,
+        format: ObjectFormatOptions,
+        resolver: &impl GetModule,
+    ) -> Result<MoveStructLayout, SuiError> {
+        let type_ = TypeTag::Struct(struct_tag);
         let layout = if format.include_types {
             TypeLayoutBuilder::build_with_types(&type_, resolver)
         } else {


### PR DESCRIPTION
- MoveObject is intended for MoveObjects, not any move struct
- It was erroneously used for events, potentially leading to catastrophic bugs in the future