### PR TITLE
Make gas objects in shared bench not run out of gas

### DIFF
--- a/crates/sui-benchmark/src/bin/shared.rs
+++ b/crates/sui-benchmark/src/bin/shared.rs
@@ -19,7 +19,7 @@ use test_utils::authority::{
     spawn_test_authorities, test_and_configure_authority_configs, test_authority_aggregator,
 };
 use test_utils::messages::{make_counter_create_transaction, make_counter_increment_transaction};
-use test_utils::objects::{generate_gas_object, generate_gas_objects};
+use test_utils::objects::generate_gas_objects_for_testing;
 use test_utils::transaction::publish_counter_package;
 use tokio::time;
 use tokio::time::Instant;
@@ -84,8 +84,8 @@ async fn main() {
 
     // Create enough gas objects to cover for creating and incrementing counters
     let mut gas = vec![];
-    let mut counters_gas = generate_gas_objects(num_shared_counters);
-    let publish_module_gas = generate_gas_object();
+    let mut counters_gas = generate_gas_objects_for_testing(num_shared_counters);
+    let publish_module_gas = generate_gas_objects_for_testing(1).pop().unwrap();
     gas.append(&mut counters_gas);
     gas.push(publish_module_gas.clone());
 

--- a/crates/test-utils/src/objects.rs
+++ b/crates/test-utils/src/objects.rs
@@ -25,12 +25,12 @@ pub fn generate_gas_object() -> Object {
 }
 
 /// Make a few test gas objects (all with the same owner).
-pub fn generate_gas_objects(count: usize) -> Vec<Object> {
+pub fn generate_gas_objects_for_testing(count: usize) -> Vec<Object> {
     (0..count)
         .map(|_i| {
             let gas_object_id = ObjectID::random();
             let (owner, _) = test_keys().pop().unwrap();
-            Object::with_id_owner_for_testing(gas_object_id, owner)
+            Object::with_id_owner_gas_for_testing(gas_object_id, owner, u64::MAX)
         })
         .collect()
 }


### PR DESCRIPTION
Since we reuse the gas objects in shared bench, we start running out of gas in long running benchmarks