### PR TITLE
[checkpoint] Fix nit on checkpoint content verify

### DIFF
--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -299,16 +299,9 @@ impl SignedCheckpointSummary {
             .verify(&self.summary, self.auth_signature.authority)?;
 
         if let Some(contents) = contents {
-            let recomputed = CheckpointSummary::new(
-                self.summary.epoch,
-                *self.summary.sequence_number(),
-                contents,
-                self.summary.previous_digest,
-            );
-
             fp_ensure!(
-                recomputed == self.summary,
-                SuiError::from("Transaction digest mismatch")
+                contents.digest() == self.summary.content_digest,
+                SuiError::from("Checkpoint contents digest mismatch")
             );
         }
 
@@ -385,16 +378,9 @@ impl CertifiedCheckpointSummary {
         obligation.verify_all()?;
 
         if let Some(contents) = contents {
-            let recomputed = CheckpointSummary::new(
-                self.summary.epoch,
-                *self.summary.sequence_number(),
-                contents,
-                self.summary.previous_digest,
-            );
-
             fp_ensure!(
-                recomputed == self.summary,
-                SuiError::from("Transaction digest mismatch")
+                contents.digest() == self.summary.content_digest,
+                SuiError::from("Checkpoint contents digest mismatch")
             );
         }
 


### PR DESCRIPTION
The content check was unnecessarily complex. What we are really checking here is the content digest.
Also fix the error message.