### PR TITLE
explorer landing page update

### DIFF
--- a/explorer/client/src/components/longtext/Longtext.module.css
+++ b/explorer/client/src/components/longtext/Longtext.module.css
@@ -8,5 +8,5 @@
 
 .longtext,
 .longtext > a {
-    @apply no-underline text-sui-dark hover:text-sky-900 cursor-pointer break-all;
+    @apply no-underline text-sui-dark hover:text-[#1F6493] cursor-pointer break-all;
 }

--- a/explorer/client/src/components/longtext/Longtext.module.css
+++ b/explorer/client/src/components/longtext/Longtext.module.css
@@ -8,5 +8,5 @@
 
 .longtext,
 .longtext > a {
-    @apply no-underline text-sky-600 hover:text-sky-900 cursor-pointer break-all;
+    @apply no-underline text-sui-dark hover:text-sky-900 cursor-pointer break-all;
 }

--- a/explorer/client/src/components/pagination/Pagination.module.css
+++ b/explorer/client/src/components/pagination/Pagination.module.css
@@ -1,22 +1,35 @@
 .pagination {
-    @apply flex flex-row items-center justify-center list-none;
+    @apply flex flex-row items-center justify-start list-none w-full;
 }
 
 .pagination ul {
-    @apply flex flex-row items-center justify-center list-none pl-0;
+    @apply flex flex-row items-center justify-center list-none  p-0 m-0;
 }
 
 .pagination ul li {
-    @apply mr-2;
+    @apply mr-2 hidden md:block;
 }
 
 .pagination ul li button {
-    @apply bg-gray-200 hover:bg-gray-300 focus:bg-gray-300 text-gray-800 hover:text-gray-800 focus:text-gray-800 font-medium py-2 px-4 rounded-none border-0 cursor-pointer 
-     md:pr-3  md:pl-3  pr-1.5  pl-1.5;
+    @apply text-gray-600 hover:text-gray-800 focus:text-gray-800 font-medium py-2 px-4 cursor-pointer 
+     md:pr-3  md:pl-3  pr-3  pl-3 border-[1px] rounded-[6px] border-white bg-[#FFFFFF] hover:bg-[#F4FBFF];
 
+    border: 1px solid #e9eaeb;
     transition: all 0.4s ease;
 }
 
+.arrow {
+    @apply block !important;
+}
+
 .activepag {
-    @apply bg-sui text-white !important;
+    @apply bg-[#F4FBFF] text-sui-dark border-sui-dark !important;
+}
+
+.paginationleft svg {
+    transform: rotate(180deg);
+}
+
+.paginationdot:hover {
+    @apply bg-[#FFFFFF] hover:bg-[#FFFFFF];
 }

--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -82,12 +82,14 @@ function Pagination({
                                     1
                                 </button>
                             </li>
-                            <li className="page-item">
-                                <button className={styles.paginationdot}>
-                                    ...
-                                </button>
-                            </li>
                         </>
+                    )}
+                    {pageIndex > pagiData.range && (
+                        <li className="page-item">
+                            <button className={styles.paginationdot}>
+                                ...
+                            </button>
+                        </li>
                     )}
                     {pagiData.listItems.map((itm: any, index: number) => (
                         <li className="page-item" key={index}>

--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -1,7 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+import cl from 'classnames';
 import { useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
+
+import { ReactComponent as ContentForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
 
 import styles from './Pagination.module.css';
 function generatePaginationArr(
@@ -10,7 +14,7 @@ function generatePaginationArr(
     totalItems: number
 ) {
     // number of list items to show before truncating
-    const range: number = 4;
+    const range: number = 2;
     const max = Math.ceil((totalItems - 1) / itemsPerPage);
     const maxRange = (Math.floor(startAt / range) + 1) * range;
     // set the min range to be the max range minus the range if it is less than the max - range
@@ -56,27 +60,34 @@ function Pagination({
             <nav className={styles.pagination}>
                 <ul>
                     {pageIndex > 1 && (
-                        <li className="page-item">
+                        <li className={styles.arrow}>
                             <button
-                                className={
-                                    pageIndex === 1 ? styles.activepag : ''
-                                }
+                                className={cl([
+                                    pageIndex === 1 ? styles.activepag : '',
+                                    styles.paginationleft,
+                                ])}
                                 onClick={changePage(pageIndex - 1)}
                             >
-                                &larr;
+                                <ContentForwardArrowDark />
                             </button>
                         </li>
                     )}
                     {pageIndex > pagiData.range - 1 && (
-                        <li className="page-item">
-                            <button
-                                className="page-link"
-                                onClick={changePage(1)}
-                            >
-                                1
-                            </button>
-                            {' ... '}
-                        </li>
+                        <>
+                            <li className="page-item">
+                                <button
+                                    className="page-link"
+                                    onClick={changePage(1)}
+                                >
+                                    1
+                                </button>
+                            </li>
+                            <li className="page-item">
+                                <button className={styles.paginationdot}>
+                                    ...
+                                </button>
+                            </li>
+                        </>
                     )}
                     {pagiData.listItems.map((itm: any, index: number) => (
                         <li className="page-item" key={index}>
@@ -92,27 +103,41 @@ function Pagination({
                     ))}
 
                     {pageIndex < pagiData.max - 1 && (
-                        <li className="page-item">
-                            {' ... '}
-                            <button
-                                className={
-                                    pageIndex === pagiData.max
-                                        ? styles.activepag
-                                        : ''
-                                }
-                                onClick={changePage(pagiData.max)}
-                            >
-                                {pagiData.max}
-                            </button>
-                        </li>
+                        <>
+                            <li className="page-item">
+                                <button
+                                    className={cl(
+                                        pageIndex === pagiData.max
+                                            ? styles.activepag
+                                            : '',
+                                        styles.paginationdot
+                                    )}
+                                >
+                                    ...
+                                </button>
+                            </li>
+
+                            <li className="page-item">
+                                <button
+                                    className={
+                                        pageIndex === pagiData.max
+                                            ? styles.activepag
+                                            : ''
+                                    }
+                                    onClick={changePage(pagiData.max)}
+                                >
+                                    {pagiData.max}
+                                </button>
+                            </li>
+                        </>
                     )}
                     {pageIndex < pagiData.max && (
-                        <li className="page-item">
+                        <li className={styles.arrow}>
                             <button
                                 className="page-link"
                                 onClick={changePage(pageIndex + 1)}
                             >
-                                →
+                                <ContentForwardArrowDark />
                             </button>
                         </li>
                     )}

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -9,7 +9,7 @@
 }
 
 .table th {
-    @apply text-left font-normal uppercase text-[#767A81] text-xs;
+    @apply text-left font-semibold uppercase text-[#767A81] text-xs;
 }
 
 .table td {
@@ -17,7 +17,7 @@
 }
 
 .table tbody tr {
-    @apply space-y-10 mt-10;
+    @apply space-y-10 mt-10 hover:bg-[#6fbcf014];
 }
 
 .addresses {
@@ -29,5 +29,5 @@
 }
 
 .tablespacing {
-    @apply pb-1 pt-1;
+    @apply pb-2 pt-2;
 }

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -17,9 +17,14 @@
 }
 
 .table tbody tr {
-    @apply space-y-10 mt-10 hover:bg-[#6fbcf014] ;
+    @apply space-y-10 mt-10 hover:bg-[#6fbcf014];
 }
-.table tbody tr:hover td{
+
+td:nth-child(1) {
+    @apply text-xs;
+}
+
+.table tbody tr:hover td {
     @apply text-black;
 }
 
@@ -34,10 +39,7 @@
 .tablespacing {
     @apply pb-2 pt-2;
 }
+
 td a {
     @apply font-mono text-[#4E555D];
-}
-
-td:nth-child(1) {
-    @apply text-xs;
 }

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -13,11 +13,14 @@
 }
 
 .table td {
-    @apply pr-5 text-[#4E555D];
+    @apply pr-5 text-[#767A81] text-sm;
 }
 
 .table tbody tr {
-    @apply space-y-10 mt-10 hover:bg-[#6fbcf014];
+    @apply space-y-10 mt-10 hover:bg-[#6fbcf014] ;
+}
+.table tbody tr:hover td{
+    @apply text-black;
 }
 
 .addresses {
@@ -30,4 +33,11 @@
 
 .tablespacing {
     @apply pb-2 pt-2;
+}
+td a {
+    @apply font-mono text-[#4E555D];
+}
+
+td:nth-child(1) {
+    @apply text-xs;
 }

--- a/explorer/client/src/components/tabs/Tabs.module.css
+++ b/explorer/client/src/components/tabs/Tabs.module.css
@@ -22,7 +22,7 @@
 }
 
 .tabsfooter {
-    @apply flex justify-between text-xs text-gray-500 capitalize items-center p-1;
+    @apply flex justify-between text-xs text-gray-500 capitalize items-center p-0;
 }
 
 .tabsfooter a {
@@ -30,5 +30,9 @@
 }
 
 .stats {
-    @apply ml-auto;
+    @apply ml-auto w-full text-right;
+}
+
+.tabsfooter nav {
+    @apply flex flex-row items-center;
 }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -81,5 +81,9 @@ div.txadd {
 }
 
 .txlatestresults td a {
-    @apply font-mono;
+    @apply font-mono text-[#4E555D];
+}
+
+.txlatestresults td:nth-child(1) {
+    @apply text-xs;
 }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -75,7 +75,9 @@ div.txadd {
 }
 
 .moretxbtn {
-    @apply text-left bg-transparent cursor-pointer border-0 pl-0 pr-0 text-[#636870]  hover:text-gray-400 transition-colors duration-200 ease-in-out font-normal text-sm;
+    @apply text-left bg-transparent cursor-pointer border-0 pl-0 pr-0 text-sui-grey-90  hover:text-gray-400 transition-colors duration-200 ease-in-out font-normal text-sm w-full;
+
+    text-decoration: none;
 }
 
 .txlatestresults td a {

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -77,3 +77,7 @@ div.txadd {
 .moretxbtn {
     @apply text-left bg-transparent cursor-pointer border-0 pl-0 pr-0 text-[#636870]  hover:text-gray-400 transition-colors duration-200 ease-in-out font-normal text-sm;
 }
+
+.txlatestresults td a {
+    @apply font-mono;
+}

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -267,12 +267,11 @@ function LatestTxCardAPI({ ...data }: RecentTx) {
     const [results, setResults] = useState(initState);
     const [network] = useContext(NetworkContext);
     const [searchParams] = useSearchParams();
-    const [txNumPerPage] = useState(txPerPage);
 
     useEffect(() => {
         let isMounted = true;
         const pagedNum: number = parseInt(searchParams.get('p') || '1', 10);
-        getRecentTransactions(network, count, txNumPerPage, pagedNum)
+        getRecentTransactions(network, count, txPerPage, pagedNum)
             .then(async (resp: any) => {
                 if (isMounted) {
                     setIsLoaded(true);
@@ -307,7 +306,6 @@ function LatestTxCardAPI({ ...data }: RecentTx) {
         paginationtype,
         searchParams,
         truncateLength,
-        txNumPerPage,
         txPerPage,
     ]);
 

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { useEffect, useState, useContext, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useState, useContext } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
 
 import { ReactComponent as ContentForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
 import TableCard from '../../components/table/TableCard';
@@ -131,16 +131,6 @@ function LatestTxView({
     const txPerPage = results.txPerPage || NUMBER_OF_TX_PER_PAGE;
     const truncateLength = results.truncateLength || TRUNCATE_LENGTH;
     const paginationtype = results.paginationtype || DEFAULT_PAGI_TYPE;
-    const [searchParams, setSearchParams] = useSearchParams();
-    const pageParam = parseInt(searchParams.get('p') || '1', 10);
-    const [showNextPage, setShowNextPage] = useState(txPerPage < totalCount);
-
-    // This is temporary, pagination component already does this
-    const changePage = useCallback(() => {
-        const nextpage = pageParam + (showNextPage ? 1 : 0);
-        setSearchParams({ p: nextpage.toString() });
-        setShowNextPage(Math.ceil(txPerPage * nextpage) < totalCount);
-    }, [pageParam, showNextPage, setSearchParams, txPerPage, totalCount]);
 
     //TODO update initial state and match the latestTx table data
     const defaultActiveTab = 0;
@@ -219,21 +209,17 @@ function LatestTxView({
                 <div title="Transactions">
                     <TableCard tabledata={recentTx} />
                     <TabFooter stats={tabsFooter.stats}>
-                        {showNextPage ? (
+                        {paginationtype !== 'none' ? (
                             paginationtype === 'pagination' ? (
                                 <Pagination
                                     totalTxCount={totalCount}
                                     txNum={txPerPage}
                                 />
                             ) : (
-                                <button
-                                    type="button"
-                                    className={styles.moretxbtn}
-                                    onClick={changePage}
-                                >
+                                <Link className={styles.moretxbtn} to={`/`}>
                                     More Transactions{' '}
                                     <ContentForwardArrowDark />
-                                </button>
+                                </Link>
                             )
                         ) : (
                             <></>

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -114,7 +114,7 @@ async function getRecentTransactions(
 }
 
 // Pass Props txPerPage, truncateLength, paginationtype to the component so that this component can be used for both the Home Page and trnasaction page
-// TODO - Passing the too much props from component to component  is not ideal way to do this - gets confusing
+// TODO - rework this - gets confusing
 function LatestTxView({
     results,
 }: {

--- a/explorer/client/src/pages/config/AppRoutes.tsx
+++ b/explorer/client/src/pages/config/AppRoutes.tsx
@@ -9,11 +9,14 @@ import { ObjectResult } from '../object-result/ObjectResult';
 import SearchResult from '../search-result/SearchResult';
 import SearchError from '../searcherror/SearchError';
 import TransactionResult from '../transaction-result/TransactionResult';
+import Transactions from '../transactions/Transactions';
 
+// Temporary use Transactions page as the default page.
 const AppRoutes = () => {
     return (
         <Routes>
-            <Route path="/" element={<Home />} />
+            <Route path="/" element={<Transactions />} />
+            <Route path="/home-other" element={<Home />} />
             <Route path="/objects/:id" element={<ObjectResult />} />
             <Route path="/transactions/:id" element={<TransactionResult />} />
             <Route path="/addresses/:id" element={<AddressResult />} />

--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -201,6 +201,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
         txId: txdata.txId,
         status: txdata.status,
         txKindName: txKindName,
+        ...(txdata.txError ? { error: txdata.txError } : {}),
     };
 
     const transactionSignatureData = {

--- a/explorer/client/src/pages/transaction-result/TxModuleView.module.css
+++ b/explorer/client/src/pages/transaction-result/TxModuleView.module.css
@@ -3,6 +3,7 @@ pre {
     margin: 1em 0;
     padding: 0.5em;
     overflow: scroll;
+    background: transparent;
 }
 
 section .codeview {

--- a/explorer/client/src/pages/transaction-result/TxModuleView.module.css
+++ b/explorer/client/src/pages/transaction-result/TxModuleView.module.css
@@ -3,7 +3,6 @@ pre {
     margin: 1em 0;
     padding: 0.5em;
     overflow: scroll;
-    background: transparent;
 }
 
 section .codeview {
@@ -37,6 +36,8 @@ section .codeview {
 
 section .codeview pre {
     @apply m-0 p-0;
+
+    background: transparent;
 }
 
 .moretxbtn {

--- a/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
@@ -17,7 +17,7 @@
 }
 
 .txid {
-    @apply text-offblack font-[600] text-lg md:text-2xl font-mono break-all block md:flex items-center;
+    @apply text-offblack font-[600] text-lg md:text-2xl font-mono break-all block  items-center;
 }
 
 .txresulttype {
@@ -29,9 +29,13 @@
 }
 
 .failed {
-    @apply bg-[#FBE9E7] capitalize text-sm font-sans text-[#D0021B] font-normal p-0 pr-3 pl-3 rounded-[10px] inline-block m-0 md:ml-2 md:mr-2;
+    @apply bg-[#EB5A291A] capitalize text-sm font-sans text-[#B94118] font-normal p-0 pr-3 pl-3 rounded-[10px] inline-block m-0 md:ml-2 md:mr-2;
 }
 
 .longtext {
     @apply bg-transparent border-0 font-sans text-sm text-[#1F6493] font-[500] cursor-pointer hover:text-sui-grey-80;
+}
+
+.error {
+    @apply w-full rounded-none m-0 text-sm p-1 pl-2 pr-2 font-normal mt-2 w-fit md:w-full;
 }

--- a/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
@@ -31,3 +31,7 @@
 .failed {
     @apply bg-[#FBE9E7] capitalize text-sm font-sans text-[#D0021B] font-normal p-0 pr-3 pl-3 rounded-[10px] inline-block m-0 md:ml-2 md:mr-2;
 }
+
+.longtext {
+    @apply bg-transparent border-0 font-sans text-sm text-[#1F6493] font-[500] cursor-pointer hover:text-sui-grey-80;
+}

--- a/explorer/client/src/pages/transaction-result/TxResultHeader.tsx
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.tsx
@@ -23,6 +23,7 @@ type TxResultState = {
     txId: string;
     status: ExecutionStatusType;
     txKindName: TransactionKindName;
+    error?: string;
 };
 
 function TxAddressHeader({ data }: { data: TxResultState }) {
@@ -70,6 +71,17 @@ function TxAddressHeader({ data }: { data: TxResultState }) {
                         {' '}
                         <TxResultStatus /> {statusName}
                     </div>
+                    {data.error && (
+                        <div
+                            className={cl([
+                                styles.txresulttype,
+                                styles.failed,
+                                styles.error,
+                            ])}
+                        >
+                            {data.error}
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/explorer/client/src/pages/transaction-result/TxResultHeader.tsx
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import cl from 'classnames';
-import { Link } from 'react-router-dom';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { ReactComponent as CallTypeIcon } from '../../assets/SVGIcons/Call.svg';
 import { ReactComponent as PublishTypeIcon } from '../../assets/SVGIcons/Publish.svg';
@@ -39,12 +40,16 @@ function TxAddressHeader({ data }: { data: TxResultState }) {
     const statusName = data.status === 'success' ? 'success' : 'failed';
     const TxResultStatus = TxStatus[statusName];
 
+    const navigate = useNavigate();
+
+    const previousPage = useCallback(() => navigate(-1), [navigate]);
+
     return (
         <div className={styles.txheader}>
             <div className={styles.txback}>
-                <Link className={styles.longtext} to={`/`}>
+                <button className={styles.longtext} onClick={previousPage}>
                     <ContentBackArrowDark /> Go Back
-                </Link>
+                </button>
             </div>
             <div className={styles.txtypes}>
                 <Icon /> {TxKindName}

--- a/explorer/client/src/pages/transactions/Transactions.module.css
+++ b/explorer/client/src/pages/transactions/Transactions.module.css
@@ -1,0 +1,11 @@
+div.container {
+    @apply mx-auto;
+}
+
+.title {
+    @apply text-2xl font-[700];
+}
+
+.container td a {
+    @apply text-sui-grey-85;
+}

--- a/explorer/client/src/pages/transactions/Transactions.tsx
+++ b/explorer/client/src/pages/transactions/Transactions.tsx
@@ -15,7 +15,8 @@ import { IS_STATIC_ENV } from '../../utils/envUtil';
 import styles from './Transactions.module.css';
 
 const initState = { count: 0, loadState: 'pending' };
-
+const TXN_PER_PAGE = 20;
+const TRUNCATE_LENGTH = 45;
 // Moved this method to the Home.tsx file so getTotalTransactionNumber can be called once across the entire component.
 async function getTransactionCount(network: Network | string): Promise<number> {
     return rpc(network).getTotalTransactionNumber();
@@ -80,9 +81,9 @@ function TransactionsAPI() {
             <h1 className={styles.title}>Transactions</h1>
             <LastestTxCard
                 count={results.count}
-                txPerPage={20}
+                txPerPage={TXN_PER_PAGE}
                 paginationtype="pagination"
-                truncateLength={45}
+                truncateLength={TRUNCATE_LENGTH}
             />
         </div>
     );

--- a/explorer/client/src/pages/transactions/Transactions.tsx
+++ b/explorer/client/src/pages/transactions/Transactions.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import cl from 'classnames';
+
 import { useEffect, useState, useContext } from 'react';
 
 import ErrorResult from '../../components/error-result/ErrorResult';
@@ -12,7 +12,7 @@ import {
 } from '../../utils/api/DefaultRpcClient';
 import { IS_STATIC_ENV } from '../../utils/envUtil';
 
-import styles from './Home.module.css';
+import styles from './Transactions.module.css';
 
 const initState = { count: 0, loadState: 'pending' };
 
@@ -21,7 +21,7 @@ async function getTransactionCount(network: Network | string): Promise<number> {
     return rpc(network).getTotalTransactionNumber();
 }
 
-function HomeStatic() {
+function TransactionsStatic() {
     const [count] = useState(500);
     return (
         <div data-testid="home-page" id="home" className={styles.home}>
@@ -30,7 +30,7 @@ function HomeStatic() {
     );
 }
 
-function HomeAPI() {
+function TransactionsAPI() {
     const [isLoaded, setIsLoaded] = useState(false);
     const [results, setResults] = useState(initState);
     const [network] = useContext(NetworkContext);
@@ -73,18 +73,22 @@ function HomeAPI() {
     }
     return (
         <div
-            data-testid="home-page"
-            id="home"
-            className={cl([styles.home, styles.container])}
+            data-testid="transaction-page"
+            id="transaction"
+            className={styles.container}
         >
-            <section className="left-item">
-                <LastestTxCard count={results.count} />
-            </section>
-            <section className="right-item"></section>
+            <h1 className={styles.title}>Transactions</h1>
+            <LastestTxCard
+                count={results.count}
+                txPerPage={20}
+                paginationtype="pagination"
+                truncateLength={45}
+            />
         </div>
     );
 }
 
-const Home = () => (IS_STATIC_ENV ? <HomeStatic /> : <HomeAPI />);
+const Transactions = () =>
+    IS_STATIC_ENV ? <TransactionsStatic /> : <TransactionsAPI />;
 
-export default Home;
+export default Transactions;


### PR DESCRIPTION
- Transaction page done 
- Set transaction page to landing page. The home current home page can be accessed from `home-other`
- Set added pagination option to tab footer
- update `RecentTxCard` component to pass options for NUMBER_OF_TX_PER_PAGE, TRUNCATE_LENGTH, and Pagination type so RecentTxCard can be reused on the home page and the transactions page.

https://user-images.githubusercontent.com/8676844/179129273-1a5ee541-74da-4745-b23c-491b02fdf513.mov

