### PR TITLE
[sui-adapter] Relax orphan rule

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -1,31 +1,28 @@
-processed 9 tasks
+processed 8 tasks
 
 task 1 'publish'. lines 6-21:
 created: object(103)
 written: object(102)
 
-task 2 'publish'. lines 23-51:
+task 2 'publish'. lines 23-53:
 created: object(105)
 written: object(104)
 
-task 3 'publish'. lines 54-80:
+task 3 'publish'. lines 56-84:
 created: object(107)
 written: object(106)
 
-task 4 'run'. lines 82-82:
+task 4 'run'. lines 86-86:
 created: object(109)
 written: object(108)
 
-task 5 'run'. lines 84-84:
+task 5 'run'. lines 88-90:
 created: object(111)
 written: object(109), object(110)
 
-task 6 'run'. lines 86-88:
-written: object(109), object(111), object(112)
+task 6 'run'. lines 91-91:
+Error: Transaction Effects Status: Invalid Shared Child Object Usage. When a child object (either direct or indirect) of a shared object is passed by-value to an entry function, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109), whose ancestor fake(111) is a shared object, and neither are defined in this module..
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedChildUse(InvalidSharedChildUse { child: fake(109), ancestor: fake(111) }), source: Some("When a child object (either direct or indirect) of a shared object is passed by-value to an entry function, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109) (defined in module 'T3::O3'), whose ancestor fake(111) is a shared object (defined in module 'T2::O2'), and neither are defined in this module 'T1::O1'") } }
 
-task 7 'run'. lines 89-89:
-Error: Transaction Effects Status: Invalid Shared Child Object Usage. When an (either direct or indirect) child object of a shared object is passed as a Move argument, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by the child object fake(109), whose ancestor fake(111) is a shared object, and neither are defined in the current module..
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedChildUse(InvalidSharedChildUse { child: fake(109), ancestor: fake(111) }), source: Some("When an (either direct or indirect) child object of a shared object is passed as a Move argument, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109) (defined in module 'T1::O1'), whose ancestor fake(111) is a shared object (defined in module 'T2::O2'), and neither are defined in this module 'T1::O1'") } }
-
-task 8 'run'. lines 91-91:
-written: object(109), object(111), object(114)
+task 7 'run'. lines 93-93:
+written: object(109), object(111), object(113)

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
@@ -41,7 +41,9 @@ module T2::O2 {
         transfer::transfer(new(child, ctx), tx_context::sender(ctx))
     }
 
-    public entry fun use_o2_o3(_o2: &mut O2, _o3: &mut O3) {}
+    public entry fun use_o2_o3(_o2: &mut O2, o3: O3, ctx: &mut TxContext) {
+        transfer::transfer(o3, tx_context::sender(ctx))
+    }
 
     fun new(child: O3, ctx: &mut TxContext): O2 {
         let id = tx_context::new_id(ctx);
@@ -70,7 +72,9 @@ module T1::O1 {
     }
 
     // This function will be invalid if _o2 is a shared object and owns _o3.
-    public entry fun use_o2_o3(_o2: &mut O2, _o3: &mut O3) {}
+    public entry fun use_o2_o3(_o2: &mut O2, o3: O3, ctx: &mut TxContext) {
+        transfer::transfer(o3, tx_context::sender(ctx))
+    }
 
     fun new(child: O2, ctx: &mut TxContext): O1 {
         let id = tx_context::new_id(ctx);
@@ -82,8 +86,6 @@ module T1::O1 {
 //# run T3::O3::create
 
 //# run T2::O2::create_shared --args object(109)
-
-//# run T2::O2::use_o2_o3 --args object(111) object(109)
 
 // This run should error as O2/O3 were not defined in O1
 //# run T1::O1::use_o2_o3 --args object(111) object(109)

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
@@ -1,0 +1,25 @@
+processed 7 tasks
+
+task 1 'publish'. lines 8-28:
+created: object(103)
+written: object(102)
+
+task 2 'publish'. lines 30-38:
+created: object(105)
+written: object(104)
+
+task 3 'run'. lines 41-41:
+created: object(107)
+written: object(106)
+
+task 4 'view-object'. lines 43-43:
+Owner: Shared
+Contents: t2::o2::O2 {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}}
+
+task 5 'run'. lines 45-45:
+Error: Transaction Effects Status: MiscellaneousError
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedUse, source: Some("When a shared object is passed as an owned Move value in an entry function, either the the shared object's type must be defined in the same module as the called function. The shared object fake(107) (defined in module 't2::o2') is not defined in this module 't1::o1'") } }
+
+task 6 'run'. lines 47-47:
+written: object(109)
+deleted: object(107)

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
@@ -17,9 +17,9 @@ Owner: Shared
 Contents: t2::o2::O2 {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}}
 
 task 5 'run'. lines 45-45:
