### PR TITLE
Simplify auth sign info verify function

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -508,17 +508,36 @@ impl PartialEq for AuthoritySignInfo {
 }
 
 impl AuthoritySignInfo {
-    pub fn add_to_verification_obligation(
+    pub fn add_to_verification_obligation<T>(
         &self,
+        data: &T,
         committee: &Committee,
         obligation: &mut VerificationObligation,
-        message_index: usize,
-    ) -> SuiResult<()> {
+    ) -> SuiResult<()>
+    where
+        T: Signable<Vec<u8>>,
+    {
+        let weight = committee.weight(&self.authority);
+        fp_ensure!(weight > 0, SuiError::UnknownSigner);
+
         obligation
             .public_keys
             .push(committee.public_key(&self.authority)?);
         obligation.signatures.push(self.signature.0);
+        let mut message = Vec::new();
+        data.write(&mut message);
+        let message_index = obligation.add_message(message);
         obligation.message_index.push(message_index);
+        Ok(())
+    }
+
+    pub fn verify<T>(&self, data: &T, committee: &Committee) -> SuiResult<()>
+    where
+        T: Signable<Vec<u8>>,
+    {
+        let mut obligation = VerificationObligation::default();
+        self.add_to_verification_obligation(data, committee, &mut obligation)?;
+        obligation.verify_all()?;
         Ok(())
     }
 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -290,13 +290,8 @@ impl SignedCheckpointSummary {
             self.summary.epoch == self.auth_signature.epoch,
             SuiError::from("Epoch in the summary doesn't match with the signature")
         );
-        fp_ensure!(
-            committee.weight(&self.auth_signature.authority) > 0,
-            SuiError::UnknownSigner
-        );
-        self.auth_signature
-            .signature
-            .verify(&self.summary, self.auth_signature.authority)?;
+
+        self.auth_signature.verify(&self.summary, committee)?;
 
         if let Some(contents) = contents {
             let recomputed = CheckpointSummary::new(


### PR DESCRIPTION
1. AuthSignInfo's `add_to_verification_obligation` can serialize the data instead of relying on the caller to do so
2. Added a verify function that allows direct verification.
3. Modified a few callsites for this change