### PR TITLE
Execution driver uses NodeSyncState for certificate execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6533,6 +6533,7 @@ dependencies = [
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=49613b62072eba3f3b2316f54fbe6a9e1926697b)",
  "node",
+ "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions",
  "prometheus",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -29,6 +29,7 @@ prometheus = "0.13.1"
 arc-swap = "1.5.0"
 tokio-retry = "0.3"
 scopeguard = "1.1"
+once_cell = "1.11.0"
 
 sui-adapter = { path = "../sui-adapter" }
 sui-framework = { path = "../sui-framework" }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -381,7 +381,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Get all stored certificate digests
-    pub fn get_pending_certificates(
+    pub fn get_pending_digests(
         &self,
     ) -> SuiResult<Vec<(InternalSequenceNumber, TransactionDigest)>> {
         Ok(self.pending_execution.iter().collect())
@@ -397,7 +397,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     // Empty the pending_execution table, and remove the certs from the certificates table.
     pub fn remove_all_pending_certificates(&self) -> SuiResult {
-        let all_pending_tx = self.get_pending_certificates()?;
+        let all_pending_tx = self.get_pending_digests()?;
         let mut batch = self.pending_execution.batch();
         batch = batch.delete_batch(
             &self.certificates,

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -30,7 +30,7 @@ use crate::epoch::reconfiguration::Reconfigurable;
 use crate::{
     authority_aggregator::{AuthorityAggregator, ReduceOutput},
     authority_client::AuthorityAPI,
-    checkpoints::{proposal::CheckpointProposal, CheckpointStore},
+    checkpoints::CheckpointStore,
     node_sync::NodeSyncState,
 };
 

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -26,12 +26,13 @@ use sui_types::{
 };
 use tokio::time::Instant;
 
-use crate::epoch::reconfiguration::Reconfigurable;
+use futures::stream::StreamExt;
+
 use crate::{
     authority_aggregator::{AuthorityAggregator, ReduceOutput},
     authority_client::AuthorityAPI,
     checkpoints::CheckpointStore,
-    node_sync::NodeSyncState,
+    epoch::reconfiguration::Reconfigurable,
 };
 
 use sui_types::committee::{Committee, StakeUnit};
@@ -647,11 +648,25 @@ where
         let (past, contents) =
             get_one_checkpoint_with_contents(net.clone(), seq, &available_authorities).await?;
 
-        active_authority
-            .node_sync_state
-            .clone()
+        let errors = active_authority
+            .node_sync_handle()
             .sync_checkpoint(&contents)
-            .await?;
+            .zip(futures::stream::iter(contents.iter()))
+            .filter_map(|(r, digests)| async move {
+                r.map_err(|e| {
+                    info!(?digests, "failed to execute digest from checkpoint: {}", e);
+                    e
+                })
+                .err()
+            })
+            .collect::<Vec<SuiError>>()
+            .await;
+
+        if !errors.is_empty() {
+            let error = "Failed to sync transactions in checkpoint".to_string();
+            error!(?seq, "{}", error);
+            return Err(SuiError::CheckpointingError { error });
+        }
 
         checkpoint_db.lock().process_new_checkpoint_certificate(
             &past,

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -85,11 +85,9 @@ where
         // map to extract digest
         .handle_execution_request(pending_transactions.iter().map(|(_, digest)| *digest))
         // zip results back together with seq
-        .zip(stream::iter(
-            pending_transactions.iter().map(|(seq, _)| *seq),
-        ))
+        .zip(stream::iter(pending_transactions.iter()))
         // filter out errors
-        .filter_map(|(result, seq)| async move { result.ok().map(|_| seq) })
+        .filter_map(|(result, (seq, _))| async move { result.ok().map(|_| seq) })
         .collect()
         .await;
 

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -4,12 +4,13 @@
 use std::sync::Arc;
 use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::CertifiedTransaction};
 use tracing::{debug, info};
-use typed_store::Map;
 
 use crate::authority::AuthorityStore;
 use crate::authority_client::AuthorityAPI;
 
-use super::{gossip::LocalCertificateHandler, ActiveAuthority};
+use futures::{stream, StreamExt};
+
+use super::ActiveAuthority;
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -74,54 +75,23 @@ async fn execute_pending<A>(active_authority: &ActiveAuthority<A>) -> SuiResult<
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    let _committee = active_authority.state.committee.load().clone();
-    let net = active_authority.net.load().clone();
-
     // Get the pending transactions
     let pending_transactions = active_authority.state.database.get_pending_digests()?;
 
-    // Get all the actual certificates mapping to these pending transactions
-    let certs = active_authority
-        .state
-        .database
-        .certificates
-        .multi_get(pending_transactions.iter().map(|(_, d)| *d))?;
+    let sync_handle = active_authority.node_sync_handle();
 
-    // Zip seq, digest with certs. Note the cert must exist in the DB
-    let cert_seq: Vec<_> = pending_transactions
-        .iter()
-        .zip(certs.iter())
-        .map(|((i, d), c)| (i, d, c.as_ref().expect("certificate must exist")))
-        .collect();
-
-    let local_handler = LocalCertificateHandler {
-        state: active_authority.state.clone(),
-    };
-
-    // TODO: implement properly efficient execution for the block of transactions.
-    let mut executed = vec![];
-    for (i, d, c) in cert_seq {
-        // Only execute if not already executed.
-        if active_authority.state.database.effects_exists(d)? {
-            executed.push(*i);
-            continue;
-        }
-
-        debug!(digest=?d, "Pending execution for certificate.");
-
-        // Sync and Execute with local authority state
-        net.sync_certificate_to_authority_with_timeout_inner(
-            c.clone(),
-            active_authority.state.name,
-            &local_handler,
-            tokio::time::Duration::from_secs(10),
-            10,
-        )
-        .await?;
-
-        // Remove from the execution list
-        executed.push(*i);
-    }
+    // Send them for execution
+    let executed = sync_handle
+        // map to extract digest
+        .handle_execution_request(pending_transactions.iter().map(|(_, digest)| *digest))
+        // zip results back together with seq
+        .zip(stream::iter(
+            pending_transactions.iter().map(|(seq, _)| *seq),
+        ))
+        // filter out errors
+        .filter_map(|(result, seq)| async move { result.ok().map(|_| seq) })
+        .collect()
+        .await;
 
     // Now update the pending store.
     active_authority

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -78,7 +78,7 @@ where
     let net = active_authority.net.load().clone();
 
     // Get the pending transactions
-    let pending_transactions = active_authority.state.database.get_pending_certificates()?;
+    let pending_transactions = active_authority.state.database.get_pending_digests()?;
 
     // Get all the actual certificates mapping to these pending transactions
     let certs = active_authority

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -85,7 +85,7 @@ async fn pending_exec_storage_notify() {
     // get back the certificates
     let certs_back = authority_state
         .database
-        .get_pending_certificates()
+        .get_pending_digests()
         .expect("DB should be there");
     assert_eq!(num_certs, certs_back.len());
 }
@@ -166,7 +166,7 @@ async fn pending_exec_full() {
         .expect("Storage is ok");
     let certs_back = authority_state
         .database
-        .get_pending_certificates()
+        .get_pending_digests()
         .expect("DB should be there");
     assert_eq!(num_certs, certs_back.len());
 
@@ -177,7 +177,7 @@ async fn pending_exec_full() {
     // get back the certificates
     let certs_back = authority_state
         .database
-        .get_pending_certificates()
+        .get_pending_digests()
         .expect("DB should be there");
     assert_eq!(0, certs_back.len());
 }

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     authority::AuthorityState,
     authority_aggregator::{AuthorityAggregator, CertificateHandler},
     authority_client::AuthorityAPI,
-    node_sync::NodeSyncDigestHandler,
     safe_client::SafeClient,
 };
 use async_trait::async_trait;
@@ -83,7 +82,7 @@ where
     follower_process(
         active_authority,
         degree,
-        NodeSyncDigestHandler::new(active_authority.node_sync_state.clone()),
+        active_authority.node_sync_handle(),
         GossipType::Full,
     )
     .await;

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -20,7 +20,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use sui_storage::{follower_store::FollowerStore, node_sync_store::NodeSyncStore};
+use sui_storage::follower_store::FollowerStore;
 use sui_types::committee::StakeUnit;
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests},
@@ -76,19 +76,14 @@ where
     .await;
 }
 
-pub async fn node_sync_process<A>(
-    active_authority: &ActiveAuthority<A>,
-    degree: usize,
-    node_sync_store: Arc<NodeSyncStore>,
-) where
+pub async fn node_sync_process<A>(active_authority: &ActiveAuthority<A>, degree: usize)
+where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    let state = active_authority.state.clone();
-    let aggregator = active_authority.net.load().clone();
     follower_process(
         active_authority,
         degree,
-        NodeSyncDigestHandler::new(state, aggregator, node_sync_store),
+        NodeSyncDigestHandler::new(active_authority.node_sync_state.clone()),
         GossipType::Full,
     )
     .await;

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1625,7 +1625,8 @@ where
 
     pub async fn handle_transaction_and_effects_info_request(
         &self,
-        digests: &ExecutionDigests,
+        digest: &TransactionDigest,
+        effects_digest: Option<&TransactionEffectsDigest>,
         // authorities known to have the effects we are requesting.
         authorities: Option<&BTreeSet<AuthorityName>>,
         timeout_total: Option<Duration>,
@@ -1636,7 +1637,7 @@ where
             |authority, client| {
                 Box::pin(async move {
                     let resp = client
-                        .handle_transaction_and_effects_info_request(digests)
+                        .handle_transaction_and_effects_info_request(digest, effects_digest)
                         .await?;
 
                     match (resp.certified_transaction, resp.signed_effects) {
@@ -1647,9 +1648,7 @@ where
                                 // cert and effects, so if they now say they don't, they're byzantine.
                                 Err(SuiError::ByzantineAuthoritySuspicion { authority })
                             } else {
-                                Err(SuiError::TransactionNotFound {
-                                    digest: digests.transaction,
-                                })
+                                Err(SuiError::TransactionNotFound { digest: *digest })
                             }
                         }
                     }

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -161,7 +161,7 @@ where
 }
 
 struct DigestsMessage {
-    digests: ExecutionDigests,
+    sync_arg: SyncArg,
     peer: Option<AuthorityName>,
     tx: Option<oneshot::Sender<SuiResult>>,
 }
@@ -169,7 +169,15 @@ struct DigestsMessage {
 impl DigestsMessage {
     fn new_for_ckpt(digests: &ExecutionDigests) -> Self {
         Self {
-            digests: *digests,
+            sync_arg: SyncArg::Checkpoint(*digests),
+            peer: None,
+            tx: None,
+        }
+    }
+
+    fn new_for_exec_driver(digest: &TransactionDigest) -> Self {
+        Self {
+            sync_arg: SyncArg::ExecDriver(*digest),
             peer: None,
             tx: None,
         }
@@ -181,19 +189,41 @@ impl DigestsMessage {
         tx: oneshot::Sender<SuiResult>,
     ) -> Self {
         Self {
-            digests: *digests,
+            sync_arg: SyncArg::Follow(*digests),
             peer: Some(peer),
             tx: Some(tx),
         }
     }
 }
 
-#[derive(Copy, Clone)]
-pub enum SyncMode {
+#[derive(Copy, Clone, Debug)]
+pub enum SyncArg {
     /// In follow mode, wait for 2f+1 votes for a tx before executing
-    Follow,
+    Follow(ExecutionDigests),
     /// In checkpoint mode, all txes are known to be final.
-    Checkpoint,
+    Checkpoint(ExecutionDigests),
+
+    /// Used by the execution driver to execute pending certs. No effects digest is provided,
+    /// because this mode is used on validators only, who must compute the effects digest
+    /// themselves - they cannot trust some other validator's version of the effects because that
+    /// validator may be byzantine.
+    ExecDriver(TransactionDigest),
+}
+
+impl SyncArg {
+    fn digests(&self) -> (&TransactionDigest, Option<&TransactionEffectsDigest>) {
+        match self {
+            SyncArg::Checkpoint(ExecutionDigests {
+                transaction,
+                effects,
+            })
+            | SyncArg::Follow(ExecutionDigests {
+                transaction,
+                effects,
+            }) => (transaction, Some(effects)),
+            SyncArg::ExecDriver(digest) => (digest, None),
+        }
+    }
 }
 
 /// NodeSyncState is shared by any number of NodeSyncDigestHandler's, and receives DigestsMessage
@@ -238,11 +268,7 @@ where
 {
     fn start(self: Arc<Self>, receiver: mpsc::Receiver<DigestsMessage>) -> JoinHandle<()> {
         let state = self;
-        tokio::spawn(async move {
-            state
-                .handle_stream(SyncMode::Follow, ReceiverStream::new(receiver))
-                .await
-        })
+        tokio::spawn(async move { state.handle_stream(ReceiverStream::new(receiver)).await })
     }
 
     pub async fn sync_checkpoint(
@@ -255,21 +281,17 @@ where
                 .iter()
                 .map(DigestsMessage::new_for_ckpt),
         );
-        self.handle_stream(SyncMode::Checkpoint, stream).await;
+        self.handle_stream(stream).await;
         Ok(())
     }
 
-    async fn handle_stream(
-        self: Arc<Self>,
-        mode: SyncMode,
-        stream: impl Stream<Item = DigestsMessage>,
-    ) {
+    async fn handle_stream(self: Arc<Self>, stream: impl Stream<Item = DigestsMessage>) {
         // this pattern for limiting concurrency is from
         // https://github.com/tokio-rs/tokio/discussions/2648
         let limit = Arc::new(Semaphore::new(MAX_NODE_SYNC_CONCURRENCY));
         let mut stream = Box::pin(stream);
 
-        while let Some(DigestsMessage { digests, peer, tx }) = stream.next().await {
+        while let Some(DigestsMessage { sync_arg, peer, tx }) = stream.next().await {
             let state = self.clone();
             let limit = limit.clone();
             tokio::spawn(async move {
@@ -277,11 +299,16 @@ where
                 // the semaphore in this context.
                 let permit = limit.acquire_owned().await.unwrap();
 
-                let res = state
-                    .process_digest(mode, peer.as_ref(), digests, permit)
-                    .await;
+                let res = state.process_digest(peer.as_ref(), sync_arg, permit).await;
                 if let Err(error) = &res {
-                    error!(?digests, ?peer, "process_digest failed: {}", error);
+                    let (digest, effects_digest) = sync_arg.digests();
+                    error!(
+                        ?digest,
+                        ?effects_digest,
+                        ?peer,
+                        "process_digest failed: {}",
+                        error
+                    );
                 }
 
                 if let Some(tx) = tx {
@@ -291,8 +318,10 @@ where
                         // This will happen any time the follower times out and restarts, but
                         // that's ok - the follower won't have marked this digest as processed so it
                         // will be retried.
+                        let (digest, effects_digest) = sync_arg.digests();
                         debug!(
-                            ?digests,
+                            ?digest,
+                            ?effects_digest,
                             ?peer,
                             "could not send process_digest response to caller",
                         );
@@ -304,15 +333,16 @@ where
 
     async fn process_digest(
         &self,
-        mode: SyncMode,
         peer: Option<&AuthorityName>,
-        digests: ExecutionDigests,
+        arg: SyncArg,
         permit: OwnedSemaphorePermit,
     ) -> SuiResult {
-        trace!(?digests, ?peer, "process_digest");
+        trace!(?arg, ?peer, "process_digest");
+
+        let (digest, effects_digest) = arg.digests();
 
         // check if we the tx is already locally final
-        if self.state.database.effects_exists(&digests.transaction)? {
+        if self.state.database.effects_exists(digest)? {
             return Ok(());
         }
 
@@ -328,9 +358,8 @@ where
         //
         // These optimizations may well be worth it at some point if we are trying to get latency
         // down.
-
-        let authorities_with_cert = match mode {
-            SyncMode::Follow => {
+        let (cert, authorities_with_cert) = match arg {
+            SyncArg::Follow(digests) => {
                 let peer = peer.ok_or_else(|| SuiError::GenericAuthorityError {
                     error: "peer should be provided in SyncMode::Follow".into(),
                 })?;
@@ -362,66 +391,111 @@ where
 
                 trace!(?digests, ?peer, "digests are now final");
 
-                Some(self.effects_stake.lock().unwrap().voters(&digests.effects))
+                (
+                    None,
+                    Some(self.effects_stake.lock().unwrap().voters(&digests.effects)),
+                )
             }
-            SyncMode::Checkpoint => {
+            SyncArg::Checkpoint(digests) => {
                 trace!(
                     ?digests,
                     ?peer,
                     "skipping finality check, syncing from checkpoint."
                 );
-                None
+                (None, None)
+            }
+            SyncArg::ExecDriver(digest) => {
+                trace!(?digest, "validator pending execution requested");
+
+                // Check if we already have the cert locally.
+                match self.state.database.read_certificate(&digest)? {
+                    Some(cert) => (Some(cert), None),
+                    None => {
+                        let authorities: BTreeSet<_> = self
+                            .committee
+                            .names()
+                            .filter(|n| **n != self.state.name)
+                            .cloned()
+                            .collect();
+                        (None, Some(authorities))
+                    }
+                }
             }
         };
 
-        // Download the cert and effects now that we have established finality and we know that the
-        // effects digest is correct.
-        let (cert, effects) = self
-            .download_cert_and_effects(authorities_with_cert, &digests)
-            .await?;
+        enum CertAndEffects {
+            // TODO: perhaps we should start storing these things in Box<>s.
+            #[allow(clippy::large_enum_variant)]
+            Fullnode(CertifiedTransaction, SignedTransactionEffects),
+            Validator(CertifiedTransaction),
+        }
+
+        let cert_and_effects = match (self.state.is_fullnode(), cert) {
+            (false, Some(cert)) => CertAndEffects::Validator(cert),
+            (is_fullnode, _) => {
+                // Download the cert and effects - either finality has been establish (above), or
+                // we are a validator.
+                let (cert, effects) = self
+                    .download_cert_and_effects(authorities_with_cert, digest, effects_digest)
+                    .await?;
+
+                if is_fullnode {
+                    CertAndEffects::Fullnode(cert, effects)
+                } else {
+                    CertAndEffects::Validator(cert)
+                }
+            }
+        };
 
         // we're done downloading at this point, so we no longer need to prevent other tasks from
         // starting.
         std::mem::drop(permit);
 
-        for parent in effects.effects.dependencies.iter() {
-            let (_, mut rx) = self.pending_txes.wait(parent).await;
+        match cert_and_effects {
+            CertAndEffects::Fullnode(cert, effects) => {
+                for parent in effects.effects.dependencies.iter() {
+                    let (_, mut rx) = self.pending_txes.wait(parent).await;
 
-            if self.state.database.effects_exists(parent)? {
-                continue;
+                    if self.state.database.effects_exists(parent)? {
+                        continue;
+                    }
+
+                    trace!(?parent, ?digest, "waiting for parent");
+                    // Since we no longer hold the semaphore permit, can be sure that our parent will be
+                    // able to start.
+                    rx.recv()
+                        .await
+                        .map_err(|e| SuiError::GenericAuthorityError {
+                            error: format!("{:?}", e),
+                        })?;
+                }
+
+                if cfg!(debug_assertions) {
+                    for parent in effects.effects.dependencies.iter() {
+                        debug_assert!(self.state.database.effects_exists(parent).unwrap());
+                    }
+                }
+
+                self.state
+                    .handle_node_sync_certificate(cert, effects.clone())
+                    .await?;
+
+                self.effects_stake
+                    .lock()
+                    .unwrap()
+                    .forget_effects(&effects.effects.digest());
             }
-
-            trace!(?parent, digest = ?digests.transaction, "waiting for parent");
-            // Since we no longer hold the semaphore permit, can be sure that our parent will be
-            // able to start.
-            rx.recv()
-                .await
-                .map_err(|e| SuiError::GenericAuthorityError {
-                    error: format!("{:?}", e),
-                })?;
-        }
-
-        if cfg!(debug_assertions) {
-            for parent in effects.effects.dependencies.iter() {
-                debug_assert!(self.state.database.effects_exists(parent).unwrap());
+            CertAndEffects::Validator(cert) => {
+                self.state.handle_certificate(cert).await?;
             }
         }
-
-        self.state
-            .handle_node_sync_certificate(cert, effects)
-            .await?;
 
         // Garbage collect data for this tx.
-        self.node_sync_store
-            .delete_cert_and_effects(&digests.transaction)?;
-        self.effects_stake
-            .lock()
-            .unwrap()
-            .forget_effects(&digests.effects);
+        self.node_sync_store.delete_cert_and_effects(digest)?;
 
         // Notify waiting child transactions.
-        trace!(digest = ?digests.transaction, "notifying parent");
-        self.pending_txes.notify(&digests.transaction, ()).await?;
+        trace!(?digest, "notifying parent");
+        self.pending_txes.notify(digest, ()).await?;
         Ok(())
     }
 
@@ -431,25 +505,27 @@ where
     async fn download_cert_and_effects(
         &self,
         authorities_with_cert: Option<BTreeSet<AuthorityName>>,
-        digests: &ExecutionDigests,
+        digest: &TransactionDigest,
+        effects_digest: Option<&TransactionEffectsDigest>,
     ) -> SuiResult<(CertifiedTransaction, SignedTransactionEffects)> {
-        let digest = digests.transaction;
-        if let Some(c) = self.node_sync_store.get_cert_and_effects(&digest)? {
+        if let Some(c) = self.node_sync_store.get_cert_and_effects(digest)? {
             return Ok(c);
         }
 
-        let (tx, mut rx) = self.pending_downloads.wait(&digest).await;
+        let (tx, mut rx) = self.pending_downloads.wait(digest).await;
         // Only start the download if there are no other concurrent downloads.
         if let Some(tx) = tx {
             let aggregator = self.aggregator.clone();
-            let digests = *digests;
             let node_sync_store = self.node_sync_store.clone();
+            let digest = *digest;
+            let effects_digest = effects_digest.cloned();
             tokio::task::spawn(async move {
                 if let Err(error) = tx.send(
                     Self::download_impl(
                         authorities_with_cert,
                         aggregator,
-                        &digests,
+                        digest,
+                        effects_digest,
                         node_sync_store,
                     )
                     .await,
@@ -466,7 +542,7 @@ where
             })??;
 
         self.node_sync_store
-            .get_cert_and_effects(&digest)?
+            .get_cert_and_effects(digest)?
             .ok_or_else(|| SuiError::GenericAuthorityError {
                 error: format!(
                     "cert/effects for {:?} should have been in the node_sync_store",
@@ -478,13 +554,17 @@ where
     async fn download_impl(
         authorities: Option<BTreeSet<AuthorityName>>,
         aggregator: Arc<AuthorityAggregator<A>>,
-        digests: &ExecutionDigests,
+        digest: TransactionDigest,
+        effects_digest: Option<TransactionEffectsDigest>,
         node_sync_store: Arc<NodeSyncStore>,
     ) -> SuiResult {
-        let digest = digests.transaction;
-
         let (cert, effects) = aggregator
-            .handle_transaction_and_effects_info_request(digests, authorities.as_ref(), None)
+            .handle_transaction_and_effects_info_request(
+                &digest,
+                effects_digest.as_ref(),
+                authorities.as_ref(),
+                None,
+            )
             .await?;
 
         node_sync_store.store_cert_and_effects(&digest, &(cert, effects))?;

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -45,8 +45,8 @@ impl<C> SafeClient<C> {
     // Here we centralize all checks for transaction info responses
     fn check_transaction_response(
         &self,
-        digest: TransactionDigest,
-        effects_digest: Option<TransactionEffectsDigest>,
+        digest: &TransactionDigest,
+        effects_digest: Option<&TransactionEffectsDigest>,
         response: &TransactionInfoResponse,
     ) -> SuiResult {
         if let Some(signed_transaction) = &response.signed_transaction {
@@ -61,7 +61,7 @@ impl<C> SafeClient<C> {
             );
             // Check it's the right transaction
             fp_ensure!(
-                signed_transaction.digest() == &digest,
+                signed_transaction.digest() == digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -73,7 +73,7 @@ impl<C> SafeClient<C> {
             certificate.verify(&self.committee)?;
             // Check it's the right transaction
             fp_ensure!(
-                certificate.digest() == &digest,
+                certificate.digest() == digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -92,7 +92,7 @@ impl<C> SafeClient<C> {
             );
             // Checks it concerns the right tx
             fp_ensure!(
-                signed_effects.effects.transaction_digest == digest,
+                signed_effects.effects.transaction_digest == *digest,
                 SuiError::ByzantineAuthoritySuspicion {
                     authority: self.address
                 }
@@ -299,7 +299,7 @@ where
             .authority_client
             .handle_transaction(transaction)
             .await?;
-        if let Err(err) = self.check_transaction_response(digest, None, &transaction_info) {
+        if let Err(err) = self.check_transaction_response(&digest, None, &transaction_info) {
             self.report_client_error(err.clone());
             return Err(err);
         }
@@ -317,7 +317,7 @@ where
             .handle_certificate(certificate)
             .await?;
 
-        if let Err(err) = self.check_transaction_response(digest, None, &transaction_info) {
+        if let Err(err) = self.check_transaction_response(&digest, None, &transaction_info) {
             self.report_client_error(err.clone());
             return Err(err);
         }
@@ -359,7 +359,7 @@ where
             .handle_transaction_info_request(request)
             .await?;
 
-        if let Err(err) = self.check_transaction_response(digest, None, &transaction_info) {
+        if let Err(err) = self.check_transaction_response(&digest, None, &transaction_info) {
             self.report_client_error(err.clone());
             return Err(err);
         }
@@ -369,18 +369,15 @@ where
     /// Handle Transaction + Effects information requests for this account.
     pub async fn handle_transaction_and_effects_info_request(
         &self,
-        digests: &ExecutionDigests,
+        digest: &TransactionDigest,
+        effects_digest: Option<&TransactionEffectsDigest>,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        let digest = digests.transaction;
-        let effects_digest = digests.effects;
-
         let transaction_info = self
             .authority_client
-            .handle_transaction_info_request(digest.into())
+            .handle_transaction_info_request((*digest).into())
             .await?;
 
-        if let Err(err) =
-            self.check_transaction_response(digest, Some(effects_digest), &transaction_info)
+        if let Err(err) = self.check_transaction_response(digest, effects_digest, &transaction_info)
         {
             self.report_client_error(err.clone());
             return Err(err);

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -82,7 +82,7 @@ async fn wait_for_advance_to_next_checkpoint(
             false => tokio::time::sleep(Duration::from_secs(1)).await,
         }
         cnt += 1;
-        assert!(cnt <= 20);
+        assert!(cnt <= 40);
     }
 
     // Ensure all authorities moved to the next checkpoint sequence number.


### PR DESCRIPTION
This takes care of the performance TODOs in execution driver (for now, at least).

It also makes it acceptable for checkpoints to pend digests for which it doesn't have certs (they will be fetched).

Note that this does not automatically fetch parent certs, and assumes that they will be enqueued as well (or are already executed). If we're not comfortable with this assumption we can certainly add parent fetching to NodeSyncState.