-Error: Transaction Effects Status: Invalid Shared Object By-Value Usage. When a shared object is passed as an owned Move value in an entry function, either the the shared object's type must be defined in the same module as the called function. The shared object fake(107) is not defined in this module.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedByValue(InvalidSharedByValue { object: fake(107) }), source: Some("When a shared object is passed as an owned Move value in an entry function, either the the shared object's type must be defined in the same module as the called function. The shared object fake(107) (defined in module 't2::o2') is not defined in this module 't1::o1'") } }
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
 
 task 6 'run'. lines 47-47:
-written: object(109)
-deleted: object(107)
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
@@ -17,8 +17,8 @@ Owner: Shared
 Contents: t2::o2::O2 {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}}
 
 task 5 'run'. lines 45-45:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedUse, source: Some("When a shared object is passed as an owned Move value in an entry function, either the the shared object's type must be defined in the same module as the called function. The shared object fake(107) (defined in module 't2::o2') is not defined in this module 't1::o1'") } }
+Error: Transaction Effects Status: Invalid Shared Object By-Value Usage. When a shared object is passed as an owned Move value in an entry function, either the the shared object's type must be defined in the same module as the called function. The shared object fake(107) is not defined in this module.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedByValue(InvalidSharedByValue { object: fake(107) }), source: Some("When a shared object is passed as an owned Move value in an entry function, either the the shared object's type must be defined in the same module as the called function. The shared object fake(107) (defined in module 't2::o2') is not defined in this module 't1::o1'") } }
 
 task 6 'run'. lines 47-47:
 written: object(109)

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.move
@@ -1,0 +1,47 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that shared objects can
+
+//# init --addresses t1=0x0 t2=0x0
+
+//# publish
+
+module t2::o2 {
+    use sui::id::{Self, VersionedID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    struct O2 has key, store {
+        id: VersionedID,
+    }
+
+    public entry fun create(ctx: &mut TxContext) {
+        let o = O2 { id: tx_context::new_id(ctx) };
+        transfer::share_object(o)
+    }
+
+    public entry fun consume_o2(o2: O2) {
+        let O2 { id } = o2;
+        id::delete(id);
+    }
+}
+
+//# publish
+
+module t1::o1 {
+    use t2::o2::{Self, O2};
+
+    public entry fun consume_o2(o2: O2) {
+        o2::consume_o2(o2);
+    }
+}
+
+
+//# run t2::o2::create
+
+//# view-object 107
+
+//# run t1::o1::consume_o2 --args object(107)
+
+//# run t2::o2::consume_o2 --args object(107)

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
@@ -11,8 +11,8 @@ task 2 'run'. lines 10-10:
 written: object(104), object(105)
 
 task 3 'run'. lines 12-12:
-Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Only an owned object can be passed by-value.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Only owned object can be passed by-value, violation found in argument 0") } }
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable objects cannot be passed by-value, violation found in argument 0") } }
 
 task 4 'run'. lines 14-14:
 Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable objects cannot be passed by mutable reference, &mut.

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
@@ -11,8 +11,8 @@ task 2 'run'. lines 10-10:
 written: object(104), object(105)
 
 task 3 'run'. lines 12-12:
-Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable objects cannot be passed by-value.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable objects cannot be passed by-value, violation found in argument 0") } }
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
 
 task 4 'run'. lines 14-14:
 Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable objects cannot be passed by mutable reference, &mut.

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -909,8 +909,8 @@ pub fn resolve_and_type_check(
                                     EntryArgumentErrorKind::InvalidObjectByValue,
                                 ),
                                 format!(
-                                    "Immutable objects cannot be pased by-value, \
-                                violation found in argument {}",
+                                    "Immutable objects cannot be passed by-value, \
+                                    violation found in argument {}",
                                     idx
                                 ),
                             ));
