### PR TITLE
wallet-ext: dapp <-> content script messaging

### DIFF
--- a/wallet/configs/ts/tsconfig.common.json
+++ b/wallet/configs/ts/tsconfig.common.json
@@ -28,7 +28,10 @@
             "_hooks": ["./src/ui/app/hooks/"],
             "_components/*": ["./src/ui/app/components/*"],
             "_messaging/*": ["./src/shared/messaging/*"],
-            "_messages/*": ["./src/shared/messaging/messages/*"]
+            "_messages": ["./src/shared/messaging/messages/"],
+            "_messages/*": ["./src/shared/messaging/messages/*"],
+            "_payloads": ["./src/shared/messaging/messages/payloads/"],
+            "_payloads/*": ["./src/shared/messaging/messages/payloads/*"]
         }
     },
     "include": ["../../src"],

--- a/wallet/package-lock.json
+++ b/wallet/package-lock.json
@@ -25,6 +25,7 @@
                 "rxjs": "^7.5.5",
                 "stream-browserify": "^3.0.0",
                 "tweetnacl": "^1.0.3",
+                "uuid": "^8.3.2",
                 "webextension-polyfill": "^0.9.0",
                 "yup": "^0.32.11"
             },
@@ -34,6 +35,7 @@
                 "@types/node": "^17.0.31",
                 "@types/react": "^18.0.8",
                 "@types/react-dom": "^18.0.3",
+                "@types/uuid": "^8.3.4",
                 "@types/webextension-polyfill": "^0.8.3",
                 "@types/webpack": "^5.28.0",
                 "concurrently": "^7.1.0",
@@ -3369,6 +3371,12 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
             "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "node_modules/@types/webextension-polyfill": {
             "version": "0.8.3",
@@ -12265,6 +12273,14 @@
             "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
             "dev": true
         },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -15113,6 +15129,12 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
             "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+        },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "@types/webextension-polyfill": {
             "version": "0.8.3",
@@ -21581,6 +21603,11 @@
             "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
             "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
             "dev": true
+        },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/wallet/package.json
+++ b/wallet/package.json
@@ -37,6 +37,7 @@
         "@types/node": "^17.0.31",
         "@types/react": "^18.0.8",
         "@types/react-dom": "^18.0.3",
+        "@types/uuid": "^8.3.4",
         "@types/webextension-polyfill": "^0.8.3",
         "@types/webpack": "^5.28.0",
         "concurrently": "^7.1.0",
@@ -86,6 +87,7 @@
         "rxjs": "^7.5.5",
         "stream-browserify": "^3.0.0",
         "tweetnacl": "^1.0.3",
+        "uuid": "^8.3.2",
         "webextension-polyfill": "^0.9.0",
         "yup": "^0.32.11"
     }

--- a/wallet/src/content-script/index.ts
+++ b/wallet/src/content-script/index.ts
@@ -2,5 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { injectDappInterface } from './interface-inject';
+import { setupMessagesProxy } from './messages-proxy';
 
 injectDappInterface();
+setupMessagesProxy();

