### PR TITLE
[sui-adapter][messages] Give more context for adapter errors

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -24,8 +24,8 @@ task 6 'run'. lines 86-88:
 written: object(109), object(111), object(112)
 
 task 7 'run'. lines 89-89:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedChildUse, source: Some("When an (either direct or indirect) child object of a shared object is passed as a Move argument,either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109) (defined in module 'T1::O1'), whose ancestor fake(111) is a shared object (defined in module 'T2::O2'), and neither are defined in this module 'T1::O1'") } }
+Error: Transaction Effects Status: Invalid Shared Child Object Usage. When an (either direct or indirect) child object of a shared object is passed as a Move argument, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by the child object fake(109), whose ancestor fake(111) is a shared object, and neither are defined in the current module..
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedChildUse(InvalidSharedChildUse { child: fake(109), ancestor: fake(111) }), source: Some("When an (either direct or indirect) child object of a shared object is passed as a Move argument, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109) (defined in module 'T1::O1'), whose ancestor fake(111) is a shared object (defined in module 'T2::O2'), and neither are defined in this module 'T1::O1'") } }
 
 task 8 'run'. lines 91-91:
 written: object(109), object(111), object(114)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/wrong_visibility.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/wrong_visibility.exp
@@ -5,13 +5,13 @@ created: object(103)
 written: object(102)
 
 task 2 'run'. lines 26-26:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidNonEntryFunction, source: Some("Can only call `entry` functions") } }
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Can only call `entry` functions") } }
 
 task 3 'run'. lines 28-28:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidNonEntryFunction, source: Some("Can only call `entry` functions") } }
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Can only call `entry` functions") } }
 
 task 4 'run'. lines 30-30:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidNonEntryFunction, source: Some("Can only call `entry` functions") } }
+Error: Transaction Effects Status: Non Entry Function Invoked. Move Call must start with an entry function
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: NonEntryFunctionInvoked, source: Some("Can only call `entry` functions") } }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_param.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_param.exp
@@ -1,5 +1,5 @@
 processed 2 tasks
 
 task 1 'publish'. lines 5-24:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected exactly one parameter for _::M1::init  of type &mut sui::tx_context::TxContext") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::M1::init  of type &mut sui::tx_context::TxContext") } }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_public.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_public.exp
@@ -1,5 +1,5 @@
 processed 2 tasks
 
 task 1 'publish'. lines 5-25:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::M1. 'init' function must be private") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::M1. 'init' function must be private") } }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_ret.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_ret.exp
@@ -1,5 +1,5 @@
 processed 2 tasks
 
 task 1 'publish'. lines 5-26:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::M1, 'init' function cannot have return values") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::M1, 'init' function cannot have return values") } }

--- a/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/freeze.exp
@@ -11,9 +11,9 @@ task 2 'run'. lines 10-10:
 written: object(104), object(105)
 
 task 3 'run'. lines 12-12:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TypeError, source: Some("Only owned object can be passed by-value, violation found in argument 0") } }
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Only an owned object can be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Only owned object can be passed by-value, violation found in argument 0") } }
 
 task 4 'run'. lines 14-14:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TypeError, source: Some("Argument 0 is expected to be mutable, immutable object found") } }
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable objects cannot be passed by mutable reference, &mut.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByMuteRef }), source: Some("Argument 0 is expected to be mutable, immutable object found") } }

--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_args_type_mismatch.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_args_type_mismatch.exp
@@ -5,9 +5,9 @@ created: object(103)
 written: object(102)
 
 task 2 'run'. lines 14-16:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidFunctionSignature, source: Some("Expected 2 arguments calling function 'create', but found 1") } }
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 1: Mismatch between the number of actual versus expected argument.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 1, kind: ArityMismatch }), source: Some("Expected 2 arguments calling function 'create', but found 1") } }
 
 task 3 'run'. lines 17-17:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VmError, source: Some(VMError { major_status: FAILED_TO_DESERIALIZE_ARGUMENT, sub_status: None, message: None, exec_state: None, location: Undefined, indices: [], offsets: [] }) } }
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: FAILED_TO_DESERIALIZE_ARGUMENT, sub_status: None, message: None, exec_state: None, location: Undefined, indices: [], offsets: [] }) } }

