### PR TITLE
[Move CLI] Added support for creating packages (includes Move version Bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3319,12 +3319,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "difference",
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3465,7 +3465,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3536,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3588,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "hex",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "hex",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3711,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3765,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "log",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "once_cell",
  "serde 1.0.137",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "better_any",
  "fail",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5262,7 +5262,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5277,7 +5277,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
+source = "git+https://github.com/move-language/move?rev=95999a9818091e382fb1c6016e68829f1dfc3127#95999a9818091e382fb1c6016e68829f1dfc3127"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3319,12 +3319,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "difference",
@@ -3436,7 +3436,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3465,7 +3465,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3500,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3536,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -3588,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "hex",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "hex",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3711,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3750,7 +3750,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3765,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -3809,8 +3809,8 @@ dependencies = [
 
 [[package]]
 name = "move-stdlib"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+version = "0.1.1"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "log",
@@ -3832,7 +3832,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "once_cell",
  "serde 1.0.137",
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "clap 3.1.18",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "better_any",
  "fail",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5262,7 +5262,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5277,7 +5277,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae#ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae"
+source = "git+https://github.com/awelc/move?rev=8a5950f256b6d558b4dee1844a561e8ddd146432#8a5950f256b6d558b4dee1844a561e8ddd146432"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/crates/generate-json-rpc-spec/Cargo.toml
+++ b/crates/generate-json-rpc-spec/Cargo.toml
@@ -24,4 +24,4 @@ sui-config = { path = "../sui-config" }
 test-utils = { path = "../test-utils" }
 workspace-hack = { path = "../workspace-hack"}
 
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }

--- a/crates/generate-json-rpc-spec/Cargo.toml
+++ b/crates/generate-json-rpc-spec/Cargo.toml
@@ -24,4 +24,4 @@ sui-config = { path = "../sui-config" }
 test-utils = { path = "../test-utils" }
 workspace-hack = { path = "../workspace-hack"}
 
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -12,9 +12,9 @@ anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
 once_cell = "1.11.0"
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 sui-framework = { path = "../sui-framework" }
 sui-verifier = { path = "../sui-verifier" }
@@ -22,4 +22,4 @@ sui-types = { path = "../sui-types" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -12,9 +12,9 @@ anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
 once_cell = "1.11.0"
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 sui-framework = { path = "../sui-framework" }
 sui-verifier = { path = "../sui-verifier" }
@@ -22,4 +22,4 @@ sui-types = { path = "../sui-types" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -30,7 +30,7 @@ sui-core = { path = "../sui-core" }
 sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }
 
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
 narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "node" }
 
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -30,7 +30,7 @@ sui-core = { path = "../sui-core" }
 sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
 narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "node" }
 
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -21,8 +21,8 @@ tracing = "0.1.34"
 
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "config" }
 narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "crypto" }
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 sui-framework = { path = "../sui-framework" }
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -21,8 +21,8 @@ tracing = "0.1.34"
 
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "config" }
 narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "crypto" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 sui-framework = { path = "../sui-framework" }
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -38,10 +38,10 @@ sui-config = { path = "../sui-config" }
 sui-json = { path = "../sui-json" }
 sui-json-rpc-api = { path = "../sui-json-rpc-api" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4"}
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
@@ -54,7 +54,7 @@ workspace-hack = { path = "../workspace-hack"}
 [dev-dependencies]
 clap = { version = "3.1.17", features = ["derive"] }
 rand = "0.7.3"
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.23"

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -38,10 +38,10 @@ sui-config = { path = "../sui-config" }
 sui-json = { path = "../sui-json" }
 sui-json-rpc-api = { path = "../sui-json-rpc-api" }
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4"}
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
@@ -54,7 +54,7 @@ workspace-hack = { path = "../workspace-hack"}
 [dev-dependencies]
 clap = { version = "3.1.17", features = ["derive"] }
 rand = "0.7.3"
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.23"

--- a/crates/sui-framework-build/Cargo.toml
+++ b/crates/sui-framework-build/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../../crates/sui-verifier" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-framework-build/Cargo.toml
+++ b/crates/sui-framework-build/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../../crates/sui-verifier" }
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -17,14 +17,14 @@ once_cell = "1.11.0"
 sui-types = { path = "../sui-types" }
 sui-framework-build = { path = "../sui-framework-build" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-cli = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 workspace-hack = { path = "../workspace-hack"}
 
@@ -32,8 +32,8 @@ workspace-hack = { path = "../workspace-hack"}
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
 sui-framework-build = { path = "../sui-framework-build" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["move-cli", "move-unit-test"]

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -17,14 +17,14 @@ once_cell = "1.11.0"
 sui-types = { path = "../sui-types" }
 sui-framework-build = { path = "../sui-framework-build" }
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-cli = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 workspace-hack = { path = "../workspace-hack"}
 
@@ -32,8 +32,8 @@ workspace-hack = { path = "../workspace-hack"}
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
 sui-framework-build = { path = "../sui-framework-build" }
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["move-cli", "move-unit-test"]

--- a/crates/sui-gateway/Cargo.toml
+++ b/crates/sui-gateway/Cargo.toml
@@ -27,7 +27,7 @@ sui-node = { path = "../sui-node" }
 
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
 workspace-hack = { path = "../workspace-hack"}
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/crates/sui-gateway/Cargo.toml
+++ b/crates/sui-gateway/Cargo.toml
@@ -27,7 +27,7 @@ sui-node = { path = "../sui-node" }
 
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
 workspace-hack = { path = "../workspace-hack"}
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/crates/sui-json-rpc-api/Cargo.toml
+++ b/crates/sui-json-rpc-api/Cargo.toml
@@ -20,8 +20,8 @@ either = "1.6.1"
 itertools = "0.10.3"
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }

--- a/crates/sui-json-rpc-api/Cargo.toml
+++ b/crates/sui-json-rpc-api/Cargo.toml
@@ -20,8 +20,8 @@ either = "1.6.1"
 itertools = "0.10.3"
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -17,13 +17,13 @@ schemars = "0.8.10"
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../sui-verifier" }
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
 test-fuzz = "3.0.2"
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 workspace-hack = { path = "../workspace-hack"}
 
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-json/Cargo.toml
+++ b/crates/sui-json/Cargo.toml
@@ -17,13 +17,13 @@ schemars = "0.8.10"
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../sui-verifier" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
 test-fuzz = "3.0.2"
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 workspace-hack = { path = "../workspace-hack"}
 
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -24,7 +24,7 @@ strum_macros = "^0.24"
 
 sui-types = { path = "../sui-types" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4"}
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
 
 workspace-hack = { path = "../workspace-hack"}
 

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -24,7 +24,7 @@ strum_macros = "^0.24"
 
 sui-types = { path = "../sui-types" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4"}
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
 
 workspace-hack = { path = "../workspace-hack"}
 

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -14,14 +14,14 @@ clap = { version = "3.1.8", features = ["derive"] }
 once_cell = "1.11.0"
 rand = "0.7.3"
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-command-line-common = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-transactional-test-runner = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 sui-framework = { path = "../sui-framework" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -14,14 +14,14 @@ clap = { version = "3.1.8", features = ["derive"] }
 once_cell = "1.11.0"
 rand = "0.7.3"
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-command-line-common = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-transactional-test-runner = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 sui-framework = { path = "../sui-framework" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -40,12 +40,12 @@ rand_latest = { version = "0.8.5", package = "rand" }
 name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
 
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-disassembler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "executor" }
 narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "crypto" }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -40,12 +40,12 @@ rand_latest = { version = "0.8.5", package = "rand" }
 name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7da89f6a52d7f60a9802b0a03147a9c89c3e4" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-disassembler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "executor" }
 narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "3cf68183b22acfe014118ef2713d5094159f2f4d", package = "crypto" }

--- a/crates/sui-verifier/Cargo.toml
+++ b/crates/sui-verifier/Cargo.toml
@@ -8,9 +8,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
 
 sui-types = { path = "../sui-types" }
 

--- a/crates/sui-verifier/Cargo.toml
+++ b/crates/sui-verifier/Cargo.toml
@@ -8,9 +8,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
 
 sui-types = { path = "../sui-types" }
 

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -32,10 +32,10 @@ colored = "2.0.0"
 unescape = "0.1.0"
 shell-words = "1.1.0"
 
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-cli = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 
 
 workspace-hack = { path = "../workspace-hack"}
@@ -48,6 +48,6 @@ typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7d
 test-utils = { path = "../test-utils" }
 sui-quorum-driver = { path = "../sui-quorum-driver" }
 rand = "0.7.3"
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 sui-core = { path = "../sui-core" }
 sui-node = { path = "../sui-node" }

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -32,10 +32,10 @@ colored = "2.0.0"
 unescape = "0.1.0"
 shell-words = "1.1.0"
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-cli = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 
 
 workspace-hack = { path = "../workspace-hack"}
@@ -48,6 +48,6 @@ typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "94d7d
 test-utils = { path = "../test-utils" }
 sui-quorum-driver = { path = "../sui-quorum-driver" }
 rand = "0.7.3"
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 sui-core = { path = "../sui-core" }
 sui-node = { path = "../sui-node" }

--- a/crates/sui/src/sui_move/mod.rs
+++ b/crates/sui/src/sui_move/mod.rs
@@ -7,6 +7,7 @@ use move_unit_test::UnitTestingConfig;
 use std::path::PathBuf;
 
 pub mod build;
+pub mod new;
 pub mod unit_test;
 
 pub fn execute_move_command(
@@ -57,7 +58,7 @@ pub fn execute_move_command(
 
             Ok(())
         }
-        PackageCommand::New { .. } => unimplemented!("'new' command not yet supported"),
+        PackageCommand::New { name } => new::execute(&package_path, &name),
         PackageCommand::Info => unimplemented!("'info' command not yet supported"),
         PackageCommand::ErrMapGen { .. } => unimplemented!("'errmap' command not yet supported"),
         PackageCommand::Prove { .. } => unimplemented!("'prove' command not yet supported"),

--- a/crates/sui/src/sui_move/new.rs
+++ b/crates/sui/src/sui_move/new.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_cli::package::cli::create_move_package;
+use std::path::Path;
+
+pub fn execute(path: &Path, name: &String) -> anyhow::Result<()> {
+    create_move_package(path,
+                        name,
+                        "0.0.1",
+                        "Sui",
+                        "{ git = \"https://github.com/MystenLabs/sui.git\", subdir = \"crates/sui-framework\", rev = \"main\" }",
+                        &name.to_lowercase(),
+                        "0x0")?;
+    Ok(())
+}

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -28,7 +28,7 @@ sui-node = { path = "../sui-node" }
 sui-swarm = { path = "../sui-swarm" }
 sui-types = { path = "../sui-types" }
 
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
 
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -28,7 +28,7 @@ sui-node = { path = "../sui-node" }
 sui-swarm = { path = "../sui-swarm" }
 sui-types = { path = "../sui-types" }
 
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
 
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -64,7 +64,7 @@ bls-crypto = { git = "https://github.com/huitseeker/celo-bls-snark-rs", branch =
 blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["fiat"] }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
@@ -258,41 +258,41 @@ minimal-lexical = { version = "0.2", default-features = false, features = ["std"
 miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-cli = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-abigen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-borrow-graph = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-command-line-common = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-coverage = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-disassembler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-docgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-errmapgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-ir-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-to-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-model = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-prover = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-read-write-set-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-resource-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-table-extension = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multimap = { version = "0.8", default-features = false }
@@ -379,8 +379,8 @@ rand_xorshift = { version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-read-write-set = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
+read-write-set = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -610,7 +610,7 @@ blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bumpalo = { version = "3" }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["fiat"] }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
@@ -833,41 +833,41 @@ miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-cli = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae" }
+move-abigen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-borrow-graph = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-bytecode-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-command-line-common = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
+move-coverage = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-disassembler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-docgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-errmapgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-ir-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-to-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-ir-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-model = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-prover = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-read-write-set-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-resource-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-table-extension = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
@@ -975,8 +975,8 @@ rand_xorshift = { version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-read-write-set = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "ae62d5f1955a9b92c3ddd31d3cc4467f9aff76ae", default-features = false }
+read-write-set = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -64,7 +64,7 @@ bls-crypto = { git = "https://github.com/huitseeker/celo-bls-snark-rs", branch =
 blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
-bytecode-interpreter-crypto = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["fiat"] }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
@@ -258,41 +258,41 @@ minimal-lexical = { version = "0.2", default-features = false, features = ["std"
 miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-borrow-graph = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-command-line-common = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-coverage = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-disassembler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-docgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-errmapgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-ir-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-to-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-model = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-prover = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-read-write-set-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-resource-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-table-extension = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-cli = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multimap = { version = "0.8", default-features = false }
@@ -379,8 +379,8 @@ rand_xorshift = { version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-read-write-set = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -610,7 +610,7 @@ blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bumpalo = { version = "3" }
-bytecode-interpreter-crypto = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["fiat"] }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 bzip2-sys = { version = "0.1", default-features = false, features = ["static"] }
@@ -833,41 +833,41 @@ miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-binary-format = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-borrow-graph = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-bytecode-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-cli = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-command-line-common = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-core-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["address20"] }
-move-coverage = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-disassembler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-docgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-errmapgen = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-ir-compiler = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-to-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-ir-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-model = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-package = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-prover = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-read-write-set-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-resource-viewer = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-stdlib = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-table-extension = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-unit-test = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-move-vm-runtime = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
-move-vm-types = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-cli = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
@@ -975,8 +975,8 @@ rand_xorshift = { version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-read-write-set = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/awelc/move", rev = "8a5950f256b6d558b4dee1844a561e8ddd146432", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "95999a9818091e382fb1c6016e68829f1dfc3127", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
This PR adds support for creating Move directory structure and the manifest file from `sui move` CLI. This increases parity with core Move CLI.