### PR TITLE
[checkpoint] Fix a bug in fragment number threshold

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -158,7 +158,10 @@ pub async fn checkpoint_process<A>(
                 update_latest_checkpoint(active_authority, &state_checkpoints, &checkpoint).await;
             match result {
                 Err(err) => {
-                    warn!("Failed to update latest checkpoint: {:?}", err);
+                    warn!(
+                        "{:?} failed to update latest checkpoint: {:?}",
+                        active_authority.state.name, err
+                    );
                     tokio::time::sleep(timing.delay_on_local_failure).await;
                     continue;
                 }
@@ -211,7 +214,10 @@ pub async fn checkpoint_process<A>(
                 .await;
             }
             Err(err) => {
-                warn!("Failure to make a new proposal: {:?}", err);
+                warn!(
+                    "{:?} failed to make a new proposal: {:?}",
+                    active_authority.state.name, err
+                );
                 tokio::time::sleep(timing.delay_on_local_failure).await;
                 continue;
             }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -654,14 +654,7 @@ pub async fn create_fragments_and_make_checkpoint<A>(
                 }
 
                 fragments_num += 1;
-                if fragments_num <= 2 {
-                    // There is no point to make a checkpoint if we don't have enough fragments.
-                    continue;
-                }
-                // TODO: here we should really wait until the fragment is sequenced, otherwise
-                //       we would be going ahead and sequencing more fragments that may not be
-                //       needed. For the moment we just linearly back-off.
-                tokio::time::sleep(fragments_num * consensus_delay_estimate).await;
+
                 let result = checkpoint_db.lock().attempt_to_construct_checkpoint(
                     active_authority.state.database.clone(),
                     committee,
@@ -676,6 +669,10 @@ pub async fn create_fragments_and_make_checkpoint<A>(
                             "Failed to construct checkpoint: {:?}",
                             err
                         );
+                        // TODO: here we should really wait until the fragment is sequenced, otherwise
+                        //       we would be going ahead and sequencing more fragments that may not be
+                        //       needed. For the moment we just linearly back-off.
+                        tokio::time::sleep(fragments_num * consensus_delay_estimate).await;
                         continue;
                     }
                     Ok(()) => {

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -329,6 +329,7 @@ async fn checkpoint_with_shared_objects() {
     transaction_digests.insert(*increment_counter_transaction.digest());
 
     // Wait for the transactions to be executed and end up in a checkpoint.
+    let mut cnt = 0;
     loop {
         // Ensure all submitted transactions are in the checkpoint.
         let ok = handles
@@ -338,8 +339,10 @@ async fn checkpoint_with_shared_objects() {
 
         match ok {
             true => break,
-            false => tokio::time::sleep(Duration::from_millis(10)).await,
+            false => tokio::time::sleep(Duration::from_secs(1)).await,
         }
+        cnt += 1;
+        assert!(cnt <= 20);
     }
 
     // Ensure all authorities moved to the next checkpoint sequence number.

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -210,6 +210,8 @@ async fn end_to_end() {
 
 #[tokio::test]
 async fn checkpoint_with_shared_objects() {
+    telemetry_subscribers::init_for_testing();
+
     // Get some gas objects to submit shared-objects transactions.
     let mut gas_objects = test_gas_objects();
 


### PR DESCRIPTION
We don't attempt to construct checkpoint when we have <=2 fragments. This doesn't work with the case where we have 4 validators and 1 byzantine: we only get 2 fragments at best.
In fact, since all validators work async, this optimization is unnecessary. Just because one validator has only sent 1 fragment out doesn't mean it hasn't received enough fragments. If any, we should optimize around the number of fragments we received so far.
This PR removes the optimization.