### PR TITLE
Explorer: Fix off by 1 error in pagination

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -53,11 +53,8 @@ function generateStartEndRange(
 ): { startGatewayTxSeqNumber: number; endGatewayTxSeqNumber: number } {
     // Pagination pageNum from query params - default to 0; No negative values
     const txPaged = pageNum && pageNum > 0 ? pageNum - 1 : 0;
-    const endGatewayTxSeqNumber: number = txCount - txNum * txPaged;
-    const tempStartGatewayTxSeqNumber: number = endGatewayTxSeqNumber - txNum;
-    // If startGatewayTxSeqNumber is less than 0, then set it 1 the first transaction sequence number
-    const startGatewayTxSeqNumber: number =
-        tempStartGatewayTxSeqNumber > 0 ? tempStartGatewayTxSeqNumber : 1;
+    const endGatewayTxSeqNumber = txCount - txNum * txPaged;
+    const startGatewayTxSeqNumber = Math.max(endGatewayTxSeqNumber - txNum, 0);
     return {
         startGatewayTxSeqNumber,
         endGatewayTxSeqNumber,


### PR DESCRIPTION
Transaction sequence number starts from 0 instead of 1

Before:
![CleanShot 2022-07-07 at 23 33 39](https://user-images.githubusercontent.com/76067158/177931385-e2265c7b-7cd0-4149-8f9d-045bb06a06db.png)



After:
![CleanShot 2022-07-07 at 23 33 09](https://user-images.githubusercontent.com/76067158/177931396-adf6ac27-e2e4-4b34-8393-cbed0ca539cc.png)


