### PR TITLE
[epoch] Index authenticated epoch data structure by its epoch ID

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1031,11 +1031,16 @@ impl AuthorityState {
                 .bulk_object_insert(&genesis.objects().iter().collect::<Vec<_>>())
                 .await
                 .expect("Cannot bulk insert genesis objects");
+            store
+                .init_genesis_epoch(genesis_committee.clone())
+                .expect("Init genesis epoch data must not fail");
             genesis_committee
-        } else if let Some(latest_epoch) = store.get_latest_authenticated_epoch() {
-            latest_epoch.epoch_info().next_epoch_committee().clone()
         } else {
-            genesis_committee
+            store
+                .get_latest_authenticated_epoch()
+                .epoch_info()
+                .committee()
+                .clone()
         };
 
         let event_handler = event_store.map(|es| Arc::new(EventHandler::new(store.clone(), es)));
@@ -1156,17 +1161,16 @@ impl AuthorityState {
 
     pub(crate) fn sign_new_epoch_and_update_committee(
         &self,
-        next_epoch_committee: Committee,
-        last_checkpoint: CheckpointSequenceNumber,
+        new_committee: Committee,
+        next_checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult {
         self.database.sign_new_epoch(
-            self.epoch(),
-            next_epoch_committee.clone(),
+            new_committee.clone(),
             self.name,
             &*self.secret,
-            last_checkpoint,
+            next_checkpoint,
         )?;
-        self.committee.swap(Arc::new(next_epoch_committee));
+        self.committee.swap(Arc::new(new_committee));
         Ok(())
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1164,12 +1164,19 @@ impl AuthorityState {
         new_committee: Committee,
         next_checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult {
+        // TODO: It's likely safer to do the following operations atomically, in case this function
+        // gets called from different threads. It cannot happen today, but worth the caution.
+        fp_ensure!(
+            self.epoch() + 1 == new_committee.epoch,
+            SuiError::from("Invalid new epoch to sign and update")
+        );
         self.database.sign_new_epoch(
             new_committee.clone(),
             self.name,
             &*self.secret,
             next_checkpoint,
         )?;
+        // TODO: Do we want to make it possible to subscribe to committee changes?
         self.committee.swap(Arc::new(new_committee));
         Ok(())
     }

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -18,8 +18,8 @@ use sui_storage::{
 };
 use sui_types::base_types::SequenceNumber;
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
-use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthoritySignInfo, EmptySignInfo};
+use sui_types::messages::AuthenticatedEpoch;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::{Owner, OBJECT_START_VERSION};
 use tokio::sync::Notify;
@@ -40,28 +40,6 @@ const NUM_SHARDS: usize = 4096;
 /// The key where the latest consensus index is stored in the database.
 // TODO: Make a single table (e.g., called `variables`) storing all our lonely variables in one place.
 const LAST_CONSENSUS_INDEX_ADDR: u64 = 0;
-
-#[derive(Clone, Serialize, Deserialize, Debug)]
-pub enum AuthenticatedEpoch {
-    Signed(SignedEpoch),
-    Certified(CertifiedEpoch),
-}
-
-impl AuthenticatedEpoch {
-    pub fn epoch(&self) -> EpochId {
-        match self {
-            Self::Signed(s) => s.epoch_info.epoch(),
-            Self::Certified(c) => c.epoch_info.epoch(),
-        }
-    }
-
-    pub fn epoch_info(&self) -> &EpochInfo {
-        match self {
-            Self::Signed(s) => &s.epoch_info,
-            Self::Certified(c) => &c.epoch_info,
-        }
-    }
-}
 
 /// ALL_OBJ_VER determines whether we want to store all past
 /// versions of every object in the store. Authority doesn't store
@@ -1339,57 +1317,53 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     // Epoch related functions
 
+    pub fn init_genesis_epoch(&self, genesis_committee: Committee) -> SuiResult {
+        assert_eq!(genesis_committee.epoch, 0);
+        let epoch_data = AuthenticatedEpoch::Genesis(GenesisEpoch::new(genesis_committee));
+        let mut writer = self.tables.epochs.batch();
+        writer = writer.insert_batch(&self.tables.epochs, iter::once((0, epoch_data)))?;
+        writer.write()?;
+        Ok(())
+    }
+
     /// This function should be called at the end of the epoch identified by `epoch`,
     /// and after this call, we expect that the node's committee has changed
-    /// to `next_epoch_committee`.
+    /// to `new_committee`.
     pub fn sign_new_epoch(
         &self,
-        epoch: EpochId,
-        next_epoch_committee: Committee,
+        new_committee: Committee,
         authority: AuthorityName,
         secret: &dyn signature::Signer<AuthoritySignature>,
-        last_checkpoint: CheckpointSequenceNumber,
+        next_checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult {
+        let cur_epoch = new_committee.epoch;
         let latest_epoch = self.get_latest_authenticated_epoch();
-        match latest_epoch {
-            Some(a) => {
-                fp_ensure!(
-                    a.epoch() + 1 == epoch,
-                    SuiError::from("Unexpected new epoch number")
-                );
-            }
-            None => {
-                fp_ensure!(
-                    epoch == 0,
-                    SuiError::from("Could not find previous epoch information")
-                );
-            }
-        }
+        fp_ensure!(
+            latest_epoch.epoch() + 1 == cur_epoch,
+            SuiError::from("Unexpected new epoch number")
+        );
 
-        let signed_epoch = SignedEpoch::new(
-            epoch,
-            next_epoch_committee,
-            authority,
-            secret,
-            last_checkpoint,
-        )?;
+        let signed_epoch = SignedEpoch::new(new_committee, authority, secret, next_checkpoint);
 
         let mut writer = self.tables.epochs.batch();
         writer = writer.insert_batch(
             &self.tables.epochs,
-            iter::once((epoch, AuthenticatedEpoch::Signed(signed_epoch))),
+            iter::once((cur_epoch, AuthenticatedEpoch::Signed(signed_epoch))),
         )?;
         writer.write()?;
         Ok(())
     }
 
-    pub fn get_latest_authenticated_epoch(&self) -> Option<AuthenticatedEpoch> {
+    pub fn get_latest_authenticated_epoch(&self) -> AuthenticatedEpoch {
         self.tables
             .epochs
             .iter()
             .skip_to_last()
             .next()
-            .map(|(_, a)| a)
+            // unwrap safe because we guarantee there is at least a genesis epoch
+            // when initializing the store.
+            .unwrap()
+            .1
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1320,9 +1320,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn init_genesis_epoch(&self, genesis_committee: Committee) -> SuiResult {
         assert_eq!(genesis_committee.epoch, 0);
         let epoch_data = AuthenticatedEpoch::Genesis(GenesisEpoch::new(genesis_committee));
-        let mut writer = self.tables.epochs.batch();
-        writer = writer.insert_batch(&self.tables.epochs, iter::once((0, epoch_data)))?;
-        writer.write()?;
+        self.tables.epochs.insert(&0, &epoch_data)?;
         Ok(())
     }
 
@@ -1344,13 +1342,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         );
 
         let signed_epoch = SignedEpoch::new(new_committee, authority, secret, next_checkpoint);
-
-        let mut writer = self.tables.epochs.batch();
-        writer = writer.insert_batch(
-            &self.tables.epochs,
-            iter::once((cur_epoch, AuthenticatedEpoch::Signed(signed_epoch))),
-        )?;
-        writer.write()?;
+        self.tables
+            .epochs
+            .insert(&cur_epoch, &AuthenticatedEpoch::Signed(signed_epoch))?;
         Ok(())
     }
 

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    authority_store::{AuthenticatedEpoch, InternalSequenceNumber, ObjectKey},
+    authority_store::{InternalSequenceNumber, ObjectKey},
     *,
 };
 use narwhal_executor::ExecutionIndices;

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -66,7 +66,7 @@ where
     pub async fn finish_epoch_change(&self) -> SuiResult {
         let epoch = self.state.committee.load().epoch;
         info!(?epoch, "Finishing epoch change");
-        let last_checkpoint = if let Some(checkpoints) = &self.state.checkpoints {
+        let next_checkpoint = if let Some(checkpoints) = &self.state.checkpoints {
             let mut checkpoints = checkpoints.lock();
             assert!(
                 checkpoints.is_ready_to_finish_epoch_change(),
@@ -85,7 +85,7 @@ where
 
             self.state.database.remove_all_pending_certificates()?;
 
-            checkpoints.next_checkpoint() - 1
+            checkpoints.next_checkpoint()
 
             // drop checkpoints lock
         } else {
@@ -111,7 +111,7 @@ where
             "New committee for the next epoch: {:?}", new_committee
         );
         self.state
-            .sign_new_epoch_and_update_committee(new_committee.clone(), last_checkpoint)?;
+            .sign_new_epoch_and_update_committee(new_committee.clone(), next_checkpoint)?;
 
         // Reconnect the network if we have an type of AuthorityClient that has a network.
         if A::needs_network_recreation() {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1868,18 +1868,23 @@ impl SignedEpoch {
         }
     }
 
-    pub fn verify(&self, committee: &Committee) -> SuiResult {
+    /// Verify the signature of this signed epoch. The committee to verify this must be the
+    /// committee from the previous epoch, as this is signed by a validator from the previous epoch.
+    pub fn verify(&self, prev_epoch_committee: &Committee) -> SuiResult {
         let epoch = self.epoch_info.epoch();
         fp_ensure!(
             epoch != 0 && epoch - 1 == self.auth_sign_info.epoch,
             SuiError::from("Epoch number in the committee inconsistent with signature")
         );
-        self.auth_sign_info.verify(&self.epoch_info, committee)?;
+        self.auth_sign_info
+            .verify(&self.epoch_info, prev_epoch_committee)?;
         Ok(())
     }
 }
 
 impl CertifiedEpoch {
+    /// Verify the signature of this certified epoch. The committee to verify this must be the
+    /// committee from the previous epoch, as this is signed by a quorum from the previous epoch.
     pub fn verify(&self, committee: &Committee) -> SuiResult {
         let epoch = self.epoch_info.epoch();
         fp_ensure!(

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1798,59 +1798,30 @@ pub enum ExecuteTransactionResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EpochInfo {
-    /// The epoch number of this epoch info.
-    /// Although we could derive it from the epoch number of `next_epoch_committee`, a potential
-    /// byzantine node may set next_epoch_committee.epoch as 0, which will make it very
-    /// inconvenient to obtain the epoch number.
-    epoch: EpochId,
-    /// The committee of the NEXT epoch. The committee of the epoch identified by the `epoch`
-    /// field is not part of this data structure. Instead, it will always be in the previous epoch
-    /// data structure. The committee for the very first epoch would be the genesis committee, which
-    /// is not in any epoch data structure, but in the genesis blob.
-    /// It's important that we commit to the next epoch committee in the current epoch, so that we
-    /// know what committee to use when verifying the next epoch data structure.
-    next_epoch_committee: Committee,
-    /// The last checkpoint included in this epoch. The first checkpoint can always be derived
-    /// from the previous epoch. The first checkpoint of the first epoch would be 0.
-    last_checkpoint: CheckpointSequenceNumber,
+    /// The committee of this epoch.
+    committee: Committee,
+    /// The first checkpoint included in this epoch.
+    first_checkpoint: CheckpointSequenceNumber,
 }
 
 impl EpochInfo {
-    pub fn new(
-        epoch: EpochId,
-        next_epoch_committee: Committee,
-        last_checkpoint: CheckpointSequenceNumber,
-    ) -> SuiResult<Self> {
-        fp_ensure!(
-            epoch < EpochId::MAX && epoch + 1 == next_epoch_committee.epoch,
-            SuiError::from("Current epoch number and next epoch number are inconsistent")
-        );
-        Ok(Self {
-            epoch,
-            next_epoch_committee,
-            last_checkpoint,
-        })
+    pub fn new(committee: Committee, first_checkpoint: CheckpointSequenceNumber) -> Self {
+        Self {
+            committee,
+            first_checkpoint,
+        }
     }
 
     pub fn epoch(&self) -> EpochId {
-        self.epoch
+        self.committee.epoch
     }
 
-    pub fn next_epoch_committee(&self) -> &Committee {
-        &self.next_epoch_committee
+    pub fn committee(&self) -> &Committee {
+        &self.committee
     }
 
-    pub fn last_checkpoint(&self) -> &CheckpointSequenceNumber {
-        &self.last_checkpoint
-    }
-
-    pub fn verify(&self) -> SuiResult {
-        let next_epoch = self.next_epoch_committee.epoch;
-        fp_ensure!(
-            next_epoch > 0 && next_epoch - 1 == self.epoch,
-            SuiError::from("Epoch number mismatch in epoch info")
-        );
-        Ok(())
+    pub fn first_checkpoint(&self) -> &CheckpointSequenceNumber {
+        &self.first_checkpoint
     }
 }
 
@@ -1860,31 +1831,49 @@ pub struct EpochEnvelop<S> {
     pub auth_sign_info: S,
 }
 
+pub type GenesisEpoch = EpochEnvelop<EmptySignInfo>;
 pub type SignedEpoch = EpochEnvelop<AuthoritySignInfo>;
 pub type CertifiedEpoch = EpochEnvelop<AuthorityStrongQuorumSignInfo>;
 
+impl GenesisEpoch {
+    pub fn new(committee: Committee) -> Self {
+        Self {
+            epoch_info: EpochInfo::new(committee, 0),
+            auth_sign_info: EmptySignInfo {},
+        }
+    }
+}
+
 impl SignedEpoch {
     pub fn new(
-        epoch: EpochId,
-        next_epoch_committee: Committee,
+        committee: Committee,
         authority: AuthorityName,
         secret: &dyn signature::Signer<AuthoritySignature>,
-        last_checkpoint: CheckpointSequenceNumber,
-    ) -> SuiResult<Self> {
-        let epoch_info = EpochInfo::new(epoch, next_epoch_committee, last_checkpoint)?;
+        first_checkpoint: CheckpointSequenceNumber,
+    ) -> Self {
+        let epoch = committee.epoch;
+        let epoch_info = EpochInfo::new(committee, first_checkpoint);
         let signature = AuthoritySignature::new(&epoch_info, secret);
-        Ok(Self {
+        Self {
             epoch_info,
             auth_sign_info: AuthoritySignInfo {
-                epoch,
+                // A epoch is always authenticated by validators from the previous epoch.
+                // This is critical: we won't be able to use the same committee to verify itself,
+                // hence we rely on the committee from the previous epoch to verify the current
+                // epoch data structure.
+                epoch: epoch - 1,
                 authority,
                 signature,
             },
-        })
+        }
     }
 
     pub fn verify(&self, committee: &Committee) -> SuiResult {
-        self.epoch_info.verify()?;
+        let epoch = self.epoch_info.epoch();
+        fp_ensure!(
+            epoch != 0 && epoch - 1 == self.auth_sign_info.epoch,
+            SuiError::from("Epoch number in the committee inconsistent with signature")
+        );
         self.auth_sign_info.verify(&self.epoch_info, committee)?;
         Ok(())
     }
@@ -1892,8 +1881,45 @@ impl SignedEpoch {
 
 impl CertifiedEpoch {
     pub fn verify(&self, committee: &Committee) -> SuiResult {
-        self.epoch_info.verify()?;
+        let epoch = self.epoch_info.epoch();
+        fp_ensure!(
+            epoch != 0 && epoch - 1 == self.auth_sign_info.epoch,
+            SuiError::from("Epoch number in the committee inconsistent with signature")
+        );
         self.auth_sign_info.verify(&self.epoch_info, committee)?;
         Ok(())
+    }
+}
+
+/// An AuthenticatedEpoch is an epoch data structure that's verifiable.
+/// The genesis epoch is the only one that doesn't require a committee to verify it, as there is
+/// only one genesis trusted from start. For a Signed or Certified epoch, it can be verified by
+/// the committee from the previous epoch.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub enum AuthenticatedEpoch {
+    Genesis(GenesisEpoch),
+    Signed(SignedEpoch),
+    Certified(CertifiedEpoch),
+}
+
+impl AuthenticatedEpoch {
+    pub fn epoch(&self) -> EpochId {
+        match self {
+            Self::Signed(s) => s.epoch_info.epoch(),
+            Self::Certified(c) => c.epoch_info.epoch(),
+            Self::Genesis(g) => {
+                let epoch = g.epoch_info.epoch();
+                debug_assert_eq!(epoch, 0);
+                epoch
+            }
+        }
+    }
+
+    pub fn epoch_info(&self) -> &EpochInfo {
+        match self {
+            Self::Signed(s) => &s.epoch_info,
+            Self::Certified(c) => &c.epoch_info,
+            Self::Genesis(g) => &g.epoch_info,
+        }
     }
 }


### PR DESCRIPTION
Previously we store epoch data structure to contain the next epoch committee. This can be confusing and adds lots of complexity to the implementation.
This PR changes it such that epoch data structure is indexed to the committee from the same epoch, and we will require an epoch data structure to be authenticated by a committee/validator from the previous epoch.