### PR TITLE
Fix a bug in TransactionEffects that didn't capture unwrapped objects

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -681,7 +681,7 @@ impl AuthorityState {
         indexes.index_tx(
             cert.sender_address(),
             cert.data.input_objects()?.iter().map(|o| o.object_id()),
-            effects.effects.mutated_and_created(),
+            effects.effects.all_mutated(),
             cert.data
                 .move_calls()?
                 .iter()

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1311,11 +1311,15 @@ pub struct TransactionEffects {
 }
 
 impl TransactionEffects {
-    /// Return an iterator that iterates through both mutated and
-    /// created objects.
-    /// It doesn't include deleted objects.
-    pub fn mutated_and_created(&self) -> impl Iterator<Item = &(ObjectRef, Owner)> + Clone {
-        self.mutated.iter().chain(self.created.iter())
+    /// Return an iterator that iterates through all mutated objects, including mutated,
+    /// created and unwrapped objects. In other words, all objects that still exist
+    /// in the object state after this transaction.
+    /// It doesn't include deleted/wrapped objects.
+    pub fn all_mutated(&self) -> impl Iterator<Item = &(ObjectRef, Owner)> + Clone {
+        self.mutated
+            .iter()
+            .chain(self.created.iter())
+            .chain(self.unwrapped.iter())
     }
 
     /// Return an iterator of mutated objects, but excluding the gas object.
@@ -1329,7 +1333,7 @@ impl TransactionEffects {
 
     pub fn is_object_mutated_here(&self, obj_ref: ObjectRef) -> bool {
         // The mutated or created case
-        if self.mutated_and_created().any(|(oref, _)| *oref == obj_ref) {
+        if self.all_mutated().any(|(oref, _)| *oref == obj_ref) {
             return true;
         }
 


### PR DESCRIPTION
In TransactionEffects, when we want to get all mutated objects, we forgot to put in the unwrapped objects.
This was causing some strange bugs when we unwrap.