### PR TITLE
[gossip] Make validator do best effort gossip

### DIFF
--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -41,6 +41,15 @@ mod node_sync;
 use node_sync::NodeSyncDigestHandler;
 use sui_types::messages::CertifiedTransaction;
 
+#[derive(Copy, Clone)]
+enum GossipType {
+    /// Must get the full sequence of the peers it is connecting to. This is used for the full node sync logic
+    /// where a full node follows all validators.
+    Full,
+    /// Just follow the latest updates. This is used by validators to do a best effort follow of others.
+    BestEffort,
+}
+
 struct Follower<A> {
     peer_name: AuthorityName,
     client: SafeClient<A>,
@@ -59,7 +68,13 @@ pub async fn gossip_process<A>(active_authority: &ActiveAuthority<A>, degree: us
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    follower_process(active_authority, degree, GossipDigestHandler::new()).await;
+    follower_process(
+        active_authority,
+        degree,
+        GossipDigestHandler::new(),
+        GossipType::BestEffort,
+    )
+    .await;
 }
 
 pub async fn node_sync_process<A>(
@@ -76,6 +91,7 @@ pub async fn node_sync_process<A>(
         active_authority,
         degree,
         NodeSyncDigestHandler::new(state, aggregator, node_sync_store),
+        GossipType::Full,
     )
     .await;
 }
@@ -84,6 +100,7 @@ async fn follower_process<A, Handler: DigestHandler<A> + Clone>(
     active_authority: &ActiveAuthority<A>,
     degree: usize,
     handler: Handler,
+    gossip_type: GossipType,
 ) where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
@@ -146,7 +163,7 @@ async fn follower_process<A, Handler: DigestHandler<A> + Clone>(
             let local_active_ref_copy = local_active.clone();
             let handler_clone = handler.clone();
             gossip_tasks.push(async move {
-                let follower = Follower::new(name, &local_active_ref_copy);
+                let follower = Follower::new(name, &local_active_ref_copy, gossip_type);
                 // Add more duration if we make more than 1 to ensure overlap
                 debug!(peer = ?name, "Starting gossip from peer");
                 follower
@@ -322,10 +339,15 @@ impl<A> Follower<A>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    pub fn new(peer_name: AuthorityName, active_authority: &ActiveAuthority<A>) -> Self {
+    pub fn new(
+        peer_name: AuthorityName,
+        active_authority: &ActiveAuthority<A>,
+        gossip_type: GossipType,
+    ) -> Self {
         // TODO: for validator gossip, we should always use None as the start_seq, but we should
         // consult the start_seq we retrieved from the db to make sure that the peer is giving
         // us new txes.
+
         let start_seq = match active_authority
             .follower_store
             .get_next_sequence(&peer_name)
@@ -334,9 +356,17 @@ where
                 // If there was no start sequence found for this peer, it is likely a new peer
                 // that has just joined the network, start at 0.
                 info!(peer = ?peer_name, "New gossip peer has joined");
+
+                // TODO: How does this interfere with reconfigurations, etc?
+                //       Do we start the seq number at zero for each new epoch?
                 0
             }
             Ok(s) => s.unwrap_or(0),
+        };
+
+        let max_seq = match gossip_type {
+            GossipType::BestEffort => None,
+            GossipType::Full => Some(start_seq),
         };
 
         debug!(peer = ?peer_name, ?start_seq, "Restarting follower at sequence");
@@ -346,7 +376,7 @@ where
             client: active_authority.net.load().authority_clients[&peer_name].clone(),
             state: active_authority.state.clone(),
             follower_store: active_authority.follower_store.clone(),
-            max_seq: Some(start_seq),
+            max_seq,
             aggregator: active_authority.net.load().clone(),
         }
     }
@@ -372,8 +402,10 @@ where
         let mut results = FuturesOrdered::new();
         let mut batch_seq_to_record = VecDeque::new();
 
+        let mut latest_seq = self.max_seq;
+
         let req = BatchInfoRequest {
-            start: self.max_seq,
+            start: latest_seq,
             length: REQUEST_FOLLOW_NUM_DIGESTS,
         };
 
@@ -393,7 +425,7 @@ where
                             let next_seq = signed_batch.batch.next_sequence_number;
                             debug!(?peer, batch_next_seq = ?next_seq, "Received signed batch");
                             batch_seq_to_record.push_back((next_seq, last_seq_in_cur_batch));
-                            if let Some(max_seq) = self.max_seq {
+                            if let Some(max_seq) = latest_seq {
                                 if next_seq < max_seq {
                                     info!("Gossip sequence number unexpected: found {:?} but previously received {:?}", next_seq, max_seq);
                                 }
@@ -426,7 +458,7 @@ where
                         None => {
                             tokio::time::sleep(Duration::from_secs(REFRESH_FOLLOWER_PERIOD_SECS / 12)).await;
                             let req = BatchInfoRequest {
-                                start: self.max_seq,
+                                start: latest_seq,
                                 length: REQUEST_FOLLOW_NUM_DIGESTS,
                             };
                             streamx = Box::pin(self.client.handle_batch_stream(req).await?);
@@ -443,6 +475,11 @@ where
                             break;
                         }
                         self.follower_store.record_next_sequence(&self.peer_name, *batch_seq)?;
+
+                        // Here we always set the minimum next sequence number to make progress
+                        // over the sequence of the peer, even if we started with a best effort
+                        // None initial sequence number for gossip.
+                        latest_seq = Some(*batch_seq);
                         batch_seq_to_record.pop_front();
                     }
                 }

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -84,7 +84,6 @@ pub async fn node_sync_process<A>(
 ) where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    // TODO: special case follower for node sync.
     let state = active_authority.state.clone();
     let aggregator = active_authority.net.load().clone();
     follower_process(
@@ -344,10 +343,6 @@ where
         active_authority: &ActiveAuthority<A>,
         gossip_type: GossipType,
     ) -> Self {
-        // TODO: for validator gossip, we should always use None as the start_seq, but we should
-        // consult the start_seq we retrieved from the db to make sure that the peer is giving
-        // us new txes.
-
         let start_seq = match active_authority
             .follower_store
             .get_next_sequence(&peer_name)


### PR DESCRIPTION
Currently validators, like full nodes, re-download the full sequence from all peers, and also do not really update the sequence number to start downloading while following a node (in case of disconnections). So in the PR we fix these two things and :
* Pass as an enum the type of gossip full or bext effort, and for best effort we start each new peer with None as a starting sequence number.
* However, in all cases we update the sequence number as we receive and process more blocks, so that subsequent connections start with a further sequence number.