### PR TITLE
make docker builds work outside of macos

### DIFF
--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -22,7 +22,8 @@ RUN sed -i '/crates\/workspace-hack/b; /crates/d' Cargo.toml \
 # and run `cargo build` in order to create a caching Docker layer
 # with all dependencies built.
 FROM chef AS builder 
-COPY --from=planner /sui/Cargo.toml /sui/Cargo.lock ./
+COPY --from=planner /sui/Cargo.toml Cargo.toml
+COPY --from=planner /sui/Cargo.lock Cargo.lock
 COPY --from=planner /sui/crates/workspace-hack crates/workspace-hack
 RUN cargo build --release
 

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y cmake clang
 #   3. Update the lockfile in order to reflect the changes to the
 #      root Cargo.toml file.
 FROM chef AS planner
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock ./
 COPY crates/workspace-hack crates/workspace-hack
 RUN sed -i '/crates\/workspace-hack/b; /crates/d' Cargo.toml \
     && cargo metadata -q >/dev/null
@@ -22,8 +22,7 @@ RUN sed -i '/crates\/workspace-hack/b; /crates/d' Cargo.toml \
 # and run `cargo build` in order to create a caching Docker layer
 # with all dependencies built.
 FROM chef AS builder 
-COPY --from=planner /sui/Cargo.toml Cargo.toml
-COPY --from=planner /sui/Cargo.lock Cargo.lock
+COPY --from=planner /sui/Cargo.toml /sui/Cargo.lock ./
 COPY --from=planner /sui/crates/workspace-hack crates/workspace-hack
 RUN cargo build --release
 
@@ -32,7 +31,7 @@ RUN cargo build --release
 # Copy in the rest of the crates (and an unmodified Cargo.toml and Cargo.lock)
 # and build the application. At this point no dependencies should need to be
 # built as they were built and cached by the previous layer.
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 RUN cargo build --release --bin sui-node
 

--- a/docker/sui-node/build.sh
+++ b/docker/sui-node/build.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # fast fail.
-set -eo pipefail
+set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -22,7 +22,8 @@ RUN sed -i '/crates\/workspace-hack/b; /crates/d' Cargo.toml \
 # and run `cargo build` in order to create a caching Docker layer
 # with all dependencies built.
 FROM chef AS builder 
-COPY --from=planner /sui/Cargo.toml /sui/Cargo.lock ./
+COPY --from=planner /sui/Cargo.toml Cargo.toml
+COPY --from=planner /sui/Cargo.lock Cargo.lock
 COPY --from=planner /sui/crates/workspace-hack crates/workspace-hack
 RUN cargo build --release
 

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y cmake clang
 #   3. Update the lockfile in order to reflect the changes to the
 #      root Cargo.toml file.
 FROM chef AS planner
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock ./
 COPY crates/workspace-hack crates/workspace-hack
 RUN sed -i '/crates\/workspace-hack/b; /crates/d' Cargo.toml \
     && cargo metadata -q >/dev/null
@@ -22,8 +22,7 @@ RUN sed -i '/crates\/workspace-hack/b; /crates/d' Cargo.toml \
 # and run `cargo build` in order to create a caching Docker layer
 # with all dependencies built.
 FROM chef AS builder 
-COPY --from=planner /sui/Cargo.toml Cargo.toml
-COPY --from=planner /sui/Cargo.lock Cargo.lock
+COPY --from=planner /sui/Cargo.toml /sui/Cargo.lock ./
 COPY --from=planner /sui/crates/workspace-hack crates/workspace-hack
 RUN cargo build --release
 
@@ -32,7 +31,7 @@ RUN cargo build --release
 # Copy in the rest of the crates (and an unmodified Cargo.toml and Cargo.lock)
 # and build the application. At this point no dependencies should need to be
 # built as they were built and cached by the previous layer.
-COPY Cargo.toml Cargo.lock .
+COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 RUN cargo build --release \
     --bin sui-node \

--- a/docker/sui-tools/build.sh
+++ b/docker/sui-tools/build.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # fast fail.
-set -eo pipefail
+set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
These builds don't work everywhere (outside of macos?).

The build scripts need either the pipefail option removed or to use bash:

> ./build.sh: 6: set: Illegal option -o pipefail

The Dockerfile configs also need a small update to some COPY operations:
 
> When using COPY with more than one source file, the destination must be a directory and end with a /