### PR TITLE
Fix flaky gateway test

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1247,7 +1247,7 @@ impl AuthorityState {
         &self,
         digest: TransactionDigest,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        QueryHelpers::get_transaction(&self.database, digest)
+        QueryHelpers::get_transaction(&self.database, &digest)
     }
 
     fn get_indexes(&self) -> SuiResult<Arc<IndexStore>> {

--- a/crates/sui-core/src/query_helpers.rs
+++ b/crates/sui-core/src/query_helpers.rs
@@ -75,12 +75,12 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> QueryHelpers<S> {
 
     pub fn get_transaction(
         database: &SuiDataStore<S>,
-        digest: TransactionDigest,
+        digest: &TransactionDigest,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        let opt = database.get_certified_transaction(&digest)?;
+        let opt = database.get_certified_transaction(digest)?;
         match opt {
-            Some(certificate) => Ok((certificate, database.get_effects(&digest)?)),
-            None => Err(anyhow!(SuiError::TransactionNotFound { digest })),
+            Some(certificate) => Ok((certificate, database.get_effects(digest)?)),
+            None => Err(anyhow!(SuiError::TransactionNotFound { digest: *digest })),
         }
     }
 }


### PR DESCRIPTION
This PR primarily fixes the flaky `test_equivocation_resilient`.
There are multiple sources of issues:
1. In the test implementation, each async task will attempt to construct a transaction by asking the gateway, which would attempt to download the object and derive its version. This could lead to the situation where a gateway is in fact downloading a newer version of the object (with sequence number 1) and constructing an entirely different transaction than intended (the intention is to stress equivocation of the same object version). This PR fixies this by constructing the transaction statically.
2. When we finish executing a transaction, we first remove the transaction from db, and then remove the lock. If another transaction (that tries to equivocate) happens in-between the above two steps, it would try to re-execute the previous transaction, but then could not find the transaction from the db, and force clearing the lock, which is incorrect. This PR fixes it by checking the certs table instead (we remove tx and insert to cert atomically).

Added more logging, added idempotency check as optimization in execute_transaction.

None of the stuff is ideal. I expect that we get rid of gateway asap.