### PR TITLE
[move, experiment] LoudWrapper example - postponed event emission

### DIFF
--- a/crates/sui-framework/sources/event.move
+++ b/crates/sui-framework/sources/event.move
@@ -2,22 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::event {
-    /// An attachable event. Should be emitted once unpacked from a
-    /// a wrapper. Holds any custom event data inside.
-    struct Event<T: copy + drop + store> has store {
-        data: T
-    }
-
-    /// Create a new `Event` wrapper for custom `data`.
-    public fun create<T: copy + drop + store>(data: T): Event<T> {
-        Event { data }
-    }
-
-    /// Unpack contents of `Event` and `emit` them.
-    public fun emit_event<T: copy + drop + store>(evt: Event<T>) {
-        let Event { data } = evt;
-        emit(data)
-    }
 
     /// Add `t` to the event log of this transaction
     // TODO(https://github.com/MystenLabs/sui/issues/19):

--- a/crates/sui-framework/sources/event.move
+++ b/crates/sui-framework/sources/event.move
@@ -2,6 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module sui::event {
+    /// An attachable event. Should be emitted once unpacked from a
+    /// a wrapper. Holds any custom event data inside.
+    struct Event<T: copy + drop + store> has store {
+        data: T
+    }
+
+    /// Create a new `Event` wrapper for custom `data`.
+    public fun create<T: copy + drop + store>(data: T): Event<T> {
+        Event { data }
+    }
+
+    /// Unpack contents of `Event` and `emit` them.
+    public fun emit_event<T: copy + drop + store>(evt: Event<T>) {
+        let Event { data } = evt;
+        emit(data)
+    }
 
     /// Add `t` to the event log of this transaction
     // TODO(https://github.com/MystenLabs/sui/issues/19):

--- a/sui_programmability/examples/basics/sources/loud_wrapper.move
+++ b/sui_programmability/examples/basics/sources/loud_wrapper.move
@@ -1,0 +1,80 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// An example of data + Event wrapping. Allows attaching `Event` to a wrapper
+/// so whenever an Wrapper is destroyed, a user-defined event is emitted
+module basics::loud_wrapper {
+    use sui::event::{Self, Event};
+    use sui::id::{Self, VersionedID};
+    use sui::tx_context::{new_id, TxContext};
+
+    /// A generic wrapper for any type T; custom Event is attached to it
+    /// to be emitted once the wrapper is destroyed.
+    struct LoudWrapper<T: store, EVT: copy + drop + store> has key {
+        id: VersionedID,
+        t: T,
+        evt: Event<EVT>
+    }
+
+    /// Wrap some T with an event EVT into a LoudWrapper.
+    public fun wrap<T: store, EVT: copy + drop + store>(
+        t: T, evt: EVT, ctx: &mut TxContext
+    ): LoudWrapper<T, EVT> {
+        LoudWrapper {
+            id: new_id(ctx),
+            t,
+            evt: event::create(evt)
+        }
+    }
+
+    /// Unwrap `LoudWrapper`: emit an Event<EVT> and return `T`.
+    public fun unwrap<T: store, EVT: copy + drop + store>(wrapper: LoudWrapper<T, EVT>): T {
+        let LoudWrapper { id, t, evt } = wrapper;
+
+        id::delete(id);
+        event::emit_event(evt);
+        t
+    }
+}
+
+#[test_only]
+module basics::gift {
+    use sui::id::{Self, ID};
+    use sui::event;
+    use sui::transfer;
+    use sui::coin::{Coin};
+    use sui::tx_context::TxContext;
+    use sui::utf8::{Self, String};
+    use basics::loud_wrapper::{Self as wrapper};
+
+    /// Some message that can be read by the receiver.
+    struct Gift<phantom T> has store {
+        text: String,
+        coin: Coin<T>
+    }
+
+    /// Emitted when a gift is sent. An ID is the ID of the Coin.
+    struct GiftSent<phantom T> has copy, drop { id: ID }
+
+    /// Emitted whenever the recipient opens the gift box and
+    /// accesses the contents. ID here is the same as in the GiftSent
+    /// event.
+    struct GiftOpened<phantom T> has store, copy, drop { id: ID }
+
+    /// Send a Gift as a generic LoudWrapper. Attach an event to it so
+    /// we know when and who has received the package.
+    public entry fun send<T>(
+        coin: Coin<T>, text: vector<u8>, to: address, ctx: &mut TxContext
+    ) {
+        let coin_id = *id::id(&coin);
+        let wrapper = wrapper::wrap(
+            Gift { coin, text: utf8::string_unsafe(text) },
+            GiftOpened<T> { id: *&coin_id },
+            ctx
+        );
+
+        event::emit(GiftSent<T> { id: coin_id });
+        transfer::transfer(wrapper, to)
+    }
+}
+

--- a/sui_programmability/examples/basics/sources/loud_wrapper.move
+++ b/sui_programmability/examples/basics/sources/loud_wrapper.move
@@ -4,7 +4,7 @@
 /// An example of data + Event wrapping. Allows attaching `Event` to a wrapper
 /// so whenever an Wrapper is destroyed, a user-defined event is emitted
 module basics::loud_wrapper {
-    use sui::event::{Self, Event};
+    use sui::event::{Self};
     use sui::id::{Self, VersionedID};
     use sui::tx_context::{new_id, TxContext};
 
@@ -13,7 +13,7 @@ module basics::loud_wrapper {
     struct LoudWrapper<T: store, EVT: copy + drop + store> has key {
         id: VersionedID,
         t: T,
-        evt: Event<EVT>
+        evt: EVT
     }
 
     /// Wrap some T with an event EVT into a LoudWrapper.
@@ -23,7 +23,7 @@ module basics::loud_wrapper {
         LoudWrapper {
             id: new_id(ctx),
             t,
-            evt: event::create(evt)
+            evt
         }
     }
 
@@ -32,7 +32,7 @@ module basics::loud_wrapper {
         let LoudWrapper { id, t, evt } = wrapper;
 
         id::delete(id);
-        event::emit_event(evt);
+        event::emit(evt);
         t
     }
 }
@@ -77,4 +77,3 @@ module basics::gift {
         transfer::transfer(wrapper, to)
     }
 }
-


### PR DESCRIPTION
This PR is another experiment and an idea of what could be done with events. Sometimes we want to track wrappers, and perhaps there is a way to do it once and for everyone. 

What this PR introduces:

### ~~Event type~~ (removed)

Serves the purpose of protecting its contents from simply being destroyed. Emitted data must be `copy + drop`, but event only has store. Storing it elsewhere could be an option but it will require additional costs for storage, and there should not be an incentive to not emit it (but we could think in this direction).

### A LoudWrapper example + Gift sending module

LoudWrapper is a generic wrapper which allows attaching a custom `Event` to the wrapped data. Once it is unwrapped, someone needs to do something with the event, and the proposed way is to emit it right away. 

Ideal test for Gift module would be: Alice sends a `LoudWrapper<Gift>` to Bob. And Bob (a compulsive gambler) uses it in crypto loans and loses everything to an anonymous dealer. Who then opens it, reads the Alice's message and gets the Coin. Alice receives an event `GiftOpened` hoping that it was Bob who opened it. 

