### PR TITLE
[checkpoint] Store checkpoint content directly

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -94,6 +94,7 @@ pub struct CheckpointStore {
     /// The mapping from checkpoint to transaction/effects contained within the checkpoint.
     /// The checkpoint content should be causally ordered and is consistent among
     /// all validators.
+    /// TODO: CheckpointContents may grow very big and becomes problematic to store as db value.
     pub checkpoint_contents: DBMap<CheckpointSequenceNumber, CheckpointContents>,
 
     /// The set of transaction/effects this authority has processed but have not yet been

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -92,11 +92,9 @@ pub struct CheckpointStore {
         DBMap<ExecutionDigests, (CheckpointSequenceNumber, TxSequenceNumber)>,
 
     /// The mapping from checkpoint to transaction/effects contained within the checkpoint.
-    /// The second part of the key is the local sequence number if the transaction was
-    /// processed or Max(u64) / 2 + offset if not. It allows the authority to store and serve
-    /// checkpoints in a causal order that can be processed in order. (Note the set
-    /// of transactions in the checkpoint is global but not the order.)
-    pub checkpoint_contents: DBMap<(CheckpointSequenceNumber, TxSequenceNumber), ExecutionDigests>,
+    /// The checkpoint content should be causally ordered and is consistent among
+    /// all validators.
+    pub checkpoint_contents: DBMap<CheckpointSequenceNumber, CheckpointContents>,
 
     /// The set of transaction/effects this authority has processed but have not yet been
     /// included in a checkpoint, and their sequence number in the local sequence
@@ -260,7 +258,7 @@ impl CheckpointStore {
         ) = reopen! (
             &db,
             "transactions_to_checkpoint";<ExecutionDigests,(CheckpointSequenceNumber, TxSequenceNumber)>,
-            "checkpoint_contents";<(CheckpointSequenceNumber,TxSequenceNumber),ExecutionDigests>,
+            "checkpoint_contents";<CheckpointSequenceNumber,CheckpointContents>,
             "extra_transactions";<ExecutionDigests,TxSequenceNumber>,
             "checkpoints";<CheckpointSequenceNumber, AuthenticatedCheckpoint>,
             "local_fragments";<AuthorityName, CheckpointFragment>,
@@ -348,13 +346,7 @@ impl CheckpointStore {
         let detail = if let &AuthenticatedCheckpoint::None = &checkpoint {
             None
         } else if detail {
-            Some(CheckpointContents::new(
-                self.checkpoint_contents
-                    .iter()
-                    .skip_to(&(seq, 0))?
-                    .take_while(|((k, _), _)| *k == seq)
-                    .map(|(_, digest)| digest),
-            ))
+            self.checkpoint_contents.get(&seq)?
         } else {
             None
         };
@@ -450,8 +442,7 @@ impl CheckpointStore {
             .delete_batch(&self.local_fragments, self.local_fragments.keys())?;
 
         // Update the transactions databases.
-        let transactions: Vec<_> = contents.transactions.to_vec();
-        self.update_new_checkpoint_inner(checkpoint_sequence_number, &transactions, batch)
+        self.update_new_checkpoint_inner(checkpoint_sequence_number, contents, batch)
     }
 
     /// Call this function internally to register the latest batch of
@@ -895,7 +886,7 @@ impl CheckpointStore {
     pub fn update_new_checkpoint(
         &mut self,
         seq: CheckpointSequenceNumber,
-        transactions: &[ExecutionDigests],
+        transactions: &CheckpointContents,
         effects_store: impl PendCertificateForExecution,
     ) -> Result<(), SuiError> {
         // Ensure we have processed all transactions contained in this checkpoint.
@@ -911,7 +902,7 @@ impl CheckpointStore {
     fn update_new_checkpoint_inner(
         &mut self,
         seq: CheckpointSequenceNumber,
-        transactions: &[ExecutionDigests],
+        transactions: &CheckpointContents,
         batch: DBBatch,
     ) -> Result<(), SuiError> {
         // Check that this checkpoint seq is new, and directly follows the last
@@ -941,23 +932,24 @@ impl CheckpointStore {
 
         // Now write the checkpoint data to the database
 
-        let checkpoint_data: Vec<_> = transactions
+        let transactions_to_checkpoint: Vec<_> = transactions
             .iter()
             .zip(transactions_with_seq.iter())
             .map(|(tx, opt)| {
                 // Unwrap safe since we have checked all transactions are processed
                 // to get to this point.
                 let iseq = opt.as_ref().unwrap();
-                ((seq, *iseq), *tx)
+                (*tx, (seq, *iseq))
             })
             .collect();
 
-        let batch = batch.insert_batch(
-            &self.transactions_to_checkpoint,
-            checkpoint_data.iter().map(|(a, b)| (b, a)),
-        )?;
+        let batch =
+            batch.insert_batch(&self.transactions_to_checkpoint, transactions_to_checkpoint)?;
 
-        let batch = batch.insert_batch(&self.checkpoint_contents, checkpoint_data.into_iter())?;
+        let batch = batch.insert_batch(
+            &self.checkpoint_contents,
+            std::iter::once((seq, transactions)),
+        )?;
 
         // Write to the database.
         batch.write()?;
@@ -1021,21 +1013,6 @@ impl CheckpointStore {
                 .filter_map(|((seq, tx), in_chk)| {
                     if in_chk.is_some() {
                         Some((tx, (in_chk.unwrap().0, *seq)))
-                    } else {
-                        None
-                    }
-                }),
-        )?;
-
-        // Update the checkpoint local sequence number
-        let batch = batch.insert_batch(
-            &self.checkpoint_contents,
-            transactions
-                .iter()
-                .zip(&in_checkpoint)
-                .filter_map(|((seq, tx), in_chk)| {
-                    if in_chk.is_some() {
-                        Some(((in_chk.unwrap().0, *seq), tx))
                     } else {
                         None
                     }

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -187,21 +187,29 @@ fn make_checkpoint_db() {
 
     // You cannot make a checkpoint without processing all transactions
     assert!(cps
-        .update_new_checkpoint(0, &[t1, t2, t4, t5], PendCertificateForExecutionNoop)
+        .update_new_checkpoint(
+            0,
+            &CheckpointContents::new([t1, t2, t4, t5].into_iter()),
+            PendCertificateForExecutionNoop
+        )
         .is_err());
 
     // Now process the extra transactions in the checkpoint
     cps.update_processed_transactions(&[(4, t4), (5, t5)])
         .unwrap();
 
-    cps.update_new_checkpoint(0, &[t1, t2, t4, t5], PendCertificateForExecutionNoop)
-        .unwrap();
-    assert_eq!(cps.checkpoint_contents.iter().count(), 4);
+    cps.update_new_checkpoint(
+        0,
+        &CheckpointContents::new([t1, t2, t4, t5].into_iter()),
+        PendCertificateForExecutionNoop,
+    )
+    .unwrap();
+    assert_eq!(cps.checkpoint_contents.iter().count(), 1);
     assert_eq!(cps.extra_transactions.iter().count(), 1);
     assert_eq!(cps.next_checkpoint(), 1);
 
     cps.update_processed_transactions(&[(6, t6)]).unwrap();
-    assert_eq!(cps.checkpoint_contents.iter().count(), 4);
+    assert_eq!(cps.checkpoint_contents.iter().count(), 1);
     assert_eq!(cps.extra_transactions.iter().count(), 2); // t3 & t6
 
     let (_cp_seq, tx_seq) = cps.transactions_to_checkpoint.get(&t4).unwrap().unwrap();
@@ -248,7 +256,11 @@ fn make_proposals() {
 
     // if not all transactions are processed we fail
     assert!(cps1
-        .update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
+        .update_new_checkpoint(
+            0,
+            &CheckpointContents::new(ckp_items.iter().cloned()),
+            PendCertificateForExecutionNoop
+        )
         .is_err());
 
     cps1.update_processed_transactions(&[(3, t1), (4, t4)])
@@ -263,14 +275,30 @@ fn make_proposals() {
     cps4.update_processed_transactions(&[(3, t1), (4, t2), (5, t3)])
         .unwrap();
 
-    cps1.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
-        .unwrap();
-    cps2.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
-        .unwrap();
-    cps3.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
-        .unwrap();
-    cps4.update_new_checkpoint(0, &ckp_items[..], PendCertificateForExecutionNoop)
-        .unwrap();
+    cps1.update_new_checkpoint(
+        0,
+        &CheckpointContents::new(ckp_items.iter().cloned()),
+        PendCertificateForExecutionNoop,
+    )
+    .unwrap();
+    cps2.update_new_checkpoint(
+        0,
+        &CheckpointContents::new(ckp_items.iter().cloned()),
+        PendCertificateForExecutionNoop,
+    )
+    .unwrap();
+    cps3.update_new_checkpoint(
+        0,
+        &CheckpointContents::new(ckp_items.iter().cloned()),
+        PendCertificateForExecutionNoop,
+    )
+    .unwrap();
+    cps4.update_new_checkpoint(
+        0,
+        &CheckpointContents::new(ckp_items.iter().cloned()),
+        PendCertificateForExecutionNoop,
+    )
+    .unwrap();
 
     assert_eq!(
         cps4.extra_transactions.keys().collect::<HashSet<_>>(),

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::slice::Iter;
 
 use crate::base_types::ExecutionDigests;
 use crate::committee::EpochId;
@@ -370,6 +371,9 @@ pub struct CheckpointContents {
 
 impl BcsSignable for CheckpointContents {}
 
+// TODO: We should create a type for ordered contents,
+// instead of mixing them in the same type.
+// https://github.com/MystenLabs/sui/issues/3038
 impl CheckpointContents {
     pub fn new<T>(contents: T) -> CheckpointContents
     where
@@ -378,6 +382,10 @@ impl CheckpointContents {
         CheckpointContents {
             transactions: contents.collect::<BTreeSet<_>>().into_iter().collect(),
         }
+    }
+
+    pub fn iter(&self) -> Iter<'_, ExecutionDigests> {
+        self.transactions.iter()
     }
 
     pub fn digest(&self) -> [u8; 32] {

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -210,6 +210,8 @@ async fn end_to_end() {
 
 #[tokio::test]
 async fn checkpoint_with_shared_objects() {
+    telemetry_subscribers::init_for_testing();
+
     // Get some gas objects to submit shared-objects transactions.
     let mut gas_objects = test_gas_objects();
 
@@ -327,6 +329,7 @@ async fn checkpoint_with_shared_objects() {
     transaction_digests.insert(*increment_counter_transaction.digest());
 
     // Wait for the transactions to be executed and end up in a checkpoint.
+    let mut cnt = 0;
     loop {
         // Ensure all submitted transactions are in the checkpoint.
         let ok = handles
@@ -336,8 +339,10 @@ async fn checkpoint_with_shared_objects() {
 
         match ok {
             true => break,
-            false => tokio::time::sleep(Duration::from_millis(10)).await,
+            false => tokio::time::sleep(Duration::from_secs(1)).await,
         }
+        cnt += 1;
+        assert!(cnt <= 20);
     }
 
     // Ensure all authorities moved to the next checkpoint sequence number.

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -32,19 +32,14 @@ fn transactions_in_checkpoint(authority: &AuthorityState) -> HashSet<Transaction
 
     // Get all transactions in the first 10 checkpoints.
     (0..10)
-        .flat_map(|checkpoint_sequence| {
-            // Get enough sequence numbers (one or two are enough).
-            (0..10)
-                .filter_map(|i| {
-                    checkpoints_store
-                        .lock()
-                        .checkpoint_contents
-                        .get(&(checkpoint_sequence, i))
-                        .unwrap()
-                })
-                .map(|x| x.transaction)
-                .collect::<HashSet<_>>()
+        .filter_map(|checkpoint_sequence| {
+            checkpoints_store
+                .lock()
+                .checkpoint_contents
+                .get(&checkpoint_sequence)
+                .unwrap()
         })
+        .flat_map(|x| x.iter().map(|tx| tx.transaction).collect::<HashSet<_>>())
         .collect::<HashSet<_>>()
 }
 


### PR DESCRIPTION
Previously we store individual transaction execution digests in the db as checkpoint contents. These individual transactions are ordered using the local tx sequence number, which will not be consistent among validators.
This PR changes that to store the CheckpointContents data structure directly. And it is only stored when we have an authenticated checkpoint, at which point the transactions have been causally ordered.
This ensures that we always return the same ordered contents.

Added a TODO to introduce separate types for ordered contents from unordered contents.