### PR TITLE
Improve fetching of checkpoints and final certs/effects

### DIFF
--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use async_trait::async_trait;
 
-use std::collections::{hash_map, HashMap};
+use std::collections::{hash_map, BTreeSet, HashMap};
 use sui_storage::node_sync_store::NodeSyncStore;
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests, TransactionDigest, TransactionEffectsDigest},
@@ -48,6 +48,16 @@ impl EffectsStakeMap {
             effects_stake_map: HashMap::new(),
             effects_vote_map: HashMap::new(),
         }
+    }
+
+    // Get the set of authorities who voted for a digest.
+    pub fn voters(&self, digest: &TransactionEffectsDigest) -> BTreeSet<AuthorityName> {
+        self.effects_vote_map
+            .get(digest)
+            .unwrap_or(HashMap::new())
+            .iter()
+            .map(|(a, s)| *a)
+            .collect()
     }
 
     /// Note that a given effects digest has been attested by a validator, and return true if the
@@ -330,10 +340,11 @@ where
             let digests = *digests;
             let peer = *peer;
             let node_sync_store = self.node_sync_store.clone();
+            let authorities = self.effects_stake.lock().unwrap().voters(&digests.effects);
             tokio::task::spawn(async move {
-                if let Err(error) =
-                    tx.send(Self::download_impl(peer, aggregator, &digests, node_sync_store).await)
-                {
+                if let Err(error) = tx.send(
+                    Self::download_impl(authorities, aggregator, &digests, node_sync_store).await,
+                ) {
                     error!(?digest, ?peer, ?error, "Could not broadcast cert response");
                 }
             });
@@ -356,29 +367,16 @@ where
     }
 
     async fn download_impl(
-        peer: AuthorityName,
+        authorities: BTreeSet<AuthorityName>,
         aggregator: Arc<AuthorityAggregator<A>>,
         digests: &ExecutionDigests,
         node_sync_store: Arc<NodeSyncStore>,
     ) -> SuiResult {
         let digest = digests.transaction;
 
-        // TODO: should we suggest that we try peer first?
-        let resp = aggregator
-            .handle_transaction_and_effects_info_request(digests)
+        let (cert, effects) = aggregator
+            .handle_transaction_and_effects_info_request(digests, &authorities, None)
             .await?;
-
-        let cert = resp.certified_transaction.ok_or_else(|| {
-            info!(?digest, ?peer, "validator did not return cert");
-            SuiError::GenericAuthorityError {
-                error: format!("validator did not return cert for {:?}", digest),
-            }
-        })?;
-
-        let effects = resp.signed_effects.ok_or_else(|| {
-            info!(?digest, ?peer, "validator did not return effects");
-            SuiError::ByzantineAuthoritySuspicion { authority: peer }
-        })?;
 
         node_sync_store.store_cert_and_effects(&digest, &(cert, effects))?;
 

--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::{broadcast, mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 const NODE_SYNC_QUEUE_LEN: usize = 500;
 
@@ -54,9 +54,9 @@ impl EffectsStakeMap {
     pub fn voters(&self, digest: &TransactionEffectsDigest) -> BTreeSet<AuthorityName> {
         self.effects_vote_map
             .get(digest)
-            .unwrap_or(HashMap::new())
+            .unwrap_or(&HashMap::new())
             .iter()
-            .map(|(a, s)| *a)
+            .map(|(a, _)| *a)
             .collect()
     }
 

--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -55,8 +55,8 @@ impl EffectsStakeMap {
         self.effects_vote_map
             .get(digest)
             .unwrap_or(&HashMap::new())
-            .iter()
-            .map(|(a, _)| *a)
+            .keys()
+            .cloned()
             .collect()
     }
 

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -568,7 +568,10 @@ where
                     },
                 };
             }
-            info!("quorum_once_with_timeout failed on all authorities, retrying");
+            info!(
+                ?authority_errors,
+                "quorum_once_with_timeout failed on all authorities, retrying"
+            );
         }
     }
 

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -9,13 +9,17 @@ use async_trait::async_trait;
 
 use futures::{future, StreamExt};
 use move_core_types::value::MoveStructLayout;
-use sui_types::crypto::{AuthoritySignature, PublicKeyBytes};
+use sui_types::crypto::AuthoritySignature;
 use sui_types::object::{Object, ObjectFormatOptions, ObjectRead};
 use sui_types::{
     base_types::*,
     committee::Committee,
     error::{SuiError, SuiResult},
     messages::*,
+    messages_checkpoint::{
+        AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
+        CheckpointContents, CheckpointRequest, CheckpointResponse,
+    },
 };
 use tracing::{debug, info, instrument, trace, Instrument};
 
