### PR TITLE
wallet-ext: check has_public_transfer

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -245,7 +245,8 @@ export function isSuiMoveObject(obj: any, _argumentName?: string): obj is SuiMov
             typeof obj === "object" ||
             typeof obj === "function") &&
         isTransactionDigest(obj.type) as boolean &&
-        isObjectContentFields(obj.fields) as boolean
+        isObjectContentFields(obj.fields) as boolean &&
+        typeof obj.has_public_transfer === "boolean"
     )
 }
 

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -33,6 +33,7 @@ export type SuiMoveObject = {
   type: string;
   /** Fields and values stored inside the Move object */
   fields: ObjectContentFields;
+  has_public_transfer: boolean;
 };
 
 export type SuiMovePackage = {
@@ -164,6 +165,12 @@ export function getMoveObject(
     return undefined;
   }
   return suiObject.data as SuiMoveObject;
+}
+
+export function hasPublicTransfer(
+  data: GetObjectDataResponse | SuiObject
+): boolean {
+  return getMoveObject(data)?.has_public_transfer ?? false;
 }
 
 export function getMovePackageContent(

--- a/wallet/src/ui/app/components/sui-object/index.tsx
+++ b/wallet/src/ui/app/components/sui-object/index.tsx
@@ -1,7 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isSuiMoveObject, isSuiMovePackage } from '@mysten/sui.js';
+import {
+    hasPublicTransfer,
+    isSuiMoveObject,
+    isSuiMovePackage,
+} from '@mysten/sui.js';
 import cl from 'classnames';
 import { memo, useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -18,10 +22,9 @@ import st from './SuiObject.module.scss';
 
 export type SuiObjectProps = {
     obj: SuiObjectType;
-    sendNFT?: boolean;
 };
 
-function SuiObject({ obj, sendNFT }: SuiObjectProps) {
+function SuiObject({ obj }: SuiObjectProps) {
     const { objectId } = obj.reference;
     const shortId = useMiddleEllipsis(objectId);
     const objType =
@@ -31,6 +34,7 @@ function SuiObject({ obj, sendNFT }: SuiObjectProps) {
     const suiMoveObjectFields = isSuiMoveObject(obj.data)
         ? obj.data.fields
         : null;
+    const sendNFT = hasPublicTransfer(obj);
 
     const sendUrl = useMemo(
         () => `/send-nft?${new URLSearchParams({ objectId }).toString()}`,

--- a/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -11,11 +11,7 @@ function NftsPage() {
     return (
         <ObjectsLayout totalItems={nfts.length} emptyMsg="No NFTs found">
             {nfts.map((anNft) => (
-                <SuiObject
-                    obj={anNft}
-                    sendNFT={true}
-                    key={anNft.reference.objectId}
-                />
+                <SuiObject obj={anNft} key={anNft.reference.objectId} />
             ))}
         </ObjectsLayout>
     );


### PR DESCRIPTION
Some NFT cannot be transferred out of box, therefore we should check this when we render the transfer button
non-transferable:
![CleanShot 2022-06-30 at 16 38 31](https://user-images.githubusercontent.com/76067158/176795863-0b97b4f1-6d2c-4dc4-a779-83c843d7f178.png)
transferable:
![CleanShot 2022-06-30 at 16 36 13](https://user-images.githubusercontent.com/76067158/176795870-65931f44-911b-427f-8e7e-6320ddc8c82b.png)
