### PR TITLE
[wallet connect] add executeSerializedMoveCall

### DIFF
--- a/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/wallet/src/background/connections/ContentScriptConnection.ts
@@ -101,6 +101,7 @@ export class ContentScriptConnection extends Connection {
                 try {
                     const result = await Transactions.executeTransaction(
                         payload.transaction,
+                        payload.transactionBytes,
                         this
                     );
                     this.send(

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -96,6 +96,16 @@ export class DAppInterface {
         );
     }
 
+    public executeSerializedMoveCall(transactionBytes: Uint8Array) {
+        return mapToPromise(
+            this.send<ExecuteTransactionRequest, ExecuteTransactionResponse>({
+                type: 'execute-transaction-request',
+                transactionBytes,
+            }),
+            (response) => response.result
+        );
+    }
+
     private send<
         RequestPayload extends Payload,
         ResponsePayload extends Payload | void = void

--- a/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
@@ -8,7 +8,8 @@ import type { BasePayload, Payload } from '_payloads';
 
 export interface ExecuteTransactionRequest extends BasePayload {
     type: 'execute-transaction-request';
-    transaction: MoveCallTransaction;
+    transaction?: MoveCallTransaction;
+    transactionBytes?: Uint8Array;
 }
 
 export function isExecuteTransactionRequest(

--- a/wallet/src/shared/messaging/messages/payloads/transactions/TransactionRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/transactions/TransactionRequest.ts
@@ -6,10 +6,18 @@ import type { MoveCallTransaction, TransactionResponse } from '@mysten/sui.js';
 export type TransactionRequest = {
     id: string;
     approved: boolean | null;
-    tx: MoveCallTransaction;
     origin: string;
     originFavIcon?: string;
     txResult?: TransactionResponse;
     txResultError?: string;
     createdDate: string;
-};
+} & (
+    {
+        type: 'move-call';
+        tx: MoveCallTransaction;
+    } |
+    {
+        type: 'serialized-move-call';
+        txBytes: Uint8Array;
+    }
+);

--- a/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
@@ -70,7 +70,7 @@ export function DappTxApprovalPage() {
     // TODO: add more tx types/make it generic
     const valuesContent = useMemo(
         () =>
-            txRequest?.tx
+            txRequest?.type === 'move-call'
                 ? [
                       { label: 'Transaction type', content: 'MoveCall' },
                       {
@@ -89,7 +89,10 @@ export function DappTxApprovalPage() {
                       },
                       { label: 'Gas budget', content: txRequest.tx.gasBudget },
                   ]
-                : [],
+                : [
+                    { label: 'Transaction type', content: 'SerializedMoveCall' },
+                    { label: 'Contents', content: txRequest?.txBytes },
+                ],
         [txRequest]
     );
     return (


### PR DESCRIPTION
Add executeSerializedMoveCall to unblock capybara DApp,
the added function header is 
```
public executeSerializedMoveCall(txBytes: Uint8Array)
```

It now has the option from the Dapp console
<img width="1158" alt="Screen Shot 2022-07-07 at 12 47 40 PM" src="https://user-images.githubusercontent.com/106119108/177859591-09bebdb9-8f96-44fa-b1e7-f491fdaf7776.png">

