### PR TITLE
Use execution driver instead of sync_authority_source_to_destination for gossip

### DIFF
--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -6,6 +6,7 @@ use crate::authority_active::gossip::configurable_batch_action_client::{
     init_configurable_authorities, BatchAction, ConfigurableBatchActionClient,
 };
 use crate::authority_active::MAX_RETRY_DELAY_MS;
+use crate::authority_aggregator::AuthorityAggregator;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -68,6 +68,8 @@ pub async fn test_gossip_error() {
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 pub async fn test_gossip_after_revert() {
+    telemetry_subscribers::init_for_testing();
+
     let action_sequence = vec![BatchAction::EmitUpdateItem(), BatchAction::EmitUpdateItem()];
     let (net, states, digests) = init_configurable_authorities(action_sequence).await;
 
@@ -163,7 +165,8 @@ async fn start_gossip_process(
             let active_state = Arc::new(
                 ActiveAuthority::new_with_ephemeral_storage_for_test(state, inner_net).unwrap(),
             );
-            active_state.spawn_gossip_process(3).await;
+            active_state.clone().spawn_gossip_process(3).await;
+            active_state.spawn_execute_process().await;
         });
         active_authorities.push(handle);
     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -230,7 +230,7 @@ pub enum ReduceOutput<S> {
 }
 
 #[async_trait]
-pub trait CertificateHandler {
+trait CertificateHandler {
     async fn handle(&self, certificate: CertifiedTransaction)
         -> SuiResult<TransactionInfoResponse>;
 
@@ -277,7 +277,7 @@ where
         level = "trace",
         skip_all
     )]
-    pub async fn sync_authority_source_to_destination<CertHandler: CertificateHandler>(
+    async fn sync_authority_source_to_destination<CertHandler: CertificateHandler>(
         &self,
         cert: CertifiedTransaction,
         source_authority: AuthorityName,
@@ -403,7 +403,7 @@ where
         Ok(())
     }
 
-    pub async fn sync_certificate_to_authority(
+    async fn sync_certificate_to_authority(
         &self,
         cert: CertifiedTransaction,
         destination_authority: AuthorityName,
@@ -418,7 +418,7 @@ where
         .await
     }
 
-    pub async fn sync_certificate_to_authority_with_timeout(
+    async fn sync_certificate_to_authority_with_timeout(
         &self,
         cert: CertifiedTransaction,
         destination_authority: AuthorityName,
@@ -449,9 +449,7 @@ where
     /// stake, in order to bring the destination authority up to date to accept
     /// the certificate. The time devoted to each attempt is bounded by
     /// `timeout_milliseconds`.
-    pub async fn sync_certificate_to_authority_with_timeout_inner<
-        CertHandler: CertificateHandler,
-    >(
+    async fn sync_certificate_to_authority_with_timeout_inner<CertHandler: CertificateHandler>(
         &self,
         cert: CertifiedTransaction,
         destination_authority: AuthorityName,


### PR DESCRIPTION
This improves parallelism, and removes the use of the (slightly) incorrect `sync_authority_source_to_destination`