### PR TITLE
Trigger reconfiguration logic in checkpoint

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -269,7 +269,10 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Acquire the lock for a tx without writing to the WAL.
-    pub async fn acquire_tx_lock<'a>(&'a self, digest: &TransactionDigest) -> CertLockGuard<'a> {
+    pub async fn acquire_tx_lock<'a, 'b>(
+        &'a self,
+        digest: &'b TransactionDigest,
+    ) -> CertLockGuard<'a> {
         self.wal.acquire_lock(digest).await
     }
 

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -36,7 +36,7 @@ async fn checkpoint_active_flow_happy_path() {
                 .unwrap(),
         );
         let _active_handle = active_state
-            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
+            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests(), false)
             .await;
     }
 
@@ -122,6 +122,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
                 .spawn_checkpoint_process_with_config(
                     Default::default(),
                     CheckpointMetrics::new_for_tests(),
+                    false,
                 )
                 .await;
         });
@@ -218,6 +219,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
                 .spawn_checkpoint_process_with_config(
                     CheckpointProcessControl::default(),
                     CheckpointMetrics::new_for_tests(),
+                    false,
                 )
                 .await;
         });
@@ -313,6 +315,7 @@ async fn test_empty_checkpoint() {
                 .spawn_checkpoint_process_with_config(
                     CheckpointProcessControl::default(),
                     CheckpointMetrics::new_for_tests(),
+                    false,
                 )
                 .await;
         });

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -34,7 +34,7 @@ async fn pending_exec_storage_notify() {
                 .unwrap(),
         );
         let _active_handle = active_state
-            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
+            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests(), false)
             .await;
     }
 
@@ -120,7 +120,7 @@ async fn pending_exec_full() {
 
             active_state.clone().spawn_execute_process().await;
             active_state
-                .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
+                .spawn_checkpoint_process(CheckpointMetrics::new_for_tests(), false)
                 .await;
         });
     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -45,6 +45,10 @@ use self::reconstruction::FragmentReconstruction;
 pub type DBLabel = usize;
 const LOCALS: DBLabel = 0;
 
+// TODO: Make last checkpoint number of each epoch more flexible.
+// TODO: Make this bigger.
+pub const CHECKPOINT_COUNT_PER_EPOCH: u64 = 3;
+
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct CheckpointLocals {
     // The next checkpoint number expected.
@@ -798,6 +802,16 @@ impl CheckpointStore {
             .skip_to_last()
             .next()
             .map(|(_, ckp)| ckp))
+    }
+
+    pub fn is_ready_to_start_epoch_change(&mut self) -> bool {
+        let next_seq = self.next_checkpoint();
+        next_seq % CHECKPOINT_COUNT_PER_EPOCH == 0 && next_seq != 0
+    }
+
+    pub fn is_ready_to_finish_epoch_change(&mut self) -> bool {
+        let next_seq = self.next_checkpoint();
+        next_seq % CHECKPOINT_COUNT_PER_EPOCH == 1 && next_seq != 1
     }
 
     // Helper write functions

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -15,8 +15,8 @@ use sui_types::committee::Committee;
 use sui_types::crypto::PublicKeyBytes;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::SignedTransaction;
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::sui_system_state::SuiSystemState;
+use tracing::{debug, info, warn};
 use typed_store::Map;
 
 #[async_trait]
@@ -25,9 +25,6 @@ pub trait Reconfigurable {
 
     fn recreate(channel: tonic::transport::Channel) -> Self;
 }
-
-// TODO: Make last checkpoint number of each epoch more flexible.
-pub const CHECKPOINT_COUNT_PER_EPOCH: u64 = 200;
 
 const WAIT_BETWEEN_EPOCH_TX_QUERY_RETRY: Duration = Duration::from_millis(300);
 
