### PR TITLE
Add execute_cert_to_true_effects

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Deref;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
     time::Duration,
 };
@@ -566,7 +566,7 @@ where
             Ok(true)
         }
         Action::NewCert => {
-            let available_authorities: BTreeSet<_> = checkpoint
+            let available_authorities: HashSet<_> = checkpoint
                 .signatory_authorities(committee)
                 .filter_map(|x| match x {
                     Ok(&a) => {
@@ -620,7 +620,7 @@ where
     let latest_checkpoint = checkpoint_db.lock().latest_stored_checkpoint()?;
     // We use the latest available authorities not the authorities that signed the checkpoint
     // since these might be gone after the epoch they were active.
-    let available_authorities: BTreeSet<_> = latest_known_checkpoint
+    let available_authorities: HashSet<_> = latest_known_checkpoint
         .signatory_authorities(&net.committee)
         .collect::<SuiResult<BTreeSet<_>>>()?
         .iter()
@@ -683,7 +683,7 @@ where
 pub async fn get_one_checkpoint_with_contents<A>(
     net: Arc<AuthorityAggregator<A>>,
     sequence_number: CheckpointSequenceNumber,
-    available_authorities: &BTreeSet<AuthorityName>,
+    available_authorities: &HashSet<AuthorityName>,
 ) -> Result<(CertifiedCheckpointSummary, CheckpointContents), SuiError>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
@@ -702,7 +702,7 @@ pub async fn get_one_checkpoint<A>(
     net: Arc<AuthorityAggregator<A>>,
     sequence_number: CheckpointSequenceNumber,
     contents: bool,
-    available_authorities: &BTreeSet<AuthorityName>,
+    available_authorities: &HashSet<AuthorityName>,
 ) -> Result<(CertifiedCheckpointSummary, Option<CheckpointContents>), SuiError>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
@@ -740,7 +740,7 @@ where
     let next_checkpoint_sequence_number = checkpoint_db.lock().next_checkpoint();
     let mut fragments_num = 0;
 
-    for authority in committee.shuffle_by_stake() {
+    for authority in committee.shuffle_by_stake(None, None).iter() {
         // We have ran out of authorities?
         if available_authorities.is_empty() {
             // We have created as many fragments as possible, so exit.

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1699,8 +1699,6 @@ where
     ) -> SuiResult<SignedTransactionEffects> {
         let digest = cert.digest();
 
-        debug!(?digest, "execute_cert_to_true_effects");
-
         #[derive(Debug)]
         struct ExecuteCertState {
             cumulative_weight: StakeUnit,
@@ -1727,6 +1725,13 @@ where
 
         let validity = self.committee.validity_threshold();
         let total_weight = self.committee.total_votes;
+
+        debug!(
+            ?validity,
+            ?total_weight,
+            ?digest,
+            "execute_cert_to_true_effects"
+        );
         let final_state = self
             .quorum_map_then_reduce_with_timeout_and_prefs(
                 Some(&signers),
@@ -1748,6 +1753,7 @@ where
                                 *entry += weight;
 
                                 if *entry >= validity {
+                                    state.true_effects = Some(effects.clone());
                                     return Ok(ReduceOutput::End(state));
                                 }
                             }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1625,8 +1625,7 @@ where
 
     pub async fn handle_transaction_and_effects_info_request(
         &self,
-        digest: &TransactionDigest,
-        effects_digest: Option<&TransactionEffectsDigest>,
+        digests: &ExecutionDigests,
         // authorities known to have the effects we are requesting.
         authorities: Option<&BTreeSet<AuthorityName>>,
         timeout_total: Option<Duration>,
@@ -1637,7 +1636,7 @@ where
             |authority, client| {
                 Box::pin(async move {
                     let resp = client
-                        .handle_transaction_and_effects_info_request(digest, effects_digest)
+                        .handle_transaction_and_effects_info_request(digests)
                         .await?;
 
                     match (resp.certified_transaction, resp.signed_effects) {
@@ -1648,7 +1647,9 @@ where
                                 // cert and effects, so if they now say they don't, they're byzantine.
                                 Err(SuiError::ByzantineAuthoritySuspicion { authority })
                             } else {
-                                Err(SuiError::TransactionNotFound { digest: *digest })
+                                Err(SuiError::TransactionNotFound {
+                                    digest: digests.transaction,
+                                })
                             }
                         }
                     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -32,6 +32,8 @@ use sui_types::committee::StakeUnit;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::{sleep, timeout};
 
+use tap::TapFallible;
+
 const OBJECT_DOWNLOAD_CHANNEL_BOUND: usize = 1024;
 pub const DEFAULT_RETRIES: usize = 4;
 
@@ -542,10 +544,38 @@ where
             Result<V, SuiError>,
         ) -> AsyncResult<'a, ReduceOutput<S>, SuiError>,
     {
-        let authorities_shuffled = self.committee.shuffle_by_stake();
+        self.quorum_map_then_reduce_with_timeout_and_prefs(
+            None,
+            initial_state,
+            map_each_authority,
+            reduce_result,
+            initial_timeout,
+        )
+        .await
+    }
+
+    pub(crate) async fn quorum_map_then_reduce_with_timeout_and_prefs<'a, S, V, FMap, FReduce>(
+        &'a self,
+        authority_prefences: Option<&HashSet<AuthorityName>>,
+        initial_state: S,
+        map_each_authority: FMap,
+        reduce_result: FReduce,
+        initial_timeout: Duration,
+    ) -> Result<S, SuiError>
+    where
+        FMap: FnOnce(AuthorityName, &'a SafeClient<A>) -> AsyncResult<'a, V, SuiError> + Clone,
+        FReduce: Fn(
+            S,
+            AuthorityName,
+            StakeUnit,
+            Result<V, SuiError>,
+        ) -> AsyncResult<'a, ReduceOutput<S>, SuiError>,
+    {
+        let authorities_shuffled = self.committee.shuffle_by_stake(authority_prefences, None);
 
         // First, execute in parallel for each authority FMap.
         let mut responses: futures::stream::FuturesUnordered<_> = authorities_shuffled
+            .iter()
             .map(|name| {
                 let client = &self.authority_clients[name];
                 let execute = map_each_authority.clone();
@@ -593,9 +623,9 @@ where
     async fn quorum_once_inner<'a, S, FMap>(
         &'a self,
         // try these authorities first
-        preferences: &[AuthorityName],
+        preferences: Option<&HashSet<AuthorityName>>,
         // only attempt from these authorities.
-        restrict_to: Option<&BTreeSet<AuthorityName>>,
+        restrict_to: Option<&HashSet<AuthorityName>>,
         // The async function used to apply to each authority. It takes an authority name,
         // and authority client parameter and returns a Result<V>.
         map_each_authority: FMap,
@@ -608,25 +638,20 @@ where
     {
         let mut delay = Duration::from_secs(1);
         loop {
-            let authorities_shuffled = self.committee.shuffle_by_stake().filter(|a| {
-                // preferences will usually be small so linear search probably ok.
-                !preferences.contains(a) && restrict_to.map(|r| r.contains(a)).unwrap_or(true)
-            });
-
-            let authorities_shuffled = preferences.iter().chain(authorities_shuffled);
+            let authorities_shuffled = self.committee.shuffle_by_stake(preferences, restrict_to);
 
             // TODO: possibly increase concurrency after first failure to reduce latency.
             for name in authorities_shuffled {
-                let client = &self.authority_clients[name];
+                let client = &self.authority_clients[&name];
 
-                let res = timeout(timeout_each_authority, map_each_authority(*name, client)).await;
+                let res = timeout(timeout_each_authority, map_each_authority(name, client)).await;
 
                 match res {
                     // timeout
-                    Err(_) => authority_errors.insert(*name, SuiError::TimeoutError),
+                    Err(_) => authority_errors.insert(name, SuiError::TimeoutError),
                     // request completed
                     Ok(inner_res) => match inner_res {
-                        Err(e) => authority_errors.insert(*name, e),
+                        Err(e) => authority_errors.insert(name, e),
                         Ok(res) => return Ok(res),
                     },
                 };
@@ -648,9 +673,9 @@ where
     pub(crate) async fn quorum_once_with_timeout<'a, S, FMap>(
         &'a self,
         // try these authorities first
-        preferences: &[AuthorityName],
+        preferences: Option<&HashSet<AuthorityName>>,
         // only attempt from these authorities.
-        restrict_to: Option<&BTreeSet<AuthorityName>>,
+        restrict_to: Option<&HashSet<AuthorityName>>,
         // The async function used to apply to each authority. It takes an authority name,
         // and authority client parameter and returns a Result<V>.
         map_each_authority: FMap,
@@ -1576,11 +1601,11 @@ where
         &self,
         request: &CheckpointRequest,
         // authorities known to have the checkpoint we are requesting.
-        authorities: &BTreeSet<AuthorityName>,
+        authorities: &HashSet<AuthorityName>,
         timeout_total: Option<Duration>,
     ) -> SuiResult<CheckpointResponse> {
         self.quorum_once_with_timeout(
-            &[],
+            None,
             Some(authorities),
             |_, client| Box::pin(async move { client.handle_checkpoint(request.clone()).await }),
             self.timeouts.serial_authority_request_timeout,
@@ -1593,11 +1618,11 @@ where
         &self,
         request: &CheckpointRequest,
         // authorities known to have the checkpoint we are requesting.
-        authorities: &BTreeSet<AuthorityName>,
+        authorities: &HashSet<AuthorityName>,
         timeout_total: Option<Duration>,
     ) -> SuiResult<(CertifiedCheckpointSummary, Option<CheckpointContents>)> {
         self.quorum_once_with_timeout(
-            &[],
+            None,
             Some(authorities),
             |_, client| {
                 Box::pin(async move {
@@ -1627,11 +1652,11 @@ where
         &self,
         digests: &ExecutionDigests,
         // authorities known to have the effects we are requesting.
-        authorities: Option<&BTreeSet<AuthorityName>>,
+        authorities: Option<&HashSet<AuthorityName>>,
         timeout_total: Option<Duration>,
     ) -> SuiResult<(CertifiedTransaction, SignedTransactionEffects)> {
         self.quorum_once_with_timeout(
-            &[],
+            None,
             authorities,
             |authority, client| {
                 Box::pin(async move {
@@ -1659,5 +1684,115 @@ where
             timeout_total,
         )
         .await
+    }
+
+    /// Given a certificate, execute the cert on remote validators (and preferentially on the
+    /// signers of the cert who are guaranteed to be able to process it immediately) until we
+    /// receive f+1 identical SignedTransactionEffects - at this point we know we have the
+    /// true effects for the cert, because of f+1 validators, at least 1 must be honest.
+    ///
+    /// It is assumed that this method will not be called by any of the signers of the cert, since
+    /// they can simply execute the cert locally and compute their own effects.
+    pub async fn execute_cert_to_true_effects(
+        &self,
+        cert: &CertifiedTransaction,
+    ) -> SuiResult<SignedTransactionEffects> {
+        let digest = cert.digest();
+
+        debug!(?digest, "execute_cert_to_true_effects");
+
+        #[derive(Debug)]
+        struct ExecuteCertState {
+            cumulative_weight: StakeUnit,
+            good_weight: StakeUnit,
+            digests: HashMap<TransactionEffectsDigest, StakeUnit>,
+            true_effects: Option<SignedTransactionEffects>,
+            errors: Vec<(AuthorityName, SuiError)>,
+        }
+
+        let signers: HashSet<_> = cert
+            .auth_sign_info
+            .authorities(&self.committee)
+            .filter_map(|r| r.ok())
+            .cloned()
+            .collect();
+
+        let initial_state = ExecuteCertState {
+            cumulative_weight: 0,
+            good_weight: 0,
+            digests: HashMap::new(),
+            true_effects: None,
+            errors: Vec::new(),
+        };
+
+        let validity = self.committee.validity_threshold();
+        let total_weight = self.committee.total_votes;
+        let final_state = self
+            .quorum_map_then_reduce_with_timeout_and_prefs(
+                Some(&signers),
+                initial_state,
+                |_name, client| {
+                    Box::pin(async move { client.handle_certificate(cert.clone()).await })
+                },
+                |mut state, name, weight, result| {
+                    Box::pin(async move {
+                        state.cumulative_weight += weight;
+                        match result {
+                            Ok(TransactionInfoResponse {
+                                signed_effects: Some(effects),
+                                ..
+                            }) => {
+                                state.good_weight += weight;
+                                trace!(?name, ?weight, "successfully executed cert on peer");
+                                let entry = state.digests.entry(*effects.digest()).or_insert(0);
+                                *entry += weight;
+
+                                if *entry >= validity {
+                                    return Ok(ReduceOutput::End(state));
+                                }
+                            }
+
+                            // validator returned OK but did not give us an effects
+                            Ok(_) => {
+                                info!(?name, "peer failed to return effects");
+                                state.errors.push((
+                                    name,
+                                    SuiError::ByzantineAuthoritySuspicion { authority: name },
+                                ));
+                            }
+
+                            Err(e) => {
+                                state.errors.push((name, e));
+                            }
+                        }
+
+                        let weight_remaining = total_weight - state.cumulative_weight;
+                        if weight_remaining + state.good_weight < validity {
+                            // The main realistic case in which this might happen is if a validator
+                            // cannot reach the rest of the committee on the network. (The
+                            // unrealistic case is that the security assumption has failed).
+                            info!(
+                                ?digest,
+                                ?total_weight,
+                                ?state,
+                                "cannot reach validity threshold for effects!"
+                            );
+                            Ok(ReduceOutput::End(state))
+                        } else {
+                            Ok(ReduceOutput::Continue(state))
+                        }
+                    })
+                },
+                // A long timeout before we hear back from a quorum
+                self.timeouts.pre_quorum_timeout,
+            )
+            .await?;
+
+        final_state
+            .true_effects
+            .ok_or(SuiError::TooManyIncorrectAuthorities {
+                errors: final_state.errors,
+            })
+            .tap_err(|e| info!(?digest, "execute_cert_to_true_effects failed: {}", e))
     }
 }

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 
 use tokio_stream::{wrappers::ReceiverStream, Stream, StreamExt};
 
-use std::collections::{hash_map, BTreeSet, HashMap};
+use std::collections::{hash_map, HashMap, HashSet};
 use sui_storage::node_sync_store::NodeSyncStore;
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests, TransactionDigest, TransactionEffectsDigest},
@@ -57,7 +57,7 @@ impl EffectsStakeMap {
     }
 
     // Get the set of authorities who voted for a digest.
-    pub fn voters(&self, digest: &TransactionEffectsDigest) -> BTreeSet<AuthorityName> {
+    pub fn voters(&self, digest: &TransactionEffectsDigest) -> HashSet<AuthorityName> {
         self.effects_vote_map
             .get(digest)
             .unwrap_or(&HashMap::new())
@@ -453,7 +453,7 @@ where
     // Transactions are not currently persisted anywhere, however (validators delete them eagerly).
     async fn download_cert_and_effects(
         &self,
-        authorities_with_cert: Option<BTreeSet<AuthorityName>>,
+        authorities_with_cert: Option<HashSet<AuthorityName>>,
         digests: &ExecutionDigests,
     ) -> SuiResult<(CertifiedTransaction, SignedTransactionEffects)> {
         if let Some(c) = self
@@ -501,7 +501,7 @@ where
     }
 
     async fn download_impl(
-        authorities: Option<BTreeSet<AuthorityName>>,
+        authorities: Option<HashSet<AuthorityName>>,
         aggregator: Arc<AuthorityAggregator<A>>,
         digests: &ExecutionDigests,
         node_sync_store: Arc<NodeSyncStore>,

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -367,16 +367,18 @@ where
     /// Handle Transaction + Effects information requests for this account.
     pub async fn handle_transaction_and_effects_info_request(
         &self,
-        digest: &TransactionDigest,
-        effects_digest: Option<&TransactionEffectsDigest>,
+        digests: &ExecutionDigests,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let transaction_info = self
             .authority_client
-            .handle_transaction_info_request((*digest).into())
+            .handle_transaction_info_request(digests.transaction.into())
             .await?;
 
-        if let Err(err) = self.check_transaction_response(digest, effects_digest, &transaction_info)
-        {
+        if let Err(err) = self.check_transaction_response(
+            &digests.transaction,
+            Some(&digests.effects),
+            &transaction_info,
+        ) {
             self.report_client_error(err.clone());
             return Err(err);
         }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -810,6 +810,48 @@ async fn test_process_certificate() {
 }
 
 #[tokio::test]
+async fn test_execute_cert_to_true_effects() {
+    let (addr1, key1) = get_key_pair();
+    let gas_object1 = Object::with_owner_for_testing(addr1);
+    let gas_object2 = Object::with_owner_for_testing(addr1);
+    let (authorities, _) =
+        init_local_authorities(4, vec![gas_object1.clone(), gas_object2.clone()]).await;
+    let authority_clients: Vec<_> = authorities.authority_clients.values().collect();
+
+    let framework_obj_ref = genesis::get_framework_object_ref();
+
+    // Make a schedule of transactions
+    let gas_ref_1 = get_latest_ref(authority_clients[0], gas_object1.id()).await;
+    let create1 =
+        crate_object_move_transaction(addr1, &key1, addr1, 100, framework_obj_ref, gas_ref_1);
+
+    do_transaction(authority_clients[0], &create1).await;
+    do_transaction(authority_clients[1], &create1).await;
+    do_transaction(authority_clients[2], &create1).await;
+
+    // Get a cert
+    let cert1 = extract_cert(&authority_clients, &authorities.committee, create1.digest()).await;
+
+    authorities
+        .execute_cert_to_true_effects(&cert1)
+        .await
+        .unwrap();
+
+    // Now two (f+1) should have the cert
+    let mut count = 0;
+    for client in &authority_clients {
+        let res = client
+            .handle_transaction_info_request((*cert1.digest()).into())
+            .await
+            .unwrap();
+        if res.signed_effects.is_some() {
+            count += 1;
+        }
+    }
+    assert_eq!(count, 2);
+}
+
+#[tokio::test]
 async fn test_process_transaction_fault_success() {
     // This test exercises the 4 different possible fauling case when one authority is faulty.
     // A transaction is sent to all authories, however one of them will error out either before or after processing the transaction.

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -10,7 +10,7 @@ use rand_latest::rngs::OsRng;
 use rand_latest::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub type EpochId = u64;
 
@@ -133,21 +133,53 @@ impl Committee {
     /// Samples authorities by weight
     pub fn sample(&self) -> &AuthorityName {
         // unwrap safe unless committee is empty
-        self.choose_multiple_weighted(1).next().unwrap()
+        Self::choose_multiple_weighted(&self.voting_rights[..], 1)
+            .next()
+            .unwrap()
     }
 
-    fn choose_multiple_weighted(&self, count: usize) -> impl Iterator<Item = &AuthorityName> {
+    fn choose_multiple_weighted(
+        slice: &[(AuthorityName, StakeUnit)],
+        count: usize,
+    ) -> impl Iterator<Item = &AuthorityName> {
         // unwrap is safe because we validate the committee composition in `new` above.
         // See https://docs.rs/rand/latest/rand/distributions/weighted/enum.WeightedError.html
         // for possible errors.
-        self.voting_rights[..]
+        slice
             .choose_multiple_weighted(&mut OsRng, count, |(_, weight)| *weight as f64)
             .unwrap()
             .map(|(a, _)| a)
     }
 
-    pub fn shuffle_by_stake(&self) -> impl Iterator<Item = &AuthorityName> {
-        self.choose_multiple_weighted(self.voting_rights.len())
+    pub fn shuffle_by_stake(
+        &self,
+        // try these authorities first
+        preferences: Option<&HashSet<AuthorityName>>,
+        // only attempt from these authorities.
+        restrict_to: Option<&HashSet<AuthorityName>>,
+    ) -> Vec<AuthorityName> {
+        let restricted = self
+            .voting_rights
+            .iter()
+            .filter(|(name, _)| {
+                if let Some(restrict_to) = restrict_to {
+                    restrict_to.contains(name)
+                } else {
+                    true
+                }
+            })
+            .cloned();
+
+        let (preferred, rest): (Vec<_>, Vec<_>) = if let Some(preferences) = preferences {
+            restricted.partition(|(name, _)| preferences.contains(name))
+        } else {
+            (Vec::new(), restricted.collect())
+        };
+
+        Self::choose_multiple_weighted(&preferred, preferred.len())
+            .chain(Self::choose_multiple_weighted(&rest, rest.len()))
+            .cloned()
+            .collect()
     }
 
     pub fn weight(&self, author: &AuthorityName) -> StakeUnit {
@@ -234,5 +266,61 @@ impl PartialEq for Committee {
         self.epoch == other.epoch
             && self.voting_rights == other.voting_rights
             && self.total_votes == other.total_votes
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::crypto::get_key_pair;
+    use narwhal_crypto::traits::KeyPair;
+
+    #[test]
+    fn test_shuffle_by_weight() {
+        let (_, sec1) = get_key_pair();
+        let (_, sec2) = get_key_pair();
+        let (_, sec3) = get_key_pair();
+        let a1: AuthorityName = sec1.public().into();
+        let a2: AuthorityName = sec2.public().into();
+        let a3: AuthorityName = sec3.public().into();
+
+        let mut authorities = BTreeMap::new();
+        authorities.insert(a1, 1);
+        authorities.insert(a2, 1);
+        authorities.insert(a3, 1);
+
+        let committee = Committee::new(0, authorities).unwrap();
+
+        assert_eq!(committee.shuffle_by_stake(None, None).len(), 3);
+
+        let mut pref = HashSet::new();
+        pref.insert(a2);
+
+        // preference always comes first
+        for _ in 0..100 {
+            assert_eq!(
+                a2,
+                *committee
+                    .shuffle_by_stake(Some(&pref), None)
+                    .first()
+                    .unwrap()
+            );
+        }
+
+        let mut restrict = HashSet::new();
+        restrict.insert(a2);
+
+        for _ in 0..100 {
+            let res = committee.shuffle_by_stake(None, Some(&restrict));
+            assert_eq!(1, res.len());
+            assert_eq!(a2, res[0]);
+        }
+
+        // empty preferences are valid
+        let res = committee.shuffle_by_stake(Some(&HashSet::new()), None);
+        assert_eq!(3, res.len());
+
+        let res = committee.shuffle_by_stake(None, Some(&HashSet::new()));
+        assert_eq!(0, res.len());
     }
 }


### PR DESCRIPTION
Given a validator, and a cert for which that validator is missing parents, this method allows the validator to execute the cert on other authorities (preferentially the signers of the cert) and obtain a trustworthy TransactionEffects back.

(Also clean up shuffle_by_stake quite a bit)

(Also partial revert of my previous PR #3323)