### PR TITLE
Rename lock error and distinguish gateway/validator error

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -542,7 +542,7 @@ impl AuthorityState {
             lock_errors.is_empty(),
             // NOTE: the error message here will say 'Error acquiring lock' but what it means is
             // 'error checking lock'.
-            SuiError::LockErrors {
+            SuiError::ObjectErrors {
                 errors: lock_errors
             }
         );

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -278,7 +278,7 @@ where
                     processed_certificates.insert(cert_digest);
                     continue;
                 }
-                Err(SuiError::LockErrors { .. }) => {}
+                Err(SuiError::ObjectErrors { .. }) => {}
                 Err(e) => return Err(e),
             }
 
@@ -1442,7 +1442,7 @@ where
                         // LockErrors indicate the authority may be out-of-date.
                         // We only attempt to update authority and retry if we are seeing LockErrors.
                         // For any other error, we stop here and return.
-                        if !matches!(res, Err(SuiError::LockErrors { .. })) {
+                        if !matches!(res, Err(SuiError::ObjectErrors { .. })) {
                             debug!(
                                 tx_digest = ?tx_digest,
                                 ?name,

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -391,7 +391,7 @@ where
 
         match self.state.handle_certificate(cert.clone()).await {
             Ok(_) => Ok(()),
-            Err(SuiError::LockErrors { .. }) => {
+            Err(SuiError::ObjectErrors { .. }) => {
                 debug!(?digest, "cert execution failed due to missing parents");
 
                 let effects = self.aggregator.execute_cert_to_true_effects(&cert).await?;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -187,7 +187,7 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
     assert!(res.is_err());
     assert_eq!(
         res.err(),
-        Some(SuiError::LockErrors {
+        Some(SuiError::ObjectErrors {
             errors: vec![SuiError::InvalidSequenceNumber],
         })
     );
@@ -240,7 +240,7 @@ async fn test_handle_shared_object_with_max_sequence_number() {
     assert!(response.is_err());
     assert_eq!(
         response.err(),
-        Some(SuiError::LockErrors {
+        Some(SuiError::ObjectErrors {
             errors: vec![SuiError::InvalidSequenceNumber],
         })
     );
@@ -1894,7 +1894,7 @@ async fn shared_object() {
 
     // Sending the certificate now fails since it was not sequenced.
     let result = authority.handle_certificate(certificate.clone()).await;
-    assert!(matches!(result, Err(SuiError::LockErrors { .. })));
+    assert!(matches!(result, Err(SuiError::ObjectErrors { .. })));
 
     // Sequence the certificate to assign a sequence number to the shared object.
     authority

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -46,8 +46,8 @@ macro_rules! exit_main {
 #[allow(clippy::large_enum_variant)]
 pub enum SuiError {
     // Object misuse issues
-    #[error("Error acquiring lock for object(s): {:?}", errors)]
-    LockErrors { errors: Vec<SuiError> },
+    #[error("Error checking transaction input objects: {:?}", errors)]
+    ObjectErrors { errors: Vec<SuiError> },
     #[error("Attempt to transfer an object that's not owned.")]
     TransferUnownedError,
     #[error("Attempt to transfer an object that does not have public transfer. Object transfer must be done instead using a distinct Move function call.")]
@@ -338,6 +338,8 @@ pub enum SuiError {
     InconsistentGatewayResult { error: String },
     #[error("Invalid transaction range query to the gateway: {:?}", error)]
     GatewayInvalidTxRangeQuery { error: String },
+    #[error("Gateway checking transaction validity failed: {:?}", error)]
+    GatewayTransactionPrepError { error: String },
 
     // Errors related to the authority-consensus interface.
     #[error("Authority state can be modified by a single consensus client at the time")]


### PR DESCRIPTION
This PR cleans up two things that have been very confusing:
1. The object checking functions and errors have been called lock check and lock errors. They have nothing to do with locks. Renaming them.
2. Gateway and Validator shares some of the input check code path. Sometimes it's hard to see if an error is caused by gateway or validator. This PR wraps the input check errors on the gateway with a gateway specific error, so that we can tell immediately.