### PR TITLE
wallet-ext: fix ApiProvider using cached signer

### DIFF
--- a/wallet/src/ui/app/ApiProvider.ts
+++ b/wallet/src/ui/app/ApiProvider.ts
@@ -81,6 +81,7 @@ export default class ApiProvider {
         this._apiFullNodeProvider = new JsonRpcProvider(
             getDefaultAPI(apiEnv).fullNode
         );
+        this._signer = null;
     }
 
     public get instance() {


### PR DESCRIPTION
* clear cached signer when switching networks to avoid using the signer for the wrong network

Before

https://user-images.githubusercontent.com/10210143/179050759-49d3df15-5996-49b0-ba67-a52a1c95b46f.mov


After

https://user-images.githubusercontent.com/10210143/179051193-d74d8e14-026d-45d2-9032-1aa2499fcd5a.mov