### PR TITLE
Add missing tx_guard.release

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -518,6 +518,7 @@ impl AuthorityState {
         let transaction_digest = *certificate.digest();
 
         if self.halted.load(Ordering::SeqCst) && !certificate.data.kind.is_system_tx() {
+            tx_guard.release();
             // TODO: Do we want to include the new validator set?
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }


### PR DESCRIPTION
Curious, why we don't just call `tx_guard.release` in `drop`? 