--- a/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/move_call_incorrect_function.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'run'. lines 7-9:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VmError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find ModuleId { address: _, name: Identifier(\"object_basics\") } in data cache"), exec_state: None, location: Undefined, indices: [], offsets: [] }) } }
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: LINKER_ERROR, sub_status: None, message: Some("Cannot find ModuleId { address: _, name: Identifier(\"object_basics\") } in data cache"), exec_state: None, location: Undefined, indices: [], offsets: [] }) } }
 
 task 1 'run'. lines 10-10:
-Error: Transaction Effects Status: MiscellaneousError
+Error: Transaction Effects Status: Function Not Found.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: FunctionNotFound, source: Some("Could not resolve function 'foo' in module sui::object_basics") } }

--- a/crates/sui-adapter-transactional-tests/tests/sui/publish_module_non_zero_address.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/publish_module_non_zero_address.exp
@@ -1,5 +1,5 @@
 processed 2 tasks
 
 task 1 'publish'. lines 8-10:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModulePublishFailure, source: Some("Publishing module M with non-zero address is not allowed") } }
+Error: Transaction Effects Status: Publish Error, Non-zero Address. The modules in the package must have their address set to zero.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: PublishErrorNonZeroAddress, source: Some("Publishing module M with non-zero address is not allowed") } }

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
@@ -16,8 +16,8 @@ Owner: Account Address ( A )
 Contents: test::m::S {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}}
 
 task 4 'transfer-object'. lines 35-35:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TransferObjectWithoutPublicTransfer, source: None } }
+Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None } }
 
 task 5 'view-object'. lines 37-40:
 Owner: Account Address ( A )
@@ -32,8 +32,8 @@ Owner: Account Address ( A )
 Contents: test::m::Cup<test::m::S> {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(110)}}, version: 1u64}}
 
 task 8 'transfer-object'. lines 46-46:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TransferObjectWithoutPublicTransfer, source: None } }
+Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None } }
 
 task 9 'view-object'. lines 48-48:
 Owner: Account Address ( A )

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
@@ -16,8 +16,8 @@ Owner: Immutable
 Contents: test::m::S {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}}
 
 task 4 'transfer-object'. lines 28-28:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TransferUnowned, source: None } }
+Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None } }
 
 task 5 'view-object'. lines 30-30:
 Owner: Immutable

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/package.exp
@@ -11,8 +11,8 @@ task 2 'view-object'. lines 13-13:
 105::m
 
 task 3 'transfer-object'. lines 15-15:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TransferUnowned, source: None } }
+Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None } }
 
 task 4 'view-object'. lines 17-17:
 105::m

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -20,8 +20,8 @@ Owner: Object ID: ( fake(107) )
 Contents: test::m::Child {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(109)}}, version: 1u64}}
 
 task 5 'transfer-object'. lines 36-36:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TransferUnowned, source: None } }
+Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None } }
 
 task 6 'view-object'. lines 38-38:
 Owner: Object ID: ( fake(107) )

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -16,8 +16,8 @@ Owner: Shared
 Contents: test::m::S {id: sui::id::VersionedID {id: sui::id::UniqueID {id: sui::id::ID {bytes: fake(107)}}, version: 1u64}}
 
 task 4 'transfer-object'. lines 27-27:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TransferUnowned, source: None } }
+Error: Transaction Effects Status: Invalid Transfer Object Transaction. Possibly not address-owned or possibly does not have public transfer.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidTransferObject, source: None } }
 
 task 5 'view-object'. lines 29-29:
 Owner: Shared

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -16,8 +16,8 @@ use sui_types::{
     batch::UpdateItem,
     crypto::{get_key_pair, AuthoritySignature, Signature},
     messages::{
-        CallArg, ExecutionFailureStatus, ExecutionStatus, ObjectArg, ObjectInfoRequestKind,
-        SingleTransactionKind, TransactionKind,
+        CallArg, EntryArgumentErrorKind, ExecutionFailureStatus, ExecutionStatus, ObjectArg,
+        ObjectInfoRequestKind, SingleTransactionKind, TransactionKind,
     },
     object::{Data, Owner},
 };
