### PR TITLE
Fix Sui CLI color rendering on windows

### DIFF
--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -52,7 +52,7 @@ pub async fn start_console(
     writeln!(out)?;
 
     let mut shell = Shell::new(
-        "sui>-$ ".bold().green(),
+        "sui>-$ ",
         context,
         ClientCommandHandler,
         CommandStructure::from_clap(&install_shell_plugins(app)),

--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -13,6 +13,9 @@ mod cli_tests;
 
 #[tokio::main]
 async fn main() {
+    #[cfg(windows)]
+    colored::control::set_virtual_terminal(true).unwrap();
+
     let bin_name = env!("CARGO_BIN_NAME");
     let cmd: SuiCommand = SuiCommand::parse();
     let _guard = match cmd {

--- a/crates/sui/src/shell.rs
+++ b/crates/sui/src/shell.rs
@@ -73,7 +73,7 @@ impl<P: Display, S: Send, H: AsyncHandler<S>> Shell<P, S, H> {
         }));
 
         loop {
-            write!(out, "{}", self.prompt)?;
+            write!(out, "{}", format!("{}", self.prompt).bold().green())?;
             out.flush()?;
 
             // Read a line


### PR DESCRIPTION
This fix the CLI color rendering issue on Windows 11

<img width="1562" alt="image" src="https://user-images.githubusercontent.com/1888654/177429134-5f5517b2-f26d-4f26-8f04-b26313fc7981.png">
