### PR TITLE
[checkpoint] Only clear proposal after we have stored a cert

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -540,6 +540,14 @@ impl CheckpointStore {
         committee: &Committee,
         handle_pending_cert: impl PendCertificateForExecution,
     ) -> Result<(), FragmentInternalError> {
+        let fragment_seq = fragment.proposer.summary.sequence_number;
+        debug!(
+            execution_index=?seq,
+            cp_seq=?fragment_seq,
+            "Fragment received from consensus. Proposal: {}, other: {}",
+            fragment.proposer.authority(),
+            fragment.other.authority(),
+        );
         // Ensure we have not already processed this fragment.
         if let Some((last_seq, _)) = self.fragments.iter().skip_to_last().next() {
             if seq <= last_seq {
@@ -554,6 +562,7 @@ impl CheckpointStore {
             .map_err(FragmentInternalError::Error)?;
 
         // Schedule for execution all the certificates that are included here.
+        // TODO: We should not schedule a cert if it has already been executed.
         handle_pending_cert
             .add_pending_certificates(
                 fragment

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -513,6 +513,7 @@ impl CheckpointStore {
         if !locals.no_more_fragments {
             // Send to consensus for sequencing.
             if let Some(sender) = &self.sender {
+                debug!("Send fragment: {} -- {}", self.name, other_name);
                 sender.send_to_consensus(fragment.clone())?;
             } else {
                 return Err(SuiError::from("No consensus sender configured"));
@@ -717,6 +718,7 @@ impl CheckpointStore {
         let locals = self.get_locals();
         let mut new_locals = locals.as_ref().clone();
         new_locals.no_more_fragments = true;
+        debug!("no_more_fragments is set");
         self.set_locals(locals, new_locals)?;
 
         Err(SuiError::from(
@@ -732,13 +734,14 @@ impl CheckpointStore {
     ) -> SuiResult {
         checkpoint.verify(committee, None)?;
         debug_assert!(matches!(
-            self.latest_stored_checkpoint()?,
+            self.latest_stored_checkpoint(),
             Some(AuthenticatedCheckpoint::Signed(_))
         ));
         let seq = checkpoint.summary.sequence_number();
         self.checkpoints
             .insert(seq, &AuthenticatedCheckpoint::Certified(checkpoint.clone()))?;
         metrics.checkpoint_sequence_number.set(*seq as i64);
+        self.clear_proposal(*seq + 1)?;
         Ok(())
     }
 
@@ -764,7 +767,22 @@ impl CheckpointStore {
             effects_store,
         )?;
         metrics.checkpoint_sequence_number.set(*seq as i64);
+        self.clear_proposal(*seq + 1)?;
         Ok(())
+    }
+
+    fn clear_proposal(
+        &mut self,
+        new_expected_next_checkpoint: CheckpointSequenceNumber,
+    ) -> SuiResult {
+        let locals = self.get_locals();
+
+        let mut new_locals = locals.as_ref().clone();
+        new_locals.current_proposal = None;
+        new_locals.proposal_next_transaction = None;
+        new_locals.no_more_fragments = false;
+        new_locals.next_checkpoint = new_expected_next_checkpoint;
+        self.set_locals(locals, new_locals)
     }
 
     // Helper read functions
@@ -780,15 +798,12 @@ impl CheckpointStore {
     }
 
     /// Get the latest stored checkpoint if there is one
-    pub fn latest_stored_checkpoint(
-        &mut self,
-    ) -> Result<Option<AuthenticatedCheckpoint>, SuiError> {
-        Ok(self
-            .checkpoints
+    pub fn latest_stored_checkpoint(&mut self) -> Option<AuthenticatedCheckpoint> {
+        self.checkpoints
             .iter()
             .skip_to_last()
             .next()
-            .map(|(_, ckp)| ckp))
+            .map(|(_, ckp)| ckp)
     }
 
     pub fn is_ready_to_start_epoch_change(&mut self) -> bool {
@@ -825,6 +840,7 @@ impl CheckpointStore {
         };
 
         let transactions = CheckpointContents::new(self.extra_transactions.keys());
+        let size = transactions.transactions.len();
         let checkpoint_proposal = CheckpointProposal::new(
             epoch,
             checkpoint_sequence,
@@ -839,7 +855,7 @@ impl CheckpointStore {
         new_locals.proposal_next_transaction = Some(next_local_tx_sequence);
         self.set_locals(locals, new_locals)?;
 
-        info!(cp_seq=?checkpoint_sequence, "A new checkpoint proposal is created");
+        info!(cp_seq=?checkpoint_sequence, ?size, "A new checkpoint proposal is created");
         Ok(checkpoint_proposal)
     }
 
@@ -946,16 +962,6 @@ impl CheckpointStore {
 
         // Write to the database.
         batch.write()?;
-
-        // Clean up our proposal if any
-        let locals = self.get_locals();
-
-        let mut new_locals = locals.as_ref().clone();
-        new_locals.current_proposal = None;
-        new_locals.proposal_next_transaction = None;
-        new_locals.no_more_fragments = false;
-        new_locals.next_checkpoint = expected_seq + 1;
-        self.set_locals(locals, new_locals)?;
 
         Ok(())
     }

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -522,49 +522,43 @@ fn latest_proposal() {
 
     // --- TEST3 ---
 
-    // No valid checkpoint proposal condition...
-    assert!(cps1.get_locals().current_proposal.is_none());
+    // Proposals are not cleared until we have a cert.
+    assert!(cps1.get_locals().current_proposal.is_some());
+
+    let signed: Vec<_> = [
+        cps1.latest_stored_checkpoint().unwrap(),
+        cps2.latest_stored_checkpoint().unwrap(),
+    ]
+    .into_iter()
+    .map(|a| match a {
+        AuthenticatedCheckpoint::Signed(s) => s,
+        _ => panic!("Unexpected type"),
+    })
+    .collect();
+    // We only need f+1 to make a cert. 2 is sufficient.
+    let cert = CertifiedCheckpointSummary::aggregate(signed, &committee).unwrap();
+    cps1.promote_signed_checkpoint_to_cert(&cert, &committee, &CheckpointMetrics::new_for_tests())
+        .unwrap();
 
     let request = CheckpointRequest::latest(false);
     let response = cps1.handle_latest_proposal(&request).expect("no errors");
     assert!(response.detail.is_none());
+    // The proposal should have been cleared now.
     assert!(matches!(
         response.info,
-        AuthorityCheckpointInfo::Proposal { .. }
+        AuthorityCheckpointInfo::Proposal {
+            current: None,
+            previous: Some(AuthenticatedCheckpoint::Certified { .. })
+        }
     ));
-    if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
-        assert!(current.is_none());
-        assert!(matches!(
-            previous,
-            Some(AuthenticatedCheckpoint::Signed { .. })
-        ));
-    }
-
-    // --- TEST 4 ---
-
-    // When details are needed, then return unexecuted transactions if there is no proposal
-    let request = CheckpointRequest::latest(true);
-    let response = cps1.handle_latest_proposal(&request).expect("no errors");
-    assert!(response.detail.is_none());
-
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::Proposal { .. }
-    ));
-    if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
-        assert!(current.is_none());
-        assert!(matches!(
-            previous,
-            Some(AuthenticatedCheckpoint::Signed { .. })
-        ));
-    }
 
     // ---
     cps1.update_processed_transactions(&[(6, t6)]).unwrap();
 
+    // Create a new proposal.
     let _p1 = cps1.set_proposal(committee.epoch).unwrap();
 
-    // --- TEST 5 ---
+    // --- TEST 4 ---
 
     // Get the full proposal with previous proposal
     let request = CheckpointRequest::latest(true);
@@ -577,7 +571,7 @@ fn latest_proposal() {
         assert!(current.is_some());
         assert!(matches!(
             previous,
-            Some(AuthenticatedCheckpoint::Signed { .. })
+            Some(AuthenticatedCheckpoint::Certified { .. })
         ));
 
         let current_proposal = current.unwrap();
@@ -1442,8 +1436,8 @@ fn test_fragment_full_flow() {
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
     assert_eq!(seq.next_transaction_index, 6);
-    // Advanced to next checkpoint
-    assert_eq!(cps0.next_checkpoint(), 1);
+    // We don't update next checkpoint yet until we get a cert.
+    assert_eq!(cps0.next_checkpoint(), 0);
 
     let response = cps0
         .handle_past_checkpoint(true, 0)
@@ -1471,7 +1465,7 @@ fn test_fragment_full_flow() {
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
     assert_eq!(cps6.fragments.iter().count(), 6);
     // Cannot advance to next checkpoint
-    assert_eq!(cps6.next_checkpoint(), 0);
+    assert!(cps6.latest_stored_checkpoint().is_none());
     // But recording of fragments is closed
 
     // However recording has stopped

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -79,10 +79,10 @@ async fn wait_for_advance_to_next_checkpoint(
 
         match ok {
             true => break,
-            false => tokio::time::sleep(Duration::from_secs(1)).await,
+            false => sleep(Duration::from_secs(1)).await,
         }
         cnt += 1;
-        assert!(cnt <= 40);
+        assert!(cnt <= 20);
     }
 
     // Ensure all authorities moved to the next checkpoint sequence number.


### PR DESCRIPTION
This PR should resolve https://github.com/MystenLabs/sui/issues/3366.
Previously, we clear the local proposal as soon as a new checkpoint is created and signed locally.
This creates a problem: if some validators have been able to do so, but some are not, the rest of the validators will no longer be able to make progress because they can no longer get a quorum of proposals.
This PR delays clearing the proposal until we have stored a checkpoint cert.

@gdanezis I noticed that the `set_locals` function takes a previous locals as argument, but doesn't use it. Is that intentional?