### PR TITLE
Make sure the next epoch validator is updated upon changes

### DIFF
--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -34,6 +34,7 @@ module sui::validator {
         net_address: vector<u8>,
         /// Total amount of validator stake that would be active in the next epoch.
         /// This only includes validator stake, and does not include delegation.
+        /// TODO: stake should include delegated stake: https://github.com/MystenLabs/sui/issues/2834
         next_epoch_stake: u64,
     }
 


### PR DESCRIPTION
When any of the validator (either existence, stake or delegation) changes, we should update the next epoch validator set to make sure it's kept up-to-date.