### PR TITLE
[checkpoint] Restructure fragment making progress

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -85,10 +85,10 @@ impl Default for CheckpointProcessControl {
         CheckpointProcessControl {
             delay_on_quorum_failure: Duration::from_secs(10),
             delay_on_local_failure: Duration::from_secs(3),
-            long_pause_between_checkpoints: Duration::from_secs(60),
+            long_pause_between_checkpoints: Duration::from_secs(120),
             timeout_until_quorum: Duration::from_secs(60),
             extra_time_after_quorum: Duration::from_millis(200),
-            consensus_delay_estimate: Duration::from_secs(1),
+            consensus_delay_estimate: Duration::from_secs(2),
             per_other_authority_delay: Duration::from_secs(30),
             epoch_change_retry_delay: Duration::from_millis(100),
         }
@@ -100,7 +100,6 @@ pub struct CheckpointMetrics {
     pub checkpoint_sequence_number: IntGauge,
     checkpoints_signed: IntCounter,
     checkpoint_frequency: Histogram,
-    checkpoint_num_fragments_sent: Histogram,
 }
 
 impl CheckpointMetrics {
@@ -124,12 +123,6 @@ impl CheckpointMetrics {
                 registry,
             )
             .unwrap(),
-            checkpoint_num_fragments_sent: register_histogram_with_registry!(
-                "checkpoint_num_fragments_sent",
-                "Number of fragments sent to consensus before this validator is able to make a checkpoint",
-                registry,
-            )
-                .unwrap(),
         }
     }
 
@@ -195,6 +188,10 @@ pub async fn checkpoint_process<A>(
         // while we do sync. We are in any case not in a position to make valuable
         // proposals.
         if let Some(checkpoint) = highest_checkpoint {
+            debug!(
+                "Highest Checkpoint Certificate from the network: {}",
+                checkpoint
+            );
             // Check if there are more historic checkpoints to catch up with
             let next_checkpoint = state_checkpoints.lock().next_checkpoint();
             // First sync until before the latest checkpoint. We will special
@@ -294,7 +291,6 @@ pub async fn checkpoint_process<A>(
                     &my_proposal,
                     committee,
                     timing.consensus_delay_estimate,
-                    &metrics,
                 )
                 .await
                 {
@@ -462,10 +458,6 @@ where
             }
         });
 
-    debug!(
-        "Highest Checkpoint Certificate from the network: {:?}",
-        highest_certificate_cert
-    );
     Ok(highest_certificate_cert)
 }
 
@@ -682,119 +674,135 @@ pub async fn create_fragments_and_make_checkpoint<A>(
     my_proposal: &CheckpointProposal,
     committee: &Committee,
     consensus_delay_estimate: Duration,
-    metrics: &CheckpointMetrics,
 ) -> bool
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    // Pick another authority, get their proposal, and submit it to consensus
-    // Exit when we have a checkpoint proposal.
-    let mut available_authorities: BTreeSet<AuthorityName> = committee
-        .voting_rights
-        .iter()
-        .map(|(name, _)| *name)
-        .collect();
-    available_authorities.remove(&active_authority.state.name); // remove ourselves
+    let mut available_authorities = committee.shuffle_by_stake(None, None);
+    // Remove ourselves and all validators that we have already diffed with.
+    let already_fragmented = checkpoint_db.lock().validators_already_fragmented_with();
+    available_authorities
+        .retain(|name| name != &active_authority.state.name && !already_fragmented.contains(name));
+    debug!(
+        fragmented_count=?already_fragmented.len(),
+        to_be_fragmented_count=?available_authorities.len(),
+        "Going through remaining validators to generate fragments",
+    );
 
     let next_checkpoint_sequence_number = checkpoint_db.lock().next_checkpoint();
-    let mut fragments_num = 0;
+    let mut num_fragments_sent = 0;
 
