### PR TITLE
Do not print object content in gateway debug info

### DIFF
--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -410,7 +410,8 @@ where
             .download_object_from_authorities(*object_id)
             .await?
             .into_object()?;
-        debug!(?object_id, ?object, "Fetched object from validators");
+        let obj_ref = object.compute_object_reference();
+        debug!(?object_id, ?obj_ref, "Fetched object from validators");
         Ok(object)
     }
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -611,3 +611,19 @@ impl Default for ObjectFormatOptions {
         }
     }
 }
+
+impl Display for ObjectRead {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Deleted(oref) => {
+                write!(f, "ObjectRead::Deleted ({:?})", oref)
+            }
+            Self::NotExists(id) => {
+                write!(f, "ObjectRead::NotExists ({:?})", id)
+            }
+            Self::Exists(oref, _, _) => {
+                write!(f, "ObjectRead::Exists ({:?})", oref)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Printing out object content in debug is too verbose.