### PR TITLE
[test][adapter] Make coin_transfer test more stable

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -1,4 +1,4 @@
-processed 8 tasks
+processed 7 tasks
 
 init:
 A: object(100), B: object(101), C: object(102)
@@ -25,7 +25,3 @@ written: object(100), object(107)
 task 6 'view-object'. lines 18-18:
 Owner: Account Address ( C )
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(100)}}, version: 2u64}, balance: sui::balance::Balance<sui::sui::SUI> {value: 99990u64}}
-
-task 7 'view-object'. lines 20-20:
-Owner: Account Address ( B )
-Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}, balance: sui::balance::Balance<sui::sui::SUI> {value: 99570u64}}

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.move
@@ -16,5 +16,3 @@
 //# run sui::coin::transfer --type-args sui::sui::SUI --args object(100) @C --sender B
 
 //# view-object 100
-
-//# view-object 107

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -400,6 +400,7 @@ impl<'a> SuiTestAdapter<'a> {
         txn_data: impl FnOnce(/* sender */ SuiAddress, /* gas */ ObjectRef) -> TransactionData,
     ) -> Transaction {
         let gas_object_id = ObjectID::new(self.rng.gen());
+        assert!(!self.object_enumeration.contains_left(&gas_object_id));
         self.enumerate_fake(gas_object_id);
         let new_key_pair;
         let (sender, sender_key) = match sender {


### PR DESCRIPTION
- coin_transfer test unnecessarily viewed a gas object
- This caused the value to change with any change to with any adjustment to the framework