### PR TITLE
[core] Modify checkpointing logic to ensure all transactions in a signed / accepted checkpoint are executed

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1105,7 +1105,11 @@ impl AuthorityState {
                     // Update the checkpointing mechanism
                     checkpoint
                         .lock()
-                        .handle_internal_batch(batch.batch.next_sequence_number, &transactions)
+                        .handle_internal_batch(
+                            batch.batch.next_sequence_number,
+                            &transactions,
+                            &state.committee.load(),
+                        )
                         .expect("Should see no errors updating the checkpointing mechanism.");
                 }
             }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use sui_types::committee::StakeUnit;
 use tracing::{debug, info, warn};
-use typed_store::Map;
+// use typed_store::Map;
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -179,18 +179,18 @@ pub async fn checkpoint_process<A>(
 
         // (3) Process any unprocessed transactions. We do this before trying to move to the
         //     next proposal.
-        if let Err(err) = process_unprocessed_digests(
-            active_authority,
-            state_checkpoints.clone(),
-            timing.per_other_authority_delay,
-        )
-        .await
-        {
-            warn!("Error processing unprocessed: {:?}", err);
-            // Nothing happens until we catch up with the unprocessed transactions of the
-            // previous checkpoint.
-            continue;
-        }
+        // if let Err(err) = process_unprocessed_digests(
+        //     active_authority,
+        //     state_checkpoints.clone(),
+        //     timing.per_other_authority_delay,
+        // )
+        // .await
+        // {
+        //     warn!("Error processing unprocessed: {:?}", err);
+        //     // Nothing happens until we catch up with the unprocessed transactions of the
+        //     // previous checkpoint.
+        //     continue;
+        // }
 
         // (4) Check if we need to advance to the next checkpoint, in case >2/3
         // have a proposal out. If so we start creating and injecting fragments
@@ -417,6 +417,8 @@ where
 {
     // Get out last checkpoint
     let latest_checkpoint = checkpoint_db.lock().latest_stored_checkpoint()?;
+    // We use the latest available authorities not the authorities that signed the checkpoint
+    // since these might be gone after the epoch they were active.
     let available_authorities: BTreeSet<_> = latest_known_checkpoint
         .signatory_authorities()
         .cloned()
@@ -734,73 +736,73 @@ where
 /// Looks into the unprocessed_digests and tries to process them all to allow
 /// for the creation of the next proposal. Also uses the unprocessed_content
 /// to look for transactions before going to fetch them from the network.
-pub async fn process_unprocessed_digests<A>(
-    active_authority: &ActiveAuthority<A>,
-    checkpoint_db: Arc<Mutex<CheckpointStore>>,
-    per_other_authority_delay: Duration,
-) -> Result<(), SuiError>
-where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
-{
-    let unprocessed_digests: Vec<_> = checkpoint_db
-        .lock()
-        .unprocessed_transactions
-        .iter()
-        .map(|(digest, _)| digest)
-        .collect();
+// pub async fn process_unprocessed_digests<A>(
+//     active_authority: &ActiveAuthority<A>,
+//     checkpoint_db: Arc<Mutex<CheckpointStore>>,
+//     per_other_authority_delay: Duration,
+// ) -> Result<(), SuiError>
+// where
+//     A: AuthorityAPI + Send + Sync + 'static + Clone,
+// {
+//     let unprocessed_digests: Vec<_> = checkpoint_db
+//         .lock()
+//         .unprocessed_transactions
+//         .iter()
+//         .map(|(digest, _)| digest)
+//         .collect();
 
-    let existing_certificates = checkpoint_db
-        .lock()
-        .unprocessed_contents
-        .multi_get(&unprocessed_digests)?;
+//     let existing_certificates = checkpoint_db
+//         .lock()
+//         .unprocessed_contents
+//         .multi_get(&unprocessed_digests)?;
 
-    // First process all certs that we have stored in the unprocessed_contents
-    let mut processed = BTreeSet::new();
-    for (digest, cert) in unprocessed_digests
-        .iter()
-        .zip(existing_certificates.iter())
-        .filter_map(|(digest, cert_opt)| cert_opt.as_ref().map(|c| (digest, c)))
-    {
-        active_authority
-            .net
-            .load()
-            .sync_certificate_to_authority_with_timeout(
-                ConfirmationTransaction::new(cert.clone()),
-                active_authority.state.name,
-                per_other_authority_delay,
-                3,
-            )
-            .await?;
-        processed.insert(digest);
-    }
+//     // First process all certs that we have stored in the unprocessed_contents
+//     let mut processed = BTreeSet::new();
+//     for (digest, cert) in unprocessed_digests
+//         .iter()
+//         .zip(existing_certificates.iter())
+//         .filter_map(|(digest, cert_opt)| cert_opt.as_ref().map(|c| (digest, c)))
+//     {
+//         active_authority
+//             .net
+//             .load()
+//             .sync_certificate_to_authority_with_timeout(
+//                 ConfirmationTransaction::new(cert.clone()),
+//                 active_authority.state.name,
+//                 per_other_authority_delay,
+//                 3,
+//             )
+//             .await?;
+//         processed.insert(digest);
+//     }
 
-    for digest in &unprocessed_digests {
-        // If we have processed this continue with the next cert, nothing to do
-        if active_authority
-            .state
-            .database
-            .effects_exists(&digest.transaction)?
-        {
-            continue;
-        }
+//     for digest in &unprocessed_digests {
+//         // If we have processed this continue with the next cert, nothing to do
+//         if active_authority
+//             .state
+//             .database
+//             .effects_exists(&digest.transaction)?
+//         {
+//             continue;
+//         }
 
-        // Download the certificate
-        debug!("Try sync for digest: {digest:?}");
-        if let Err(err) = sync_digest(
-            active_authority.state.name,
-            active_authority.net.load().clone(),
-            digest.transaction,
-            per_other_authority_delay,
-        )
-        .await
-        {
-            warn!("Error doing sync from digest {digest:?}: {err}");
-            return Err(err);
-        }
-    }
+//         // Download the certificate
+//         debug!("Try sync for digest: {digest:?}");
+//         if let Err(err) = sync_digest(
+//             active_authority.state.name,
+//             active_authority.net.load().clone(),
+//             digest.transaction,
+//             per_other_authority_delay,
+//         )
+//         .await
+//         {
+//             warn!("Error doing sync from digest {digest:?}: {err}");
+//             return Err(err);
+//         }
+//     }
 
-    Ok(())
-}
+//     Ok(())
+// }
 
 /// Sync to a transaction certificate
 pub async fn sync_digest<A>(

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -177,22 +177,7 @@ pub async fn checkpoint_process<A>(
             }
         }
 
-        // (3) Process any unprocessed transactions. We do this before trying to move to the
-        //     next proposal.
-        // if let Err(err) = process_unprocessed_digests(
-        //     active_authority,
-        //     state_checkpoints.clone(),
-        //     timing.per_other_authority_delay,
-        // )
-        // .await
-        // {
-        //     warn!("Error processing unprocessed: {:?}", err);
-        //     // Nothing happens until we catch up with the unprocessed transactions of the
-        //     // previous checkpoint.
-        //     continue;
-        // }
-
-        // (4) Check if we need to advance to the next checkpoint, in case >2/3
+        // (3) Check if we need to advance to the next checkpoint, in case >2/3
         // have a proposal out. If so we start creating and injecting fragments
         // into the consensus protocol to make the new checkpoint.
         let weight: StakeUnit = proposals
@@ -732,77 +717,6 @@ where
 
     Ok(fragment)
 }
-
-/// Looks into the unprocessed_digests and tries to process them all to allow
-/// for the creation of the next proposal. Also uses the unprocessed_content
-/// to look for transactions before going to fetch them from the network.
-// pub async fn process_unprocessed_digests<A>(
-//     active_authority: &ActiveAuthority<A>,
-//     checkpoint_db: Arc<Mutex<CheckpointStore>>,
-//     per_other_authority_delay: Duration,
-// ) -> Result<(), SuiError>
-// where
-//     A: AuthorityAPI + Send + Sync + 'static + Clone,
-// {
-//     let unprocessed_digests: Vec<_> = checkpoint_db
-//         .lock()
-//         .unprocessed_transactions
-//         .iter()
-//         .map(|(digest, _)| digest)
-//         .collect();
-
-//     let existing_certificates = checkpoint_db
-//         .lock()
-//         .unprocessed_contents
-//         .multi_get(&unprocessed_digests)?;
-
-//     // First process all certs that we have stored in the unprocessed_contents
-//     let mut processed = BTreeSet::new();
-//     for (digest, cert) in unprocessed_digests
-//         .iter()
-//         .zip(existing_certificates.iter())
-//         .filter_map(|(digest, cert_opt)| cert_opt.as_ref().map(|c| (digest, c)))
-//     {
-//         active_authority
-//             .net
-//             .load()
-//             .sync_certificate_to_authority_with_timeout(
-//                 ConfirmationTransaction::new(cert.clone()),
-//                 active_authority.state.name,
-//                 per_other_authority_delay,
-//                 3,
-//             )
-//             .await?;
-//         processed.insert(digest);
-//     }
-
-//     for digest in &unprocessed_digests {
-//         // If we have processed this continue with the next cert, nothing to do
-//         if active_authority
-//             .state
-//             .database
-//             .effects_exists(&digest.transaction)?
-//         {
-//             continue;
-//         }
-
-//         // Download the certificate
-//         debug!("Try sync for digest: {digest:?}");
-//         if let Err(err) = sync_digest(
-//             active_authority.state.name,
-//             active_authority.net.load().clone(),
-//             digest.transaction,
-//             per_other_authority_delay,
-//         )
-//         .await
-//         {
-//             warn!("Error doing sync from digest {digest:?}: {err}");
-//             return Err(err);
-//         }
-//     }
-
-//     Ok(())
-// }
 
 /// Sync to a transaction certificate
 pub async fn sync_digest<A>(

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -28,7 +28,6 @@ use crate::{
 };
 use sui_types::committee::StakeUnit;
 use tracing::{debug, info, warn};
-// use typed_store::Map;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -111,7 +111,6 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
     for inner_state in authorities.clone() {
         let clients = aggregator.clone_inner_clients();
         let _active_handle = tokio::task::spawn(async move {
-
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
@@ -121,10 +120,8 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
                 .unwrap(),
             );
 
-            
             println!("Start active execution process.");
             active_state.clone().spawn_execute_process().await;
-
 
             // Spin the gossip service.
             active_state
@@ -209,7 +206,6 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
     for inner_state in authorities.clone() {
         let clients = aggregator.clone_inner_clients();
         let _active_handle = tokio::task::spawn(async move {
-
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -15,7 +15,7 @@ async fn pending_exec_storage_notify() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();
 
-    let setup = checkpoint_tests_setup(20, Duration::from_millis(200)).await;
+    let setup = checkpoint_tests_setup(20, Duration::from_millis(200), true).await;
 
     let TestSetup {
         committee: _committee,
@@ -93,10 +93,10 @@ async fn pending_exec_storage_notify() {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn pending_exec_full() {
-    use telemetry_subscribers::init_for_testing;
-    init_for_testing();
+    // use telemetry_subscribers::init_for_testing;
+    // init_for_testing();
 
-    let setup = checkpoint_tests_setup(20, Duration::from_millis(200)).await;
+    let setup = checkpoint_tests_setup(20, Duration::from_millis(200), true).await;
 
     let TestSetup {
         committee: _committee,

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -199,10 +199,11 @@ impl crate::authority::AuthorityState {
                 // If a checkpointing service is present, register the batch with it
                 // to insert the transactions into future checkpoint candidates
                 if let Some(checkpoint) = &self.checkpoints {
-                    if let Err(err) = checkpoint
-                        .lock()
-                        .handle_internal_batch(new_batch.batch.next_sequence_number, &current_batch)
-                    {
+                    if let Err(err) = checkpoint.lock().handle_internal_batch(
+                        new_batch.batch.next_sequence_number,
+                        &current_batch,
+                        &self.committee.load(),
+                    ) {
                         error!("Checkpointing service error: {}", err);
                     }
                 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -756,24 +756,24 @@ impl CheckpointStore {
                         return Ok(Some(contents));
                     }
                 }
-            }
-        } else {
-            // Sets the reconstruction to false, we have all fragments we need, but
-            // just cannot reconstruct the contents.
-            let locals = self.get_locals();
-            let mut new_locals = locals.as_ref().clone();
-            new_locals.no_more_fragments = true;
-            self.set_locals(locals, new_locals)
-                .map_err(FragmentInternalError::Error)?;
+            } else {
+                // A little argument about how the fragment -> checkpoint process is live
+                //
+                // A global checkpoint candidate must contain at least 2f+1 stake. And as
+                // a result of this f+1 stake will be from honest nodes that by definition
+                // must have submitted a proposal (because it is included!).
+                // So f+1 honest authorities will be able to reconstruct and sign the
+                // checkpoint. And all other authorities by asking all authorities will be
+                // able to get f+1 signatures and construct a checkpoint certificate.
 
-            // A little argument about how the fragment -> checkpoint process is live
-            //
-            // A global checkpoint candidate must contain at least 2f+1 stake. And as
-            // a result of this f+1 stake will be from honest nodes that by definition
-            // must have submitted a proposal (because it is included!).
-            // So f+1 honest authorities will be able to reconstruct and sign the
-            // checkpoint. And all other authorities by asking all authorities will be
-            // able to get f+1 signatures and construct a checkpoint certificate.
+                // Sets the reconstruction to false, we have all fragments we need, but
+                // just cannot reconstruct the contents.
+                let locals = self.get_locals();
+                let mut new_locals = locals.as_ref().clone();
+                new_locals.no_more_fragments = true;
+                self.set_locals(locals, new_locals)
+                    .map_err(FragmentInternalError::Error)?;
+            }
 
             return Err(FragmentInternalError::Error(SuiError::from(
                 "Missing info to construct known checkpoint.",

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -13,6 +13,7 @@ use sui_types::{
     messages_checkpoint::{CheckpointFragment, CheckpointSummary},
     waypoint::{GlobalCheckpoint, WaypointError},
 };
+use tracing::error;
 
 pub struct FragmentReconstruction {
     pub committee: Committee,
@@ -96,7 +97,7 @@ impl FragmentReconstruction {
                             // This is bad news, we did not intend to fail here.
                             // We should have checked all conditions to avoid being
                             // in this situation. TODO: audit this.
-                            println!("Unexpected result: {:?}", other);
+                            error!("Unexpected result: {:?}", other);
                             unreachable!();
                         }
                     }

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -13,7 +13,6 @@ use sui_types::{
     messages_checkpoint::{CheckpointFragment, CheckpointSummary},
     waypoint::{GlobalCheckpoint, WaypointError},
 };
-use tracing::error;
 
 pub struct FragmentReconstruction {
     pub committee: Committee,
@@ -97,8 +96,8 @@ impl FragmentReconstruction {
                             // This is bad news, we did not intend to fail here.
                             // We should have checked all conditions to avoid being
                             // in this situation. TODO: audit this.
-                            error!("Unexpected result: {:?}", other);
-                            unreachable!();
+                            panic!("Unexpected result: {:?}", other);
+                            // Or: unreachable!();
                         }
                     }
                 }

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -462,7 +462,9 @@ fn latest_proposal() {
 
     // When details are needed, then return unexecuted transactions if there is no proposal
     let request = CheckpointRequest::latest(true);
-    let response = cps1.handle_latest_proposal(committee.epoch, &request).expect("no errors");
+    let response = cps1
+        .handle_latest_proposal(committee.epoch, &request)
+        .expect("no errors");
     assert!(response.detail.is_none());
 
     assert!(matches!(

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -161,16 +161,12 @@ fn make_checkpoint_db() {
         .unwrap();
     assert_eq!(cps.checkpoint_contents.iter().count(), 0);
     assert_eq!(cps.extra_transactions.iter().count(), 3);
-    // assert_eq!(cps.unprocessed_transactions.iter().count(), 0);
 
     assert_eq!(cps.next_checkpoint(), 0);
 
     cps.update_new_checkpoint(0, &[t1, t2, t4, t5]).unwrap();
     assert_eq!(cps.checkpoint_contents.iter().count(), 4);
     assert_eq!(cps.extra_transactions.iter().count(), 1);
-    // assert_eq!(cps.unprocessed_transactions.iter().count(), 2);
-
-    // assert_eq!(cps.lowest_unprocessed_checkpoint(), 0);
 
     let (_cp_seq, tx_seq) = cps.transactions_to_checkpoint.get(&t4).unwrap().unwrap();
     assert!(tx_seq >= u64::MAX / 2);
@@ -181,9 +177,6 @@ fn make_checkpoint_db() {
         .unwrap();
     assert_eq!(cps.checkpoint_contents.iter().count(), 4);
     assert_eq!(cps.extra_transactions.iter().count(), 2); // t3 & t6
-                                                          // assert_eq!(cps.unprocessed_transactions.iter().count(), 0);
-
-    // assert_eq!(cps.lowest_unprocessed_checkpoint(), 1);
 
     let (_cp_seq, tx_seq) = cps.transactions_to_checkpoint.get(&t4).unwrap().unwrap();
     assert_eq!(tx_seq, 4);
@@ -231,11 +224,6 @@ fn make_proposals() {
     cps2.update_new_checkpoint(0, &ckp_items[..]).unwrap();
     cps3.update_new_checkpoint(0, &ckp_items[..]).unwrap();
     cps4.update_new_checkpoint(0, &ckp_items[..]).unwrap();
-
-    // assert_eq!(
-    //     cps4.unprocessed_transactions.keys().collect::<HashSet<_>>(),
-    //     [t1, t2, t3].into_iter().collect::<HashSet<_>>()
-    // );
 
     assert_eq!(
         cps4.extra_transactions.keys().collect::<HashSet<_>>(),
@@ -460,10 +448,6 @@ fn latest_proposal() {
     let request = CheckpointRequest::latest(true);
     let response = cps1.handle_latest_proposal(committee.epoch, &request).expect("no errors");
     assert!(response.detail.is_none());
-    // use typed_store::traits::Map;
-    // let txs = response.detail.unwrap();
-    // let unprocessed = CheckpointContents::new(cps1.unprocessed_transactions.keys());
-    // assert_eq!(txs.transactions, unprocessed.transactions);
 
     assert!(matches!(
         response.info,
@@ -1173,7 +1157,6 @@ fn set_fragment_reconstruct_two_mutual() {
 
     let t2 = ExecutionDigests::random();
     let t3 = ExecutionDigests::random();
-    // let t6 = TransactionDigest::random();
 
     for (_, cps) in &mut test_objects {
         cps.update_processed_transactions(&[(1, t2), (2, t3)])

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -34,11 +34,7 @@ where
                 Self::is_second_last_checkpoint_epoch(next_cp),
                 "start_epoch_change called at the wrong checkpoint",
             );
-            //assert_eq!(
-            //    checkpoints.lowest_unprocessed_checkpoint(),
-            //    next_cp,
-            //    "start_epoch_change called when there are still unprocessed transactions",
-            //);
+
             // drop checkpoints lock
         } else {
             unreachable!();

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -71,7 +71,6 @@ where
                 self.state
                     .database
                     .revert_state_update(&tx_digest.transaction)?;
-
             }
 
             // Delete any extra certificates now unprocessed.

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -34,11 +34,11 @@ where
                 Self::is_second_last_checkpoint_epoch(next_cp),
                 "start_epoch_change called at the wrong checkpoint",
             );
-            assert_eq!(
-                checkpoints.lowest_unprocessed_checkpoint(),
-                next_cp,
-                "start_epoch_change called when there are still unprocessed transactions",
-            );
+            //assert_eq!(
+            //    checkpoints.lowest_unprocessed_checkpoint(),
+            //    next_cp,
+            //    "start_epoch_change called when there are still unprocessed transactions",
+            //);
             // drop checkpoints lock
         } else {
             unreachable!();
@@ -66,17 +66,19 @@ where
                 Self::is_last_checkpoint_epoch(next_cp),
                 "finish_epoch_change called at the wrong checkpoint",
             );
-            assert_eq!(
-                checkpoints.lowest_unprocessed_checkpoint(),
-                next_cp,
-                "finish_epoch_change called when there are still unprocessed transactions",
-            );
+
             for (tx_digest, _) in checkpoints.extra_transactions.iter() {
                 self.state
                     .database
                     .revert_state_update(&tx_digest.transaction)?;
+
             }
+
+            // Delete any extra certificates now unprocessed.
             checkpoints.extra_transactions.clear()?;
+
+            // TODO: Delete certificates from the pending store.
+
             // drop checkpoints lock
         } else {
             unreachable!();

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -72,7 +72,7 @@ where
             // Delete any extra certificates now unprocessed.
             checkpoints.extra_transactions.clear()?;
 
-            // TODO: Delete certificates from the pending store.
+            // TODO(issue #2708): Delete certificates from the pending store.
 
             // drop checkpoints lock
         } else {

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -68,7 +68,7 @@ async fn sequence_fragments() {
             let checkpoints_store = handle.state().checkpoints().unwrap();
             checkpoints_store
                 .lock()
-                .handle_internal_batch(next_sequence_number, &transactions, &committee)
+                .handle_internal_batch(next_sequence_number, &transactions, committee)
                 .unwrap();
             let proposal = checkpoints_store
                 .lock()

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -249,6 +249,10 @@ async fn checkpoint_with_shared_objects() {
                 long_pause_between_checkpoints: Duration::from_millis(10),
                 ..CheckpointProcessControl::default()
             };
+
+            println!("Start active execution process.");
+            active_state.clone().spawn_execute_process().await;
+
             active_state
                 .spawn_checkpoint_process_with_config(Some(checkpoint_process_control))
                 .await

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -68,7 +68,7 @@ async fn sequence_fragments() {
             let checkpoints_store = handle.state().checkpoints().unwrap();
             checkpoints_store
                 .lock()
-                .handle_internal_batch(next_sequence_number, &transactions)
+                .handle_internal_batch(next_sequence_number, &transactions, &committee)
                 .unwrap();
             let proposal = checkpoints_store
                 .lock()

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -108,7 +108,7 @@ async fn wait_for_tx(wait_digest: TransactionDigest, state: Arc<AuthorityState>)
 async fn wait_for_all_txes(wait_digests: Vec<TransactionDigest>, state: Arc<AuthorityState>) {
     let mut wait_digests: HashSet<_> = wait_digests.iter().collect();
 
-    let mut timeout = Box::pin(sleep(Duration::from_millis(5000)));
+    let mut timeout = Box::pin(sleep(Duration::from_millis(15_000)));
 
     let mut max_seq = Some(0);
 


### PR DESCRIPTION
We want checkpoints to represent transactions that have been fully stored, executed, and effects checked. This is in part dealing with issue #2473. This PR adapts the current checkpoint logic to do this:
* [x] Ensure checkpoint contents are executed before signing or accepting a checkpoint.
* [x] Connect the checkpoint logic to the pending execution logic.

For future PR
* Ensure all transactions in the checkpoint are not included in prev checkpoints, and the list is complete.
* Order the contents of checkpoints in a causal and standard order.
* Provide facilities to upload a whole checkpoint with transactions et al, and execute.
