### PR TITLE
Limit number of retries in shared_object_on_gateway test

### DIFF
--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -400,6 +400,7 @@ async fn shared_object_on_gateway() {
     // to only filter "timeout" errors, but the game way simply returns `anyhow::Error`, this
     // will be fixed by issue #1717. Note that the gateway has an internal retry mechanism but
     // it is not an infinite loop.
+    let mut retry = 10;
     loop {
         let futures: Vec<_> = gas_objects
             .iter()
@@ -426,6 +427,10 @@ async fn shared_object_on_gateway() {
         if replies.iter().all(|result| result.is_ok()) {
             break;
         }
+        if retry == 0 {
+            unreachable!("Failed after 10 retries. Latest replies: {:?}", replies);
+        }
+        retry -= 1;
     }
 
     let assert_value_transaction = move_transaction(


### PR DESCRIPTION
This test sometimes timeout. Add a limit to retry, rather fail than hang.