### PR TITLE
[bugfix] - Stack overflow when installing Sui binaries in windows

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,5 +10,3 @@ xclippy = [
 ]
 xlint = "run --package x --bin x -- lint"
 
-[target.'cfg(target_family = "windows")']
-rustflags = [ "-C",  "link-args=/STACK:64000000" ]

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -12,7 +12,7 @@ use std::{
 /// Save revision info to environment variable
 fn main() {
     #[cfg(target_family = "windows")]
-    println!("cargo:rustc-link-arg=/STACK:64000000");
+    println!("cargo:rustc-link-arg=STACK:64000000");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let sui_framwork_path = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -12,7 +12,7 @@ use std::{
 /// Save revision info to environment variable
 fn main() {
     #[cfg(target_family = "windows")]
-    println!("cargo:rustc-link-arg=STACK:64000000");
+    println!("cargo:rustc-link-arg=-zstack-size=64000000");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let sui_framwork_path = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -14,35 +14,28 @@ use std::{
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let sui_framwork_path = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let move_stdlib_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("deps/move-stdlib");
+    let sui_framework_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let move_stdlib_path = sui_framework_path.join("deps").join("move-stdlib");
 
-    let sui_build_config = BuildConfig::default();
-
-    let move_stdlib = move_stdlib_path.clone();
-    Builder::new()
-        .stack_size(16 * 1024 * 1024)
-        .spawn(move || {
-            let sui_framework =
-                sui_framework_build::build_move_package(sui_framwork_path, sui_build_config)
-                    .unwrap();
-            let move_stdlib = sui_framework_build::build_move_stdlib_modules(&move_stdlib).unwrap();
-
-            serialize_modules_to_file(sui_framework, &out_dir.join("sui-framework")).unwrap();
-            serialize_modules_to_file(move_stdlib, &out_dir.join("move-stdlib")).unwrap();
-        })
+    let stdlib_path = move_stdlib_path.clone();
+    let (sui_framework, move_stdlib) = Builder::new()
+        .stack_size(16 * 1024 * 1024) // build_move_package require bigger stack size on windows.
+        .spawn(move || build_framework_and_stdlib(sui_framework_path, &stdlib_path))
         .unwrap()
         .join()
         .unwrap();
 
+    serialize_modules_to_file(sui_framework, &out_dir.join("sui-framework")).unwrap();
+    serialize_modules_to_file(move_stdlib, &out_dir.join("move-stdlib")).unwrap();
+
     println!("cargo:rerun-if-changed=build.rs");
     println!(
         "cargo:rerun-if-changed={}",
-        sui_framwork_path.join("Move.toml").display()
+        sui_framework_path.join("Move.toml").display()
     );
     println!(
         "cargo:rerun-if-changed={}",
-        sui_framwork_path.join("sources").display()
+        sui_framework_path.join("sources").display()
     );
     println!(
         "cargo:rerun-if-changed={}",
@@ -52,6 +45,17 @@ fn main() {
         "cargo:rerun-if-changed={}",
         move_stdlib_path.join("sources").display()
     );
+}
+
+fn build_framework_and_stdlib(
+    sui_framework_path: &Path,
+    move_stdlib_path: &Path,
+) -> (Vec<CompiledModule>, Vec<CompiledModule>) {
+    let sui_framework =
+        sui_framework_build::build_move_package(sui_framework_path, BuildConfig::default())
+            .unwrap();
+    let move_stdlib = sui_framework_build::build_move_stdlib_modules(move_stdlib_path).unwrap();
+    (sui_framework, move_stdlib)
 }
 
 fn serialize_modules_to_file(modules: Vec<CompiledModule>, file: &Path) -> Result<()> {

--- a/crates/sui-framework/build.rs
+++ b/crates/sui-framework/build.rs
@@ -11,6 +11,8 @@ use std::{
 
 /// Save revision info to environment variable
 fn main() {
+    #[cfg(target_family = "windows")]
+    println!("cargo:rustc-link-arg=/STACK:64000000");
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let sui_framwork_path = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
This PR fixes stack overflow issue when installing Sui on windows.

Prior to this PR, we fixed the SO issue by adding `rustflags = [ "-C", "link-args=/STACK:64000000" ]` to `.cargo/config` file, this works if we are using `cargo build`, however it won't work for `cargo install --git`.