### PR TITLE
wallet-ext: fix menu backdrop

### DIFF
--- a/wallet/src/ui/app/components/menu/content/MenuContent.module.scss
+++ b/wallet/src/ui/app/components/menu/content/MenuContent.module.scss
@@ -13,6 +13,7 @@
     height: 100%;
     background-color: colors.$gray-100;
     opacity: 0.8;
+    border-radius: 20px 20px 0 0;
 }
 
 .content {


### PR DESCRIPTION
* sometimes the top corners are not rendered rounded for the backdrop and it doesn't look nice - this seems to fix the issue

(Sometimes) Before:

<img width="401" alt="Screenshot 2022-07-19 at 18 24 12" src="https://user-images.githubusercontent.com/10210143/179790459-590481f7-7299-4bb9-9d4e-05490e9b443f.png">


After: 

<img width="401" alt="Screenshot 2022-07-19 at 18 26 02" src="https://user-images.githubusercontent.com/10210143/179790537-251064dd-0d77-4579-97af-d25ed931b153.png">
