### PR TITLE
Read network information from chain

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -194,6 +194,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                     consensus_config: Some(consensus_config),
                     enable_event_processing: false,
                     enable_gossip: true,
+                    enable_reconfig: false,
                     genesis: crate::node::Genesis::new(genesis.clone()),
                 }
             })

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -41,6 +41,9 @@ pub struct NodeConfig {
     #[serde(default)]
     pub enable_gossip: bool,
 
+    #[serde(default)]
+    pub enable_reconfig: bool,
+
     pub genesis: Genesis,
 }
 

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -72,6 +72,7 @@ impl NetworkConfig {
             consensus_config: None,
             enable_event_processing: true,
             enable_gossip: true,
+            enable_reconfig: false,
             genesis: validator_config.genesis.clone(),
         }
     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1007,7 +1007,7 @@ impl AuthorityState {
             adapter::new_move_vm(native_functions.clone())
                 .expect("We defined natives to not fail here"),
         );
-
+        // TODO: update this function to not take genesis, committee if store already exists
         // Only initialize an empty database.
         if store
             .database_is_empty()

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1511,7 +1511,7 @@ pub async fn generate_genesis_system_object<S: Eq + Serialize + for<'de> Deseria
             CallArg::Pure(bcs::to_bytes(&pubkeys).unwrap()),
             CallArg::Pure(bcs::to_bytes(&sui_addresses).unwrap()),
             CallArg::Pure(bcs::to_bytes(&names).unwrap()),
-            // TODO: below is netaddress, for now just use names as we don't yet want to expose them.
+            // TODO Laura: below is netaddress, for now just use names as we don't yet want to expose them.
             CallArg::Pure(bcs::to_bytes(&names).unwrap()),
             CallArg::Pure(bcs::to_bytes(&stakes).unwrap()),
         ],

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1511,7 +1511,7 @@ pub async fn generate_genesis_system_object<S: Eq + Serialize + for<'de> Deseria
             CallArg::Pure(bcs::to_bytes(&pubkeys).unwrap()),
             CallArg::Pure(bcs::to_bytes(&sui_addresses).unwrap()),
             CallArg::Pure(bcs::to_bytes(&names).unwrap()),
-            // TODO Laura: below is netaddress, for now just use names as we don't yet want to expose them.
+            // TODO: below is netaddress, for now just use names as we don't yet want to expose them.
             CallArg::Pure(bcs::to_bytes(&names).unwrap()),
             CallArg::Pure(bcs::to_bytes(&stakes).unwrap()),
         ],

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -100,7 +100,7 @@ where
             self.gateway_metrics.clone(),
         ));
         self.net.store(new_net.clone());
-        // TODO: Also reconnect network if changed.
+        // TODO Laura: Also reconnect network if changed.
         // This is blocked for now since we are not storing network info on-chain yet.
 
         // TODO: Update all committee in all components safely,

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -4,15 +4,26 @@
 use crate::authority_active::ActiveAuthority;
 use crate::authority_aggregator::AuthorityAggregator;
 use crate::authority_client::AuthorityAPI;
+use async_trait::async_trait;
+use multiaddr::Multiaddr;
+use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_network::tonic;
 use sui_types::committee::Committee;
 use sui_types::crypto::PublicKeyBytes;
-use sui_types::error::SuiResult;
+use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{ConfirmationTransaction, SignedTransaction};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use typed_store::Map;
+
+#[async_trait]
+pub trait Reconfigurable {
+    fn needs_network_recreation() -> bool;
+
+    fn recreate(channel: tonic::transport::Channel) -> Self;
+}
 
 // TODO: Make last checkpoint number of each epoch more flexible.
 pub const CHECKPOINT_COUNT_PER_EPOCH: u64 = 200;
@@ -21,7 +32,7 @@ const WAIT_BETWEEN_EPOCH_TX_QUERY_RETRY: Duration = Duration::from_millis(300);
 
 impl<A> ActiveAuthority<A>
 where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
