### PR TITLE
[docs] Update Move analyzer installation instructions

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -82,7 +82,7 @@ And ensure the `.cargo/bin` directory appears. Access the help for any of these 
 For Move development, we recommend the [Visual Studio Code (vscode)](https://code.visualstudio.com/) IDE with the Move Analyzer language server plugin installed:
 
 ```shell
-$ cargo install --git https://github.com/move-language/move move-analyzer
+$ cargo install --git https://github.com/move-language/move move-analyzer --features "address20"
 ```
 
 Then follow the Visual Studio Marketplace instructions to install the [Move Analyzer extension](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer). (The `cargo install` command for the language server is broken there; hence, we include the correct command above.)


### PR DESCRIPTION
Updated installation instructions for Move analyzer to accommodate longer address length required by Sui Move (this was previously enabled in core Move in https://github.com/move-language/move/pull/260