### PR TITLE
wallet-ext: fix coin field definition

### DIFF
--- a/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -54,7 +54,7 @@ export class Coin {
     }
 
     public static getID(obj: SuiMoveObject): ObjectId {
-        return obj.fields.id.id;
+        return obj.fields.info.id;
     }
 
     public static getCoinTypeFromArg(coinTypeArg: string) {


### PR DESCRIPTION
The original id field has been renamed to info in https://github.com/MystenLabs/sui/pull/3241/files

Verified that the coin transfer succeeded 
![CleanShot 2022-07-22 at 15 41 44](https://user-images.githubusercontent.com/76067158/180577598-f254eced-6a81-4e24-a1a4-e33918778f0d.png)
