### PR TITLE
Fix sui console prompt color

### DIFF
--- a/crates/sui/src/shell.rs
+++ b/crates/sui/src/shell.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use std::borrow::Cow;
+use std::borrow::Cow::Owned;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::env;
@@ -73,9 +75,6 @@ impl<P: Display, S: Send, H: AsyncHandler<S>> Shell<P, S, H> {
         }));
 
         loop {
-            write!(out, "{}", format!("{}", self.prompt).bold().green())?;
-            out.flush()?;
-
             // Read a line
             let readline = rl.readline(&self.prompt.to_string());
             let line = match readline {
@@ -196,7 +195,15 @@ impl Hinter for ShellHelper {
     type Hint = String;
 }
 
-impl Highlighter for ShellHelper {}
+impl Highlighter for ShellHelper {
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        _default: bool,
+    ) -> Cow<'b, str> {
+        Owned(prompt.bold().green().to_string())
+    }
+}
 
 impl Validator for ShellHelper {}
 


### PR DESCRIPTION
using rustyline highlighter to change the prompt colour to green, this works correctly in windows as well

Results:

windows
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/1888654/178256767-f866c527-3cab-44a7-ac4a-b5d3035104eb.png">

OSX:
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/1888654/178256877-200ec456-60f6-426a-a7e4-eda49fb045d1.png">

this PR depends on https://github.com/MystenLabs/sui/pull/3134, which is causing build failure in windows