### PR TITLE
Split the server and client runimtes in shared bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6578,6 +6578,7 @@ name = "sui-benchmark"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "clap 3.1.18",
  "crossterm 0.23.2",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1.53"
 rayon = "1.5.3"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 futures = "0.3.21"

--- a/crates/sui-benchmark/src/stress/context.rs
+++ b/crates/sui-benchmark/src/stress/context.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+
+use sui_config::NetworkConfig;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef},
+    crypto::EmptySignInfo,
+    messages::TransactionEnvelope,
+    object::{Object, Owner},
+};
+
+pub type Gas = (ObjectRef, Owner);
+
+pub trait Payload: Send + Sync {
+    fn make_new_payload(&self, new_object: ObjectRef, new_gas: ObjectRef) -> Box<dyn Payload>;
+    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo>;
+    fn get_object_id(&self) -> ObjectID;
+}
+
+#[async_trait]
+pub trait StressTestCtx<T: Payload + ?Sized> {
+    fn get_gas_objects(&mut self) -> Vec<Object>;
+    async fn make_test_payloads(&self, configs: &NetworkConfig) -> Vec<Box<T>>;
+}

--- a/crates/sui-benchmark/src/stress/mod.rs
+++ b/crates/sui-benchmark/src/stress/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod benchmark;
-pub mod stress;
+pub mod context;
+pub mod shared_counter;
+pub mod transfer_object;

--- a/crates/sui-benchmark/src/stress/shared_counter.rs
+++ b/crates/sui-benchmark/src/stress/shared_counter.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use futures::future::join_all;
+use sui_config::NetworkConfig;
+use sui_quorum_driver::QuorumDriverHandler;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef},
+    crypto::EmptySignInfo,
+    messages::{
+        ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
+        TransactionEnvelope,
+    },
+    object::Object,
+};
+use test_utils::{
+    authority::test_authority_aggregator,
+    messages::{make_counter_create_transaction, make_counter_increment_transaction},
+    objects::{generate_gas_object, generate_gas_objects_for_testing},
+    transaction::publish_counter_package,
+};
+
+use super::context::{Gas, Payload, StressTestCtx};
+
+pub struct SharedCounterTestPayload {
+    package_ref: ObjectRef,
+    counter_id: ObjectID,
+    gas: Gas,
+}
+
+impl Payload for SharedCounterTestPayload {
+    fn make_new_payload(&self, _: ObjectRef, new_gas: ObjectRef) -> Box<dyn Payload> {
+        Box::new(SharedCounterTestPayload {
+            package_ref: self.package_ref,
+            counter_id: self.counter_id,
+            gas: (new_gas, self.gas.1),
+        })
+    }
+    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo> {
+        make_counter_increment_transaction(self.gas.0, self.package_ref, self.counter_id)
+    }
+    fn get_object_id(&self) -> ObjectID {
+        self.counter_id
+    }
+}
+
+pub struct SharedCounterTestCtx {
+    counter_gas: Vec<Object>,
+    publish_module_gas: Object,
+}
+
+impl SharedCounterTestCtx {
+    pub fn make_ctx(count: u64, _configs: &NetworkConfig) -> Box<dyn StressTestCtx<dyn Payload>> {
+        // create enough gas to increment shared counters and publish module
+        let counter_gas = generate_gas_objects_for_testing(count as usize);
+        let publish_module_gas = generate_gas_object();
+        Box::<dyn StressTestCtx<dyn Payload>>::from(Box::new(SharedCounterTestCtx {
+            counter_gas,
+            publish_module_gas,
+        }))
+    }
+}
+#[async_trait]
+impl StressTestCtx<dyn Payload> for SharedCounterTestCtx {
+    fn get_gas_objects(&mut self) -> Vec<Object> {
+        let mut gas = vec![];
+        gas.append(&mut self.counter_gas.clone());
+        gas.push(self.publish_module_gas.clone());
+        gas
+    }
+    async fn make_test_payloads(&self, configs: &NetworkConfig) -> Vec<Box<dyn Payload>> {
+        let clients = test_authority_aggregator(configs);
+        let quorum_driver_handler = QuorumDriverHandler::new(clients.clone());
+        // Publish basics package
+        eprintln!("Publishing basics package");
+        let package_ref =
+            publish_counter_package(self.publish_module_gas.clone(), configs.validator_set()).await;
+        let qd_and_gas = self
+            .counter_gas
+            .clone()
+            .into_iter()
+            .map(|g| (quorum_driver_handler.clone_quorum_driver(), g));
+        // create counters
+        let futures = qd_and_gas.map(|(qd, gas_object)| async move {
+            let tx =
+                make_counter_create_transaction(gas_object.compute_object_reference(), package_ref);
+            if let ExecuteTransactionResponse::EffectsCert(result) = qd
+                .execute_transaction(ExecuteTransactionRequest {
+                    transaction: tx,
+                    request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+                })
+                .await
+                .unwrap()
+            {
+                let (_, effects) = *result;
+                Box::new(SharedCounterTestPayload {
+                    package_ref,
+                    counter_id: effects.effects.created[0].0 .0,
+                    gas: effects.effects.gas_object,
+                })
+            } else {
+                panic!("Failed to create shared counter!");
+            }
+        });
+        eprintln!("Creating shared counters, this may take a while..");
+        join_all(futures)
+            .await
+            .into_iter()
+            .map(|b| Box::<dyn Payload>::from(b))
+            .collect()
+    }
+}

