### PR TITLE
Cleanup GatewayMetrics

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -44,7 +44,7 @@ use tracing::error;
 
 use crate::{
     authority::AuthorityState, authority_aggregator::AuthorityAggregator,
-    authority_client::AuthorityAPI, gateway_state::GatewayMetrics,
+    authority_client::AuthorityAPI,
 };
 use tokio::time::Instant;
 
@@ -52,6 +52,7 @@ pub mod gossip;
 use gossip::{gossip_process, node_sync_process};
 
 pub mod checkpoint_driver;
+use crate::authority_aggregator::AuthAggMetrics;
 use checkpoint_driver::checkpoint_process;
 
 pub mod execution_driver;
@@ -117,7 +118,7 @@ impl<A> ActiveAuthority<A> {
         authority: Arc<AuthorityState>,
         follower_store: Arc<FollowerStore>,
         authority_clients: BTreeMap<AuthorityName, A>,
-        gateway_metrics: GatewayMetrics,
+        auth_agg_metrics: AuthAggMetrics,
     ) -> SuiResult<Self> {
         let committee = authority.clone_committee();
 
@@ -133,7 +134,7 @@ impl<A> ActiveAuthority<A> {
             net: ArcSwap::from(Arc::new(AuthorityAggregator::new(
                 committee,
                 authority_clients,
-                gateway_metrics,
+                auth_agg_metrics,
             ))),
         })
     }
@@ -141,7 +142,7 @@ impl<A> ActiveAuthority<A> {
     pub fn new_with_ephemeral_follower_store(
         authority: Arc<AuthorityState>,
         authority_clients: BTreeMap<AuthorityName, A>,
-        gateway_metrics: GatewayMetrics,
+        auth_agg_metrics: AuthAggMetrics,
     ) -> SuiResult<Self> {
         let working_dir = tempfile::tempdir().unwrap();
         let follower_store = Arc::new(FollowerStore::open(&working_dir).expect("cannot open db"));
@@ -149,7 +150,7 @@ impl<A> ActiveAuthority<A> {
             authority,
             follower_store,
             authority_clients,
-            gateway_metrics,
+            auth_agg_metrics,
         )
     }
 

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -110,7 +110,6 @@ pub struct ActiveAuthority<A> {
     pub net: ArcSwap<AuthorityAggregator<A>>,
     // Network health
     pub health: Arc<Mutex<HashMap<AuthorityName, AuthorityHealth>>>,
-    pub gateway_metrics: GatewayMetrics,
 }
 
 impl<A> ActiveAuthority<A> {
@@ -134,9 +133,8 @@ impl<A> ActiveAuthority<A> {
             net: ArcSwap::from(Arc::new(AuthorityAggregator::new(
                 committee,
                 authority_clients,
-                gateway_metrics.clone(),
+                gateway_metrics,
             ))),
-            gateway_metrics,
         })
     }
 
@@ -208,7 +206,6 @@ impl<A> Clone for ActiveAuthority<A> {
             follower_store: self.follower_store.clone(),
             net: ArcSwap::from(self.net.load().clone()),
             health: self.health.clone(),
-            gateway_metrics: self.gateway_metrics.clone(),
         }
     }
 }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     authority_active::{checkpoint_driver::CheckpointProcessControl, ActiveAuthority},
+    authority_aggregator::AuthAggMetrics,
     authority_client::LocalAuthorityClient,
     checkpoints::checkpoint_tests::TestSetup,
-    gateway_state::GatewayMetrics,
     safe_client::SafeClient,
 };
 
@@ -36,7 +36,7 @@ async fn checkpoint_active_flow_happy_path() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );
@@ -114,7 +114,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );
@@ -208,7 +208,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );
@@ -302,7 +302,7 @@ async fn test_empty_checkpoint() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     authority_active::{checkpoint_driver::CheckpointProcessControl, ActiveAuthority},
-    authority_aggregator::AuthAggMetrics,
     authority_client::LocalAuthorityClient,
     checkpoints::checkpoint_tests::TestSetup,
     safe_client::SafeClient,
