### PR TITLE
[checkpoint] Allow empty checkpoint

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -282,3 +282,54 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
     // After the end all authorities are the same
     assert!(value_set.len() == 1, "Got set {:?}", value_set);
 }
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_empty_checkpoint() {
+    use telemetry_subscribers::init_for_testing;
+    init_for_testing();
+
+    let setup = checkpoint_tests_setup(0, Duration::from_millis(200), false).await;
+
+    let TestSetup {
+        committee: _committee,
+        authorities,
+        transactions: _,
+        aggregator,
+    } = setup;
+
+    // Start active part of authority.
+    for inner_state in authorities.clone() {
+        let clients = aggregator.clone_inner_clients();
+        let _active_handle = tokio::task::spawn(async move {
+            let active_state = Arc::new(
+                ActiveAuthority::new_with_ephemeral_follower_store(
+                    inner_state.authority.clone(),
+                    clients,
+                    GatewayMetrics::new_for_tests(),
+                )
+                .unwrap(),
+            );
+
+            active_state.clone().spawn_execute_process().await;
+
+            // Spin the gossip service.
+            active_state
+                .spawn_checkpoint_process_with_config(Some(CheckpointProcessControl::default()))
+                .await;
+        });
+    }
+
+    // Wait for long enough to have generated some checkpoint.
+    tokio::time::sleep(Duration::from_secs(10 * 60)).await;
+
+    for a in authorities {
+        let next_checkpoint_sequence = a
+            .authority
+            .checkpoints
+            .as_ref()
+            .unwrap()
+            .lock()
+            .next_checkpoint();
+        assert!(next_checkpoint_sequence > 0)
+    }
+}

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -81,16 +81,15 @@ async fn checkpoint_active_flow_happy_path() {
             .unwrap()
             .lock()
             .next_checkpoint();
+        // TODO: This check is not very meaningful after we allowed empty checkpoints.
+        // What we want to check is probably the number of non-empty checkpoints.
         assert!(
             next_checkpoint_sequence >= 2,
-            "Expected {} > 2",
+            "Expected {} >= 2",
             next_checkpoint_sequence
         );
         value_set.insert(next_checkpoint_sequence);
     }
-
-    // After the end all authorities are the same
-    assert!(value_set.len() == 1, "Got set {:?}", value_set);
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -176,16 +175,15 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
             .unwrap()
             .lock()
             .next_checkpoint();
+        // TODO: This check is not very meaningful after we allowed empty checkpoints.
+        // What we want to check is probably the number of non-empty checkpoints.
         assert!(
             next_checkpoint_sequence > 1,
-            "Expected {} > 2",
+            "Expected {} > 1",
             next_checkpoint_sequence
         );
         value_set.insert(next_checkpoint_sequence);
     }
-
-    // After the end all authorities are the same
-    assert!(value_set.len() == 1, "Got set {:?}", value_set);
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -271,16 +269,15 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
             .unwrap()
             .lock()
             .next_checkpoint();
+        // TODO: This check is not very meaningful after we allowed empty checkpoints.
+        // What we want to check is probably the number of non-empty checkpoints.
         assert!(
             next_checkpoint_sequence > 1,
-            "Expected {} > 2",
+            "Expected {} > 1",
             next_checkpoint_sequence
         );
         value_set.insert(next_checkpoint_sequence);
     }
-
-    // After the end all authorities are the same
-    assert!(value_set.len() == 1, "Got set {:?}", value_set);
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -48,7 +48,9 @@ pub struct CheckpointLocals {
     // The next checkpoint number expected.
     pub next_checkpoint: CheckpointSequenceNumber,
 
-    // The next transaction after what is included in the proposal
+    // The next transaction after what is included in the proposal.
+    // NOTE: This will be set to 0 if the current checkpoint is empty
+    // and doesn't contain any transactions.
     pub proposal_next_transaction: Option<TxSequenceNumber>,
 
     // The next transaction sequence number of transactions processed
@@ -870,7 +872,6 @@ impl CheckpointStore {
         // Check that:
         // - there is no current proposal.
         // - there are no unprocessed transactions.
-        // - there are some extra transactions to include.
 
         let locals = self.get_locals();
 
@@ -878,14 +879,14 @@ impl CheckpointStore {
             return Ok(proposal.clone());
         }
 
-        if self.extra_transactions.iter().count() == 0 {
-            return Err(SuiError::from("Cannot propose an empty set."));
-        }
-
         // Include the sequence number of all extra transactions not already in a
         // checkpoint. And make a list of the transactions.
         let checkpoint_sequence = self.next_checkpoint();
-        let next_local_tx_sequence = self.extra_transactions.values().max().unwrap() + 1;
+        let next_local_tx_sequence = if let Some(m) = self.extra_transactions.values().max() {
+            m + 1
+        } else {
+            0
+        };
 
         // Extract the previous checkpoint digest if there is one.
         let previous_digest = self.get_prev_checkpoint_digest(checkpoint_sequence)?;

--- a/crates/sui-core/src/checkpoints/proposal.rs
+++ b/crates/sui-core/src/checkpoints/proposal.rs
@@ -13,7 +13,7 @@ use sui_types::{
     waypoint::WaypointDiff,
 };
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointProposal {
     /// Name of the authority
     pub signed_summary: SignedCheckpointSummary,

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -435,8 +435,6 @@ fn latest_proposal() {
 
     // No valid checkpoint proposal condition...
     assert!(cps1.get_locals().current_proposal.is_none());
-    // ... because a valid checkpoint cannot be generated.
-    assert!(cps1.set_proposal(committee.epoch).is_err());
 
     let request = CheckpointRequest::latest(false);
     let response = cps1.handle_latest_proposal(&request).expect("no errors");


### PR DESCRIPTION
We want a relatively stable control on the frequency of checkpoints. However if we require that a checkpoint must have at least one transaction, it's possible that when traffic is low, we may not have checkpoint for a long time, which will mean that the duration of an epoch is highly unpredictable in such cases, which is not ideal. Also we need to halt the validator in the last checkpoint of the epoch, and hence we want the last checkpoint to be as short as possible. Requiring at least one transaction makes it difficult to control that.

Any thoughts on the consequences of doing this, and if there is a better way?