### PR TITLE
[bugfix] - Fix openrpc doc generation subscription method handling

### DIFF
--- a/crates/sui-open-rpc-macros/src/lib.rs
+++ b/crates/sui-open-rpc-macros/src/lib.rs
@@ -57,11 +57,12 @@ pub fn open_rpc(attr: TokenStream, item: TokenStream) -> TokenStream {
         } else {
             quote! {None;}
         };
+        let is_pubsub = method.is_pubsub;
         methods.push(quote! {
             let mut inputs: Vec<sui_open_rpc::ContentDescriptor> = Vec::new();
             #(#inputs)*
             let result = #returns_ty
-            builder.add_method(#namespace, #name, inputs, result, #doc, #tag);
+            builder.add_method(#namespace, #name, inputs, result, #doc, #tag, #is_pubsub);
         })
     }
     let open_rpc_name = quote::format_ident!("{}OpenRpc", &rpc_definition.name);
@@ -118,17 +119,32 @@ struct Method {
     params: Vec<(String, Type)>,
     returns: Option<Type>,
     doc: String,
+    is_pubsub: bool,
 }
 
 fn parse_rpc_method(trait_data: &mut syn::ItemTrait) -> Result<RpcDefinition, syn::Error> {
     let mut methods = Vec::new();
     for trait_item in &mut trait_data.items {
         if let TraitItem::Method(method) = trait_item {
-            let method_name = if let Some(attr) = find_attr(&method.attrs, "method").cloned() {
+            let (method_name, returns, is_pubsub) = if let Some(attr) =
+                find_attr(&method.attrs, "method").cloned()
+            {
                 let token: TokenStream = attr.tokens.clone().into();
-                parse::<NamedAttribute>(token)?.value.value()
+                let returns = match &method.sig.output {
+                    syn::ReturnType::Default => None,
+                    syn::ReturnType::Type(_, output) => extract_type_from(&*output, "RpcResult"),
+                };
+                (
+                    parse::<NamedAttribute>(token)?.value.value(),
+                    returns,
+                    false,
+                )
+            } else if let Some(attr) = find_attr(&method.attrs, "subscription").cloned() {
+                let token: TokenStream = attr.tokens.clone().into();
+                let attribute = parse::<SubscriptionNamedAttribute>(token)?;
+                (attribute.value.value(), Some(attribute.item), true)
             } else {
-                "Unknown method name".to_string()
+                panic!("Unknown method name")
             };
 
             let doc = extract_doc_comments(&method.attrs).to_string();
@@ -155,15 +171,12 @@ fn parse_rpc_method(trait_data: &mut syn::ItemTrait) -> Result<RpcDefinition, sy
                 })
                 .collect::<Result<_, _>>()?;
 
-            let returns = match &method.sig.output {
-                syn::ReturnType::Default => None,
-                syn::ReturnType::Type(_, output) => extract_type_from(&*output, "RpcResult"),
-            };
             methods.push(Method {
                 name: method_name,
                 params,
                 returns,
                 doc,
+                is_pubsub,
             });
         }
     }
@@ -287,4 +300,24 @@ struct NamedAttribute {
     _eq_token: Token![=],
     #[inside(_paren_token)]
     value: syn::LitStr,
+}
+
+#[derive(Parse, Debug)]
+struct SubscriptionNamedAttribute {
+    #[paren]
+    _paren_token: Paren,
+    #[inside(_paren_token)]
+    _ident: Ident,
+    #[inside(_paren_token)]
+    _eq_token: Token![=],
+    #[inside(_paren_token)]
+    value: syn::LitStr,
+    #[inside(_paren_token)]
+    _comma: Token![,],
+    #[inside(_paren_token)]
+    _item_ident: Ident,
+    #[inside(_paren_token)]
+    _item_eq_token: Token![=],
+    #[inside(_paren_token)]
+    item: Type,
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -16,23 +16,6 @@
   },
   "methods": [
     {
-      "name": "sui_Unknown method name",
-      "tags": [
-        {
-          "name": "Event Subscription"
-        }
-      ],
-      "params": [
-        {
-          "name": "filter",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/EventFilter"
-          }
-        }
-      ]
-    },
-    {
       "name": "sui_batchTransaction",
       "tags": [
         {
@@ -1108,6 +1091,36 @@
         "required": true,
         "schema": {
           "$ref": "#/components/schemas/TransactionBytes"
+        }
+      }
+    },
+    {
+      "name": "sui_subscribeEvent",
+      "tags": [
+        {
+          "name": "Event Subscription"
+        },
+        {
+          "name": "Websocket"
+        },
+        {
+          "name": "PubSub"
+        }
+      ],
+      "params": [
+        {
+          "name": "filter",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/EventFilter"
+          }
+        }
+      ],
+      "result": {
+        "name": "SuiEventEnvelope",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/EventEnvelope"
         }
       }
     },

--- a/crates/sui-open-rpc/src/lib.rs
+++ b/crates/sui-open-rpc/src/lib.rs
@@ -109,7 +109,7 @@ struct Method {
 struct Tag {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    summery: Option<String>,
+    summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
 }
@@ -196,6 +196,7 @@ impl RpcModuleDocBuilder {
         result: Option<ContentDescriptor>,
         doc: &str,
         tag: Option<String>,
+        is_pubsub: bool,
     ) {
         let description = if doc.trim().is_empty() {
             None
@@ -203,6 +204,28 @@ impl RpcModuleDocBuilder {
             Some(doc.trim().to_string())
         };
         let name = format!("{}_{}", namespace, name);
+        let mut tags = tag
+            .map(|t| Tag {
+                name: t,
+                summary: None,
+                description: None,
+            })
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        if is_pubsub {
+            tags.push(Tag {
+                name: "Websocket".to_string(),
+                summary: None,
+                description: None,
+            });
+            tags.push(Tag {
+                name: "PubSub".to_string(),
+                summary: None,
+                description: None,
+            });
+        }
+
         self.methods.insert(
             name.clone(),
             Method {
@@ -210,14 +233,7 @@ impl RpcModuleDocBuilder {
                 description,
                 params,
                 result,
-                tags: tag
-                    .map(|t| Tag {
-                        name: t,
-                        summery: None,
-                        description: None,
-                    })
-                    .into_iter()
-                    .collect(),
+                tags,
             },
         );
     }


### PR DESCRIPTION
OpenRPC doc generation wasn't expecting subscription methods, result in creating doc with method name `sui_Unknown method name`, this PR fixes this.

I have also added `Websocket` and `PubSub` tag for the subscription method.