### PR TITLE
ci: run windows in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,8 +60,12 @@ jobs:
   test:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [self-hosted, self-hosted-ubuntu]
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os:
+          - [self-hosted, self-hosted-ubuntu]
+          - windows-latest
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: beta
+            override: true
       - uses: taiki-e/install-action@nextest
       - name: cargo test
         run: |


### PR DESCRIPTION
Try running windows CI with 1.62 beta due to a potential fix to use @argfiles https://github.com/rust-lang/rust/blob/master/RELEASES.md#cargo