### PR TITLE
set max_header_delay to 5s

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -9,8 +9,9 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use debug_ignore::DebugIgnore;
-use narwhal_config::{Authority, PrimaryAddresses, Stake, WorkerAddresses};
+use narwhal_config::{Authority, Parameters, PrimaryAddresses, Stake, WorkerAddresses};
 use rand::rngs::OsRng;
+use std::time::Duration;
 use std::{
     collections::BTreeMap,
     num::NonZeroUsize,
@@ -180,7 +181,10 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                 let consensus_config = ConsensusConfig {
                     consensus_address,
                     consensus_db_path,
-                    narwhal_config: Default::default(),
+                    narwhal_config: Parameters {
+                        max_header_delay: Duration::from_secs(5),
+                        ..Default::default()
+                    },
                     narwhal_committee: narwhal_committee.clone(),
                 };
 


### PR DESCRIPTION
Narwhal's max_header_delay was defaulted to 100ms, which generates lot of warning when running local network.
```
2022-06-28T19:51:15.448828Z  WARN node{name=0x1c9e41b8fa11b364df85e2ff89e08e9e722a90da}: primary::proposer: Timer expired for round 18
2022-06-28T19:51:15.459284Z  WARN node{name=0x41cac9db0dfd846d6b6ec41b574c88790a9c67f3}: primary::proposer: Timer expired for round 19
2022-06-28T19:51:20.447018Z  WARN node{name=0x62d7e9affbe97114e283062926f334536e9b5498}: primary::proposer: Timer expired for round 19
2022-06-28T19:51:20.449244Z  WARN node{name=0x4ad1e1a3051b7e56a79666b267de774a5ab8e3a8}: primary::proposer: Timer expired for round 19
2022-06-28T19:51:20.452101Z  WARN node{name=0x1c9e41b8fa11b364df85e2ff89e08e9e722a90da}: primary::proposer: Timer expired for round 19
2022-06-28T19:51:20.462253Z  WARN node{name=0x41cac9db0dfd846d6b6ec41b574c88790a9c67f3}: primary::proposer: Timer expired for round 20
```

I am setting it to 5s as per @asonnino 's advice to prevent the timer expire warning 