### PR TITLE
[cleanup] Remove unnecessary checks around TransferSui

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -881,7 +881,7 @@ pub fn resolve_and_type_check(
                 t @ SignatureToken::Struct(_)
                 | t @ SignatureToken::StructInstantiation(_, _)
                 | t @ SignatureToken::TypeParameter(_) => {
-                    if !object.is_owned() {
+                    if !object.is_owned_or_quasi_shared() {
                         // Forbid passing shared (both mutable and immutable) object by value.
                         // This ensures that shared object cannot be transferred, deleted or wrapped.
                         return Err(ExecutionError::new_with_source(

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -823,7 +823,7 @@ impl AuthorityState {
             ObjectInfoRequestKind::LatestObjectInfo(request_layout) => {
                 match self.get_object(&request.object_id).await {
                     Ok(Some(object)) => {
-                        let lock = if !object.is_owned() {
+                        let lock = if !object.is_owned_or_quasi_shared() {
                             // Unowned obejcts have no locks.
                             None
                         } else {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -816,7 +816,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         let owned_inputs: Vec<_> = active_inputs
             .iter()
-            .filter(|(id, _, _)| objects.get(id).unwrap().is_owned())
+            .filter(|(id, _, _)| objects.get(id).unwrap().is_owned_or_quasi_shared())
             .cloned()
             .collect();
 
@@ -921,7 +921,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             let new_locks_to_init: Vec<_> = written
                 .iter()
                 .filter_map(|(_, (object_ref, new_object))| {
-                    if new_object.is_owned() {
+                    if new_object.is_owned_or_quasi_shared() {
                         Some(*object_ref)
                     } else {
                         None

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -232,6 +232,7 @@ where
             }
         })
         .collect();
+
     for (object_kind, object) in input_objects.into_iter().zip(objects) {
         // All objects must exist in the DB.
         let object = match object {

--- a/crates/sui-framework/src/natives/test_scenario.rs
+++ b/crates/sui-framework/src/natives/test_scenario.rs
@@ -197,7 +197,7 @@ fn get_inventory_for(
                     let obj_signer = obj.signer.unwrap();
                     obj.owner
                         == Owner::ObjectOwner(SuiAddress::try_from(parent.as_slice()).unwrap())
-                        && (!obj_signer.is_owned() || obj_signer == signer)
+                        && (!obj_signer.is_owned_or_quasi_shared() || obj_signer == signer)
                 } else {
                     obj.owner == signer
                 }

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{ExecutionError, ExecutionErrorKind},
     error::{SuiError, SuiResult},
     gas_coin::GasCoin,
-    object::Object,
+    object::{Object, Owner},
 };
 use move_core_types::{
     gas_schedule::{
@@ -301,13 +301,13 @@ impl<'a> SuiGasStatus<'a> {
 }
 
 /// Check whether the given gas_object and gas_budget is legit:
-/// 1. If the gas object is owned.
+/// 1. If the gas object has an address owner.
 /// 2. If it's enough to pay the flat minimum transaction fee
 /// 3. If it's less than the max gas budget allowed
 /// 4. If the gas_object actually has enough balance to pay for the budget.
 pub fn check_gas_balance(gas_object: &Object, gas_budget: u64, gas_price: u64) -> SuiResult {
     ok_or_gas_error!(
-        gas_object.is_owned(),
+        matches!(gas_object.owner, Owner::AddressOwner(_)),
         "Gas object must be owned Move object".to_owned()
     )?;
     ok_or_gas_error!(

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -291,14 +291,16 @@ impl Owner {
     }
 
     pub fn is_immutable(&self) -> bool {
-        self == &Owner::Immutable
+        matches!(self, Owner::Immutable)
     }
 
+    /// Is owned by an address or an object
+    /// In the object case, it might be owned by an address owned object, a shared object, or
+    /// another object owned object.
+    /// If the root of this ownership is a shared object, we refer to these objects as
+    /// "quasi-shared", as they are not shared themselves, but behave similarly in some cases
     pub fn is_owned_or_quasi_shared(&self) -> bool {
-        match self {
-            Owner::AddressOwner(_) | Owner::ObjectOwner(_) => true,
-            Owner::Shared | Owner::Immutable => false,
-        }
+        matches!(self, Owner::AddressOwner(_) | Owner::ObjectOwner(_))
     }
 
     pub fn is_shared(&self) -> bool {

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -500,6 +500,20 @@ impl Object {
         }
     }
 
+    pub fn with_object_owner_for_testing(id: ObjectID, owner: ObjectID) -> Self {
+        let data = Data::Move(MoveObject {
+            type_: GasCoin::type_(),
+            has_public_transfer: true,
+            contents: GasCoin::new(id, SequenceNumber::new(), GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
+        });
+        Self {
+            owner: Owner::ObjectOwner(owner.into()),
+            data,
+            previous_transaction: TransactionDigest::genesis(),
+            storage_rebate: 0,
+        }
+    }
+
     pub fn with_id_owner_for_testing(id: ObjectID, owner: SuiAddress) -> Self {
         // For testing, we provide sufficient gas by default.
         Self::with_id_owner_gas_for_testing(id, owner, GAS_VALUE_FOR_TESTING)

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -294,7 +294,7 @@ impl Owner {
         self == &Owner::Immutable
     }
 
-    pub fn is_owned(&self) -> bool {
+    pub fn is_owned_or_quasi_shared(&self) -> bool {
         match self {
             Owner::AddressOwner(_) | Owner::ObjectOwner(_) => true,
             Owner::Shared | Owner::Immutable => false,
@@ -388,8 +388,8 @@ impl Object {
         self.owner.is_immutable()
     }
 
-    pub fn is_owned(&self) -> bool {
-        self.owner.is_owned()
+    pub fn is_owned_or_quasi_shared(&self) -> bool {
+        self.owner.is_owned_or_quasi_shared()
     }
 
     pub fn is_shared(&self) -> bool {
@@ -460,25 +460,16 @@ impl Object {
 
     /// Change the owner of `self` to `new_owner`. This function does not increase the version
     /// number of the object.
-    pub fn transfer_without_version_change(
-        &mut self,
-        new_owner: SuiAddress,
-    ) -> Result<(), ExecutionError> {
-        self.ensure_public_transfer_eligible()?;
+    pub fn transfer_without_version_change(&mut self, new_owner: SuiAddress) {
         self.owner = Owner::AddressOwner(new_owner);
-        Ok(())
     }
 
     /// Change the owner of `self` to `new_owner`. This function will increment the version
     /// number of the object after transfer.
-    pub fn transfer_and_increment_version(
-        &mut self,
-        new_owner: SuiAddress,
-    ) -> Result<(), ExecutionError> {
-        self.transfer_without_version_change(new_owner)?;
+    pub fn transfer_and_increment_version(&mut self, new_owner: SuiAddress) {
+        self.transfer_without_version_change(new_owner);
         let data = self.data.try_as_move_mut().unwrap();
         data.increment_version();
-        Ok(())
     }
 
     pub fn immutable_with_id_for_testing(id: ObjectID) -> Self {


### PR DESCRIPTION
- Remove check for public transfer in TransferSui
- Fix gas object check around owned objects