### PR TITLE
[Explorer] Fixes mistaken rendering of image in case of 0x2

### DIFF
--- a/explorer/client/src/utils/objectUtils.ts
+++ b/explorer/client/src/utils/objectUtils.ts
@@ -22,7 +22,7 @@ export function parseImageURL(data: any): string {
 
     if (findIPFSvalue(url)) return url;
 
-    //String respresenting true http/https URLs are valid:
+    // String respresenting true http/https URLs are valid:
     try {
         new URL(url);
         return url;

--- a/explorer/client/src/utils/objectUtils.ts
+++ b/explorer/client/src/utils/objectUtils.ts
@@ -7,16 +7,30 @@ import {
     type ObjectOwner,
 } from '@mysten/sui.js';
 
+import { findIPFSvalue } from './stringUtils';
+
 import type { GetObjectDataResponse } from '@mysten/sui.js';
 
 export function parseImageURL(data: any): string {
-    return (
+    const url =
         data?.url ||
         // TODO: Remove Legacy format
         data?.display ||
-        data?.contents?.display ||
-        ''
-    );
+        data?.contents?.display;
+
+    // When url undefined return blank string:
+    if (!url) return '';
+
+    //Strings representing IPFS values are valid:
+    if (findIPFSvalue(url)) return url;
+
+    //String respresenting true http/https URLs are valid:
+    try {
+        new URL(url);
+        return url;
+    } catch {
+        return '';
+    }
 }
 
 export function parseObjectType(data: GetObjectDataResponse): string {

--- a/explorer/client/src/utils/objectUtils.ts
+++ b/explorer/client/src/utils/objectUtils.ts
@@ -21,7 +21,6 @@ export function parseImageURL(data: any): string {
     // When url undefined return blank string:
     if (!url) return '';
 
-    //Strings representing IPFS values are valid:
     if (findIPFSvalue(url)) return url;
 
     //String respresenting true http/https URLs are valid:

--- a/explorer/client/src/utils/objectUtils.ts
+++ b/explorer/client/src/utils/objectUtils.ts
@@ -18,7 +18,6 @@ export function parseImageURL(data: any): string {
         data?.display ||
         data?.contents?.display;
 
-    // When url undefined return blank string:
     if (!url) return '';
 
     if (findIPFSvalue(url)) return url;

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -20,12 +20,15 @@ export const handleCoinType = (str: string): string =>
         ? 'SUI'
         : str.match(/^([a-zA-Z0-9:]*)<([a-zA-Z0-9:]*)>$/)?.[2] || str;
 
+export const findIPFSvalue = (url: string): string | undefined =>
+    url.match(/^ipfs:\/\/(.*)/)?.[1];
+
 export function transformURL(url: string) {
-    const found = url.match(/^ipfs:\/\/(.*)/);
+    const found = findIPFSvalue(url);
     if (!found) {
         return url;
     }
-    return `https://ipfs.io/ipfs/${found[1]}`;
+    return `https://ipfs.io/ipfs/${found}`;
 }
 
 export function truncate(fullStr: string, strLen: number, separator?: string) {


### PR DESCRIPTION
Currently, in the case of the package 0x2, the Sui Explorer attempts to display a non-existant image. 

![image](https://user-images.githubusercontent.com/11377188/176747297-3d39de71-939f-4ef5-8ca7-0f558f2f15b6.png)

This is because the package 0x2 contains a module `url` that confuses the website.

This fix adds checks to ensure that the string associated with URL is ether an IPFS resource or valid URL.

Here is the fix working for 0x2:

![image](https://user-images.githubusercontent.com/11377188/176747599-b216df70-5152-4070-8283-483a6dfc8dba.png)

IPFS resources remain unaffected:
![image](https://user-images.githubusercontent.com/11377188/176747699-e735ea31-3725-4791-8e39-cb291e65ccd3.png)

So do conventional image URLs:
![image](https://user-images.githubusercontent.com/11377188/176748019-fe82f74b-343b-4899-945c-a220fe755d07.png)