--- a/crates/sui-benchmark/src/stress/transfer_object.rs
+++ b/crates/sui-benchmark/src/stress/transfer_object.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use rand::seq::IteratorRandom;
+use sui_config::NetworkConfig;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef, SuiAddress},
+    crypto::{get_key_pair, EmptySignInfo, KeyPair},
+    messages::TransactionEnvelope,
+    object::{Object, Owner},
+};
+
+use test_utils::{
+    messages::make_transfer_object_transaction, objects::generate_gas_objects_with_owner,
+};
+
+use super::context::{Gas, Payload, StressTestCtx};
+
+pub struct TransferObjectTestPayload {
+    transfer_object: ObjectRef,
+    transfer_from: SuiAddress,
+    transfer_to: SuiAddress,
+    gas: Vec<Gas>,
+    keypairs: Arc<HashMap<SuiAddress, KeyPair>>,
+}
+
+impl Payload for TransferObjectTestPayload {
+    fn make_new_payload(&self, new_object: ObjectRef, new_gas: ObjectRef) -> Box<dyn Payload> {
+        let updated_gas: Vec<Gas> = self
+            .gas
+            .iter()
+            .map(|x| {
+                if x.1.get_owner_address().unwrap() == self.transfer_from {
+                    (new_gas, Owner::AddressOwner(self.transfer_from))
+                } else {
+                    *x
+                }
+            })
+            .collect();
+        let (_, recipient) = self
+            .gas
+            .iter()
+            .find(|x| x.1.get_owner_address().unwrap() != self.transfer_to)
+            .unwrap();
+        Box::new(TransferObjectTestPayload {
+            transfer_object: new_object,
+            transfer_from: self.transfer_to,
+            transfer_to: recipient.get_owner_address().unwrap(),
+            gas: updated_gas,
+            keypairs: self.keypairs.clone(),
+        })
+    }
+    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo> {
+        let (gas_obj, _) = self
+            .gas
+            .iter()
+            .find(|x| x.1.get_owner_address().unwrap() == self.transfer_from)
+            .unwrap();
+        make_transfer_object_transaction(
+            self.transfer_object,
+            *gas_obj,
+            self.transfer_from,
+            self.keypairs.get(&self.transfer_from).unwrap(),
+            self.transfer_to,
+        )
+    }
+    fn get_object_id(&self) -> ObjectID {
+        self.transfer_object.0
+    }
+}
+
+pub struct TransferObjectTestCtx {
+    transfer_gas: Vec<Vec<Object>>,
+    transfer_objects: Vec<Object>,
+    transfer_objects_owner: SuiAddress,
+    keypairs: Arc<HashMap<SuiAddress, KeyPair>>,
+}
+
+impl TransferObjectTestCtx {
+    pub fn make_ctx(
+        count: u64,
+        num_accounts: u64,
+        _configs: &NetworkConfig,
+    ) -> Box<dyn StressTestCtx<dyn Payload>> {
+        // create several accounts to transfer object between
+        let keypairs: Arc<HashMap<SuiAddress, KeyPair>> =
+            Arc::new((0..num_accounts).map(|_| get_key_pair()).collect());
+        // create enough gas to do those transfers
+        let gas: Vec<Vec<Object>> = (0..count)
+            .map(|_| {
+                keypairs
+                    .iter()
+                    .map(|(owner, _)| generate_gas_objects_with_owner(1, *owner).pop().unwrap())
+                    .collect()
+            })
+            .collect();
+        // choose a random owner to be the owner of transfer objects
+        let owner = *keypairs.keys().choose(&mut rand::thread_rng()).unwrap();
+        // create transfer objects
+        let transfer_objects = generate_gas_objects_with_owner(count as usize, owner);
+        Box::new(TransferObjectTestCtx {
+            transfer_gas: gas,
+            transfer_objects,
+            transfer_objects_owner: owner,
+            keypairs,
+        })
+    }
+}
+
+#[async_trait]
+impl StressTestCtx<dyn Payload> for TransferObjectTestCtx {
+    fn get_gas_objects(&mut self) -> Vec<Object> {
+        let mut gas: Vec<Object> = self.transfer_gas.clone().into_iter().flatten().collect();
+        gas.append(&mut self.transfer_objects.clone());
+        gas
+    }
+    async fn make_test_payloads(&self, _configs: &NetworkConfig) -> Vec<Box<dyn Payload>> {
+        let refs: Vec<(Vec<Gas>, ObjectRef)> = self
+            .transfer_gas
+            .iter()
+            .zip(self.transfer_objects.iter())
+            .map(|(g, t)| {
+                (
+                    g.iter()
+                        .map(|x| (x.compute_object_reference(), x.owner))
+                        .collect(),
+                    t.compute_object_reference(),
+                )
+            })
+            .collect();
+        refs.iter()
+            .map(|(g, t)| {
+                let from = self.transfer_objects_owner;
+                let (_, to) = *g
+                    .iter()
+                    .find(|x| x.1.get_owner_address().unwrap() != from)
+                    .unwrap();
+                Box::new(TransferObjectTestPayload {
+                    transfer_object: *t,
+                    transfer_from: from,
+                    transfer_to: to.get_owner_address().unwrap(),
+                    gas: g.clone(),
+                    keypairs: self.keypairs.clone(),
+                })
+            })
+            .map(|b| Box::<dyn Payload>::from(b))
+            .collect()
+    }
+}


### PR DESCRIPTION
The current benchmark seems to suffer from resource contention between client and server tasks when running locally. Isolating them on two different runtimes helps a little bit with performance and adds to the flexibility in how we can set things up. What I've observed is: increasing server threads reduces the time out errors  and vice-versa and increasing client threads+workers reduces client observed latency and vice-versa. Obviously, with the limited resources on a single machine, increasing resources for one will starve the other. With the current defaults, my cpu usage hovers around 90+% (all cores). It'll be interesting to see a flamegraph of where it is being spent.