### PR TITLE
fixed pagination

### DIFF
--- a/explorer/client/src/components/pagination/Pagination.module.css
+++ b/explorer/client/src/components/pagination/Pagination.module.css
@@ -3,7 +3,7 @@
 }
 
 .pagination ul {
-    @apply flex flex-row items-center justify-center list-none  p-0 m-0;
+    @apply flex flex-row items-center justify-center list-none  p-0 m-0 w-full md:w-min;
 }
 
 .arrow {
@@ -19,8 +19,8 @@
 }
 
 .pagination ul li button {
-    @apply text-gray-600 hover:text-gray-800 focus:text-gray-800 font-medium py-2 px-3 md:px-4 cursor-pointer 
-     md:pr-3  md:pl-3  pr-2  pl-2 border-[1px] rounded-[6px] border-white bg-[#FFFFFF] hover:bg-[#F4FBFF];
+    @apply text-gray-600 hover:text-gray-800 focus:text-gray-800 font-medium py-2 px-4 cursor-pointer 
+     pr-3  pl-3  border-[1px] rounded-[6px] border-white bg-[#FFFFFF] hover:bg-[#F4FBFF];
 
     border: 1px solid #e9eaeb;
     transition: all 0.4s ease;
@@ -36,6 +36,10 @@ button.activepag {
 
 .paginationleft svg {
     transform: rotate(180deg);
+}
+
+.paginationdot {
+    @apply px-1;
 }
 
 .pagilink,

--- a/explorer/client/src/components/pagination/Pagination.module.css
+++ b/explorer/client/src/components/pagination/Pagination.module.css
@@ -15,12 +15,12 @@
 }
 
 .pagination ul li {
-    @apply mr-2 hidden md:block;
+    @apply mr-1 hidden md:block;
 }
 
 .pagination ul li button {
-    @apply text-gray-600 hover:text-gray-800 focus:text-gray-800 font-medium py-2 px-4 cursor-pointer 
-     md:pr-3  md:pl-3  pr-3  pl-3 border-[1px] rounded-[6px] border-white bg-[#FFFFFF] hover:bg-[#F4FBFF];
+    @apply text-gray-600 hover:text-gray-800 focus:text-gray-800 font-medium py-2 px-3 md:px-4 cursor-pointer 
+     md:pr-3  md:pl-3  pr-2  pl-2 border-[1px] rounded-[6px] border-white bg-[#FFFFFF] hover:bg-[#F4FBFF];
 
     border: 1px solid #e9eaeb;
     transition: all 0.4s ease;
@@ -36,6 +36,11 @@ button.activepag {
 
 .paginationleft svg {
     transform: rotate(180deg);
+}
+
+.pagilink,
+.paginationdot {
+    @apply block !important;
 }
 
 .paginationdot:hover {

--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { memo, useState, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { memo, useState, useCallback, useEffect } from 'react';
 
 import { ReactComponent as ContentForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
 
@@ -42,25 +41,43 @@ const generatePaginationArr = (
 function Pagination({
     totalTxCount,
     txNum,
+    currentPage = 0,
+    onPagiChangeFn,
 }: {
     totalTxCount: number;
     txNum: number;
+    currentPage: number;
+    onPagiChangeFn: Function;
 }) {
-    const [searchParams, setSearchParams] = useSearchParams();
-    const pageIndex = parseInt(searchParams.get('p') || '1', 10) || 1;
-    const initData = generatePaginationArr(pageIndex, txNum, totalTxCount);
+    const [txNumPerPage, setTxNumPerPage] = useState(txNum);
+    const initData = generatePaginationArr(
+        currentPage,
+        txNumPerPage,
+        totalTxCount
+    );
     const [pagiData, setPagiData] = useState(initData);
+
+    useEffect(() => {
+        setPagiData(
+            generatePaginationArr(currentPage, txNumPerPage, totalTxCount)
+        );
+        setTxNumPerPage(txNum);
+    }, [currentPage, totalTxCount, txNum, txNumPerPage]);
 
     const changePage = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
             const pageNum = parseInt(e.currentTarget.dataset.pagidata || '0');
             // don't allow page to be less than 1 or equal to current page index
-            if (pageNum < 1 || pageNum === pageIndex || pageNum > pagiData.max)
+            if (
+                pageNum < 1 ||
+                pageNum === currentPage ||
+                pageNum > pagiData.max
+            )
                 return;
-            setSearchParams({ p: pageNum.toString() });
-            setPagiData(generatePaginationArr(pageNum, txNum, totalTxCount));
+            // call parent function to change page
+            onPagiChangeFn(pageNum);
         },
-        [pageIndex, pagiData.max, setSearchParams, txNum, totalTxCount]
+        [currentPage, pagiData.max, onPagiChangeFn]
     );
 
     return (
@@ -70,12 +87,12 @@ function Pagination({
                     <li
                         className={cl(
                             styles.arrow,
-                            pageIndex > 1 ? styles.activearrow : ''
+                            currentPage > 1 ? styles.activearrow : ''
                         )}
                     >
                         <button
                             className={styles.paginationleft}
-                            data-pagidata={Math.max(0, pageIndex - 1)}
+                            data-pagidata={Math.max(0, currentPage - 1)}
                             onClick={changePage}
                         >
                             <ContentForwardArrowDark />
@@ -83,7 +100,9 @@ function Pagination({
                     </li>
                     <li className={styles.pagilink}>
                         <button
-                            className={pageIndex === 1 ? styles.activepag : ''}
+                            className={
+                                currentPage === 1 ? styles.activepag : ''
+                            }
                             onClick={changePage}
                             data-pagidata={1}
                         >
@@ -91,8 +110,8 @@ function Pagination({
                         </button>
                     </li>
 
-                    {pageIndex > pagiData.range &&
-                        pageIndex > pagiData.range + 1 && (
+                    {currentPage > pagiData.range &&
+                        currentPage > pagiData.range + 1 && (
                             <li className={styles.paginationdot}>...</li>
                         )}
                     {pagiData.listItems
@@ -100,13 +119,13 @@ function Pagination({
                         .map((itm: any, index: number) => (
                             <li
                                 className={
-                                    pageIndex === itm ? styles.pagilink : ''
+                                    currentPage === itm ? styles.pagilink : ''
                                 }
                                 key={index}
                             >
                                 <button
                                     className={
-                                        pageIndex === itm
+                                        currentPage === itm
                                             ? styles.activepag
                                             : ''
                                     }
@@ -118,7 +137,7 @@ function Pagination({
                             </li>
                         ))}
 
-                    {pageIndex < pagiData.max - (pagiData.range + 1) && (
+                    {currentPage < pagiData.max - (pagiData.range + 1) && (
                         <>
                             <li className={styles.paginationdot}>...</li>
                         </>
@@ -127,7 +146,7 @@ function Pagination({
                     <li className={styles.pagilink}>
                         <button
                             className={
-                                pageIndex === pagiData.max
+                                currentPage === pagiData.max
                                     ? styles.activepag
                                     : ''
                             }
@@ -140,12 +159,12 @@ function Pagination({
                     <li
                         className={cl(
                             styles.arrow,
-                            pageIndex < pagiData.max ? styles.activearrow : ''
+                            currentPage < pagiData.max ? styles.activearrow : ''
                         )}
                     >
                         <button
                             className="page-link"
-                            data-pagidata={pageIndex + 1}
+                            data-pagidata={currentPage + 1}
                             onClick={changePage}
                         >
                             <ContentForwardArrowDark />

--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -81,7 +81,7 @@ function Pagination({
                             <ContentForwardArrowDark />
                         </button>
                     </li>
-                    <li>
+                    <li className={styles.pagilink}>
                         <button
                             className={pageIndex === 1 ? styles.activepag : ''}
                             onClick={changePage}
@@ -93,16 +93,17 @@ function Pagination({
 
                     {pageIndex > pagiData.range &&
                         pageIndex > pagiData.range + 1 && (
-                            <li className="page-item">
-                                <button className={styles.paginationdot}>
-                                    ...
-                                </button>
-                            </li>
+                            <li className={styles.paginationdot}>...</li>
                         )}
                     {pagiData.listItems
                         .filter((itm) => itm !== pagiData.max && itm !== 1)
                         .map((itm: any, index: number) => (
-                            <li className="page-item" key={index}>
+                            <li
+                                className={
+                                    pageIndex === itm ? styles.pagilink : ''
+                                }
+                                key={index}
+                            >
                                 <button
                                     className={
                                         pageIndex === itm
@@ -117,24 +118,13 @@ function Pagination({
                             </li>
                         ))}
 
-                    {pageIndex < pagiData.max - 1 && (
+                    {pageIndex < pagiData.max - (pagiData.range + 1) && (
                         <>
-                            <li className="page-item">
-                                <button
-                                    className={cl(
-                                        pageIndex === pagiData.max
-                                            ? styles.activepag
-                                            : '',
-                                        styles.paginationdot
-                                    )}
-                                >
-                                    ...
-                                </button>
-                            </li>
+                            <li className={styles.paginationdot}>...</li>
                         </>
                     )}
 
-                    <li className="page-item">
+                    <li className={styles.pagilink}>
                         <button
                             className={
                                 pageIndex === pagiData.max

--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -15,7 +15,7 @@ const generatePaginationArr = (
 ) => {
     // number of list items to show before truncating
     const range: number = 2;
-    const max = Math.ceil((totalItems - 1) / itemsPerPage);
+    const max = Math.ceil(totalItems / itemsPerPage);
     const maxRange = (Math.floor(startAt / range) + 1) * range;
     // set the min range to be the max range minus the range if it is less than the max - range
     const minRange = startAt <= max - range ? maxRange - range : max - range;
@@ -39,30 +39,30 @@ const generatePaginationArr = (
 };
 
 function Pagination({
-    totalTxCount,
-    txNum,
+    totalItems,
+    itemsPerPage,
     currentPage = 0,
     onPagiChangeFn,
 }: {
-    totalTxCount: number;
-    txNum: number;
+    totalItems: number;
+    itemsPerPage: number;
     currentPage: number;
     onPagiChangeFn: Function;
 }) {
-    const [txNumPerPage, setTxNumPerPage] = useState(txNum);
+    const [txNumPerPage, setTxNumPerPage] = useState(itemsPerPage);
     const initData = generatePaginationArr(
         currentPage,
         txNumPerPage,
-        totalTxCount
+        totalItems
     );
     const [pagiData, setPagiData] = useState(initData);
 
     useEffect(() => {
         setPagiData(
-            generatePaginationArr(currentPage, txNumPerPage, totalTxCount)
+            generatePaginationArr(currentPage, txNumPerPage, totalItems)
         );
-        setTxNumPerPage(txNum);
-    }, [currentPage, totalTxCount, txNum, txNumPerPage]);
+        setTxNumPerPage(itemsPerPage);
+    }, [currentPage, totalItems, itemsPerPage, txNumPerPage]);
 
     const changePage = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {

--- a/explorer/client/src/components/tabs/TabFooter.tsx
+++ b/explorer/client/src/components/tabs/TabFooter.tsx
@@ -1,22 +1,38 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import { useState, useCallback } from 'react';
 
 import { numberSuffix } from '../../utils/numberUtil';
 
 import styles from './Tabs.module.css';
 
-//TODO: update this component to use account for multipe formats
+const NUMBER_OF_TX_PER_PAGE_OPTIONS = [20, 40, 60];
 // Update this footer now accept React.ReactElement as a child
 function TabFooter({
     stats,
     children,
+    paging,
+    itemsPerPageChange,
 }: {
     children?: React.ReactElement;
     stats?: {
         count: number | string;
         stats_text: string;
     };
+    paging?: number;
+    itemsPerPageChange?: Function;
 }) {
+    const [currentItemsPerPage, setPurrentItemsPerPage] = useState(
+        paging || NUMBER_OF_TX_PER_PAGE_OPTIONS[0]
+    );
+    const selectChange = useCallback(
+        (event: React.ChangeEvent<HTMLSelectElement>) => {
+            const selectedNum = parseInt(event.target.value);
+            setPurrentItemsPerPage(selectedNum);
+            itemsPerPageChange && itemsPerPageChange(selectedNum);
+        },
+        [itemsPerPageChange]
+    );
     return (
         <section className={styles.tabsfooter}>
             {children ? (
@@ -24,13 +40,31 @@ function TabFooter({
             ) : (
                 <></>
             )}
-            {stats && (
-                <p className={styles.stats}>
-                    {typeof stats.count === 'number'
-                        ? numberSuffix(stats.count)
-                        : stats.count}{' '}
-                    {stats.stats_text}
-                </p>
+            {(stats || paging) && (
+                <div className={styles.stats}>
+                    {stats && (
+                        <p>
+                            {typeof stats.count === 'number'
+                                ? numberSuffix(stats.count)
+                                : stats.count}{' '}
+                            {stats.stats_text}
+                        </p>
+                    )}
+                    {paging && (
+                        <div className={styles.pagedropdown}>
+                            <select
+                                value={currentItemsPerPage}
+                                onChange={selectChange}
+                            >
+                                {NUMBER_OF_TX_PER_PAGE_OPTIONS.map((item) => (
+                                    <option value={item} key={item}>
+                                        {item} Per Page
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    )}
+                </div>
             )}
         </section>
     );

--- a/explorer/client/src/components/tabs/Tabs.module.css
+++ b/explorer/client/src/components/tabs/Tabs.module.css
@@ -22,7 +22,7 @@
 }
 
 .tabsfooter {
-    @apply flex justify-between text-xs text-gray-500 capitalize items-center p-0;
+    @apply block md:flex justify-between text-gray-500 capitalize items-center p-0 mt-2  text-sm;
 }
 
 .tabsfooter a {
@@ -30,9 +30,56 @@
 }
 
 .stats {
-    @apply ml-auto w-full text-right;
+    @apply ml-auto w-full text-center md:text-right flex gap-2 justify-center md:justify-end items-center;
 }
 
 .tabsfooter nav {
     @apply flex flex-row items-center;
+}
+
+.pagedropdown button {
+    @apply text-[#767A81] font-[500] py-2 px-3 cursor-pointer 
+   border-[1px]  border-white bg-[#FFFFFF] hover:bg-[#F4FBFF] hidden md:flex text-[13px] w-[122px] justify-between items-center rounded-[6px];
+
+    border: 1px solid #f0f1f2;
+    transition: all 0.4s ease;
+}
+
+.pagedropdown svg {
+    @apply align-bottom;
+}
+
+.pagedropdown ul {
+    @apply absolute z-50 bg-[#FFFFFF] w-[120px] m-auto list-none  p-0 text-[13px] hidden;
+
+    border: 1px solid #f0f1f2;
+    border-radius: 0 0 6px 6px;
+    margin-top: -3px;
+    border-top: none;
+    transition: all 0.4s ease;
+}
+
+.pagedropdown ul li {
+    border-bottom: 1px solid #f0f1f2;
+}
+
+.pagedropdown ul li button {
+    @apply py-2 w-full;
+
+    border: none;
+    border-radius: 0;
+}
+
+.pagedropdown ul.open {
+    @apply block;
+}
+
+.pagedropdown ul li:first-child {
+    border-top: 1px solid #f0f1f2;
+}
+
+.pagedropdown select {
+    @apply text-[#767A81] font-[500] py-1.5 px-3 rounded-[6px] text-[13px] hidden md:block;
+
+    border: 1px solid #f0f1f2;
 }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -306,8 +306,8 @@ function LatestTxCard({ ...data }: RecentTx) {
                         {paginationtype !== 'none' ? (
                             paginationtype === 'pagination' ? (
                                 <Pagination
-                                    totalTxCount={count}
-                                    txNum={txPerPage}
+                                    totalItems={count}
+                                    itemsPerPage={txPerPage}
                                     onPagiChangeFn={setpageIndex}
                                     currentPage={pageIndex}
                                 />

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -160,11 +160,17 @@ function LatestTxCard({ ...data }: RecentTx) {
 
     useEffect(() => {
         let isMounted = true;
+
+        // If pageIndex is greater than maxTxPage, set to maxTxPage
+        const maxTxPage = Math.ceil(count / txPerPage);
+        const pg = pageIndex > maxTxPage ? maxTxPage : pageIndex;
+        setpageIndex(pg);
+
         pageIndex > 1
-            ? setSearchParams({ p: pageIndex.toString() })
+            ? setSearchParams({ p: pg.toString() })
             : setSearchParams({});
 
-        getRecentTransactions(network, count, txPerPage, pageIndex)
+        getRecentTransactions(network, count, txPerPage, pg)
             .then(async (resp: any) => {
                 if (isMounted) {
                     setIsLoaded(true);
@@ -190,15 +196,7 @@ function LatestTxCard({ ...data }: RecentTx) {
         return () => {
             isMounted = false;
         };
-    }, [
-        count,
-        network,
-        pageIndex,
-        paginationtype,
-        searchParams,
-        setSearchParams,
-        txPerPage,
-    ]);
+    }, [count, network, pageIndex, paginationtype, setSearchParams, txPerPage]);
 
     // update the page index when the user clicks on the pagination buttons
 

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -81,6 +81,21 @@ function generateStartEndRange(
     };
 }
 
+// Static data for development and testing
+const getRecentTransactionsStatic = (): Promise<TxnData[]> => {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const latestTx = getAllMockTransaction().map((tx) => ({
+                ...tx,
+                status: tx.status as ExecutionStatusType,
+                kind: tx.kind as TransactionKindName,
+            }));
+            resolve(latestTx as TxnData[]);
+        }, 500);
+    });
+};
+
+// TOD0: Optimize this method to use fewer API calls. Move the total tx count to this component.
 async function getRecentTransactions(
     network: Network | string,
     totalTx: number,
@@ -88,8 +103,11 @@ async function getRecentTransactions(
     pageNum?: number
 ): Promise<TxnData[]> {
     try {
+        // If static env, use static data
+        if (IS_STATIC_ENV) {
+            return getRecentTransactionsStatic();
+        }
         // Get the latest transactions
-
         // Instead of getRecentTransactions, use getTransactionCount
         // then use getTransactionDigestsInRange using the totalTx as the start totalTx sequence number - txNum as the end sequence number
         // Get the total number of transactions, then use as the start and end values for the getTransactionDigestsInRange
@@ -114,24 +132,96 @@ async function getRecentTransactions(
     }
 }
 
-// Pass Props txPerPage, truncateLength, paginationtype to the component so that this component can be used for both the Home Page and trnasaction page
-// TODO - rework this - gets confusing
-function LatestTxView({
-    results,
-}: {
-    results: {
-        loadState: string;
-        latestTx: TxnData[];
-        totalTxcount?: number;
-        txPerPage?: number;
-        truncateLength?: number;
-        paginationtype?: PaginationType;
-    };
-}) {
-    const totalCount = results.totalTxcount || 1;
-    const txPerPage = results.txPerPage || NUMBER_OF_TX_PER_PAGE;
-    const truncateLength = results.truncateLength || TRUNCATE_LENGTH;
-    const paginationtype = results.paginationtype || DEFAULT_PAGI_TYPE;
+type RecentTx = {
+    count?: number;
+    paginationtype?: PaginationType;
+    txPerPage?: number;
+    truncateLength?: number;
+};
+
+function LatestTxCard({ ...data }: RecentTx) {
+    const {
+        count = 0,
+        truncateLength = TRUNCATE_LENGTH,
+        paginationtype = DEFAULT_PAGI_TYPE,
+    } = data;
+
+    const [txPerPage, setTxPerPage] = useState(
+        data.txPerPage || NUMBER_OF_TX_PER_PAGE
+    );
+    const [isLoaded, setIsLoaded] = useState(false);
+    const [results, setResults] = useState(initState);
+    const [network] = useContext(NetworkContext);
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const [pageIndex, setpageIndex] = useState(
+        parseInt(searchParams.get('p') || '1', 10) || 1
+    );
+
+    useEffect(() => {
+        let isMounted = true;
+        pageIndex > 1
+            ? setSearchParams({ p: pageIndex.toString() })
+            : setSearchParams({});
+
+        getRecentTransactions(network, count, txPerPage, pageIndex)
+            .then(async (resp: any) => {
+                if (isMounted) {
+                    setIsLoaded(true);
+                }
+                setResults({
+                    loadState: 'loaded',
+                    latestTx: resp,
+                    totalTxcount: count,
+                });
+            })
+            .catch((err) => {
+                setResults({
+                    ...initState,
+                    loadState: 'fail',
+                });
+                setIsLoaded(false);
+                console.error(
+                    'Encountered error when fetching recent transactions',
+                    err
+                );
+                Sentry.captureException(err);
+            });
+        return () => {
+            isMounted = false;
+        };
+    }, [
+        count,
+        network,
+        pageIndex,
+        paginationtype,
+        searchParams,
+        setSearchParams,
+        txPerPage,
+    ]);
+
+    // update the page index when the user clicks on the pagination buttons
+
+    if (results.loadState === 'pending') {
+        return (
+            <div className={theme.textresults}>
+                <div className={styles.content}>Loading...</div>
+            </div>
+        );
+    }
+
+    if (!isLoaded && results.loadState === 'fail') {
+        return (
+            <ErrorResult
+                id=""
+                errorMsg="There was an issue getting the latest transactions"
+            />
+        );
+    }
+
+    if (results.loadState === 'loaded' && !results.latestTx.length) {
+        return <ErrorResult id="" errorMsg="No Transactions Found" />;
+    }
 
     //TODO update initial state and match the latestTx table data
     const defaultActiveTab = 0;
@@ -199,9 +289,10 @@ function LatestTxView({
     };
     const tabsFooter = {
         stats: {
-            count: totalCount || 0,
+            count,
             stats_text: 'Total transactions',
         },
+        pagingElement: txPerPage,
     };
 
     return (
@@ -209,12 +300,18 @@ function LatestTxView({
             <Tabs selected={defaultActiveTab}>
                 <div title="Transactions">
                     <TableCard tabledata={recentTx} />
-                    <TabFooter stats={tabsFooter.stats}>
+                    <TabFooter
+                        stats={tabsFooter.stats}
+                        paging={tabsFooter.pagingElement}
+                        itemsPerPageChange={setTxPerPage}
+                    >
                         {paginationtype !== 'none' ? (
                             paginationtype === 'pagination' ? (
                                 <Pagination
-                                    totalTxCount={totalCount}
+                                    totalTxCount={count}
                                     txNum={txPerPage}
+                                    onPagiChangeFn={setpageIndex}
+                                    currentPage={pageIndex}
                                 />
                             ) : (
                                 <Link className={styles.moretxbtn} to={`/`}>
@@ -231,116 +328,5 @@ function LatestTxView({
         </div>
     );
 }
-
-function LatestTxCardStatic() {
-    const latestTx = getAllMockTransaction().map((tx) => ({
-        ...tx,
-        status: tx.status as ExecutionStatusType,
-        kind: tx.kind as TransactionKindName,
-    }));
-
-    const results = {
-        loadState: 'loaded',
-        latestTx: latestTx,
-    };
-    return (
-        <>
-            <LatestTxView results={results} />
-        </>
-    );
-}
-
-type RecentTx = {
-    count?: number;
-    paginationtype?: PaginationType;
-    txPerPage?: number;
-    truncateLength?: number;
-};
-
-function LatestTxCardAPI({ ...data }: RecentTx) {
-    const {
-        count = 0,
-        txPerPage = NUMBER_OF_TX_PER_PAGE,
-        truncateLength = TRUNCATE_LENGTH,
-        paginationtype = DEFAULT_PAGI_TYPE,
-    } = data;
-    const [isLoaded, setIsLoaded] = useState(false);
-    const [results, setResults] = useState(initState);
-    const [network] = useContext(NetworkContext);
-    const [searchParams] = useSearchParams();
-
-    useEffect(() => {
-        let isMounted = true;
-        const pagedNum: number = parseInt(searchParams.get('p') || '1', 10);
-        getRecentTransactions(network, count, txPerPage, pagedNum)
-            .then(async (resp: any) => {
-                if (isMounted) {
-                    setIsLoaded(true);
-                }
-                setResults({
-                    loadState: 'loaded',
-                    latestTx: resp,
-                    totalTxcount: count,
-                    txPerPage: txPerPage,
-                    truncateLength: truncateLength,
-                    paginationtype,
-                });
-            })
-            .catch((err) => {
-                setResults({
-                    ...initState,
-                    loadState: 'fail',
-                });
-                setIsLoaded(false);
-                console.error(
-                    'Encountered error when fetching recent transactions',
-                    err
-                );
-                Sentry.captureException(err);
-            });
-
-        return () => {
-            isMounted = false;
-        };
-    }, [
-        count,
-        network,
-        paginationtype,
-        searchParams,
-        truncateLength,
-        txPerPage,
-    ]);
-
-    if (results.loadState === 'pending') {
-        return (
-            <div className={theme.textresults}>
-                <div className={styles.content}>Loading...</div>
-            </div>
-        );
-    }
-
-    if (!isLoaded && results.loadState === 'fail') {
-        return (
-            <ErrorResult
-                id=""
-                errorMsg="There was an issue getting the latest transactions"
-            />
-        );
-    }
-
-    if (results.loadState === 'loaded' && !results.latestTx.length) {
-        return <ErrorResult id="" errorMsg="No Transactions Found" />;
-    }
-
-    return (
-        <>
-            <LatestTxView results={results} />
-        </>
-    );
-}
-
-// Provide option to show pagination or not, so we can reuse this component for both homepage and the transactions page
-const LatestTxCard = ({ ...data }: RecentTx) =>
-    IS_STATIC_ENV ? <LatestTxCardStatic /> : <LatestTxCardAPI {...data} />;
 
 export default LatestTxCard;

--- a/explorer/client/src/pages/transaction-result/TxModuleView.module.css
+++ b/explorer/client/src/pages/transaction-result/TxModuleView.module.css
@@ -7,7 +7,7 @@ pre {
 
 section .codeview {
     border-color: transparent !important;
-    height: 450px !important;
+    max-height: 450px !important;
     @apply font-mono text-sm pl-0 pr-0;
 }
 
@@ -62,7 +62,7 @@ section .codeview pre {
 }
 
 .viewmore {
-    @apply flex justify-end;
+    @apply flex justify-end w-full font-normal text-sm;
 }
 
 .modulewrapper {
@@ -89,4 +89,12 @@ section .codeview pre {
     padding-right: 1em;
     user-select: none;
     opacity: 0.5;
+}
+
+.modulewraper nav ul {
+    @apply mt-3 md:mt-1 mx-0 px-0 justify-start;
+}
+
+.modulesfooter {
+    @apply flex justify-items-start md:justify-between text-[#636870] text-sm items-center;
 }

--- a/explorer/client/src/pages/transaction-result/TxModulesWrapper.tsx
+++ b/explorer/client/src/pages/transaction-result/TxModulesWrapper.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import cl from 'classnames';
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 
+import Pagination from '../../components/pagination/Pagination';
 import TxModuleView from './TxModuleView';
 
 import styles from './TxModuleView.module.css';
@@ -13,42 +13,47 @@ type TxModules = {
     content: any[];
 };
 
+const TX_MODULES_PER_PAGE = 3;
 // TODO: Include Pagination for now use viewMore and viewLess
 function TxModuleViewWrapper({ data }: { data: TxModules }) {
     const moduleData = useMemo(() => data, [data]);
-    const [viewMore, setVeiwMore] = useState(false);
+    const [modulesPageNumber, setModulesPageNumber] = useState(1);
     const totalModulesCount = moduleData.content.length;
-    const numOfMudulesToShow = 3;
-    const viewAll = useCallback(() => {
-        setVeiwMore(!viewMore);
-    }, [viewMore]);
+    const numOfMudulesToShow = TX_MODULES_PER_PAGE;
+
+    useEffect(() => {
+        setModulesPageNumber(modulesPageNumber);
+    }, [modulesPageNumber]);
+
     return (
-        <>
+        <div className={styles.modulewraper}>
             <h3 className={styles.txtitle}>Modules </h3>
             <div className={styles.txmodule}>
                 {moduleData.content
-                    .slice(0, viewMore ? totalModulesCount : numOfMudulesToShow)
+                    .filter(
+                        (_, index) =>
+                            index >=
+                                (modulesPageNumber - 1) * numOfMudulesToShow &&
+                            index < modulesPageNumber * numOfMudulesToShow
+                    )
                     .map((item, idx) => (
                         <TxModuleView itm={item} key={idx} />
                     ))}
             </div>
             {totalModulesCount > numOfMudulesToShow && (
-                <div className={styles.viewmore}>
-                    <button
-                        type="button"
-                        className={cl([
-                            styles.moretxbtn,
-                            viewMore && styles.viewless,
-                        ])}
-                        onClick={viewAll}
-                    >
-                        {viewMore
-                            ? 'View Less'
-                            : `View all (${totalModulesCount})`}
-                    </button>
+                <div className={styles.modulesfooter}>
+                    <Pagination
+                        totalItems={totalModulesCount}
+                        itemsPerPage={numOfMudulesToShow}
+                        currentPage={modulesPageNumber}
+                        onPagiChangeFn={setModulesPageNumber}
+                    />
+                    <div className={styles.viewmore}>
+                        {totalModulesCount} Total Modules
+                    </div>
                 </div>
             )}
-        </>
+        </div>
     );
 }
 export default TxModuleViewWrapper;


### PR DESCRIPTION
- Rewrite RecentTxCard to remove Static Component and just use static data. No need to duplicate components
- Pagination no longer triggers page change. The parent component handles that 
- Added dropdown selector that changes the number of transactions to display per page 
- Update the design to match the design update 
- update the mobile display base on the conversation on slack 
- Fix ... showing based on https://github.com/MystenLabs/sui/pull/3157#discussion_r924570934

https://user-images.githubusercontent.com/8676844/179850272-f0dab283-9021-472f-aa06-86c95ee238d2.mov



![Screen Shot 2022-07-19 at 11 09 45 AM](https://user-images.githubusercontent.com/8676844/179788199-5d8b284c-4b9b-4125-a178-6cfda8191db4.png)
![Screen Shot 2022-07-19 at 11 09 11 AM](https://user-images.githubusercontent.com/8676844/179788257-c8bb4290-9a93-4fad-9007-2e853367b86f.png)


