### PR TITLE
Enable building Docker image with debug symbols as an option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,10 @@ members = [
 # debug = true
 # strip = "debuginfo"
 
+[profile.bench-profiling]
+inherits = "release"
+# Important for performance/memory profiling
+debug = true
+
 [profile.bench]
 debug = true

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -39,8 +39,9 @@ RUN cargo build --profile $PROFILE --bin sui-node
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
+ARG PROFILE=release
 WORKDIR sui
-COPY --from=builder /sui/target/$PROFILE/sui-node /usr/local/bin
+COPY --from=builder "/sui/target/$PROFILE/sui-node" /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -1,4 +1,5 @@
 FROM rust:1.62.0 AS chef
+ARG PROFILE=release
 WORKDIR sui
 RUN apt-get update && apt-get install -y cmake clang
 
@@ -25,7 +26,7 @@ FROM chef AS builder
 COPY --from=planner /sui/Cargo.toml Cargo.toml
 COPY --from=planner /sui/Cargo.lock Cargo.lock
 COPY --from=planner /sui/crates/workspace-hack crates/workspace-hack
-RUN cargo build --release
+RUN cargo build --profile $PROFILE
 
 # Build application
 #
@@ -34,12 +35,12 @@ RUN cargo build --release
 # built as they were built and cached by the previous layer.
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
-RUN cargo build --release --bin sui-node
+RUN cargo build --profile $PROFILE --bin sui-node
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
 WORKDIR sui
-COPY --from=builder /sui/target/release/sui-node /usr/local/bin
+COPY --from=builder /sui/target/$PROFILE/sui-node /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-node/build.sh
+++ b/docker/sui-node/build.sh
@@ -15,9 +15,14 @@ BUILD_DATE="$(date -u +'%Y-%m-%d')"
 if [[ "$1" == "--debug-symbols" ]]; then
 	PROFILE="bench-profiling"
 	echo "Building with debug symbols enabled"
-else
+elif [[ -z "$1 " ]]; then
 	PROFILE="release"
+else
+	PROFILE=""
+	echo "Did not understand arg $1... try --debug-symbols"
+	exit 1
 fi
+shift
 
 echo
 echo "Building sui-node docker image"

--- a/docker/sui-node/build.sh
+++ b/docker/sui-node/build.sh
@@ -11,6 +11,14 @@ DOCKERFILE="$DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --dirty)"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 
+# option to build using debug symbols
+if [[ "$1" == "--debug-symbols" ]]; then
+	PROFILE="bench-profiling"
+	echo "Building with debug symbols enabled"
+else
+	PROFILE="release"
+fi
+
 echo
 echo "Building sui-node docker image"
 echo "Dockerfile: \t$DOCKERFILE"
@@ -22,4 +30,5 @@ echo
 docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
+	--build-arg PROFILE="$PROFILE" \
 	"$@"


### PR DESCRIPTION
This is part of being able to profile our nodes in production.

Note that the default image built has no debug symbols.