### PR TITLE
Explorer: add 'ago' to time column

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -136,7 +136,7 @@ function LatestTxView({
     const defaultActiveTab = 0;
     const recentTx = {
         data: results.latestTx.map((txn) => ({
-            date: `${timeAgo(txn.timestamp_ms, undefined, true)} `,
+            date: `${timeAgo(txn.timestamp_ms, undefined, true)} ago`,
             transactionId: [
                 {
                     url: txn.txId,


### PR DESCRIPTION
Design spec
![CleanShot 2022-07-15 at 13 06 31](https://user-images.githubusercontent.com/76067158/179303203-724cb9b3-32f3-4fcd-814f-7971312024c9.png)


Before
![CleanShot 2022-07-15 at 13 08 35](https://user-images.githubusercontent.com/76067158/179303177-7dbe0757-09aa-4d1a-8a4a-6d1302e87b55.png)


After
![CleanShot 2022-07-15 at 13 05 02](https://user-images.githubusercontent.com/76067158/179303114-26eab350-2094-4dad-9455-4c4382debf21.png)
