### PR TITLE
[checkpoint] Sort transactions in causal order before creating the checkpoint

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -427,10 +427,10 @@ impl AuthorityState {
         self.process_certificate(tx_guard, certificate).await
     }
 
-    async fn acquire_tx_guard<'a>(
+    async fn acquire_tx_guard<'a, 'b>(
         &'a self,
-        digest: &TransactionDigest,
-        cert: &CertifiedTransaction,
+        digest: &'b TransactionDigest,
+        cert: &'b CertifiedTransaction,
     ) -> SuiResult<CertTxGuard<'a>> {
         match self.database.wal.begin_tx(digest, cert).await? {
             Some(g) => Ok(g),

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -10,16 +10,15 @@ use std::{
 
 use parking_lot::Mutex;
 use sui_types::{
-    base_types::{AuthorityName, ExecutionDigests, TransactionDigest},
+    base_types::{AuthorityName, ExecutionDigests},
     error::SuiError,
-    messages::{CertifiedTransaction, ConfirmationTransaction, TransactionInfoRequest},
+    messages::{CertifiedTransaction, TransactionInfoRequest},
     messages_checkpoint::{
         AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
         CheckpointContents, CheckpointDigest, CheckpointFragment, CheckpointRequest,
         CheckpointResponse, CheckpointSequenceNumber, SignedCheckpointSummary,
     },
 };
-use tokio::time::timeout;
 
 use crate::{
     authority_aggregator::{AuthorityAggregator, ReduceOutput},
@@ -732,101 +731,4 @@ where
     fragment.certs = diff_certs;
 
     Ok(fragment)
-}
-
-/// Sync to a transaction certificate
-pub async fn sync_digest<A>(
-    name: AuthorityName,
-    net: Arc<AuthorityAggregator<A>>,
-    cert_digest: TransactionDigest,
-    timeout_period: Duration,
-) -> Result<(), SuiError>
-where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
-{
-    let mut source_authorities: BTreeSet<AuthorityName> = net.committee.names().copied().collect();
-    source_authorities.remove(&name);
-
-    // Now try to update the destination authority sequentially using
-    // the source authorities we have sampled.
-    debug_assert!(!source_authorities.is_empty());
-    for source_authority in source_authorities {
-        // Note: here we could improve this function by passing into the
-        //       `sync_authority_source_to_destination` call a cache of
-        //       certificates and parents to avoid re-downloading them.
-
-        let client = net.clone_client(&source_authority);
-        let sync_fut = async {
-            let response = client
-                .handle_transaction_info_request(TransactionInfoRequest::from(cert_digest))
-                .await?;
-
-            // If we have cert, use that cert to sync
-            if let Some(cert) = response.certified_transaction {
-                net.sync_certificate_to_authority_with_timeout(
-                    ConfirmationTransaction::new(cert.clone()),
-                    name,
-                    // Ok to have a fixed, and rather long timeout, since the future is controlled,
-                    // and interrupted by a global timeout as well, that can be controlled.
-                    Duration::from_secs(60),
-                    3,
-                )
-                .await?;
-
-                return Result::<(), SuiError>::Ok(());
-            }
-
-            // If we have a transaction, make a cert and sync
-            if let Some(transaction) = response.signed_transaction {
-                // Make a cert afresh
-                let (cert, _effects) = net
-                    .execute_transaction(&transaction.to_transaction())
-                    .await
-                    .map_err(|_e| SuiError::AuthorityUpdateFailure)?;
-
-                // Make sure the cert is syned with this authority
-                net.sync_certificate_to_authority_with_timeout(
-                    ConfirmationTransaction::new(cert.clone()),
-                    name,
-                    // Ok to have a fixed, and rather long timeout, since the future is controlled,
-                    // and interrupted by a global timeout as well, that can be controlled.
-                    Duration::from_secs(60),
-                    3,
-                )
-                .await?;
-
-                return Result::<(), SuiError>::Ok(());
-            }
-
-            Err(SuiError::AuthorityUpdateFailure)
-        };
-
-        // Be careful.  timeout() returning OK just means the Future completed.
-        if let Ok(inner_res) = timeout(timeout_period, sync_fut).await {
-            match inner_res {
-                Ok(_) => {
-                    // If the updates succeeds we return, since there is no need
-                    // to try other sources.
-                    return Ok(());
-                }
-                // Getting here means the sync_authority_source fn finished within timeout but errored out.
-                Err(_err) => {
-                    warn!("Failed sync with {:?}", source_authority);
-                }
-            }
-        } else {
-            warn!("Timeout exceeded");
-        }
-
-        // If we are here it means that the update failed, either due to the
-        // source being faulty or the destination being faulty.
-        //
-        // TODO: We should probably be keeping a record of suspected faults
-        // upon failure to de-prioritize authorities that we have observed being
-        // less reliable.
-    }
-
-    // Eventually we should add more information to this error about the destination
-    // and maybe event the certificate.
-    Err(SuiError::AuthorityUpdateFailure)
 }

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -31,14 +31,15 @@ use sui_types::crypto::KeyPair;
 pub struct TestCausalOrderPendCertNoop;
 
 impl CausalOrder for TestCausalOrderPendCertNoop {
-    fn get_complete_causal_order(
+    fn get_complete_causal_order<'a>(
         &self,
-        transactions: &[ExecutionDigests],
+        transactions: impl Iterator<Item = &'a ExecutionDigests>,
         _ckpt_store: &mut CheckpointStore,
     ) -> SuiResult<Vec<ExecutionDigests>> {
-        Ok(transactions.to_vec())
+        Ok(transactions.cloned().collect())
     }
 }
+
 impl PendCertificateForExecution for TestCausalOrderPendCertNoop {
     fn add_pending_certificates(
         &self,

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -185,13 +185,16 @@ fn make_checkpoint_db() {
     assert_eq!(cps.next_checkpoint(), 0);
 
     // You cannot make a checkpoint without processing all transactions
-    assert!(cps.update_new_checkpoint(0, &[t1, t2, t4, t5]).is_err());
+    assert!(cps
+        .update_new_checkpoint(0, &[t1, t2, t4, t5], PendCertificateForExecutionNoop)
+        .is_err());
 
     // Now process the extra transactions in the checkpoint
     cps.update_processed_transactions(&[(4, t4), (5, t5)])
         .unwrap();
 
-    cps.update_new_checkpoint(0, &[t1, t2, t4, t5]).unwrap();
+    cps.update_new_checkpoint(0, &[t1, t2, t4, t5], PendCertificateForExecutionNoop)
+        .unwrap();
     assert_eq!(cps.checkpoint_contents.iter().count(), 4);
     assert_eq!(cps.extra_transactions.iter().count(), 1);
     assert_eq!(cps.next_checkpoint(), 1);
@@ -243,7 +246,9 @@ fn make_proposals() {
         .collect();
 
     // if not all transactions are processed we fail
-    assert!(cps1.update_new_checkpoint(0, &ckp_items[..]).is_err());
+    assert!(cps1
+        .update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
+        .is_err());
 
     cps1.update_processed_transactions(&[(3, t1), (4, t4)])
         .unwrap();
@@ -257,10 +262,14 @@ fn make_proposals() {
     cps4.update_processed_transactions(&[(3, t1), (4, t2), (5, t3)])
         .unwrap();
 
-    cps1.update_new_checkpoint(0, &ckp_items[..]).unwrap();
-    cps2.update_new_checkpoint(0, &ckp_items[..]).unwrap();
-    cps3.update_new_checkpoint(0, &ckp_items[..]).unwrap();
-    cps4.update_new_checkpoint(0, &ckp_items[..]).unwrap();
+    cps1.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
+        .unwrap();
+    cps2.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
+        .unwrap();
+    cps3.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
+        .unwrap();
+    cps4.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
+        .unwrap();
 
     assert_eq!(
         cps4.extra_transactions.keys().collect::<HashSet<_>>(),

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -360,11 +360,6 @@ impl CertifiedCheckpointSummary {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointContents {
-    pub transactions: BTreeSet<ExecutionDigests>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct OrderedCheckpointContents {
     pub transactions: Vec<ExecutionDigests>,
 }
 
@@ -376,7 +371,7 @@ impl CheckpointContents {
         T: Iterator<Item = ExecutionDigests>,
     {
         CheckpointContents {
-            transactions: contents.collect(),
+            transactions: contents.collect::<BTreeSet<_>>().into_iter().collect(),
         }
     }
 
@@ -437,6 +432,7 @@ impl CheckpointFragment {
 mod tests {
     use rand::prelude::StdRng;
     use rand::SeedableRng;
+    use std::collections::BTreeSet;
 
     use super::*;
     use crate::utils::make_committee_key;

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -363,6 +363,11 @@ pub struct CheckpointContents {
     pub transactions: BTreeSet<ExecutionDigests>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OrderedCheckpointContents {
+    pub transactions: Vec<ExecutionDigests>,
+}
+
 impl BcsSignable for CheckpointContents {}
 
 impl CheckpointContents {


### PR DESCRIPTION
The core of this change is in crates/sui-core/src/checkpoints/mod.rs
where we causal order them before creating the checkpoint.
Also removing sync_digest because it's simply not being used.