### PR TITLE
[core / node-sync] Get semaphore permit before launching task

### DIFF
--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -336,11 +336,12 @@ where
         while let Some(DigestsMessage { sync_arg, tx }) = receiver.recv().await {
             let state = self.clone();
             let limit = limit.clone();
-            tokio::spawn(async move {
-                // hold semaphore permit until task completes. unwrap ok because we never close
-                // the semaphore in this context.
-                let permit = limit.acquire_owned().await.unwrap();
 
+            // hold semaphore permit until task completes. unwrap ok because we never close
+            // the semaphore in this context.
+            let permit = limit.acquire_owned().await.unwrap();
+
+            tokio::spawn(async move {
                 let res = state.process_digest(sync_arg, permit).await;
                 if let Err(error) = &res {
                     error!(?sync_arg, "process_digest failed: {}", error);


### PR DESCRIPTION
Previously we got items out of a (bounded) channel, launched a task, and then tried to get a semaphore permit. This means that in practice the channel was unbounded, and so were the number of tasks we could potentially launch. In this PR we take the semaphore ticket before we launch a task, in effect bounding the number of active tasks to execute digests, and allowing the channel to apply back pressure when execution is slow.