### PR TITLE
[explorer] Migrate address view transaction table to new table UI

### DIFF
--- a/explorer/client/src/__tests__/e2e.test.ts
+++ b/explorer/client/src/__tests__/e2e.test.ts
@@ -395,24 +395,25 @@ describe('End-to-end Tests', () => {
         });
     });
     describe('Transactions for ID', () => {
-        const txResults =
-            'TxIdTimeTxTypeStatusAddressesXHTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressYHTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZHTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZITP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZJTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZKTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZLTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZMTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZNTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZOTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressZPTP9gcFmF5K...KFhdqfpdK8=<1secagoTransfer✔From:senderAddressTo:receiv...dressGHTP9gcFmF5K...KFhdqfpdK8=1min3secsagoTransfer✖From:senderAddressTo:receiv...dressDa4vHc9IwbvO...+xnJ7Zx5E4=17days1houragoTransfer✔From:senderAddressTo:receiv...dress';
-
         it('are displayed from and to address', async () => {
             const address = 'ownsAllAddress';
             await page.goto(`${BASE_URL}/addresses/${address}`);
             const fromResults = await cssInteract(page)
-                .with('#tx')
+                .with('[data-testid="tx"]')
                 .get.textContent();
-            expect(fromResults.replace(/\s/g, '')).toBe(txResults);
+            expect(fromResults.replace(/\s/g, '')).toMatchInlineSnapshot(
+                `"TimeTxTypeTransactionIDAddressesGas<1secagoTransferXHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferYHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZITP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZJTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZKTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZLTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZMTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZNTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZOTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZPTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress411m3sagoTransferGHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress4117d1hagoTransferDa4vHc9IwbvO...+xnJ7Zx5E4=senderAddressreceiv...dress41"`
+            );
         });
         it('are displayed for input and mutated object', async () => {
             const address = 'CollectionObject';
             await page.goto(`${BASE_URL}/addresses/${address}`);
             const fromResults = await cssInteract(page)
-                .with('#tx')
+                .with('[data-testid="tx"]')
                 .get.textContent();
-            expect(fromResults.replace(/\s/g, '')).toBe(txResults);
+            expect(fromResults.replace(/\s/g, '')).toMatchInlineSnapshot(
+                `"TimeTxTypeTransactionIDAddressesGas<1secagoTransferXHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferYHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZITP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZJTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZKTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZLTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZMTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZNTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZOTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress41<1secagoTransferZPTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress411m3sagoTransferGHTP9gcFmF5K...KFhdqfpdK8=senderAddressreceiv...dress4117d1hagoTransferDa4vHc9IwbvO...+xnJ7Zx5E4=senderAddressreceiv...dress41"`
+            );
         });
     });
 });

--- a/explorer/client/src/components/transactions-for-id/TxForID.tsx
+++ b/explorer/client/src/components/transactions-for-id/TxForID.tsx
@@ -129,7 +129,11 @@ function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
 
     if (!showData || showData.length === 0) return null;
 
