### PR TITLE
Explorer: render original Move field names

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -48,7 +48,6 @@ function ObjectLoaded({ data }: { data: DataType }) {
         [showConnectedEntities]
     );
     const clickSetShowTx = useCallback(() => setShowTx(!showTx), [showTx]);
-    const prepLabel = (label: string) => label.split('_').join(' ');
     const checkIsPropertyType = (value: any) =>
         ['number', 'string'].includes(typeof value);
 
@@ -256,7 +255,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                 <div className={styles.propertybox}>
                                     {properties.map(([key, value], index) => (
                                         <div key={`property-${index}`}>
-                                            <p>{prepLabel(key)}</p>
+                                            <p>{key}</p>
                                             <p>{value}</p>
                                         </div>
                                     ))}
@@ -303,7 +302,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                                 <div className={styles.bytecodebox}>
                                     {properties.map(([key, value], index) => (
                                         <div key={`property-${index}`}>
-                                            <div>{prepLabel(key)}</div>
+                                            <div>{key}</div>
                                             <div className={codestyle.code}>
                                                 {value}
                                             </div>

--- a/explorer/client/src/pages/object-result/ObjectResult.module.css
+++ b/explorer/client/src/pages/object-result/ObjectResult.module.css
@@ -64,7 +64,7 @@ div.propertybox > div > p {
 }
 
 div.propertybox > div > p:first-child {
-    @apply font-sans font-semibold uppercase;
+    @apply font-sans font-semibold;
 }
 
 /* Clickable Header CSS */


### PR DESCRIPTION
closes https://github.com/MystenLabs/sui/issues/2865

before
![CleanShot 2022-07-26 at 07 15 06](https://user-images.githubusercontent.com/76067158/181029064-e8fd6f82-9314-40e7-8a7c-3cf98042e60a.png)


After
![CleanShot 2022-07-26 at 07 17 11](https://user-images.githubusercontent.com/76067158/181029015-c6e7d5ca-9055-4912-b379-bbb7765ab9e1.png)
