### PR TITLE
Add WalletSyncApi

### DIFF
--- a/crates/generate-json-rpc-spec/src/main.rs
+++ b/crates/generate-json-rpc-spec/src/main.rs
@@ -19,7 +19,7 @@ use sui_config::genesis_config::GenesisConfig;
 use sui_config::SUI_WALLET_CONFIG;
 use sui_json::SuiJsonValue;
 use sui_json_rpc::bcs_api::BcsApiImpl;
-use sui_json_rpc::gateway_api::{RpcGatewayImpl, TransactionBuilderImpl};
+use sui_json_rpc::gateway_api::{GatewayWalletSyncApiImpl, RpcGatewayImpl, TransactionBuilderImpl};
 use sui_json_rpc::read_api::{FullNodeApi, ReadApi};
 use sui_json_rpc::sui_rpc_doc;
 use sui_json_rpc::SuiRpcModule;
@@ -27,10 +27,10 @@ use sui_json_rpc_api::rpc_types::{
     GetObjectDataResponse, SuiObjectInfo, TransactionEffectsResponse, TransactionResponse,
 };
 use sui_json_rpc_api::EventApiOpenRpc;
-use sui_json_rpc_api::QuorumDriverApiClient;
 use sui_json_rpc_api::RpcReadApiClient;
 use sui_json_rpc_api::RpcTransactionBuilderClient;
 use sui_json_rpc_api::TransactionBytes;
+use sui_json_rpc_api::WalletSyncApiClient;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::sui_serde::{Base64, Encoding};
 use sui_types::SUI_FRAMEWORK_ADDRESS;
@@ -84,6 +84,7 @@ async fn main() {
     open_rpc.add_module(FullNodeApi::rpc_doc_module());
     open_rpc.add_module(BcsApiImpl::rpc_doc_module());
     open_rpc.add_module(EventApiOpenRpc::module_doc());
+    open_rpc.add_module(GatewayWalletSyncApiImpl::rpc_doc_module());
 
     match options.action {
         Action::Print => {

--- a/crates/sui-gateway/src/rpc_gateway_client.rs
+++ b/crates/sui-gateway/src/rpc_gateway_client.rs
@@ -16,6 +16,7 @@ use sui_json_rpc_api::QuorumDriverApiClient;
 use sui_json_rpc_api::RpcBcsApiClient;
 use sui_json_rpc_api::RpcTransactionBuilderClient;
 use sui_json_rpc_api::TransactionBytes;
+use sui_json_rpc_api::WalletSyncApiClient;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::messages::{Transaction, TransactionData};
 use sui_types::sui_serde::Base64;
@@ -80,7 +81,7 @@ impl GatewayAPI for RpcGatewayClient {
 
     async fn sync_account_state(&self, account_addr: SuiAddress) -> Result<(), Error> {
         self.client
-            .quorum_driver()
+            .wallet_sync_api()
             .sync_account_state(account_addr)
             .await?;
         Ok(())

--- a/crates/sui-json-rpc-api/src/client.rs
+++ b/crates/sui-json-rpc-api/src/client.rs
@@ -7,6 +7,7 @@ use crate::QuorumDriverApiClient;
 use crate::RpcFullNodeReadApiClient;
 use crate::RpcReadApiClient;
 use crate::RpcTransactionBuilderClient;
+use crate::WalletSyncApiClient;
 
 pub struct SuiRpcClient {
     client: HttpClient,
@@ -22,6 +23,9 @@ impl SuiRpcClient {
         &self.client
     }
     pub fn quorum_driver(&self) -> &impl QuorumDriverApiClient {
+        &self.client
+    }
+    pub fn wallet_sync_api(&self) -> &impl WalletSyncApiClient {
         &self.client
     }
     pub fn full_node_read_api(&self) -> &impl RpcFullNodeReadApiClient {

--- a/crates/sui-json-rpc-api/src/lib.rs
+++ b/crates/sui-json-rpc-api/src/lib.rs
@@ -39,7 +39,11 @@ pub trait QuorumDriverApi {
         signature: Base64,
         pub_key: Base64,
     ) -> RpcResult<TransactionResponse>;
+}
 
+#[open_rpc(namespace = "sui", tag = "Wallet Sync API")]
+#[rpc(server, client, namespace = "sui")]
+pub trait WalletSyncApi {
     /// Synchronize client state with validators.
     #[method(name = "syncAccountState")]
     async fn sync_account_state(&self, address: SuiAddress) -> RpcResult<()>;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -760,7 +760,7 @@
       "name": "sui_syncAccountState",
       "tags": [
         {
-          "name": "Quorum Driver API"
+          "name": "Wallet Sync API"
         }
       ],
       "description": "Synchronize client state with validators.",

--- a/crates/sui/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui/src/unit_tests/rpc_server_tests.rs
@@ -11,6 +11,7 @@ use sui_json_rpc_api::rpc_types::{
 };
 use sui_json_rpc_api::{
     QuorumDriverApiClient, RpcReadApiClient, RpcTransactionBuilderClient, TransactionBytes,
+    WalletSyncApiClient,
 };
 use sui_types::sui_serde::Base64;
 use sui_types::{

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -16,10 +16,13 @@ use sui_config::PersistedConfig;
 use sui_config::{Config, SUI_GATEWAY_CONFIG, SUI_NETWORK_CONFIG, SUI_WALLET_CONFIG};
 use sui_core::gateway_state::GatewayMetrics;
 use sui_gateway::create_client;
-use sui_json_rpc::gateway_api::{GatewayReadApiImpl, RpcGatewayImpl, TransactionBuilderImpl};
+use sui_json_rpc::gateway_api::{
+    GatewayReadApiImpl, GatewayWalletSyncApiImpl, RpcGatewayImpl, TransactionBuilderImpl,
+};
 use sui_json_rpc_api::QuorumDriverApiServer;
 use sui_json_rpc_api::RpcReadApiServer;
 use sui_json_rpc_api::RpcTransactionBuilderServer;
+use sui_json_rpc_api::WalletSyncApiServer;
 use sui_swarm::memory::Swarm;
 use sui_types::base_types::SuiAddress;
 const NUM_VALIDAOTR: usize = 4;
@@ -114,6 +117,7 @@ async fn start_rpc_gateway(
     module.merge(RpcGatewayImpl::new(client.clone()).into_rpc())?;
     module.merge(GatewayReadApiImpl::new(client.clone()).into_rpc())?;
     module.merge(TransactionBuilderImpl::new(client.clone()).into_rpc())?;
+    module.merge(GatewayWalletSyncApiImpl::new(client.clone()).into_rpc())?;
 
     let handle = server.start(module)?;
     Ok((addr, handle))


### PR DESCRIPTION
The sync account API doesn't really belong to the quorum driver (quorum driver will be stateless). Adding a new json rpc api class for this function.