### PR TITLE
[wallet ext] add stake feature

### DIFF
--- a/wallet/src/ui/app/components/coin-balance/index.tsx
+++ b/wallet/src/ui/app/components/coin-balance/index.tsx
@@ -14,9 +14,10 @@ import st from './CoinBalance.module.scss';
 export type CoinProps = {
     type: string;
     balance: bigint;
+    stake: boolean;
 };
 
-function CoinBalance({ type, balance }: CoinProps) {
+function CoinBalance({ type, balance, stake }: CoinProps) {
     const symbol = useMemo(() => Coin.getCoinSymbol(type), [type]);
     const intl = useIntl();
     const balanceFormatted = useMemo(
@@ -27,6 +28,11 @@ function CoinBalance({ type, balance }: CoinProps) {
         () => `/send?${new URLSearchParams({ type }).toString()}`,
         [type]
     );
+    const stakeUrl = useMemo(
+        () => `/stake?${new URLSearchParams({ type }).toString()}`,
+        [type]
+    );
+
     return (
         <div className={st.container}>
             <span className={st.type} title={type}>
@@ -39,6 +45,11 @@ function CoinBalance({ type, balance }: CoinProps) {
             <Link className={cl('btn', st.send)} to={sendUrl}>
                 Send
             </Link>
+            {stake ? (
+                <Link className={cl('btn', st.send)} to={stakeUrl}>
+                    Stake
+                </Link>
+            ) : null}
         </div>
     );
 }

--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -10,6 +10,7 @@ import { DappTxApprovalPage } from '_pages/dapp-tx-approval';
 import HomePage, {
     NftsPage,
     SettingsPage,
+    StakePage,
     TokensPage,
     TransactionDetailsPage,
     TransactionsPage,
@@ -51,6 +52,7 @@ const App = () => {
                 <Route path="settings" element={<SettingsPage />} />
                 <Route path="send" element={<TransferCoinPage />} />
                 <Route path="send-nft" element={<TransferNFTPage />} />
+                <Route path="stake" element={<StakePage />} />
                 <Route
                     path="tx/:txDigest"
                     element={<TransactionDetailsPage />}

--- a/wallet/src/ui/app/pages/home/index.tsx
+++ b/wallet/src/ui/app/pages/home/index.tsx
@@ -53,6 +53,7 @@ const HomePage = () => {
 export default HomePage;
 export { default as NftsPage } from './nfts';
 export { default as SettingsPage } from './settings';
+export { default as StakePage } from './stake';
 export { default as TokensPage } from './tokens';
 export { default as TransactionDetailsPage } from './transaction-details';
 export { default as TransactionsPage } from './transactions';

--- a/wallet/src/ui/app/pages/home/stake/StakeForm.module.scss
+++ b/wallet/src/ui/app/pages/home/stake/StakeForm.module.scss
@@ -1,0 +1,38 @@
+.container {
+    display: flex;
+    flex-flow: column nowrap;
+    flex: 1;
+    align-self: stretch;
+}
+
+.group {
+    display: flex;
+    flex-flow: column nowrap;
+
+    & + & {
+        margin-top: 8px;
+    }
+}
+
+.label {
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+
+.error {
+    color: #8b1111;
+    line-height: 1em;
+    min-height: 1em;
+    margin-top: 2px;
+}
+
+.muted {
+    font-size: 10px;
+    font-weight: 400;
+    color: #666;
+    margin-top: 1px;
+}
+
+.input {
+    padding: 12px;
+}

--- a/wallet/src/ui/app/pages/home/stake/StakeForm.tsx
+++ b/wallet/src/ui/app/pages/home/stake/StakeForm.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ErrorMessage, Field, Form, useFormikContext } from 'formik';
+import { useEffect, useRef, memo } from 'react';
+import { useIntl } from 'react-intl';
+
+import Alert from '_components/alert';
+import LoadingIndicator from '_components/loading/LoadingIndicator';
+import NumberInput from '_components/number-input';
+import {
+    DEFAULT_GAS_BUDGET_FOR_STAKE,
+    GAS_SYMBOL,
+} from '_redux/slices/sui-objects/Coin';
+import { balanceFormatOptions } from '_shared/formatting';
+
+import type { FormValues } from '.';
+
+import st from './StakeForm.module.scss';
+
+export type StakeFromProps = {
+    submitError: string | null;
+    // TODO(ggao): remove this if needed
+    coinBalance: string;
+    coinSymbol: string;
+    onClearSubmitError: () => void;
+};
+
+function StakeForm({
+    submitError,
+    // TODO(ggao): remove this if needed
+    coinBalance,
+    coinSymbol,
+    onClearSubmitError,
+}: StakeFromProps) {
+    const {
+        isSubmitting,
+        isValid,
+        values: { amount },
+    } = useFormikContext<FormValues>();
+
+    const onClearRef = useRef(onClearSubmitError);
+    onClearRef.current = onClearSubmitError;
+    useEffect(() => {
+        onClearRef.current();
+    }, [amount]);
+    const intl = useIntl();
+    return (
+        <Form className={st.container} autoComplete="off" noValidate={true}>
+            <div className={st.group}>
+                <label className={st.label}>Amount:</label>
+                <Field
+                    component={NumberInput}
+                    allowNegative={false}
+                    name="amount"
+                    placeholder={`Total ${coinSymbol.toLocaleUpperCase()} to stake`}
+                    className={st.input}
+                />
+                <div className={st.muted}>
+                    Available balance:{' '}
+                    {intl.formatNumber(
+                        BigInt(coinBalance),
+                        balanceFormatOptions
+                    )}{' '}
+                    {coinSymbol}
+                </div>
+                <ErrorMessage
+                    className={st.error}
+                    name="amount"
+                    component="div"
+                />
+            </div>
+            <div className={st.group}>
+                * Total transaction fee estimate (gas cost):{' '}
+                {DEFAULT_GAS_BUDGET_FOR_STAKE} {GAS_SYMBOL}
+            </div>
+            {submitError ? (
+                <div className={st.group}>
+                    <Alert>
+                        <strong>Stake failed.</strong>{' '}
+                        <small>{submitError}</small>
+                    </Alert>
+                </div>
+            ) : null}
+            <div className={st.group}>
+                <button
+                    type="submit"
+                    disabled={!isValid || isSubmitting}
+                    className="btn"
+                >
+                    {isSubmitting ? <LoadingIndicator /> : 'Stake'}
+                </button>
+            </div>
+        </Form>
+    );
+}
+
+export default memo(StakeForm);

--- a/wallet/src/ui/app/pages/home/stake/index.tsx
+++ b/wallet/src/ui/app/pages/home/stake/index.tsx
@@ -1,0 +1,135 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Formik } from 'formik';
+import { useCallback, useMemo, useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+
+import StakeForm from './StakeForm';
+import { createValidationSchema } from './validation';
+import Loading from '_components/loading';
+import { useAppSelector, useAppDispatch } from '_hooks';
+import {
+    accountAggregateBalancesSelector,
+    accountItemizedBalancesSelector,
+} from '_redux/slices/account';
+import { Coin, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
+import { StakeTokens } from '_redux/slices/transactions';
+import { balanceFormatOptions } from '_shared/formatting';
+
+import type { SerializedError } from '@reduxjs/toolkit';
+import type { FormikHelpers } from 'formik';
+
+const initialValues = {
+    amount: '',
+};
+
+export type FormValues = typeof initialValues;
+
+function StakePage() {
+    const [searchParams] = useSearchParams();
+    const coinType = useMemo(() => searchParams.get('type'), [searchParams]);
+    const balances = useAppSelector(accountItemizedBalancesSelector);
+    const aggregateBalances = useAppSelector(accountAggregateBalancesSelector);
+    const coinBalance = useMemo(
+        () => (coinType && aggregateBalances[coinType]) || BigInt(0),
+        [coinType, aggregateBalances]
+    );
+    const totalGasCoins = useMemo(
+        () => balances[GAS_TYPE_ARG]?.length || 0,
+        [balances]
+    );
+    const gasAggregateBalance = useMemo(
+        () => aggregateBalances[GAS_TYPE_ARG] || BigInt(0),
+        [aggregateBalances]
+    );
+    const coinSymbol = useMemo(
+        () => (coinType && Coin.getCoinSymbol(coinType)) || '',
+        [coinType]
+    );
+    const [sendError, setSendError] = useState<string | null>(null);
+    const intl = useIntl();
+    const validationSchema = useMemo(
+        () =>
+            createValidationSchema(
+                coinType || '',
+                coinBalance,
+                coinSymbol,
+                gasAggregateBalance,
+                totalGasCoins,
+                intl,
+                balanceFormatOptions
+            ),
+        [
+            coinType,
+            coinBalance,
+            coinSymbol,
+            gasAggregateBalance,
+            totalGasCoins,
+            intl,
+        ]
+    );
+
+    const dispatch = useAppDispatch();
+    const navigate = useNavigate();
+    const onHandleSubmit = useCallback(
+        async (
+            { amount }: FormValues,
+            { resetForm }: FormikHelpers<FormValues>
+        ) => {
+            if (coinType === null) {
+                return;
+            }
+            setSendError(null);
+            try {
+                const response = await dispatch(
+                    StakeTokens({
+                        amount: BigInt(amount),
+                        tokenTypeArg: coinType,
+                    })
+                ).unwrap();
+                const txDigest =
+                    response.EffectResponse.certificate.transactionDigest;
+                resetForm();
+                navigate(`/tx/${encodeURIComponent(txDigest)}`);
+            } catch (e) {
+                setSendError((e as SerializedError).message || null);
+            }
+        },
+        [dispatch, navigate, coinType]
+    );
+    const handleOnClearSubmitError = useCallback(() => {
+        setSendError(null);
+    }, []);
+    const loadingBalance = useAppSelector(
+        ({ suiObjects }) => suiObjects.loading && !suiObjects.lastSync
+    );
+
+    if (!coinType) {
+        return <Navigate to="/" replace={true} />;
+    }
+
+    return (
+        <>
+            <h3>Stake {coinSymbol}</h3>
+            <Loading loading={loadingBalance}>
+                <Formik
+                    initialValues={initialValues}
+                    validateOnMount={false}
+                    validationSchema={validationSchema}
+                    onSubmit={onHandleSubmit}
+                >
+                    <StakeForm
+                        submitError={sendError}
+                        coinBalance={coinBalance.toString()}
+                        coinSymbol={coinSymbol}
+                        onClearSubmitError={handleOnClearSubmitError}
+                    />
+                </Formik>
+            </Loading>
+        </>
+    );
+}
+
+export default StakePage;

--- a/wallet/src/ui/app/pages/home/stake/validation.ts
+++ b/wallet/src/ui/app/pages/home/stake/validation.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as Yup from 'yup';
+
+import {
+    DEFAULT_GAS_BUDGET_FOR_STAKE,
+    GAS_TYPE_ARG,
+    GAS_SYMBOL,
+} from '_redux/slices/sui-objects/Coin';
+
+import type { FormatNumberOptions, IntlShape } from 'react-intl';
+
+export function createValidationSchema(
+    coinType: string,
+    coinBalance: bigint,
+    coinSymbol: string,
+    gasBalance: bigint,
+    totalGasCoins: number,
+    intl: IntlShape,
+    formatOptions: FormatNumberOptions
+) {
+    return Yup.object({
+        amount: Yup.number()
+            .integer()
+            .required()
+            .min(
+                1,
+                `\${path} must be greater than or equal to \${min} ${coinSymbol}`
+            )
+            .test(
+                'max',
+                `\${path} must be less than or equal to ${intl.formatNumber(
+                    coinBalance,
+                    formatOptions
+                )} ${coinSymbol}`,
+                (amount) =>
+                    typeof amount === 'undefined' ||
+                    BigInt(amount) <= coinBalance
+            )
+            .test(
+                'gas-balance-check',
+                `Insufficient ${GAS_SYMBOL} balance to cover gas fee`,
+                (amount) => {
+                    try {
+                        let availableGas = gasBalance;
+                        if (coinType === GAS_TYPE_ARG) {
+                            availableGas -= BigInt(amount || 0);
+                        }
+                        return availableGas >= DEFAULT_GAS_BUDGET_FOR_STAKE;
+                    } catch (e) {
+                        return false;
+                    }
+                }
+            )
+            .test(
+                'num-gas-coins-check',
+                `Need at least 2 ${GAS_SYMBOL} coins to stake a ${GAS_SYMBOL} coin`,
+                () => {
+                    return coinType !== GAS_TYPE_ARG || totalGasCoins >= 2;
+                }
+            )
+            .label('Amount'),
+    });
+}

--- a/wallet/src/ui/app/pages/home/tokens/index.tsx
+++ b/wallet/src/ui/app/pages/home/tokens/index.tsx
@@ -22,6 +22,7 @@ function TokensPage() {
                     <CoinBalance
                         type={aCoinType}
                         balance={aCoinBalance}
+                        stake={true}
                         key={aCoinType}
                     />
                 );

--- a/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -14,6 +14,7 @@ import type {
     TransactionResponse,
     RawSigner,
     SuiAddress,
+    JsonRpcProvider,
 } from '@mysten/sui.js';
 
 const COIN_TYPE = '0x2::coin::Coin';
@@ -21,9 +22,12 @@ const COIN_TYPE_ARG_REGEX = /^0x2::coin::Coin<(.+)>$/;
 export const DEFAULT_GAS_BUDGET_FOR_SPLIT = 1000;
 export const DEFAULT_GAS_BUDGET_FOR_MERGE = 500;
 export const DEFAULT_GAS_BUDGET_FOR_TRANSFER = 100;
+export const DEFAULT_GAS_BUDGET_FOR_STAKE = 1000;
 export const GAS_TYPE_ARG = '0x2::sui::SUI';
 export const GAS_SYMBOL = 'SUI';
 export const DEFAULT_NFT_TRANSFER_GAS_FEE = 450;
+export const SUI_SYSTEM_STATE_OBJECT_ID =
+    '0x0000000000000000000000000000000000000005';
 
 // TODO use sdk
 export class Coin {
@@ -76,6 +80,32 @@ export class Coin {
             objectId: coin,
             gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER,
             recipient: recipient,
+        });
+    }
+
+    /**
+     * Stake `amount` of Coin<T> to `validator`. Technically it means user delegates `amount` of Coin<T> to `validator`,
+     * such that `validator` will stake the `amount` of Coin<T> for the user.
+     *
+     * @param signer A signer with connection to the gateway:e.g., new RawSigner(keypair, new JsonRpcProvider(endpoint))
+     * @param coins A list of Coins owned by the signer with the same generic type(e.g., 0x2::Sui::Sui)
+     * @param amount The amount to be staked
+     * @param validator The sui address of the chosen validator
+     */
+    public static async stakeCoin(
+        signer: RawSigner,
+        coins: SuiMoveObject[],
+        amount: bigint,
+        validator: SuiAddress
+    ): Promise<TransactionResponse> {
+        const coin = await Coin.selectCoin(signer, coins, amount);
+        return await signer.executeMoveCall({
+            packageObjectId: '0x2',
+            module: 'sui_system',
+            function: 'request_add_delegation',
+            typeArguments: [],
+            arguments: [SUI_SYSTEM_STATE_OBJECT_ID, coin, validator],
+            gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
         });
     }
 
@@ -141,5 +171,16 @@ export class Coin {
         }
         // primary coin might have a balance smaller than the `amount`
         return primaryCoin;
+    }
+
+    public static async getActiveValidators(
+        provider: JsonRpcProvider
+    ): Promise<Array<SuiMoveObject>> {
+        const contents = await provider.getObject(SUI_SYSTEM_STATE_OBJECT_ID);
+        const data = (contents.details as SuiObject).data;
+        const validators = (data as SuiMoveObject).fields.validators;
+        const active_validators = (validators as SuiMoveObject).fields
+            .active_validators;
+        return active_validators as Array<SuiMoveObject>;
     }
 }


### PR DESCRIPTION
Add wallet stake feature based on the existing design.

![wallet_stake](https://user-images.githubusercontent.com/106119108/178359811-4ca1aa8d-ed35-4db2-bab2-ebab4377b5e7.gif)

known issues or TODOs:
- now we just pick the first active validator, we will have a drop down and let users pick that
- now on the success page, it shows Call because today, stake is a moveCall, will change that to Stake.

This will close #2447 