-    return <TableCard tabledata={tableData} />;
+    return (
+        <div data-testid="tx">
+            <TableCard tabledata={tableData} />
+        </div>
+    );
 }
 
 function TxForIDStatic({

--- a/explorer/client/src/components/transactions-for-id/TxForID.tsx
+++ b/explorer/client/src/components/transactions-for-id/TxForID.tsx
@@ -6,8 +6,7 @@ import {
     type ExecutionStatusType,
     type TransactionKindName,
 } from '@mysten/sui.js';
-import cl from 'classnames';
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useMemo } from 'react';
 
 import { NetworkContext } from '../../context';
 import {
@@ -15,15 +14,14 @@ import {
     getDataOnTxDigests,
 } from '../../utils/api/DefaultRpcClient';
 import { IS_STATIC_ENV } from '../../utils/envUtil';
+import { numberSuffix } from '../../utils/numberUtil';
 import { deduplicate } from '../../utils/searchUtil';
 import { findTxfromID, findTxDatafromID } from '../../utils/static/searchUtil';
 import { truncate } from '../../utils/stringUtils';
 import { timeAgo } from '../../utils/timeUtils';
 import ErrorResult from '../error-result/ErrorResult';
-import Longtext from '../longtext/Longtext';
 import PaginationLogic from '../pagination/PaginationLogic';
-
-import styles from './TxForID.module.css';
+import TableCard from '../table/TableCard';
 
 const TRUNCATE_LENGTH = 14;
 const ITEMS_PER_PAGE = 20;
@@ -40,6 +38,7 @@ type TxnData = {
     From: string;
     To?: string;
     timestamp_ms?: number | null;
+    txGas: number;
 };
 
 type categoryType = 'address' | 'object';
@@ -56,72 +55,81 @@ const getTx = async (
 const viewFn = (results: any) => <TxForIDView showData={results} />;
 
 function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
-    if (!showData || showData.length === 0) return <></>;
+    // TODO: Ideally move this to a prop:
+    const hasTimeColumn = showData?.[0].timestamp_ms;
 
-    return (
-        <div id="tx" className={styles.txresults}>
-            <div className={styles.txheader}>
-                <div className={styles.txid}>TxId</div>
-                {showData[0].timestamp_ms && (
-                    <div className={styles.txage}>Time</div>
-                )}
-                <div className={styles.txtype}>TxType</div>
-                <div className={styles.txstatus}>Status</div>
-                <div className={styles.txadd}>Addresses</div>
-            </div>
-
-            {showData.map((x, index) => (
-                <div key={`txid-${index}`} className={styles.txrow}>
-                    <div className={styles.txid}>
-                        <Longtext
-                            text={x.txId}
-                            category="transactions"
-                            isLink={true}
-                            alttext={truncate(x.txId, 26, '...')}
-                        />
-                    </div>
-                    {x.timestamp_ms && (
-                        <div className={styles.txage}>
-                            {`${timeAgo(x.timestamp_ms)} ago`}
-                        </div>
-                    )}
-                    <div className={styles.txtype}>{x.kind}</div>
-                    <div
-                        className={cl(
-                            styles.txstatus,
-                            styles[x.status.toLowerCase()]
-                        )}
-                    >
-                        {x.status === 'success' ? '\u2714' : '\u2716'}
-                    </div>
-                    <div className={styles.txadd}>
-                        <div>
-                            From:
-                            <Longtext
-                                text={x.From}
-                                category="addresses"
-                                isLink={true}
-                                isCopyButton={false}
-                                alttext={truncate(x.From, TRUNCATE_LENGTH)}
-                            />
-                        </div>
-                        {x.To && (
-                            <div>
-                                To :
-                                <Longtext
-                                    text={x.To}
-                                    category="addresses"
-                                    isLink={true}
-                                    isCopyButton={false}
-                                    alttext={truncate(x.To, TRUNCATE_LENGTH)}
-                                />
-                            </div>
-                        )}
-                    </div>
-                </div>
-            ))}
-        </div>
+    const tableData = useMemo(
+        () => ({
+            data: (showData ?? []).map((data) => ({
+                date: `${timeAgo(data.timestamp_ms, undefined, true)} ago`,
+                txTypes: {
+                    txTypeName: data.kind,
+                    status: data.status,
+                },
+                transactionId: [
+                    {
+                        url: data.txId,
+                        name: truncate(data.txId, 26, '...'),
+                        category: 'transactions',
+                        isLink: true,
+                        copy: false,
+                    },
+                ],
+                addresses: [
+                    {
+                        url: data.From,
+                        name: truncate(data.From, TRUNCATE_LENGTH),
+                        category: 'addresses',
+                        isLink: true,
+                        copy: false,
+                    },
+                    ...(data.To
+                        ? [
+                              {
+                                  url: data.To,
+                                  name: truncate(data.To, TRUNCATE_LENGTH),
+                                  category: 'addresses',
+                                  isLink: true,
+                                  copy: false,
+                              },
+                          ]
+                        : []),
+                ],
+                gas: numberSuffix(data.txGas),
+            })),
+            columns: [
+                ...(hasTimeColumn
+                    ? [
+                          {
+                              headerLabel: 'Time',
+                              accessorKey: 'date',
+                          },
+                      ]
+                    : []),
+                {
+                    headerLabel: 'TxType',
+                    accessorKey: 'txTypes',
+                },
+                {
+                    headerLabel: 'Transaction ID',
+                    accessorKey: 'transactionId',
+                },
+                {
+                    headerLabel: 'Addresses',
+                    accessorKey: 'addresses',
+                },
+                {
+                    headerLabel: 'Gas',
+                    accessorKey: 'gas',
+                },
+            ],
+        }),
+        [hasTimeColumn, showData]
     );
+
+    if (!showData || showData.length === 0) return null;
+
+    return <TableCard tabledata={tableData} />;
 }
 
 function TxForIDStatic({
@@ -168,6 +176,7 @@ function TxForIDAPI({ id, category }: { id: string; category: categoryType }) {
                             kind: el!.kind,
                             From: el!.From,
                             To: el!.To,
+                            txGas: el!.txGas,
                             timestamp_ms: el!.timestamp_ms,
                         }));
                         setData({

--- a/explorer/client/src/components/transactions-for-id/TxForID.tsx
+++ b/explorer/client/src/components/transactions-for-id/TxForID.tsx
@@ -56,7 +56,7 @@ const viewFn = (results: any) => <TxForIDView showData={results} />;
 
 function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
     // TODO: Ideally move this to a prop:
-    const hasTimeColumn = showData?.[0].timestamp_ms;
+    const hasTimeColumn = showData?.[0]?.timestamp_ms;
 
     const tableData = useMemo(
         () => ({


### PR DESCRIPTION
This updates the table to match the new table UI. This fixes #3502.

On main:
<img width="1248" alt="Screen Shot 2022-07-26 at 1 00 37 PM" src="https://user-images.githubusercontent.com/109986297/181101381-10f8d155-a645-42a4-a866-a87b3cce7cec.png">


This PR:
<img width="1107" alt="Screen Shot 2022-07-26 at 12 57 11 PM" src="https://user-images.githubusercontent.com/109986297/181101313-9626c3aa-28e8-432b-aa8c-7f17ce09508f.png">
