### PR TITLE
[sui-verifier] Added support for characteristic types

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.exp
@@ -22,7 +22,7 @@ written: object(109), object(110)
 
 task 6 'run'. lines 89-89:
 Error: Transaction Effects Status: Invalid Shared Child Object Usage. When a child object (either direct or indirect) of a shared object is passed by-value to an entry function, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109), whose ancestor fake(111) is a shared object, and neither are defined in this module..
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedChildUse(InvalidSharedChildUse { child: fake(109), ancestor: fake(111) }), source: Some("When a child object (either direct or indirect) of a shared object is passed by-value to an entry function, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109) (defined in module 'T3::O3'), whose ancestor fake(111) is a shared object (defined in module 'T2::O2'), and neither are defined in this module 'T1::O1'") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidSharedChildUse(InvalidSharedChildUse { child: fake(109), ancestor: fake(111) }), source: Some("When a child object (either direct or indirect) of a shared object is passed by-value to an entry function, either the child object's type or the shared object's type must be defined in the same module as the called function. This is violated by object fake(109) (defined in module 't3::o3'), whose ancestor fake(111) is a shared object (defined in module 't2::o2'), and neither are defined in this module 't1::o1'") } }
 
 task 7 'run'. lines 91-91:
 written: object(109), object(111), object(113)

--- a/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/children/child_of_shared_object.move
@@ -1,91 +1,91 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --addresses T1=0x0 T2=0x0 T3=0x0 A=0x42
+//# init --addresses t1=0x0 t2=0x0 t3=0x0 A=0x42
 
 //# publish
 
