### PR TITLE
wallet-ext: menu expanded remove border-radius

### DIFF
--- a/wallet/src/ui/app/components/menu/content/MenuContent.module.scss
+++ b/wallet/src/ui/app/components/menu/content/MenuContent.module.scss
@@ -28,4 +28,5 @@
 
 .expanded {
     height: 100%;
+    border-radius: 0;
 }


### PR DESCRIPTION
closes #3545 

<img width="376" alt="Screenshot 2022-07-27 at 17 52 44" src="https://user-images.githubusercontent.com/10210143/181279861-dfe1a7be-1a3d-4b68-a6bd-f2b210118632.png">