@@ -63,6 +63,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<ExecutionStatus>(&samples)?;
     tracer.trace_type::<ExecutionFailureStatus>(&samples)?;
     tracer.trace_type::<AbortLocation>(&samples)?;
+    tracer.trace_type::<EntryArgumentErrorKind>(&samples)?;
     tracer.trace_type::<CallArg>(&samples)?;
     tracer.trace_type::<ObjectArg>(&samples)?;
     tracer.trace_type::<Data>(&samples)?;

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -401,7 +401,7 @@ async fn test_object_owning_another_object() {
     // we expect this to be and error due to Deleting an Object Owned Object
     assert!(matches!(
         effects.status.unwrap_err(),
-        ExecutionFailureStatus::MiscellaneousError,
+        ExecutionFailureStatus::DeleteObjectOwnedObject,
     ));
 
     // Remove the child from the parent.

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -46,6 +46,10 @@ ChangeEpoch:
     - epoch: U64
     - storage_charge: U64
     - computation_charge: U64
+CircularObjectOwnership:
+  STRUCT:
+    - object:
+        TYPENAME: ObjectID
 Data:
   ENUM:
     0:
@@ -56,6 +60,25 @@ Data:
       Package:
         NEWTYPE:
           TYPENAME: MovePackage
+EntryArgumentError:
+  STRUCT:
+    - argument_idx: U8
+    - kind:
+        TYPENAME: EntryArgumentErrorKind
+EntryArgumentErrorKind:
+  ENUM:
+    0:
+      TypeMismatch: UNIT
+    1:
+      InvalidObjectByValue: UNIT
+    2:
+      InvalidObjectByMuteRef: UNIT
+    3:
+      ObjectKindMismatch: UNIT
+    4:
+      UnsupportedPureArg: UNIT
+    5:
+      ArityMismatch: UNIT
 ExecutionDigests:
   STRUCT:
     - transaction:
@@ -67,12 +90,62 @@ ExecutionFailureStatus:
     0:
       InsufficientGas: UNIT
     1:
+      InvalidGasObject: UNIT
+    2:
+      InvalidTransactionUpdate: UNIT
+    3:
+      ModuleNotFound: UNIT
+    4:
+      FunctionNotFound: UNIT
+    5:
+      InvariantViolation: UNIT
+    6:
+      InvalidTransferObject: UNIT
+    7:
+      InvalidTransferSui: UNIT
+    8:
+      InvalidTransferSuiInsufficientBalance: UNIT
+    9:
+      NonEntryFunctionInvoked: UNIT
+    10:
+      EntryTypeArityMismatch: UNIT
+    11:
+      EntryArgumentError:
+        NEWTYPE:
+          TYPENAME: EntryArgumentError
+    12:
+      CircularObjectOwnership:
+        NEWTYPE:
+          TYPENAME: CircularObjectOwnership
+    13:
+      MissingObjectOwner:
+        NEWTYPE:
+          TYPENAME: MissingObjectOwner
+    14:
+      InvalidSharedChildUse:
+        NEWTYPE:
+          TYPENAME: InvalidSharedChildUse
+    15:
+      DeleteObjectOwnedObject: UNIT
+    16:
+      PublishErrorEmptyPackage: UNIT
+    17:
+      PublishErrorNonZeroAddress: UNIT
+    18:
+      PublishErrorDuplicateModule: UNIT
+    19:
+      SuiMoveVerificationError: UNIT
+    20:
+      MovePrimitiveRuntimeError: UNIT
+    21:
       MoveAbort:
         TUPLE:
-          - TYPENAME: AbortLocation
+          - TYPENAME: ModuleId
           - U64
-    2:
-      MiscellaneousError: UNIT
+    22:
+      VMVerificationOrDeserializationError: UNIT
+    23:
+      VMInvariantViolation: UNIT
 ExecutionStatus:
   ENUM:
     0:
@@ -84,6 +157,18 @@ ExecutionStatus:
               TYPENAME: ExecutionFailureStatus
 Identifier:
   NEWTYPESTRUCT: STR
+InvalidSharedChildUse:
+  STRUCT:
+    - child:
+        TYPENAME: ObjectID
+    - ancestor:
+        TYPENAME: ObjectID
+MissingObjectOwner:
+  STRUCT:
+    - child:
+        TYPENAME: ObjectID
+    - parent:
+        TYPENAME: SuiAddress
 ModuleId:
   STRUCT:
     - address:

--- a/crates/sui-types/src/balance.rs
+++ b/crates/sui-types/src/balance.rs
@@ -41,7 +41,7 @@ impl Balance {
         fp_ensure!(
             self.value >= amount,
             ExecutionError::new_with_source(
-                ExecutionErrorKind::TransferInsufficientBalance,
+                ExecutionErrorKind::InvalidTransferSuiInsufficientBalance,
                 format!("balance: {} required: {}", self.value, amount)
             )
         );

--- a/crates/sui-types/src/gas_coin.rs
+++ b/crates/sui-types/src/gas_coin.rs
@@ -82,13 +82,13 @@ impl TryFrom<&MoveObject> for GasCoin {
     fn try_from(value: &MoveObject) -> Result<GasCoin, ExecutionError> {
         if value.type_ != GasCoin::type_() {
             return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::TypeError,
+                ExecutionErrorKind::InvalidGasObject,
                 format!("Gas object type is not a gas coin: {}", value.type_),
             ));
         }
         let gas_coin: GasCoin = bcs::from_bytes(value.contents()).map_err(|err| {
             ExecutionError::new_with_source(
-                ExecutionErrorKind::TypeError,
+                ExecutionErrorKind::InvalidGasObject,
                 format!("Unable to deserialize gas object: {:?}", err),
             )
         })?;
@@ -103,7 +103,7 @@ impl TryFrom<&Object> for GasCoin {
         match &value.data {
             Data::Move(obj) => obj.try_into(),
             Data::Package(_) => Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::TypeError,
+                ExecutionErrorKind::InvalidGasObject,
                 format!("Gas object type is not a gas coin: {:?}", value),
             )),
         }

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -577,14 +577,14 @@ impl Object {
 
     pub fn ensure_public_transfer_eligible(&self) -> Result<(), ExecutionError> {
         if !matches!(self.owner, Owner::AddressOwner(_)) {
-            return Err(ExecutionErrorKind::TransferUnowned.into());
+            return Err(ExecutionErrorKind::InvalidTransferObject.into());
         }
         let has_public_transfer = match &self.data {
             Data::Move(m) => m.has_public_transfer(),
             Data::Package(_) => false,
         };
         if !has_public_transfer {
-            return Err(ExecutionErrorKind::TransferObjectWithoutPublicTransfer.into());
+            return Err(ExecutionErrorKind::InvalidTransferObject.into());
         }
         Ok(())
     }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_invalid.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_with_key_invalid.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 6-16:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: std::option::Option<T0>") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: std::option::Option<T0>") } }
 
 task 1 'publish'. lines 18-28:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: vector<std::option::Option<T0>>") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: vector<std::option::Option<T0>>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 6-17:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::S") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::S") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 6-21:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::Obj<_::m::NoStore>") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::Obj<_::m::NoStore>") } }
 
 task 1 'publish'. lines 23-35:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::Obj<T0>") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: _::m::Obj<T0>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_vector.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 6-17:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: vector<_::m::S>") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: vector<_::m::S>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.exp
