### PR TITLE
Refactor authenticated checkpoint data structures

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -652,8 +652,8 @@ pub async fn diff_proposals<A>(
                     {
                         Ok(fragment) => {
                             // On success send the fragment to consensus
-                            let proposer = &fragment.proposer.0.authority;
-                            let other = &fragment.other.0.authority;
+                            let proposer = &fragment.proposer.0.auth_signature.authority;
+                            let other = &fragment.other.0.auth_signature.authority;
                             debug!("Send fragment: {proposer:?} -- {other:?}");
                             let _ = checkpoint_db.lock().handle_receive_fragment(
                                 &fragment,
@@ -712,7 +712,7 @@ where
     let client = active_authority
         .net
         .load()
-        .clone_client(&fragment.other.0.authority);
+        .clone_client(&fragment.other.0.auth_signature.authority);
     for tx_digest in &fragment.diff.first.items {
         let response = client
             .handle_transaction_info_request(TransactionInfoRequest::from(tx_digest.transaction))

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -21,9 +21,9 @@ use sui_types::{
     fp_ensure,
     messages::CertifiedTransaction,
     messages_checkpoint::{
-        AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpoint, CheckpointContents,
-        CheckpointDigest, CheckpointFragment, CheckpointRequest, CheckpointResponse,
-        CheckpointSequenceNumber, CheckpointSummary, SignedCheckpoint, SignedCheckpointProposal,
+        AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
+        CheckpointContents, CheckpointDigest, CheckpointFragment, CheckpointRequest,
+        CheckpointResponse, CheckpointSequenceNumber, CheckpointSummary, SignedCheckpointSummary,
     },
 };
 use typed_store::{
@@ -186,16 +186,16 @@ impl CheckpointStore {
                 .map(|(digest, _)| digest);
             let transactions = CheckpointContents::new(transactions);
             let previous_digest = self.get_prev_checkpoint_digest(checkpoint_sequence)?;
-            let proposal = SignedCheckpointProposal(SignedCheckpoint::new(
+            let summary = SignedCheckpointSummary::new(
                 epoch,
                 checkpoint_sequence,
                 self.name,
                 &*self.secret,
                 &transactions,
                 previous_digest,
-            ));
+            );
 
-            let proposal_and_transactions = CheckpointProposal::new(proposal, transactions);
+            let proposal_and_transactions = CheckpointProposal::new(summary, transactions);
             locals.current_proposal = Some(proposal_and_transactions);
         }
 
@@ -423,7 +423,7 @@ impl CheckpointStore {
 
         // Sign the new checkpoint
         let signed_checkpoint = AuthenticatedCheckpoint::Signed(
-            SignedCheckpoint::new_from_summary(checkpoint, self.name, &*self.secret),
+            SignedCheckpointSummary::new_from_summary(checkpoint, self.name, &*self.secret),
         );
 
         // Make a DB batch
@@ -440,7 +440,7 @@ impl CheckpointStore {
                 &self.fragments,
                 self.fragments.iter().filter_map(|(k, v)| {
                     // Delete all keys for checkpoints smaller than what we are committing now.
-                    if *v.proposer.0.checkpoint.sequence_number() <= checkpoint_sequence_number {
+                    if *v.proposer.checkpoint.sequence_number() <= checkpoint_sequence_number {
                         Some(k)
                     } else {
                         None
@@ -494,7 +494,7 @@ impl CheckpointStore {
         // Does the fragment event suggest it is for the current round?
         let next_checkpoint_seq = self.next_checkpoint();
         fp_ensure!(
-            *fragment.proposer.0.checkpoint.sequence_number() == next_checkpoint_seq,
+            *fragment.proposer.checkpoint.sequence_number() == next_checkpoint_seq,
             SuiError::GenericAuthorityError {
                 error: format!(
                     "Incorrect sequence number, expected {}",
@@ -506,19 +506,18 @@ impl CheckpointStore {
         // Only a fragment that involves ourselves to be sequenced through
         // this node.
         fp_ensure!(
-            fragment.proposer.0.auth_signature.authority == self.name
-                || fragment.other.0.auth_signature.authority == self.name,
+            fragment.proposer.authority() == &self.name || fragment.other.authority() == &self.name,
             SuiError::from("Fragment does not involve this node")
         );
 
         // Save in the list of local fragments for this sequence.
-        let other_name = if fragment.proposer.0.auth_signature.authority == self.name {
-            fragment.other.0.auth_signature.authority
+        let other_name = if fragment.proposer.authority() == &self.name {
+            fragment.other.authority()
         } else {
-            fragment.proposer.0.auth_signature.authority
+            fragment.proposer.authority()
         };
-        if !self.local_fragments.contains_key(&other_name)? {
-            self.local_fragments.insert(&other_name, fragment)?;
+        if !self.local_fragments.contains_key(other_name)? {
+            self.local_fragments.insert(other_name, fragment)?;
         } else {
             // We already have this fragment, so we can ignore it.
             return Err(SuiError::GenericAuthorityError {
@@ -609,19 +608,19 @@ impl CheckpointStore {
 
         // If the fragment contains us also save it in the list of local fragments
         let next_sequence_number = self.next_checkpoint();
-        if *_fragment.proposer.0.checkpoint.sequence_number() == next_sequence_number {
-            if _fragment.proposer.0.auth_signature.authority == self.name {
+        if *_fragment.proposer.checkpoint.sequence_number() == next_sequence_number {
+            if _fragment.proposer.authority() == &self.name {
                 self.local_fragments
-                    .insert(&_fragment.other.0.auth_signature.authority, &_fragment)
+                    .insert(_fragment.other.authority(), &_fragment)
                     .map_err(|_err| {
                         // There is a possibility this was not stored!
                         let fragment = _fragment.clone();
                         FragmentInternalError::Retry(Box::new(fragment))
                     })?;
             }
-            if _fragment.other.0.auth_signature.authority == self.name {
+            if _fragment.other.authority() == &self.name {
                 self.local_fragments
-                    .insert(&_fragment.proposer.0.auth_signature.authority, &_fragment)
+                    .insert(_fragment.proposer.authority(), &_fragment)
                     .map_err(|_err| {
                         // There is a possibility this was not stored!
                         let fragment = _fragment.clone();
@@ -645,7 +644,7 @@ impl CheckpointStore {
         let fragments: Vec<_> = self
             .fragments
             .values()
-            .filter(|frag| *frag.proposer.0.checkpoint.sequence_number() == next_sequence_number)
+            .filter(|frag| *frag.proposer.checkpoint.sequence_number() == next_sequence_number)
             .collect();
 
         // Run the reconstruction logic to build a checkpoint.
@@ -722,7 +721,7 @@ impl CheckpointStore {
                         .unwrap();
 
                     // Extract the diff
-                    let diff = if fragment.proposer.0.auth_signature.authority == self.name {
+                    let diff = if fragment.proposer.authority() == &self.name {
                         fragment.diff
                     } else {
                         fragment.diff.swap()
@@ -799,7 +798,7 @@ impl CheckpointStore {
     /// it came from the internal consensus.
     pub fn handle_checkpoint_certificate(
         &mut self,
-        checkpoint: &CertifiedCheckpoint,
+        checkpoint: &CertifiedCheckpointSummary,
         contents: &Option<CheckpointContents>,
         committee: &Committee,
     ) -> Result<CheckpointResponse, SuiError> {
@@ -953,16 +952,16 @@ impl CheckpointStore {
         let previous_digest = self.get_prev_checkpoint_digest(checkpoint_sequence)?;
 
         let transactions = CheckpointContents::new(self.extra_transactions.keys());
-        let proposal = SignedCheckpointProposal(SignedCheckpoint::new(
+        let summary = SignedCheckpointProposal(SignedCheckpoint::new(
             epoch,
             checkpoint_sequence,
             self.name,
             &*self.secret,
             &transactions,
             previous_digest,
-        ));
+        );
 
-        let proposal_and_transactions = CheckpointProposal::new(proposal, transactions);
+        let proposal_and_transactions = CheckpointProposal::new(summary, transactions);
 
         // Record the checkpoint in the locals
         let mut new_locals = locals.as_ref().clone();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -151,8 +151,8 @@ impl CheckpointStore {
             self.checkpoints
                 .get(&(checkpoint_sequence - 1))?
                 .map(|prev_checkpoint| match prev_checkpoint {
-                    AuthenticatedCheckpoint::Certified(cert) => cert.checkpoint.digest(),
-                    AuthenticatedCheckpoint::Signed(signed) => signed.checkpoint.digest(),
+                    AuthenticatedCheckpoint::Certified(cert) => cert.summary.digest(),
+                    AuthenticatedCheckpoint::Signed(signed) => signed.summary.digest(),
                     _ => {
                         unreachable!();
                     }
@@ -332,7 +332,7 @@ impl CheckpointStore {
         // Get the current proposal if there is one.
         let current = latest_checkpoint_proposal
             .as_ref()
-            .map(|proposal| proposal.proposal.clone());
+            .map(|proposal| proposal.signed_summary.clone());
 
         // If requested include either the transactions in the latest checkpoint proposal
         // or the unprocessed transactions that block the generation of a proposal.
@@ -440,7 +440,7 @@ impl CheckpointStore {
                 &self.fragments,
                 self.fragments.iter().filter_map(|(k, v)| {
                     // Delete all keys for checkpoints smaller than what we are committing now.
-                    if *v.proposer.checkpoint.sequence_number() <= checkpoint_sequence_number {
+                    if *v.proposer.summary.sequence_number() <= checkpoint_sequence_number {
                         Some(k)
                     } else {
                         None
@@ -494,7 +494,7 @@ impl CheckpointStore {
         // Does the fragment event suggest it is for the current round?
         let next_checkpoint_seq = self.next_checkpoint();
         fp_ensure!(
-            *fragment.proposer.checkpoint.sequence_number() == next_checkpoint_seq,
+            *fragment.proposer.summary.sequence_number() == next_checkpoint_seq,
             SuiError::GenericAuthorityError {
                 error: format!(
                     "Incorrect sequence number, expected {}",
@@ -608,7 +608,7 @@ impl CheckpointStore {
 
         // If the fragment contains us also save it in the list of local fragments
         let next_sequence_number = self.next_checkpoint();
-        if *_fragment.proposer.checkpoint.sequence_number() == next_sequence_number {
+        if *_fragment.proposer.summary.sequence_number() == next_sequence_number {
             if _fragment.proposer.authority() == &self.name {
                 self.local_fragments
                     .insert(_fragment.other.authority(), &_fragment)
@@ -644,7 +644,7 @@ impl CheckpointStore {
         let fragments: Vec<_> = self
             .fragments
             .values()
-            .filter(|frag| *frag.proposer.checkpoint.sequence_number() == next_sequence_number)
+            .filter(|frag| *frag.proposer.summary.sequence_number() == next_sequence_number)
             .collect();
 
         // Run the reconstruction logic to build a checkpoint.
@@ -803,9 +803,7 @@ impl CheckpointStore {
         committee: &Committee,
     ) -> Result<CheckpointResponse, SuiError> {
         // Get the record in our checkpoint database for this sequence number.
-        let current = self
-            .checkpoints
-            .get(checkpoint.checkpoint.sequence_number())?;
+        let current = self.checkpoints.get(checkpoint.summary.sequence_number())?;
 
         match &current {
             // If cert exists, do nothing (idempotent)
@@ -819,12 +817,12 @@ impl CheckpointStore {
                     checkpoint.verify_with_transactions(committee, contents)?;
                     self.handle_internal_set_checkpoint(
                         committee.epoch,
-                        checkpoint.checkpoint.clone(),
+                        checkpoint.summary.clone(),
                         contents,
                     )?;
                     // Then insert it
                     self.checkpoints.insert(
-                        checkpoint.checkpoint.sequence_number(),
+                        checkpoint.summary.sequence_number(),
                         &AuthenticatedCheckpoint::Certified(checkpoint.clone()),
                     )?;
 
@@ -847,7 +845,7 @@ impl CheckpointStore {
             Some(AuthenticatedCheckpoint::Signed(_)) => {
                 checkpoint.verify(committee)?;
                 self.checkpoints.insert(
-                    checkpoint.checkpoint.sequence_number(),
+                    checkpoint.summary.sequence_number(),
                     &AuthenticatedCheckpoint::Certified(checkpoint.clone()),
                 )?;
             }
@@ -952,7 +950,7 @@ impl CheckpointStore {
         let previous_digest = self.get_prev_checkpoint_digest(checkpoint_sequence)?;
 
         let transactions = CheckpointContents::new(self.extra_transactions.keys());
-        let summary = SignedCheckpointProposal(SignedCheckpoint::new(
+        let summary = SignedCheckpointSummary::new(
             epoch,
             checkpoint_sequence,
             self.name,

--- a/crates/sui-core/src/checkpoints/proposal.rs
+++ b/crates/sui-core/src/checkpoints/proposal.rs
@@ -16,7 +16,7 @@ use sui_types::{
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CheckpointProposal {
     /// Name of the authority
-    pub proposal: SignedCheckpointSummary,
+    pub signed_summary: SignedCheckpointSummary,
     /// The transactions included in the proposal.
     /// TODO: only include a commitment by default.
     pub transactions: CheckpointContents,
@@ -30,14 +30,14 @@ impl CheckpointProposal {
     ///       an AuthorityName.
     pub fn new(proposal: SignedCheckpointSummary, transactions: CheckpointContents) -> Self {
         CheckpointProposal {
-            proposal,
+            signed_summary: proposal,
             transactions,
         }
     }
 
     /// Returns the sequence number of this proposal
     pub fn sequence_number(&self) -> &CheckpointSequenceNumber {
-        self.proposal.checkpoint.sequence_number()
+        self.signed_summary.summary.sequence_number()
     }
 
     // Iterate over all transaction/effects
@@ -47,12 +47,12 @@ impl CheckpointProposal {
 
     // Get the inner checkpoint
     pub fn checkpoint(&self) -> &CheckpointSummary {
-        &self.proposal.checkpoint
+        &self.signed_summary.summary
     }
 
     // Get the authority name
     pub fn name(&self) -> &AuthorityName {
-        self.proposal.authority()
+        self.signed_summary.authority()
     }
 
     /// Construct a Diff structure between this proposal and another
@@ -84,8 +84,8 @@ impl CheckpointProposal {
         );
 
         CheckpointFragment {
-            proposer: self.proposal.clone(),
-            other: other_proposal.proposal.clone(),
+            proposer: self.signed_summary.clone(),
+            other: other_proposal.signed_summary.clone(),
             diff,
             certs: BTreeMap::new(),
         }

--- a/crates/sui-core/src/checkpoints/proposal.rs
+++ b/crates/sui-core/src/checkpoints/proposal.rs
@@ -52,7 +52,7 @@ impl CheckpointProposal {
 
     // Get the authority name
     pub fn name(&self) -> &AuthorityName {
-        &self.proposal.0.authority
+        &self.proposal.0.auth_signature.authority
     }
 
     /// Construct a Diff structure between this proposal and another

--- a/crates/sui-core/src/checkpoints/proposal.rs
+++ b/crates/sui-core/src/checkpoints/proposal.rs
@@ -4,11 +4,11 @@
 use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
+use sui_types::messages_checkpoint::SignedCheckpointSummary;
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests},
     messages_checkpoint::{
         CheckpointContents, CheckpointFragment, CheckpointSequenceNumber, CheckpointSummary,
-        SignedCheckpointProposal,
     },
     waypoint::WaypointDiff,
 };
@@ -16,7 +16,7 @@ use sui_types::{
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CheckpointProposal {
     /// Name of the authority
-    pub proposal: SignedCheckpointProposal,
+    pub proposal: SignedCheckpointSummary,
     /// The transactions included in the proposal.
     /// TODO: only include a commitment by default.
     pub transactions: CheckpointContents,
@@ -28,7 +28,7 @@ impl CheckpointProposal {
     /// proposed transactions.
     /// TODO: Add an identifier for the proposer, probably
     ///       an AuthorityName.
-    pub fn new(proposal: SignedCheckpointProposal, transactions: CheckpointContents) -> Self {
+    pub fn new(proposal: SignedCheckpointSummary, transactions: CheckpointContents) -> Self {
         CheckpointProposal {
             proposal,
             transactions,
@@ -37,7 +37,7 @@ impl CheckpointProposal {
 
     /// Returns the sequence number of this proposal
     pub fn sequence_number(&self) -> &CheckpointSequenceNumber {
-        self.proposal.0.checkpoint.sequence_number()
+        self.proposal.checkpoint.sequence_number()
     }
 
     // Iterate over all transaction/effects
@@ -47,12 +47,12 @@ impl CheckpointProposal {
 
     // Get the inner checkpoint
     pub fn checkpoint(&self) -> &CheckpointSummary {
-        &self.proposal.0.checkpoint
+        &self.proposal.checkpoint
     }
 
     // Get the authority name
     pub fn name(&self) -> &AuthorityName {
-        &self.proposal.0.auth_signature.authority
+        self.proposal.authority()
     }
 
     /// Construct a Diff structure between this proposal and another

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -50,7 +50,7 @@ impl FragmentReconstruction {
 
             // Check the checkpoint summary of the proposal is the same as the previous one.
             // Otherwise ignore the link.
-            let n1 = &frag.proposer.0.authority;
+            let n1 = &frag.proposer.0.auth_signature.authority;
             if *proposals
                 .entry(*n1)
                 .or_insert_with(|| frag.proposer.0.checkpoint.clone())
@@ -59,7 +59,7 @@ impl FragmentReconstruction {
                 continue;
             }
 
-            let n2 = &frag.other.0.authority;
+            let n2 = &frag.other.0.auth_signature.authority;
             if *proposals
                 .entry(*n2)
                 .or_insert_with(|| frag.other.0.checkpoint.clone())
@@ -79,7 +79,9 @@ impl FragmentReconstruction {
                 // Get all links that are part of this component
                 let mut active_links: VecDeque<_> = fragments_used
                     .into_iter()
-                    .filter(|frag| span.top_node(&frag.proposer.0.authority).0 == top)
+                    .filter(|frag| {
+                        span.top_node(&frag.proposer.0.auth_signature.authority).0 == top
+                    })
                     .collect();
 
                 let mut global = GlobalCheckpoint::new();

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -46,15 +46,15 @@ impl FragmentReconstruction {
 
         for frag in fragments {
             // Double check we have only been given waypoints for the correct sequence number
-            debug_assert!(*frag.proposer.checkpoint.sequence_number() == seq);
+            debug_assert!(*frag.proposer.summary.sequence_number() == seq);
 
             // Check the checkpoint summary of the proposal is the same as the previous one.
             // Otherwise ignore the link.
             let n1 = frag.proposer.authority();
             if *proposals
                 .entry(*n1)
-                .or_insert_with(|| frag.proposer.checkpoint.clone())
-                != frag.proposer.checkpoint
+                .or_insert_with(|| frag.proposer.summary.clone())
+                != frag.proposer.summary
             {
                 continue;
             }
@@ -62,8 +62,8 @@ impl FragmentReconstruction {
             let n2 = frag.other.authority();
             if *proposals
                 .entry(*n2)
-                .or_insert_with(|| frag.other.checkpoint.clone())
-                != frag.other.checkpoint
+                .or_insert_with(|| frag.other.summary.clone())
+                != frag.other.summary
             {
                 continue;
             }

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -46,24 +46,24 @@ impl FragmentReconstruction {
 
         for frag in fragments {
             // Double check we have only been given waypoints for the correct sequence number
-            debug_assert!(*frag.proposer.0.checkpoint.sequence_number() == seq);
+            debug_assert!(*frag.proposer.checkpoint.sequence_number() == seq);
 
             // Check the checkpoint summary of the proposal is the same as the previous one.
             // Otherwise ignore the link.
-            let n1 = &frag.proposer.0.auth_signature.authority;
+            let n1 = frag.proposer.authority();
             if *proposals
                 .entry(*n1)
-                .or_insert_with(|| frag.proposer.0.checkpoint.clone())
-                != frag.proposer.0.checkpoint
+                .or_insert_with(|| frag.proposer.checkpoint.clone())
+                != frag.proposer.checkpoint
             {
                 continue;
             }
 
-            let n2 = &frag.other.0.auth_signature.authority;
+            let n2 = frag.other.authority();
             if *proposals
                 .entry(*n2)
-                .or_insert_with(|| frag.other.0.checkpoint.clone())
-                != frag.other.0.checkpoint
+                .or_insert_with(|| frag.other.checkpoint.clone())
+                != frag.other.checkpoint
             {
                 continue;
             }
@@ -79,9 +79,7 @@ impl FragmentReconstruction {
                 // Get all links that are part of this component
                 let mut active_links: VecDeque<_> = fragments_used
                     .into_iter()
-                    .filter(|frag| {
-                        span.top_node(&frag.proposer.0.auth_signature.authority).0 == top
-                    })
+                    .filter(|frag| span.top_node(frag.proposer.authority()).0 == top)
                     .collect();
 
                 let mut global = GlobalCheckpoint::new();

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -135,13 +135,12 @@ fn crash_recovery() {
     assert_eq!(locals.next_transaction_sequence, 7);
 
     assert_eq!(
-        &proposal.proposal.0.checkpoint,
+        &proposal.proposal.checkpoint,
         &locals
             .current_proposal
             .as_ref()
             .unwrap()
             .proposal
-            .0
             .checkpoint
     );
 }
@@ -368,8 +367,8 @@ fn latest_proposal() {
         assert!(matches!(previous, AuthenticatedCheckpoint::None));
 
         let current_proposal = current.unwrap();
-        current_proposal.0.verify().expect("no signature error");
-        assert_eq!(*current_proposal.0.checkpoint.sequence_number(), 0);
+        current_proposal.verify().expect("no signature error");
+        assert_eq!(*current_proposal.checkpoint.sequence_number(), 0);
     }
 
     // --- TEST 2 ---
@@ -390,10 +389,9 @@ fn latest_proposal() {
 
         let current_proposal = current.unwrap();
         current_proposal
-            .0
             .verify_with_transactions(response.detail.as_ref().unwrap())
             .expect("no signature error");
-        assert_eq!(*current_proposal.0.checkpoint.sequence_number(), 0);
+        assert_eq!(*current_proposal.checkpoint.sequence_number(), 0);
     }
 
     // ---
@@ -488,8 +486,8 @@ fn latest_proposal() {
         assert!(matches!(previous, AuthenticatedCheckpoint::Signed { .. }));
 
         let current_proposal = current.unwrap();
-        current_proposal.0.verify().expect("no signature error");
-        assert_eq!(*current_proposal.0.checkpoint.sequence_number(), 1);
+        current_proposal.verify().expect("no signature error");
+        assert_eq!(current_proposal.checkpoint.sequence_number, 1);
     }
 }
 
@@ -577,7 +575,7 @@ fn set_get_checkpoint() {
     }
 
     // Make a certificate
-    let mut signed_checkpoint: Vec<SignedCheckpoint> = Vec::new();
+    let mut signed_checkpoint: Vec<SignedCheckpointSummary> = Vec::new();
     for x in [&mut cps1, &mut cps2, &mut cps3] {
         match x.handle_past_checkpoint(true, 0).unwrap().info {
             AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Signed(signed)) => {
@@ -591,7 +589,8 @@ fn set_get_checkpoint() {
 
     // We can set the checkpoint cert to those that have it
 
-    let checkpoint_cert = CertifiedCheckpoint::aggregate(signed_checkpoint, &committee).unwrap();
+    let checkpoint_cert =
+        CertifiedCheckpointSummary::aggregate(signed_checkpoint, &committee).unwrap();
 
     // Send the certificate to a party that has the data
     let response_ckp = cps1
@@ -1626,7 +1625,7 @@ async fn checkpoint_messaging_flow() {
     // We need at least f+1 signatures
     assert!(signed_checkpoint.len() > 1);
     let checkpoint_cert =
-        CertifiedCheckpoint::aggregate(signed_checkpoint, &setup.committee.clone())
+        CertifiedCheckpointSummary::aggregate(signed_checkpoint, &setup.committee.clone())
             .expect("all ok");
 
     // Step 4 -- Upload the certificate back up.

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -135,13 +135,13 @@ fn crash_recovery() {
     assert_eq!(locals.next_transaction_sequence, 7);
 
     assert_eq!(
-        &proposal.proposal.checkpoint,
+        &proposal.signed_summary.summary,
         &locals
             .current_proposal
             .as_ref()
             .unwrap()
-            .proposal
-            .checkpoint
+            .signed_summary
+            .summary
     );
 }
 
@@ -368,7 +368,7 @@ fn latest_proposal() {
 
         let current_proposal = current.unwrap();
         current_proposal.verify().expect("no signature error");
-        assert_eq!(*current_proposal.checkpoint.sequence_number(), 0);
+        assert_eq!(*current_proposal.summary.sequence_number(), 0);
     }
 
     // --- TEST 2 ---
@@ -391,7 +391,7 @@ fn latest_proposal() {
         current_proposal
             .verify_with_transactions(response.detail.as_ref().unwrap())
             .expect("no signature error");
-        assert_eq!(*current_proposal.checkpoint.sequence_number(), 0);
+        assert_eq!(*current_proposal.summary.sequence_number(), 0);
     }
 
     // ---
@@ -487,7 +487,7 @@ fn latest_proposal() {
 
         let current_proposal = current.unwrap();
         current_proposal.verify().expect("no signature error");
-        assert_eq!(current_proposal.checkpoint.sequence_number, 1);
+        assert_eq!(current_proposal.summary.sequence_number, 1);
     }
 }
 


### PR DESCRIPTION
This PR makes the following refactoring around checkpoint data structures:
1. Use the envelope pattern for Signed and Certified Checkpoint, which allows us to share code and reuse some of the signature verification code as well.
2. Rename SignedCheckpoint and CertifiedCheckpoint to SignedCheckpointSummary and CertifiedCheckpointSummary
3. Remove SignedCheckpointProposal as it's redundant
4. Rename a few fields

Happy to drop any of the above commits if not appropriate. The change may seem big but since CLion did most of the heavy-lifting, it's quite trivial to make/revert.