-module T3::O3 {
+module t3::o3 {
     use sui::object::{Self, Info};
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    struct O3 has key, store {
+    struct Obj3 has key, store {
         info: Info,
     }
 
     public entry fun create(ctx: &mut TxContext) {
-        let o = O3 { info: object::new(ctx) };
+        let o = Obj3 { info: object::new(ctx) };
         transfer::transfer(o, tx_context::sender(ctx))
     }
 }
 
 //# publish
 
-module T2::O2 {
+module t2::o2 {
     use sui::object::{Self, Info};
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
-    use T3::O3::O3;
+    use t3::o3::Obj3;
 
-    struct O2 has key, store {
+    struct Obj2 has key, store {
         info: Info,
     }
 
-    public entry fun create_shared(child: O3, ctx: &mut TxContext) {
+    public entry fun create_shared(child: Obj3, ctx: &mut TxContext) {
         transfer::share_object(new(child, ctx))
     }
 
-    public entry fun create_owned(child: O3, ctx: &mut TxContext) {
+    public entry fun create_owned(child: Obj3, ctx: &mut TxContext) {
         transfer::transfer(new(child, ctx), tx_context::sender(ctx))
     }
 
-    public entry fun use_o2_o3(_o2: &mut O2, o3: O3, ctx: &mut TxContext) {
+    public entry fun use_o2_o3(_o2: &mut Obj2, o3: Obj3, ctx: &mut TxContext) {
         transfer::transfer(o3, tx_context::sender(ctx))
     }
 
-    fun new(child: O3, ctx: &mut TxContext): O2 {
+    fun new(child: Obj3, ctx: &mut TxContext): Obj2 {
         let info = object::new(ctx);
         transfer::transfer_to_object_id(child, &info);
-        O2 { info }
+        Obj2 { info }
     }
 }
 
 
 //# publish
 
-module T1::O1 {
+module t1::o1 {
     use sui::object::{Self, Info};
     use sui::transfer;
     use sui::tx_context::{Self, TxContext};
-    use T2::O2::O2;
-    use T3::O3::O3;
+    use t2::o2::Obj2;
+    use t3::o3::Obj3;
 
-    struct O1 has key {
+    struct Obj1 has key {
         info: Info,
     }
 
-    public entry fun create_shared(child: O2, ctx: &mut TxContext) {
+    public entry fun create_shared(child: Obj2, ctx: &mut TxContext) {
         transfer::share_object(new(child, ctx))
     }
 
     // This function will be invalid if _o2 is a shared object and owns _o3.
-    public entry fun use_o2_o3(_o2: &mut O2, o3: O3, ctx: &mut TxContext) {
+    public entry fun use_o2_o3(_o2: &mut Obj2, o3: Obj3, ctx: &mut TxContext) {
         transfer::transfer(o3, tx_context::sender(ctx))
     }
 
-    fun new(child: O2, ctx: &mut TxContext): O1 {
+    fun new(child: Obj2, ctx: &mut TxContext): Obj1 {
         let info = object::new(ctx);
         transfer::transfer_to_object_id(child, &info);
-        O1 { info }
+        Obj1 { info }
     }
 }
 
-//# run T3::O3::create
+//# run t3::o3::create
 
-//# run T2::O2::create_shared --args object(109)
+//# run t2::o2::create_shared --args object(109)
 
-// This run should error as O2/O3 were not defined in O1
-//# run T1::O1::use_o2_o3 --args object(111) object(109)
+// This run should error as Obj2/Obj3 were not defined in o1
+//# run t1::o1::use_o2_o3 --args object(111) object(109)
 
-//# run T2::O2::use_o2_o3 --args object(111) object(109)
+//# run t2::o2::use_o2_o3 --args object(111) object(109)

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_param.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_param.exp
@@ -2,4 +2,4 @@ processed 2 tasks
 
 task 1 'publish'. lines 5-24:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::M1::init  of type &mut sui::tx_context::TxContext") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last parameter for _::M1::init to be &mut sui::tx_context::TxContext, but found &mut sui::tx_context::TxContext") } }

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
@@ -14,7 +14,7 @@ written: object(106)
 
 task 4 'view-object'. lines 43-43:
 Owner: Shared
-Contents: t2::o2::O2 {info: sui::object::Info {id: sui::object::ID {bytes: fake(107)}, version: 1u64}}
+Contents: t2::o2::Obj2 {info: sui::object::Info {id: sui::object::ID {bytes: fake(107)}, version: 1u64}}
 
 task 5 'run'. lines 45-45:
 Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.move
@@ -12,17 +12,17 @@ module t2::o2 {
     use sui::transfer;
     use sui::tx_context::TxContext;
 
-    struct O2 has key, store {
+    struct Obj2 has key, store {
         info: Info,
     }
 
     public entry fun create(ctx: &mut TxContext) {
-        let o = O2 { info: object::new(ctx) };
+        let o = Obj2 { info: object::new(ctx) };
         transfer::share_object(o)
     }
 
-    public entry fun consume_o2(o2: O2) {
-        let O2 { info } = o2;
+    public entry fun consume_o2(o2: Obj2) {
+        let Obj2 { info } = o2;
         object::delete(info);
     }
 }
@@ -30,9 +30,9 @@ module t2::o2 {
 //# publish
 
 module t1::o1 {
-    use t2::o2::{Self, O2};
+    use t2::o2::{Self, Obj2};
 
-    public entry fun consume_o2(o2: O2) {
+    public entry fun consume_o2(o2: Obj2) {
         o2::consume_o2(o2);
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/bool_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/bool_field.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+created: object(103)
+written: object(102)

--- a/crates/sui-verifier-transactional-tests/tests/char_type/bool_field.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/bool_field.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// correct, bool field specified at source level
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop { some_field: bool }
+
+    fun init(_: M, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/instantiate.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/instantiate.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-20:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("characteristic type _::m::M is instantiated in the _::m::pack function and must never be") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/instantiate.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/instantiate.move
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, struct type incorrectly instantiated
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop { }
+
+    fun init(_: M, _ctx: &mut sui::tx_context::TxContext) {
+    }
+
+
+    fun pack(): M {
+        M {}
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/more_abilities.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/more_abilities.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-20:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("characteristic type candidate _::m::M must have a single ability: drop") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/more_abilities.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/more_abilities.move
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, struct type has abilities beyond drop
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop, copy { }
+
+    fun init(_: M, _ctx: &mut sui::tx_context::TxContext) {
+    }
+
+
+    fun pack(): M {
+        M {}
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/no_drop.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/no_drop.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-16:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("characteristic type candidate _::m::M must have a single ability: drop") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/no_drop.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/no_drop.move
@@ -1,0 +1,16 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, char type has no drop ability
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M { }
+
+    fun init(t: M, _: &mut sui::tx_context::TxContext) {
+        let M { } = t;
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/no_field.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/no_field.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+created: object(103)
+written: object(102)

--- a/crates/sui-verifier-transactional-tests/tests/char_type/no_field.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/no_field.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// correct, no field specified at source level
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop { }
+
+    fun init(_: M, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/no_init_arg.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/no_init_arg.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("init function of a module containing characteristic type candidate must have _::m::M as the first parameter") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/no_init_arg.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/no_init_arg.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, no char type parameter in init
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop { value: bool }
+
+    fun init(_: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/other_mod_def.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/other_mod_def.exp
@@ -1,0 +1,9 @@
+processed 3 tasks
+
+task 1 'publish'. lines 8-12:
+created: object(103)
+written: object(102)
+
+task 2 'publish'. lines 14-19:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::n::init  of type &mut sui::tx_context::TxContext") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/other_mod_def.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/other_mod_def.move
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, characteristic type candidate used in a different module
+
+//# init --addresses test1=0x0 test2=0x0
+
+//# publish
+module test1::m {
+
+    struct M has drop { }
+}
+
+//# publish
+module test2::n {
+
+    fun init(_: test1::m::M, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/type_param.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/type_param.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("_::m. 'init' function cannot have type parameters") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/type_param.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/type_param.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, struct type has type param
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M<phantom T> has drop { }
+
+    fun init<T>(_: M<T>, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_field_type.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_field_type.exp
@@ -2,4 +2,4 @@ processed 2 tasks
 
 task 1 'publish'. lines 8-15:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("characteristic type candidate _::m::M must have a single bool field only") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("characteristic type candidate _::m::M must have a single bool field only (or no fields)") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_field_type.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_field_type.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("characteristic type candidate _::m::M must have a single bool field only") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_field_type.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_field_type.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, wrong struct field type
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop { value: u64 }
+
+    fun init(_: M, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_init_type.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_init_type.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-17:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("init function of a module containing characteristic type candidate must have _::m::M as the first parameter") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_init_type.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_init_type.move
@@ -1,0 +1,17 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, wrong type of the init function's first param
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct M has drop { }
+
+    struct N has drop { }
+
+    fun init(_: N, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::m::init  of type &mut sui::tx_context::TxContext") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, wrong characteristic type name
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m {
+
+    struct CharType has drop { }
+
+    fun init(_: CharType, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name_format.exp
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name_format.exp
@@ -1,0 +1,5 @@
+processed 2 tasks
+
+task 1 'publish'. lines 8-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::mod::init  of type &mut sui::tx_context::TxContext") } }

--- a/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name_format.move
+++ b/crates/sui-verifier-transactional-tests/tests/char_type/wrong_name_format.move
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, wrong characteristic type name format
+
+//# init --addresses test=0x0
+
+//# publish
+module test::mod {
+
+    struct Mod has drop { }
+
+    fun init(_: Mod, _ctx: &mut sui::tx_context::TxContext) {
+    }
+}

--- a/crates/sui-verifier-transactional-tests/tests/init/must_have_txn_context.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/must_have_txn_context.exp
@@ -2,7 +2,7 @@ processed 2 tasks
 
 task 0 'publish'. lines 4-11:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected exactly one parameter for _::m::init  of type &mut sui::tx_context::TxContext") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected at least one and at most two parameters for _::m::init") } }
 
 task 1 'publish'. lines 14-21:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.

--- a/crates/sui-verifier-transactional-tests/tests/init/not_txn_context.exp
+++ b/crates/sui-verifier-transactional-tests/tests/init/not_txn_context.exp
@@ -2,16 +2,16 @@ processed 4 tasks
 
 task 0 'publish'. lines 4-11:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found u64") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last parameter for _::m::init to be &mut sui::tx_context::TxContext, but found u64") } }
 
 task 1 'publish'. lines 13-20:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::tx_context::init to be &mut sui::tx_context::TxContext, but found _::tx_context::TxContext") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last parameter for _::tx_context::init to be &mut sui::tx_context::TxContext, but found _::tx_context::TxContext") } }
 
 task 2 'publish'. lines 22-29:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found &sui::tx_context::TxContext") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last parameter for _::m::init to be &mut sui::tx_context::TxContext, but found &sui::tx_context::TxContext") } }
 
 task 3 'publish'. lines 32-39:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected parameter for _::m::init to be &mut sui::tx_context::TxContext, but found sui::tx_context::TxContext") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last parameter for _::m::init to be &mut sui::tx_context::TxContext, but found sui::tx_context::TxContext") } }

--- a/crates/sui-verifier/src/char_type_verifier.rs
+++ b/crates/sui-verifier/src/char_type_verifier.rs
@@ -73,7 +73,7 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
                     .map_err(verification_failure)?;
             } else {
                 // if there is no characteristic type candidate than the init function should have
-                // only one parameter of tx_context type
+                // only one parameter of TxContext type
                 verify_init_function_single_param(module, fn_handle)
                     .map_err(verification_failure)?;
             }
@@ -174,7 +174,7 @@ fn is_char_type(
     false
 }
 
-/// Checks if this module's `init` function has a single parameter of tx_context type only
+/// Checks if this module's `init` function has a single parameter of TxContext type only
 fn verify_init_function_single_param(
     module: &CompiledModule,
     fn_handle: &FunctionHandle,

--- a/crates/sui-verifier/src/char_type_verifier.rs
+++ b/crates/sui-verifier/src/char_type_verifier.rs
@@ -69,10 +69,10 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
         let fn_handle = module.function_handle_at(fn_def.function);
         let fn_name = module.identifier_at(fn_handle.name);
         if fn_name == INIT_FN_NAME {
-            if let Some((struct_name, struct_handle, _)) = char_type_candidate {
+            if let Some((candidate_name, candidate_handle, _)) = char_type_candidate {
                 // only verify if init function conforms to characteristic types requirements if we
                 // have a characteristic type candidate
-                verify_init_function_char_type(module, fn_handle, struct_name, struct_handle)
+                verify_init_function_char_type(module, fn_handle, candidate_name, candidate_handle)
                     .map_err(verification_failure)?;
             } else {
                 // if there is no characteristic type candidate than the init function should have
@@ -81,10 +81,10 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
                     .map_err(verification_failure)?;
             }
         }
-        if let Some((struct_name, _, def)) = char_type_candidate {
+        if let Some((candidate_name, _, def)) = char_type_candidate {
             // only verify lack of characteristic types instantiations if we have a
             // characteristic type candidate
-            verify_no_instantiations(module, fn_def, struct_name, def)
+            verify_no_instantiations(module, fn_def, candidate_name, def)
                 .map_err(verification_failure)?;
         }
     }
@@ -103,7 +103,7 @@ fn verify_char_type(
     // must have only one ability: drop
     let drop_set = AbilitySet::EMPTY | Ability::Drop;
     let abilities = struct_handle.abilities;
-    if !(abilities.has_drop() && (abilities.union(drop_set)) == drop_set) {
+    if abilities != drop_set {
         return Err(format!(
             "characteristic type candidate {}::{} must have a single ability: drop",
             module.self_id(),

--- a/crates/sui-verifier/src/char_type_verifier.rs
+++ b/crates/sui-verifier/src/char_type_verifier.rs
@@ -1,0 +1,219 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A module can define a "characteristic type", that is a type that is instantiated only once, and
+//! this property is enforced by the system. We define a characteristic type as a struct type that
+//! has the same name as the module that defines it but with all the letter capitalized, and
+//! possessing certain special properties specified below (please note that by convention, "regular"
+//! struct type names are expressed in camel case).  In other words, if a module defines a struct
+//! type whose name is the same as the module name, this type MUST possess these special properties,
+//! otherwise the module definition will be considered invalid and will be rejected by the
+//! validator:
+//!
+//! - it has only one ability: drop
+//! - it has only one arbitrarily named field of type boolean (since Move structs cannot be empty)
+//! - its definition does not involve type parameters
+//! - its only instance in existence is passed as an argument to the module initializer
+//! - it is never instantiated anywhere in its defining module
+
+use move_binary_format::{
+    access::ModuleAccess,
+    binary_views::BinaryIndexedView,
+    file_format::{
+        Ability, AbilitySet, Bytecode, CompiledModule, FunctionDefinition, FunctionHandle,
+        SignatureToken, StructDefinition, StructHandle, TypeSignature,
+    },
+};
+use sui_types::{
+    base_types::{TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
+    error::ExecutionError,
+    SUI_FRAMEWORK_ADDRESS,
+};
+
+use crate::{verification_failure, INIT_FN_NAME};
+
+pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
+    let view = BinaryIndexedView::Module(module);
+    let struct_defs = &module.struct_defs;
+    for def in struct_defs {
+        let struct_handle = module.struct_handle_at(def.struct_handle);
+        let struct_name = view.identifier_at(struct_handle.name).as_str();
+        let mod_handle = view.module_handle_at(module.self_module_handle_idx);
+        let mod_name = view.identifier_at(mod_handle.name).as_str();
+        let mut candidate_exists = false;
+        if struct_name.to_ascii_uppercase() == struct_name
+            && mod_name.to_ascii_uppercase() == struct_name
+        {
+            verify_char_type(module, struct_name, struct_handle, def)
+                .map_err(verification_failure)?;
+            // if we reached this point, it means we have a legitimate characteristic type candidate
+            // and we have to make sure that both the init function's signature reflects this and
+            // that this type is not instantiated in any function of the module
+            candidate_exists = true;
+        }
+        for fn_def in &module.function_defs {
+            let fn_handle = module.function_handle_at(fn_def.function);
+            let fn_name = module.identifier_at(fn_handle.name);
+            if fn_name == INIT_FN_NAME {
+                if candidate_exists {
+                    // only verify if init function conforms to characteristic types requirements if
+                    // we have a
+                    // characteristic type candidate
+                    verify_init_function_char_type(module, fn_handle, struct_name, struct_handle)
+                        .map_err(verification_failure)?;
+                } else {
+                    // if there is no characteristic type candidate than the init function should
+                    // have only one parameter of tx_context type
+                    verify_init_function_single_param(module, fn_handle)
+                        .map_err(verification_failure)?;
+                }
+            }
+            if candidate_exists {
+                // only verify lack of characteristic types instantiations if we have a
+                // characteristic type candidate
+                verify_no_instantiations(module, fn_def, struct_name, def)
+                    .map_err(verification_failure)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Verifies all required properties of a characteristic type candidate (that is a type whose name is
+// the same as the name of a
+fn verify_char_type(
+    module: &CompiledModule,
+    struct_name: &str,
+    struct_handle: &StructHandle,
+    struct_def: &StructDefinition,
+) -> Result<(), String> {
+    // must have only one ability: drop
+    let drop_set = AbilitySet::from_u8(Ability::Drop as u8).unwrap();
+    let abilities = struct_handle.abilities;
+    if !(abilities.has_drop() && (abilities.union(drop_set)) == drop_set) {
+        return Err(format!(
+            "characteristic type candidate {}::{} must have a single ability: drop",
+            module.self_id(),
+            struct_name,
+        ));
+    }
+    let field_count = struct_def.declared_field_count().map_err(|_| {
+        format!(
+            "characteristic type candidate {}::{} cannot be a native structure",
+            module.self_id(),
+            struct_name
+        )
+    })?;
+
+    // unwrap below is safe as it will always be successful if declared_field_count call above is
+    // successful
+    if field_count != 1
+        || struct_def.field(0).unwrap().signature != TypeSignature(SignatureToken::Bool)
+    {
+        return Err(format!(
+            "characteristic type candidate {}::{} must have a single bool field only",
+            module.self_id(),
+            struct_name,
+        ));
+    }
+
+    if !struct_handle.type_parameters.is_empty() {
+        return Err(format!(
+            "characteristic type candidate {}::{} cannot have type parameters",
+            module.self_id(),
+            struct_name,
+        ));
+    }
+
+    Ok(())
+}
+
+/// Checks if this module's `init` function conformant with the characteristic type
+fn verify_init_function_char_type(
+    module: &CompiledModule,
+    fn_handle: &FunctionHandle,
+    struct_name: &str,
+    struct_handle: &StructHandle,
+) -> Result<(), String> {
+    let view = &BinaryIndexedView::Module(module);
+    let fn_sig = view.signature_at(fn_handle.parameters);
+    if fn_sig.len() != 2 || !is_char_type(view, &fn_sig.0[0], struct_handle) {
+        // check only the first parameter - the other one is checked in entry_points verification
+        // pass
+        return Err(format!(
+            "init function of a module containing characteristic type candidate must have {}::{} as the first parameter",
+            module.self_id(),
+            struct_name,
+        ));
+    }
+
+    Ok(())
+}
+
+// Checks if a given SignatureToken represents a characteristic type struct
+fn is_char_type(
+    view: &BinaryIndexedView,
+    tok: &SignatureToken,
+    struct_handle: &StructHandle,
+) -> bool {
+    if let SignatureToken::Struct(idx) = tok {
+        if view.struct_handle_at(*idx) == struct_handle {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Checks if this module's `init` function has a single parameter of tx_context type only
+fn verify_init_function_single_param(
+    module: &CompiledModule,
+    fn_handle: &FunctionHandle,
+) -> Result<(), String> {
+    let view = &BinaryIndexedView::Module(module);
+    let fn_sig = view.signature_at(fn_handle.parameters);
+    if fn_sig.len() != 1 {
+        return Err(format!(
+            "Expected exactly one parameter for {}::{}  of type &mut {}::{}::{}",
+            module.self_id(),
+            INIT_FN_NAME,
+            SUI_FRAMEWORK_ADDRESS,
+            TX_CONTEXT_MODULE_NAME,
+            TX_CONTEXT_STRUCT_NAME,
+        ));
+    }
+
+    Ok(())
+}
+
+/// Checks if this module function does not contain instantiation of the characteristic type
+fn verify_no_instantiations(
+    module: &CompiledModule,
+    fn_def: &FunctionDefinition,
+    struct_name: &str,
+    struct_def: &StructDefinition,
+) -> Result<(), String> {
+    let view = &BinaryIndexedView::Module(module);
+    if let Some(code) = &fn_def.code {
+        for bcode in &code.code {
+            if let Bytecode::Pack(struct_def_idx) = bcode {
+                // unwrap is safe below since we know we are getting a struct out of a module (see
+                // definition of struct_def_at)
+                if view.struct_def_at(*struct_def_idx).unwrap() == struct_def {
+                    let fn_handle = module.function_handle_at(fn_def.function);
+                    let fn_name = module.identifier_at(fn_handle.name);
+                    return Err(format!(
+                        "characteristic type {}::{} is instantiated in the {}::{} function and must never be",
+                        module.self_id(),
+                        struct_name,
+                        module.self_id(),
+                        fn_name,
+                    ));
+                }
+            }
+        }
+    };
+
+    Ok(())
+}

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -131,6 +131,10 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
         ));
     }
 
+    // Checking only the last (and possibly the only) parameter here. If there are two parameters,
+    // then the first parameter must be of a characteristic type and must be passed by value. This
+    // is checked by the verifier pass handling characteristic types (char_type) - please see the
+    // description of this pass for additional details.
     if is_tx_context(view, &parameters[parameters.len() - 1]) {
         Ok(())
     } else {
@@ -144,10 +148,6 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
             format_signature_token(view, &parameters[0]),
         ))
     }
-
-    // If there are two parameters, then the first parameter must be of a characteristic type and
-    // must be passed by value. This is checked by the verifier pass handling characteristic types
-    // (char_type) - please see the description of this pass for additional details.
 }
 
 fn verify_entry_function_impl(

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -131,7 +131,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
         ));
     }
 
-    if is_tx_context(view, &parameters[parameters.len() - 1]) {
+    if parameters.len() == 0 || is_tx_context(view, &parameters[parameters.len() - 1]) {
         Ok(())
     } else {
         Err(format!(

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -7,7 +7,7 @@ use move_binary_format::{
     file_format::{AbilitySet, Bytecode, FunctionDefinition, SignatureToken, Visibility},
     CompiledModule,
 };
-use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 use sui_types::{
     base_types::{
         STD_OPTION_MODULE_NAME, STD_OPTION_STRUCT_NAME, TX_CONTEXT_MODULE_NAME,
@@ -18,9 +18,7 @@ use sui_types::{
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 
-use crate::{format_signature_token, resolve_struct, verification_failure};
-
-pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
+use crate::{format_signature_token, resolve_struct, verification_failure, INIT_FN_NAME};
 
 /// Checks valid rules rules for entry points, both for module initialization and transactions
 ///
@@ -28,7 +26,10 @@ pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
 /// - The existence of the function is optional
 /// - The function must have the name specified by `INIT_FN_NAME`
 /// - The function must have `Visibility::Private`
-/// - The function can have a single parameter: &mut TxContext (see `is_tx_context`)
+/// - The function can have at most two parameters:
+///   - mandatory &mut TxContext (see `is_tx_context`) in the last position
+///   - optional characteristic type (see char_type verifier pass) passed by value in the first
+///   position
 ///
 /// For transaction entry points
 /// - The function must have `is_entry` true
@@ -113,7 +114,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
         ));
     }
 
-    if !view.signature_at(fhandle.return_).0.is_empty() {
+    if !view.signature_at(fhandle.return_).is_empty() {
         return Err(format!(
             "{}, '{}' function cannot have return values",
             module.self_id(),
@@ -122,22 +123,19 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
     }
 
     let parameters = &view.signature_at(fhandle.parameters).0;
-    if parameters.len() != 1 {
+    if parameters.len() > 2 {
         return Err(format!(
-            "Expected exactly one parameter for {}::{}  of type &mut {}::{}::{}",
+            "Expected at most two parameters for {}::{}",
             module.self_id(),
             INIT_FN_NAME,
-            SUI_FRAMEWORK_ADDRESS,
-            TX_CONTEXT_MODULE_NAME,
-            TX_CONTEXT_STRUCT_NAME,
         ));
     }
 
-    if is_tx_context(view, &parameters[0]) {
+    if is_tx_context(view, &parameters[parameters.len() - 1]) {
         Ok(())
     } else {
         Err(format!(
-            "Expected parameter for {}::{} to be &mut {}::{}::{}, but found {}",
+            "Expected last parameter for {}::{} to be &mut {}::{}::{}, but found {}",
             module.self_id(),
             INIT_FN_NAME,
             SUI_FRAMEWORK_ADDRESS,
@@ -146,6 +144,10 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
             format_signature_token(view, &parameters[0]),
         ))
     }
+
+    // If there are two parameters, then the first parameter must be of a characteristic type and
+    // must be passed by value. This is checked by the verifier pass handling characteristic types
+    // (char_type) - please see the description of this pass for additional details.
 }
 
 fn verify_entry_function_impl(

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -123,15 +123,15 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
     }
 
     let parameters = &view.signature_at(fhandle.parameters).0;
-    if parameters.len() > 2 {
+    if parameters.is_empty() || parameters.len() > 2 {
         return Err(format!(
-            "Expected at most two parameters for {}::{}",
+            "Expected at least one and at most two parameters for {}::{}",
             module.self_id(),
             INIT_FN_NAME,
         ));
     }
 
-    if parameters.len() == 0 || is_tx_context(view, &parameters[parameters.len() - 1]) {
+    if is_tx_context(view, &parameters[parameters.len() - 1]) {
         Ok(())
     } else {
         Err(format!(

--- a/crates/sui-verifier/src/lib.rs
+++ b/crates/sui-verifier/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod verifier;
 
+pub mod char_type_verifier;
 pub mod entry_points_verifier;
 pub mod global_storage_access_verifier;
 pub mod id_leak_verifier;
@@ -13,8 +14,10 @@ use move_binary_format::{
     binary_views::BinaryIndexedView,
     file_format::{SignatureToken, StructHandleIndex},
 };
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
+use move_core_types::{account_address::AccountAddress, ident_str, identifier::IdentStr};
 use sui_types::error::{ExecutionError, ExecutionErrorKind};
+
+pub const INIT_FN_NAME: &IdentStr = ident_str!("init");
 
 fn verification_failure(error: String) -> ExecutionError {
     ExecutionError::new_with_source(ExecutionErrorKind::SuiMoveVerificationError, error)

--- a/crates/sui-verifier/src/verifier.rs
+++ b/crates/sui-verifier/src/verifier.rs
@@ -7,8 +7,8 @@ use move_binary_format::file_format::CompiledModule;
 use sui_types::error::ExecutionError;
 
 use crate::{
-    entry_points_verifier, global_storage_access_verifier, id_leak_verifier, private_generics,
-    struct_with_key_verifier,
+    char_type_verifier, entry_points_verifier, global_storage_access_verifier, id_leak_verifier,
+    private_generics, struct_with_key_verifier,
 };
 
 /// Helper for a "canonical" verification of a module.
@@ -17,5 +17,6 @@ pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
     global_storage_access_verifier::verify_module(module)?;
     id_leak_verifier::verify_module(module)?;
     private_generics::verify_module(module)?;
-    entry_points_verifier::verify_module(module)
+    entry_points_verifier::verify_module(module)?;
+    char_type_verifier::verify_module(module)
 }

--- a/sui_programmability/examples/fungible_tokens/sources/basket.move
+++ b/sui_programmability/examples/fungible_tokens/sources/basket.move
@@ -33,9 +33,9 @@ module fungible_tokens::basket {
     /// Needed to deposit a 1:1 ratio of SUI and MANAGED for minting, but deposited a different ratio
     const EBadDepositRatio: u64 = 0;
 
-    fun init(ctx: &mut TxContext) {
+    fun init(witness: BASKET, ctx: &mut TxContext) {
         // Get a treasury cap for the coin put it in the reserve
-        let total_supply = balance::create_supply<BASKET>(BASKET {});
+        let total_supply = balance::create_supply<BASKET>(witness);
 
         transfer::share_object(Reserve {
             info: object::new(ctx),
@@ -92,6 +92,6 @@ module fungible_tokens::basket {
 
     #[test_only]
     public fun init_for_testing(ctx: &mut TxContext) {
-        init(ctx)
+        init(BASKET {}, ctx)
     }
 }

--- a/sui_programmability/examples/fungible_tokens/sources/managed.move
+++ b/sui_programmability/examples/fungible_tokens/sources/managed.move
@@ -16,9 +16,9 @@ module fungible_tokens::managed {
     /// Register the managed currency to acquire its `TreasuryCap`. Because
     /// this is a module initializer, it ensures the currency only gets
     /// registered once.
-    fun init(ctx: &mut TxContext) {
+    fun init(witness: MANAGED, ctx: &mut TxContext) {
         // Get a treasury cap for the coin and give it to the transaction sender
-        let treasury_cap = coin::create_currency<MANAGED>(MANAGED{}, ctx);
+        let treasury_cap = coin::create_currency<MANAGED>(witness, ctx);
         transfer::transfer(treasury_cap, tx_context::sender(ctx))
     }
 
@@ -40,6 +40,6 @@ module fungible_tokens::managed {
     #[test_only]
     /// Wrapper of module initializer for testing
     public fun test_init(ctx: &mut TxContext) {
-        init(ctx)
+        init(MANAGED {}, ctx)
     }
 }

--- a/sui_programmability/examples/fungible_tokens/sources/regulated_coin.move
+++ b/sui_programmability/examples/fungible_tokens/sources/regulated_coin.move
@@ -84,7 +84,7 @@ module rc::regulated_coin {
     }
 }
 
-/// ABC is a RegulatedCoin which:
+/// Abc is a RegulatedCoin which:
 ///
 /// - is managed account creation (only admins can create a new balance)
 /// - has a denylist for addresses managed by the coin admins
@@ -98,13 +98,13 @@ module abc::abc {
     use sui::transfer;
     use std::vector;
 
-    /// The ticker of ABC regulated token
-    struct ABC has drop {}
+    /// The ticker of Abc regulated token
+    struct Abc has drop {}
 
-    /// A restricted transfer of ABC to another account.
+    /// A restricted transfer of Abc to another account.
     struct Transfer has key {
         info: Info,
-        balance: Balance<ABC>,
+        balance: Balance<Abc>,
         to: address,
     }
 
@@ -115,18 +115,18 @@ module abc::abc {
         swapped_amount: u64,
     }
 
-    /// For when an attempting to interact with another account's RegulatedCoin<ABC>.
+    /// For when an attempting to interact with another account's RegulatedCoin<Abc>.
     const ENotOwner: u64 = 1;
 
     /// For when address has been banned and someone is trying to access the balance
     const EAddressBanned: u64 = 2;
 
-    /// Create the ABC currency and send the TreasuryCap to the creator
-    /// as well as the first (and empty) balance of the RegulatedCoin<ABC>.
+    /// Create the Abc currency and send the TreasuryCap to the creator
+    /// as well as the first (and empty) balance of the RegulatedCoin<Abc>.
     ///
     /// Also creates a shared Registry which holds banned addresses.
     fun init(ctx: &mut TxContext) {
-        let treasury_cap = coin::create_currency(ABC {}, ctx);
+        let treasury_cap = coin::create_currency(Abc {}, ctx);
         let sender = tx_context::sender(ctx);
 
         transfer::transfer(zero(sender, ctx), sender);
@@ -153,27 +153,27 @@ module abc::abc {
 
     // === Admin actions: creating balances, minting coins and banning addresses ===
 
-    /// Create an empty `RCoin<ABC>` instance for account `for`. TreasuryCap is passed for
+    /// Create an empty `RCoin<Abc>` instance for account `for`. TreasuryCap is passed for
     /// authentification purposes - only admin can create new accounts.
-    public entry fun create(_: &TreasuryCap<ABC>, for: address, ctx: &mut TxContext) {
+    public entry fun create(_: &TreasuryCap<Abc>, for: address, ctx: &mut TxContext) {
         transfer::transfer(zero(for, ctx), for)
     }
 
-    /// Mint more ABC. Requires TreasuryCap for authorization, so can only be done by admins.
-    public entry fun mint(treasury: &mut TreasuryCap<ABC>, owned: &mut RCoin<ABC>, value: u64) {
+    /// Mint more Abc. Requires TreasuryCap for authorization, so can only be done by admins.
+    public entry fun mint(treasury: &mut TreasuryCap<Abc>, owned: &mut RCoin<Abc>, value: u64) {
         balance::join(borrow_mut(owned), coin::mint_balance(treasury, value));
     }
 
-    /// Burn `value` amount of `RCoin<ABC>`. Requires TreasuryCap for authorization, so can only be done by admins.
+    /// Burn `value` amount of `RCoin<Abc>`. Requires TreasuryCap for authorization, so can only be done by admins.
     ///
     /// TODO: Make TreasuryCap a part of Balance module instead of Coin.
-    public entry fun burn(treasury: &mut TreasuryCap<ABC>, owned: &mut RCoin<ABC>, value: u64, ctx: &mut TxContext) {
+    public entry fun burn(treasury: &mut TreasuryCap<Abc>, owned: &mut RCoin<Abc>, value: u64, ctx: &mut TxContext) {
         coin::burn(treasury, coin::take(borrow_mut(owned), value, ctx));
     }
 
     /// Ban some address and forbid making any transactions from or to this address.
     /// Only owner of the TreasuryCap can perform this action.
-    public entry fun ban(_cap: &TreasuryCap<ABC>, registry: &mut Registry, to_ban: address) {
+    public entry fun ban(_cap: &TreasuryCap<Abc>, registry: &mut Registry, to_ban: address) {
         vector::push_back(&mut registry.banned, to_ban)
     }
 
@@ -183,7 +183,7 @@ module abc::abc {
     /// `to` account for being accepted later.
     /// Fails if sender is not an creator of the `RegulatedCoin` or if any of the parties is in
     /// the ban list in Registry.
-    public entry fun transfer(r: &Registry, coin: &mut RCoin<ABC>, value: u64, to: address, ctx: &mut TxContext) {
+    public entry fun transfer(r: &Registry, coin: &mut RCoin<Abc>, value: u64, to: address, ctx: &mut TxContext) {
         let sender = tx_context::sender(ctx);
 
         assert!(rcoin::creator(coin) == sender, ENotOwner);
@@ -200,9 +200,9 @@ module abc::abc {
     /// Accept an incoming transfer by joining an incoming balance with an owned one.
     ///
     /// Fails if:
-    /// 1. the `RegulatedCoin<ABC>.creator` does not match `Transfer.to`;
+    /// 1. the `RegulatedCoin<Abc>.creator` does not match `Transfer.to`;
     /// 2. the address of the creator/recipient is banned;
-    public entry fun accept_transfer(r: &Registry, coin: &mut RCoin<ABC>, transfer: Transfer, _: &mut TxContext) {
+    public entry fun accept_transfer(r: &Registry, coin: &mut RCoin<Abc>, transfer: Transfer, _: &mut TxContext) {
         let Transfer { info, balance, to } = transfer;
 
         assert!(rcoin::creator(coin) == to, ENotOwner);
@@ -218,9 +218,9 @@ module abc::abc {
     /// a `Coin`. Update `Registry` to keep track of the swapped amount.
     ///
     /// Fails if:
-    /// 1. `RegulatedCoin<ABC>.creator` was banned;
-    /// 2. `RegulatedCoin<ABC>` is not owned by the tx sender;
-    public entry fun take(r: &mut Registry, coin: &mut RCoin<ABC>, value: u64, ctx: &mut TxContext) {
+    /// 1. `RegulatedCoin<Abc>.creator` was banned;
+    /// 2. `RegulatedCoin<Abc>` is not owned by the tx sender;
+    public entry fun take(r: &mut Registry, coin: &mut RCoin<Abc>, value: u64, ctx: &mut TxContext) {
         let sender = tx_context::sender(ctx);
 
         assert!(rcoin::creator(coin) == sender, ENotOwner);
@@ -235,9 +235,9 @@ module abc::abc {
     /// Take `Coin` and put to the `RegulatedCoin`'s balance.
     ///
     /// Fails if:
-    /// 1. `RegulatedCoin<ABC>.creator` was banned;
-    /// 2. `RegulatedCoin<ABC>` is not owned by the tx sender;
-    public entry fun put_back(r: &mut Registry, rc_coin: &mut RCoin<ABC>, coin: Coin<ABC>, ctx: &mut TxContext) {
+    /// 1. `RegulatedCoin<Abc>.creator` was banned;
+    /// 2. `RegulatedCoin<Abc>` is not owned by the tx sender;
+    public entry fun put_back(r: &mut Registry, rc_coin: &mut RCoin<Abc>, coin: Coin<Abc>, ctx: &mut TxContext) {
         let balance = coin::into_balance(coin);
         let sender = tx_context::sender(ctx);
 
@@ -252,24 +252,24 @@ module abc::abc {
 
     // === Private implementations accessors and type morphing ===
 
-    fun borrow(coin: &RCoin<ABC>): &Balance<ABC> { rcoin::borrow(ABC {}, coin) }
-    fun borrow_mut(coin: &mut RCoin<ABC>): &mut Balance<ABC> { rcoin::borrow_mut(ABC {}, coin) }
-    fun zero(creator: address, ctx: &mut TxContext): RCoin<ABC> { rcoin::zero(ABC {}, creator, ctx) }
+    fun borrow(coin: &RCoin<Abc>): &Balance<Abc> { rcoin::borrow(Abc {}, coin) }
+    fun borrow_mut(coin: &mut RCoin<Abc>): &mut Balance<Abc> { rcoin::borrow_mut(Abc {}, coin) }
+    fun zero(creator: address, ctx: &mut TxContext): RCoin<Abc> { rcoin::zero(Abc {}, creator, ctx) }
 
-    fun into_balance(coin: RCoin<ABC>): Balance<ABC> { rcoin::into_balance(ABC {}, coin) }
-    fun from_balance(balance: Balance<ABC>, creator: address, ctx: &mut TxContext): RCoin<ABC> {
-        rcoin::from_balance(ABC {}, balance, creator, ctx)
+    fun into_balance(coin: RCoin<Abc>): Balance<Abc> { rcoin::into_balance(Abc {}, coin) }
+    fun from_balance(balance: Balance<Abc>, creator: address, ctx: &mut TxContext): RCoin<Abc> {
+        rcoin::from_balance(Abc {}, balance, creator, ctx)
     }
 
     // === Testing utilities ===
 
     #[test_only] public fun init_for_testing(ctx: &mut TxContext) { init(ctx) }
-    #[test_only] public fun borrow_for_testing(coin: &RCoin<ABC>): &Balance<ABC> { borrow(coin) }
-    #[test_only] public fun borrow_mut_for_testing(coin: &mut RCoin<ABC>): &Balance<ABC> { borrow_mut(coin) }
+    #[test_only] public fun borrow_for_testing(coin: &RCoin<Abc>): &Balance<Abc> { borrow(coin) }
+    #[test_only] public fun borrow_mut_for_testing(coin: &mut RCoin<Abc>): &Balance<Abc> { borrow_mut(coin) }
 }
 
 #[test_only]
-/// Tests for the ABC module. They are sequential and based on top of each other.
+/// Tests for the abc module. They are sequential and based on top of each other.
 /// ```
 /// * - test_minting
 /// |   +-- test_creation
@@ -283,7 +283,7 @@ module abc::abc {
 /// |               +-- test_not_owned_balance_fail
 /// ```
 module abc::tests {
-    use abc::abc::{Self, ABC, Registry};
+    use abc::abc::{Self, Abc, Registry};
     use rc::regulated_coin::{Self as rcoin, RegulatedCoin as RCoin};
 
     use sui::coin::{Coin, TreasuryCap};
@@ -322,7 +322,7 @@ module abc::tests {
     fun scenario(): Scenario { test_scenario::begin(&@0xABC) }
     fun people(): (address, address, address) { (@0xABC, @0xE05, @0xFACE) }
 
-    // Admin creates a regulated coin ABC and mints 1,000,000 of it.
+    // Admin creates a regulated coin Abc and mints 1,000,000 of it.
     fun test_minting_(test: &mut Scenario) {
         let (admin, _, _) = people();
 
@@ -331,8 +331,8 @@ module abc::tests {
         };
 
         next_tx(test, &admin); {
-            let cap = test_scenario::take_owned<TreasuryCap<ABC>>(test);
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let cap = test_scenario::take_owned<TreasuryCap<Abc>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
 
             abc::mint(&mut cap, &mut coin, 1000000);
 
@@ -350,7 +350,7 @@ module abc::tests {
         test_minting_(test);
 
         next_tx(test, &admin); {
-            let cap = test_scenario::take_owned<TreasuryCap<ABC>>(test);
+            let cap = test_scenario::take_owned<TreasuryCap<Abc>>(test);
 
             abc::create(&cap, user1, ctx(test));
 
@@ -358,7 +358,7 @@ module abc::tests {
         };
 
         next_tx(test, &user1); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
 
             assert!(rcoin::creator(&coin) == user1, 1);
             assert!(rcoin::value(&coin) == 0, 2);
@@ -375,7 +375,7 @@ module abc::tests {
         test_creation_(test);
 
         next_tx(test, &admin); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 
@@ -386,7 +386,7 @@ module abc::tests {
         };
 
         next_tx(test, &user1); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let transfer = test_scenario::take_owned<abc::Transfer>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
@@ -400,15 +400,15 @@ module abc::tests {
         };
     }
 
-    // Admin burns 100,000 of `RCoin<ABC>`
+    // Admin burns 100,000 of `RCoin<Abc>`
     fun test_burn_(test: &mut Scenario) {
         let (admin, _, _) = people();
 
         test_transfer_(test);
 
         next_tx(test, &admin); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
-            let treasury_cap = test_scenario::take_owned<TreasuryCap<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
+            let treasury_cap = test_scenario::take_owned<TreasuryCap<Abc>>(test);
 
             abc::burn(&mut treasury_cap, &mut coin, 100000, ctx(test));
 
@@ -420,14 +420,14 @@ module abc::tests {
     }
 
     // User1 cashes 100,000 of his `RegulatedCoin` into a `Coin`;
-    // User1 sends Coin<ABC> it to `user2`.
+    // User1 sends Coin<Abc> it to `user2`.
     fun test_take_(test: &mut Scenario) {
         let (_, user1, user2) = people();
 
         test_transfer_(test);
 
         next_tx(test, &user1); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 
@@ -441,12 +441,12 @@ module abc::tests {
         };
 
         next_tx(test, &user1); {
-            let coin = test_scenario::take_owned<Coin<ABC>>(test);
+            let coin = test_scenario::take_owned<Coin<Abc>>(test);
             sui::transfer::transfer(coin, user2);
         };
     }
 
-    // User2 sends his `Coin<ABC>` to `admin`.
+    // User2 sends his `Coin<Abc>` to `admin`.
     // Admin puts this coin to his RegulatedCoin balance.
     fun test_put_back_(test: &mut Scenario) {
         let (admin, _, user2) = people();
@@ -454,13 +454,13 @@ module abc::tests {
         test_take_(test);
 
         next_tx(test, &user2); {
-            let coin = test_scenario::take_owned<Coin<ABC>>(test);
+            let coin = test_scenario::take_owned<Coin<Abc>>(test);
             sui::transfer::transfer(coin, admin);
         };
 
         next_tx(test, &admin); {
-            let coin = test_scenario::take_owned<Coin<ABC>>(test);
-            let reg_coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<Coin<Abc>>(test);
+            let reg_coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 
@@ -478,7 +478,7 @@ module abc::tests {
         test_transfer_(test);
 
         next_tx(test, &admin); {
-            let cap = test_scenario::take_owned<TreasuryCap<ABC>>(test);
+            let cap = test_scenario::take_owned<TreasuryCap<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 
@@ -496,7 +496,7 @@ module abc::tests {
         test_ban_(test);
 
         next_tx(test, &user1); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 
@@ -514,7 +514,7 @@ module abc::tests {
         test_ban_(test);
 
         next_tx(test, &admin); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 
@@ -533,12 +533,12 @@ module abc::tests {
         test_ban_(test);
 
         next_tx(test, &user1); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             sui::transfer::transfer(coin, user2);
         };
 
         next_tx(test, &user2); {
-            let coin = test_scenario::take_owned<RCoin<ABC>>(test);
+            let coin = test_scenario::take_owned<RCoin<Abc>>(test);
             let reg = test_scenario::take_shared<Registry>(test);
             let reg_ref = test_scenario::borrow_mut(&mut reg);
 


### PR DESCRIPTION
This PR is the first step towards implementing so called one-time-witness in the form of so called characteristic type. The idea is to guarantee that a given [witness type](http://examples.sui.io/patterns/witness.html) can be used only once.

An example use is to guarantee that there can be only one instance of a treasure capability for a given coin (a "permission-less coin)- treasure capability uses a witness type to [create a new coin](http://examples.sui.io/samples/coin.html).

This is realized by having a very specific type (optionally) defined in a module, and guarantee that this type can be instantiated only once and the instance cannot be stored or copied. This type must fulfill the following properties which are checked in a verifier pass implemented in this PR:
- it has only one ability: drop
- it has only one arbitrarily named field of type boolean (since Move structs cannot be empty)
- its definition does not involve type parameters
- its only instance in existence is passed as an argument to the module initializer
- it is never instantiated anywhere in its defining module

A followup to this PR will be another one that implements a native function checking if a given type is a characteristic type and providing an example of how all this can be used to implement a permission-less coin.
