### PR TITLE
Fix inconsistent sui system state object id

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1345,6 +1345,7 @@ async fn test_genesis_sui_sysmtem_state_object() {
         .await
         .unwrap()
         .unwrap();
+    assert_eq!(sui_system_object.version(), SequenceNumber::from(1));
     let move_object = sui_system_object.data.try_as_move().unwrap();
     let _sui_system_state = bcs::from_bytes::<SuiSystemState>(move_object.contents()).unwrap();
     assert_eq!(move_object.type_, SuiSystemState::type_());


### PR DESCRIPTION
When the sui system state object is created, since it has a hardcoded ID 0x5, it's not included in the created id list, and was treated as an unwrapped object. This leads to its version to be incremented twice and becomes 2, which is inconsistent with the expected version 1.