### PR TITLE
[checkpoint] Not make active progress in passive code

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -971,15 +971,10 @@ impl AuthorityState {
             .lock();
         match &request.request_type {
             CheckpointRequestType::LatestCheckpointProposal => {
-                checkpoint_store.handle_latest_proposal(self.committee.load().epoch, request)
+                checkpoint_store.handle_latest_proposal(request)
             }
             CheckpointRequestType::PastCheckpoint(seq) => {
                 checkpoint_store.handle_past_checkpoint(request.detail, *seq)
-            }
-            CheckpointRequestType::SetCertificate(cert, opt_contents) => checkpoint_store
-                .handle_checkpoint_certificate(cert, opt_contents, &self.committee.load()),
-            CheckpointRequestType::SetFragment(fragment) => {
-                checkpoint_store.handle_receive_fragment(fragment, &self.committee.load())
             }
         }
     }
@@ -1105,11 +1100,7 @@ impl AuthorityState {
                     // Update the checkpointing mechanism
                     checkpoint
                         .lock()
-                        .handle_internal_batch(
-                            batch.batch.next_sequence_number,
-                            &transactions,
-                            &state.committee.load(),
-                        )
+                        .handle_internal_batch(batch.batch.next_sequence_number, &transactions)
                         .expect("Should see no errors updating the checkpointing mechanism.");
                 }
             }

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -199,11 +199,10 @@ impl crate::authority::AuthorityState {
                 // If a checkpointing service is present, register the batch with it
                 // to insert the transactions into future checkpoint candidates
                 if let Some(checkpoint) = &self.checkpoints {
-                    if let Err(err) = checkpoint.lock().handle_internal_batch(
-                        new_batch.batch.next_sequence_number,
-                        &current_batch,
-                        &self.committee.load(),
-                    ) {
+                    if let Err(err) = checkpoint
+                        .lock()
+                        .handle_internal_batch(new_batch.batch.next_sequence_number, &current_batch)
+                    {
                         error!("Checkpointing service error: {}", err);
                     }
                 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -97,23 +97,6 @@ impl CheckpointRequest {
             detail,
         }
     }
-
-    pub fn set_checkpoint(
-        certificate: CertifiedCheckpointSummary,
-        contents: Option<CheckpointContents>,
-    ) -> CheckpointRequest {
-        CheckpointRequest {
-            request_type: CheckpointRequestType::SetCertificate(certificate, contents),
-            detail: false,
-        }
-    }
-
-    pub fn set_fragment(fragment: CheckpointFragment) -> CheckpointRequest {
-        CheckpointRequest {
-            request_type: CheckpointRequestType::SetFragment(Box::new(fragment)),
-            detail: false,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -122,10 +105,6 @@ pub enum CheckpointRequestType {
     LatestCheckpointProposal,
     // Requests a past checkpoint
     PastCheckpoint(CheckpointSequenceNumber),
-    // Set a checkpoint certificate
-    SetCertificate(CertifiedCheckpointSummary, Option<CheckpointContents>),
-    // Submit a consensus fragment to a node
-    SetFragment(Box<CheckpointFragment>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -68,7 +68,7 @@ async fn sequence_fragments() {
             let checkpoints_store = handle.state().checkpoints().unwrap();
             checkpoints_store
                 .lock()
-                .handle_internal_batch(next_sequence_number, &transactions, committee)
+                .handle_internal_batch(next_sequence_number, &transactions)
                 .unwrap();
             let proposal = checkpoints_store
                 .lock()
@@ -103,7 +103,7 @@ async fn sequence_fragments() {
             .checkpoints()
             .unwrap()
             .lock()
-            .handle_receive_fragment(&fragment, committee);
+            .submit_local_fragment_to_consensus(&fragment, committee);
     }
 
     // Wait until all validators sequence and process the fragment.


### PR DESCRIPTION
Currently we optimize the checkpoint progress by doing the a few things in the passive code path:
1. When a validator receives a request for the latest proposal, it actively creates a new proposal.
2. When a validator receives a new fragment from consensus, it attempts to create a new checkpoint.
3. When a new batch is made, it attempts to create a new checkpoint.
4. When a validator receives a new certificate, it will eventually both try to create a new proposal and create a new checkpoint
5. When a validator receives a new local fragment, it will attempt to create a new checkpoint.

Although these things help us make progress as quickly as we can whenever a new piece of information is available, it makes it very difficult to reason about the checkpoint process: when is a new proposal made? when is a new checkpoint created? It also makes it hard to reason about the interaction between the passive code vs the active checkpoint process. I believe that these issues will limit our productivity for new people to work on this code, as it's hard to explain how the checkpoint process works.

This PR does the following things:
1. The SetCertificate and SetFragment requests are not needed, delete them. Also renaming the handling functions because they are no longer handlers.
2. No longer creates a new proposal when requested on a proposal. This leads to some changes to the tests.
3. No longer creates a new checkpoint when receiving a new fragment from consensus. This also means that in the active loop, we need to make sure that this step is added.

I could be missing something or not understanding the significance of the code I deleted, so please let me know!