### PR TITLE
Use BTreeMap::get instead of bracket notation to avoid panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6866,6 +6866,7 @@ dependencies = [
  "sui-open-rpc",
  "sui-open-rpc-macros",
  "sui-types",
+ "tracing",
  "workspace-hack 0.1.0",
 ]
 

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -18,6 +18,7 @@ serde_with = { version = "1.14.0", features = ["hex"] }
 colored = "2.0.0"
 either = "1.7.0"
 itertools = "0.10.3"
+tracing = "0.1.35"
 
 move-core-types = { git = "https://github.com/move-language/move", rev = "7733658048a8bc80e9ba415b8c99aed9234eaa5f", features = ["address20"] }
 move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7733658048a8bc80e9ba415b8c99aed9234eaa5f" }


### PR DESCRIPTION
The type conversion from MoveStruct to GasCoin is failing in staging, probably cause by discrepancies between data and code.

The conversion is accessing the map using bracket notation, which will panic if the entry is not found, this PR change that to use the get method instead, also log to warn for any type conversion failure.