### PR TITLE
Merge `handle_confirmation_transaction` and `handle_consensus_transaction`

### DIFF
--- a/crates/sui-benchmark/src/benchmark/load_generator.rs
+++ b/crates/sui-benchmark/src/benchmark/load_generator.rs
@@ -61,7 +61,7 @@ pub async fn send_tx_chunks(
                     .await
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
                 let resp2 = client
-                    .handle_confirmation_transaction(ConfirmationTransaction { certificate })
+                    .handle_certificate(certificate)
                     .await
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
                 resps.push(resp1);
@@ -138,7 +138,7 @@ pub async fn send_confs(
             let mut resps = Vec::new();
             for certificate in txns {
                 let resp = client
-                    .handle_confirmation_transaction(ConfirmationTransaction { certificate })
+                    .handle_certificate(certificate)
                     .await
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
                 resps.push(resp);

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
-use sui_types::messages::{ConfirmationTransaction, ExecutionStatus};
+use sui_types::messages::ExecutionStatus;
 
 use crate::checkpoints::checkpoint_tests::checkpoint_tests_setup;
 
@@ -143,7 +143,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
             let client: SafeClient<LocalAuthorityClient> =
                 sender_aggregator.authority_clients[sample_authority].clone();
             let _response = client
-                .handle_confirmation_transaction(ConfirmationTransaction::new(new_certificate))
+                .handle_certificate(new_certificate)
                 .await
                 .expect("Problem processing certificate");
 
@@ -237,7 +237,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
             let client: SafeClient<LocalAuthorityClient> =
                 sender_aggregator.authority_clients[sample_authority].clone();
             let _response = client
-                .handle_confirmation_transaction(ConfirmationTransaction::new(new_certificate))
+                .handle_certificate(new_certificate)
                 .await
                 .expect("Problem processing certificate");
 

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -9,7 +9,7 @@ use typed_store::Map;
 use crate::authority::AuthorityStore;
 use crate::authority_client::AuthorityAPI;
 
-use super::{gossip::LocalConfirmationTransactionHandler, ActiveAuthority};
+use super::{gossip::LocalCertificateHandler, ActiveAuthority};
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -94,7 +94,7 @@ where
         .map(|((i, d), c)| (i, d, c.as_ref().expect("certificate must exist")))
         .collect();
 
-    let local_handler = LocalConfirmationTransactionHandler {
+    let local_handler = LocalCertificateHandler {
         state: active_authority.state.clone(),
     };
 
@@ -111,7 +111,7 @@ where
 
         // Sync and Execute with local authority state
         net.sync_certificate_to_authority_with_timeout_inner(
-            sui_types::messages::ConfirmationTransaction::new(c.clone()),
+            c.clone(),
             active_authority.state.name,
             &local_handler,
             tokio::time::Duration::from_secs(10),

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -21,8 +21,8 @@ use sui_types::crypto::{get_key_pair, KeyPair, PublicKeyBytes};
 use sui_types::error::SuiError;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    ConfirmationTransaction, ConsensusTransaction, ObjectInfoRequest, ObjectInfoResponse,
-    Transaction, TransactionInfoRequest, TransactionInfoResponse,
+    CertifiedTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
+    TransactionInfoRequest, TransactionInfoResponse,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::Object;
@@ -103,23 +103,12 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
         state.handle_transaction(transaction).await
     }
 
-    async fn handle_confirmation_transaction(
+    async fn handle_certificate(
         &self,
-        transaction: ConfirmationTransaction,
+        certificate: CertifiedTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let state = self.state.clone();
-        state.handle_confirmation_transaction(transaction).await
-    }
-
-    async fn handle_consensus_transaction(
-        &self,
-        _transaction: ConsensusTransaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        Ok(TransactionInfoResponse {
-            signed_transaction: None,
-            certified_transaction: None,
-            signed_effects: None,
-        })
+        state.handle_certificate(certificate).await
     }
 
     async fn handle_account_info_request(

--- a/crates/sui-core/src/authority_active/gossip/node_sync.rs
+++ b/crates/sui-core/src/authority_active/gossip/node_sync.rs
@@ -305,7 +305,7 @@ where
         }
 
         self.state
-            .handle_node_sync_transaction(cert, effects)
+            .handle_node_sync_certificate(cert, effects)
             .await?;
 
         // Garbage collect data for this tx.

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::authority::AuthorityState;
+
 use crate::checkpoints::CheckpointLocals;
 use crate::checkpoints::ConsensusSender;
 use bytes::Bytes;
@@ -16,13 +16,12 @@ use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     hash::{Hash, Hasher},
 };
-use sui_types::messages::ConfirmationTransaction;
 use sui_types::messages_checkpoint::CheckpointFragment;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::{
     committee::Committee,
     error::{SuiError, SuiResult},
-    messages::{ConsensusTransaction, TransactionInfoResponse},
+    messages::ConsensusTransaction,
 };
 use tokio::{
     sync::{
@@ -67,8 +66,6 @@ type ConsensusOutput = (
 
 /// Submit Sui certificates to the consensus.
 pub struct ConsensusAdapter {
-    /// The authority's state.
-    state: Arc<AuthorityState>,
     /// The network client connecting to the consensus node of this authority.
     consensus_client: TransactionsClient<sui_network::tonic::transport::Channel>,
     /// The Sui committee information.
@@ -84,7 +81,6 @@ pub struct ConsensusAdapter {
 impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
-        state: Arc<AuthorityState>,
         consensus_address: Multiaddr,
         committee: Committee,
         tx_consensus_listener: Sender<ConsensusListenerMessage>,
@@ -95,7 +91,6 @@ impl ConsensusAdapter {
                 .expect("Failed to connect to consensus"),
         );
         Self {
-            state,
             consensus_client,
             committee,
             tx_consensus_listener,
@@ -110,10 +105,7 @@ impl ConsensusAdapter {
     }
 
     /// Submit a transaction to consensus, wait for its processing, and notify the caller.
-    pub async fn submit(
-        &self,
-        certificate: &ConsensusTransaction,
-    ) -> SuiResult<TransactionInfoResponse> {
+    pub async fn submit(&self, certificate: &ConsensusTransaction) -> SuiResult {
         // Check the Sui certificate (submitted by the user).
         certificate.verify(&self.committee)?;
 
@@ -144,8 +136,8 @@ impl ConsensusAdapter {
         // certificate will be sequenced. So the best we can do is to set a timer and notify the
         // client to retry if we timeout without hearing back from consensus (this module does not
         // handle retries). The best timeout value depends on the consensus protocol.
-        let info = match timeout(self.max_delay, receiver).await {
-            Ok(reply) => reply.expect("Failed to read back from consensus listener"),
+        match timeout(self.max_delay, receiver).await {
+            Ok(_) => Ok(()),
             Err(e) => {
                 let message = ConsensusListenerMessage::Cleanup(serialized);
                 self.tx_consensus_listener
@@ -154,28 +146,6 @@ impl ConsensusAdapter {
                     .expect("Cleanup channel with consensus listener dropped");
                 Err(SuiError::FailedToHearBackFromConsensus(e.to_string()))
             }
-        }?;
-
-        if info.is_empty() {
-            // Consensus successfully assigned shared-locks to this certificate.
-            match certificate {
-                ConsensusTransaction::UserTransaction(certificate) => {
-                    let confirmation = ConfirmationTransaction {
-                        certificate: *certificate.clone(),
-                    };
-                    self.state
-                        .handle_confirmation_transaction(confirmation)
-                        .await
-                }
-                message => {
-                    tracing::error!("Unexpected message {message:?}");
-                    Err(SuiError::UnexpectedMessage)
-                }
-            }
-        } else {
-            // This certificate has already been executed.
-            bincode::deserialize(&info)
-                .map_err(|e| SuiError::ConsensusSuiSerializationError(e.to_string()))
         }
     }
 }

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -14,7 +14,7 @@ use sui_network::tonic;
 use sui_types::committee::Committee;
 use sui_types::crypto::PublicKeyBytes;
 use sui_types::error::{SuiError, SuiResult};
-use sui_types::messages::{ConfirmationTransaction, SignedTransaction};
+use sui_types::messages::SignedTransaction;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::sui_system_state::SuiSystemState;
 use typed_store::Map;
@@ -146,7 +146,7 @@ where
                 .await
             {
                 self.state
-                    .handle_confirmation_transaction(ConfirmationTransaction { certificate })
+                    .handle_certificate(certificate)
                     .await
                     .expect("Executing the special cert cannot fail");
                 break;

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -15,7 +15,7 @@ use sui_types::{
     crypto::{get_key_pair, AuthoritySignature, Signature},
     error::SuiError,
     gas::SuiGasStatus,
-    messages::{ConfirmationTransaction, SignatureAggregator, Transaction, TransactionData},
+    messages::{SignatureAggregator, Transaction, TransactionData},
     object::Object,
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
@@ -119,9 +119,7 @@ async fn test_start_epoch_change() {
     let certificate = cert.unwrap();
     assert_eq!(
         state
-            .handle_confirmation_transaction(ConfirmationTransaction {
-                certificate: certificate.clone()
-            })
+            .handle_certificate(certificate.clone())
             .await
             .unwrap_err(),
         SuiError::ValidatorHaltedAtEpochEnd

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -309,15 +309,15 @@ where
         Ok(transaction_info)
     }
 
-    /// Confirm a transfer to a Sui or Primary account.
-    pub async fn handle_confirmation_transaction(
+    /// Execute a certificate.
+    pub async fn handle_certificate(
         &self,
-        transaction: ConfirmationTransaction,
+        certificate: CertifiedTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let digest = *transaction.certificate.digest();
+        let digest = *certificate.digest();
         let transaction_info = self
             .authority_client
-            .handle_confirmation_transaction(transaction)
+            .handle_certificate(certificate)
             .await?;
 
         if let Err(err) = self.check_transaction_response(digest, None, &transaction_info) {
@@ -325,16 +325,6 @@ where
             return Err(err);
         }
         Ok(transaction_info)
-    }
-
-    pub async fn handle_consensus_transaction(
-        &self,
-        transaction: ConsensusTransaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        // TODO: Add safety checks on the response.
-        self.authority_client
-            .handle_consensus_transaction(transaction)
-            .await
     }
 
     pub async fn handle_account_info_request(

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -293,7 +293,7 @@ where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
     authority
-        .handle_confirmation_transaction(ConfirmationTransaction::new(cert.clone()))
+        .handle_certificate(cert.clone())
         .await
         .unwrap()
         .signed_effects
@@ -305,9 +305,7 @@ pub async fn do_cert_configurable<A>(authority: &A, cert: &CertifiedTransaction)
 where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
-    let result = authority
-        .handle_confirmation_transaction(ConfirmationTransaction::new(cert.clone()))
-        .await;
+    let result = authority.handle_certificate(cert.clone()).await;
     if result.is_err() {
         println!("Error in do cert {:?}", result.err());
     }

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -24,8 +24,8 @@ use std::fs;
 use std::sync::Arc;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    ConfirmationTransaction, ConsensusTransaction, ObjectInfoRequest, ObjectInfoResponse,
-    Transaction, TransactionInfoRequest, TransactionInfoResponse,
+    CertifiedTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
+    TransactionInfoRequest, TransactionInfoResponse,
 };
 use sui_types::object::Object;
 
@@ -505,20 +505,9 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         })
     }
 
-    async fn handle_confirmation_transaction(
+    async fn handle_certificate(
         &self,
-        _transaction: ConfirmationTransaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        Ok(TransactionInfoResponse {
-            signed_transaction: None,
-            certified_transaction: None,
-            signed_effects: None,
-        })
-    }
-
-    async fn handle_consensus_transaction(
-        &self,
-        _transaction: ConsensusTransaction,
+        _certificate: CertifiedTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         Ok(TransactionInfoResponse {
             signed_transaction: None,
@@ -631,20 +620,9 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         })
     }
 
-    async fn handle_confirmation_transaction(
+    async fn handle_certificate(
         &self,
-        _transaction: ConfirmationTransaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        Ok(TransactionInfoResponse {
-            signed_transaction: None,
-            certified_transaction: None,
-            signed_effects: None,
-        })
-    }
-
-    async fn handle_consensus_transaction(
-        &self,
-        _transaction: ConsensusTransaction,
+        _certificate: CertifiedTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         Ok(TransactionInfoResponse {
             signed_transaction: None,

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -151,7 +151,6 @@ async fn submit_transaction_to_consensus() {
 
     // Make a new consensus submitter instance.
     let submitter = ConsensusAdapter::new(
-        state_guard.clone(),
         consensus_address.clone(),
         committee,
         tx_consensus_listener,

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -30,18 +30,9 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
-                .name("confirmation_transaction")
-                .route_name("ConfirmationTransaction")
+                .name("handle_certificate")
+                .route_name("CertifiedTransaction")
                 .input_type("sui_types::messages::CertifiedTransaction")
-                .output_type("sui_types::messages::TransactionInfoResponse")
-                .codec_path(codec_path)
-                .build(),
-        )
-        .method(
-            Method::builder()
-                .name("consensus_transaction")
-                .route_name("ConsensusTransaction")
-                .input_type("sui_types::messages::ConsensusTransaction")
                 .output_type("sui_types::messages::TransactionInfoResponse")
                 .codec_path(codec_path)
                 .build(),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -772,11 +772,6 @@ impl PartialEq for SignedTransaction {
 
 pub type CertifiedTransaction = TransactionEnvelope<AuthorityStrongQuorumSignInfo>;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ConfirmationTransaction {
-    pub certificate: CertifiedTransaction,
-}
-
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct AccountInfoRequest {
     pub account: SuiAddress,
@@ -1340,12 +1335,6 @@ impl Display for CertifiedTransaction {
         )?;
         write!(writer, "{}", &self.data.kind)?;
         write!(f, "{}", writer)
-    }
-}
-
-impl ConfirmationTransaction {
-    pub fn new(certificate: CertifiedTransaction) -> Self {
-        Self { certificate }
     }
 }
 


### PR DESCRIPTION
The AuthorityAPI provides two separate interfaces for handling shared object transactions and single-writer object transactions. This is error-prone: we must be careful when sending a transaction, always need to check the nature of the transaction. This is unnecessary complexity. For instance, I already found a place in authority_aggregator where we forgot to check.
This PR merges these two APIs into one: `handle_certificate`.
This leads to a lot of refactoring, but the core of this change is in the following 3 files:
1. auithority_server.rs: This is where we merge the two functions. Please review carefully to make sure I am not missing anything.
2. consensus_adapter.rs: Previously, when we submit a transaction to consensus, we also attempt to execute it after hearing back from consensus. This makes things unnecessarily complex and hard to reason about. This PR removes the execution part. The caller of submit will be responsible for executing it. Also ended up removing `state` from consensus adaptor fields.
3. authority.rs: Get rid of try_skip_consensus, as we now do the checks in authority_server. A few cleanups.

Also ended up getting rid of ConfirmationTransaction, as it's no longer needed after this change.