### PR TITLE
A few gateway fixes

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -644,15 +644,16 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                 &(object.owner, object_ref.0),
                 &ObjectInfo::new(&object_ref, object),
             )?;
+            // Only initialize lock for owned objects.
+            // TODO: Skip this for quasi-shared objects.
+            self.lock_service
+                .initialize_locks(&[object_ref], false /* is_force_reset */)
+                .await?;
         }
 
         // Update the parent
         self.parent_sync
             .insert(&object_ref, &object.previous_transaction)?;
-
-        self.lock_service
-            .initialize_locks(&[object_ref], false /* is_force_reset */)
-            .await?;
 
         Ok(())
     }

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -383,6 +383,13 @@ where
     /// And when it's out-of-dated in the rare case, we need to be able to understand the error
     /// returned from validators and update the object locally so that the wallet can retry.
     async fn get_object_internal(&self, object_id: &ObjectID) -> SuiResult<Object> {
+        if let Ok(Some(o)) = self.store.get_object(object_id) {
+            if o.is_immutable() {
+                // If an object is immutable, it can never be mutated and hence is guaranteed to
+                // be up-to-date. No need to download from validators.
+                return Ok(o);
+            }
+        }
         let object = self
             .download_object_from_authorities(*object_id)
             .await?


### PR DESCRIPTION
Two fixes in this PR:
1. We currently download the framework package each time we use it. This is very wasteful. It also adds a lot of noise to the logs that made it difficult for me when I was investigating gateway issues. In general, we shouldn't need to download an object if it's immutable as it's guaranteed to be up-to-date.
2. We should not initialize object locks for shared objects in the gateway. They will never gets deleted.