### PR TITLE
[governance] add delegation switching and some tests

### DIFF
--- a/crates/sui-framework/sources/balance.move
+++ b/crates/sui-framework/sources/balance.move
@@ -115,6 +115,12 @@ module sui::balance {
         let Balance { value } = self;
         value
     }
+
+    #[test_only]
+    /// Create a `Supply` of any coin for testing purposes.
+    public fun create_supply_for_testing<T>(value: u64): Supply<T> {
+        Supply { value }
+    }
 }
 
 #[test_only]

--- a/crates/sui-framework/sources/governance/validator.move
+++ b/crates/sui-framework/sources/governance/validator.move
@@ -21,6 +21,8 @@ module sui::validator {
     friend sui::validator_tests;
     #[test_only]
     friend sui::validator_set_tests;
+    #[test_only]
+    friend sui::governance_test_utils;
 
     struct ValidatorMetadata has store, drop, copy {
         /// The Sui Address of the validator. This is the sender that created the Validator object,

--- a/crates/sui-framework/sources/governance/validator_set.move
+++ b/crates/sui-framework/sources/governance/validator_set.move
@@ -21,10 +21,10 @@ module sui::validator_set {
     struct ValidatorSet has store {
         /// Total amount of stake from all active validators (not including delegation),
         /// at the beginning of the epoch.
-        validator_stake: u64,
+        total_validator_stake: u64,
 
         /// Total amount of stake from delegation, at the beginning of the epoch.
-        delegation_stake: u64,
+        total_delegation_stake: u64,
 
         /// The amount of accumulated stake to reach a quorum among all active validators.
         /// This is always 2/3 of total stake. Keep it here to reduce potential inconsistencies
@@ -48,10 +48,10 @@ module sui::validator_set {
     }
 
     public(friend) fun new(init_active_validators: vector<Validator>): ValidatorSet {
-        let (validator_stake, delegation_stake, quorum_stake_threshold) = calculate_total_stake_and_quorum_threshold(&init_active_validators);
+        let (total_validator_stake, total_delegation_stake, quorum_stake_threshold) = calculate_total_stake_and_quorum_threshold(&init_active_validators);
         let validators = ValidatorSet {
-            validator_stake,
-            delegation_stake,
+            total_validator_stake,
+            total_delegation_stake,
             quorum_stake_threshold,
             active_validators: init_active_validators,
             pending_validators: vector::empty(),
@@ -208,7 +208,7 @@ module sui::validator_set {
         // epoch's stake information to compute reward distribution.
         let rewards = compute_reward_distribution(
             &self.active_validators,
-            self.validator_stake,
+            self.total_validator_stake,
             balance::value(computation_reward),
         );
 
@@ -225,17 +225,32 @@ module sui::validator_set {
         self.next_epoch_validators = derive_next_epoch_validators(self);
 
         let (validator_stake, delegation_stake, quorum_stake_threshold) = calculate_total_stake_and_quorum_threshold(&self.active_validators);
-        self.validator_stake = validator_stake;
-        self.delegation_stake = delegation_stake;
+        self.total_validator_stake = validator_stake;
+        self.total_delegation_stake = delegation_stake;
         self.quorum_stake_threshold = quorum_stake_threshold;
     }
 
-    public fun validator_stake(self: &ValidatorSet): u64 {
-        self.validator_stake
+    public fun total_validator_stake(self: &ValidatorSet): u64 {
+        self.total_validator_stake
     }
 
-    public fun delegation_stake(self: &ValidatorSet): u64 {
-        self.delegation_stake
+    public fun total_delegation_stake(self: &ValidatorSet): u64 {
+        self.total_delegation_stake
+    }
+
+    public fun validator_stake_amount(self: &ValidatorSet, validator_address: address): u64 {
+        let validator = get_validator_ref(&self.active_validators, validator_address);
+        validator::stake_amount(validator)
+    }
+
+    public fun validator_delegate_amount(self: &ValidatorSet, validator_address: address): u64 {
+        let validator = get_validator_ref(&self.active_validators, validator_address);
+        validator::delegate_amount(validator)
+    }
+
+    public fun validator_delegator_count(self: &ValidatorSet, validator_address: address): u64 {
+        let validator = get_validator_ref(&self.active_validators, validator_address);
+        validator::delegator_count(validator)
     }
 
     /// Checks whether a duplicate of `new_validator` is already in `validators`.
@@ -277,6 +292,16 @@ module sui::validator_set {
         assert!(option::is_some(&validator_index_opt), 0);
         let validator_index = option::extract(&mut validator_index_opt);
         vector::borrow_mut(validators, validator_index)
+    }
+
+    fun get_validator_ref(
+        validators: &vector<Validator>,
+        validator_address: address,
+    ): &Validator {
+        let validator_index_opt = find_validator(validators, validator_address);
+        assert!(option::is_some(&validator_index_opt), 0);
+        let validator_index = option::extract(&mut validator_index_opt);
+        vector::borrow(validators, validator_index)
     }
 
     /// Process the pending withdraw requests. For each pending request, the validator
@@ -431,8 +456,8 @@ module sui::validator_set {
         self: ValidatorSet,
     ) {
         let ValidatorSet {
-            validator_stake: _,
-            delegation_stake: _,
+            total_validator_stake: _,
+            total_delegation_stake: _,
             quorum_stake_threshold: _,
             active_validators,
             pending_validators,

--- a/crates/sui-framework/tests/delegation_tests.move
+++ b/crates/sui-framework/tests/delegation_tests.move
@@ -1,0 +1,138 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::delegation_tests {
+    use sui::coin;
+    use sui::test_scenario::{Self, Scenario};
+    use sui::sui_system::{Self, SuiSystemState};
+    use sui::delegation::{Self, Delegation};
+    use sui::governance_test_utils::{
+        Self, 
+        create_validator_for_testing, 
+        create_sui_system_state_for_testing
+    };
+
+    const VALIDATOR_ADDR_1: address = @0x1;
+    const VALIDATOR_ADDR_2: address = @0x2;
+
+    const DELEGATOR_ADDR_1: address = @0x42;
+    const DELEGATOR_ADDR_2: address = @0x43;
+
+    #[test]
+    fun test_add_remove_delegation_flow() {
+        let scenario = &mut test_scenario::begin(&VALIDATOR_ADDR_1);
+        set_up_sui_system_state(scenario);
+
+        test_scenario::next_tx(scenario, &DELEGATOR_ADDR_1);
+        {
+            let system_state_wrapper = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = test_scenario::borrow_mut(&mut system_state_wrapper);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create two delegations to VALIDATOR_ADDR_1.
+            sui_system::request_add_delegation(
+                system_state_mut_ref, coin::mint_for_testing(10, ctx), VALIDATOR_ADDR_1, ctx);
+            sui_system::request_add_delegation(
+                system_state_mut_ref, coin::mint_for_testing(60, ctx), VALIDATOR_ADDR_1, ctx);
+
+            // Advance the epoch so that the delegation changes can take into effect.
+            governance_test_utils::advance_epoch(system_state_mut_ref, scenario);
+
+            // Check that the delegation amount and count are changed correctly.
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 70, 101);
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_2) == 0, 102);
+            assert!(sui_system::validator_delegator_count(system_state_mut_ref, VALIDATOR_ADDR_1) == 2, 103);
+            assert!(sui_system::validator_delegator_count(system_state_mut_ref, VALIDATOR_ADDR_2) == 0, 104);
+            test_scenario::return_shared(scenario, system_state_wrapper);
+        };
+
+        
+        test_scenario::next_tx(scenario, &DELEGATOR_ADDR_1);
+        {
+            
+            let delegation = test_scenario::take_last_created_owned<Delegation>(scenario);
+            assert!(delegation::delegate_amount(&delegation) == 60, 105);
+
+            
+            let system_state_wrapper = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = test_scenario::borrow_mut(&mut system_state_wrapper);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Undelegate 60 SUIs from VALIDATOR_ADDR_1
+            sui_system::request_remove_delegation(
+                system_state_mut_ref, &mut delegation, ctx);
+
+            // Check that the delegation object indeed becomes inactive.
+            assert!(!delegation::is_active(&delegation), 106);
+            test_scenario::return_owned(scenario, delegation);
+
+            governance_test_utils::advance_epoch(system_state_mut_ref, scenario);
+
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 10, 107);
+            assert!(sui_system::validator_delegator_count(system_state_mut_ref, VALIDATOR_ADDR_1) == 1, 108);
+            test_scenario::return_shared(scenario, system_state_wrapper);
+        };
+    }
+
+    #[test]
+    fun test_switch_delegation_flow() {
+        let scenario = &mut test_scenario::begin(&VALIDATOR_ADDR_1);
+        set_up_sui_system_state(scenario);
+
+        test_scenario::next_tx(scenario, &DELEGATOR_ADDR_1);
+        {
+            let system_state_wrapper = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = test_scenario::borrow_mut(&mut system_state_wrapper);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Create one delegation to VALIDATOR_ADDR_1, and one to VALIDATOR_ADDR_2.
+            sui_system::request_add_delegation(
+                system_state_mut_ref, coin::mint_for_testing(60, ctx), VALIDATOR_ADDR_1, ctx);
+            sui_system::request_add_delegation(
+                system_state_mut_ref, coin::mint_for_testing(10, ctx), VALIDATOR_ADDR_2, ctx);
+
+            governance_test_utils::advance_epoch(system_state_mut_ref, scenario);
+            test_scenario::return_shared(scenario, system_state_wrapper);
+        };
+
+        test_scenario::next_tx(scenario, &DELEGATOR_ADDR_1);
+        {
+            
+            let delegation = test_scenario::take_last_created_owned<Delegation>(scenario);
+            
+            let system_state_wrapper = test_scenario::take_shared<SuiSystemState>(scenario);
+            let system_state_mut_ref = test_scenario::borrow_mut(&mut system_state_wrapper);
+
+            let ctx = test_scenario::ctx(scenario);
+
+            // Switch the 10 SUI delegation from VALIDATOR_ADDR_2 to VALIDATOR_ADDR_1
+            sui_system::request_switch_delegation(
+                system_state_mut_ref, &mut delegation, VALIDATOR_ADDR_1, ctx);
+
+            test_scenario::return_owned(scenario, delegation);
+
+            governance_test_utils::advance_epoch(system_state_mut_ref, scenario);
+
+            // Check that now VALIDATOR_ADDR_1 has all the delegations
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_1) == 70, 101);
+            assert!(sui_system::validator_delegate_amount(system_state_mut_ref, VALIDATOR_ADDR_2) == 0, 102);
+            assert!(sui_system::validator_delegator_count(system_state_mut_ref, VALIDATOR_ADDR_1) == 2, 103);
+            assert!(sui_system::validator_delegator_count(system_state_mut_ref, VALIDATOR_ADDR_2) == 0, 104);
+            test_scenario::return_shared(scenario, system_state_wrapper);
+        };
+    }
+
+    fun set_up_sui_system_state(scenario: &mut Scenario) {
+        let ctx = test_scenario::ctx(scenario);
+
+        let validators = vector[
+            create_validator_for_testing(VALIDATOR_ADDR_1, 100, ctx), 
+            create_validator_for_testing(VALIDATOR_ADDR_2, 100, ctx)
+        ];
+        create_sui_system_state_for_testing(validators, 300, 100);
+    }
+}

--- a/crates/sui-framework/tests/governance_test_utils.move
+++ b/crates/sui-framework/tests/governance_test_utils.move
@@ -1,0 +1,46 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module sui::governance_test_utils {
+    use sui::balance;
+    use sui::sui::SUI;
+    use sui::tx_context::{Self, TxContext};
+    use sui::validator::{Self, Validator};
+    use sui::sui_system::{Self, SuiSystemState};
+    use sui::test_scenario::{Self, Scenario};
+    use std::option;
+
+    public fun create_validator_for_testing(
+        addr: address, init_stake_amount: u64, ctx: &mut TxContext
+    ): Validator {
+        validator::new(
+            addr,
+            x"FF",
+            b"ValidatorName",
+            x"FFFF",
+            balance::create_for_testing<SUI>(init_stake_amount),
+            option::none(),
+            ctx
+        )
+    }
+
+    public fun create_sui_system_state_for_testing(
+        validators: vector<Validator>, sui_supply_amount: u64, storage_fund_amount: u64
+    ) {
+        sui_system::create(
+            validators,
+            balance::create_supply_for_testing(sui_supply_amount), // sui_supply
+            balance::create_for_testing<SUI>(storage_fund_amount), // storage_fund
+            1024, // max_validator_candidate_count
+            0, // min_validator_stake
+            1, //storage_gas_price
+        )
+    }
+
+    public fun advance_epoch(state: &mut SuiSystemState, scenario: &mut Scenario) {
+        test_scenario::next_epoch(scenario);
+        let new_epoch = tx_context::epoch(test_scenario::ctx(scenario));
+        sui_system::advance_epoch(state, new_epoch, 0, 0, &mut tx_context::dummy());
+    }
+}

--- a/crates/sui-framework/tests/validator_set_tests.move
+++ b/crates/sui-framework/tests/validator_set_tests.move
@@ -27,7 +27,7 @@ module sui::validator_set_tests {
         // Create a validator set with only the first validator in it.
         let validator_set = validator_set::new(vector[validator1]);
         assert!(validator_set::total_validator_candidate_count(&validator_set) == 1, 0);
-        assert!(validator_set::validator_stake(&validator_set) == 100, 0);
+        assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
 
         // Add the other 3 validators one by one.
         validator_set::request_add_validator(
@@ -36,7 +36,7 @@ module sui::validator_set_tests {
         );
         // Adding validator during the epoch should not affect stake and quorum threshold.
         assert!(validator_set::total_validator_candidate_count(&validator_set) == 2, 0);
-        assert!(validator_set::validator_stake(&validator_set) == 100, 0);
+        assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
 
         validator_set::request_add_validator(
             &mut validator_set,
@@ -54,7 +54,7 @@ module sui::validator_set_tests {
             );
             // Adding stake to existing active validator during the epoch
             // should not change total stake.
-            assert!(validator_set::validator_stake(&validator_set) == 100, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
         };
 
         test_scenario::next_tx(&mut scenario, &@0x1);
@@ -69,7 +69,7 @@ module sui::validator_set_tests {
                 ctx1,
             );
             test_scenario::return_owned(&mut scenario, stake1);
-            assert!(validator_set::validator_stake(&validator_set) == 100, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 100, 0);
 
             validator_set::request_add_validator(
                 &mut validator_set,
@@ -84,7 +84,7 @@ module sui::validator_set_tests {
             validator_set::advance_epoch(&mut validator_set, &mut reward, ctx1);
             // The total stake and quorum should reflect 4 validators.
             assert!(validator_set::total_validator_candidate_count(&validator_set) == 4, 0);
-            assert!(validator_set::validator_stake(&validator_set) == 1000, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 1000, 0);
 
             validator_set::request_remove_validator(
                 &mut validator_set,
@@ -92,10 +92,10 @@ module sui::validator_set_tests {
             );
             // Total validator candidate count changes, but total stake remains during epoch.
             assert!(validator_set::total_validator_candidate_count(&validator_set) == 3, 0);
-            assert!(validator_set::validator_stake(&validator_set) == 1000, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 1000, 0);
             validator_set::advance_epoch(&mut validator_set, &mut reward, ctx1);
             // Validator1 is gone.
-            assert!(validator_set::validator_stake(&validator_set) == 900, 0);
+            assert!(validator_set::total_validator_stake(&validator_set) == 900, 0);
             balance::destroy_zero(reward);
         };
 


### PR DESCRIPTION
This PR:
- adds a function `sui_system::request_switch_delegation` that allows a delegator to switch delegation from one validator to another in one transaction
- adds tests for delegation which didn't exist before
- adds a `governance_test_utils` module containing some util functions that might be handy for testing `sui_system` related governance logic
- changes the naming of some fields in `ValidatorSet` for better clarity

Addresses issue #2801 