### PR TITLE
Separate checkpoint digest and checkpoint content digest type name

### DIFF
--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -161,6 +161,7 @@ impl AuthenticatedCheckpoint {
 }
 
 pub type CheckpointDigest = [u8; 32];
+pub type CheckpointContentsDigest = [u8; 32];
 
 // The constituent parts of checkpoints, signed and certified
 
@@ -169,7 +170,7 @@ pub struct CheckpointSummary {
     pub epoch: EpochId,
     pub sequence_number: CheckpointSequenceNumber,
     pub waypoint: Box<Waypoint>, // Bigger structure, can live on heap.
-    pub content_digest: CheckpointDigest,
+    pub content_digest: CheckpointContentsDigest,
     pub previous_digest: Option<CheckpointDigest>,
     // TODO: add digest of previous checkpoint summary
 }
@@ -201,7 +202,7 @@ impl CheckpointSummary {
         &self.sequence_number
     }
 
-    pub fn digest(&self) -> [u8; 32] {
+    pub fn digest(&self) -> CheckpointDigest {
         sha3_hash(self)
     }
 }
@@ -388,7 +389,7 @@ impl CheckpointContents {
         self.transactions.iter()
     }
 
-    pub fn digest(&self) -> [u8; 32] {
+    pub fn digest(&self) -> CheckpointContentsDigest {
         sha3_hash(self)
     }
 }


### PR DESCRIPTION
It was a bit confusing to use the same type alias for the two as they are very different.