### PR TITLE
ci: limit tests to 30m

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [self-hosted, self-hosted-ubuntu]
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,7 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [self-hosted, self-hosted-ubuntu]
+    timeout-minutes: 60
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
Default timeout is 6 hours, lets reduce this to an hour.  Sometimes issues pop up where tests can take a really long time (e.g. https://github.com/MystenLabs/sui/actions/runs/2576600173)