### PR TITLE
Add transfer_sui to TS SDK

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, TransferObjectTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, TransactionEffectsResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, MergeCoinResponse, SplitCoinResponse, PublishResponse, SuiPackage, TransactionResponse } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, TransactionEffectsResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, MergeCoinResponse, SplitCoinResponse, PublishResponse, SuiPackage, TransactionResponse } from "./index";
 import { BN } from "bn.js";
 import { Base64DataBuffer } from "./serialization/base64";
 import { PublicKey } from "./cryptography/publickey";
@@ -63,6 +63,19 @@ export function isTransferObjectTransaction(obj: any, _argumentName?: string): o
             isTransactionDigest(obj.gasPayment) as boolean) &&
         isSequenceNumber(obj.gasBudget) as boolean &&
         isTransactionDigest(obj.recipient) as boolean
+    )
+}
+
+export function isTransferSuiTransaction(obj: any, _argumentName?: string): obj is TransferSuiTransaction {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isTransactionDigest(obj.suiObjectId) as boolean &&
+        isSequenceNumber(obj.gasBudget) as boolean &&
+        isTransactionDigest(obj.recipient) as boolean && 
+        (typeof obj.amount === "undefined" || 
+            isSequenceNumber(obj.amount))
     )
 }
 

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -13,6 +13,7 @@ import {
   MergeCoinTransaction,
   SplitCoinTransaction,
   TransferObjectTransaction,
+  TransferSuiTransaction,
   TxnDataSerializer,
   PublishTransaction,
 } from './txn-data-serializers/txn-data-serializer';
@@ -74,6 +75,20 @@ export abstract class SignerWithProvider implements Signer {
   ): Promise<TransactionResponse> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newTransferObject(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransaction(txBytes);
+  }
+
+  /**
+   * Serialize and Sign a `TransferSui` transaction and submit to the Gateway for execution
+   */
+  async transferSui(
+    transaction: TransferSuiTransaction
+  ): Promise<TransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newTransferSui(
       signerAddress,
       transaction
     );

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -10,6 +10,7 @@ import {
   MergeCoinTransaction,
   SplitCoinTransaction,
   TransferObjectTransaction,
+  TransferSuiTransaction,
   PublishTransaction,
   TxnDataSerializer,
 } from './txn-data-serializer';
@@ -45,7 +46,23 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
-      throw new Error(`Error transferring coin: ${err} with args ${t}`);
+      throw new Error(`Error transferring object: ${err} with args ${t}`);
+    }
+  }
+
+  async newTransferSui(
+    signerAddress: SuiAddress,
+    t: TransferSuiTransaction
+  ): Promise<Base64DataBuffer> {
+    try {
+      const resp = await this.client.requestWithType(
+        'sui_transferSui',
+        [signerAddress, t.suiObjectId, t.gasBudget, t.recipient, t.amount],
+        isTransactionBytes
+      );
+      return new Base64DataBuffer(resp.txBytes);
+    } catch (err) {
+      throw new Error(`Error transferring Sui coin: ${err} with args ${t}`);
     }
   }
 

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -13,6 +13,13 @@ export interface TransferObjectTransaction {
   recipient: SuiAddress;
 }
 
+export interface TransferSuiTransaction {
+  suiObjectId: ObjectId;
+  gasBudget: number;
+  recipient: SuiAddress;
+  amount?: number;
+}
+
 export interface MergeCoinTransaction {
   primaryCoin: ObjectId;
   coinToMerge: ObjectId;
@@ -53,6 +60,11 @@ export interface TxnDataSerializer {
   newTransferObject(
     signerAddress: SuiAddress,
     txn: TransferObjectTransaction
+  ): Promise<Base64DataBuffer>;
+
+  newTransferSui(
+    signerAddress: SuiAddress,
+    txn: TransferSuiTransaction
   ): Promise<Base64DataBuffer>;
 
   newMoveCall(


### PR DESCRIPTION
On wallet, when transfer Sui coins, we should call transferSui instead of transferObject, this PR unblocks that by adding it to the TS SDK.

Tested locally and make sure that transferSui can be triggered from TS side
![Screen Shot 2022-07-27 at 9 27 10 PM](https://user-images.githubusercontent.com/106119108/181400795-232fce45-c1b1-4f73-973d-9622e3d08d40.png)
.