@@ -1,17 +1,17 @@
 processed 4 tasks
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Entry function foo cannot have return values") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values") } }
 
 task 1 'publish'. lines 13-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Entry function foo cannot have return values") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values") } }
 
 task 2 'publish'. lines 22-29:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Entry function foo cannot have return values") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values") } }
 
 task 3 'publish'. lines 32-39:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Entry function foo cannot have return values") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Entry function foo cannot have return values") } }

--- a/crates/sui-verifier-transactional-tests/tests/global_storage_access/all.exp
+++ b/crates/sui-verifier-transactional-tests/tests/global_storage_access/all.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-31:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [Exists(StructDefinitionIndex(0)), ExistsGeneric(StructDefInstantiationIndex(0)), ImmBorrowGlobal(StructDefinitionIndex(0)), ImmBorrowGlobalGeneric(StructDefInstantiationIndex(0)), MutBorrowGlobal(StructDefinitionIndex(0)), MutBorrowGlobalGeneric(StructDefInstantiationIndex(0)), MoveFrom(StructDefinitionIndex(0)), MoveFromGeneric(StructDefInstantiationIndex(0)), MoveTo(StructDefinitionIndex(0)), MoveToGeneric(StructDefInstantiationIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [Exists(StructDefinitionIndex(0)), ExistsGeneric(StructDefInstantiationIndex(0)), ImmBorrowGlobal(StructDefinitionIndex(0)), ImmBorrowGlobalGeneric(StructDefInstantiationIndex(0)), MutBorrowGlobal(StructDefinitionIndex(0)), MutBorrowGlobalGeneric(StructDefInstantiationIndex(0)), MoveFrom(StructDefinitionIndex(0)), MoveFromGeneric(StructDefInstantiationIndex(0)), MoveTo(StructDefinitionIndex(0)), MoveToGeneric(StructDefInstantiationIndex(0))]") } }

--- a/crates/sui-verifier-transactional-tests/tests/global_storage_access/borrow_global.exp
+++ b/crates/sui-verifier-transactional-tests/tests/global_storage_access/borrow_global.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 4-15:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [ImmBorrowGlobal(StructDefinitionIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [ImmBorrowGlobal(StructDefinitionIndex(0))]") } }
 
 task 1 'publish'. lines 17-27:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [ImmBorrowGlobalGeneric(StructDefInstantiationIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [ImmBorrowGlobalGeneric(StructDefInstantiationIndex(0))]") } }

--- a/crates/sui-verifier-transactional-tests/tests/global_storage_access/borrow_global_mut.exp
+++ b/crates/sui-verifier-transactional-tests/tests/global_storage_access/borrow_global_mut.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 4-15:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [MutBorrowGlobal(StructDefinitionIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [MutBorrowGlobal(StructDefinitionIndex(0))]") } }
 
 task 1 'publish'. lines 17-27:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [MutBorrowGlobalGeneric(StructDefInstantiationIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [MutBorrowGlobalGeneric(StructDefInstantiationIndex(0))]") } }

--- a/crates/sui-verifier-transactional-tests/tests/global_storage_access/exists.exp
+++ b/crates/sui-verifier-transactional-tests/tests/global_storage_access/exists.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 4-14:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [Exists(StructDefinitionIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [Exists(StructDefinitionIndex(0))]") } }
 
 task 1 'publish'. lines 16-25:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [ExistsGeneric(StructDefInstantiationIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [ExistsGeneric(StructDefInstantiationIndex(0))]") } }

--- a/crates/sui-verifier-transactional-tests/tests/global_storage_access/move_from.exp
+++ b/crates/sui-verifier-transactional-tests/tests/global_storage_access/move_from.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 4-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveFrom(StructDefinitionIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveFrom(StructDefinitionIndex(0))]") } }
 
 task 1 'publish'. lines 22-38:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveFromGeneric(StructDefInstantiationIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveFromGeneric(StructDefInstantiationIndex(0))]") } }

--- a/crates/sui-verifier-transactional-tests/tests/global_storage_access/move_to.exp
+++ b/crates/sui-verifier-transactional-tests/tests/global_storage_access/move_to.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 4-15:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveTo(StructDefinitionIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveTo(StructDefinitionIndex(0))]") } }
 
 task 1 'publish'. lines 17-27:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveToGeneric(StructDefInstantiationIndex(0))]") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Access to Move global storage is not allowed. Found in function no: [MoveToGeneric(StructDefInstantiationIndex(0))]") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/write_id_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/write_id_field.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VmError, source: Some(VMError { major_status: WRITEREF_WITHOUT_DROP_ABILITY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(FunctionDefinition, 0)], offsets: [(FunctionDefinitionIndex(0), 5)] }) } }
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: WRITEREF_WITHOUT_DROP_ABILITY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(FunctionDefinition, 0)], offsets: [(FunctionDefinitionIndex(0), 5)] }) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-25:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some(\"ID leaked through function call.\") } }") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function call.\") } }") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-25:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some(\"ID leaked through function call.\") } }") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function call.\") } }") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-19:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some(\"ID leaked through function return.\") } }") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function return.\") } }") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-19:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some(\"ID leaked through function return.\") } }") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function return.\") } }") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_reference.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_reference.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VmError, source: Some(VMError { major_status: WRITEREF_WITHOUT_DROP_ABILITY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(FunctionDefinition, 0)], offsets: [(FunctionDefinitionIndex(0), 5)] }) } }
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: WRITEREF_WITHOUT_DROP_ABILITY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(FunctionDefinition, 0)], offsets: [(FunctionDefinitionIndex(0), 5)] }) } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some(\"ID is leaked into a vector\") } }") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID is leaked into a vector\") } }") } }

