### PR TITLE
[cli] Made selected subcommands only asynchronous

### DIFF
--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
+futures = "0.3.21"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.80"
 tokio = { version = "1.18.2", features = ["full"] }

--- a/crates/sui/src/main.rs
+++ b/crates/sui/src/main.rs
@@ -33,5 +33,5 @@ async fn main() {
     if let Some(git_rev) = option_env!("GIT_REVISION") {
         debug!("Sui CLI built at git revision {git_rev}");
     }
-    exit_main!(cmd.execute().await);
+    exit_main!(cmd.execute());
 }

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -41,18 +41,17 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     let start = SuiCommand::Start {
         config: Some(config),
     }
-    .execute()
-    .await;
+    .execute();
     assert!(matches!(start, Err(..)));
     // Genesis
-    SuiCommand::Genesis {
+    let gen = SuiCommand::Genesis {
         working_dir: Some(working_dir.to_path_buf()),
         write_config: None,
         force: false,
         from_config: None,
     }
-    .execute()
-    .await?;
+    .execute();
+    assert!(gen.is_ok());
 
     // Get all the new file names
     let files = read_dir(working_dir)?
@@ -93,8 +92,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         force: false,
         from_config: None,
     }
-    .execute()
-    .await;
+    .execute();
     assert!(matches!(result, Err(..)));
 
     temp_dir.close()?;


### PR DESCRIPTION
This PR makes only selected subcommand of `sui` asynchronous instead of the whole CLI. The reason is that otherwise it is difficult to integrate external subcommands that themselves use parallel runtimes such as Tokio (core Move prover is an example of such command).