### PR TITLE
Fix typo for std::debug in docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6746,6 +6746,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "uuid",
  "workspace-hack 0.1.0",
 ]
 
@@ -8211,6 +8212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom 0.2.6",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9229,6 +9240,7 @@ dependencies = [
  "unzip-n",
  "url",
  "utf8parse",
+ "uuid",
  "variant_count",
  "vcpkg",
  "vec_map",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,9 +3,10 @@
 DevNet releases can be found in the `devnet` branch.
 
 ## Current Release
-* 22-07-19: [0.6.1](https://github.com/MystenLabs/sui/releases/tag/devnet-0.6.1)
+* 22-07-26: [0.6.2](https://github.com/MystenLabs/sui/releases/tag/devnet-0.6.2)
 
 ## Past Releases
+* 22-07-19: [0.6.1](https://github.com/MystenLabs/sui/releases/tag/devnet-0.6.1)
 * 22-07-12: [0.6.0](https://github.com/MystenLabs/sui/releases/tag/devnet-0.6.0-rc)
 * 22-06-22: [0.5.0](https://github.com/MystenLabs/sui/releases/tag/devnet-0.5.0-rc)
 * 22-06-07: [0.4.0](https://github.com/MystenLabs/sui/releases/tag/devnet-0.4.0-rc)

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1247,7 +1247,7 @@ impl AuthorityState {
         &self,
         digest: TransactionDigest,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        QueryHelpers::get_transaction(&self.database, digest)
+        QueryHelpers::get_transaction(&self.database, &digest)
     }
 
     fn get_indexes(&self) -> SuiResult<Arc<IndexStore>> {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1511,7 +1511,7 @@ impl ExecutionState for AuthorityState {
                 // consensus.
                 certificate.verify(&self.committee.load())?;
 
-                debug!(digest = ?certificate.digest(), "handle_consensus_transaction UserTransaction");
+                debug!(tx_digest = ?certificate.digest(), "handle_consensus_transaction UserTransaction");
 
                 self.database
                     .persist_certificate_and_lock_shared_objects(*certificate, consensus_index)

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -867,7 +867,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // on subsequent calls.
         trace!(
             ?assigned_seq,
-            digest = ?transaction_digest,
+            tx_digest = ?transaction_digest,
             ?effects_digest,
             "storing sequence number to executed_sequence"
         );
@@ -1234,7 +1234,7 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             })
             .unzip();
 
-        trace!(digest = ?transaction_digest,
+        trace!(tx_digest = ?transaction_digest,
                ?sequenced_to_write, ?schedule_to_write,
                "locking shared objects");
 

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -257,7 +257,7 @@ where
                 continue;
             }
 
-            debug!(digest = ?cert_digest, authority =? cert_handler.destination_name(), "Running confirmation transaction for missing cert");
+            debug!(tx_digest = ?cert_digest, authority =? cert_handler.destination_name(), "Running confirmation transaction for missing cert");
 
             match cert_handler.handle(target_cert.clone()).await {
                 Ok(_) => {
@@ -272,7 +272,7 @@ where
             // the previous certificates, so we need to read them from the source
             // authority.
             debug!(
-                digest = ?cert_digest,
+                tx_digest = ?cert_digest,
                 "Missing previous certificates, need to find parents from source authorities"
             );
 
@@ -280,7 +280,7 @@ where
             // we try to get its dependencies. But the second time we have already tried
             // to update its dependencies, so we should just admit failure.
             if attempted_certificates.contains(&cert_digest) {
-                trace!(digest = ?cert_digest, "bailing out after second attempt to fetch");
+                trace!(tx_digest = ?cert_digest, "bailing out after second attempt to fetch");
                 return Err(SuiError::AuthorityInformationUnavailable);
             }
             attempted_certificates.insert(cert_digest);
@@ -332,9 +332,9 @@ where
                 .signed_effects
                 .ok_or(SuiError::AuthorityInformationUnavailable)?;
 
-            trace!(digest = ?cert_digest, dependencies =? &signed_effects.effects.dependencies, "Got dependencies from source");
+            trace!(tx_digest = ?cert_digest, dependencies =? &signed_effects.effects.dependencies, "Got dependencies from source");
             for returned_digest in &signed_effects.effects.dependencies {
-                trace!(digest =? returned_digest, "Found parent of missing cert");
+                trace!(tx_digest =? returned_digest, "Found parent of missing cert");
 
                 let inner_transaction_info = source_client
                     .handle_transaction_info_request(TransactionInfoRequest {
@@ -1093,7 +1093,9 @@ where
         // Now broadcast the transaction to all authorities.
         let threshold = self.committee.quorum_threshold();
         let validity = self.committee.validity_threshold();
+        let tx_digest = transaction.digest();
         debug!(
+            tx_digest = ?tx_digest,
             quorum_threshold = threshold,
             validity_threshold = validity,
             "Broadcasting transaction request to authorities"
@@ -1139,7 +1141,8 @@ where
                                 certified_transaction: Some(inner_certificate),
                                 ..
                             }) => {
-                                trace!(?name, weight, "Received prev certificate from authority");
+                                let tx_digest = inner_certificate.digest();
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Received prev certificate from validator handle_transaction");
                                 state.certificate = Some(inner_certificate);
                             }
 
@@ -1150,6 +1153,8 @@ where
                                 signed_transaction: Some(inner_signed_transaction),
                                 ..
                             }) => {
+                                let tx_digest = inner_signed_transaction.digest();
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Received signed transaction from validator handle_transaction");
                                 state.signatures.push((
                                     name,
                                     inner_signed_transaction.auth_sign_info.signature,
@@ -1178,6 +1183,7 @@ where
                             Err(err) => {
                                 // We have an error here.
                                 // Append to the list off errors
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed transaction from validator handle_transaction");
                                 state.errors.push(err);
                                 state.bad_stake += weight; // This is the bad stake counter
                             }
@@ -1195,9 +1201,10 @@ where
                         if state.bad_stake > validity {
                             // Too many errors
                             debug!(
+                                tx_digest = ?tx_digest,
                                 num_errors = state.errors.len(),
                                 bad_stake = state.bad_stake,
-                                "Too many errors, validity threshold exceeded. Errors={:?}",
+                                "Too many errors from validators handle_transaction, validity threshold exceeded. Errors={:?}",
                                 state.errors
                             );
                             self.metrics
@@ -1232,12 +1239,13 @@ where
             .await?;
 
         debug!(
+            tx_digest = ?tx_digest,
             num_errors = state.errors.len(),
             good_stake = state.good_stake,
             bad_stake = state.bad_stake,
             num_signatures = state.signatures.len(),
             has_certificate = state.certificate.is_some(),
-            "Received signatures response from authorities for transaction req broadcast"
+            "Received signatures response from validators handle_transaction"
         );
         if !state.errors.is_empty() {
             trace!("Errors received: {:?}", state.errors);
@@ -1281,12 +1289,14 @@ where
             errors: vec![],
         };
 
+        let tx_digest = certificate.digest();
         let timeout_after_quorum = self.timeouts.post_quorum_timeout;
 
         let cert_ref = &certificate;
         let threshold = self.committee.quorum_threshold();
         let validity = self.committee.validity_threshold();
         debug!(
+            tx_digest = ?tx_digest,
             quorum_threshold = threshold,
             validity_threshold = validity,
             ?timeout_after_quorum,
@@ -1309,6 +1319,11 @@ where
                                 .await;
 
                         if res.is_ok() {
+                            debug!(
+                                tx_digest = ?tx_digest,
+                                ?name,
+                                "Validator handled certificate successfully",
+                            );
                             // We got an ok answer, so returning the result of processing
                             // the transaction.
                             return res;
@@ -1318,11 +1333,16 @@ where
                         // We only attempt to update authority and retry if we are seeing LockErrors.
                         // For any other error, we stop here and return.
                         if !matches!(res, Err(SuiError::LockErrors { .. })) {
-                            debug!("Error from handle_confirmation_transaction(): {:?}", res);
+                            debug!(
+                                tx_digest = ?tx_digest,
+                                ?name,
+                                "Error from validator handle_confirmation_transaction: {:?}",
+                                res
+                            );
                             return res;
                         }
 
-                        debug!(authority =? name, error =? res, ?timeout_after_quorum, "Authority out of date - syncing certificates");
+                        debug!(authority =? name, error =? res, ?timeout_after_quorum, "Validator out of date - syncing certificates");
                         // If we got LockErrors, we try to update the authority.
                         self
                             .sync_certificate_to_authority(
@@ -1366,6 +1386,10 @@ where
 
                                 if entry.stake >= threshold {
                                     // It will set the timeout quite high.
+                                    debug!(
+                                        tx_digest = ?tx_digest,
+                                        "Got quorum for validators handle_certificate."
+                                    );
                                     return Ok(ReduceOutput::ContinueWithTimeout(
                                         state,
                                         timeout_after_quorum,
@@ -1383,8 +1407,11 @@ where
                                 state.errors.push(err);
                                 state.bad_stake += weight;
                                 if state.bad_stake > validity {
-                                    debug!(bad_stake = state.bad_stake,
-                                        "Too many bad responses from cert processing, validity threshold exceeded.");
+                                    debug!(
+                                        tx_digest = ?tx_digest,
+                                        bad_stake = state.bad_stake,
+                                        "Too many bad responses from validators cert processing, validity threshold exceeded."
+                                    );
                                     return Err(SuiError::QuorumFailedToExecuteCertificate { errors: state.errors });
                                 }
                             }
@@ -1398,9 +1425,10 @@ where
             .await?;
 
         debug!(
+            tx_digest = ?tx_digest,
             num_unique_effects = state.effects_map.len(),
             bad_stake = state.bad_stake,
-            "Received effects responses from authorities"
+            "Received effects responses from validators"
         );
 
         // Check that one effects structure has more than 2f votes,
@@ -1413,6 +1441,7 @@ where
             } = stake_info;
             if stake >= threshold {
                 debug!(
+                    tx_digest = ?tx_digest,
                     good_stake = stake,
                     "Found an effect with good stake over threshold"
                 );

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -62,7 +62,7 @@ impl EventHandler {
             .await?;
         trace!(
             num_events = envelopes.len(),
-            digest =? effects.transaction_digest,
+            tx_digest =? effects.transaction_digest,
             checkpoint_num, "Finished writing events to event store"
         );
 

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -547,7 +547,7 @@ where
         let tx_digest = transaction.digest();
         let span = tracing::debug_span!(
             "execute_transaction",
-            digest = ?tx_digest,
+            tx_digest = ?tx_digest,
             tx_kind = transaction.data.kind_as_str()
         );
         let exec_result = self
@@ -564,7 +564,7 @@ where
         let (new_certificate, effects) = exec_result?;
 
         debug!(
-            digest = ?tx_digest,
+            tx_digest = ?tx_digest,
             ?effects.effects,
             "Transaction completed successfully"
         );
@@ -785,7 +785,7 @@ where
             ?package,
             ?created_objects,
             ?updated_gas,
-            digest = ?certificate.digest(),
+            tx_digest = ?certificate.digest(),
             "Created Publish response"
         );
 
@@ -1066,7 +1066,7 @@ where
         let tx_kind = tx.data.kind.clone();
         let tx_digest = tx.digest();
 
-        debug!(digest = ?tx_digest, "Received execute_transaction request");
+        debug!(tx_digest = ?tx_digest, "Received execute_transaction request");
 
         let span = tracing::debug_span!(
             "gateway_execute_transaction",
@@ -1114,7 +1114,7 @@ where
         let (certificate, effects) = res.unwrap();
         let effects = effects.effects;
 
-        debug!(digest = ?tx_digest, "Transaction succeeded");
+        debug!(tx_digest = ?tx_digest, "Transaction succeeded");
         // Create custom response base on the request type
         if let TransactionKind::Single(tx_kind) = tx_kind {
             match tx_kind {
@@ -1230,6 +1230,11 @@ where
     // TODO: Get rid of the sync API.
     // https://github.com/MystenLabs/sui/issues/1045
     async fn sync_account_state(&self, account_addr: SuiAddress) -> Result<(), anyhow::Error> {
+        debug!(
+            ?account_addr,
+            "Syncing account states from validators starts."
+        );
+
         let (active_object_certs, _deleted_refs_certs) = self
             .authorities
             .sync_all_owned_objects(account_addr, Duration::from_secs(60))
@@ -1239,7 +1244,7 @@ where
             ?active_object_certs,
             deletec = ?_deleted_refs_certs,
             ?account_addr,
-            "Syncing account states"
+            "Syncing account states from validators ends."
         );
 
         for (object, _option_layout, _option_cert) in active_object_certs {
@@ -1247,6 +1252,7 @@ where
                 .insert_object_direct(object.compute_object_reference(), &object)
                 .await?;
         }
+        debug!(?account_addr, "Syncing account states ends.");
 
         Ok(())
     }

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -631,7 +631,11 @@ where
                     pending_transaction,
                 } => {
                     debug!(tx_digest=?pending_transaction, "Objects locked by a previous transaction, re-executing the previous transaction");
-                    if self.retry_pending_tx(pending_transaction).await.is_err() {
+                    if let Err(err) = self.retry_pending_tx(pending_transaction).await {
+                        debug!(
+                            "Retrying pending tx failed: {:?}. Resetting the transaction lock",
+                            err
+                        );
                         self.store.reset_transaction_lock(&owned_objects).await?;
                     }
                     self.set_transaction_lock(&owned_objects, transaction.clone())
@@ -663,12 +667,21 @@ where
     }
 
     async fn retry_pending_tx(&self, digest: TransactionDigest) -> Result<(), anyhow::Error> {
-        let tx = self
-            .store
-            .get_transaction(&digest)?
-            .ok_or(SuiError::TransactionNotFound { digest })?;
-        self.execute_transaction(tx).await?;
-        Ok(())
+        let tx = self.store.get_transaction(&digest)?;
+        match tx {
+            Some(tx) => {
+                self.execute_transaction(tx).await?;
+                Ok(())
+            }
+            None => {
+                // It's possible that the tx has been executed already.
+                if self.store.get_certified_transaction(&digest)?.is_some() {
+                    Ok(())
+                } else {
+                    Err(SuiError::TransactionNotFound { digest }.into())
+                }
+            }
+        }
     }
 
     async fn download_object_from_authorities(&self, object_id: ObjectID) -> SuiResult<ObjectRead> {
@@ -676,7 +689,8 @@ where
         if let ObjectRead::Exists(obj_ref, object, _) = &result {
             let local_object = self.store.get_object(&object_id)?;
             if local_object.is_none()
-                || &local_object.unwrap().compute_object_reference() != obj_ref
+                // We only update local object if the validator version is newer.
+                || local_object.unwrap().version() < obj_ref.1
             {
                 self.store.insert_object_direct(*obj_ref, object).await?;
             }
@@ -1068,53 +1082,61 @@ where
 
         debug!(tx_digest = ?tx_digest, "Received execute_transaction request");
 
-        let span = tracing::debug_span!(
-            "gateway_execute_transaction",
-            ?tx_digest,
-            tx_kind = tx.data.kind_as_str()
-        );
-
-        // Use start_coarse_time() if the below turns out to have a perf impact
-        let timer = self.metrics.transaction_latency.start_timer();
-        let mut res = self
-            .execute_transaction_impl(tx.clone(), false)
-            .instrument(span.clone())
-            .await;
-        // NOTE: below only records latency if this completes.
-        timer.stop_and_record();
-
-        let mut remaining_retries = MAX_NUM_TX_RETRIES;
-        while res.is_err() {
-            if remaining_retries == 0 {
-                error!(
-                    num_retries = MAX_NUM_TX_RETRIES,
+        // Ensure idempotency.
+        let (certificate, effects) = match QueryHelpers::get_transaction(&self.store, tx_digest) {
+            Ok((cert, effects)) => (cert, effects),
+            _ => {
+                let span = tracing::debug_span!(
+                    "gateway_execute_transaction",
                     ?tx_digest,
-                    "All transaction retries failed"
+                    tx_kind = tx.data.kind_as_str()
                 );
-                // Okay to unwrap since we checked that this is an error
-                return Err(res.unwrap_err());
+
+                // Use start_coarse_time() if the below turns out to have a perf impact
+                let timer = self.metrics.transaction_latency.start_timer();
+                let mut res = self
+                    .execute_transaction_impl(tx.clone(), false)
+                    .instrument(span.clone())
+                    .await;
+                // NOTE: below only records latency if this completes.
+                timer.stop_and_record();
+
+                let mut remaining_retries = MAX_NUM_TX_RETRIES;
+                while res.is_err() {
+                    if remaining_retries == 0 {
+                        error!(
+                            num_retries = MAX_NUM_TX_RETRIES,
+                            ?tx_digest,
+                            "All transaction retries failed"
+                        );
+                        // Okay to unwrap since we checked that this is an error
+                        return Err(res.unwrap_err());
+                    }
+                    remaining_retries -= 1;
+                    self.metrics.total_tx_retries.inc();
+
+                    debug!(
+                        remaining_retries,
+                        ?tx_digest,
+                        ?res,
+                        "Retrying failed transaction"
+                    );
+
+                    res = self
+                        .execute_transaction_impl(tx.clone(), remaining_retries == 0)
+                        .instrument(span.clone())
+                        .await;
+                }
+
+                // Okay to unwrap() since we checked that this is Ok
+                let (certificate, effects) = res.unwrap();
+                let effects = effects.effects;
+
+                debug!(?tx_digest, "Transaction succeeded");
+                (certificate, effects)
             }
-            remaining_retries -= 1;
-            self.metrics.total_tx_retries.inc();
+        };
 
-            debug!(
-                remaining_retries,
-                ?tx_digest,
-                ?res,
-                "Retrying failed transaction"
-            );
-
-            res = self
-                .execute_transaction_impl(tx.clone(), remaining_retries == 0)
-                .instrument(span.clone())
-                .await;
-        }
-
-        // Okay to unwrap() since we checked that this is Ok
-        let (certificate, effects) = res.unwrap();
-        let effects = effects.effects;
-
-        debug!(tx_digest = ?tx_digest, "Transaction succeeded");
         // Create custom response base on the request type
         if let TransactionKind::Single(tx_kind) = tx_kind {
             match tx_kind {
@@ -1436,7 +1458,7 @@ where
         &self,
         digest: TransactionDigest,
     ) -> Result<TransactionEffectsResponse, anyhow::Error> {
-        let (cert, effect) = QueryHelpers::get_transaction(&self.store, digest)?;
+        let (cert, effect) = QueryHelpers::get_transaction(&self.store, &digest)?;
 
         Ok(TransactionEffectsResponse {
             certificate: cert.try_into()?,

--- a/crates/sui-core/src/query_helpers.rs
+++ b/crates/sui-core/src/query_helpers.rs
@@ -75,12 +75,12 @@ impl<S: Eq + Serialize + for<'de> Deserialize<'de>> QueryHelpers<S> {
 
     pub fn get_transaction(
         database: &SuiDataStore<S>,
-        digest: TransactionDigest,
+        digest: &TransactionDigest,
     ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
-        let opt = database.get_certified_transaction(&digest)?;
+        let opt = database.get_certified_transaction(digest)?;
         match opt {
-            Some(certificate) => Ok((certificate, database.get_effects(&digest)?)),
-            None => Err(anyhow!(SuiError::TransactionNotFound { digest })),
+            Some(certificate) => Ok((certificate, database.get_effects(digest)?)),
+            None => Err(anyhow!(SuiError::TransactionNotFound { digest: *digest })),
         }
     }
 }

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -19,6 +19,8 @@ tower = { version = "0.4.12", features = ["util", "timeout", "load-shed", "limit
 tower-http = { version = "0.3.4", features = ["cors"] }
 http = { version = "0.2.8" }
 
+uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
+
 sui = { path = "../sui" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -8,6 +8,7 @@ use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
 };
+use uuid::Uuid;
 
 mod simple_faucet;
 pub use self::simple_faucet::SimpleFaucet;
@@ -28,6 +29,7 @@ pub trait Faucet {
     /// Send `Coin<SUI>` of the specified amount to the recipient
     async fn send(
         &self,
+        id: Uuid,
         recipient: SuiAddress,
         amounts: &[u64],
     ) -> Result<FaucetReceipt, FaucetError>;
@@ -68,7 +70,10 @@ mod tests {
         let recipient = SuiAddress::random_for_testing_only();
         let amounts = vec![1, 2, 3];
 
-        let FaucetReceipt { sent } = faucet.send(recipient, &amounts).await.unwrap();
+        let FaucetReceipt { sent } = faucet
+            .send(Uuid::new_v4(), recipient, &amounts)
+            .await
+            .unwrap();
         let mut actual_amounts: Vec<u64> = sent.iter().map(|c| c.amount).collect();
         actual_amounts.sort_unstable();
         assert_eq!(actual_amounts, amounts);

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-node"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -192,8 +192,9 @@ impl SuiNode {
                         ),
                     )
                 } else {
-                    let metrics = CheckpointMetrics::new(&prometheus_registry);
-                    active_authority.sync_to_latest_checkpoint(&metrics).await?;
+                    // TODO: enable checkpoint sync on fullnode
+                    // let metrics = CheckpointMetrics::new(&prometheus_registry);
+                    // active_authority.sync_to_latest_checkpoint(&metrics).await?;
                     (
                         Some(active_authority.spawn_node_sync_process().await),
                         None,

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -184,7 +184,7 @@ impl LockServiceImpl {
                 // TODO: it should be impossible for this to fail unless the store has been
                 // corrupted. Remove this check when we feel confident enough.
                 if let Err(e) = self.locks_exist(inputs) {
-                    error!(digest = ?tx, "Locks did not exist for unsequenced transaction! \
+                    error!(tx_digest = ?tx, "Locks did not exist for unsequenced transaction! \
                                          possible data store corruption");
                     Err(e)
                 } else {

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-tool"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -546,6 +546,7 @@ unsigned-varint = { version = "0.7", default-features = false, features = ["std"
 untrusted = { version = "0.7", default-features = false }
 url = { version = "2", default-features = false }
 utf8parse = { version = "0.2" }
+uuid = { version = "1", features = ["fast-rng", "private_getrandom", "private_rand", "rng", "std", "v4"] }
 vec_map = { version = "0.8", default-features = false }
 vte = { version = "0.10", features = ["arrayvec", "no_std"] }
 wait-timeout = { version = "0.2", default-features = false }
@@ -1187,6 +1188,7 @@ untrusted = { version = "0.7", default-features = false }
 unzip-n = { version = "0.1", default-features = false }
 url = { version = "2", default-features = false }
 utf8parse = { version = "0.2" }
+uuid = { version = "1", features = ["fast-rng", "private_getrandom", "private_rand", "rng", "std", "v4"] }
 variant_count = { version = "1", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 vec_map = { version = "0.8", default-features = false }

--- a/doc/src/build/json-rpc.md
+++ b/doc/src/build/json-rpc.md
@@ -35,12 +35,19 @@ Export a local user variable to store the hardcoded hostname + port that the loc
 export SUI_RPC_HOST=http://127.0.0.1:5001
 ```
 
+## Software development kits
+
+Sui offers the following SDKs for development:
+
+* See the [Rust SDK page](rust-sdk.md) and [README](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) for Sui developers using Rust.
+* Follow the [TypeScript SDK documentation](https://github.com/MystenLabs/sui/tree/main/sdk/typescript) and [reference files](https://www.npmjs.com/package/@mysten/sui.js) if your application is written in JavaScript or TypeScript.
+
 ## Sui JSON-RPC API
 
-In the following sections we will show how to use Sui's JSON-RPC API with
+In the following sections we will show how to use Sui's [JSON-RPC API](https://docs.sui.io/sui-jsonrpc) with
 the `curl` command.
 
-> **Tip:** If your application is written in JavaScript or TypeScript, follow the [TypeScript SDK documentation](https://github.com/MystenLabs/sui/tree/main/sdk/typescript) and [reference files](https://www.npmjs.com/package/@mysten/sui.js).
+> **Tip:** 
 
 ## Sui JSON-RPC methods
 

--- a/doc/src/build/move/debug-publish.md
+++ b/doc/src/build/move/debug-publish.md
@@ -3,21 +3,21 @@ title: Debug and Publish the SUi Move Package
 ---
 
 ## Debugging a package
-At the moment there isn't a yet debugger for Move. To help with debugging, however, you could use `Std::Debug` module to print out arbitrary value. To do so, first import the `Debug` module:
+At the moment there isn't a yet debugger for Move. To help with debugging, however, you could use `std::debug` module to print out arbitrary value. To do so, first import the `debug` module:
 ```
-use Std::Debug;
+use std::debug;
 ```
 Then in places where you want to print out a value `v`, regardless of its type, simply do:
 ```
-Debug::print(&v);
+debug::print(&v);
 ```
 or the following if v is already a reference:
 ```
-Debug::print(v);
+debug::print(v);
 ```
-`Debug` module also provides a function to print out the current stacktrace:
+`debug` module also provides a function to print out the current stacktrace:
 ```
-Debug::print_stack_trace();
+debug::print_stack_trace();
 ```
 Alternatively, any call to `abort` or assertion failure will also print the stacktrace at the point of failure.
 


### PR DESCRIPTION
- Docs are incorrect on debugging page. `Std::Debug` --> `std::debug`