### PR TITLE
[bench + driver] Fix quorum driver deadlock

### DIFF
--- a/crates/sui-benchmark/src/bin/shared.rs
+++ b/crates/sui-benchmark/src/bin/shared.rs
@@ -249,7 +249,7 @@ async fn main() {
                                         )))
                                     }
                                     Err(_sui_err) => {
-                                        //eprintln!("{}", sui_err);
+                                        println!("{}", _sui_err);
                                         // TODO (GAS-LEAK): How do we add this gas back in the pool?
                                         NextOp::Response(None)
                                     }

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -35,7 +35,7 @@ async fn test_execute_transaction_immediate() {
     let (_handles, clients, tx) = setup().await;
     let digest = *tx.digest();
 
-    let mut quorum_driver_handler = QuorumDriverHandler::new(clients);
+    let quorum_driver_handler = QuorumDriverHandler::new(clients);
     let quorum_driver = quorum_driver_handler.clone_quorum_driver();
     let handle = tokio::task::spawn(async move {
         let (cert, effects) = quorum_driver_handler.subscribe().recv().await.unwrap();
@@ -61,7 +61,7 @@ async fn test_execute_transaction_wait_for_cert() {
     let (_handles, clients, tx) = setup().await;
     let digest = *tx.digest();
 
-    let mut quorum_driver_handler = QuorumDriverHandler::new(clients);
+    let quorum_driver_handler = QuorumDriverHandler::new(clients);
     let quorum_driver = quorum_driver_handler.clone_quorum_driver();
     let handle = tokio::task::spawn(async move {
         let (cert, effects) = quorum_driver_handler.subscribe().recv().await.unwrap();
@@ -89,7 +89,7 @@ async fn test_execute_transaction_wait_for_effects() {
     let (_handles, clients, tx) = setup().await;
     let digest = *tx.digest();
 
-    let mut quorum_driver_handler = QuorumDriverHandler::new(clients);
+    let quorum_driver_handler = QuorumDriverHandler::new(clients);
     let quorum_driver = quorum_driver_handler.clone_quorum_driver();
     let handle = tokio::task::spawn(async move {
         let (cert, effects) = quorum_driver_handler.subscribe().recv().await.unwrap();


### PR DESCRIPTION
This fixes the benchmark getting blocked / deadlocked after a number of transactions. The issue was that notifications of correct transactions were sent down a bounded channel, but the bounded channel was not being drained by a receiver. As a result at some point the sending was blocking, and everything stopped. The solution is to use a tokio broadcast channel that just drops items in full channels.

Incidentally I also fixed a further potential deadlock where a message was sent down a channel in the same loop as the receiver -- potentially leading to a situation where we would block on a full channel, but we also block the only location that could receive to unlock.