### PR TITLE
[explorer] Move bytecode improve for Object Results

### DIFF
--- a/explorer/client/src/components/module/ModuleView.module.css
+++ b/explorer/client/src/components/module/ModuleView.module.css
@@ -15,22 +15,22 @@ section .codeview {
     @apply text-sm font-semibold pt-2 pb-2;
 }
 
-.txmodule {
+.module {
     @apply grid grid-cols-1 md:grid-cols-3 gap-0 pt-2 md:pb-2;
 }
 
-.txmodule section {
+.module section {
     border-top: 1px solid #f0f1f2;
     border-bottom: 1px solid #f0f1f2;
     @apply md:p-3 pb-0;
 }
 
-.txmodule section:first-child {
+.module section:first-child {
     @apply pl-0;
 }
 
 .itemviewtitle,
-.txtitle {
+.title {
     @apply text-sui-grey-100 font-[500] text-lg  mt-5 mb-0;
 }
 
@@ -38,23 +38,6 @@ section .codeview pre {
     @apply m-0 p-0;
 
     background: transparent;
-}
-
-.moretxbtn {
-    @apply text-right bg-transparent cursor-pointer border-0  text-[#636870] hover:text-gray-400 transition-colors duration-200 ease-in-out font-normal text-sm p-2;
-}
-
-.moretxbtn::after {
-    margin: 5px;
-    content: '';
-    background-image: url('../../assets/SVGIcons/chevron-down.svg');
-    @apply text-sm;
-
-    width: 12px;
-    height: 12px;
-    position: absolute;
-    margin-top: 4px;
-    transform: rotate(0deg);
 }
 
 .viewless::after {

--- a/explorer/client/src/components/module/ModuleView.tsx
+++ b/explorer/client/src/components/module/ModuleView.tsx
@@ -8,13 +8,13 @@ import codestyle from '../../styles/bytecode.module.css';
 
 import type { Language } from 'prism-react-renderer';
 
-import styles from './TxModuleView.module.css';
+import styles from './ModuleView.module.css';
 // inclue Rust language.
 // @ts-ignore
 (typeof global !== 'undefined' ? global : window).Prism = Prism;
 require('prismjs/components/prism-rust');
 
-function TxModuleView({ itm }: { itm: any }) {
+function ModuleView({ itm }: { itm: any }) {
     return (
         <section className={styles.modulewrapper}>
             <div className={styles.moduletitle}>{itm[0]}</div>
@@ -58,4 +58,4 @@ function TxModuleView({ itm }: { itm: any }) {
     );
 }
 
-export default TxModuleView;
+export default ModuleView;

--- a/explorer/client/src/components/module/ModulesWrapper.tsx
+++ b/explorer/client/src/components/module/ModulesWrapper.tsx
@@ -32,7 +32,7 @@ function ModuleViewWrapper({ data }: { data: Modules }) {
 
     return (
         <div className={styles.modulewraper}>
-            <h3 className={styles.title}>Modules </h3>
+            <h3 className={styles.title}>{data.title}</h3>
             <div className={styles.module}>
                 {moduleData.content
                     .filter(

--- a/explorer/client/src/components/module/ModulesWrapper.tsx
+++ b/explorer/client/src/components/module/ModulesWrapper.tsx
@@ -4,22 +4,22 @@
 import { useMemo, useState, useEffect } from 'react';
 
 import Pagination from '../../components/pagination/Pagination';
-import TxModuleView from './TxModuleView';
+import ModuleView from './ModuleView';
 
-import styles from './TxModuleView.module.css';
+import styles from './ModuleView.module.css';
 
-type TxModules = {
+type Modules = {
     title: string;
     content: any[];
 };
 
-const TX_MODULES_PER_PAGE = 3;
+const MODULES_PER_PAGE = 3;
 // TODO: Include Pagination for now use viewMore and viewLess
-function TxModuleViewWrapper({ data }: { data: TxModules }) {
+function ModuleViewWrapper({ data }: { data: Modules }) {
     const moduleData = useMemo(() => data, [data]);
     const [modulesPageNumber, setModulesPageNumber] = useState(1);
     const totalModulesCount = moduleData.content.length;
-    const numOfMudulesToShow = TX_MODULES_PER_PAGE;
+    const numOfMudulesToShow = MODULES_PER_PAGE;
 
     useEffect(() => {
         setModulesPageNumber(modulesPageNumber);
@@ -32,8 +32,8 @@ function TxModuleViewWrapper({ data }: { data: TxModules }) {
 
     return (
         <div className={styles.modulewraper}>
-            <h3 className={styles.txtitle}>Modules </h3>
-            <div className={styles.txmodule}>
+            <h3 className={styles.title}>Modules </h3>
+            <div className={styles.module}>
                 {moduleData.content
                     .filter(
                         (_, index) =>
@@ -42,7 +42,7 @@ function TxModuleViewWrapper({ data }: { data: TxModules }) {
                             index < modulesPageNumber * numOfMudulesToShow
                     )
                     .map((item, idx) => (
-                        <TxModuleView itm={item} key={idx} />
+                        <ModuleView itm={item} key={idx} />
                     ))}
             </div>
             {totalModulesCount > numOfMudulesToShow && (
@@ -57,4 +57,4 @@ function TxModuleViewWrapper({ data }: { data: TxModules }) {
         </div>
     );
 }
-export default TxModuleViewWrapper;
+export default ModuleViewWrapper;

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -293,7 +293,7 @@ function ObjectLoaded({ data }: { data: DataType }) {
                     ) : (
                         <ModulesWrapper
                             data={{
-                                title: '',
+                                title: 'Modules',
                                 content: properties,
                             }}
                         />

--- a/explorer/client/src/pages/object-result/ObjectLoaded.tsx
+++ b/explorer/client/src/pages/object-result/ObjectLoaded.tsx
@@ -6,9 +6,9 @@ import ReactJson from 'react-json-view';
 
 import DisplayBox from '../../components/displaybox/DisplayBox';
 import Longtext from '../../components/longtext/Longtext';
+import ModulesWrapper from '../../components/module/ModulesWrapper';
 import OwnedObjects from '../../components/ownedobjects/OwnedObjects';
 import TxForID from '../../components/transactions-for-id/TxForID';
-import codestyle from '../../styles/bytecode.module.css';
 import theme from '../../styles/theme.module.css';
 import { getOwnerStr, parseImageURL } from '../../utils/objectUtils';
 import { trimStdLibPrefix } from '../../utils/stringUtils';
@@ -291,26 +291,12 @@ function ObjectLoaded({ data }: { data: DataType }) {
                             Child Objects {showConnectedEntities ? '' : '+'}
                         </h2>
                     ) : (
-                        <div>
-                            <h2
-                                className={styles.clickableheader}
-                                onClick={clickSetShowProperties}
-                            >
-                                Modules {showProperties ? '' : '+'}
-                            </h2>
-                            {showProperties && (
-                                <div className={styles.bytecodebox}>
-                                    {properties.map(([key, value], index) => (
-                                        <div key={`property-${index}`}>
-                                            <div>{key}</div>
-                                            <div className={codestyle.code}>
-                                                {value}
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
+                        <ModulesWrapper
+                            data={{
+                                title: '',
+                                content: properties,
+                            }}
+                        />
                     )}
                     {showConnectedEntities &&
                         data.objType !== 'Move Package' && (

--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -15,10 +15,10 @@ import {
 import cl from 'classnames';
 
 import Longtext from '../../components/longtext/Longtext';
+import ModulesWrapper from '../../components/module/ModulesWrapper';
 import Tabs from '../../components/tabs/Tabs';
 import SendReceiveView from './SendReceiveView';
 import TxLinks from './TxLinks';
-import TxModulesWrapper from './TxModulesWrapper';
 import TxResultHeader from './TxResultHeader';
 
 import type { DataType, Category } from './TransactionResultType';
@@ -345,7 +345,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                                     styles.txgridcolspan3,
                                 ])}
                             >
-                                <TxModulesWrapper data={modules} />
+                                <ModulesWrapper data={modules} />
                             </section>
                         )}
                     </div>


### PR DESCRIPTION
Implements Figma Design on Modules for Object Results whilst keeping the modles code to one component.

Here's a video showing it in action:

https://user-images.githubusercontent.com/11377188/181065598-0d48312b-e576-4b16-b55f-e11b380e4fe9.mp4


