### PR TITLE
bump version for wallet extension

### DIFF
--- a/wallet/package.json
+++ b/wallet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sui-wallet",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "A wallet for Sui",
     "main": "./dist/ui.js",
     "scripts": {


### PR DESCRIPTION
Saw an error while trying to update the extension,

```
error_code: 'PKG_INVALID_VERSION_NUMBER',
error_detail: 'Invalid version number in manifest: 0.0.1. Please make sure the newly uploaded package has a larger version in file manifest.json than the published package: 0.0.1.'
```

Thus I am changing the version here and will try that again.