+    A: AuthorityAPI + Send + Sync + 'static + Clone + Reconfigurable,
 {
     /// This function should be called by the active checkpoint process, when it finishes processing
     /// all transactions from the second to the least checkpoint of the epoch. It's called by a
@@ -94,18 +105,69 @@ where
             .collect();
         let new_committee = Committee::new(next_epoch, votes)?;
         self.state.insert_new_epoch_info(&new_committee)?;
-        let new_net = Arc::new(AuthorityAggregator::new(
-            new_committee,
-            self.net.load().clone_inner_clients(),
-            self.gateway_metrics.clone(),
-        ));
-        self.net.store(new_net.clone());
-        // TODO Laura: Also reconnect network if changed.
-        // This is blocked for now since we are not storing network info on-chain yet.
 
+        // Reconnect the network if we have an type of AuthorityClient that has a network.
+        if A::needs_network_recreation() {
+            let mut new_clients = BTreeMap::new();
+            let sui_system_state = self
+                .state
+                .get_sui_system_state_object()
+                .await
+                .map_err(|e| SuiError::GenericAuthorityError {
+                    error: e.to_string(),
+                })
+                .unwrap();
+            let next_epoch_validators = sui_system_state.validators.next_epoch_validators;
+
+            let mut net_config = mysten_network::config::Config::new();
+            net_config.connect_timeout = Some(Duration::from_secs(5));
+            net_config.request_timeout = Some(Duration::from_secs(5));
+            net_config.http2_keepalive_interval = Some(Duration::from_secs(5));
+
+            for validator in next_epoch_validators {
+                let net_addr: &[u8] = &validator.net_address.clone();
+                let str_addr =
+                    std::str::from_utf8(net_addr).map_err(|e| SuiError::GenericAuthorityError {
+                        error: e.to_string(),
+                    });
+                let address: Multiaddr = str_addr
+                    .unwrap()
+                    .parse()
+                    .map_err(|e: multiaddr::Error| SuiError::GenericAuthorityError {
+                        error: e.to_string(),
+                    })
+                    .unwrap();
+
+                let channel = net_config
+                    .connect_lazy(&address)
+                    .map_err(|e| SuiError::GenericAuthorityError {
+                        error: e.to_string(),
+                    })
+                    .unwrap();
+                let client: A = A::recreate(channel);
+                let name: &[u8] = &validator.name;
+                let public_key_bytes = PublicKeyBytes::try_from(name)?;
+                new_clients.insert(public_key_bytes, client);
+            }
+
+            // Replace the clients in the authority aggregator with new clients.
+            let new_net = Arc::new(AuthorityAggregator::new(
+                new_committee,
+                new_clients,
+                self.gateway_metrics.clone(),
+            ));
+            self.net.store(new_net);
+        } else {
+            // update the authorities with the new committee
+            let new_net = Arc::new(AuthorityAggregator::new(
+                new_committee,
+                self.net.load().clone_inner_clients(),
+                self.gateway_metrics.clone(),
+            ));
+            self.net.store(new_net.clone());
+        }
         // TODO: Update all committee in all components safely,
-        // potentially restart some authority clients.
-        // Including: self.net, narwhal committee/consensus adapter,
+        // potentially restart narwhal committee/consensus adapter,
         // all active processes, maybe batch service.
         // We should also reduce the amount of committee passed around.
 
@@ -124,7 +186,9 @@ where
         // Collect a certificate for this system transaction that changes epoch,
         // and execute it locally.
         loop {
-            if let Ok(certificate) = new_net
+            if let Ok(certificate) = self
+                .net
+                .load()
                 .process_transaction(advance_epoch_tx.clone().to_transaction())
                 .await
             {


### PR DESCRIPTION
On startup of a node, if the epoch is no 0, instead of using genesis network information, load the network information from what was written in the move object for the current epoch's validators. 

At the end of the reconfiguration, if our client is of type NetworkAuthorityClient, use the network information that was written to the move object on registration of the next epochs validators to re-recreated the NetworkAuthorityClients in-place with the new network addresses. 

https://github.com/MystenLabs/sui/issues/2706