--- a/crates/sui-verifier-transactional-tests/tests/init/cannot_call_init.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/cannot_call_init.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-17:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::init at offset 1. Cannot call a module's 'init' function from another Move function") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::init at offset 1. Cannot call a module's 'init' function from another Move function") } }

--- a/crates/sui-verifier-transactional-tests/tests/init/must_have_txn_context.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/must_have_txn_context.exp
@@ -1,9 +1,9 @@
 processed 2 tasks
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected exactly one parameter for _::m::init  of type &mut sui::tx_context::TxContext") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::m::init  of type &mut sui::tx_context::TxContext") } }
 
 task 1 'publish'. lines 14-21:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected exactly one parameter for _::m::init  of type &mut sui::tx_context::TxContext") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::m::init  of type &mut sui::tx_context::TxContext") } }

--- a/crates/sui-verifier-transactional-tests/tests/init/not_generic.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/not_generic.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m. 'init' function cannot have type parameters") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m. 'init' function cannot have type parameters") } }

--- a/crates/sui-verifier-transactional-tests/tests/init/not_private.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/not_private.exp
@@ -1,13 +1,13 @@
 processed 3 tasks
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m. 'init' function must be private") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m. 'init' function must be private") } }
 
 task 1 'publish'. lines 13-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m. 'init' function must be private") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m. 'init' function must be private") } }
 
 task 2 'publish'. lines 22-29:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m. 'init' function must be private") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m. 'init' function must be private") } }

