### PR TITLE
[bug fix] - Remove dup ReadApi methods from openrpc spec

### DIFF
--- a/crates/generate-json-rpc-spec/src/main.rs
+++ b/crates/generate-json-rpc-spec/src/main.rs
@@ -19,7 +19,7 @@ use sui_config::genesis_config::GenesisConfig;
 use sui_config::SUI_WALLET_CONFIG;
 use sui_json::SuiJsonValue;
 use sui_json_rpc::bcs_api::BcsApiImpl;
-use sui_json_rpc::gateway_api::{GatewayReadApiImpl, RpcGatewayImpl, TransactionBuilderImpl};
+use sui_json_rpc::gateway_api::{RpcGatewayImpl, TransactionBuilderImpl};
 use sui_json_rpc::read_api::{FullNodeApi, ReadApi};
 use sui_json_rpc::sui_rpc_doc;
 use sui_json_rpc::SuiRpcModule;
@@ -79,7 +79,6 @@ async fn main() {
     let mut open_rpc = sui_rpc_doc();
     open_rpc.add_module(TransactionBuilderImpl::rpc_doc_module());
     open_rpc.add_module(RpcGatewayImpl::rpc_doc_module());
-    open_rpc.add_module(GatewayReadApiImpl::rpc_doc_module());
     open_rpc.add_module(ReadApi::rpc_doc_module());
     open_rpc.add_module(FullNodeApi::rpc_doc_module());
     open_rpc.add_module(BcsApiImpl::rpc_doc_module());

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -129,31 +129,6 @@
       }
     },
     {
-      "name": "sui_getObject",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return the object information for a specified object",
-      "params": [
-        {
-          "name": "object_id",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ObjectID"
-          }
-        }
-      ],
-      "result": {
-        "name": "GetObjectDataResponse",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/ObjectRead"
-        }
-      }
-    },
-    {
       "name": "sui_getObjectsOwnedByAddress",
       "tags": [
         {
@@ -167,61 +142,6 @@
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/SuiAddress"
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<SuiObjectInfo>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/ObjectInfo"
-          }
-        }
-      }
-    },
-    {
-      "name": "sui_getObjectsOwnedByAddress",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "description": "Return the list of objects owned by an address.",
-      "params": [
-        {
-          "name": "address",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/SuiAddress"
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<SuiObjectInfo>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "$ref": "#/components/schemas/ObjectInfo"
-          }
-        }
-      }
-    },
-    {
-      "name": "sui_getObjectsOwnedByObject",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "params": [
-        {
-          "name": "object_id",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/ObjectID"
           }
         }
       ],
@@ -330,47 +250,6 @@
       }
     },
     {
-      "name": "sui_getRecentTransactions",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "params": [
-        {
-          "name": "count",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<(GatewayTxSeqNumber,TransactionDigest)>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": [
-              {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              {
-                "$ref": "#/components/schemas/TransactionDigest"
-              }
-            ],
-            "maxItems": 2,
-            "minItems": 2
-          }
-        }
-      }
-    },
-    {
       "name": "sui_getTotalTransactionNumber",
       "tags": [
         {
@@ -385,48 +264,6 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
-        }
-      }
-    },
-    {
-      "name": "sui_getTotalTransactionNumber",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "params": [],
-      "result": {
-        "name": "u64",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        }
-      }
-    },
-    {
-      "name": "sui_getTransaction",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "params": [
-        {
-          "name": "digest",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/TransactionDigest"
-          }
-        }
-      ],
-      "result": {
-        "name": "TransactionEffectsResponse",
-        "required": true,
-        "schema": {
-          "$ref": "#/components/schemas/TransactionEffectsResponse"
         }
       }
     },
@@ -545,56 +382,6 @@
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/SuiAddress"
-          }
-        }
-      ],
-      "result": {
-        "name": "Vec<(GatewayTxSeqNumber,TransactionDigest)>",
-        "required": true,
-        "schema": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": [
-              {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              {
-                "$ref": "#/components/schemas/TransactionDigest"
-              }
-            ],
-            "maxItems": 2,
-            "minItems": 2
-          }
-        }
-      }
-    },
-    {
-      "name": "sui_getTransactionsInRange",
-      "tags": [
-        {
-          "name": "Read API"
-        }
-      ],
-      "params": [
-        {
-          "name": "start",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          }
-        },
-        {
-          "name": "end",
-          "required": true,
-          "schema": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
           }
         }
       ],


### PR DESCRIPTION
Both `ReadApi` and `GatewayReadApiImpl` implement the same RPC interface, we only need to include one for the doc generation, this is the cause of dups in the jsonRPC docs