### PR TITLE
Support workload spec to pass in different workload combinations in benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.6.1+6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4431,6 +4437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5330,6 +5337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.6",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits 0.2.15",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6656,6 +6673,7 @@ dependencies = [
  "num_cpus",
  "prometheus",
  "rand 0.8.5",
+ "rand_distr",
  "rayon",
  "rocksdb",
  "serde 1.0.140",
@@ -8999,6 +9017,7 @@ dependencies = [
  "lexical-core",
  "libc",
  "libloading",
+ "libm",
  "librocksdb-sys",
  "libsqlite3-sys",
  "libtest-mimic",
@@ -9160,6 +9179,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.5.1",
  "rand_core 0.6.3",
+ "rand_distr",
  "rand_pcg",
  "rand_xorshift",
  "rand_xoshiro",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -29,6 +29,7 @@ multiaddr = "0.14.0"
 crossterm = "0.23.2"
 rand = "0.8.5"
 base64 = "0.13.0"
+rand_distr = "0.4.3"
 
 bcs = "0.1.3"
 sui-core = { path = "../sui-core" }

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -6,6 +6,16 @@ use futures::future::try_join_all;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use futures::{stream::FuturesUnordered, StreamExt};
+use sui_benchmark::workloads::workload::get_latest;
+use sui_benchmark::workloads::workload::WorkloadType;
+use sui_config::Config;
+use sui_config::PersistedConfig;
+use sui_core::authority_aggregator::AuthAggMetrics;
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::SuiAddress;
+use tokio::sync::OnceCell;
+
+use std::collections::HashMap;
 use std::collections::{BTreeMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -14,21 +24,16 @@ use std::time::Duration;
 use strum_macros::EnumString;
 use sui_benchmark::workloads::shared_counter::SharedCounterWorkload;
 use sui_benchmark::workloads::transfer_object::TransferObjectWorkload;
-use sui_benchmark::workloads::workload::get_latest;
+use sui_benchmark::workloads::workload::CombinationWorkload;
 use sui_benchmark::workloads::workload::Payload;
 use sui_benchmark::workloads::workload::Workload;
 use sui_config::gateway::GatewayConfig;
-use sui_config::Config;
-use sui_config::PersistedConfig;
-use sui_core::authority_aggregator::AuthAggMetrics;
 use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::gateway_state::GatewayState;
 use sui_node::SuiNode;
 use sui_quorum_driver::QuorumDriverHandler;
 use sui_sdk::crypto::SuiKeystore;
-use sui_types::base_types::ObjectID;
-use sui_types::base_types::SuiAddress;
 use sui_types::crypto::EncodeDecodeBase64;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::{AccountKeyPair, EmptySignInfo};
@@ -42,7 +47,6 @@ use test_utils::objects::generate_gas_objects_with_owner;
 use test_utils::test_account_keys;
 use tokio::runtime::Builder;
 use tokio::sync::Barrier;
-use tokio::sync::OnceCell;
 use tokio::time;
 use tokio::time::Instant;
 use tracing::{debug, error};
@@ -68,9 +72,6 @@ struct Opts {
     /// Stat collection interval seconds
     #[clap(long, default_value = "10", global = true)]
     pub stat_collection_interval: u64,
-    /// Shared counter or transfer object
-    #[clap(arg_enum, default_value = "owned", global = true, ignore_case = true)]
-    pub transaction_type: TransactionType,
     /// Num server threads
     #[clap(long, default_value = "24", global = true)]
     pub num_server_threads: u64,
@@ -97,6 +98,35 @@ struct Opts {
     /// gateway_config_path, keypair_path and primary_gas_id
     #[clap(long, parse(try_from_str), default_value = "true", global = true)]
     pub local: bool,
+    // Default workload is 100% transfer object
+    #[clap(subcommand)]
+    workload_spec: OptWorkloadSpec,
+}
+
+#[derive(Debug, Clone, Parser, Eq, PartialEq, EnumString)]
+#[non_exhaustive]
+#[clap(rename_all = "kebab-case")]
+pub enum OptWorkloadSpec {
+    // Allow the ability to mix shared object and
+    // single owner transactions in the benchmarking
+    // framework. Currently, only shared counter
+    // and transfer obejct transaction types are
+    // supported but there will be more in future. Also
+    // there is no dependency between individual
+    // transactions such that they can all be executed
+    // and make progress in parallel. But this too
+    // will likely change in future to support
+    // more representative workloads.
+    WorkloadSpec {
+        // relative weight of shared counter
+        // transaction in the benchmark workload
+        #[clap(long, default_value = "0")]
+        shared_counter: u32,
+        // relative weight of transfer object
+        // transactions in the benchmark workload
+        #[clap(long, default_value = "1")]
+        transfer_object: u32,
+    },
 }
 
 struct Stats {
@@ -109,15 +139,6 @@ struct Stats {
     pub min_latency: Duration,
     pub max_latency: Duration,
     pub duration: Duration,
-}
-
-#[derive(Parser, Debug, Clone, PartialEq, ArgEnum, EnumString, Eq)]
-#[clap(rename_all = "kebab-case")]
-enum TransactionType {
-    #[clap(name = "shared")]
-    SharedCounter,
-    #[clap(name = "owned")]
-    TransferObject,
 }
 
 type RetryType = Box<(TransactionEnvelope<EmptySignInfo>, Box<dyn Payload>)>;
@@ -371,20 +392,37 @@ fn make_workload(
     primary_gas_account_keypair: Arc<AccountKeyPair>,
     opts: &Opts,
 ) -> Box<dyn Workload<dyn Payload>> {
-    match opts.transaction_type {
-        TransactionType::SharedCounter => SharedCounterWorkload::new_boxed(
-            primary_gas_id,
-            primary_gas_account_owner,
-            primary_gas_account_keypair,
-            None,
-        ),
-        TransactionType::TransferObject => TransferObjectWorkload::new_boxed(
-            opts.num_transfer_accounts,
-            primary_gas_id,
-            primary_gas_account_owner,
-            primary_gas_account_keypair,
-        ),
+    let mut workloads = HashMap::<WorkloadType, (u32, Box<dyn Workload<dyn Payload>>)>::new();
+    match opts.workload_spec {
+        OptWorkloadSpec::WorkloadSpec {
+            shared_counter,
+            transfer_object,
+        } => {
+            if shared_counter > 0 {
+                let workload = SharedCounterWorkload::new_boxed(
+                    primary_gas_id,
+                    primary_gas_account_owner,
+                    primary_gas_account_keypair.clone(),
+                    None,
+                );
+                workloads
+                    .entry(WorkloadType::SharedCounter)
+                    .or_insert((shared_counter, workload));
+            }
+            if transfer_object > 0 {
+                let workload = TransferObjectWorkload::new_boxed(
+                    opts.num_transfer_accounts,
+                    primary_gas_id,
+                    primary_gas_account_owner,
+                    primary_gas_account_keypair,
+                );
+                workloads
+                    .entry(WorkloadType::TransferObject)
+                    .or_insert((transfer_object, workload));
+            }
+        }
     }
+    CombinationWorkload::new_boxed(workloads)
 }
 
 #[tokio::main]

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use sui_core::{
     authority_aggregator::AuthorityAggregator, authority_client::NetworkAuthorityClient,
@@ -24,6 +26,9 @@ use sui_types::{
 };
 use test_utils::messages::make_transfer_sui_transaction;
 use tracing::log::error;
+
+use rand::{prelude::*, rngs::OsRng};
+use rand_distr::WeightedAliasIndex;
 
 // This is the maximum gas we will transfer from primary coin into any gas coin
 // for running the benchmark
@@ -121,6 +126,53 @@ pub trait Payload: Send + Sync {
     fn get_workload_type(&self) -> WorkloadType;
 }
 
+pub struct CombinationPayload {
+    payloads: Vec<Box<dyn Payload>>,
+    dist: WeightedAliasIndex<u32>,
+    curr_index: usize,
+    rng: OsRng,
+}
+
+impl Payload for CombinationPayload {
+    fn make_new_payload(
+        self: Box<Self>,
+        new_object: ObjectRef,
+        new_gas: ObjectRef,
+    ) -> Box<dyn Payload> {
+        let mut new_payloads = vec![];
+        for (pos, e) in self.payloads.into_iter().enumerate() {
+            if pos == self.curr_index {
+                let updated = e.make_new_payload(new_object, new_gas);
+                new_payloads.push(updated);
+            } else {
+                new_payloads.push(e);
+            }
+        }
+        let mut rng = self.rng;
+        let next_index = self.dist.sample(&mut rng);
+        Box::new(CombinationPayload {
+            payloads: new_payloads,
+            dist: self.dist,
+            curr_index: next_index,
+            rng: self.rng,
+        })
+    }
+    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo> {
+        let curr = self.payloads.get(self.curr_index).unwrap();
+        curr.make_transaction()
+    }
+    fn get_object_id(&self) -> ObjectID {
+        let curr = self.payloads.get(self.curr_index).unwrap();
+        curr.get_object_id()
+    }
+    fn get_workload_type(&self) -> WorkloadType {
+        self.payloads
+            .get(self.curr_index)
+            .unwrap()
+            .get_workload_type()
+    }
+}
+
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
 pub enum WorkloadType {
     SharedCounter,
@@ -135,4 +187,59 @@ pub trait Workload<T: Payload + ?Sized>: Send + Sync {
         count: u64,
         client: &AuthorityAggregator<NetworkAuthorityClient>,
     ) -> Vec<Box<T>>;
+}
+
+type WeightAndPayload = (u32, Box<dyn Workload<dyn Payload>>);
+pub struct CombinationWorkload {
+    workloads: HashMap<WorkloadType, WeightAndPayload>,
+}
+
+#[async_trait]
+impl Workload<dyn Payload> for CombinationWorkload {
+    async fn init(&mut self, aggregator: &AuthorityAggregator<NetworkAuthorityClient>) {
+        for (_, (_, workload)) in self.workloads.iter_mut() {
+            workload.init(aggregator).await;
+        }
+    }
+    async fn make_test_payloads(
+        &self,
+        count: u64,
+        aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
+    ) -> Vec<Box<dyn Payload>> {
+        let mut workloads: HashMap<WorkloadType, (u32, Vec<Box<dyn Payload>>)> = HashMap::new();
+        for (workload_type, (weight, workload)) in self.workloads.iter() {
+            let payloads: Vec<Box<dyn Payload>> =
+                workload.make_test_payloads(count, aggregator).await;
+            assert_eq!(payloads.len() as u64, count);
+            workloads
+                .entry(*workload_type)
+                .or_insert_with(|| (*weight, payloads));
+        }
+        let mut res = vec![];
+        for _i in 0..count {
+            let mut all_payloads: Vec<Box<dyn Payload>> = vec![];
+            let mut dist = vec![];
+            for (_type, (weight, payloads)) in workloads.iter_mut() {
+                all_payloads.push(payloads.pop().unwrap());
+                dist.push(*weight);
+            }
+            res.push(Box::new(CombinationPayload {
+                payloads: all_payloads,
+                dist: WeightedAliasIndex::new(dist).unwrap(),
+                curr_index: 0,
+                rng: OsRng::default(),
+            }));
+        }
+        res.into_iter()
+            .map(|b| Box::<dyn Payload>::from(b))
+            .collect()
+    }
+}
+
+impl CombinationWorkload {
+    pub fn new_boxed(
+        workloads: HashMap<WorkloadType, WeightAndPayload>,
+    ) -> Box<dyn Workload<dyn Payload>> {
+        Box::new(CombinationWorkload { workloads })
+    }
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -249,6 +249,7 @@ lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", defau
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
 lexical-core = { version = "0.7", features = ["arrayvec", "correct", "ryu", "static_assertions", "std", "table"] }
 libc = { version = "0.2", features = ["std"] }
+libm = { version = "0.2" }
 librocksdb-sys = { version = "0.6", features = ["bzip2", "bzip2-sys", "libz-sys", "lz4", "snappy", "static", "zlib", "zstd", "zstd-sys"] }
 libsqlite3-sys = { version = "0.24", default-features = false, features = ["bundled", "bundled_bindings", "cc", "pkg-config", "unlock_notify", "vcpkg"] }
 libtest-mimic = { version = "0.4", default-features = false }
@@ -327,7 +328,7 @@ num-integer = { version = "0.1", default-features = false, features = ["i128", "
 num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint", "num-bigint-std", "std"] }
 num-traits-c65f7effa3be6d31 = { package = "num-traits", version = "0.1", default-features = false }
-num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128", "std"] }
+num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128", "libm", "std"] }
 num_cpus = { version = "1", default-features = false }
 num_enum = { version = "0.5", features = ["std"] }
 object-1f5adca70f036a62 = { package = "object", version = "0.28", default-features = false, features = ["archive", "coff", "elf", "macho", "pe", "read_core", "unaligned"] }
@@ -388,6 +389,7 @@ rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc"
 rand_chacha = { version = "0.3", features = ["std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_distr = { version = "0.4", features = ["alloc", "std"] }
 rand_pcg = { version = "0.2", default-features = false }
 rand_xorshift = { version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
@@ -850,6 +852,7 @@ lazycell = { version = "1", default-features = false }
 lexical-core = { version = "0.7", features = ["arrayvec", "correct", "ryu", "static_assertions", "std", "table"] }
 libc = { version = "0.2", features = ["std"] }
 libloading = { version = "0.7", default-features = false }
+libm = { version = "0.2" }
 librocksdb-sys = { version = "0.6", features = ["bzip2", "bzip2-sys", "libz-sys", "lz4", "snappy", "static", "zlib", "zstd", "zstd-sys"] }
 libsqlite3-sys = { version = "0.24", default-features = false, features = ["bundled", "bundled_bindings", "cc", "pkg-config", "unlock_notify", "vcpkg"] }
 libtest-mimic = { version = "0.4", default-features = false }
@@ -931,7 +934,7 @@ num-integer = { version = "0.1", default-features = false, features = ["i128", "
 num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint", "num-bigint-std", "std"] }
 num-traits-c65f7effa3be6d31 = { package = "num-traits", version = "0.1", default-features = false }
-num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128", "std"] }
+num-traits-6f8ce4dd05d13bba = { package = "num-traits", version = "0.2", features = ["i128", "libm", "std"] }
 num_cpus = { version = "1", default-features = false }
 num_enum = { version = "0.5", features = ["std"] }
 num_enum_derive = { version = "0.5", default-features = false, features = ["proc-macro-crate", "std"] }
@@ -1011,6 +1014,7 @@ rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc"
 rand_chacha = { version = "0.3", features = ["std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_distr = { version = "0.4", features = ["alloc", "std"] }
 rand_pcg = { version = "0.2", default-features = false }
 rand_xorshift = { version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }


### PR DESCRIPTION
Add workload spec in benchmark to support passing in different workload combinations.

```
cargo run --release  --package sui-benchmark --bin stress -- --target-qps 1000 workload-spec --shared-counter 50 --transfer-object 50