### PR TITLE
[checkpoint] Remove AuthenticatedCheckpoint::None

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -360,7 +360,7 @@ where
         responses: Vec<(
             AuthorityName,
             Option<SignedCheckpointProposalSummary>,
-            AuthenticatedCheckpoint,
+            Option<AuthenticatedCheckpoint>,
         )>,
         errors: Vec<(AuthorityName, SuiError)>,
     }
@@ -429,7 +429,7 @@ where
     // Extract the highest checkpoint cert returned.
     let mut highest_certificate_cert: Option<CertifiedCheckpointSummary> = None;
     for state in &final_state.responses {
-        if let AuthenticatedCheckpoint::Certified(cert) = &state.2 {
+        if let Some(AuthenticatedCheckpoint::Certified(cert)) = &state.2 {
             if let Some(old_cert) = &highest_certificate_cert {
                 if cert.summary.sequence_number > old_cert.summary.sequence_number {
                     highest_certificate_cert = Some(cert.clone());
@@ -450,7 +450,7 @@ where
         .responses
         .iter()
         .for_each(|(auth, _proposal, checkpoint)| {
-            if let AuthenticatedCheckpoint::Signed(signed) = checkpoint {
+            if let Some(AuthenticatedCheckpoint::Signed(signed)) = checkpoint {
                 // We are interested in this signed checkpoint only if it is
                 // newer than the highest known cert checkpoint.
                 if let Some(newest_checkpoint) = &highest_certificate_cert {
@@ -759,7 +759,7 @@ where
         {
             if let AuthorityCheckpointInfo::Proposal { current, previous } = &response.info {
                 // Check if there is a latest checkpoint
-                if let AuthenticatedCheckpoint::Certified(prev) = previous {
+                if let Some(AuthenticatedCheckpoint::Certified(prev)) = previous {
                     if prev.summary.sequence_number >= next_checkpoint_sequence_number {
                         // We are now behind, stop the process
                         break;

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1605,7 +1605,9 @@ where
 
                     if let CheckpointResponse {
                         info:
-                            AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Certified(past)),
+                            AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Certified(
+                                past,
+                            ))),
                         detail,
                     } = resp
                     {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -400,7 +400,7 @@ fn latest_proposal() {
     ));
     if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
         assert!(current.is_none());
-        assert!(matches!(previous, AuthenticatedCheckpoint::None));
+        assert!(matches!(previous, None));
     }
 
     // ---
@@ -423,7 +423,7 @@ fn latest_proposal() {
     ));
     if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
         assert!(current.is_some());
-        assert!(matches!(previous, AuthenticatedCheckpoint::None));
+        assert!(matches!(previous, None));
 
         let current_proposal = current.unwrap();
         current_proposal
@@ -444,7 +444,7 @@ fn latest_proposal() {
     ));
     if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
         assert!(current.is_some());
-        assert!(matches!(previous, AuthenticatedCheckpoint::None));
+        assert!(matches!(previous, None));
 
         let current_proposal = current.unwrap();
         current_proposal
@@ -535,7 +535,10 @@ fn latest_proposal() {
     ));
     if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
         assert!(current.is_none());
-        assert!(matches!(previous, AuthenticatedCheckpoint::Signed { .. }));
+        assert!(matches!(
+            previous,
+            Some(AuthenticatedCheckpoint::Signed { .. })
+        ));
     }
 
     // --- TEST 4 ---
@@ -551,7 +554,10 @@ fn latest_proposal() {
     ));
     if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
         assert!(current.is_none());
-        assert!(matches!(previous, AuthenticatedCheckpoint::Signed { .. }));
+        assert!(matches!(
+            previous,
+            Some(AuthenticatedCheckpoint::Signed { .. })
+        ));
     }
 
     // ---
@@ -570,7 +576,10 @@ fn latest_proposal() {
     ));
     if let AuthorityCheckpointInfo::Proposal { current, previous } = response.info {
         assert!(current.is_some());
-        assert!(matches!(previous, AuthenticatedCheckpoint::Signed { .. }));
+        assert!(matches!(
+            previous,
+            Some(AuthenticatedCheckpoint::Signed { .. })
+        ));
 
         let current_proposal = current.unwrap();
         current_proposal
@@ -616,18 +625,12 @@ fn set_get_checkpoint() {
 
     // There is no previous checkpoint
     let response = cps1.handle_past_checkpoint(true, 0).unwrap();
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::None)
-    ));
+    assert!(matches!(response.info, AuthorityCheckpointInfo::Past(None)));
     assert!(response.detail.is_none());
 
     // There is no previous checkpoint
     let response = cps1.handle_past_checkpoint(true, 0).unwrap();
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::None)
-    ));
+    assert!(matches!(response.info, AuthorityCheckpointInfo::Past(None)));
     assert!(response.detail.is_none());
 
     // ---
@@ -694,9 +697,11 @@ fn set_get_checkpoint() {
     let response = cps1.handle_past_checkpoint(true, 0).unwrap();
     assert!(matches!(
         response.info,
-        AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Signed(..))
+        AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Signed(..)))
     ));
-    if let AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Signed(signed)) = response.info {
+    if let AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Signed(signed))) =
+        response.info
+    {
         signed.verify(&committee, response.detail.as_ref()).unwrap();
     }
 
@@ -704,7 +709,7 @@ fn set_get_checkpoint() {
     let mut signed_checkpoint: Vec<SignedCheckpointSummary> = Vec::new();
     for x in [&mut cps1, &mut cps2, &mut cps3] {
         match x.handle_past_checkpoint(true, 0).unwrap().info {
-            AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Signed(signed)) => {
+            AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Signed(signed))) => {
                 signed_checkpoint.push(signed)
             }
             _ => unreachable!(),
@@ -726,7 +731,7 @@ fn set_get_checkpoint() {
     let response = cps1.handle_past_checkpoint(true, 0).unwrap();
     assert!(matches!(
         response.info,
-        AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Certified(..))
+        AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Certified(..)))
     ));
 
     // --- TEST 3 ---
@@ -756,7 +761,7 @@ fn set_get_checkpoint() {
     let response = cps4.handle_past_checkpoint(true, 0).unwrap();
     assert!(matches!(
         response.info,
-        AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Certified(..))
+        AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Certified(..)))
     ));
 }
 
@@ -1814,7 +1819,7 @@ async fn checkpoint_messaging_flow() {
             .expect("No issues");
 
         match &response.info {
-            AuthorityCheckpointInfo::Past(AuthenticatedCheckpoint::Signed(checkpoint)) => {
+            AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Signed(checkpoint))) => {
                 signed_checkpoint.push(checkpoint.clone());
                 contents = response.detail.clone();
             }


### PR DESCRIPTION
We store AuthenticatedCheckpoint in the checkpoints db, and one enum entry is AuthenticatedCheckpoint::None. This doesn't make much sense: we never store a None entry.
We only needed it because sometimes we need to return None in checkpoint queries if a checkpoint is not found locally. In that case, we can just return Option::None.