### PR TITLE
[reconfig] Remove all pending transactions at epoch boundary

### DIFF
--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -72,7 +72,7 @@ where
             // Delete any extra certificates now unprocessed.
             checkpoints.extra_transactions.clear()?;
 
-            // TODO(issue #2708): Delete certificates from the pending store.
+            self.state.database.remove_all_pending_certificates()?;
 
             // drop checkpoints lock
         } else {


### PR DESCRIPTION
Any pending transaction left will not be executed. Delete them.
Do I need to do anything about the pending transaction seq number?
This should resolve https://github.com/MystenLabs/sui/issues/2708