### PR TITLE
Send telemetry events to Google analytics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,6 +6920,7 @@ dependencies = [
  "sui-json-rpc",
  "sui-network",
  "sui-storage",
+ "sui-telemetry",
  "sui-types",
  "telemetry-subscribers",
  "tokio",
@@ -7045,6 +7046,17 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic-health",
+ "tracing",
+ "workspace-hack 0.1.0",
+]
+
+[[package]]
+name = "sui-telemetry"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde 1.0.140",
+ "tokio",
  "tracing",
  "workspace-hack 0.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/sui-sdk",
     "crates/sui-storage",
     "crates/sui-swarm",
+    "crates/sui-telemetry",
     "crates/sui-tool",
     "crates/sui-transactional-test-runner",
     "crates/sui-types",

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -23,6 +23,7 @@ sui-core = { path = "../sui-core" }
 sui-storage = { path = "../sui-storage" }
 sui-network = { path = "../sui-network" }
 sui-json-rpc = { path = "../sui-json-rpc" }
+sui-telemetry = { path = "../sui-telemetry" }
 sui-types = { path = "../sui-types" }
 
 telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -5,7 +5,11 @@ use anyhow::Result;
 use clap::Parser;
 use multiaddr::Multiaddr;
 use std::path::PathBuf;
+use std::time::Duration;
 use sui_config::{Config, NodeConfig};
+use sui_telemetry::send_telemetry_event;
+use tokio::task;
+use tokio::time::sleep;
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
@@ -73,6 +77,14 @@ async fn main() -> Result<()> {
             }
         });
     }
+
+    task::spawn(async move {
+        loop {
+            sleep(Duration::from_secs(3600)).await;
+            send_telemetry_event().await;
+        }
+    })
+    .await?;
 
     sui_node::admin::start_admin_server(config.admin_interface_port, filter_handle);
 

--- a/crates/sui-telemetry/Cargo.toml
+++ b/crates/sui-telemetry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sui-telemetry"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.139", features = ["derive"] }
+reqwest = { version = "0.11.10", features = ["json"] }
+tokio = { version = "1.17.0", features = ["full", "tracing"] }
+tracing = "0.1.35"
+workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-telemetry/src/lib.rs
+++ b/crates/sui-telemetry/src/lib.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use tracing::trace;
+
+pub(crate) const GA_API_SECRET: &str = "zeq-aYEzS0aGdRJ8kNZTEg";
+pub(crate) const GA_EVENT_NAME: &str = "node_telemetry_event";
+pub(crate) const GA_MEASUREMENT_ID: &str = "G-96DM59YK2F";
+pub(crate) const GA_URL: &str = "https://www.google-analytics.com/mp/collect";
+// need this hardcoded client ID as only existing client is valid.
+// see below for details:
+// https://developers.google.com/analytics/devguides/collection/protocol/ga4/verify-implementation?client_type=gtag
+pub(crate) const HARDCODED_CLIENT_ID: &str = "1871165366.1648333069";
+pub(crate) const IPLOOKUP_URL: &str = "https://api.ipify.org?format=json";
+pub(crate) const UNKNOWN_STRING: &str = "UNKNOWN";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TelemetryEvent {
+    name: String,
+    params: BTreeMap<String, String>,
+}
+
+// The payload needs to meet this requirement in
+// https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#payload_post_body
+#[derive(Debug, Serialize, Deserialize)]
+struct TelemetryPayload {
+    client_id: String,
+    events: Vec<TelemetryEvent>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IpResponse {
+    ip: String,
+}
+
+pub async fn send_telemetry_event() {
+    let ip_address = get_ip().await;
+    let telemetry_event = TelemetryEvent {
+        name: GA_EVENT_NAME.into(),
+        params: BTreeMap::from([("node_address".into(), ip_address.clone())]),
+    };
+
+    let telemetry_payload = TelemetryPayload {
+        client_id: HARDCODED_CLIENT_ID.into(),
+        events: vec![telemetry_event],
+    };
+
+    send_telemetry_event_impl(telemetry_payload).await
+}
+
+async fn get_ip() -> String {
+    let resp = reqwest::get(IPLOOKUP_URL).await;
+    match resp {
+        Ok(json) => match json.json::<IpResponse>().await {
+            Ok(ip_json) => ip_json.ip,
+            Err(_) => UNKNOWN_STRING.into(),
+        },
+        Err(_) => UNKNOWN_STRING.into(),
+    }
+}
+
+async fn send_telemetry_event_impl(telemetry_payload: TelemetryPayload) {
+    let client = reqwest::Client::new();
+    let response_result = client
+        .post(format!(
+            "{}?&measurement_id={}&api_secret={}",
+            GA_URL, GA_MEASUREMENT_ID, GA_API_SECRET
+        ))
+        .json::<TelemetryPayload>(&telemetry_payload)
+        .send()
+        .await;
+
+    match response_result {
+        Ok(response) => {
+            let status = response.status().as_u16();
+            if (200..299).contains(&status) {
+                trace!("SUCCESS: Sent telemetry event: {:?}", &telemetry_payload,);
+            } else {
+                trace!(
+                    "FAIL: Sending telemetry event failed with status: {} and response {:?}.",
+                    response.status(),
+                    response
+                );
+            }
+        }
+        Err(error) => {
+            trace!(
+                "FAIL: Sending telemetry event failed with error: {:?}",
+                error
+            );
+        }
+    }
+}


### PR DESCRIPTION
- added a sui-telemetry crate
- spawn a task to send telemetry event to GA each hour

testing while running validator and fullnode locally
- events sending can be triggered from both validators and fullnodes
![Screen Shot 2022-07-20 at 6 22 10 PM](https://user-images.githubusercontent.com/106119108/180092749-bd12884b-8364-4af4-a616-a93a4fbf6f89.png)

- events also show on GA's dashboard with my IP address
![Screen Shot 2022-07-20 at 6 12 34 PM](https://user-images.githubusercontent.com/106119108/180092772-7aeb64e2-ff0b-4736-8d92-63ae4ed79c47.png)
![Screen Shot 2022-07-20 at 6 12 46 PM](https://user-images.githubusercontent.com/106119108/180092778-e3c216cb-dba6-4ac8-92b0-ffb9170b4f30.png)



