### PR TITLE
wallet-ext: exclude node_modules from ts-loader

### DIFF
--- a/wallet/configs/webpack/webpack.config.common.ts
+++ b/wallet/configs/webpack/webpack.config.common.ts
@@ -107,6 +107,7 @@ const commonConfig: () => Promise<Configuration> = async () => {
                     options: {
                         configFile: TS_CONFIG_FILE,
                     },
+                    exclude: /node_modules/,
                 },
                 {
                     test: /\.(s)?css$/i,


### PR DESCRIPTION
* improves build times

| before | after |
| ---- | ---- |
| <img width="590" alt="Screenshot 2022-06-23 at 11 05 31" src="https://user-images.githubusercontent.com/10210143/175275655-d29ac792-55eb-42d0-a6ec-ffcf6cbae616.png"> | <img width="590" alt="Screenshot 2022-06-23 at 11 08 33" src="https://user-images.githubusercontent.com/10210143/175275727-13858bee-b84e-4abf-8c50-59c6f7e537ac.png"> |
| <img width="590" alt="Screenshot 2022-06-23 at 11 07 51" src="https://user-images.githubusercontent.com/10210143/175275692-31487fc9-7f97-4c91-8a36-e474441d44ea.png"> | <img width="590" alt="Screenshot 2022-06-23 at 11 09 00" src="https://user-images.githubusercontent.com/10210143/175275744-d7942299-e0da-4676-a69e-de9f8b14fe7f.png"> |