### PR TITLE
wallet-ext: fix errors after pr 2605

### DIFF
--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -16,7 +16,7 @@ import ImportPage from './pages/initialize/import';
 import SelectPage from './pages/initialize/select';
 import SiteConnectPage from './pages/site-connect';
 import TransactionDetailsPage from './pages/transaction-details';
-import PublicTransferObjectPage from './pages/transfer-coin';
+import TransferCoinPage from './pages/transfer-coin';
 import WelcomePage from './pages/welcome';
 import { AppType } from './redux/slices/app/AppType';
 import { useAppDispatch, useAppSelector } from '_hooks';
@@ -44,7 +44,7 @@ const App = () => {
                 <Route path="nfts" element={<NftsPage />} />
                 <Route path="transactions" element={<TransactionsPage />} />
                 <Route path="settings" element={<SettingsPage />} />
-                <Route path="send" element={<PublicTransferObjectPage />} />
+                <Route path="send" element={<TransferCoinPage />} />
                 <Route
                     path="tx/:txDigest"
                     element={<TransactionDetailsPage />}

--- a/wallet/src/ui/app/pages/transfer-coin/TransferCoinForm.tsx
+++ b/wallet/src/ui/app/pages/transfer-coin/TransferCoinForm.tsx
@@ -17,21 +17,21 @@ import { balanceFormatOptions } from '_shared/formatting';
 
 import type { FormValues } from './';
 
-import st from './PublicTransferObjectForm.module.scss';
+import st from './TransferCoinForm.module.scss';
 
-export type PublicTransferObjectFormProps = {
+export type TransferCoinFormProps = {
     submitError: string | null;
     coinBalance: string;
     coinSymbol: string;
     onClearSubmitError: () => void;
 };
 
-function PublicTransferObjectForm({
+function TransferCoinForm({
     submitError,
     coinBalance,
     coinSymbol,
     onClearSubmitError,
-}: PublicTransferObjectFormProps) {
+}: TransferCoinFormProps) {
     const {
         isSubmitting,
         isValid,
@@ -103,4 +103,4 @@ function PublicTransferObjectForm({
     );
 }
 
-export default memo(PublicTransferObjectForm);
+export default memo(TransferCoinForm);

--- a/wallet/src/ui/app/pages/transfer-coin/index.tsx
+++ b/wallet/src/ui/app/pages/transfer-coin/index.tsx
@@ -6,7 +6,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 
-import PublicTransferObjectForm from './PublicTransferObjectForm';
+import TransferCoinForm from './TransferCoinForm';
 import { createValidationSchema } from './validation';
 import Loading from '_components/loading';
 import { useAppSelector, useAppDispatch } from '_hooks';
@@ -29,7 +29,7 @@ const initialValues = {
 export type FormValues = typeof initialValues;
 
 // TODO: show out of sync when sui objects locally might be outdated
-function PublicTransferObjectPage() {
+function TransferCoinPage() {
     const [searchParams] = useSearchParams();
     const coinType = useMemo(() => searchParams.get('type'), [searchParams]);
     const balances = useAppSelector(accountItemizedBalancesSelector);
@@ -120,7 +120,7 @@ function PublicTransferObjectPage() {
                     validationSchema={validationSchema}
                     onSubmit={onHandleSubmit}
                 >
-                    <PublicTransferObjectForm
+                    <TransferCoinForm
                         submitError={sendError}
                         coinBalance={coinBalance.toString()}
                         coinSymbol={coinSymbol}
@@ -132,4 +132,4 @@ function PublicTransferObjectPage() {
     );
 }
 
-export default PublicTransferObjectPage;
+export default TransferCoinPage;

--- a/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -64,7 +64,7 @@ export class Coin {
      * @param amount The amount to be transfer
      * @param recipient The sui address of the recipient
      */
-    public static async publicTransferObject(
+    public static async transferCoin(
         signer: RawSigner,
         coins: SuiMoveObject[],
         amount: bigint,

--- a/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -29,9 +29,9 @@ export const fetchAllOwnedObjects = createAsyncThunk<
     const allSuiObjects: SuiObject[] = [];
     if (address) {
         const allObjectRefs =
-            await api.instance.gateway.getObjectsOwnedByAddress(`${address}`);
+            await api.instance.fullNode.getObjectsOwnedByAddress(`${address}`);
         const objectIDs = allObjectRefs.map((anObj) => anObj.objectId);
-        const allObjRes = await api.instance.gateway.getObjectBatch(objectIDs);
+        const allObjRes = await api.instance.fullNode.getObjectBatch(objectIDs);
         for (const objRes of allObjRes) {
             const suiObj = getObjectExistsResponse(objRes);
             if (suiObj) {

--- a/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -48,7 +48,7 @@ export const sendTokens = createAsyncThunk<
                     isSuiMoveObject(anObj.data) && anObj.data.type === coinType
             )
             .map(({ data }) => data as SuiMoveObject);
-        const response = await Coin.publicTransferObject(
+        const response = await Coin.transferCoin(
             api.getSignerInstance(keypairVault.getKeyPair()),
             coins,
             amount,

--- a/wallet/src/ui/app/redux/slices/txresults/index.ts
+++ b/wallet/src/ui/app/redux/slices/txresults/index.ts
@@ -92,7 +92,9 @@ export const getTransactionsByAddress = createAsyncThunk<
                             const txn = txns[0];
                             const txKind = getTransactionKindName(txn);
                             const recipient =
-                                getPublicTransferObjectTransaction(txn)?.recipient;
+                                getPublicTransferObjectTransaction(
+                                    txn
+                                )?.recipient;
 
                             return {
                                 seq,


### PR DESCRIPTION
* using fullnode for objects (because testing locally the gateway didn't work but makes sense to use fullnode since we use it for the transactions)
* fixed missing files after renaming only the reference
* reverted some name changes back to coin since wallet does only coin transfer at the moment