### PR TITLE
[explorer] Removes word copyright from footer

### DIFF
--- a/explorer/client/src/components/footer/Footer.tsx
+++ b/explorer/client/src/components/footer/Footer.tsx
@@ -14,8 +14,8 @@ function Footer() {
                 <div className={styles.logodesktop}>
                     <SuiLogoIcon />
                     <div className={styles.copyright}>
-                        <div>&copy;2022 Copyright Sui.</div>
-                        <div>All rights reserved.</div>
+                        <div>&copy;2022 Sui</div>
+                        <div>All rights reserved</div>
                     </div>
                 </div>
 
@@ -86,7 +86,7 @@ function Footer() {
             <div className={styles.logomobile}>
                 <SuiLogoIcon />
                 <div className={styles.copyright}>
-                    <div>&copy;2022 Copyright Sui. All rights reserved.</div>
+                    <div>&copy;2022 Sui. All rights reserved.</div>
                 </div>
             </div>
 

--- a/explorer/client/yarn.lock
+++ b/explorer/client/yarn.lock
@@ -1691,6 +1691,18 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tanstack/react-table@^8.1.4":
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.2.6.tgz#a44855d1958d9e8fa7a34280f81f08d2ef7f8d4f"
+  integrity sha512-hHEKSqRPSojhFLosSpqKMRNDX8mk/UVvFdekXHai86NAg1WaLYB51hWVg18IqFe9PCaPZNpTPNguJ7u54ed8Gg==
+  dependencies:
+    "@tanstack/table-core" "8.2.6"
+
+"@tanstack/table-core@8.2.6":
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.2.6.tgz#7240ac14a43cc43adbe01fbc6ae4d8a2bf82541a"
+  integrity sha512-yHjKksyq5ZI4GoVJgR/+X8Z1gaZdOL1om3G9M4af6yTTyRP5ZquMlU5318MBtx2NzXl4BxtENLXBWYrcz5WKSA==
+
 "@testing-library/dom@^8.0.0":
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"


### PR DESCRIPTION
This removes the word 'Copyright' from the footer in both the Desktop and Mobile views.

The below video shows this in action

https://user-images.githubusercontent.com/11377188/179062173-1979e84a-65c5-40aa-93fd-ca9b9e7cb3da.mp4