@@ -993,7 +993,7 @@ fn check_shared_object_rules(
                 return Err(ExecutionError::new_with_source(
                     ExecutionErrorKind::invalid_shared_child_use(child_id, ancestor_id),
                     format!(
-        "When an (either direct or indirect) child object of a shared object is passed by-value to \
+        "When a child object (either direct or indirect) of a shared object is passed by-value to \
         an entry function, either the child object's type or the shared object's type must be \
         defined in the same module as the called function. This is violated by object {child_id} \
         (defined in module '{child_module}'), whose ancestor {ancestor_id} is a shared \

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -901,15 +901,15 @@ pub fn resolve_and_type_check(
                 | t @ SignatureToken::StructInstantiation(_, _)
                 | t @ SignatureToken::TypeParameter(_) => {
                     match &object.owner {
-                        Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Shared => (),
-                        Owner::Immutable => {
+                        Owner::AddressOwner(_) | Owner::ObjectOwner(_) => (),
+                        Owner::Shared | Owner::Immutable => {
                             return Err(ExecutionError::new_with_source(
                                 ExecutionErrorKind::entry_argument_error(
                                     idx,
                                     EntryArgumentErrorKind::InvalidObjectByValue,
                                 ),
                                 format!(
-                                    "Immutable objects cannot be passed by-value, \
+                                    "Immutable and shared objects cannot be passed by-value, \
                                     violation found in argument {}",
                                     idx
                                 ),
@@ -1005,25 +1005,26 @@ fn check_shared_object_rules(
         }
     }
 
-    // check shared object by value rule
-    let by_value_shared_object = object_owner_map
-        .iter()
-        .filter(|(id, owner)| matches!(owner, Owner::Shared) && by_value_objects.contains(id))
-        .map(|(id, _)| *id);
-    for shared_object_id in by_value_shared_object {
-        let shared_object_module = object_type_map.get(&shared_object_id).unwrap();
-        if shared_object_module != &current_module {
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::invalid_shared_by_value(shared_object_id),
-                format!(
-        "When a shared object is passed as an owned Move value in an entry function, either the \
-        the shared object's type must be defined in the same module as the called function. The \
-        shared object {shared_object_id} (defined in module '{shared_object_module}') is not \
-        defined in this module '{current_module}'",
-                ),
-            ));
-        }
-    }
+    // TODO not yet supported
+    // // check shared object by value rule
+    // let by_value_shared_object = object_owner_map
+    //     .iter()
+    //     .filter(|(id, owner)| matches!(owner, Owner::Shared) && by_value_objects.contains(id))
+    //     .map(|(id, _)| *id);
+    // for shared_object_id in by_value_shared_object {
+    //     let shared_object_module = object_type_map.get(&shared_object_id).unwrap();
+    //     if shared_object_module != &current_module {
+    //         return Err(ExecutionError::new_with_source(
+    //             ExecutionErrorKind::invalid_shared_by_value(shared_object_id),
+    //             format!(
+    //     "When a shared object is passed as an owned Move value in an entry function, either the \
+    //     the shared object's type must be defined in the same module as the called function. The \
+    //     shared object {shared_object_id} (defined in module '{shared_object_module}') is not \
+    //     defined in this module '{current_module}'",
+    //             ),
+    //         ));
+    //     }
+    // }
     Ok(())
 }
 

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -900,20 +900,21 @@ pub fn resolve_and_type_check(
                 t @ SignatureToken::Struct(_)
                 | t @ SignatureToken::StructInstantiation(_, _)
                 | t @ SignatureToken::TypeParameter(_) => {
-                    if !object.is_owned_or_quasi_shared() {
-                        // Forbid passing shared (both mutable and immutable) object by value.
-                        // This ensures that shared object cannot be transferred, deleted or wrapped.
-                        return Err(ExecutionError::new_with_source(
-                            ExecutionErrorKind::entry_argument_error(
-                                idx,
-                                EntryArgumentErrorKind::InvalidObjectByValue,
-                            ),
-                            format!(
-                                "Only owned object can be passed by-value, violation found in \
-                                argument {}",
-                                idx
-                            ),
-                        ));
+                    match &object.owner {
+                        Owner::AddressOwner(_) | Owner::ObjectOwner(_) | Owner::Shared => (),
+                        Owner::Immutable => {
+                            return Err(ExecutionError::new_with_source(
+                                ExecutionErrorKind::entry_argument_error(
+                                    idx,
+                                    EntryArgumentErrorKind::InvalidObjectByValue,
+                                ),
+                                format!(
+                                    "Immutable objects cannot be pased by-value, \
+                                violation found in argument {}",
+                                    idx
+                                ),
+                            ));
+                        }
                     }
                     by_value_objects.insert(id);
                     t
@@ -937,7 +938,12 @@ pub fn resolve_and_type_check(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    check_child_object_of_shared_object(objects, &object_type_map, module.self_id())?;
+    check_shared_object_rules(
+        objects,
+        &by_value_objects,
+        &object_type_map,
+        module.self_id(),
+    )?;
 
     Ok(TypeCheckSuccess {
         module_id,
@@ -949,11 +955,17 @@ pub fn resolve_and_type_check(
     })
 }
 
-/// Check that for each pair of a shared object and a descendant of it (through object ownership),
-/// at least one of the types of the shared object and the descendant must be defined in the
-/// same module as the function being called (somewhat similar to Rust's orphan rule).
-fn check_child_object_of_shared_object(
+/// Check rules for shared object + by-value child rules and rules for by-value shared object rules:
+/// - For each pair of a shared object and a descendant of it (through object ownership), if the
+///   descendant is used by-value, at least one of the types of the shared object and the descendant
+///   must be defined in the same module as the entry function being called
+///   (somewhat similar to Rust's orphan rule where a trait impl must be defined in the same crate
+///   as the type implementing the trait or the trait itself).
+/// - For each shared object used by-value, the type of the shared object must be defined in the
+///   same module as the entry function being called.
+fn check_shared_object_rules(
     objects: &BTreeMap<ObjectID, impl Borrow<Object>>,
+    by_value_objects: &BTreeSet<ObjectID>,
     object_type_map: &BTreeMap<ObjectID, ModuleId>,
     current_module: ModuleId,
 ) -> Result<(), ExecutionError> {
@@ -962,35 +974,54 @@ fn check_child_object_of_shared_object(
         .map(|(id, obj)| (*id, obj.borrow().owner))
         .collect();
     let ancestor_map = ObjectRootAncestorMap::new(&object_owner_map)?;
-    for (object_id, owner) in object_owner_map {
-        // We are only interested in objects owned by objects.
-        let owner = match owner {
-            Owner::ObjectOwner(o) => o,
-            _ => continue,
-        };
-        let (ancestor_id, ancestor_owner) = match ancestor_map.get_root_ancestor(&object_id) {
+    let by_value_object_owned = object_owner_map
+        .iter()
+        .filter_map(|(id, owner)| match owner {
+            Owner::ObjectOwner(owner) if by_value_objects.contains(id) => Some((*id, *owner)),
+            _ => None,
+        });
+    for (child_id, owner) in by_value_object_owned {
+        let (ancestor_id, ancestor_owner) = match ancestor_map.get_root_ancestor(&child_id) {
             Some(ancestor) => ancestor,
-            None => return Err(ExecutionErrorKind::missing_object_owner(object_id, owner).into()),
+            None => return Err(ExecutionErrorKind::missing_object_owner(child_id, owner).into()),
         };
         if ancestor_owner.is_shared() {
             // unwrap safe because the object ID exists in object_owner_map.
-            let child_module = object_type_map.get(&object_id).unwrap();
+            let child_module = object_type_map.get(&child_id).unwrap();
             let ancestor_module = object_type_map.get(&ancestor_id).unwrap();
             if !(child_module == &current_module || ancestor_module == &current_module) {
                 return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::invalid_shared_child_use(object_id, ancestor_id),
+                    ExecutionErrorKind::invalid_shared_child_use(child_id, ancestor_id),
                     format!(
-"When an (either direct or indirect) child object of a shared object is passed as a Move argument, \
-either the child object's type or the shared object's type must be defined in the same module \
-as the called function. This is violated by object {child} (defined in module '{child_module}'), \
-whose ancestor {ancestor} is a shared object (defined in module '{ancestor_module}'), \
-and neither are defined in this module '{current_module}'",
-                    child = object_id,
-                    child_module = current_module,
-                    ancestor = ancestor_id,
+        "When an (either direct or indirect) child object of a shared object is passed by-value to \
+        an entry function, either the child object's type or the shared object's type must be \
+        defined in the same module as the called function. This is violated by object {child_id} \
+        (defined in module '{child_module}'), whose ancestor {ancestor_id} is a shared \
+        object (defined in module '{ancestor_module}'), and neither are defined in this module \
+        '{current_module}'",
                     ),
                 ));
             }
+        }
+    }
+
+    // check shared object by value rule
+    let by_value_shared_object = object_owner_map
+        .iter()
+        .filter(|(id, owner)| matches!(owner, Owner::Shared) && by_value_objects.contains(id))
+        .map(|(id, _)| *id);
+    for shared_object_id in by_value_shared_object {
+        let shared_object_module = object_type_map.get(&shared_object_id).unwrap();
+        if shared_object_module != &current_module {
+            return Err(ExecutionError::new_with_source(
+                ExecutionErrorKind::invalid_shared_by_value(shared_object_id),
+                format!(
+        "When a shared object is passed as an owned Move value in an entry function, either the \
+        the shared object's type must be defined in the same module as the called function. The \
+        shared object {shared_object_id} (defined in module '{shared_object_module}') is not \
+        defined in this module '{current_module}'",
+                ),
+            ));
         }
     }
     Ok(())

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -126,25 +126,29 @@ ExecutionFailureStatus:
         NEWTYPE:
           TYPENAME: InvalidSharedChildUse
     15:
-      DeleteObjectOwnedObject: UNIT
+      InvalidSharedByValue:
+        NEWTYPE:
+          TYPENAME: InvalidSharedByValue
     16:
-      PublishErrorEmptyPackage: UNIT
+      DeleteObjectOwnedObject: UNIT
     17:
-      PublishErrorNonZeroAddress: UNIT
+      PublishErrorEmptyPackage: UNIT
     18:
-      PublishErrorDuplicateModule: UNIT
+      PublishErrorNonZeroAddress: UNIT
     19:
-      SuiMoveVerificationError: UNIT
+      PublishErrorDuplicateModule: UNIT
     20:
-      MovePrimitiveRuntimeError: UNIT
+      SuiMoveVerificationError: UNIT
     21:
+      MovePrimitiveRuntimeError: UNIT
+    22:
       MoveAbort:
         TUPLE:
           - TYPENAME: ModuleId
           - U64
-    22:
-      VMVerificationOrDeserializationError: UNIT
     23:
+      VMVerificationOrDeserializationError: UNIT
+    24:
       VMInvariantViolation: UNIT
 ExecutionStatus:
   ENUM:
@@ -157,6 +161,10 @@ ExecutionStatus:
               TYPENAME: ExecutionFailureStatus
 Identifier:
   NEWTYPESTRUCT: STR
+InvalidSharedByValue:
+  STRUCT:
+    - object:
+        TYPENAME: ObjectID
 InvalidSharedChildUse:
   STRUCT:
     - child:

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1154,7 +1154,7 @@ impl Display for EntryArgumentErrorKind {
         match self {
             EntryArgumentErrorKind::TypeMismatch => write!(f, "Type mismatch."),
             EntryArgumentErrorKind::InvalidObjectByValue => {
-                write!(f, "Immutable objects cannot be passed by-value.")
+                write!(f, "Immutable and shared objects cannot be passed by-value.")
             }
             EntryArgumentErrorKind::InvalidObjectByMuteRef => {
                 write!(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -964,6 +964,7 @@ pub enum ExecutionFailureStatus {
     CircularObjectOwnership(CircularObjectOwnership),
     MissingObjectOwner(MissingObjectOwner),
     InvalidSharedChildUse(InvalidSharedChildUse),
+    InvalidSharedByValue(InvalidSharedByValue),
     // Likely going to be removed
     DeleteObjectOwnedObject,
 
@@ -1020,6 +1021,11 @@ pub struct InvalidSharedChildUse {
     pub ancestor: ObjectID,
 }
 
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Serialize, Deserialize, Hash)]
+pub struct InvalidSharedByValue {
+    pub object: ObjectID,
+}
+
 impl ExecutionFailureStatus {
     pub fn entry_argument_error(argument_idx: LocalIndex, kind: EntryArgumentErrorKind) -> Self {
         EntryArgumentError { argument_idx, kind }.into()
@@ -1035,6 +1041,10 @@ impl ExecutionFailureStatus {
 
     pub fn invalid_shared_child_use(child: ObjectID, ancestor: ObjectID) -> Self {
         InvalidSharedChildUse { child, ancestor }.into()
+    }
+
+    pub fn invalid_shared_by_value(object: ObjectID) -> Self {
+        InvalidSharedByValue { object }.into()
     }
 }
 
@@ -1076,16 +1086,19 @@ impl std::fmt::Display for ExecutionFailureStatus {
                 "Number of type arguments does not match the expected value",
             ),
             ExecutionFailureStatus::EntryArgumentError(data) => {
-                write!(f, "Entry Argument Type Error. {}", data)
+                write!(f, "Entry Argument Type Error. {data}")
             }
             ExecutionFailureStatus::CircularObjectOwnership(data) => {
-                write!(f, "Circular  Object Ownership. {}", data)
+                write!(f, "Circular  Object Ownership. {data}")
             }
             ExecutionFailureStatus::MissingObjectOwner(data) => {
-                write!(f, "Missing Object Owner. {}", data)
+                write!(f, "Missing Object Owner. {data}")
             }
             ExecutionFailureStatus::InvalidSharedChildUse(data) => {
-                write!(f, "Invalid Shared Child Object Usage. {}.", data)
+                write!(f, "Invalid Shared Child Object Usage. {data}.")
+            }
+            ExecutionFailureStatus::InvalidSharedByValue(data) => {
+                write!(f, "Invalid Shared Object By-Value Usage. {data}.")
             }
             ExecutionFailureStatus::DeleteObjectOwnedObject => write!(
                 f,
@@ -1198,6 +1211,18 @@ impl Display for InvalidSharedChildUse {
     }
 }
 
+impl Display for InvalidSharedByValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let InvalidSharedByValue { object } = self;
+        write!(
+            f,
+        "When a shared object is passed as an owned Move value in an entry function, either the \
+        the shared object's type must be defined in the same module as the called function. The \
+        shared object {object} is not defined in this module",
+        )
+    }
+}
+
 impl std::error::Error for ExecutionFailureStatus {}
 
 impl ExecutionStatus {
@@ -1253,6 +1278,12 @@ impl From<MissingObjectOwner> for ExecutionFailureStatus {
 impl From<InvalidSharedChildUse> for ExecutionFailureStatus {
     fn from(error: InvalidSharedChildUse) -> Self {
         Self::InvalidSharedChildUse(error)
+    }
+}
+
+impl From<InvalidSharedByValue> for ExecutionFailureStatus {
+    fn from(error: InvalidSharedByValue) -> Self {
+        Self::InvalidSharedByValue(error)
     }
 }
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1154,7 +1154,7 @@ impl Display for EntryArgumentErrorKind {
         match self {
             EntryArgumentErrorKind::TypeMismatch => write!(f, "Type mismatch."),
             EntryArgumentErrorKind::InvalidObjectByValue => {
-                write!(f, "Only an owned object can be passed by-value.")
+                write!(f, "Immutable objects cannot be passed by-value.")
             }
             EntryArgumentErrorKind::InvalidObjectByMuteRef => {
                 write!(
@@ -1202,11 +1202,11 @@ impl Display for InvalidSharedChildUse {
         let InvalidSharedChildUse { child, ancestor } = self;
         write!(
             f,
-            "When an (either direct or indirect) child object of a shared object is passed as a \
-            Move argument, either the child object's type or the shared object's type must be \
-            defined in the same module as the called function. This is violated by the child \
-            object {child}, whose ancestor {ancestor} is a shared object, and neither are defined \
-            in the current module."
+            "When a child object (either direct or indirect) of a shared object is passed by-value \
+            to an entry function, either the child object's type or the shared object's type must \
+            be defined in the same module as the called function. This is violated by object \
+            {child}, whose ancestor {ancestor} is a shared object, and neither are defined in \
+            this module.",
         )
     }
 }


### PR DESCRIPTION
- Relax orphan rule so that it only pertains to by-value child object usage
- ~~Relax by-value object rule so shared objects can be consumed~~
- ~~Shared objects can be taken by-value in only their defining module~~