### PR TITLE
chore: fix build error on beta channel

### DIFF
--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -312,8 +312,7 @@ where
             });
         }
 
-        let _ = rx
-            .recv()
+        rx.recv()
             .await
             .map_err(|e| SuiError::GenericAuthorityError {
                 error: format!("{:?}", e),


### PR DESCRIPTION
Fixes this error on the nightly rust beta-channel toolchain:

```
error: this let-binding has unit value
--> crates/sui-core/src/authority_active/gossip/node_sync.rs:315:9
|
315| /        let _ = rx
316| |            .recv()
317| |            .await
318| |            .map_err(|e| SuiError::GenericAuthorityError {
319| |                error: format!("{:?}", e),
320| |            })??;
| |_________________^
|
= note: `-D clippy::let-unit-value` implied by `-D warnings`
= help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value
help: omit the `let` binding
|
315~ rx
316+             .recv()
317+             .await
318+             .map_err(|e| SuiError::GenericAuthorityError {
319+                 error: format!("{:?}", e),
320+             })??;
```