### PR TITLE
crypto: remove dalek dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6644,7 +6644,6 @@ dependencies = [
  "camino",
  "clap 3.1.18",
  "colored",
- "ed25519-dalek",
  "executor",
  "futures",
  "jemalloc-ctl",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.80"
 signature = "1.5.0"
 camino = "1.0.9"
-ed25519-dalek = "1"
 base64ct = "1"
 tokio = { version = "1.20.1", features = ["full"] }
 async-trait = "0.1.53"


### PR DESCRIPTION
the dep is introduced by encoding base 64 using dalek's library, but with the keyfile switching to narwhal crypto's `EncodeDecode65` trait, its no longer needed: https://github.com/MystenLabs/sui/pull/3424/files#diff-2a984493fca1d1972708de2bbc2c5628548175baf0087d599fd8cf1412e56526L119