### PR TITLE
Fix SDK name mismatch

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -1,9 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 /*
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.

--- a/sdk/typescript/src/rpc/client.guard.ts
+++ b/sdk/typescript/src/rpc/client.guard.ts
@@ -1,9 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 /*
  * Generated type guards for "client.ts".
  * WARNING: Do not manually change this file.

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -44,7 +44,7 @@ export type EpochId = number;
 
 export type AuthorityQuorumSignInfo = {
   epoch: EpochId;
-  signatures: AuthoritySignature[];
+  signature: AuthoritySignature[];
 };
 
 export type CertifiedTransaction = {


### PR DESCRIPTION
I did not update a variable name in the SDK after changing it in the node.