### PR TITLE
[checkpoint] Separate sync process and active process

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -123,7 +123,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
             println!("Start active execution process.");
             active_state.clone().spawn_execute_process().await;
 
-            // Spin the gossip service.
+            // Spin the checkpoint service.
             active_state
                 .spawn_checkpoint_process_with_config(Some(CheckpointProcessControl::default()))
                 .await;
@@ -273,7 +273,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
             .next_checkpoint();
         assert!(
             next_checkpoint_sequence > 1,
-            "Expected {} > 2",
+            "Expected {} > 1",
             next_checkpoint_sequence
         );
         value_set.insert(next_checkpoint_sequence);

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -406,7 +406,7 @@ fn latest_proposal() {
 
     // Fail to set if transactions not processed.
     assert!(cps1
-        .handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+        .sign_new_checkpoint(summary.clone(), &transactions)
         .is_err());
 
     // Set the transactions as executed.
@@ -422,14 +422,13 @@ fn latest_proposal() {
     cps4.handle_internal_batch(0, &batch).unwrap();
 
     // Try to get checkpoint
-    cps1.handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+    cps1.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
-    cps2.handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+    cps2.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
-    cps3.handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+    cps3.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
-    cps4.handle_internal_set_checkpoint(committee.epoch, summary, &transactions)
-        .unwrap();
+    cps4.sign_new_checkpoint(summary, &transactions).unwrap();
 
     // --- TEST3 ---
 
@@ -552,7 +551,7 @@ fn set_get_checkpoint() {
 
     // Need to load the transactions as processed, before getting a checkpoint.
     assert!(cps1
-        .handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+        .sign_new_checkpoint(summary.clone(), &transactions)
         .is_err());
     let batch: Vec<_> = transactions
         .transactions
@@ -564,12 +563,11 @@ fn set_get_checkpoint() {
     cps2.handle_internal_batch(0, &batch).unwrap();
     cps3.handle_internal_batch(0, &batch).unwrap();
 
-    cps1.handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+    cps1.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
-    cps2.handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+    cps2.sign_new_checkpoint(summary.clone(), &transactions)
         .unwrap();
-    cps3.handle_internal_set_checkpoint(committee.epoch, summary, &transactions)
-        .unwrap();
+    cps3.sign_new_checkpoint(summary, &transactions).unwrap();
     // cps4.handle_internal_set_checkpoint(summary, &transactions)
     //     .unwrap();
 
@@ -702,9 +700,7 @@ fn checkpoint_integration() {
 
         // If we have a previous checkpoint, now lets try to process again?
         if let Some((summary, transactions)) = checkpoint_opt.take() {
-            assert!(cps
-                .handle_internal_set_checkpoint(committee.epoch, summary, &transactions)
-                .is_ok());
+            assert!(cps.sign_new_checkpoint(summary, &transactions).is_ok());
 
             // Loop invariant to ensure termination or error
             assert_eq!(cps.get_locals().next_checkpoint, old_checkpoint + 1);
@@ -744,7 +740,7 @@ fn checkpoint_integration() {
 
         // Cannot register the checkpoint while there are no-executed transactions.
         assert!(cps
-            .handle_internal_set_checkpoint(committee.epoch, summary.clone(), &transactions)
+            .sign_new_checkpoint(summary.clone(), &transactions)
             .is_err());
 
         checkpoint_opt = Some((summary, transactions));

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -148,6 +148,16 @@ pub enum AuthenticatedCheckpoint {
     Certified(CertifiedCheckpointSummary),
 }
 
+impl AuthenticatedCheckpoint {
+    pub fn summary(&self) -> &CheckpointSummary {
+        match self {
+            Self::Signed(s) => &s.summary,
+            Self::Certified(c) => &c.summary,
+            Self::None => unreachable!(),
+        }
+    }
+}
+
 pub type CheckpointDigest = [u8; 32];
 
 // The constituent parts of checkpoints, signed and certified


### PR DESCRIPTION
During the sync process, we also try to create proposals and construct new checkpoints. This is not intuitive because when we are behind, there is no need to do these things.
This PR removes the proposal creation and checkpoint creation code from the checkpoint setting code, and we will simply rely on the active process to do these things step by step.
Added some more comments and TODOs so that we don't forget some of the items left.