-    for authority in committee.shuffle_by_stake(None, None).iter() {
+    loop {
+        // Always try to construct checkpoint first. This gives a chance to construct checkpoint
+        // even when `available_authorities` is empty already.
+        let result = checkpoint_db
+            .lock()
+            .attempt_to_construct_checkpoint(active_authority.state.database.clone(), committee);
+
+        match result {
+            Err(err) => {
+                // We likely don't have enough fragments. Fall through to send more fragments.
+                debug!(
+                    ?next_checkpoint_sequence_number,
+                    ?num_fragments_sent,
+                    "Failed to construct checkpoint: {:?}",
+                    err
+                );
+            }
+            Ok(()) => {
+                // A new checkpoint has been made.
+                return true;
+            }
+        }
+
+        if checkpoint_db.lock().get_locals().no_more_fragments {
+            // Sending more fragments won't help anymore.
+            break;
+        }
+
         // We have ran out of authorities?
         if available_authorities.is_empty() {
             // We have created as many fragments as possible, so exit.
             break;
         }
-        if !available_authorities.remove(authority) {
-            continue;
-        }
+        let authority = available_authorities.pop().unwrap();
 
         // Get a client
-        let client = active_authority.net.load().authority_clients[authority].clone();
+        let client = active_authority.net.load().authority_clients[&authority].clone();
 
-        if let Ok(response) = client
+        match client
             .handle_checkpoint(CheckpointRequest::proposal(true))
             .await
         {
-            if let AuthorityCheckpointInfo::CheckpointProposal {
-                proposal,
-                prev_cert,
-            } = &response.info
-            {
-                // Check if there is a latest checkpoint
-                if let Some(prev) = prev_cert {
-                    if prev.summary.sequence_number >= next_checkpoint_sequence_number {
-                        // We are now behind, stop the process
-                        break;
-                    }
-                }
-
-                // For some reason the proposal is empty?
-                if proposal.is_none() || response.detail.is_none() {
-                    continue;
-                }
-
-                // Check the proposal is also for the same checkpoint sequence number
-                if &proposal.as_ref().unwrap().summary.sequence_number
-                    != my_proposal.sequence_number()
+            Ok(response) => {
+                if let AuthorityCheckpointInfo::CheckpointProposal {
+                    proposal,
+                    prev_cert,
+                } = &response.info
                 {
-                    // Target validator may be byzantine or behind, ignore it.
-                    continue;
-                }
-
-                let other_proposal = CheckpointProposal::new_from_signed_proposal_summary(
-                    proposal.as_ref().unwrap().clone(),
-                    response.detail.unwrap(),
-                );
-
-                let fragment = my_proposal.fragment_with(&other_proposal);
-
-                // We need to augment the fragment with the missing transactions
-                match augment_fragment_with_diff_transactions(active_authority, fragment).await {
-                    Ok(fragment) => {
-                        // On success send the fragment to consensus
-                        if let Err(err) = checkpoint_db.lock().submit_local_fragment_to_consensus(
-                            &fragment,
-                            &active_authority.state.committee.load(),
-                        ) {
-                            warn!("Error submitting local fragment to consensus: {err:?}");
+                    // Check if there is a latest checkpoint
+                    if let Some(prev) = prev_cert {
+                        if prev.summary.sequence_number >= next_checkpoint_sequence_number {
+                            // We are now behind, stop the process
+                            debug!(
+                                latest_cp_cert_seq=?prev.summary.sequence_number,
+                                expected_cp_seq=?next_checkpoint_sequence_number,
+                                "We are behind, abort checkpoint construction process",
+                            );
+                            break;
                         }
                     }
-                    Err(err) => {
-                        warn!("Error augmenting the fragment: {err:?}");
-                    }
-                }
 
-                fragments_num += 1;
-
-                let result = checkpoint_db.lock().attempt_to_construct_checkpoint(
-                    active_authority.state.database.clone(),
-                    committee,
-                );
-
-                match result {
-                    Err(err) => {
-                        // We likely don't have enough fragments, keep trying.
-                        debug!(
-                            ?next_checkpoint_sequence_number,
-                            ?fragments_num,
-                            "Failed to construct checkpoint: {:?}",
-                            err
-                        );
-                        // TODO: here we should really wait until the fragment is sequenced, otherwise
-                        //       we would be going ahead and sequencing more fragments that may not be
-                        //       needed. For the moment we just linearly back-off.
-                        tokio::time::sleep(fragments_num * consensus_delay_estimate).await;
+                    // For some reason the proposal is empty?
+                    if proposal.is_none() || response.detail.is_none() {
                         continue;
                     }
-                    Ok(()) => {
-                        // A new checkpoint has been made.
-                        metrics
-                            .checkpoint_num_fragments_sent
-                            .observe(fragments_num as f64);
-                        return true;
+
+                    // Check the proposal is also for the same checkpoint sequence number
+                    if &proposal.as_ref().unwrap().summary.sequence_number
+                        != my_proposal.sequence_number()
+                    {
+                        // Target validator may be byzantine or behind, ignore it.
+                        continue;
+                    }
+
+                    let other_proposal = CheckpointProposal::new_from_signed_proposal_summary(
+                        proposal.as_ref().unwrap().clone(),
+                        response.detail.unwrap(),
+                    );
+
+                    let fragment = my_proposal.fragment_with(&other_proposal);
+
+                    // We need to augment the fragment with the missing transactions
+                    match augment_fragment_with_diff_transactions(active_authority, fragment).await
+                    {
+                        Ok(fragment) => {
+                            // On success send the fragment to consensus
+                            if let Err(err) =
+                                checkpoint_db.lock().submit_local_fragment_to_consensus(
+                                    &fragment,
+                                    &active_authority.state.committee.load(),
+                                )
+                            {
+                                warn!("Error submitting local fragment to consensus: {err:?}");
+                            }
+                            // TODO: here we should really wait until the fragment is sequenced, otherwise
+                            //       we would be going ahead and sequencing more fragments that may not be
+                            //       needed. For the moment we just rely on linearly back-off.
+                            num_fragments_sent += 1;
+                            tokio::time::sleep(num_fragments_sent * consensus_delay_estimate).await;
+                        }
+                        Err(err) => {
+                            warn!("Error augmenting the fragment: {err:?}");
+                        }
                     }
                 }
+            }
+            Err(err) => {
+                warn!(
+                    "Error querying checkpoint proposal from validator {}: {:?}",
+                    authority, err
+                );
             }
         }
     }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -567,6 +567,16 @@ impl Hash for AuthoritySignInfo {
     }
 }
 
+impl Display for AuthoritySignInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "AuthoritySignInfo {{ epoch: {:?}, authority: {} }}",
+            self.epoch, self.authority,
+        )
+    }
+}
+
 impl PartialEq for AuthoritySignInfo {
     fn eq(&self, other: &Self) -> bool {
         // We do not compare the signature, because there can be multiple

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fmt::{Display, Formatter};
 use std::slice::Iter;
 
 use crate::base_types::ExecutionDigests;
@@ -237,10 +238,32 @@ impl CheckpointSummary {
     }
 }
 
+impl Display for CheckpointSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CheckpointSummary {{ epoch: {:?}, seq: {:?}, content_digest: {} }}",
+            self.epoch,
+            self.sequence_number,
+            hex::encode(&self.content_digest),
+        )
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointSummaryEnvelope<S> {
     pub summary: CheckpointSummary,
     pub auth_signature: S,
+}
+
+impl Display for SignedCheckpointSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "SignedCheckpointSummary {{ summary: {}, signature: {} }}",
+            self.summary, self.auth_signature,
+        )
+    }
 }
 
 pub type SignedCheckpointSummary = CheckpointSummaryEnvelope<AuthoritySignInfo>;
@@ -316,6 +339,16 @@ impl SignedCheckpointSummary {
 // clients and more efficient sync protocols.
 
 pub type CertifiedCheckpointSummary = CheckpointSummaryEnvelope<AuthorityWeakQuorumSignInfo>;
+
+impl Display for CertifiedCheckpointSummary {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "CertifiedCheckpointSummary {{ summary: {}, signature: {} }}",
+            self.summary, self.auth_signature,
+        )
+    }
+}
 
 impl CertifiedCheckpointSummary {
     /// Aggregate many checkpoint signatures to form a checkpoint certificate.


### PR DESCRIPTION
This PR makes slight adjustments to the fragment and checkpoint construction process:
1. Makes various timing longer. This helps reduce checkpoint logs a bit and makes the progress more obvious
2. Added more logging
3. In `create_fragments_and_make_checkpoint`, we only ask for proposals from validators that we don't have a local fragment yet. This avoids repeat constructing fragments that we have constructed before. We also do not attempt to make fragments up-front if `no_more_fragments` is set. Also, to make sure we always have a chance to construct checkpoint, we always try to construct checkpoint first, before making new fragments.
4. Removed `checkpoint_num_fragments_sent` metric. It's not meaningful