### PR TITLE
[Move CLI] Added disassemble and coverage command-line options

### DIFF
--- a/crates/sui/src/sui_move/coverage.rs
+++ b/crates/sui/src/sui_move/coverage.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use move_cli::base::coverage;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+pub struct Coverage {
+    #[clap(flatten)]
+    pub coverage: coverage::Coverage,
+}
+
+impl Coverage {
+    pub fn execute(self, path: Option<PathBuf>, build_config: BuildConfig) -> anyhow::Result<()> {
+        self.coverage.execute(path, build_config)?;
+        Ok(())
+    }
+}

--- a/crates/sui/src/sui_move/disassemble.rs
+++ b/crates/sui/src/sui_move/disassemble.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use move_cli::base::disassemble;
+use move_package::BuildConfig;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+pub struct Disassemble {
+    #[clap(flatten)]
+    pub disassemble: disassemble::Disassemble,
+}
+
+impl Disassemble {
+    pub fn execute(self, path: Option<PathBuf>, build_config: BuildConfig) -> anyhow::Result<()> {
+        self.disassemble.execute(path, build_config)?;
+        Ok(())
+    }
+}

--- a/crates/sui/src/sui_move/mod.rs
+++ b/crates/sui/src/sui_move/mod.rs
@@ -8,12 +8,16 @@ use move_unit_test::UnitTestingConfig;
 use std::path::PathBuf;
 
 pub mod build;
+pub mod coverage;
+pub mod disassemble;
 pub mod new;
 pub mod unit_test;
 
 #[derive(Parser)]
 pub enum Command {
     Build(build::Build),
+    Coverage(coverage::Coverage),
+    Disassemble(disassemble::Disassemble),
     New(new::New),
     Test(unit_test::Test),
 }
@@ -25,6 +29,8 @@ pub fn execute_move_command(
 ) -> anyhow::Result<()> {
     match command {
         Command::Build(c) => c.execute(package_path, build_config),
+        Command::Coverage(c) => c.execute(package_path, build_config),
+        Command::Disassemble(c) => c.execute(package_path, build_config),
         Command::Test(c) => {
             let unit_test_config = UnitTestingConfig {
                 instruction_execution_bound: c.test.instruction_execution_bound,


### PR DESCRIPTION
This PR brings `disassemble` and `coverage` commands from core Move CLI to Sui Move. Hand-tested both commands and confirmed that they work as expected. Did not test all the options but since it's a simple redirect to core Move all should be good.