### PR TITLE
[Explorer] Fix parsing for null values

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -220,6 +220,10 @@ function LatestTxCardAPI({ count }: { count: number }) {
                     loadState: 'fail',
                 });
                 setIsLoaded(false);
+                console.error(
+                    'Encountered error when fetching recent transactions',
+                    err
+                );
             });
 
         return () => {

--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -46,16 +46,20 @@ export class JsonRpcClient {
         try {
           let res: Response = await fetch(url, options);
           const text = await res.text();
-          const result = JSON.stringify(LosslessJSON.parse(text, (key : string, value : any) => {
-            if (key === "balance") return value.toString(); 
-            try {
-              if (value.isLosslessNumber) return value.valueOf();
-            } catch {
-              return value.toString();
-            }
-            return value;
-          }
-          ));
+          const result = JSON.stringify(
+            LosslessJSON.parse(text, (key: string, value: any) => {
+              if (value == null) {
+                return value;
+              }
+              if (key === 'balance') return value.toString();
+              try {
+                if (value.isLosslessNumber) return value.valueOf();
+              } catch {
+                return value.toString();
+              }
+              return value;
+            })
+          );
           if (res.ok) {
             callback(null, result);
           } else {


### PR DESCRIPTION
The SDK will throw upon null values in the values, which was not triggered until the recent introduction of `timestamp_ms` field.


## Testing

before
<img width="1607" alt="CleanShot 2022-06-21 at 14 53 33@2x" src="https://user-images.githubusercontent.com/76067158/174903429-3b5a524f-fcf6-461e-9585-330da194caec.png">

after
<img width="1594" alt="CleanShot 2022-06-21 at 14 53 58@2x" src="https://user-images.githubusercontent.com/76067158/174903471-2fa6c520-1031-4b10-93e8-0657f9d9ccb4.png">

