### PR TITLE
update css styles

### DIFF
--- a/explorer/client/src/pages/transaction-result/SendReceiveView.module.css
+++ b/explorer/client/src/pages/transaction-result/SendReceiveView.module.css
@@ -3,14 +3,18 @@
 }
 
 .txaddresssender a,
-.txaddresssender span {
-    @apply pl-2 pr-0;
-}
-
-.txaddresssender a,
 .txaddresssender,
 .txaddress ul li a {
     @apply break-all font-mono text-sm text-sui-dark;
+}
+
+.label span {
+    @apply text-sui-grey-80 font-[500] text-[13px] mb-2;
+}
+
+.recipient.txaddresssender a,
+.recipient.txaddresssender span {
+    @apply pl-2 pr-0;
 }
 
 .txaddress ul li {
@@ -21,10 +25,14 @@
 }
 
 .txaddresssender {
-    @apply relative pl-1.5;
+    @apply relative mt-1;
 }
 
-.txaddresssender::before {
+.recipient.txaddresssender {
+    @apply pl-1.5;
+}
+
+.recipient.txaddresssender::before {
     content: '';
     background-image: url('../../assets/SVGIcons/Start.svg');
     background-size: 16px 16px;
@@ -37,7 +45,7 @@
     align-items: center;
 }
 
-.txaddresssender::after {
+.recipient.txaddresssender::after {
     @apply ml-[-0.5rem];
 
     top: 10px;
@@ -55,7 +63,7 @@
 
 .label {
     border-bottom: 1px solid #f0f1f2;
-    @apply text-sui-grey-85 font-[500] text-lg  mt-0 mb-2 border-b-[1px] border-[#f0f1f2] md:border-0;
+    @apply text-sui-grey-100 font-[500] text-lg  mt-0 mb-2 border-b-[1px] border-[#f0f1f2] md:border-0;
 }
 
 .txaddressheader {
@@ -102,8 +110,4 @@
 
 .txrecipents li :first-child::after {
     height: 20px;
-}
-
-.label span {
-    @apply text-sui-grey-80 font-[500] text-[13px] mb-2;
 }

--- a/explorer/client/src/pages/transaction-result/SendReceiveView.tsx
+++ b/explorer/client/src/pages/transaction-result/SendReceiveView.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import cl from 'classnames';
+
 import Longtext from '../../components/longtext/Longtext';
 
 import styles from './SendReceiveView.module.css';
@@ -21,7 +23,12 @@ function SendRecieveView({ data }: { data: TxAddress }) {
                     )}
                 </h3>
             </div>
-            <div className={styles.txaddresssender}>
+            <div
+                className={cl([
+                    styles.txaddresssender,
+                    data.recipient?.length ? styles.recipient : '',
+                ])}
+            >
                 <Longtext
                     text={data.sender}
                     category="addresses"

--- a/explorer/client/src/pages/transaction-result/TransactionResult.module.css
+++ b/explorer/client/src/pages/transaction-result/TransactionResult.module.css
@@ -21,7 +21,7 @@
 }
 
 .txsender {
-    @apply col-start-2 md:col-start-3 md:row-start-1 md:row-end-2;
+    @apply col-start-2 md:col-start-3 md:row-start-1 md:row-end-2 mt-1;
 }
 
 .itemviewtitle,

--- a/explorer/client/src/pages/transaction-result/TxLinks.module.css
+++ b/explorer/client/src/pages/transaction-result/TxLinks.module.css
@@ -1,5 +1,5 @@
 .mutatedcreatedlist ul {
-    @apply list-none p-0 m-0;
+    @apply list-none p-0 m-0 !important;
 }
 
 .mutatedcreatedlist ul li {
@@ -13,7 +13,7 @@
 
 .label {
     border-bottom: 1px solid #f0f1f2;
-    @apply text-sui-grey-85 font-[500] text-lg mb-2 mt-0 border-b-[1px] border-[#f0f1f2] md:border-0;
+    @apply text-sui-grey-100 font-[500] text-lg mb-2 mt-1 border-b-[1px] border-[#f0f1f2] md:border-0;
 }
 
 .moretxbtn {


### PR DESCRIPTION

Before
<img width="1490" alt="Screen Shot 2022-07-15 at 4 45 27 PM" src="https://user-images.githubusercontent.com/8676844/179308101-35718000-4217-4fd1-b7fa-ae12e53560ec.png">

After
<img width="1524" alt="Screen Shot 2022-07-15 at 4 43 40 PM" src="https://user-images.githubusercontent.com/8676844/179307851-618058e5-8749-4ab4-81d9-a2e58aceed6f.png">

<img width="1525" alt="Screen Shot 2022-07-15 at 4 44 10 PM" src="https://user-images.githubusercontent.com/8676844/179307914-7627811b-faec-4b65-a374-5e338f89a86a.png">

- In the transaction result page remove the sender icon on instances that we do not have a recipient 
- Change the text color for `Sender & Recipients` ,`Mutated and Create`, `Gas & Storage Fees` to dark gray base on the design update.
- Alignment fixes 