### PR TITLE
[checkpoint] A few small improvements/cleanups

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -379,13 +379,14 @@ impl CheckpointStore {
             return Ok(());
         }
 
-        // Is this the next expected certificate?
+        // Is this the next expected checkpoint?
         fp_ensure!(
             self.next_checkpoint() == checkpoint_sequence_number,
             SuiError::GenericAuthorityError {
                 error: format!(
-                    "Unexpected certificate, expected next seq={}",
-                    self.next_checkpoint()
+                    "Unexpected checkpoint, expected next seq={}, provided seq={}",
+                    self.next_checkpoint(),
+                    checkpoint_sequence_number,
                 ),
             }
         );
@@ -614,15 +615,6 @@ impl CheckpointStore {
         let next_sequence_number = self.next_checkpoint();
 
         if let Ok(Some(contents)) = self.reconstruct_contents(committee) {
-            // Here we check, and ensure, all transactions are processed before we
-            // move to sign the checkpoint.
-            if !self
-                .all_checkpoint_transactions_executed(&contents)
-                .map_err(FragmentInternalError::Error)?
-            {
-                return Ok(false);
-            }
-
             let previous_digest = self
                 .get_prev_checkpoint_digest(next_sequence_number)
                 .map_err(FragmentInternalError::Error)?;
@@ -821,7 +813,7 @@ impl CheckpointStore {
 
     // Helper read functions
 
-    /// Return the seq number of the last checkpoint we have recorded.
+    /// Return the seq number of the next checkpoint.
     pub fn next_checkpoint(&mut self) -> CheckpointSequenceNumber {
         self.get_locals().next_checkpoint
     }
@@ -916,23 +908,13 @@ impl CheckpointStore {
         &self,
         transactions: &CheckpointContents,
     ) -> SuiResult<bool> {
-        let new_transactions = self
+        // TODO: What mechanisms are there to ensure these not-yet-executed transactions
+        // will eventually be executed?
+        Ok(self
             .extra_transactions
             .multi_get(transactions.transactions.iter())?
-            .into_iter()
-            .zip(transactions.transactions.iter())
-            .filter_map(
-                |(opt_seq, tx)| {
-                    if opt_seq.is_none() {
-                        Some(*tx)
-                    } else {
-                        None
-                    }
-                },
-            )
-            .count();
-
-        Ok(new_transactions == 0)
+            .iter()
+            .any(|opt| opt.is_none()))
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Two notable changes:
1. When examining signed checkpoints in the quorum, change from > to >=
2. When constructing checkpoint, we don't need to check if all transactions are executed, because we will check it when we try to set it.