--- a/crates/sui-verifier-transactional-tests/tests/init/not_txn_context.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/not_txn_context.exp
@@ -1,17 +1,17 @@
 processed 4 tasks
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found u64") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found u64") } }
 
 task 1 'publish'. lines 13-20:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected parameter for _::tx_context::init to be &mut sui::tx_context::TxContext, but found _::tx_context::TxContext") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::tx_context::init to be &mut sui::tx_context::TxContext, but found _::tx_context::TxContext") } }
 
 task 2 'publish'. lines 22-29:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found &sui::tx_context::TxContext") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found &sui::tx_context::TxContext") } }
 
 task 3 'publish'. lines 32-39:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found sui::tx_context::TxContext") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found sui::tx_context::TxContext") } }

--- a/crates/sui-verifier-transactional-tests/tests/init/return_values.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/return_values.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m, 'init' function cannot have return values") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m, 'init' function cannot have return values") } }

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer.exp
@@ -5,37 +5,37 @@ created: object(103)
 written: object(102)
 
 task 2 'publish'. lines 13-18:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 3 'publish'. lines 20-29:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object_id' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object_id' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 4 'publish'. lines 31-36:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::freeze_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::freeze_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 5 'publish'. lines 38-43:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::share_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::share_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 6 'publish'. lines 45-51:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 7 'publish'. lines 53-59:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 8 'publish'. lines 61-69:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 9 'publish'. lines 71-79:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 10 'publish'. lines 81-89:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_address' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_address' on an object of type 'a::m::S'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_generic.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_generic.exp
