### PR TITLE
Fix wrong installation instruction

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -60,7 +60,7 @@ In addition, to conduct advanced work such as altering Sui itself, also obtain:
 To develop in Sui, you will need the Sui binaries. After installing `cargo`, run:
 
 ```shell
-$ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch "devnet" sui sui-json-rpc
+$ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch "devnet" sui sui-gateway
 ```
 
 This will put the following binaries in your `PATH` (ex. under `~/.cargo/bin`) that provide these command line interfaces (CLIs):

--- a/doc/utils/sui-setup.sh
+++ b/doc/utils/sui-setup.sh
@@ -15,7 +15,7 @@ command -v cargo >/dev/null 2>&1 || { echo "Cargo (https://doc.rust-lang.org/car
 rm -rf sui/
 
 ## Build and install Sui binaries
-cargo install --locked --git https://github.com/MystenLabs/sui.git --branch devnet sui sui-json-rpc
+cargo install --locked --git https://github.com/MystenLabs/sui.git --branch devnet sui sui-gateway
 
 ## Install Move Analyzer language server plugin
 cargo install --git https://github.com/move-language/move move-analyzer


### PR DESCRIPTION
the rpc-server bin is now located in `sui-gateway`, the doc was mistakenly installing `sui-json-rpc` crate