--- a/wallet/src/content-script/messages-proxy.ts
+++ b/wallet/src/content-script/messages-proxy.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { WindowMessageStream } from '_messaging/WindowMessageStream';
+
+export function setupMessagesProxy() {
+    const windowMsgStream = new WindowMessageStream(
+        'sui_content-script',
+        'sui_in-page'
+    );
+    windowMsgStream.messages.subscribe((msg) => {
+        // TODO implement
+        // eslint-disable-next-line no-console
+        console.log('[ContentScriptProxy] message from inPage', msg);
+    });
+}

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -1,10 +1,56 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export class DAppInterface {
-    private _window: Window;
+import { filter, lastValueFrom, map, take } from 'rxjs';
 
-    constructor(theWindow: Window) {
-        this._window = window;
+import { createMessage } from '_messages';
+import { WindowMessageStream } from '_messaging/WindowMessageStream';
+import { isErrorPayload } from '_payloads';
+
+import type { SuiAddress } from '@mysten/sui.js';
+import type { Payload } from '_payloads';
+import type { GetAccount } from '_payloads/account/GetAccount';
+import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
+import type { Observable } from 'rxjs';
+
+export class DAppInterface {
+    private _messagesStream: WindowMessageStream;
+
+    constructor() {
+        this._messagesStream = new WindowMessageStream(
+            'sui_in-page',
+            'sui_content-script'
+        );
+    }
+
+    public getAccounts(): Promise<SuiAddress[]> {
+        const stream = this.send<GetAccount, GetAccountResponse>({
+            type: 'get-account',
+        }).pipe(
+            take(1),
+            map((response) => {
+                if (isErrorPayload(response)) {
+                    // TODO: throw proper error
+                    throw new Error(response.message);
+                }
+                return response.accounts;
+            })
+        );
+        return lastValueFrom(stream);
+    }
+
+    private send<
+        RequestPayload extends Payload,
+        ResponsePayload extends Payload | void = void
+    >(
+        payload: RequestPayload,
+        responseForID?: string
+    ): Observable<ResponsePayload> {
+        const msg = createMessage(payload, responseForID);
+        this._messagesStream.send(msg);
+        return this._messagesStream.messages.pipe(
+            filter(({ id }) => id === msg.id),
+            map((msg) => msg.payload as ResponsePayload)
+        );
     }
 }

--- a/wallet/src/dapp-interface/index.ts
+++ b/wallet/src/dapp-interface/index.ts
@@ -6,5 +6,5 @@ import { DAppInterface } from './DAppInterface';
 Object.defineProperty(window, 'suiWallet', {
     enumerable: false,
     configurable: false,
-    value: new DAppInterface(window),
+    value: new DAppInterface(),
 });

--- a/wallet/src/shared/messaging/WindowMessageStream.ts
+++ b/wallet/src/shared/messaging/WindowMessageStream.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { filter, fromEvent, map } from 'rxjs';
+
+import type { Message } from '_messages';
+import type { Observable } from 'rxjs';
+
+export type ClientType = 'sui_in-page' | 'sui_content-script';
+
+type WindowMessage = {
+    target: ClientType;
+    payload: Message;
+};
+
+export class WindowMessageStream {
+    public readonly messages: Observable<Message>;
+    private _name: ClientType;
+    private _target: ClientType;
+
+    constructor(name: ClientType, target: ClientType) {
+        if (name === target) {
+            throw new Error(
+                '[WindowMessageStream] name and target must be different'
+            );
+        }
+        this._name = name;
+        this._target = target;
+        this.messages = fromEvent<MessageEvent<WindowMessage>>(
+            window,
+            'message'
+        ).pipe(
+            filter(
+                (message) =>
+                    message.source === window &&
+                    message.data.target === this._name
+            ),
+            map((message) => message.data.payload)
+        );
+    }
+
+    public send(payload: Message) {
+        const msg: WindowMessage = {
+            target: this._target,
+            payload,
+        };
+        window.postMessage(msg);
+    }
+}

--- a/wallet/src/shared/messaging/messages/Message.ts
+++ b/wallet/src/shared/messaging/messages/Message.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { v4 as uuidV4 } from 'uuid';
+
+import type { Payload } from './payloads/Payload';
+
+export type Message = {
+    id: string;
+    payload: Payload;
+};
+
+export function createMessage<MsgPayload extends Payload>(
+    payload: MsgPayload,
+    id?: string
+): Message {
+    return {
+        id: id || uuidV4(),
+        payload,
+    };
+}

--- a/wallet/src/shared/messaging/messages/index.ts
+++ b/wallet/src/shared/messaging/messages/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './Message';

--- a/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Payload } from './Payload';
+
+export type PayloadType =
+    | 'permission-request'
+    | 'permission-response'
+    | 'get-permission-requests'
+    | 'get-account'
+    | 'get-account-response';
+
+export interface BasePayload {
+    type: PayloadType;
+}
+
+export function isBasePayload(payload: Payload): payload is BasePayload {
+    return 'type' in payload && typeof payload.type !== 'undefined';
+}

--- a/wallet/src/shared/messaging/messages/payloads/ErrorPayload.ts
+++ b/wallet/src/shared/messaging/messages/payloads/ErrorPayload.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Payload } from './Payload';
+
+export interface ErrorPayload {
+    error: true;
+    code: number;
+    message: string;
+}
+
+export function isErrorPayload(payload: Payload): payload is ErrorPayload {
+    return 'error' in payload && payload.error === true;
+}

--- a/wallet/src/shared/messaging/messages/payloads/Payload.ts
+++ b/wallet/src/shared/messaging/messages/payloads/Payload.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { BasePayload } from './BasePayload';
+import type { ErrorPayload } from './ErrorPayload';
+
+export type Payload = BasePayload | ErrorPayload;

--- a/wallet/src/shared/messaging/messages/payloads/account/GetAccount.ts
+++ b/wallet/src/shared/messaging/messages/payloads/account/GetAccount.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { BasePayload } from '_payloads';
+
+export interface GetAccount extends BasePayload {
+    type: 'get-account';
+}

--- a/wallet/src/shared/messaging/messages/payloads/account/GetAccountResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/account/GetAccountResponse.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SuiAddress } from '@mysten/sui.js';
+import type { BasePayload } from '_payloads';
+
+export interface GetAccountResponse extends BasePayload {
+    type: 'get-account-response';
+    accounts: SuiAddress[];
+}

--- a/wallet/src/shared/messaging/messages/payloads/index.ts
+++ b/wallet/src/shared/messaging/messages/payloads/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './BasePayload';
+export * from './ErrorPayload';
+export * from './Payload';


### PR DESCRIPTION
* use window message events to pass messages between the web page and the content script

---- 

To test open a web page and in the console run:

```
suiWallet.getAccounts().then((a) => console.log('accounts response: ', a));
```

Then copy the id of the message in the console.

eg: `b906b12d-504b-4283-88cd-a8da108b588b` from

<img width="721" alt="Screenshot 2022-06-27 at 22 03 45" src="https://user-images.githubusercontent.com/10210143/176035222-97a1cb86-6319-44bf-8e7c-ccbce5c02649.png">

and run the following after replacing the id 

```
window.postMessage({target: 'sui_in-page', payload: {id: 'REPLACE_THE_ID', payload: { type: 'get-account-response', accounts: ['test']}}})
```

You should see the 'accounts response: ' ['test'] message in the console.

closes: #2724 
