### PR TITLE
fix pagination and style fixes

### DIFF
--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -225,7 +225,7 @@ describe('End-to-end Tests', () => {
 
             //Click on Owner text:
             await cssInteract(page)
-                .with('div#owner > span:first-child')
+                .with('div#owner > div >span:first-child')
                 .click();
 
             //Looking for object or address?
@@ -274,7 +274,7 @@ describe('End-to-end Tests', () => {
             ).toBe('noImage');
 
             //Parent Object contains an image:
-            await page.click('div#owner > span:first-child');
+            await page.click('div#owner > div > span:first-child');
             await page.waitForFunction(
                 () => !document.querySelector('#pleaseWaitImage')
             );

--- a/explorer/client/src/assets/SVGIcons/Copy.svg
+++ b/explorer/client/src/assets/SVGIcons/Copy.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="18" viewBox="0 0 16 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 3H2.93103C1.86455 3 1 3.86455 1 4.93103V15.069C1 16.1354 1.86455 17 2.93103 17H13.069C14.1354 17 15 16.1354 15 15.069V4.93103C15 3.86455 14.1354 3 13.069 3H12" stroke="#A0B6C3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 2.5C4 1.67157 4.67157 1 5.5 1H10.5C11.3284 1 12 1.67157 12 2.5V3.5C12 4.32843 11.3284 5 10.5 5H5.5C4.67157 5 4 4.32843 4 3.5V2.5Z" stroke="#A0B6C3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/explorer/client/src/components/longtext/Longtext.module.css
+++ b/explorer/client/src/components/longtext/Longtext.module.css
@@ -1,12 +1,25 @@
 .copy {
-    @apply cursor-pointer;
+    @apply cursor-pointer mr-2;
+
+    /* fix some wiered vertical spacing svg with copy 16px is the high of svg */
+    font-size: 16px !important;
+    vertical-align: middle;
+    line-height: 100%;
 }
 
 .copied {
-    @apply text-green-600;
+    @apply text-green-600 ml-1 text-sm;
 }
 
 .longtext,
 .longtext > a {
-    @apply no-underline text-sui-dark hover:text-[#1F6493] cursor-pointer break-all;
+    @apply no-underline text-sui-dark hover:text-[#1F6493] cursor-pointer break-all inline mr-2;
+}
+
+.linktext {
+    @apply mr-2;
+}
+
+.longtextwrapper {
+    @apply inline md:block;
 }

--- a/explorer/client/src/components/longtext/Longtext.tsx
+++ b/explorer/client/src/components/longtext/Longtext.tsx
@@ -4,8 +4,8 @@
 import { useCallback, useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { ReactComponent as ContentCopyIcon } from '../../assets/SVGIcons/Copy.svg';
 import { ReactComponent as ContentForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
-import { ReactComponent as ContentCopyIcon } from '../../assets/content_copy_black_18dp.svg';
 import { NetworkContext } from '../../context';
 import { navigateWithUnknown } from '../../utils/searchUtil';
 import ExternalLink from '../external-link/ExternalLink';
@@ -110,13 +110,16 @@ function Longtext({
             );
         }
     } else {
-        textComponent = <span>{alttext ? alttext : text}</span>;
+        textComponent = (
+            <span className={styles.linktext}>{alttext ? alttext : text}</span>
+        );
     }
 
     return (
-        <>
-            {textComponent}&nbsp;{icon}
-        </>
+        <div className={styles.longtextwrapper}>
+            {textComponent}
+            {icon}
+        </div>
     );
 }
 

--- a/explorer/client/src/components/pagination/Pagination.module.css
+++ b/explorer/client/src/components/pagination/Pagination.module.css
@@ -6,6 +6,14 @@
     @apply flex flex-row items-center justify-center list-none  p-0 m-0;
 }
 
+.arrow {
+    @apply block opacity-50 cursor-default !important;
+}
+
+.arrow button {
+    @apply border-transparent cursor-default;
+}
+
 .pagination ul li {
     @apply mr-2 hidden md:block;
 }
@@ -18,12 +26,12 @@
     transition: all 0.4s ease;
 }
 
-.arrow {
-    @apply block !important;
+button.activepag {
+    @apply bg-[#F4FBFF] text-sui-dark border-sui-dark !important;
 }
 
-.activepag {
-    @apply bg-[#F4FBFF] text-sui-dark border-sui-dark !important;
+.activearrow {
+    @apply block opacity-100 cursor-pointer !important;
 }
 
 .paginationleft svg {

--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -2,34 +2,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { useState, useCallback } from 'react';
+import { memo, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { ReactComponent as ContentForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
 
 import styles from './Pagination.module.css';
-function generatePaginationArr(
+
+const generatePaginationArr = (
     startAt: number,
     itemsPerPage: number,
     totalItems: number
-) {
+) => {
     // number of list items to show before truncating
     const range: number = 2;
     const max = Math.ceil((totalItems - 1) / itemsPerPage);
     const maxRange = (Math.floor(startAt / range) + 1) * range;
     // set the min range to be the max range minus the range if it is less than the max - range
     const minRange = startAt <= max - range ? maxRange - range : max - range;
+
+    // generate array of numbers to show in the pagination where the total number of pages is the total tx value / items per page
+    // show only the range eg if startAt is 5 and range is 5 then show 5, 6, 7, 8, 9, 10
+    // generate an array of numbers of length range, starting at startAt and ending at max,
+    const rangelength = maxRange <= range + 1 ? range + 3 : range;
+
+    const listItems = Array.from({ length: max }, (_, i) => i + 1).filter(
+        (x: number, i) =>
+            (x >= minRange && x <= maxRange) || (i + 1 < rangelength && i > 0)
+    );
+
     return {
         max,
         maxRange,
-        // generate array of numbers to show in the pagination where the total number of pages is the total tx value / items per page
-        // show only the range eg if startAt is 5 and range is 5 then show 5, 6, 7, 8, 9, 10
-        listItems: Array.from({ length: max }, (_, i) => i + 1).filter(
-            (x: number) => x >= minRange && x <= maxRange
-        ),
+        listItems,
         range,
     };
-}
+};
 
 function Pagination({
     totalTxCount,
@@ -39,70 +47,75 @@ function Pagination({
     txNum: number;
 }) {
     const [searchParams, setSearchParams] = useSearchParams();
-    const [pageIndex, setPage] = useState(
-        parseInt(searchParams.get('p') || '1', 10) || 1
-    );
-    const [pagiData, setPagiData] = useState(
-        generatePaginationArr(pageIndex, txNum, totalTxCount)
-    );
+    const pageIndex = parseInt(searchParams.get('p') || '1', 10) || 1;
+    const initData = generatePaginationArr(pageIndex, txNum, totalTxCount);
+    const [pagiData, setPagiData] = useState(initData);
 
     const changePage = useCallback(
-        (pageNum: number) => () => {
-            setPage(pageNum);
+        (e: React.MouseEvent<HTMLElement>) => {
+            const pageNum = parseInt(e.currentTarget.dataset.pagidata || '0');
+            // don't allow page to be less than 1 or equal to current page index
+            if (pageNum < 1 || pageNum === pageIndex || pageNum > pagiData.max)
+                return;
             setSearchParams({ p: pageNum.toString() });
             setPagiData(generatePaginationArr(pageNum, txNum, totalTxCount));
         },
-        [setSearchParams, txNum, totalTxCount]
+        [pageIndex, pagiData.max, setSearchParams, txNum, totalTxCount]
     );
 
     return (
         <>
             <nav className={styles.pagination}>
                 <ul>
-                    {pageIndex > 1 && (
-                        <li className={styles.arrow}>
-                            <button
-                                className={cl([
-                                    pageIndex === 1 ? styles.activepag : '',
-                                    styles.paginationleft,
-                                ])}
-                                onClick={changePage(pageIndex - 1)}
-                            >
-                                <ContentForwardArrowDark />
-                            </button>
-                        </li>
-                    )}
-                    {pageIndex > pagiData.range - 1 && (
-                        <>
+                    <li
+                        className={cl(
+                            styles.arrow,
+                            pageIndex > 1 ? styles.activearrow : ''
+                        )}
+                    >
+                        <button
+                            className={styles.paginationleft}
+                            data-pagidata={Math.max(0, pageIndex - 1)}
+                            onClick={changePage}
+                        >
+                            <ContentForwardArrowDark />
+                        </button>
+                    </li>
+                    <li>
+                        <button
+                            className={pageIndex === 1 ? styles.activepag : ''}
+                            onClick={changePage}
+                            data-pagidata={1}
+                        >
+                            1
+                        </button>
+                    </li>
+
+                    {pageIndex > pagiData.range &&
+                        pageIndex > pagiData.range + 1 && (
                             <li className="page-item">
-                                <button
-                                    className="page-link"
-                                    onClick={changePage(1)}
-                                >
-                                    1
+                                <button className={styles.paginationdot}>
+                                    ...
                                 </button>
                             </li>
-                        </>
-                    )}
-                    {pageIndex > pagiData.range && (
-                        <li className="page-item">
-                            <button className={styles.paginationdot}>
-                                ...
-                            </button>
-                        </li>
-                    )}
-                    {pagiData.listItems.map((itm: any, index: number) => (
-                        <li className="page-item" key={index}>
-                            <button
-                                className={
-                                    pageIndex === itm ? styles.activepag : ''
-                                }
-                                onClick={changePage(itm)}
-                            >
-                                {itm}
-                            </button>
-                        </li>
-                    ))}
+                        )}
+                    {pagiData.listItems
+                        .filter((itm) => itm !== pagiData.max && itm !== 1)
+                        .map((itm: any, index: number) => (
+                            <li className="page-item" key={index}>
+                                <button
+                                    className={
+                                        pageIndex === itm
+                                            ? styles.activepag
+                                            : ''
+                                    }
+                                    data-pagidata={itm}
+                                    onClick={changePage}
+                                >
+                                    {itm}
+                                </button>
+                            </li>
+                        ))}
 
                     {pageIndex < pagiData.max - 1 && (
                         <>
@@ -118,35 +131,40 @@ function Pagination({
                                     ...
                                 </button>
                             </li>
-
-                            <li className="page-item">
-                                <button
-                                    className={
-                                        pageIndex === pagiData.max
-                                            ? styles.activepag
-                                            : ''
-                                    }
-                                    onClick={changePage(pagiData.max)}
-                                >
-                                    {pagiData.max}
-                                </button>
-                            </li>
                         </>
                     )}
-                    {pageIndex < pagiData.max && (
-                        <li className={styles.arrow}>
-                            <button
-                                className="page-link"
-                                onClick={changePage(pageIndex + 1)}
-                            >
-                                <ContentForwardArrowDark />
-                            </button>
-                        </li>
-                    )}
+
+                    <li className="page-item">
+                        <button
+                            className={
+                                pageIndex === pagiData.max
+                                    ? styles.activepag
+                                    : ''
+                            }
+                            data-pagidata={pagiData.max}
+                            onClick={changePage}
+                        >
+                            {pagiData.max}
+                        </button>
+                    </li>
+                    <li
+                        className={cl(
+                            styles.arrow,
+                            pageIndex < pagiData.max ? styles.activearrow : ''
+                        )}
+                    >
+                        <button
+                            className="page-link"
+                            data-pagidata={pageIndex + 1}
+                            onClick={changePage}
+                        >
+                            <ContentForwardArrowDark />
+                        </button>
+                    </li>
                 </ul>
             </nav>
         </>
     );
 }
 
-export default Pagination;
+export default memo(Pagination);

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -33,7 +33,7 @@ td:nth-child(1) {
 }
 
 .addresses svg {
-    @apply mr-1;
+    @apply mr-2;
 }
 
 .tablespacing {
@@ -42,4 +42,9 @@ td:nth-child(1) {
 
 td a {
     @apply font-mono text-[#4E555D];
+}
+
+.longtextwrapper {
+    display: flex;
+    align-items: center;
 }

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -1,5 +1,5 @@
 .content {
-    @apply container overflow-x-auto text-left text-[#4E555D];
+    @apply w-full overflow-x-auto text-left text-[#4E555D];
 }
 
 .table {

--- a/explorer/client/src/components/table/TableCard.tsx
+++ b/explorer/client/src/components/table/TableCard.tsx
@@ -60,7 +60,7 @@ function TxAddresses({ content }: { content: Link[] }) {
     return (
         <section className={styles.addresses}>
             {content.map((itm, idx) => (
-                <div key={idx + itm.url}>
+                <div key={idx + itm.url} className={styles.longtextwrapper}>
                     <Longtext
                         text={itm.url}
                         alttext={itm.name}

--- a/explorer/client/src/index.css
+++ b/explorer/client/src/index.css
@@ -39,3 +39,10 @@ textarea:focus,
 select:focus {
     outline: none;
 }
+
+/* Fix inconsistent font size rendering on iphone */
+@media screen and (max-device-width: 480px) {
+    body {
+        text-size-adjust: none;
+    }
+}

--- a/explorer/client/src/pages/transaction-result/SendReceiveView.module.css
+++ b/explorer/client/src/pages/transaction-result/SendReceiveView.module.css
@@ -14,7 +14,15 @@
 
 .recipient.txaddresssender a,
 .recipient.txaddresssender span {
-    @apply pl-2 pr-0;
+    @apply pl-0 pr-0 mx-0;
+}
+
+.txaddress ul li div {
+    @apply ml-2;
+}
+
+.recipient.txaddresssender > div {
+    @apply ml-2;
 }
 
 .txaddress ul li {
@@ -83,7 +91,7 @@
     height: 16px;
     width: 16px;
     position: absolute;
-    left: 4px;
+    left: 8px;
     z-index: 2;
     display: flex;
     align-items: center;

--- a/explorer/client/src/pages/transaction-result/SendReceiveView.tsx
+++ b/explorer/client/src/pages/transaction-result/SendReceiveView.tsx
@@ -32,6 +32,7 @@ function SendRecieveView({ data }: { data: TxAddress }) {
                 <Longtext
                     text={data.sender}
                     category="addresses"
+                    isCopyButton={false}
                     isLink={true}
                 />
                 {data.recipient && (
@@ -42,6 +43,7 @@ function SendRecieveView({ data }: { data: TxAddress }) {
                                     text={add}
                                     category="addresses"
                                     isLink={true}
+                                    isCopyButton={false}
                                     alttext={add}
                                 />
                             </li>

--- a/explorer/client/src/pages/transaction-result/TransactionResult.module.css
+++ b/explorer/client/src/pages/transaction-result/TransactionResult.module.css
@@ -36,16 +36,20 @@
 
 .itemviewcontent {
     @apply mb-2 mt-2;
+
+    box-sizing: border-box;
 }
 
 .itemviewcontent .itemviewcontentitem {
     @apply grid gap-1 text-[14px] md:text-[15px] text-gray-500;
 
-    grid-template-columns: 1fr 2fr;
+    grid-template-columns: 1fr 3fr;
 }
 
 .itemviewcontentvalue {
-    @apply text-sm pt-2 pb-2 text-gray-800;
+    @apply text-sm pt-2 pb-2 text-gray-800 contents md:block;
+
+    box-sizing: border-box;
 }
 
 .itemviewcontent .itemviewcontentitem a,

--- a/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
@@ -3,9 +3,13 @@
 }
 
 .txback {
-    @apply w-full pb-2;
+    @apply w-full pb-2 px-0;
 
     border-bottom: 1px solid #f0f1f2;
+}
+
+.txback button {
+    @apply px-0;
 }
 
 .txback a {
@@ -17,7 +21,13 @@
 }
 
 .txid {
-    @apply text-offblack font-[600] text-lg md:text-2xl font-mono break-all block  items-center;
+    @apply text-offblack font-[600] text-lg md:text-2xl font-mono break-all block items-center;
+}
+
+.txaddress {
+    @apply block md:flex justify-start align-middle items-center;
+
+    box-sizing: border-box;
 }
 
 .txresulttype {
@@ -25,17 +35,23 @@
 }
 
 .success {
-    @apply bg-[#ECFBF7] capitalize text-sm font-sans text-[#008C65] font-normal p-0 pr-3 pl-3 rounded-[10px] inline-block m-0 md:ml-2 md:mr-2;
+    @apply bg-[#ECFBF7] capitalize text-sm font-sans text-[#008C65] font-normal p-0.5 pr-3 pl-3 rounded-[10px] inline-block m-0 mt-1;
 }
 
 .failed {
-    @apply bg-[#EB5A291A] capitalize text-sm font-sans text-[#B94118] font-normal p-0 pr-3 pl-3 rounded-[10px] inline-block m-0 md:ml-2 md:mr-2;
+    @apply bg-[#EB5A291A] capitalize text-sm font-sans text-[#B94118] font-normal p-0.5 pr-3 pl-3 rounded-[10px] inline-block m-0 mt-1;
+
+    box-sizing: border-box;
 }
 
 .longtext {
     @apply bg-transparent border-0 font-sans text-sm text-[#1F6493] font-[500] cursor-pointer hover:text-sui-grey-80;
+
+    box-sizing: border-box;
 }
 
 .error {
-    @apply w-full rounded-none m-0 text-sm p-1 pl-2 pr-2 font-normal mt-2 w-fit md:w-full;
+    @apply w-full rounded-none m-0 text-sm p-1 pl-2 pr-2 font-normal mt-2  w-full;
+
+    box-sizing: border-box;
 }

--- a/explorer/client/src/pages/transaction-result/TxResultHeader.tsx
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.tsx
@@ -59,7 +59,7 @@ function TxAddressHeader({ data }: { data: TxResultState }) {
                 <Icon /> {TxKindName}
             </div>
             <div className={styles.txid}>
-                <div>
+                <div className={styles.txaddress}>
                     <Longtext
                         text={data.txId}
                         category="addresses"
@@ -74,18 +74,18 @@ function TxAddressHeader({ data }: { data: TxResultState }) {
                         {' '}
                         <TxResultStatus /> {statusName}
                     </div>
-                    {data.error && (
-                        <div
-                            className={cl([
-                                styles.txresulttype,
-                                styles.failed,
-                                styles.error,
-                            ])}
-                        >
-                            {data.error}
-                        </div>
-                    )}
                 </div>
+                {data.error && (
+                    <div
+                        className={cl([
+                            styles.txresulttype,
+                            styles.failed,
+                            styles.error,
+                        ])}
+                    >
+                        {data.error}
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
- Fixed content overflow on mobile 
- fixed last pagination number sometimes appearing twice
- Replace the copy to clipboard icon on links
- Fixed inconsistent font rendering on some iPhones. 
- Remove the copy icon on sender/receiver address transaction details
<img width="390" alt="Screen Shot 2022-07-16 at 9 48 22 AM" src="https://user-images.githubusercontent.com/8676844/179358901-522a6272-72a3-4a3a-b0db-69f331d33e9b.png">
<img width="517" alt="Screen Shot 2022-07-16 at 9 48 37 AM" src="https://user-images.githubusercontent.com/8676844/179358905-5c621e2e-4f93-4f7f-90a6-9f64f4508a70.png">
<img width="547" alt="Screen Shot 2022-07-16 at 9 49 00 AM" src="https://user-images.githubusercontent.com/8676844/179358908-f1996038-343a-43ab-bc3b-3dc752689be4.png">

<img width="391" alt="Screen Shot 2022-07-16 at 10 26 49 AM" src="https://user-images.githubusercontent.com/8676844/179358978-2eaf798d-be8c-43e1-ac22-3bc27e61fa9d.png">
 