@@ -30,13 +29,12 @@ async fn checkpoint_active_flow_happy_path() {
 
     // Start active part of authority.
     for inner_state in authorities.clone() {
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
+                    inner_agg,
                 )
                 .unwrap(),
             );
@@ -108,13 +106,12 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
 
     // Start active part of authority.
     for inner_state in authorities.clone() {
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
+                    inner_agg,
                 )
                 .unwrap(),
             );
@@ -202,13 +199,12 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
 
     // Start active part of authority.
     for inner_state in authorities.clone() {
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
+                    inner_agg,
                 )
                 .unwrap(),
             );
@@ -296,13 +292,12 @@ async fn test_empty_checkpoint() {
 
     // Start active part of authority.
     for inner_state in authorities.clone() {
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
+                    inner_agg,
                 )
                 .unwrap(),
             );

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::gateway_state::GatewayMetrics;
+use crate::authority_aggregator::AuthAggMetrics;
 use crate::{authority_active::ActiveAuthority, checkpoints::checkpoint_tests::TestSetup};
 
 use std::sync::Arc;
@@ -34,7 +34,7 @@ async fn pending_exec_storage_notify() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );
@@ -118,7 +118,7 @@ async fn pending_exec_full() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority_aggregator::AuthAggMetrics;
 use crate::{authority_active::ActiveAuthority, checkpoints::checkpoint_tests::TestSetup};
 
 use std::sync::Arc;
@@ -28,13 +27,12 @@ async fn pending_exec_storage_notify() {
 
     // Start active part of authority.
     for inner_state in authorities.clone() {
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
+                    inner_agg,
                 )
                 .unwrap(),
             );
@@ -112,13 +110,12 @@ async fn pending_exec_full() {
 
     // Start active part of authority.
     for inner_state in authorities.clone() {
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     inner_state.authority.clone(),
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
+                    inner_agg,
                 )
                 .unwrap(),
             );

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -5,6 +5,7 @@
 use crate::authority::AuthorityState;
 use crate::authority::AuthorityStore;
 use crate::authority_aggregator::authority_aggregator_tests::*;
+use crate::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use crate::authority_client::{AuthorityAPI, BatchInfoResponseItemStream};
 use crate::safe_client::SafeClient;
 use async_trait::async_trait;
