### PR TITLE
wallet-ext: add hasPermissions and requestPermissions to dapp interface

### DIFF
--- a/wallet/src/background/Permissions.ts
+++ b/wallet/src/background/Permissions.ts
@@ -27,7 +27,7 @@ class Permissions {
     private _permissionResponses: Subject<PermissionResponse> = new Subject();
 
     public async acquirePermissions(
-        permissionTypes: PermissionType[],
+        permissionTypes: readonly PermissionType[],
         connection: ContentScriptConnection
     ): Promise<Permission> {
         const { origin } = connection;
@@ -127,7 +127,7 @@ class Permissions {
 
     public async hasPermissions(
         origin: string,
-        permissionTypes: PermissionType[],
+        permissionTypes: readonly PermissionType[],
         permission?: Permission | null
     ): Promise<boolean> {
         const existingPermission = await this.getPermission(origin, permission);
@@ -142,7 +142,7 @@ class Permissions {
 
     private async createPermissionRequest(
         origin: string,
-        permissionTypes: PermissionType[],
+        permissionTypes: readonly PermissionType[],
         favIcon: string | undefined,
         existingPermission?: Permission | null
     ): Promise<Permission> {
@@ -164,7 +164,7 @@ class Permissions {
                 createdDate: new Date().toISOString(),
                 origin,
                 favIcon,
-                permissions: permissionTypes,
+                permissions: permissionTypes as PermissionType[],
                 responseDate: null,
             };
         }

--- a/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -8,7 +8,11 @@ export type PayloadType =
     | 'permission-response'
     | 'get-permission-requests'
     | 'get-account'
-    | 'get-account-response';
+    | 'get-account-response'
+    | 'has-permissions-request'
+    | 'has-permissions-response'
+    | 'acquire-permissions-request'
+    | 'acquire-permissions-response';
 
 export interface BasePayload {
     type: PayloadType;

--- a/wallet/src/shared/messaging/messages/payloads/permissions/AcquirePermissionsRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/AcquirePermissionsRequest.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { PermissionType } from './PermissionType';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface AcquirePermissionsRequest extends BasePayload {
+    type: 'acquire-permissions-request';
+    permissions: readonly PermissionType[];
+}
+
+export function isAcquirePermissionsRequest(
+    payload: Payload
+): payload is AcquirePermissionsRequest {
+    return (
+        isBasePayload(payload) && payload.type === 'acquire-permissions-request'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/permissions/AcquirePermissionsResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/AcquirePermissionsResponse.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface AcquirePermissionsResponse extends BasePayload {
+    type: 'acquire-permissions-response';
+    result: boolean;
+}
+
+export function isAcquirePermissionsResponse(
+    payload: Payload
+): payload is AcquirePermissionsResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'acquire-permissions-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/permissions/HasPermissionsRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/HasPermissionsRequest.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { PermissionType } from './PermissionType';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface HasPermissionsRequest extends BasePayload {
+    type: 'has-permissions-request';
+    permissions: readonly PermissionType[];
+}
+
+export function isHasPermissionRequest(
+    payload: Payload
+): payload is HasPermissionsRequest {
+    return isBasePayload(payload) && payload.type === 'has-permissions-request';
+}

--- a/wallet/src/shared/messaging/messages/payloads/permissions/HasPermissionsResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/HasPermissionsResponse.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface HasPermissionsResponse extends BasePayload {
+    type: 'has-permissions-response';
+    result: boolean;
+}
+
+export function isHasPermissionResponse(
+    payload: Payload
+): payload is HasPermissionsResponse {
+    return (
+        isBasePayload(payload) && payload.type === 'has-permissions-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
@@ -1,4 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export type PermissionType = 'viewAccount' | 'suggestTransactions';
+export const ALL_PERMISSION_TYPES = [
+    'viewAccount',
+    'suggestTransactions',
+] as const;
+type AllPermissionsType = typeof ALL_PERMISSION_TYPES;
+export type PermissionType = AllPermissionsType[number];

--- a/wallet/src/shared/messaging/messages/payloads/permissions/index.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/index.ts
@@ -6,3 +6,7 @@ export * from './PermissionRequests';
 export * from './PermissionResponse';
 export * from './PermissionType';
 export * from './Permission';
+export * from './HasPermissionsRequest';
+export * from './HasPermissionsResponse';
+export * from './AcquirePermissionsRequest';
+export * from './AcquirePermissionsResponse';


### PR DESCRIPTION
* `hasPermissions` to check for permissions (no user interaction)
* `requestPermissions` asks the user to give the requested permissions
* `getAccounts` now fails when missing the required permissions (it doesn't prompt the user to allow permissions)

closes: #2728 