### PR TITLE
[consensus] Ensure we use the latest checkpoint seq number

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -223,7 +223,7 @@ impl ValidatorService {
                 /* consensus_address */ consensus_config.address().to_owned(),
                 /* tx_consensus_listener */ tx_sui_to_consensus,
                 rx_checkpoint_consensus_adapter,
-                /* checkpoint_locals */ checkpoint_store.lock().get_locals(),
+                /* checkpoint_locals */ checkpoint_store,
                 /* retry_delay */ Duration::from_millis(5_000),
                 /* max_pending_transactions */ 10_000,
             )


### PR DESCRIPTION
We used to just get the checkpoint locals once upon init and reuse the same ones. Now we get a proper Arc to the checkpoint store, and use an up-to-data locals structure for each call.