### PR TITLE
wallet-ext:  load API_ENV during app init

### DIFF
--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -24,12 +24,10 @@ import SelectPage from '_pages/initialize/select';
 import SiteConnectPage from '_pages/site-connect';
 import WelcomePage from '_pages/welcome';
 import { loadAccountFromStorage } from '_redux/slices/account';
-import { loadNetworkFromStorage } from '_redux/slices/app';
 
 const App = () => {
     const dispatch = useAppDispatch();
     useEffect(() => {
-        dispatch(loadNetworkFromStorage());
         dispatch(loadAccountFromStorage());
     }, [dispatch]);
     const isPopup = useAppSelector(

--- a/wallet/src/ui/app/pages/home/transaction-details/index.tsx
+++ b/wallet/src/ui/app/pages/home/transaction-details/index.tsx
@@ -28,6 +28,8 @@ const txKindToTxt: Record<TransactionKindName, string> = {
     TransferObject: 'Object transfer',
     Call: 'Call',
     Publish: 'Publish',
+    TransferSui: 'Sui transfer',
+    ChangeEpoch: 'Change epoch',
 };
 
 function TransactionDetailsPage() {

--- a/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -82,7 +82,13 @@ const initialState = objectsAdapter.getInitialState<SuiObjectsManualState>({
 const slice = createSlice({
     name: 'sui-objects',
     initialState: initialState,
-    reducers: {},
+    reducers: {
+        clearForNetworkSwitch: (state) => {
+            state.error = false;
+            state.lastSync = null;
+            objectsAdapter.removeAll(state);
+        },
+    },
     extraReducers: (builder) => {
         builder
             .addCase(fetchAllOwnedObjects.fulfilled, (state, action) => {
@@ -105,6 +111,8 @@ const slice = createSlice({
 });
 
 export default slice.reducer;
+
+export const { clearForNetworkSwitch } = slice.actions;
 
 export const suiObjectsAdapterSelectors = objectsAdapter.getSelectors(
     (state: RootState) => state.suiObjects

--- a/wallet/src/ui/app/redux/store/index.ts
+++ b/wallet/src/ui/app/redux/store/index.ts
@@ -4,6 +4,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import { KeypairVaultMiddleware } from './middlewares/KeypairVaultMiddleware';
+import { NetworkSwitchMiddleware } from './middlewares/NetworkSwitchMiddleware';
 import { thunkExtras } from './thunk-extras';
 import rootReducer from '_redux/RootReducer';
 
@@ -14,7 +15,7 @@ const store = configureStore({
             thunk: {
                 extraArgument: thunkExtras,
             },
-        }).concat(KeypairVaultMiddleware),
+        }).concat(KeypairVaultMiddleware, NetworkSwitchMiddleware),
 });
 
 export default store;

--- a/wallet/src/ui/app/redux/store/middlewares/NetworkSwitchMiddleware.ts
+++ b/wallet/src/ui/app/redux/store/middlewares/NetworkSwitchMiddleware.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isAnyOf } from '@reduxjs/toolkit';
+
+import { changeRPCNetwork } from '_redux/slices/app';
+import { clearForNetworkSwitch } from '_redux/slices/sui-objects';
+
+import type { Middleware } from '@reduxjs/toolkit';
+
+const isChangeNetwork = isAnyOf(changeRPCNetwork.pending);
+
+export const NetworkSwitchMiddleware: Middleware =
+    ({ dispatch }) =>
+    (next) =>
+    (action) => {
+        if (isChangeNetwork(action)) {
+            dispatch(clearForNetworkSwitch());
+        }
+        return next(action);
+    };

--- a/wallet/src/ui/index.tsx
+++ b/wallet/src/ui/index.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { HashRouter } from 'react-router-dom';
 
 import App from './app';
-import { initAppType } from '_redux/slices/app';
+import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
 import { getFromLocationSearch } from '_redux/slices/app/AppType';
 import store from '_store';
 import { thunkExtras } from '_store/thunk-extras';
@@ -19,8 +19,8 @@ async function init() {
     if (process.env.NODE_ENV === 'development') {
         Object.defineProperty(window, 'store', { value: store });
     }
-
     store.dispatch(initAppType(getFromLocationSearch(window.location.search)));
+    await store.dispatch(initNetworkFromStorage()).unwrap();
     await thunkExtras.background.init(store.dispatch);
 }
 


### PR DESCRIPTION
* [wallet-ext: set API_ENV during app init](https://github.com/MystenLabs/sui/commit/c6551e454b32fc35ee4dab350ce24c95ab23f175)

Also includes:
* [wallet-ext: fix ts error after sdk update](https://github.com/MystenLabs/sui/commit/028cf5ff497ff3a9b0345b8b26faab31d59bb33f)
* [wallet-ext: clear sui objects from state when switching networks](https://github.com/MystenLabs/sui/commit/2d252e963b8904de60c0c36662a01824a4bb1e6a)

Before: 

https://user-images.githubusercontent.com/10210143/179782572-24bc7887-06b7-47f3-a382-87da327c657d.mov


After: 


https://user-images.githubusercontent.com/10210143/179782691-3da3428e-ac43-45de-9b9a-46db7b48d1c8.mov



closes #2936 