@@ -196,7 +197,7 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
 pub async fn init_configurable_authorities(
     authority_action: Vec<BatchAction>,
 ) -> (
-    BTreeMap<AuthorityName, ConfigurableBatchActionClient>,
+    AuthorityAggregator<ConfigurableBatchActionClient>,
     Vec<Arc<AuthorityState>>,
     Vec<ExecutionDigests>,
 ) {
@@ -312,5 +313,10 @@ pub async fn init_configurable_authorities(
         .into_iter()
         .map(|(name, client)| (name, client.authority_client().clone()))
         .collect();
-    (authority_clients, states, executed_digests)
+    let net = AuthorityAggregator::new(
+        committee,
+        authority_clients,
+        AuthAggMetrics::new_for_tests(),
+    );
+    (net, states, executed_digests)
 }

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -6,8 +6,6 @@ use crate::authority_active::gossip::configurable_batch_action_client::{
     init_configurable_authorities, BatchAction, ConfigurableBatchActionClient,
 };
 use crate::authority_active::MAX_RETRY_DELAY_MS;
-use crate::authority_aggregator::AuthAggMetrics;
-use std::collections::BTreeMap;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 
@@ -19,14 +17,13 @@ pub async fn test_gossip_plain() {
         BatchAction::EmitUpdateItem(),
     ];
 
-    let (clients, states, digests) = init_configurable_authorities(action_sequence).await;
+    let (net, states, digests) = init_configurable_authorities(action_sequence).await;
 
-    let _active_authorities = start_gossip_process(states.clone(), clients.clone()).await;
+    let _active_authorities = start_gossip_process(states.clone(), net.clone()).await;
     tokio::time::sleep(Duration::from_secs(20)).await;
 
     // Expected outcome of gossip: each digest's tx signature and cert is now on every authority.
-    let clients_final: Vec<_> = clients.values().collect();
-    for client in clients_final.iter() {
+    for client in net.clone_inner_clients().values() {
         for digest in &digests {
             let result1 = client
                 .handle_transaction_info_request(TransactionInfoRequest {
@@ -46,14 +43,13 @@ pub async fn test_gossip_plain() {
 pub async fn test_gossip_error() {
     let action_sequence = vec![BatchAction::EmitError(), BatchAction::EmitUpdateItem()];
 
-    let (clients, states, digests) = init_configurable_authorities(action_sequence).await;
+    let (net, states, digests) = init_configurable_authorities(action_sequence).await;
 
-    let _active_authorities = start_gossip_process(states.clone(), clients.clone()).await;
+    let _active_authorities = start_gossip_process(states.clone(), net.clone()).await;
     // failure back-offs were set from the errors
     tokio::time::sleep(Duration::from_millis(MAX_RETRY_DELAY_MS)).await;
 
-    let clients_final: Vec<_> = clients.values().collect();
-    for client in clients_final.iter() {
+    for client in net.clone_inner_clients().values() {
         for digest in &digests {
             let result1 = client
                 .handle_transaction_info_request(TransactionInfoRequest {
@@ -72,7 +68,7 @@ pub async fn test_gossip_error() {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 pub async fn test_gossip_after_revert() {
     let action_sequence = vec![BatchAction::EmitUpdateItem(), BatchAction::EmitUpdateItem()];
-    let (clients, states, digests) = init_configurable_authorities(action_sequence).await;
+    let (net, states, digests) = init_configurable_authorities(action_sequence).await;
 
     tokio::time::sleep(Duration::from_secs(20)).await;
     // 3 (quorum) of the validators have executed 2 transactions, and 1 has none.
@@ -103,11 +99,10 @@ pub async fn test_gossip_after_revert() {
         }
     }
 
-    let _active_authorities = start_gossip_process(states.clone(), clients.clone()).await;
+    let _active_authorities = start_gossip_process(states.clone(), net.clone()).await;
     tokio::time::sleep(Duration::from_secs(20)).await;
 
-    let clients_final: Vec<_> = clients.values().collect();
-    for client in clients_final.iter() {
+    for client in net.clone_inner_clients().values() {
         let result = client
             .handle_transaction_info_request(TransactionInfoRequest {
                 transaction_digest: digests[0].transaction,
@@ -155,22 +150,17 @@ pub async fn test_gossip_after_revert() {
 
 async fn start_gossip_process(
     states: Vec<Arc<AuthorityState>>,
-    clients: BTreeMap<AuthorityName, ConfigurableBatchActionClient>,
+    net: AuthorityAggregator<ConfigurableBatchActionClient>,
 ) -> Vec<JoinHandle<()>> {
     let mut active_authorities = Vec::new();
 
     // Start active processes.
     for state in states {
-        let inner_clients = clients.clone();
+        let inner_net = net.clone();
 
         let handle = tokio::task::spawn(async move {
             let active_state = Arc::new(
-                ActiveAuthority::new_with_ephemeral_follower_store(
-                    state,
-                    inner_clients,
-                    AuthAggMetrics::new_for_tests(),
-                )
-                .unwrap(),
+                ActiveAuthority::new_with_ephemeral_follower_store(state, inner_net).unwrap(),
             );
             active_state.spawn_gossip_process(3).await;
         });

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -6,7 +6,7 @@ use crate::authority_active::gossip::configurable_batch_action_client::{
     init_configurable_authorities, BatchAction, ConfigurableBatchActionClient,
 };
 use crate::authority_active::MAX_RETRY_DELAY_MS;
-use crate::gateway_state::GatewayMetrics;
+use crate::authority_aggregator::AuthAggMetrics;
 use std::collections::BTreeMap;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -168,7 +168,7 @@ async fn start_gossip_process(
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     state,
                     inner_clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority_client::AuthorityAPI;
-use crate::gateway_state::GatewayMetrics;
 use crate::safe_client::SafeClient;
 use async_trait::async_trait;
 
@@ -128,7 +127,7 @@ pub struct AuthorityAggregator<A> {
     /// How to talk to this committee.
     pub authority_clients: BTreeMap<AuthorityName, SafeClient<A>>,
     // Metrics
-    pub metrics: GatewayMetrics,
+    pub metrics: AuthAggMetrics,
     pub timeouts: TimeoutConfig,
 }
 
@@ -136,7 +135,7 @@ impl<A> AuthorityAggregator<A> {
     pub fn new(
         committee: Committee,
         authority_clients: BTreeMap<AuthorityName, A>,
-        metrics: GatewayMetrics,
+        metrics: AuthAggMetrics,
     ) -> Self {
         Self::new_with_timeouts(committee, authority_clients, metrics, Default::default())
     }
@@ -144,7 +143,7 @@ impl<A> AuthorityAggregator<A> {
     pub fn new_with_timeouts(
         committee: Committee,
         authority_clients: BTreeMap<AuthorityName, A>,
-        metrics: GatewayMetrics,
+        metrics: AuthAggMetrics,
         timeouts: TimeoutConfig,
     ) -> Self {
         Self {
@@ -1449,7 +1448,7 @@ where
             .process_transaction(transaction.clone())
             .instrument(tracing::debug_span!("process_tx"))
             .await?;
-        self.metrics.total_tx_certificates.inc();
+        self.metrics.total_tx_certificates_created.inc();
         let response = self
             .process_certificate(new_certificate.clone())
             .instrument(tracing::debug_span!("process_cert"))

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     authority_batch::batch_tests::init_state_parameters_from_rng,
     authority_client::LocalAuthorityClient,
-    gateway_state::GatewayMetrics,
 };
 use rand::prelude::StdRng;
 use rand::SeedableRng;
@@ -25,6 +24,7 @@ use sui_types::{
     waypoint::GlobalCheckpoint,
 };
 
+use crate::authority_aggregator::AuthAggMetrics;
 use parking_lot::Mutex;
 use sui_types::crypto::KeyPair;
 
@@ -1654,7 +1654,7 @@ pub async fn checkpoint_tests_setup(
                 )
             })
             .collect(),
-        GatewayMetrics::new_for_tests(),
+        AuthAggMetrics::new_for_tests(),
     );
 
     TestSetup {

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -115,7 +115,7 @@ where
             let new_net = Arc::new(AuthorityAggregator::new(
                 new_committee,
                 self.net.load().clone_inner_clients(),
-                self.gateway_metrics.clone(),
+                self.net.load().metrics.clone(),
             ));
             self.net.store(new_net);
         }
@@ -213,7 +213,7 @@ where
         let new_net = Arc::new(AuthorityAggregator::new(
             new_committee,
             new_clients,
-            self.gateway_metrics.clone(),
+            self.net.load().metrics.clone(),
         ));
         self.net.store(new_net);
         Ok(())

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -20,7 +20,7 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
-use crate::gateway_state::GatewayMetrics;
+use crate::authority_aggregator::AuthAggMetrics;
 use crate::{
     authority::TemporaryStore, authority_active::ActiveAuthority,
     authority_aggregator::authority_aggregator_tests::init_local_authorities,
@@ -56,7 +56,7 @@ async fn test_start_epoch_change() {
     let active = ActiveAuthority::new_with_ephemeral_follower_store(
         state.clone(),
         net.clone_inner_clients(),
-        GatewayMetrics::new_for_tests(),
+        AuthAggMetrics::new_for_tests(),
     )
     .unwrap();
     // Make the high watermark differ from low watermark.
@@ -167,7 +167,7 @@ async fn test_finish_epoch_change() {
             ActiveAuthority::new_with_ephemeral_follower_store(
                 state.clone(),
                 net.clone_inner_clients(),
-                GatewayMetrics::new_for_tests(),
+                AuthAggMetrics::new_for_tests(),
             )
             .unwrap()
         })

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -20,7 +20,6 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
-use crate::authority_aggregator::AuthAggMetrics;
 use crate::{
     authority::TemporaryStore, authority_active::ActiveAuthority,
     authority_aggregator::authority_aggregator_tests::init_local_authorities,
@@ -53,12 +52,8 @@ async fn test_start_epoch_change() {
         })
         .unwrap();
     // Create an active authority for the first authority state.
-    let active = ActiveAuthority::new_with_ephemeral_follower_store(
-        state.clone(),
-        net.clone_inner_clients(),
-        AuthAggMetrics::new_for_tests(),
-    )
-    .unwrap();
+    let active =
+        ActiveAuthority::new_with_ephemeral_follower_store(state.clone(), net.clone()).unwrap();
     // Make the high watermark differ from low watermark.
     let ticket = state.batch_notifier.ticket().unwrap();
 
@@ -164,12 +159,7 @@ async fn test_finish_epoch_change() {
     let actives: Vec<_> = states
         .iter()
         .map(|state| {
-            ActiveAuthority::new_with_ephemeral_follower_store(
-                state.clone(),
-                net.clone_inner_clients(),
-                AuthAggMetrics::new_for_tests(),
-            )
-            .unwrap()
+            ActiveAuthority::new_with_ephemeral_follower_store(state.clone(), net.clone()).unwrap()
         })
         .collect();
     let results: Vec<_> = states

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -79,7 +79,7 @@ pub async fn init_local_authorities_with_genesis(
         AuthorityAggregator::new_with_timeouts(
             committee,
             clients,
-            GatewayMetrics::new_for_tests(),
+            AuthAggMetrics::new_for_tests(),
             timeouts,
         ),
         states,

--- a/crates/sui-gateway/src/config.rs
+++ b/crates/sui-gateway/src/config.rs
@@ -12,7 +12,6 @@ use std::{
 };
 use sui_config::Config;
 use sui_config::ValidatorInfo;
-use sui_core::gateway_state::GatewayMetrics;
 use sui_core::{
     authority_client::NetworkAuthorityClient,
     gateway_state::{GatewayClient, GatewayState},
@@ -68,12 +67,12 @@ impl GatewayType {
                 let path = config.db_folder_path.clone();
                 let committee = config.make_committee()?;
                 let authority_clients = config.make_authority_clients();
-                let metrics = GatewayMetrics::new(&prometheus::Registry::new());
+                let registry = prometheus::Registry::new();
                 Arc::new(GatewayState::new(
                     path,
                     committee,
                     authority_clients,
-                    metrics,
+                    &registry,
                 )?)
             }
             GatewayType::RPC(url) => Arc::new(RpcGatewayClient::new(url.clone())?),

--- a/crates/sui-gateway/src/lib.rs
+++ b/crates/sui-gateway/src/lib.rs
@@ -3,17 +3,18 @@
 
 use crate::config::GatewayConfig;
 use anyhow::anyhow;
+use prometheus::Registry;
 use std::path::Path;
 use std::sync::Arc;
 use sui_config::PersistedConfig;
-use sui_core::gateway_state::{GatewayClient, GatewayMetrics, GatewayState};
+use sui_core::gateway_state::{GatewayClient, GatewayState};
 
 pub mod config;
 pub mod rpc_gateway_client;
 
 pub fn create_client(
     config_path: &Path,
-    gateway_metrics: GatewayMetrics,
+    prometheus_registry: &Registry,
 ) -> Result<GatewayClient, anyhow::Error> {
     let config: GatewayConfig = PersistedConfig::read(config_path).map_err(|e| {
         anyhow!(
@@ -28,6 +29,6 @@ pub fn create_client(
         config.db_folder_path,
         committee,
         authority_clients,
-        gateway_metrics,
+        prometheus_registry,
     )?))
 }

--- a/crates/sui-gateway/src/main.rs
+++ b/crates/sui-gateway/src/main.rs
@@ -8,7 +8,6 @@ use std::{
 };
 use sui_config::sui_config_dir;
 use sui_config::SUI_GATEWAY_CONFIG;
-use sui_core::gateway_state::GatewayMetrics;
 use sui_gateway::create_client;
 use sui_json_rpc::bcs_api::BcsApiImpl;
 use sui_json_rpc::gateway_api::{GatewayReadApiImpl, TransactionBuilderImpl};
@@ -57,8 +56,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Starting Prometheus HTTP endpoint at {}", prom_binding);
     let prometheus_registry = sui_node::metrics::start_prometheus_server(prom_binding);
 
-    let metrics = GatewayMetrics::new(&prometheus_registry);
-    let client = create_client(&config_path, metrics)?;
+    let client = create_client(&config_path, &prometheus_registry)?;
 
     let address = SocketAddr::new(IpAddr::V4(options.host), options.port);
     let mut server = JsonRpcServerBuilder::new(false, &prometheus_registry)?;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -13,6 +13,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tracing::info;
 
 use sui_config::NodeConfig;
+use sui_core::authority_aggregator::AuthAggMetrics;
 use sui_core::authority_server::ValidatorService;
 use sui_core::{
     authority::{AuthorityState, AuthorityStore},
@@ -157,13 +158,11 @@ impl SuiNode {
                 }
             }
 
-            let gateway_metrics =
-                sui_core::gateway_state::GatewayMetrics::new(&prometheus_registry);
             let active_authority = Arc::new(ActiveAuthority::new(
                 state.clone(),
                 follower_store,
                 authority_clients,
-                gateway_metrics,
+                AuthAggMetrics::new(&prometheus_registry),
             )?);
 
             Some(if is_validator {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -13,7 +13,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use tracing::info;
 
 use sui_config::NodeConfig;
-use sui_core::authority_aggregator::AuthAggMetrics;
+use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use sui_core::authority_server::ValidatorService;
 use sui_core::{
     authority::{AuthorityState, AuthorityStore},
@@ -157,13 +157,14 @@ impl SuiNode {
                     authority_clients.insert(validator.public_key(), client);
                 }
             }
-
-            let active_authority = Arc::new(ActiveAuthority::new(
-                state.clone(),
-                follower_store,
+            let net = AuthorityAggregator::new(
+                state.clone_committee(),
                 authority_clients,
                 AuthAggMetrics::new(&prometheus_registry),
-            )?);
+            );
+
+            let active_authority =
+                Arc::new(ActiveAuthority::new(state.clone(), follower_store, net)?);
 
             Some(if is_validator {
                 // TODO: get degree from config file.

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -3,7 +3,6 @@
 use rand::{rngs::StdRng, SeedableRng};
 use std::collections::HashSet;
 use std::sync::Arc;
-use sui_core::authority_aggregator::AuthAggMetrics;
 use sui_core::{
     authority::AuthorityState,
     authority_active::{checkpoint_driver::CheckpointProcessControl, ActiveAuthority},
@@ -145,15 +144,10 @@ async fn end_to_end() {
     // Start active part of each authority.
     for authority in &handles {
         let state = authority.state().clone();
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_authority_handle = tokio::spawn(async move {
             let active_state = Arc::new(
-                ActiveAuthority::new_with_ephemeral_follower_store(
-                    state,
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
-                )
-                .unwrap(),
+                ActiveAuthority::new_with_ephemeral_follower_store(state, inner_agg).unwrap(),
             );
             let checkpoint_process_control = CheckpointProcessControl {
                 long_pause_between_checkpoints: Duration::from_millis(10),
@@ -235,15 +229,10 @@ async fn checkpoint_with_shared_objects() {
     // Start active part of each authority.
     for authority in &handles {
         let state = authority.state().clone();
-        let clients = aggregator.clone_inner_clients();
+        let inner_agg = aggregator.clone();
         let _active_authority_handle = tokio::spawn(async move {
             let active_state = Arc::new(
-                ActiveAuthority::new_with_ephemeral_follower_store(
-                    state,
-                    clients,
-                    AuthAggMetrics::new_for_tests(),
-                )
-                .unwrap(),
+                ActiveAuthority::new_with_ephemeral_follower_store(state, inner_agg).unwrap(),
             );
             let checkpoint_process_control = CheckpointProcessControl {
                 long_pause_between_checkpoints: Duration::from_millis(10),

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -3,10 +3,10 @@
 use rand::{rngs::StdRng, SeedableRng};
 use std::collections::HashSet;
 use std::sync::Arc;
+use sui_core::authority_aggregator::AuthAggMetrics;
 use sui_core::{
     authority::AuthorityState,
     authority_active::{checkpoint_driver::CheckpointProcessControl, ActiveAuthority},
-    gateway_state::GatewayMetrics,
 };
 use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest},
@@ -151,7 +151,7 @@ async fn end_to_end() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     state,
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );
@@ -241,7 +241,7 @@ async fn checkpoint_with_shared_objects() {
                 ActiveAuthority::new_with_ephemeral_follower_store(
                     state,
                     clients,
-                    GatewayMetrics::new_for_tests(),
+                    AuthAggMetrics::new_for_tests(),
                 )
                 .unwrap(),
             );

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -5,6 +5,7 @@ use rand::{prelude::StdRng, SeedableRng};
 use std::collections::BTreeMap;
 use std::time::Duration;
 use sui_config::{NetworkConfig, ValidatorInfo};
+use sui_core::authority_aggregator::AuthAggMetrics;
 use sui_core::{
     authority_aggregator::AuthorityAggregator, authority_client::AuthorityAPI,
     authority_client::NetworkAuthorityClient,
@@ -79,7 +80,7 @@ pub fn test_authority_aggregator(
             )
         })
         .collect();
-    let metrics = sui_core::gateway_state::GatewayMetrics::new(&prometheus::Registry::new());
+    let metrics = AuthAggMetrics::new(&prometheus::Registry::new());
     AuthorityAggregator::new(committee, clients, metrics)
 }
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -13,7 +13,6 @@ use sui::{
 use sui_config::genesis_config::GenesisConfig;
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_GATEWAY_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{PersistedConfig, SUI_KEYSTORE_FILENAME};
-use sui_core::gateway_state::GatewayMetrics;
 use sui_gateway::create_client;
 use sui_json_rpc::gateway_api::{
     GatewayReadApiImpl, GatewayWalletSyncApiImpl, RpcGatewayImpl, TransactionBuilderImpl,
@@ -111,8 +110,8 @@ async fn start_rpc_gateway(
 ) -> Result<(SocketAddr, HttpServerHandle), anyhow::Error> {
     let server = HttpServerBuilder::default().build("127.0.0.1:0").await?;
     let addr = server.local_addr()?;
-    let metrics = GatewayMetrics::new(&prometheus::Registry::new());
-    let client = create_client(config_path, metrics)?;
+    let registry = prometheus::Registry::new();
+    let client = create_client(config_path, &registry)?;
     let mut module = RpcModule::new(());
     module.merge(RpcGatewayImpl::new(client.clone()).into_rpc())?;
     module.merge(GatewayReadApiImpl::new(client.clone()).into_rpc())?;


### PR DESCRIPTION
This PR cleans up the following things:
1. GatewayMetrics is not used in ActiveAuthority, removing it.
2. We are using the same GatewayMetrics in both gateway and authority aggregator, which is confusing. Creating a new AuthAggMetrics to track metrics in the authority aggregator.
3. Cleaned up the constructor of ActiveAuthority.

unblocks https://github.com/MystenLabs/sui/issues/3193