@@ -524,6 +528,50 @@ where
         Ok(accumulated_state)
     }
 
+    async fn quorum_once_inner<'a, S, FMap>(
+        &'a self,
+        // try these authorities first
+        preferences: &[AuthorityName],
+        // only attempt from these authorities.
+        restrict_to: Option<&BTreeSet<AuthorityName>>,
+        // The async function used to apply to each authority. It takes an authority name,
+        // and authority client parameter and returns a Result<V>.
+        map_each_authority: FMap,
+        timeout_each_authority: Duration,
+        authority_errors: &mut HashMap<AuthorityName, SuiError>,
+    ) -> Result<S, SuiError>
+    where
+        FMap: Fn(AuthorityName, &'a SafeClient<A>) -> AsyncResult<'a, S, SuiError>,
+        S: Send,
+    {
+        loop {
+            let authorities_shuffled = self.committee.shuffle_by_stake().filter(|a| {
+                // preferences will usually be small so linear search probably ok.
+                !preferences.contains(a) && restrict_to.map(|r| r.contains(a)).unwrap_or(true)
+            });
+
+            let authorities_shuffled = preferences.iter().chain(authorities_shuffled);
+
+            // TODO: possibly increase concurrency after first failure to reduce latency.
+            for name in authorities_shuffled {
+                let client = &self.authority_clients[name];
+
+                let res = timeout(timeout_each_authority, map_each_authority(*name, client)).await;
+
+                match res {
+                    // timeout
+                    Err(_) => authority_errors.insert(*name, SuiError::TimeoutError),
+                    // request completed
+                    Ok(inner_res) => match inner_res {
+                        Err(e) => authority_errors.insert(*name, e),
+                        Ok(res) => return Ok(res),
+                    },
+                };
+            }
+            info!("quorum_once_with_timeout failed on all authorities, retrying");
+        }
+    }
+
     /// Like quorum_map_then_reduce_with_timeout, but for things that need only a single
     /// successful response, such as fetching a Transaction from some authority.
     /// This is intended for cases in which byzantine authorities can time out or slow-loris, but
@@ -531,38 +579,47 @@ where
     /// quorum-signed object such as a checkpoint has been requested.
     pub(crate) async fn quorum_once_with_timeout<'a, S, FMap>(
         &'a self,
+        // try these authorities first
+        preferences: &[AuthorityName],
+        // only attempt from these authorities.
+        restrict_to: Option<&BTreeSet<AuthorityName>>,
         // The async function used to apply to each authority. It takes an authority name,
         // and authority client parameter and returns a Result<V>.
         map_each_authority: FMap,
         timeout_each_authority: Duration,
+        // When to give up on the attempt entirely.
+        timeout_total: Option<Duration>,
     ) -> Result<S, SuiError>
     where
         FMap: Fn(AuthorityName, &'a SafeClient<A>) -> AsyncResult<'a, S, SuiError>,
+        S: Send,
     {
-        let authorities_shuffled = self.committee.shuffle_by_stake();
+        let mut authority_errors = HashMap::new();
 
-        let mut authority_errors: Vec<(AuthorityName, SuiError)> = Vec::new();
+        let fut = self.quorum_once_inner(
+            preferences,
+            restrict_to,
+            map_each_authority,
+            timeout_each_authority,
+            &mut authority_errors,
+        );
 
-        // TODO: possibly increase concurrency after first failure to reduce latency.
-        for name in authorities_shuffled {
-            let client = &self.authority_clients[name];
-
-            let res = timeout(timeout_each_authority, map_each_authority(*name, client)).await;
-
-            match res {
-                // timeout
-                Err(_) => authority_errors.push((*name, SuiError::TimeoutError)),
-                // request completed
-                Ok(inner_res) => match inner_res {
-                    Err(e) => authority_errors.push((*name, e)),
-                    Ok(_) => return inner_res,
-                },
-            }
+        if let Some(t) = timeout_total {
+            timeout(t, fut).await.map_err(|_timeout_error| {
+                if authority_errors.is_empty() {
+                    SuiError::TimeoutError
+                } else {
+                    SuiError::TooManyIncorrectAuthorities {
+                        errors: authority_errors
+                            .iter()
+                            .map(|(a, b)| (*a, b.clone()))
+                            .collect(),
+                    }
+                }
+            })?
+        } else {
+            fut.await
         }
-
-        Err(SuiError::TooManyIncorrectAuthorities {
-            errors: authority_errors,
-        })
     }
 
     /// Return all the information in the network regarding the latest state of a specific object.
@@ -1411,7 +1468,7 @@ where
     /// The object ids are also returned so the caller can determine which fetches failed
     /// NOTE: This function assumes all authorities are honest
     async fn fetch_one_object(
-        authority_clients: BTreeMap<PublicKeyBytes, SafeClient<A>>,
+        authority_clients: BTreeMap<AuthorityName, SafeClient<A>>,
         object_ref: ObjectRef,
         timeout: Duration,
         sender: tokio::sync::mpsc::Sender<Result<Object, SuiError>>,
@@ -1458,20 +1515,85 @@ where
             .expect("Cannot send object on channel after object fetch attempt");
     }
 
+    pub async fn handle_checkpoint_request(
+        &self,
+        request: &CheckpointRequest,
+        // authorities known to have the checkpoint we are requesting.
+        authorities: &BTreeSet<AuthorityName>,
+        timeout_total: Option<Duration>,
+    ) -> SuiResult<CheckpointResponse> {
+        self.quorum_once_with_timeout(
+            &[],
+            Some(authorities),
+            |authority, client| {
+                Box::pin(async move { client.handle_checkpoint(request.clone()).await })
+            },
+            self.timeouts.serial_authority_request_timeout,
+            timeout_total,
+        )
+        .await
+    }
+
+    pub async fn get_certified_checkpoint(
+        &self,
+        request: &CheckpointRequest,
+        // authorities known to have the checkpoint we are requesting.
+        authorities: &BTreeSet<AuthorityName>,
+        timeout_total: Option<Duration>,
+    ) -> SuiResult<(CertifiedCheckpointSummary, Option<CheckpointContents>)> {
+        self.quorum_once_with_timeout(
+            &[],
+            Some(authorities),
+            |authority, client| {
+                Box::pin(async move {
+                    let resp = client.handle_checkpoint(request.clone()).await?;
+
+                    if let CheckpointResponse {
+                        info:
+                            AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Certified(past)),
+                        detail,
+                    } = resp
+                    {
+                        Ok((past, detail))
+                    } else {
+                        Err(SuiError::GenericAuthorityError {
+                            error: "expected Certified checkpoint".into(),
+                        })
+                    }
+                })
+            },
+            self.timeouts.serial_authority_request_timeout,
+            timeout_total,
+        )
+        .await
+    }
+
     pub async fn handle_transaction_and_effects_info_request(
         &self,
         digests: &ExecutionDigests,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+        // authorities known to have the effects we are requesting.
+        authorities: &BTreeSet<AuthorityName>,
+        timeout_total: Option<Duration>,
+    ) -> SuiResult<(CertifiedTransaction, SignedTransactionEffects)> {
         self.quorum_once_with_timeout(
-            |_name, client| {
+            &[],
+            Some(authorities),
+            |authority, client| {
                 Box::pin(async move {
-                    client
+                    let resp = client
                         .handle_transaction_and_effects_info_request(digests)
-                        .await
+                        .await?;
+
+                    match (resp.certified_transaction, resp.signed_effects) {
+                        (Some(cert), Some(effects)) => Ok((cert, effects)),
+                        // The caller is passing in authorities that have claimed to have the cert and
+                        // effects, so if they now say they don't, they're byzantine.
+                        _ => Err(SuiError::ByzantineAuthoritySuspicion { authority }),
+                    }
                 })
             },
-            // A long timeout before we hear back from a quorum
             self.timeouts.serial_authority_request_timeout,
+            timeout_total,
         )
         .await
     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1528,9 +1528,7 @@ where
         self.quorum_once_with_timeout(
             &[],
             Some(authorities),
-            |authority, client| {
-                Box::pin(async move { client.handle_checkpoint(request.clone()).await })
-            },
+            |_, client| Box::pin(async move { client.handle_checkpoint(request.clone()).await }),
             self.timeouts.serial_authority_request_timeout,
             timeout_total,
         )
@@ -1547,7 +1545,7 @@ where
         self.quorum_once_with_timeout(
             &[],
             Some(authorities),
-            |authority, client| {
+            |_, client| {
                 Box::pin(async move {
                     let resp = client.handle_checkpoint(request.clone()).await?;
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -8,8 +8,8 @@ use signature::Signer;
 
 use sui_adapter::genesis;
 use sui_config::genesis::Genesis;
-use sui_types::crypto::get_key_pair;
 use sui_types::crypto::Signature;
+use sui_types::crypto::{get_key_pair, PublicKeyBytes};
 
 use sui_types::messages::Transaction;
 use sui_types::object::{Object, GAS_VALUE_FOR_TESTING};


### PR DESCRIPTION
Both of these structures are things where the requester knows which authorities have them, so we can be quite strict about refusing responses that claim not to have them.

These requests also never time out, they keep trying the committee until they get a good response. As long as the <= f assumption holds the requests must finish eventually.

(Happy to put long but finite timeouts on them if we feel better about that)