@@ -39,23 +36,23 @@ where
     /// all transactions from the second to the least checkpoint of the epoch. It's called by a
     /// validator that belongs to the committee of the current epoch.
     pub async fn start_epoch_change(&self) -> SuiResult {
+        let epoch = self.state.committee.load().epoch;
+        info!(epoch=?epoch, "Starting epoch change");
         if let Some(checkpoints) = &self.state.checkpoints {
-            let mut checkpoints = checkpoints.lock();
-            let next_cp = checkpoints.get_locals().next_checkpoint;
             assert!(
-                Self::is_second_last_checkpoint_epoch(next_cp),
+                checkpoints.lock().is_ready_to_start_epoch_change(),
                 "start_epoch_change called at the wrong checkpoint",
             );
-
-            // drop checkpoints lock
         } else {
             unreachable!();
         }
 
         self.state.halted.store(true, Ordering::SeqCst);
+        info!(epoch=?epoch, "Validator halted for epoch change");
         while !self.state.batch_notifier.ticket_drained() {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
+        info!(epoch=?epoch, "Epoch change started");
         Ok(())
     }
 
@@ -63,19 +60,21 @@ where
     /// all transactions from the last checkpoint of the epoch. This function needs to be called by
     /// a validator that belongs to the committee of the next epoch.
     pub async fn finish_epoch_change(&self) -> SuiResult {
+        let epoch = self.state.committee.load().epoch();
+        info!(epoch=?epoch, "Finishing epoch change");
         assert!(
             self.state.halted.load(Ordering::SeqCst),
             "finish_epoch_change called when validator is not halted",
         );
         if let Some(checkpoints) = &self.state.checkpoints {
             let mut checkpoints = checkpoints.lock();
-            let next_cp = checkpoints.get_locals().next_checkpoint;
             assert!(
-                Self::is_last_checkpoint_epoch(next_cp),
+                checkpoints.is_ready_to_finish_epoch_change(),
                 "finish_epoch_change called at the wrong checkpoint",
             );
 
             for (tx_digest, _) in checkpoints.extra_transactions.iter() {
+                debug!(epoch=?epoch, tx_digest=?tx_digest.transaction, "Reverting local transaction effects");
                 self.state
                     .database
                     .revert_state_update(&tx_digest.transaction)?;
@@ -105,6 +104,7 @@ where
             })
             .collect();
         let new_committee = Committee::new(next_epoch, votes)?;
+        debug!(epoch=?epoch, "New committee for the next epoch: {:?}", new_committee);
         self.state.insert_new_epoch_info(&new_committee)?;
 
         // Reconnect the network if we have an type of AuthorityClient that has a network.
@@ -131,6 +131,7 @@ where
             self.state.name,
             &*self.state.secret,
         );
+        debug!(epoch=?epoch, "System transaction to advance epoch: {:?}", advance_epoch_tx);
         // Add the signed transaction to the store.
         self.state
             .set_transaction_lock(&[], advance_epoch_tx.clone())
@@ -139,33 +140,28 @@ where
         // Collect a certificate for this system transaction that changes epoch,
         // and execute it locally.
         loop {
-            if let Ok(certificate) = self
+            let err = match self
                 .net
                 .load()
                 .process_transaction(advance_epoch_tx.clone().to_transaction())
                 .await
             {
-                self.state
-                    .handle_certificate(certificate)
-                    .await
-                    .expect("Executing the special cert cannot fail");
-                break;
-            }
-
+                Ok(certificate) => match self.state.handle_certificate(certificate).await {
+                    Ok(_) => {
+                        break;
+                    }
+                    Err(err) => err,
+                },
+                Err(err) => err,
+            };
+            warn!(epoch=?epoch, "Error when processing advance epoch transaction: {:?}", err);
             tokio::time::sleep(WAIT_BETWEEN_EPOCH_TX_QUERY_RETRY).await;
         }
 
         // Resume the validator to start accepting transactions for the new epoch.
         self.state.unhalt_validator()?;
+        info!(epoch=?epoch, "Validator unhalted. Epoch change finished");
         Ok(())
-    }
-
-    pub fn is_last_checkpoint_epoch(checkpoint: CheckpointSequenceNumber) -> bool {
-        checkpoint > 0 && checkpoint % CHECKPOINT_COUNT_PER_EPOCH == 0
-    }
-
-    pub fn is_second_last_checkpoint_epoch(checkpoint: CheckpointSequenceNumber) -> bool {
-        (checkpoint + 1) % CHECKPOINT_COUNT_PER_EPOCH == 0
     }
 
     /// Recreates the network if the client is a type of client that has a network, and swap the new

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -21,9 +21,10 @@ use sui_types::{
 };
 
 use crate::{
-    authority::TemporaryStore, authority_active::ActiveAuthority,
+    authority::TemporaryStore,
+    authority_active::ActiveAuthority,
     authority_aggregator::authority_aggregator_tests::init_local_authorities,
-    checkpoints::CheckpointLocals, epoch::reconfiguration::CHECKPOINT_COUNT_PER_EPOCH,
+    checkpoints::{CheckpointLocals, CHECKPOINT_COUNT_PER_EPOCH},
     execution_engine,
 };
 
@@ -44,7 +45,7 @@ async fn test_start_epoch_change() {
         .unwrap()
         .lock()
         .set_locals_for_testing(CheckpointLocals {
-            next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH - 1,
+            next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
             proposal_next_transaction: None,
             next_transaction_sequence: 0,
             no_more_fragments: true,
@@ -168,7 +169,7 @@ async fn test_finish_epoch_change() {
             async {
                 // Set the checkpoint number to be near the end of epoch.
                 let mut locals = CheckpointLocals {
-                    next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH - 1,
+                    next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
                     proposal_next_transaction: None,
                     next_transaction_sequence: 0,
                     no_more_fragments: true,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -183,9 +183,10 @@ impl SuiNode {
                         Some(active_authority.clone().spawn_execute_process().await),
                         Some(
                             active_authority
-                                .spawn_checkpoint_process(CheckpointMetrics::new(
-                                    &prometheus_registry,
-                                ))
+                                .spawn_checkpoint_process(
+                                    CheckpointMetrics::new(&prometheus_registry),
+                                    config.enable_reconfig,
+                                )
                                 .await,
                         ),
                     )

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -90,6 +90,7 @@ pub async fn spawn_checkpoint_processes(
             .spawn_checkpoint_process_with_config(
                 checkpoint_process_control,
                 CheckpointMetrics::new_for_tests(),
+                false,
             )
             .await;
     }


### PR DESCRIPTION
This PR adds the connection between checkpoint and reconfiguration: it starts and finishes the reconfig process at specific checkpoints.
Currently it's gated behind a config and it's off.
The lifetime strikes again and I had to annotate `acquire_tx_lock`. 