### PR TITLE
[core] Logic to order causally a set of transactions

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -104,7 +104,7 @@ pub struct SuiDataStore<S> {
     /// (ie in `certificates`) and the effects its execution has on the authority state. This
     /// structure is used to ensure we do not double process a certificate, and that we can return
     /// the same response for any call after the first (ie. make certificate processing idempotent).
-    effects: DBMap<TransactionDigest, TransactionEffectsEnvelope<S>>,
+    pub(crate) effects: DBMap<TransactionDigest, TransactionEffectsEnvelope<S>>,
 
     /// Hold the lock for shared objects. These locks are written by a single task: upon receiving a valid
     /// certified transaction from consensus, the authority assigns a lock to each shared objects of the

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -216,7 +216,7 @@ pub async fn checkpoint_process<A>(
 
         let success = state_checkpoints
             .lock()
-            .attempt_to_construct_checkpoint(committee);
+            .attempt_to_construct_checkpoint(committee, active_authority.state.database.clone());
 
         match success {
             Err(err) => {

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -45,7 +45,6 @@ pub trait EffectsStore {
         transactions: &[ExecutionDigests],
         ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-
         // Order inputs
         // let transaction_set : BTreeSet<_> = transactions.iter().cloned().collect();
         // let transactions : Vec<_> = transaction_set.into_iter().collect();

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -45,15 +45,15 @@ pub trait EffectsStore {
         transactions: &[ExecutionDigests],
         ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-        let effetcs = self.get_effects(transactions)?;
+        let effects = self.get_effects(transactions)?;
 
         // Ensure all transactions included are executed (static property). This should be true since we should not
         // be signing a checkpoint unless we have processed all transactions within it.
-        debug_assert!(effetcs.iter().all(|e| e.is_some()));
+        debug_assert!(effects.iter().all(|e| e.is_some()));
 
         // Include in the checkpoint the computed effects,  rather than the effects provided.
         // (Which could have been provided by < f+1 byz validators and be incorrect).
-        let digests = effetcs
+        let digests = effects
             .iter()
             .map(|e| {
                 let e = &e.as_ref().unwrap();
@@ -70,7 +70,7 @@ pub trait EffectsStore {
             .collect();
 
         // Index the effects by transaction digest, as we will need to look them up.
-        let mut effect_map: BTreeMap<TransactionDigest, &TransactionEffects> = effetcs
+        let mut effect_map: BTreeMap<TransactionDigest, &TransactionEffects> = effects
             .iter()
             .map(|e| {
                 let e = e.as_ref().unwrap();
@@ -150,18 +150,32 @@ pub trait EffectsStore {
             let next_transaction = *candidates.iter().next().unwrap();
             candidates.remove(next_transaction);
 
+            // If nothing depends on this tx move on to the next
+            let forward_deps = forward_index.get(next_transaction);
+            if forward_deps.is_none() {
+                continue;
+            }
+
             // Check all transactions that depend on it, to see if all
             // dependencies are  satisfied.
-            for dep in forward_index.get(next_transaction).unwrap() {
-                // The candidate is its parent. If it is the last parent the above will be true
-                // but only once, so we should not already have sequenced it.
-                debug_assert!(!master_set.contains(dep));
+            for dep in forward_deps.unwrap() {
+                // If the forward dependency is not included in the current checkpoint, ignore.
+                if !effect_map.contains_key(*dep) {
+                    continue;
+                }
+
+                // We have already included this into the candidate set once.
+                if master_set.contains(dep) {
+                    continue;
+                }
 
                 if effect_map
                     .get(*dep)
                     .unwrap()
                     .dependencies
                     .iter()
+                    // All dependencies sequenced in the master seq or in previous checkpoint
+                    .filter(|item| tx_not_in_checkpoint.contains(*item))
                     .all(|item| master_set.contains(item))
                 {
                     // It seems like all dependencies are satisfied for dep, so sequence it.
@@ -221,5 +235,187 @@ impl CausalOrder for Arc<AuthorityStore> {
         _ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
         self.causal_order_from_effects(transactions, _ckpt_store)
+    }
+}
+
+impl EffectsStore for BTreeMap<TransactionDigest, TransactionEffects> {
+    fn get_effects(
+        &self,
+        transactions: &[ExecutionDigests],
+    ) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        Ok(transactions
+            .iter()
+            .map(|item| self.get(&item.transaction).cloned())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, env, fs, sync::Arc};
+
+    use crate::checkpoints::causal_order::EffectsStore;
+    use crate::checkpoints::CheckpointStore;
+    use rand::{prelude::StdRng, SeedableRng};
+    use sui_types::{
+        base_types::{ExecutionDigests, ObjectDigest, ObjectID, SequenceNumber, TransactionDigest},
+        gas::GasCostSummary,
+        messages::{ExecutionStatus, TransactionEffects},
+        object::Owner,
+        utils::make_committee_key,
+    };
+    use typed_store::Map;
+
+    fn effects_from(
+        transaction_digest: TransactionDigest,
+        dependencies: Vec<TransactionDigest>,
+    ) -> TransactionEffects {
+        TransactionEffects {
+            // The only fields that matter
+            transaction_digest,
+            dependencies,
+
+            // Other fields do not really matter here
+            status: ExecutionStatus::Success,
+            gas_used: GasCostSummary {
+                computation_cost: 0,
+                storage_cost: 0,
+                storage_rebate: 0,
+            },
+            shared_objects: vec![],
+            created: vec![],
+            mutated: vec![],
+            unwrapped: vec![],
+            deleted: vec![],
+            wrapped: vec![],
+            // Nonsense is ok for the purposes of these tests
+            gas_object: (
+                (
+                    ObjectID::random(),
+                    SequenceNumber::from(0),
+                    ObjectDigest::random(),
+                ),
+                Owner::Immutable,
+            ),
+            events: vec![],
+        }
+    }
+
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn causal_just_reorder() {
+        let mut rng = StdRng::from_seed([1; 32]);
+        let (keys, committee) = make_committee_key(&mut rng);
+        let k = keys[0].copy();
+
+        // Setup
+
+        let dir = env::temp_dir();
+        let path = dir.join(format!("SC_{:?}", ObjectID::random()));
+        fs::create_dir(&path).unwrap();
+
+        // Create an authority
+        // Open store first time
+
+        let mut cps = CheckpointStore::open(
+            path,
+            None,
+            committee.epoch,
+            *k.public_key_bytes(),
+            Arc::pin(k.copy()),
+        )
+        .unwrap();
+
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+
+        // Make some transactions
+        let t0 = TransactionDigest::random();
+        let t1 = TransactionDigest::random();
+        let t2 = TransactionDigest::random();
+        let t3 = TransactionDigest::random();
+
+        let e0 = effects_from(t0, vec![]);
+        let e1 = effects_from(t1, vec![t0]);
+        let e2 = effects_from(t2, vec![t1]);
+        let e3 = effects_from(t3, vec![t2]);
+
+        let mut effect_map = BTreeMap::new();
+        effect_map.extend([
+            (t0, e0),
+            (t1, e1.clone()),
+            (t2, e2.clone()),
+            (t3, e3.clone()),
+        ]);
+
+        let input: Vec<_> = vec![e2.clone(), e1.clone(), e3.clone()]
+            .iter()
+            .map(|item| ExecutionDigests::new(item.transaction_digest, item.digest()))
+            .collect();
+
+        // TEST 1
+        // None are recorded as new transactions in the checkpoint DB so the end sequence is empty
+        let x = effect_map.causal_order_from_effects(&input, &mut cps);
+        assert_eq!(x.unwrap().len(), 0);
+
+        cps.extra_transactions.insert(&input[0], &0).unwrap();
+        cps.extra_transactions.insert(&input[1], &1).unwrap();
+        cps.extra_transactions.insert(&input[2], &2).unwrap();
+
+        // TEST 2
+        // The two transactions are recorded as new so they are re-ordered and sequenced
+        let x = effect_map.causal_order_from_effects(&input[..2], &mut cps);
+        assert!(x.clone().unwrap().len() == 2);
+        // Its in the correct order
+        assert!(x.unwrap() == vec![input[1], input[0]]);
+
+        // TEST3
+        // Skip t2. and order [t3, t1]
+        let input: Vec<_> = vec![e3, e1.clone()]
+            .iter()
+            .map(|item| ExecutionDigests::new(item.transaction_digest, item.digest()))
+            .collect();
+
+        let x = effect_map.causal_order_from_effects(&input[..2], &mut cps);
+
+        assert!(x.clone().unwrap().len() == 1);
+        // Its in the correct order
+        assert!(x.unwrap() == vec![input[1]]);
+
+        // Test4
+        // Many dependencies
+        println!("Test 4");
+
+        // Make some transactions
+        let tx = TransactionDigest::random();
+        let ty = TransactionDigest::random();
+
+        let ex = effects_from(tx, vec![t0, t1]);
+        let ey = effects_from(ty, vec![tx, t2]);
+
+        effect_map.extend([(tx, ex.clone()), (ty, ey.clone())]);
+
+        let input: Vec<_> = vec![e2.clone(), ex.clone(), ey.clone(), e1.clone()]
+            .iter()
+            .map(|item| ExecutionDigests::new(item.transaction_digest, item.digest()))
+            .collect();
+
+        cps.extra_transactions.insert(&input[1], &3).unwrap();
+        cps.extra_transactions.insert(&input[2], &4).unwrap();
+
+        assert!(input[1..].len() == 3);
+        let x = effect_map.causal_order_from_effects(&input[1..], &mut cps);
+
+        println!("result: {:?}", x);
+        assert_eq!(x.clone().unwrap().len(), 2);
+        // Its in the correct order
+        assert_eq!(x.unwrap(), vec![input[3], input[1]]);
+
+        // TESt 5 all
+
+        let x = effect_map.causal_order_from_effects(&input, &mut cps);
+
+        println!("result: {:?}", x);
+        assert_eq!(x.clone().unwrap().len(), 4);
     }
 }

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -45,7 +45,12 @@ pub trait EffectsStore {
         transactions: &[ExecutionDigests],
         ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-        let effects = self.get_effects(transactions)?;
+
+        // Order inputs
+        // let transaction_set : BTreeSet<_> = transactions.iter().cloned().collect();
+        // let transactions : Vec<_> = transaction_set.into_iter().collect();
+
+        let effects = self.get_effects(&transactions[..])?;
 
         // Ensure all transactions included are executed (static property). This should be true since we should not
         // be signing a checkpoint unless we have processed all transactions within it.

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -1,9 +1,16 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashSet, BTreeSet},
+    sync::Arc,
+};
 
-use sui_types::{base_types::ExecutionDigests, error::SuiResult};
+use sui_types::{
+    base_types::{ExecutionDigests, TransactionDigest},
+    error::SuiResult,
+    messages::TransactionEffects,
+};
 use typed_store::Map;
 
 use crate::authority::AuthorityStore;
@@ -21,35 +28,21 @@ use super::CheckpointStore;
 
 pub trait CausalOrder {
     fn get_complete_causal_order(
-        self: Self,
+        self: &Self,
         transactions: &[ExecutionDigests],
         ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>>;
 }
 
-/// An identity causal order that returns just the same order. For testing.
-pub struct TestCausalOrderNoop;
+pub trait EffectsStore {
+    fn get_effects(self: &Self, transactions : &[ExecutionDigests]) -> SuiResult<Vec<Option<TransactionEffects>>>;
 
-impl CausalOrder for TestCausalOrderNoop {
-    fn get_complete_causal_order(
-        self: Self,
+    fn causal_order_from_effects(
+        self: &Self,
         transactions: &[ExecutionDigests],
-        _ckpt_store: &mut CheckpointStore,
+        ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-        Ok(transactions.iter().cloned().collect())
-    }
-}
-
-/// Now this is a real causal orderer based on having an Arc<AuthorityStore> handy.
-impl CausalOrder for Arc<AuthorityStore> {
-    fn get_complete_causal_order(
-        self: Self,
-        transactions: &[ExecutionDigests],
-        _ckpt_store: &mut CheckpointStore,
-    ) -> SuiResult<Vec<ExecutionDigests>> {
-        let effetcs = self
-            .effects
-            .multi_get(transactions.iter().map(|d| d.transaction))?;
+        let effetcs = self.get_effects(transactions)?;
 
         // Ensure all transactions included are executed (static property). This should be true since we should not
         // be signing a checkpoint unless we have processed all transactions within it.
@@ -58,28 +51,155 @@ impl CausalOrder for Arc<AuthorityStore> {
         // Include in the checkpoint the computed effects,  rather than the effects provided.
         // (Which could have been provided by < f+1 byz validators and be incorrect).
         let digests = effetcs
-            .into_iter()
+            .iter()
             .map(|e| {
-                let e = e.unwrap().effects;
+                let e = &e.as_ref().unwrap();
                 ExecutionDigests::new(e.transaction_digest, e.digest())
             })
             .collect::<Vec<ExecutionDigests>>();
+
+        // Load the extra transactions in memory, we will use them quite a bit.
+        // TODO: monitor memory use here.
+        let tx_not_in_checkpoint: HashSet<_> = ckpt_store.extra_transactions.keys().map(|e| e.transaction).collect();
+
+        // Index the effects by transaction digest, as we will need to look them up.
+        let mut effect_map: BTreeMap<TransactionDigest, &TransactionEffects> = effetcs
+            .iter()
+            .map(|e| {
+                let e = e.as_ref().unwrap();
+                (e.transaction_digest, e)
+            })
+            .collect();
 
         // Only include in the checkpoint transactions that have not been checkpointed before.
         // Due to the construction of the checkpoint table `extra_transactions` and given that
         // we must have processed all transactions in the proposed checkpoint, this check is
         // reduced to ensuring that the transactions are in the table `extra_transactions`
         // (that lists transactions executed but not yet checkpointed).
-        let in_store =_ckpt_store.extra_transactions.multi_get(&digests)?;
-        let digests : Vec<_> = digests.iter().zip(in_store).filter_map(|(d, instore)| {
-            if instore.is_some() {
+        let _digests: BTreeSet<_> = digests
+            .iter()
+            .filter_map(|d| {
+                if tx_not_in_checkpoint.contains(&d.transaction) {
+                    Some(d.transaction)
+                } else {
+                    // We remove the effects map entries for transactions
+                    // that are already checkpointed.
+                    effect_map.remove(&d.transaction);
+                    None
+                }
+            })
+            .collect();
+
+        // Set of starting transactions that depend only on previously
+        // checkpointed objects.
+        let initial_transactions : BTreeSet<_> = 
+        effect_map.iter().filter_map(|(d, e)| {
+            // All dependencies must be in checkpoint.
+            if e.dependencies.iter().all(|d| !tx_not_in_checkpoint.contains(d)) {
                 Some(d)
             }
-            else {
+            else{
                 None
             }
         }).collect();
 
+        // Build a forward index of transactions. This will allow us to start with the initial
+        // and then sequenced trasnactions and efficiently determine which other transactions
+        // become candidates for sequencing.
+        let mut forward_index:BTreeMap<&TransactionDigest, Vec<&TransactionDigest>> = BTreeMap::new();
+        for (d, effect) in &effect_map {
+            for dep in &effect.dependencies {
+                // We only record the dependencies not in a checkpoint, as the ones
+                // in a checkpoint are already satisfied presumably.
+                if tx_not_in_checkpoint.contains(dep) {
+                    forward_index.entry(&dep).or_default().push(d);
+                }
+            }
+        }
+
+        // Define the master sequence, to contain the initial transactions 
+        // by transaction digest order.
+        let mut master_sequence : Vec<&TransactionDigest> = initial_transactions.iter().cloned().collect();
+        // A set mirroring the contents of the mater sequence for quick lookup
+        let mut master_set = initial_transactions.clone();
+        // The transactions that just became executed.
+        let mut candidates = initial_transactions;
+
+        // Trace forward the executed transactions, starting from the initial set, and adding more
+        // trasnactions as all their dependencies become executed. The candidates represent executed
+        // transactions that need to have subsequent transactions depending on them examined to 
+        // determine if all their dependencies are executed. If so they are sequenced, and also added
+        // to the candidate set to be examiner once.
+        while !candidates.is_empty()  {
+            // we continue while we can make progress
+
+            // Take a transaction
+            let next_transaction = *candidates.iter().next().unwrap();
+            candidates.remove(next_transaction);
+
+            // Check all transactions that depend on it, to see if all 
+            // dependencies are  satisfied.
+            for dep in forward_index.get(next_transaction).unwrap() {
+
+                // The candidate is its parent. If it is the last parent the above will be true
+                // but only once, so we should not already have sequenced it.
+                debug_assert!(!master_set.contains(dep));
+
+                if effect_map.get(*dep).unwrap().dependencies.iter().all(|item| master_set.contains(item)) {
+                    // It seems like all dependencies are satisfied for dep, so sequence it.
+                    master_sequence.push(dep);
+                    master_set.insert(dep);
+                    candidates.insert(dep);
+                }
+            }
+
+        }
+
+        // NOTE: not all transactions have to be seqeunced into the checkpoint. In particular if a 
+        // byzantine node includes some transaction into their proposal but not its previous dependencies
+        // they may not be checkpointed. That is ok, since we promise finality only if >2/3 honest 
+        // eventually include in proposal, which means that at leats 1 honest will include in a checkpoint
+        // and honest nodes include full causal sequences in proposals.
+
+
         Ok(transactions.iter().cloned().collect())
+    }
+
+}
+
+
+impl EffectsStore for Arc<AuthorityStore> {
+    fn get_effects(self: &Self, transactions : &[ExecutionDigests]) -> SuiResult<Vec<Option<TransactionEffects>>> {
+        Ok(self
+        .effects
+        .multi_get(transactions.iter().map(|d| d.transaction))?
+        .into_iter()
+        .map(|item| item.map(|x| x.effects))
+        .collect())
+    }
+}
+
+/// An identity causal order that returns just the same order. For testing.
+pub struct TestCausalOrderNoop;
+
+impl CausalOrder for TestCausalOrderNoop {
+    fn get_complete_causal_order(
+        self: &Self,
+        transactions: &[ExecutionDigests],
+        _ckpt_store: &mut CheckpointStore,
+    ) -> SuiResult<Vec<ExecutionDigests>> {
+        Ok(transactions.iter().cloned().collect())
+    }
+}
+
+
+/// Now this is a real causal orderer based on having an Arc<AuthorityStore> handy.
+impl CausalOrder for Arc<AuthorityStore> {
+    fn get_complete_causal_order(
+        self: &Self,
+        transactions: &[ExecutionDigests],
+        _ckpt_store: &mut CheckpointStore,
+    ) -> SuiResult<Vec<ExecutionDigests>> {
+        self.causal_order_from_effects(transactions, _ckpt_store)
     }
 }

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -45,7 +45,6 @@ pub trait EffectsStore {
         transactions: &[ExecutionDigests],
         ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-
         let effects = self.get_effects(transactions)?;
 
         // Ensure all transactions included are executed (static property). This should be true since we should not

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -189,8 +189,8 @@ pub trait EffectsStore {
         // NOTE: not all transactions have to be seqeunced into the checkpoint. In particular if a
         // byzantine node includes some transaction into their proposal but not its previous dependencies
         // they may not be checkpointed. That is ok, since we promise finality only if >2/3 honest
-        // eventually include in proposal, which means that at leats 1 honest will include in a checkpoint
-        // and honest nodes include full causal sequences in proposals.
+        // eventually include a transactions in a proposal, which means that at leats 1 honest will
+        // include it in a proposal and honest nodes include full causal sequences in proposals.
 
         // Map transaction digest back to correct execution digest.
         Ok(master_sequence

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use sui_types::{base_types::ExecutionDigests, error::SuiResult};
+use typed_store::Map;
+
+use crate::authority::AuthorityStore;
+
+use super::CheckpointStore;
+
+/// The interfaces here allow a separation between checkpoint store, that knows about digests largely,
+/// and other parts of the system that know about the transaction semantics, hold and can interpret the
+/// transaction effects.
+///
+/// A point of interaction between these two worlds is necessary when we need to order the execution digests
+/// within a checkpoint, as well as detect digest already in checkpoints of missing to have a full causal history.
+/// The interface here allows these computations to be implemented without passing in a full authority / authority store
+/// for the sake of keeping components separate enough to be tested without one another.
+
+pub trait CausalOrder {
+    fn get_complete_causal_order(
+        self: Self,
+        transactions: &[ExecutionDigests],
+        ckpt_store: &mut CheckpointStore,
+    ) -> SuiResult<Vec<ExecutionDigests>>;
+}
+
+/// An identity causal order that returns just the same order. For testing.
+pub struct TestCausalOrderNoop;
+
+impl CausalOrder for TestCausalOrderNoop {
+    fn get_complete_causal_order(
+        self: Self,
+        transactions: &[ExecutionDigests],
+        _ckpt_store: &mut CheckpointStore,
+    ) -> SuiResult<Vec<ExecutionDigests>> {
+        Ok(transactions.iter().cloned().collect())
+    }
+}
+
+/// Now this is a real causal orderer based on having an Arc<AuthorityStore> handy.
+impl CausalOrder for Arc<AuthorityStore> {
+    fn get_complete_causal_order(
+        self: Self,
+        transactions: &[ExecutionDigests],
+        _ckpt_store: &mut CheckpointStore,
+    ) -> SuiResult<Vec<ExecutionDigests>> {
+        let effetcs = self
+            .effects
+            .multi_get(transactions.iter().map(|d| d.transaction))?;
+
+        // Ensure all transactions included are executed (static property). This should be true since we should not
+        // be signing a checkpoint unless we have processed all transactions within it.
+        debug_assert!(effetcs.iter().all(|e| e.is_some()));
+
+        // Include in the checkpoint the computed effects,  rather than the effects provided.
+        // (Which could have been provided by < f+1 byz validators and be incorrect).
+        let digests = effetcs
+            .into_iter()
+            .map(|e| {
+                let e = e.unwrap().effects;
+                ExecutionDigests::new(e.transaction_digest, e.digest())
+            })
+            .collect::<Vec<ExecutionDigests>>();
+
+        // Only include in the checkpoint transactions that have not been checkpointed before.
+        // Due to the construction of the checkpoint table `extra_transactions` and given that
+        // we must have processed all transactions in the proposed checkpoint, this check is
+        // reduced to ensuring that the transactions are in the table `extra_transactions`
+        // (that lists transactions executed but not yet checkpointed).
+        let in_store =_ckpt_store.extra_transactions.multi_get(&digests)?;
+        let digests : Vec<_> = digests.iter().zip(in_store).filter_map(|(d, instore)| {
+            if instore.is_some() {
+                Some(d)
+            }
+            else {
+                None
+            }
+        }).collect();
+
+        Ok(transactions.iter().cloned().collect())
+    }
+}

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -45,11 +45,8 @@ pub trait EffectsStore {
         transactions: &[ExecutionDigests],
         ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-        // Order inputs
-        // let transaction_set : BTreeSet<_> = transactions.iter().cloned().collect();
-        // let transactions : Vec<_> = transaction_set.into_iter().collect();
 
-        let effects = self.get_effects(&transactions[..])?;
+        let effects = self.get_effects(transactions)?;
 
         // Ensure all transactions included are executed (static property). This should be true since we should not
         // be signing a checkpoint unless we have processed all transactions within it.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -628,9 +628,11 @@ impl CheckpointStore {
 
         if let Ok(Some(contents)) = self.reconstruct_contents(committee, our_proposal) {
             let old_order: Vec<_> = contents.iter().cloned().collect();
-            let _new_order = orderer
+            let new_order = orderer
                 .get_complete_causal_order(&old_order, self)
                 .map_err(FragmentInternalError::Error)?;
+
+            let ordered_contents = CheckpointContents::new(new_order.into_iter());
 
             let previous_digest = self
                 .get_prev_checkpoint_digest(next_sequence_number)
@@ -638,10 +640,10 @@ impl CheckpointStore {
             let summary = CheckpointSummary::new(
                 committee.epoch,
                 next_sequence_number,
-                &contents,
+                &ordered_contents,
                 previous_digest,
             );
-            self.sign_new_checkpoint(summary, &contents)
+            self.sign_new_checkpoint(summary, &ordered_contents)
                 .map_err(FragmentInternalError::Error)?;
 
             return Ok(true);

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -12,7 +12,11 @@ pub(crate) mod checkpoint_tests;
 use narwhal_executor::ExecutionIndices;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
-use std::{collections::{HashSet, BTreeSet}, path::Path, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    path::Path,
+    sync::Arc,
+};
 use sui_storage::default_db_options;
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests},
@@ -696,7 +700,7 @@ impl CheckpointStore {
             {
                 // We are included in the proposal, so we can go ahead and construct the
                 // full checkpoint!
-                let mut contents : BTreeSet<_> = our_proposal.transactions.iter().cloned().collect();
+                let mut contents: BTreeSet<_> = our_proposal.transactions.iter().cloned().collect();
                 contents.extend(
                     // Add all items missing to reach then global waypoint
                     reconstructed.global.authority_waypoints[&self.name]

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -463,6 +463,14 @@ impl CheckpointStore {
         next_sequence_number: TxSequenceNumber,
         transactions: &[(TxSequenceNumber, ExecutionDigests)],
     ) -> Result<(), SuiError> {
+
+        // Check if we have already processed this block, and if
+        // so just return.
+        let locals = self.get_locals();
+        if next_sequence_number <= locals.next_transaction_sequence {
+            return Ok(());
+        } 
+
         self.update_processed_transactions(transactions)?;
 
         // Updates the local sequence number of transactions processed.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod causal_order;
 pub mod proposal;
 pub mod reconstruction;
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -960,13 +960,12 @@ impl CheckpointStore {
 
         // Now write the checkpoint data to the database
 
-        let checkpoint_data: Vec<_> = transactions
+        let checkpoint_data = transactions
             .iter()
             .enumerate()
-            .map(|(i, digest)| ((seq, i as u64), *digest))
-            .collect();
+            .map(|(i, digest)| ((seq, i as u64), *digest));
 
-        let batch = batch.insert_batch(&self.checkpoint_contents, checkpoint_data.into_iter())?;
+        let batch = batch.insert_batch(&self.checkpoint_contents, checkpoint_data)?;
 
         // Write to the database.
         batch.write()?;

--- a/crates/sui-core/src/checkpoints/proposal.rs
+++ b/crates/sui-core/src/checkpoints/proposal.rs
@@ -42,7 +42,7 @@ impl CheckpointProposal {
 
     // Iterate over all transaction/effects
     pub fn transactions(&self) -> impl Iterator<Item = &ExecutionDigests> {
-        self.transactions.transactions.iter()
+        self.transactions.iter()
     }
 
     // Get the inner checkpoint
@@ -66,7 +66,7 @@ impl CheckpointProposal {
     pub fn fragment_with(&self, other_proposal: &CheckpointProposal) -> CheckpointFragment {
         let all_elements = self
             .transactions()
-            .chain(other_proposal.transactions.transactions.iter())
+            .chain(other_proposal.transactions.iter())
             .collect::<HashSet<_>>();
 
         let my_transactions = self.transactions().collect();

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -412,7 +412,6 @@ fn latest_proposal() {
 
     // Set the transactions as executed.
     let batch: Vec<_> = transactions
-        .transactions
         .iter()
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
@@ -553,7 +552,6 @@ fn set_get_checkpoint() {
         .sign_new_checkpoint(summary.clone(), &transactions)
         .is_err());
     let batch: Vec<_> = transactions
-        .transactions
         .iter()
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
@@ -1296,7 +1294,7 @@ fn test_fragment_full_flow() {
         .handle_past_checkpoint(true, 0)
         .expect("No errors on response");
     // Ensure the reconstruction worked
-    assert_eq!(response.detail.unwrap().transactions.len(), 2);
+    assert_eq!(response.detail.unwrap().iter().count(), 2);
 
     // TEST 3 -- feed the framents to the node 6 which cannot decode the
     // sequence of fragments.
@@ -1693,7 +1691,7 @@ async fn checkpoint_messaging_flow() {
         }
     }
 
-    assert_eq!(contents.as_ref().unwrap().transactions.len(), 1);
+    assert_eq!(contents.as_ref().unwrap().iter().count(), 1);
 
     // Construct a certificate
     // We need at least f+1 signatures

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -180,7 +180,6 @@ fn make_checkpoint_db() {
     cps.update_processed_transactions(&[(6, t6)]).unwrap();
     assert_eq!(cps.checkpoint_contents.iter().count(), 4);
     assert_eq!(cps.extra_transactions.iter().count(), 2); // t3 & t6
-
 }
 
 #[test]

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -416,10 +416,10 @@ fn latest_proposal() {
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
         .collect();
-    cps1.handle_internal_batch(0, &batch).unwrap();
-    cps2.handle_internal_batch(0, &batch).unwrap();
-    cps3.handle_internal_batch(0, &batch).unwrap();
-    cps4.handle_internal_batch(0, &batch).unwrap();
+    cps1.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps2.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps3.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps4.handle_internal_batch(batch.len() as u64, &batch).unwrap();
 
     // Try to get checkpoint
     cps1.sign_new_checkpoint(summary.clone(), &transactions)
@@ -556,9 +556,9 @@ fn set_get_checkpoint() {
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
         .collect();
-    cps1.handle_internal_batch(0, &batch).unwrap();
-    cps2.handle_internal_batch(0, &batch).unwrap();
-    cps3.handle_internal_batch(0, &batch).unwrap();
+    cps1.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps2.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps3.handle_internal_batch(batch.len() as u64, &batch).unwrap();
 
     cps1.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
@@ -628,7 +628,7 @@ fn set_get_checkpoint() {
     assert!(response_ckp.is_err());
 
     // Process transactions and then ask for checkpoint.
-    cps4.handle_internal_batch(0, &batch).unwrap();
+    cps4.handle_internal_batch(batch.len() as u64 , &batch).unwrap();
     let response_ckp = cps4
         .process_checkpoint_certificate(&checkpoint_cert, &Some(transactions), &committee)
         .unwrap();

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     authority_batch::batch_tests::init_state_parameters_from_rng,
     authority_client::LocalAuthorityClient,
+    checkpoints::causal_order::TestCausalOrderNoop,
     gateway_state::GatewayMetrics,
 };
 use rand::prelude::StdRng;
@@ -1279,7 +1280,8 @@ fn test_fragment_full_flow() {
                 &PendCertificateForExecutionNoop
             )
             .is_ok());
-        cps0.attempt_to_construct_checkpoint(&committee).unwrap();
+        cps0.attempt_to_construct_checkpoint(&committee, TestCausalOrderNoop)
+            .unwrap();
         seq.next(
             /* total_batches */ 100, /* total_transactions */ 100,
         );
@@ -1663,7 +1665,7 @@ async fn checkpoint_messaging_flow() {
     for auth in &setup.authorities {
         auth.checkpoint
             .lock()
-            .attempt_to_construct_checkpoint(&setup.committee)
+            .attempt_to_construct_checkpoint(&setup.committee, TestCausalOrderNoop)
             .unwrap();
     }
 
@@ -1799,7 +1801,7 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[0]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(&setup.committee)
+        .attempt_to_construct_checkpoint(&setup.committee, TestCausalOrderNoop)
         .unwrap());
 
     // Expecting more fragments
@@ -1815,7 +1817,7 @@ async fn test_no_more_fragments() {
     assert!(!setup.authorities[3]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(&setup.committee)
+        .attempt_to_construct_checkpoint(&setup.committee, TestCausalOrderNoop)
         .unwrap());
 
     // Expecting more fragments
@@ -1837,6 +1839,6 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(&setup.committee)
+        .attempt_to_construct_checkpoint(&setup.committee, TestCausalOrderNoop)
         .unwrap());
 }

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -181,8 +181,6 @@ fn make_checkpoint_db() {
     assert_eq!(cps.checkpoint_contents.iter().count(), 4);
     assert_eq!(cps.extra_transactions.iter().count(), 2); // t3 & t6
 
-    let (_cp_seq, tx_seq) = cps.transactions_to_checkpoint.get(&t4).unwrap().unwrap();
-    assert_eq!(tx_seq, 4);
 }
 
 #[test]
@@ -416,10 +414,14 @@ fn latest_proposal() {
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
         .collect();
-    cps1.handle_internal_batch(batch.len() as u64, &batch).unwrap();
-    cps2.handle_internal_batch(batch.len() as u64, &batch).unwrap();
-    cps3.handle_internal_batch(batch.len() as u64, &batch).unwrap();
-    cps4.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps1.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
+    cps2.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
+    cps3.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
+    cps4.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
 
     // Try to get checkpoint
     cps1.sign_new_checkpoint(summary.clone(), &transactions)
@@ -556,9 +558,12 @@ fn set_get_checkpoint() {
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
         .collect();
-    cps1.handle_internal_batch(batch.len() as u64, &batch).unwrap();
-    cps2.handle_internal_batch(batch.len() as u64, &batch).unwrap();
-    cps3.handle_internal_batch(batch.len() as u64, &batch).unwrap();
+    cps1.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
+    cps2.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
+    cps3.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
 
     cps1.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
@@ -628,7 +633,8 @@ fn set_get_checkpoint() {
     assert!(response_ckp.is_err());
 
     // Process transactions and then ask for checkpoint.
-    cps4.handle_internal_batch(batch.len() as u64 , &batch).unwrap();
+    cps4.handle_internal_batch(batch.len() as u64, &batch)
+        .unwrap();
     let response_ckp = cps4
         .process_checkpoint_certificate(&checkpoint_cert, &Some(transactions), &committee)
         .unwrap();

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -360,7 +360,7 @@ impl CertifiedCheckpointSummary {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointContents {
-    pub transactions: BTreeSet<ExecutionDigests>,
+    transactions: BTreeSet<ExecutionDigests>,
 }
 
 impl BcsSignable for CheckpointContents {}
@@ -377,6 +377,10 @@ impl CheckpointContents {
 
     pub fn digest(&self) -> [u8; 32] {
         sha3_hash(self)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item=&ExecutionDigests> {
+        self.transactions.iter()
     }
 }
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::base_types::ExecutionDigests;
 use crate::committee::EpochId;
@@ -360,7 +360,7 @@ impl CertifiedCheckpointSummary {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointContents {
-    transactions: BTreeSet<ExecutionDigests>,
+    transactions: Vec<ExecutionDigests>,
 }
 
 impl BcsSignable for CheckpointContents {}

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -51,7 +51,7 @@ use serde::{Deserialize, Serialize};
 
     Once a checkpoint is determined each authority forms a CheckpointSummary
     with all the transactions in the checkpoint, and signs it with its
-    authority key to form a SignedCheckpoint. A collection of 2/3 authority
+    authority key to form a SignedCheckpoint. A collection of >1/3 authority
     signatures on a checkpoint forms a CertifiedCheckpoint. And this is the
     structure that is kept in the long term to attest of the sequence of
     checkpoints. Once a CertifiedCheckpoint is recoded for a checkpoint
@@ -434,6 +434,8 @@ impl CheckpointFragment {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use rand::prelude::StdRng;
     use rand::SeedableRng;
 

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -379,7 +379,7 @@ impl CheckpointContents {
         sha3_hash(self)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item=&ExecutionDigests> {
+    pub fn iter(&self) -> impl Iterator<Item = &ExecutionDigests> {
         self.transactions.iter()
     }
 }


### PR DESCRIPTION
This PR provides functions that take a sequence of transactions, a checkpoint store and some way to get their effects and:
* remove transactions that are already check pointed
* orders the transactions causally
* remove any transactions that are not causally linked (in case of missing transactions).
* re-computes the effects digests.
* runs the above and re-orders execution digests before signing a checkpoint.

Furthermore, the transactions in checkpoint are now stored according to their sequence in the checkpoint and the table `transaction_to_checkpoint` is removed.

This covers the checkpoint parts of https://github.com/MystenLabs/sui/issues/2039