### PR TITLE
Revert "set max_header_delay to 5s (#2787)"

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -9,9 +9,8 @@ use crate::{
 };
 use arc_swap::ArcSwap;
 use debug_ignore::DebugIgnore;
-use narwhal_config::{Authority, Parameters, PrimaryAddresses, Stake, WorkerAddresses};
+use narwhal_config::{Authority, PrimaryAddresses, Stake, WorkerAddresses};
 use rand::rngs::OsRng;
-use std::time::Duration;
 use std::{
     collections::BTreeMap,
     num::NonZeroUsize,
@@ -181,10 +180,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                 let consensus_config = ConsensusConfig {
                     consensus_address,
                     consensus_db_path,
-                    narwhal_config: Parameters {
-                        max_header_delay: Duration::from_secs(5),
-                        ..Default::default()
-                    },
+                    narwhal_config: Default::default(),
                     narwhal_committee: narwhal_committee.clone(),
                 };
 


### PR DESCRIPTION
This reverts commit eccef177105a47a7efc16653fa20ea851aed3ef1.
It makes shared object transaction extremely slow. Some tests now start to take a very long time.
We need to take a closer look at what happens there.