### PR TITLE
Split authenticated checkpoint and proposal request

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -988,6 +988,12 @@ impl AuthorityState {
             CheckpointRequestType::PastCheckpoint(seq) => {
                 checkpoint_store.handle_past_checkpoint(request.detail, *seq)
             }
+            CheckpointRequestType::AuthenticatedCheckpoint(seq) => {
+                checkpoint_store.handle_authenticated_checkpoint(seq, request.detail)
+            }
+            CheckpointRequestType::CheckpointProposal => {
+                checkpoint_store.handle_proposal(request.detail)
+            }
         }
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -982,9 +982,6 @@ impl AuthorityState {
             })?
             .lock();
         match &request.request_type {
-            CheckpointRequestType::LatestCheckpointProposal => {
-                checkpoint_store.handle_latest_proposal(request)
-            }
             CheckpointRequestType::AuthenticatedCheckpoint(seq) => {
                 checkpoint_store.handle_authenticated_checkpoint(seq, request.detail)
             }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -985,9 +985,6 @@ impl AuthorityState {
             CheckpointRequestType::LatestCheckpointProposal => {
                 checkpoint_store.handle_latest_proposal(request)
             }
-            CheckpointRequestType::PastCheckpoint(seq) => {
-                checkpoint_store.handle_past_checkpoint(request.detail, *seq)
-            }
             CheckpointRequestType::AuthenticatedCheckpoint(seq) => {
                 checkpoint_store.handle_authenticated_checkpoint(seq, request.detail)
             }

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -55,9 +55,7 @@ use gossip::{gossip_process, node_sync_process};
 pub mod checkpoint_driver;
 use crate::authority_active::checkpoint_driver::CheckpointMetrics;
 use crate::epoch::reconfiguration::Reconfigurable;
-use checkpoint_driver::{
-    checkpoint_process, get_latest_proposal_and_checkpoint_from_all, sync_to_checkpoint,
-};
+use checkpoint_driver::{checkpoint_process, get_latest_checkpoint_from_all, sync_to_checkpoint};
 
 pub mod execution_driver;
 
@@ -261,7 +259,7 @@ where
         // TODO: fullnode should not get proposals
         // TODO: potentially move get_latest_proposal_and_checkpoint_from_all and
         // sync_to_checkpoint out of checkpoint_driver
-        let (checkpoint_summary, _) = get_latest_proposal_and_checkpoint_from_all(
+        let checkpoint_summary = get_latest_checkpoint_from_all(
             self.net(),
             checkpoint_process_control.extra_time_after_quorum,
             checkpoint_process_control.timeout_until_quorum,

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -708,7 +708,8 @@ where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
     net.get_certified_checkpoint(
-        &CheckpointRequest::past(sequence_number, contents),
+        sequence_number,
+        contents,
         available_authorities,
         // Loop forever until we get the cert from someone.
         None,

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -20,8 +20,7 @@ use sui_types::{
     messages_checkpoint::{
         AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
         CheckpointContents, CheckpointDigest, CheckpointFragment, CheckpointProposal,
-        CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
-        SignedCheckpointProposalSummary, SignedCheckpointSummary,
+        CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber, SignedCheckpointSummary,
     },
 };
 use tokio::time::Instant;
@@ -170,17 +169,17 @@ pub async fn checkpoint_process<A>(
             tokio::time::sleep(Duration::from_millis(100)).await;
             continue;
         }
-        // (1) Get the latest summaries and proposals
+        // (1) Get the latest checkpoint cert from the network.
         // TODO: This may not work if we are many epochs behind: we won't be able to download
         // from the current network. We will need to consolidate sync implementation.
-        let state_of_world = get_latest_proposal_and_checkpoint_from_all(
+        let highest_checkpoint = get_latest_checkpoint_from_all(
             net.clone(),
             timing.extra_time_after_quorum,
             timing.timeout_until_quorum,
         )
         .await;
 
-        let (checkpoint, proposals) = match state_of_world {
+        let highest_checkpoint = match highest_checkpoint {
             Ok(s) => s,
             Err(err) => {
                 warn!("Cannot get a quorum of checkpoint information: {:?}", err);
@@ -195,7 +194,7 @@ pub async fn checkpoint_process<A>(
         // Its ok nothing else goes on in terms of the active checkpoint logic
         // while we do sync. We are in any case not in a position to make valuable
         // proposals.
-        if let Some(checkpoint) = checkpoint {
+        if let Some(checkpoint) = highest_checkpoint {
             // Check if there are more historic checkpoints to catch up with
             let next_checkpoint = state_checkpoints.lock().next_checkpoint();
             // First sync until before the latest checkpoint. We will special
@@ -285,35 +284,14 @@ pub async fn checkpoint_process<A>(
 
         let proposal = state_checkpoints.lock().set_proposal(committee.epoch);
 
-        // (4) Check if we need to advance to the next checkpoint, in case >2/3
-        // have a proposal out. If so we start creating and injecting fragments
-        // into the consensus protocol to make the new checkpoint.
-        let weight: StakeUnit = proposals
-            .iter()
-            .map(|(auth, _)| committee.weight(auth))
-            .sum();
-
-        if weight < committee.quorum_threshold() {
-            debug!(
-                ?weight,
-                "Not enough proposals to make progress on checkpoint creation"
-            );
-            // We don't have a quorum of proposals yet, we won't succeed making a checkpoint
-            // even if we try. Sleep and come back latter.
-            tokio::time::sleep(timing.delay_on_local_failure).await;
-            continue;
-        }
-
         // (5) Now we try to create fragments and construct checkpoint.
+        // TODO: Restructure the fragment making process.
         match proposal {
             Ok(my_proposal) => {
                 if create_fragments_and_make_checkpoint(
                     active_authority,
                     state_checkpoints.clone(),
                     &my_proposal,
-                    // We use the list of validators that responded with a proposal
-                    // to download proposal details.
-                    proposals.into_iter().map(|(name, _)| name).collect(),
                     committee,
                     timing.consensus_delay_estimate,
                     &metrics,
@@ -322,6 +300,9 @@ pub async fn checkpoint_process<A>(
                 {
                     info!(cp_seq=?my_proposal.sequence_number(), "A new checkpoint is created and signed locally");
                     metrics.checkpoints_signed.inc();
+                } else {
+                    debug!("Failed to make checkpoint after going through all available proposals");
+                    tokio::time::sleep(timing.delay_on_local_failure).await;
                 }
             }
             Err(err) => {
@@ -336,19 +317,14 @@ pub async fn checkpoint_process<A>(
     }
 }
 
-/// Reads the latest checkpoint / proposal info from all validators
-/// and extracts the latest checkpoint as well as the set of proposals
-pub async fn get_latest_proposal_and_checkpoint_from_all<A>(
+/// Obtain the highest checkpoint certificate from all validators.
+/// It's done by querying the latest authenticated checkpoints from a quorum of validators.
+/// If we get a quorum of signed checkpoints of the same sequence number, form a cert on the fly.
+pub async fn get_latest_checkpoint_from_all<A>(
     net: Arc<AuthorityAggregator<A>>,
     timeout_after_quorum: Duration,
     timeout_until_quorum: Duration,
-) -> Result<
-    (
-        Option<CertifiedCheckpointSummary>,
-        Vec<(AuthorityName, SignedCheckpointProposalSummary)>,
-    ),
-    SuiError,
->
+) -> Result<Option<CertifiedCheckpointSummary>, SuiError>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
@@ -356,11 +332,7 @@ where
     struct CheckpointSummaries {
         good_weight: StakeUnit,
         bad_weight: StakeUnit,
-        responses: Vec<(
-            AuthorityName,
-            Option<SignedCheckpointProposalSummary>,
-            Option<AuthenticatedCheckpoint>,
-        )>,
+        responses: Vec<(AuthorityName, Option<AuthenticatedCheckpoint>)>,
         errors: Vec<(AuthorityName, SuiError)>,
     }
     let initial_state = CheckpointSummaries::default();
@@ -373,18 +345,18 @@ where
                 Box::pin(async move {
                     // Request and return an error if any
                     client
-                        .handle_checkpoint(CheckpointRequest::latest(false))
+                        .handle_checkpoint(CheckpointRequest::authenticated(None, false))
                         .await
                 })
             },
             |mut state, name, weight, result| {
                 Box::pin(async move {
                     if let Ok(CheckpointResponse {
-                        info: AuthorityCheckpointInfo::Proposal { current, previous },
+                        info: AuthorityCheckpointInfo::AuthenticatedCheckpoint(checkpoint),
                         ..
                     }) = result
                     {
-                        state.responses.push((name, current, previous));
+                        state.responses.push((name, checkpoint));
                         state.good_weight += weight;
                     } else {
                         state.bad_weight += weight;
@@ -428,7 +400,7 @@ where
     // Extract the highest checkpoint cert returned.
     let mut highest_certificate_cert: Option<CertifiedCheckpointSummary> = None;
     for state in &final_state.responses {
-        if let Some(AuthenticatedCheckpoint::Certified(cert)) = &state.2 {
+        if let Some(AuthenticatedCheckpoint::Certified(cert)) = &state.1 {
             if let Some(old_cert) = &highest_certificate_cert {
                 if cert.summary.sequence_number > old_cert.summary.sequence_number {
                     highest_certificate_cert = Some(cert.clone());
@@ -445,32 +417,29 @@ where
         (CheckpointSequenceNumber, CheckpointDigest),
         Vec<(AuthorityName, SignedCheckpointSummary)>,
     > = BTreeMap::new();
-    final_state
-        .responses
-        .iter()
-        .for_each(|(auth, _proposal, checkpoint)| {
-            if let Some(AuthenticatedCheckpoint::Signed(signed)) = checkpoint {
-                // We are interested in this signed checkpoint only if it is
-                // newer than the highest known cert checkpoint.
-                if let Some(newest_checkpoint) = &highest_certificate_cert {
-                    if newest_checkpoint.summary.sequence_number >= signed.summary.sequence_number {
-                        return;
-                    }
+    final_state.responses.iter().for_each(|(auth, checkpoint)| {
+        if let Some(AuthenticatedCheckpoint::Signed(signed)) = checkpoint {
+            // We are interested in this signed checkpoint only if it is
+            // newer than the highest known cert checkpoint.
+            if let Some(newest_checkpoint) = &highest_certificate_cert {
+                if newest_checkpoint.summary.sequence_number >= signed.summary.sequence_number {
+                    return;
                 }
-
-                // Collect signed checkpoints by sequence number and digest.
-                partial_checkpoints
-                    .entry((signed.summary.sequence_number, signed.summary.digest()))
-                    .or_insert_with(Vec::new)
-                    .push((*auth, signed.clone()));
             }
-        });
+
+            // Collect signed checkpoints by sequence number and digest.
+            partial_checkpoints
+                .entry((signed.summary.sequence_number, signed.summary.digest()))
+                .or_insert_with(Vec::new)
+                .push((*auth, signed.clone()));
+        }
+    });
 
     // We use a BTreeMap here to ensure we iterate in increasing order of checkpoint
     // sequence numbers. If we find a valid checkpoint we are sure this is the highest.
     partial_checkpoints
         .iter()
-        .for_each(|((_seq, _digest), signed)| {
+        .for_each(|((seq, _digest), signed)| {
             let weight: StakeUnit = signed
                 .iter()
                 .map(|(auth, _)| net.committee.weight(auth))
@@ -487,31 +456,17 @@ where
                     &net.committee,
                 );
                 if let Ok(cert) = certificate {
+                    debug!(cp_seq=?seq, "A checkpoint certificate is formed from the network");
                     highest_certificate_cert = Some(cert);
                 }
             }
         });
 
-    let next_proposal_sequence_number = highest_certificate_cert
-        .as_ref()
-        .map(|cert| cert.summary.sequence_number + 1)
-        .unwrap_or(0);
-
-    // Collect proposals
-    let proposals: Vec<_> = final_state
-        .responses
-        .iter()
-        .filter_map(|(auth, proposal, _checkpoint)| {
-            if let Some(p) = proposal {
-                if p.summary.sequence_number == next_proposal_sequence_number {
-                    return Some((*auth, p.clone()));
-                }
-            }
-            None
-        })
-        .collect();
-
-    Ok((highest_certificate_cert, proposals))
+    debug!(
+        "Highest Checkpoint Certificate from the network: {:?}",
+        highest_certificate_cert
+    );
+    Ok(highest_certificate_cert)
 }
 
 /// The latest certified checkpoint can either be a checkpoint downloaded from another validator,
@@ -725,7 +680,6 @@ pub async fn create_fragments_and_make_checkpoint<A>(
     active_authority: &ActiveAuthority<A>,
     checkpoint_db: Arc<Mutex<CheckpointStore>>,
     my_proposal: &CheckpointProposal,
-    mut available_authorities: BTreeSet<AuthorityName>,
     committee: &Committee,
     consensus_delay_estimate: Duration,
     metrics: &CheckpointMetrics,
@@ -735,7 +689,11 @@ where
 {
     // Pick another authority, get their proposal, and submit it to consensus
     // Exit when we have a checkpoint proposal.
-
+    let mut available_authorities: BTreeSet<AuthorityName> = committee
+        .voting_rights
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
     available_authorities.remove(&active_authority.state.name); // remove ourselves
 
     let next_checkpoint_sequence_number = checkpoint_db.lock().next_checkpoint();
@@ -755,12 +713,16 @@ where
         let client = active_authority.net.load().authority_clients[authority].clone();
 
         if let Ok(response) = client
-            .handle_checkpoint(CheckpointRequest::latest(true))
+            .handle_checkpoint(CheckpointRequest::proposal(true))
             .await
         {
-            if let AuthorityCheckpointInfo::Proposal { current, previous } = &response.info {
+            if let AuthorityCheckpointInfo::CheckpointProposal {
+                proposal,
+                prev_cert,
+            } = &response.info
+            {
                 // Check if there is a latest checkpoint
-                if let Some(AuthenticatedCheckpoint::Certified(prev)) = previous {
+                if let Some(prev) = prev_cert {
                     if prev.summary.sequence_number >= next_checkpoint_sequence_number {
                         // We are now behind, stop the process
                         break;
@@ -768,20 +730,20 @@ where
                 }
 
                 // For some reason the proposal is empty?
-                if current.is_none() || response.detail.is_none() {
+                if proposal.is_none() || response.detail.is_none() {
                     continue;
                 }
 
                 // Check the proposal is also for the same checkpoint sequence number
-                if &current.as_ref().unwrap().summary.sequence_number
+                if &proposal.as_ref().unwrap().summary.sequence_number
                     != my_proposal.sequence_number()
                 {
-                    // Target validator could be byzantine, just ignore it.
+                    // Target validator may be byzantine or behind, ignore it.
                     continue;
                 }
 
                 let other_proposal = CheckpointProposal::new_from_signed_proposal_summary(
-                    current.as_ref().unwrap().clone(),
+                    proposal.as_ref().unwrap().clone(),
                     response.detail.unwrap(),
                 );
 

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -32,6 +32,7 @@ use sui_types::committee::StakeUnit;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::{sleep, timeout};
 
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tap::TapFallible;
 
 const OBJECT_DOWNLOAD_CHANNEL_BOUND: usize = 1024;
@@ -1697,23 +1698,26 @@ where
 
     pub async fn get_certified_checkpoint(
         &self,
-        request: &CheckpointRequest,
+        sequence_number: CheckpointSequenceNumber,
+        request_contents: bool,
         // authorities known to have the checkpoint we are requesting.
         authorities: &BTreeSet<AuthorityName>,
         timeout_total: Option<Duration>,
     ) -> SuiResult<(CertifiedCheckpointSummary, Option<CheckpointContents>)> {
+        let request = CheckpointRequest::authenticated(Some(sequence_number), request_contents);
         self.quorum_once_with_timeout(
             None,
             Some(authorities),
             |_, client| {
+                let r = request.clone();
                 Box::pin(async move {
-                    let resp = client.handle_checkpoint(request.clone()).await?;
+                    let resp = client.handle_checkpoint(r).await?;
 
                     if let CheckpointResponse {
                         info:
-                            AuthorityCheckpointInfo::Past(Some(AuthenticatedCheckpoint::Certified(
-                                past,
-                            ))),
+                            AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(
+                                AuthenticatedCheckpoint::Certified(past),
+                            )),
                         detail,
                     } = resp
                     {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -378,26 +378,6 @@ impl CheckpointStore {
         })
     }
 
-    pub fn handle_past_checkpoint(
-        &self,
-        detail: bool,
-        seq: CheckpointSequenceNumber,
-    ) -> Result<CheckpointResponse, SuiError> {
-        // Get the checkpoint with a given sequence number
-        let checkpoint = self.checkpoints.get(&seq)?;
-
-        // If a checkpoint is found, and if requested, return the list of transaction digest in it.
-        let content = match (detail, &checkpoint) {
-            (true, Some(_)) => self.checkpoint_contents.get(&seq)?,
-            _ => None,
-        };
-
-        Ok(CheckpointResponse {
-            info: AuthorityCheckpointInfo::Past(checkpoint),
-            detail: content,
-        })
-    }
-
     pub fn handle_authenticated_checkpoint(
         &mut self,
         seq: &Option<CheckpointSequenceNumber>,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -471,7 +471,7 @@ impl CheckpointStore {
         &mut self,
         fragment: &CheckpointFragment,
         committee: &Committee,
-    ) -> Result<CheckpointResponse, SuiError> {
+    ) -> SuiResult {
         // Check structure is correct and signatures verify
         fragment.verify(committee)?;
 
@@ -524,10 +524,7 @@ impl CheckpointStore {
         //       according to the byte length of the fragment, to create
         //       incentives for nodes to submit smaller fragments.
 
-        Ok(CheckpointResponse {
-            info: AuthorityCheckpointInfo::Success,
-            detail: None,
-        })
+        Ok(())
     }
 
     /// This function should be called by the consensus output, it is idempotent,

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -436,7 +436,7 @@ fn latest_proposal() {
     // --- TEST 2 ---
 
     // Check the latest checkpoint with detail
-    let response = cps1.handle_proposal(false).expect("no errors");
+    let response = cps1.handle_proposal(true).expect("no errors");
     assert!(response.detail.is_some());
     assert!(matches!(
         response.info,
@@ -552,7 +552,7 @@ fn latest_proposal() {
         response.info,
         AuthorityCheckpointInfo::CheckpointProposal {
             proposal: None,
-            prev_cert: Some(_)
+            prev_cert: None,
         }
     ));
 

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -432,6 +432,8 @@ where
 
         let resp = self.authority_client.handle_checkpoint(request).await?;
 
+        // TODO: Some errors below are byzantine suspicion errors, but we are not returning it that way.
+
         // Verify signatures
         resp.verify(&self.committee)?;
 
@@ -446,17 +448,6 @@ where
                     authority: self.address,
                 }),
             },
-            CheckpointRequestType::PastCheckpoint(seq) => {
-                if let AuthorityCheckpointInfo::Past(past) = &resp.info {
-                    self.verify_contents_exist(detail, past, &resp.detail)?;
-                    self.verify_checkpoint_sequence(Some(*seq), past)?;
-                    Ok(resp)
-                } else {
-                    Err(SuiError::ByzantineAuthoritySuspicion {
-                        authority: self.address,
-                    })
-                }
-            }
             CheckpointRequestType::AuthenticatedCheckpoint(seq) => {
                 if let AuthorityCheckpointInfo::AuthenticatedCheckpoint(checkpoint) = &resp.info {
                     // Checks that the sequence number is correct.

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
@@ -576,6 +576,23 @@ impl<const STRONG_THRESHOLD: bool> AuthorityQuorumSignInfo<STRONG_THRESHOLD> {
         let message_index = obligation.add_message(data);
         self.add_to_verification_obligation(committee, &mut obligation, message_index)?;
         obligation.verify_all()?;
+        Ok(())
+    }
+}
+
+impl<const S: bool> Display for AuthorityQuorumSignInfo<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "{} {{ epoch: {:?}, signers_map: {:?} }}",
+            if S {
+                "AuthorityStrongQuorumSignInfo"
+            } else {
+                "AuthorityWeakQuorumSignInfo"
+            },
+            self.epoch,
+            self.signers_map,
+        )?;
         Ok(())
     }
 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -122,7 +122,6 @@ pub struct CheckpointResponse {
 impl CheckpointResponse {
     pub fn verify(&self, committee: &Committee) -> SuiResult {
         match &self.info {
-            AuthorityCheckpointInfo::Success => Ok(()),
             AuthorityCheckpointInfo::Proposal { current, previous } => {
                 if let Some(current) = current {
                     current.verify(committee, self.detail.as_ref())?;
@@ -145,8 +144,6 @@ impl CheckpointResponse {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AuthorityCheckpointInfo {
-    // Denotes success of he operation with no return
-    Success,
     // Returns the current proposal if any, and
     // the previous checkpoint.
     Proposal {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -92,14 +92,6 @@ impl CheckpointRequest {
         }
     }
 
-    /// Create a request for a past checkpoint from the authority
-    pub fn past(seq: CheckpointSequenceNumber, detail: bool) -> CheckpointRequest {
-        CheckpointRequest {
-            request_type: CheckpointRequestType::PastCheckpoint(seq),
-            detail,
-        }
-    }
-
     pub fn authenticated(seq: Option<CheckpointSequenceNumber>, detail: bool) -> CheckpointRequest {
         CheckpointRequest {
             request_type: CheckpointRequestType::AuthenticatedCheckpoint(seq),
@@ -112,8 +104,6 @@ impl CheckpointRequest {
 pub enum CheckpointRequestType {
     // Request the latest proposal and previous checkpoint.
     LatestCheckpointProposal,
-    // Requests a past checkpoint
-    PastCheckpoint(CheckpointSequenceNumber),
     /// Request a stored authenticated checkpoint.
     /// if a sequence number is specified, return the checkpoint with that sequence number;
     /// otherwise if None returns the latest authenticated checkpoint stored.
@@ -144,12 +134,6 @@ impl CheckpointResponse {
                     if let Some(previous) = previous {
                         previous.verify(committee, None)?;
                     }
-                }
-                Ok(())
-            }
-            AuthorityCheckpointInfo::Past(ckpt) => {
-                if let Some(ckpt) = ckpt {
-                    ckpt.verify(committee, self.detail.as_ref())?;
                 }
                 Ok(())
             }
@@ -194,8 +178,6 @@ pub enum AuthorityCheckpointInfo {
         // updates.
         // last_local_sequence: TxSequenceNumber,
     },
-    // Returns the requested checkpoint.
-    Past(Option<AuthenticatedCheckpoint>),
     AuthenticatedCheckpoint(Option<AuthenticatedCheckpoint>),
     /// The latest proposal must be signed by the validator.
     /// For any proposal with sequence number > 0, a certified checkpoint for the previous


### PR DESCRIPTION
This PR refactors the CheckpointRequest to two types:
1. AuthenticatedCheckpoint: this can be used to either query a past authenticated checkpoint, or the latest authenticated checkpoint.
2. CheckpointProposal: this is used to query the current checkpoint proposal.

This refactoring has several benefits:
1. When we query the latest authenticated checkpoint and proposals at the beginning of the checkpoint driver in the existing code, we are not actually using the returned proposals. It's a waste to include them.
2. Makes the logic clearer
3. Allows us to start restructuring the fragment making progress (will be addressed in a separate PR)
4. Removes the overloaded AuthorityCheckpointInfo (removed the Success case)

This PR also fixes an issue in the safe client: we are not reporting all the byzantine validator error cases.
Added more logs.