@@ -1,37 +1,37 @@
 processed 10 tasks
 
 task 1 'publish'. lines 10-15:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 2 'publish'. lines 17-26:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object_id' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object_id' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 3 'publish'. lines 28-33:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::freeze_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::freeze_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 4 'publish'. lines 35-40:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::share_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::share_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 5 'publish'. lines 42-48:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 6 'publish'. lines 50-56:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::transfer::transfer_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 7 'publish'. lines 58-65:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 8 'publish'. lines 67-74:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_object' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
 
 task 9 'publish'. lines 76-83:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_address' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::transfer_child_to_object. Invalid call to 'sui::transfer::transfer_child_to_address' on an object of type 'T0'. The transferred object's type must be defined in the current module, or must have the 'store' type ability") } }

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.exp
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.exp
@@ -5,17 +5,17 @@ created: object(103)
 written: object(102)
 
 task 2 'publish'. lines 13-18:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'a::m::S'. The event's type must be defined in the current module") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'a::m::S'. The event's type must be defined in the current module") } }
 
 task 3 'publish'. lines 20-25:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'T0'. The event's type must be defined in the current module") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'T0'. The event's type must be defined in the current module") } }
 
 task 4 'publish'. lines 27-32:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'u64'. The event's type must be defined in the current module") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'u64'. The event's type must be defined in the current module") } }
 
 task 5 'publish'. lines 34-40:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'vector<_::m::X>'. The event's type must be defined in the current module") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m::t. Invalid call to 'sui::event::emit' with an event type 'vector<_::m::X>'. The event's type must be defined in the current module") } }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_first_field_not_id.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_first_field_not_id.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-10:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("First field of struct S must be 'id', flag found") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("First field of struct S must be 'id', flag found") } }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_address.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("First field of struct S must be of type sui::id::VersionedID, _::id::VersionedID type found") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("First field of struct S must be of type sui::id::VersionedID, _::id::VersionedID type found") } }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_name.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_name.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-10:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("First field of struct S must be of type sui::id::VersionedID, sui::id::ID type found") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("First field of struct S must be of type sui::id::VersionedID, sui::id::ID type found") } }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_type.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_type.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-10:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("First field of struct S must be of ID type, Bool type found") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("First field of struct S must be of ID type, Bool type found") } }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_second_field_id.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_second_field_id.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ModuleVerificationFailure, source: Some("First field of struct S must be 'id', flag found") } }
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("First field of struct S must be 'id', flag found") } }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_with_drop.exp
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_with_drop.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-11:
-Error: Transaction Effects Status: MiscellaneousError
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VmError, source: Some(VMError { major_status: FIELD_MISSING_TYPE_ABILITY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(StructDefinition, 0)], offsets: [] }) } }
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: FIELD_MISSING_TYPE_ABILITY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: _, name: Identifier("m") }), indices: [(StructDefinition, 0)], offsets: [] }) } }

--- a/crates/sui-verifier/src/lib.rs
+++ b/crates/sui-verifier/src/lib.rs
@@ -17,7 +17,7 @@ use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
 
 fn verification_failure(error: String) -> ExecutionError {
-    ExecutionError::new_with_source(ExecutionErrorKind::ModuleVerificationFailure, error)
+    ExecutionError::new_with_source(ExecutionErrorKind::SuiMoveVerificationError, error)
 }
 
 // TODO move these to move bytecode utils


### PR DESCRIPTION
- We scaled back execution errors to a single error type to not leak too much information
- I have added back more detailed information in a controlled manner for specific adapter errors
- It is important to provide some amount of information for these errors, as they are not always easy to test/debug locally.
- @bmwill tell me if you think this is too much info.
- I'm a bit worried about the various ones that refer to objects
  - There may actually be more than one object error for a given transaction
  - Which one we actually give is dependent on the iteration through objects, usually a BTreeMap.
  - I think this should be fine, but it may be an area of brittleness in future updates that we will have to be careful about. 
  
Solves #2678 