### PR TITLE
include a validator's delegated stake in committee

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -97,6 +97,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                 ValidatorInfo {
                     public_key,
                     stake,
+                    delegation: 0, // no delegation yet at genesis
                     network_address,
                 }
             })

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -45,12 +45,10 @@ impl Genesis {
     }
 
     pub fn committee(&self) -> SuiResult<Committee> {
-        let voting_rights = self
-            .validator_set()
-            .iter()
-            .map(|validator| (validator.public_key(), validator.stake()))
-            .collect();
-        Committee::new(self.epoch(), voting_rights)
+        Committee::new(
+            self.epoch(),
+            ValidatorInfo::voting_rights(self.validator_set()),
+        )
     }
 
     pub fn get_default_genesis() -> Self {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -10,6 +10,7 @@ use narwhal_config::Parameters as ConsensusParameters;
 use narwhal_config::SharedCommittee as ConsensusCommittee;
 use narwhal_crypto::ed25519::Ed25519PublicKey;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -139,6 +140,7 @@ impl ConsensusConfig {
 pub struct ValidatorInfo {
     pub public_key: PublicKeyBytes,
     pub stake: StakeUnit,
+    pub delegation: StakeUnit,
     pub network_address: Multiaddr,
 }
 
@@ -155,8 +157,24 @@ impl ValidatorInfo {
         self.stake
     }
 
+    pub fn delegation(&self) -> StakeUnit {
+        self.delegation
+    }
+
     pub fn network_address(&self) -> &Multiaddr {
         &self.network_address
+    }
+
+    pub fn voting_rights(validator_set: &[Self]) -> BTreeMap<PublicKeyBytes, u64> {
+        validator_set
+            .iter()
+            .map(|validator| {
+                (
+                    validator.public_key(),
+                    validator.stake() + validator.delegation(),
+                )
+            })
+            .collect()
     }
 }
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -100,7 +100,7 @@ where
                 (
                     PublicKeyBytes::try_from(metadata.pubkey_bytes.as_ref())
                         .expect("Validity of public key bytes should be verified on-chain"),
-                    metadata.next_epoch_stake,
+                    metadata.next_epoch_stake + metadata.next_epoch_delegation,
                 )
             })
             .collect();

--- a/crates/sui-gateway/src/config.rs
+++ b/crates/sui-gateway/src/config.rs
@@ -95,12 +95,10 @@ impl Config for GatewayConfig {}
 
 impl GatewayConfig {
     pub fn make_committee(&self) -> SuiResult<Committee> {
-        let voting_rights = self
-            .validator_set
-            .iter()
-            .map(|validator| (validator.public_key(), validator.stake()))
-            .collect();
-        Committee::new(self.epoch, voting_rights)
+        Committee::new(
+            self.epoch,
+            ValidatorInfo::voting_rights(&self.validator_set),
+        )
     }
 
     pub fn make_authority_clients(&self) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -38,6 +38,7 @@ pub struct ValidatorMetadata {
     pub name: Vec<u8>,
     pub net_address: Vec<u8>,
     pub next_epoch_stake: u64,
+    pub next_epoch_delegation: u64,
 }
 
 /// Rust version of the Move sui::validator::Validator type

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -114,6 +114,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
             validator_set: vec![ValidatorInfo {
                 public_key: *get_key_pair().1.public_key_bytes(),
                 stake: 1,
+                delegation: 1,
                 network_address: "/dns/localhost/tcp/8080/http".parse().unwrap(),
             }],
             ..Default::default()

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -67,11 +67,7 @@ pub fn test_authority_aggregator(
     config: &NetworkConfig,
 ) -> AuthorityAggregator<NetworkAuthorityClient> {
     let validators_info = config.validator_set();
-    let voting_rights: BTreeMap<_, _> = validators_info
-        .iter()
-        .map(|config| (config.public_key(), config.stake()))
-        .collect();
-    let committee = Committee::new(0, voting_rights).unwrap();
+    let committee = Committee::new(0, ValidatorInfo::voting_rights(validators_info)).unwrap();
     let clients: BTreeMap<_, _> = validators_info
         .iter()
         .map(|config| {


### PR DESCRIPTION
Right now only the validator's stake is included in voting rights while the committee is formed. This PR makes sure that the validator's delegated stake is also included.