### PR TITLE
wallet-ext: inject (empty) dapp interface

### DIFF
--- a/wallet/configs/webpack/webpack.config.common.ts
+++ b/wallet/configs/webpack/webpack.config.common.ts
@@ -79,6 +79,8 @@ const commonConfig: () => Promise<Configuration> = async () => {
         entry: {
             background: './background',
             ui: './ui',
+            'content-script': './content-script',
+            'dapp-interface': './dapp-interface',
         },
         output: {
             path: OUTPUT_ROOT,

--- a/wallet/src/content-script/index.ts
+++ b/wallet/src/content-script/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { injectDappInterface } from './interface-inject';
+
+injectDappInterface();

--- a/wallet/src/content-script/interface-inject.ts
+++ b/wallet/src/content-script/interface-inject.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import Browser from 'webextension-polyfill';
+
+export function injectDappInterface() {
+    const script = document.createElement('script');
+    script.setAttribute('src', Browser.runtime.getURL('dapp-interface.js'));
+    const container = document.head || document.documentElement;
+    container.insertBefore(script, container.firstElementChild);
+    container.removeChild(script);
+}

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export class DAppInterface {
+    private _window: Window;
+
+    constructor(theWindow: Window) {
+        this._window = window;
+    }
+}

--- a/wallet/src/dapp-interface/index.ts
+++ b/wallet/src/dapp-interface/index.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DAppInterface } from './DAppInterface';
+
+Object.defineProperty(window, 'suiWallet', {
+    enumerable: false,
+    configurable: false,
+    value: new DAppInterface(window),
+});

--- a/wallet/src/manifest/manifest.json
+++ b/wallet/src/manifest/manifest.json
@@ -20,5 +20,18 @@
         "32": "manifest/icons/sui-icon-32.png",
         "48": "manifest/icons/sui-icon-48.png",
         "128": "manifest/icons/sui-icon-128.png"
-    }
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content-script.js"],
+            "run_at": "document_start"
+        }
+    ],
+    "web_accessible_resources": [
+        {
+            "resources": ["dapp-interface.js"],
+            "matches": ["<all_urls>"]
+        }
+    ]
 }


### PR DESCRIPTION
* add a `suiWallet` property on the window that exposes the dapp interface (empty for now)

<img width="590" alt="Screenshot 2022-06-23 at 11 57 42" src="https://user-images.githubusercontent.com/10210143/175285536-5897dc98-d6ac-4c35-8077-3239b7b37308.png">
