### PR TITLE
Make shared object version assignment safe wrt checkpoints

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1383,7 +1383,9 @@ impl AuthorityState {
     ) -> SuiResult<bool> {
         let digest = certificate.digest();
         let shared_inputs = certificate.shared_input_objects();
-        let shared_locks = self.database.sequenced(digest, shared_inputs)?;
+        let shared_locks = self
+            .database
+            .get_assigned_object_versions(digest, shared_inputs)?;
         Ok(shared_locks[0].is_some())
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1386,7 +1386,7 @@ impl AuthorityState {
         let shared_locks = self
             .database
             .get_assigned_object_versions(digest, shared_inputs)?;
-        Ok(shared_locks[0].is_some())
+        Ok(shared_locks.iter().all(|l| l.is_some()))
     }
 
     /// Get a read reference to an object/seq lock
@@ -1461,36 +1461,12 @@ impl ExecutionState for AuthorityState {
                     SuiError::NotASharedObjectTransaction
                 );
 
-                // Check if we already assigned locks to the shared objects.
-                let shared_locks = self.transaction_shared_locks_exist(&certificate).await?;
+                // Check the certificate. Remember that Byzantine authorities may input anything into
+                // consensus.
+                certificate.verify(&self.committee.load())?;
 
-                // If we already executed this transaction, return the signed effects.
-                // This is not an optimization, and is critical for safety. It is to ensure that
-                // we don't end up re-assigning shared object locks after they are unlocked when
-                // the transaction was committed.
-                let digest = certificate.digest();
-                if let Some(response) = self.check_tx_already_executed(digest).await? {
-                    return Ok(bincode::serialize(&response).expect("Failed to serialize tx info"));
-                }
-
-                // If we didn't already assigned shared-locks to this transaction, we do it now.
-                if !shared_locks {
-                    // Check the certificate. Remember that Byzantine authorities may input anything into
-                    // consensus.
-                    certificate.verify(&self.committee.load())?;
-
-                    // Persist the certificate since we are about to lock one or more shared object.
-                    // We thus need to make sure someone (if not the client) can continue the protocol.
-                    // Also atomically lock the shared objects for this particular transaction and
-                    // increment the last consensus index. Note that a single process can ever call
-                    // this function and that the last consensus index is also kept in memory. It is
-                    // thus ok to only persist now (despite this function may have returned earlier).
-                    // In the worst case, the synchronizer of the consensus client will catch up.
-                    self.database.persist_certificate_and_lock_shared_objects(
-                        *certificate,
-                        consensus_index,
-                    )?;
-                }
+                self.database
+                    .persist_certificate_and_lock_shared_objects(*certificate, consensus_index)?;
 
                 // TODO: This return time is not ideal.
                 Ok(Vec::default())

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -112,6 +112,16 @@ pub struct SuiDataStore<S> {
     assigned_object_versions: DBMap<(TransactionDigest, ObjectID), SequenceNumber>,
     next_object_versions: DBMap<ObjectID, SequenceNumber>,
 
+    /// Track which transactions have been processed in handle_consensus_transaction. We must be
+    /// sure to advance next_object_versions exactly once for each transaction we receive from
+    /// consensus. But, we may also be processing transactions from checkpoints, so we need to
+    /// track this state separately.
+    ///
+    /// Entries in this table can be garbage collected whenever we can prove that we won't receive
+    /// another handle_consensus_transaction call for the given digest. This probably means at
+    /// epoch change.
+    consensus_message_processed: DBMap<TransactionDigest, bool>,
+
     // Tables used for authority batch structure
     /// A sequence on all executed certificates and effects.
     pub executed_sequence: DBMap<TxSequenceNumber, ExecutionDigests>,
@@ -147,6 +157,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                 ("effects", &point_lookup),
                 ("assigned_object_versions", &options),
                 ("next_object_versions", &options),
+                ("consensus_message_processed", &options),
                 ("executed_sequence", &options),
                 ("batches", &options),
                 ("last_consensus_index", &options),
@@ -169,6 +180,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             effects,
             assigned_object_versions,
             next_object_versions,
+            consensus_message_processed,
             batches,
             last_consensus_index,
             epochs,
@@ -183,6 +195,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             "effects";<TransactionDigest, TransactionEffectsEnvelope<S>>,
             "assigned_object_versions";<(TransactionDigest, ObjectID), SequenceNumber>,
             "next_object_versions";<ObjectID, SequenceNumber>,
+            "consensus_message_processed";<TransactionDigest, bool>,
             "batches";<TxSequenceNumber, SignedBatch>,
             "last_consensus_index";<u64, ExecutionIndices>,
             "epochs";<EpochId, EpochInfoLocals>
@@ -221,6 +234,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             effects,
             assigned_object_versions,
             next_object_versions,
+            consensus_message_processed,
             executed_sequence,
             batches,
             last_consensus_index,
@@ -1116,6 +1130,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     /// Lock a sequence number for the shared objects of the input transaction. Also update the
     /// last consensus index.
+    /// This function must only be called from the consensus task (i.e. from handle_consensus_transaction).
     pub fn persist_certificate_and_lock_shared_objects(
         &self,
         certificate: CertifiedTransaction,
@@ -1123,7 +1138,15 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     ) -> Result<(), SuiError> {
         // Make an iterator to save the certificate.
         let transaction_digest = *certificate.digest();
-        // let certificate_to_write = std::iter::once((transaction_digest, &certificate));
+
+        // Ensure that we only advance next_object_versions exactly once for every cert received from
+        // consensus.
+        if self
+            .consensus_message_processed
+            .contains_key(&transaction_digest)?
+        {
+            return Ok(());
+        }
 
         // Make an iterator to update the locks of the transaction's shared objects.
         let ids = certificate.shared_input_objects();
@@ -1165,6 +1188,10 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             write_batch.insert_batch(&self.assigned_object_versions, sequenced_to_write)?;
         write_batch = write_batch.insert_batch(&self.next_object_versions, schedule_to_write)?;
         write_batch = write_batch.insert_batch(&self.last_consensus_index, index_to_write)?;
+        write_batch = write_batch.insert_batch(
+            &self.consensus_message_processed,
+            std::iter::once((transaction_digest, true)),
+        )?;
         write_batch.write().map_err(SuiError::from)
     }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::Identifier, language_storage::TypeTag,
 };
 use narwhal_executor::ExecutionIndices;
-use rand::{prelude::StdRng, SeedableRng};
+use rand::{prelude::StdRng, Rng, SeedableRng};
 use std::collections::BTreeMap;
 use std::fs;
 use std::{convert::TryInto, env};
@@ -1578,30 +1578,35 @@ async fn test_store_revert_state_update() {
 }
 
 // helpers
-
 #[cfg(test)]
-fn init_state_parameters() -> (Committee, SuiAddress, KeyPair, Arc<AuthorityStore>) {
-    let (authority_address, authority_key) = get_key_pair();
-    let mut authorities = BTreeMap::new();
-    authorities.insert(
-        /* address */ *authority_key.public_key_bytes(),
-        /* voting right */ 1,
-    );
-    let committee = Committee::new(0, authorities).unwrap();
-
-    // Create a random directory to store the DB
-
-    let dir = env::temp_dir();
-    let path = dir.join(format!("DB_{:?}", ObjectID::random()));
-    fs::create_dir(&path).unwrap();
-
-    let store = Arc::new(AuthorityStore::open(path, None));
-    (committee, authority_address, authority_key, store)
+fn init_store() -> Arc<AuthorityStore> {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("authority_db");
+    Arc::new(AuthorityStore::open(path, None))
 }
 
 #[cfg(test)]
 pub async fn init_state() -> AuthorityState {
-    let (committee, _, authority_key, store) = init_state_parameters();
+    init_state_with_committee(None).await
+}
+
+#[cfg(test)]
+pub async fn init_state_with_committee(committee: Option<(Committee, KeyPair)>) -> AuthorityState {
+    let (committee, authority_key) = match committee {
+        Some(c) => c,
+        None => {
+            let (authority_address, authority_key) = get_key_pair();
+            let mut authorities = BTreeMap::new();
+            authorities.insert(
+                /* address */ *authority_key.public_key_bytes(),
+                /* voting right */ 1,
+            );
+            (Committee::new(0, authorities).unwrap(), authority_key)
+        }
+    };
+
+    let store = init_store();
+
     AuthorityState::new(
         committee,
         *authority_key.public_key_bytes(),
@@ -1643,7 +1648,14 @@ pub async fn init_state_with_ids_and_versions<
 }
 
 pub async fn init_state_with_objects<I: IntoIterator<Item = Object>>(objects: I) -> AuthorityState {
-    let state = init_state().await;
+    init_state_with_objects_and_committee(objects, None).await
+}
+
+pub async fn init_state_with_objects_and_committee<I: IntoIterator<Item = Object>>(
+    objects: I,
+    committee_and_keypair: Option<(Committee, KeyPair)>,
+) -> AuthorityState {
+    let state = init_state_with_committee(committee_and_keypair).await;
     for o in objects {
         state.insert_genesis_object(o).await;
     }
@@ -1793,6 +1805,58 @@ pub async fn create_move_object(
     .await
 }
 
+#[cfg(test)]
+async fn make_test_transaction(
+    sender: &SuiAddress,
+    sender_key: &KeyPair,
+    shared_object_id: ObjectID,
+    gas_object_ref: &ObjectRef,
+    authorities: &[&AuthorityState],
+) -> CertifiedTransaction {
+    // Make a sample transaction.
+    let module = "object_basics";
+    let function = "create";
+    let package_object_ref = authorities[0].get_framework_object_ref().await.unwrap();
+
+    let data = TransactionData::new_move_call(
+        *sender,
+        package_object_ref,
+        ident_str!(module).to_owned(),
+        ident_str!(function).to_owned(),
+        /* type_args */ vec![],
+        *gas_object_ref,
+        /* args */
+        vec![
+            CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
+            CallArg::Pure(16u64.to_le_bytes().to_vec()),
+            CallArg::Pure(bcs::to_bytes(&AccountAddress::from(*sender)).unwrap()),
+        ],
+        MAX_GAS,
+    );
+    let signature = Signature::new(&data, sender_key);
+    let transaction = Transaction::new(data, signature);
+    let transaction_digest = *transaction.digest();
+
+    let committee = authorities[0].committee.load();
+    let mut sig = SignatureAggregator::try_new(transaction.clone(), &committee).unwrap();
+
+    for authority in authorities {
+        let response = authority
+            .handle_transaction(transaction.clone())
+            .await
+            .unwrap();
+        let vote = response.signed_transaction.unwrap();
+        if let Some(cert) = sig
+            .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
+            .unwrap()
+        {
+            return cert;
+        }
+    }
+
+    unreachable!("couldn't form cert")
+}
+
 #[tokio::test]
 async fn shared_object() {
     let (sender, keypair) = get_key_pair();
@@ -1814,41 +1878,15 @@ async fn shared_object() {
 
     let authority = init_state_with_objects(vec![gas_object, shared_object]).await;
 
-    // Make a sample transaction.
-    let module = "object_basics";
-    let function = "create";
-    let package_object_ref = authority.get_framework_object_ref().await.unwrap();
-
-    let data = TransactionData::new_move_call(
-        sender,
-        package_object_ref,
-        ident_str!(module).to_owned(),
-        ident_str!(function).to_owned(),
-        /* type_args */ vec![],
-        gas_object_ref,
-        /* args */
-        vec![
-            CallArg::Object(ObjectArg::SharedObject(shared_object_id)),
-            CallArg::Pure(16u64.to_le_bytes().to_vec()),
-            CallArg::Pure(bcs::to_bytes(&AccountAddress::from(sender)).unwrap()),
-        ],
-        MAX_GAS,
-    );
-    let signature = Signature::new(&data, &keypair);
-    let transaction = Transaction::new(data, signature);
-    let transaction_digest = *transaction.digest();
-
-    // Submit the transaction and assemble a certificate.
-    let response = authority
-        .handle_transaction(transaction.clone())
-        .await
-        .unwrap();
-    let vote = response.signed_transaction.unwrap();
-    let certificate = SignatureAggregator::try_new(transaction, &authority.committee.load())
-        .unwrap()
-        .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
-        .unwrap()
-        .unwrap();
+    let certificate = make_test_transaction(
+        &sender,
+        &keypair,
+        shared_object_id,
+        &gas_object_ref,
+        &[&authority],
+    )
+    .await;
+    let transaction_digest = certificate.digest();
 
     // Sending the certificate now fails since it was not sequenced.
     let result = authority.handle_certificate(certificate.clone()).await;
@@ -1890,4 +1928,120 @@ async fn shared_object() {
         .unwrap()
         .version();
     assert_eq!(shared_object_version, SequenceNumber::from(2));
+}
+
+#[tokio::test]
+async fn test_consensus_message_processed() {
+    telemetry_subscribers::init_for_testing();
+
+    let (sender, keypair) = get_key_pair();
+
+    let mut authorities = BTreeMap::new();
+    let (a1, sec1) = get_key_pair();
+    let (a2, sec2) = get_key_pair();
+    authorities.insert(*sec1.public_key_bytes(), 1);
+    authorities.insert(*sec2.public_key_bytes(), 1);
+
+    let committee = Committee::new(0, authorities.clone()).unwrap();
+
+    let gas_object_id = ObjectID::random();
+    let gas_object = Object::with_id_owner_for_testing(gas_object_id, sender);
+    let mut gas_object_ref = gas_object.compute_object_reference();
+
+    let shared_object_id = ObjectID::random();
+    let shared_object = {
+        use sui_types::gas_coin::GasCoin;
+        use sui_types::object::MoveObject;
+
+        let content = GasCoin::new(shared_object_id, OBJECT_START_VERSION, 10);
+        let obj = MoveObject::new_gas_coin(content.to_bcs_bytes());
+        Object::new_move(obj, Owner::Shared, TransactionDigest::genesis())
+    };
+
+    let authority1 = init_state_with_objects_and_committee(
+        vec![gas_object.clone(), shared_object.clone()],
+        Some((committee.clone(), sec1)),
+    )
+    .await;
+    let authority2 = init_state_with_objects_and_committee(
+        vec![gas_object.clone(), shared_object.clone()],
+        Some((committee.clone(), sec2)),
+    )
+    .await;
+
+    async fn send_consensus(authority: &AuthorityState, cert: &CertifiedTransaction) {
+        authority
+            .handle_consensus_transaction(
+                ExecutionIndices::default(),
+                ConsensusTransaction::UserTransaction(Box::new(cert.clone())),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn handle_cert(
+        authority: &AuthorityState,
+        cert: &CertifiedTransaction,
+    ) -> SignedTransactionEffects {
+        if let TransactionInfoResponse {
+            signed_effects: Some(effects),
+            ..
+        } = authority.handle_certificate(cert.clone()).await.unwrap()
+        {
+            effects
+        } else {
+            unreachable!("authority1 should have returned effects");
+        }
+    }
+
+    let seed = [1u8; 32];
+    let mut rng = StdRng::from_seed(seed);
+    for _ in 0..50 {
+        let certificate = make_test_transaction(
+            &sender,
+            &keypair,
+            shared_object_id,
+            &gas_object_ref,
+            &[&authority1, &authority2],
+        )
+        .await;
+        let transaction_digest = certificate.digest();
+
+        // on authority1, we always sequence via consensus
+        send_consensus(&authority1, &certificate).await;
+        let effects1 = handle_cert(&authority1, &certificate).await;
+
+        // now, on authority2, we send 0 or 1 consensus messages, then we either sequence and execute via
+        // effects or via handle_certificate, then send 0 or 1 consensus messages.
+        if rng.gen_bool(0.5) {
+            send_consensus(&authority2, &certificate).await;
+        }
+
+        authority2
+            .handle_node_sync_certificate(certificate.clone(), effects1.clone())
+            .await
+            .unwrap();
+        let effects2 = authority2
+            .database
+            .effects
+            .get(transaction_digest)
+            .unwrap()
+            .unwrap();
+
+        // verify the two validators are never out of sync.
+        assert_eq!(effects1.effects, effects2.effects);
+
+        if rng.gen_bool(0.5) {
+            send_consensus(&authority2, &certificate).await;
+        }
+
+        // Update to the new gas object for new tx
+        gas_object_ref = *effects1
+            .effects
+            .mutated
+            .iter()
+            .map(|(objref, _)| objref)
+            .find(|objref| objref.0 == gas_object_ref.0)
+            .unwrap();
+    }
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1865,7 +1865,7 @@ async fn shared_object() {
 
     let shared_object_version = authority
         .db()
-        .sequenced(&transaction_digest, [shared_object_id].iter())
+        .get_assigned_object_versions(&transaction_digest, [shared_object_id].iter())
         .unwrap()[0]
         .unwrap();
     assert_eq!(shared_object_version, OBJECT_START_VERSION);
@@ -1879,7 +1879,7 @@ async fn shared_object() {
 
     let shared_object_lock = authority
         .db()
-        .sequenced(&transaction_digest, [shared_object_id].iter())
+        .get_assigned_object_versions(&transaction_digest, [shared_object_id].iter())
         .unwrap()[0];
     assert!(shared_object_lock.is_none());
 


### PR DESCRIPTION
Shared object versions can currently be set in two ways:

1. Via handle_consensus_transaction, which advances the shared object versions in accordance with the sequencing output by narhwal.
2. Via handle_node_sync_certificate, which sets shared object versions from an TransactionEffects structure.

Currently, 1 only happens on validators, and 2 only happens on nodes. However, we want to be able to call handle_node_sync_certificate on validators so that they can catch up to the current checkpoint if they are disconnected from the network temporarily.

This PR allows these two mechanisms to coexist such that a validator's state will not diverge from its peers if it executes a transaction via handle_node_sync_certificate before receiving that same certificate from consensus.

Another solution to this problem would be to have validators never call handle_node_sync_certificate, and instead wait to receive consensus messages before processing checkpoint certificates. I like this solution better because it can be made very fast (no single-thread bottleneck), and it also makes the code in `handle_consensus_transaction` more obviously-correct to my eye.