### PR TITLE
[crypto] commit user signatures

### DIFF
--- a/crates/sui-benchmark/src/benchmark/transaction_creator.rs
+++ b/crates/sui-benchmark/src/benchmark/transaction_creator.rs
@@ -70,7 +70,7 @@ fn make_cert(network_config: &NetworkConfig, tx: &Transaction) -> CertifiedTrans
             .key_pair();
 
         let pubx: AuthorityPublicKeyBytes = secx.public().into();
-        let sig = AuthoritySignature::new(&tx.data, secx);
+        let sig = AuthoritySignature::new(&tx.signed_data, secx);
         let authority_weight = committee.weight(&pubx);
         sigs.push((pubx, sig));
         total_stake += authority_weight;

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1236,7 +1236,7 @@ where
             validity_threshold = validity,
             "Broadcasting transaction request to authorities"
         );
-        trace!("Transaction data: {:?}", transaction.data);
+        trace!("Transaction data: {:?}", transaction.signed_data.data);
 
         struct ProcessTransactionState {
             // The list of signatures gathered at any point

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -267,7 +267,7 @@ impl ValidatorService {
         let span = tracing::debug_span!(
             "process_tx",
             ?tx_digest,
-            tx_kind = transaction.data.kind_as_str()
+            tx_kind = transaction.signed_data.data.kind_as_str()
         );
 
         let info = state
@@ -323,7 +323,7 @@ impl ValidatorService {
         let span = tracing::debug_span!(
             "execute_transaction",
             ?tx_digest,
-            tx_kind = certificate.data.kind_as_str()
+            tx_kind = certificate.signed_data.data.kind_as_str()
         );
 
         let response = state

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -115,7 +115,7 @@ async fn test_start_epoch_change() {
         cert = sigs
             .append(
                 state.name,
-                AuthoritySignature::new(&transaction.data, &*state.secret),
+                AuthoritySignature::new(&transaction.signed_data, &*state.secret),
             )
             .unwrap();
     }
@@ -135,6 +135,7 @@ async fn test_start_epoch_change() {
         state.database.clone(),
         InputObjects::new(
             transaction
+                .signed_data
                 .data
                 .input_objects()
                 .unwrap()
@@ -147,7 +148,7 @@ async fn test_start_epoch_change() {
     let (inner_temporary_store, effects, _) = execution_engine::execute_transaction_to_effects(
         vec![],
         temporary_store,
-        transaction.data.clone(),
+        transaction.signed_data.data.clone(),
         tx_digest,
         BTreeSet::new(),
         &state.move_vm,

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -574,7 +574,7 @@ where
     /// If any object does not exist in the store, give it a chance
     /// to download from authorities.
     async fn sync_input_objects_with_authorities(&self, transaction: &Transaction) -> SuiResult {
-        let input_objects = transaction.data.input_objects()?;
+        let input_objects = transaction.signed_data.data.input_objects()?;
         let mut objects = self.read_objects_from_store(&input_objects).await?;
         for (object_opt, kind) in objects.iter_mut().zip(&input_objects) {
             if object_opt.is_none() {
@@ -608,7 +608,7 @@ where
         let span = tracing::debug_span!(
             "execute_transaction",
             tx_digest = ?tx_digest,
-            tx_kind = transaction.data.kind_as_str()
+            tx_kind = transaction.signed_data.data.kind_as_str()
         );
         let exec_result = self
             .authorities
@@ -952,8 +952,8 @@ where
         effects: TransactionEffects,
     ) -> Result<SuiParsedTransactionResponse, anyhow::Error> {
         let call = Self::try_get_move_call(&certificate)?;
-        let signer = certificate.data.signer();
-        let (gas_payment, _, _) = certificate.data.gas();
+        let signer = certificate.signed_data.data.signer();
+        let (gas_payment, _, _) = certificate.signed_data.data.gas();
         let (coin_object_id, split_arg) = match call.arguments.as_slice() {
             [CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))), CallArg::Pure(arg)] => {
                 (id, arg)
@@ -1019,7 +1019,7 @@ where
                 .into())
             }
         };
-        let (gas_payment, _, _) = certificate.data.gas();
+        let (gas_payment, _, _) = certificate.signed_data.data.gas();
 
         if let ExecutionStatus::Failure { error } = effects.status {
             return Err(error.into());
@@ -1051,7 +1051,7 @@ where
 
     fn try_get_move_call(certificate: &CertifiedTransaction) -> Result<&MoveCall, anyhow::Error> {
         if let TransactionKind::Single(SingleTransactionKind::Call(ref call)) =
-            certificate.data.kind
+            certificate.signed_data.data.kind
         {
             Ok(call)
         } else {
@@ -1214,7 +1214,7 @@ where
         &self,
         tx: Transaction,
     ) -> Result<SuiTransactionResponse, anyhow::Error> {
-        let tx_kind = tx.data.kind.clone();
+        let tx_kind = tx.signed_data.data.kind.clone();
         let tx_digest = tx.digest();
 
         debug!(tx_digest = ?tx_digest, "Received execute_transaction request");
@@ -1226,7 +1226,7 @@ where
                 let span = tracing::debug_span!(
                     "gateway_execute_transaction",
                     ?tx_digest,
-                    tx_kind = tx.data.kind_as_str()
+                    tx_kind = tx.signed_data.data.kind_as_str()
                 );
 
                 // Use start_coarse_time() if the below turns out to have a perf impact

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -29,13 +29,13 @@ where
     let mut gas_status = check_gas(
         store,
         transaction.gas_payment_object_ref().0,
-        transaction.data.gas_budget,
-        transaction.data.gas_price,
-        &transaction.data.kind,
+        transaction.signed_data.data.gas_budget,
+        transaction.signed_data.data.gas_price,
+        &transaction.signed_data.data.kind,
     )
     .await?;
 
-    let input_objects = check_objects(store, &transaction.data).await?;
+    let input_objects = check_objects(store, &transaction.signed_data.data).await?;
 
     if transaction.contains_shared_object() {
         // It's important that we do this here to make sure there is enough

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -276,7 +276,7 @@ where
                 signed.auth_sign_info.signature.clone(),
             ));
             if let Some(inner_transaction) = transaction {
-                assert!(inner_transaction.data == signed.data);
+                assert!(inner_transaction.signed_data.data == signed.signed_data.data);
             }
             transaction = Some(signed);
         }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -119,8 +119,8 @@ async fn test_handle_transfer_transaction_bad_signature() {
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone();
-    bad_signature_transfer_transaction.tx_signature =
-        Signature::new(&transfer_transaction.data, &unknown_key);
+    bad_signature_transfer_transaction.signed_data.tx_signature =
+        Signature::new(&transfer_transaction.signed_data.data, &unknown_key);
     assert!(authority_state
         .handle_transaction(bad_signature_transfer_transaction)
         .await
@@ -401,8 +401,9 @@ async fn test_handle_transfer_transaction_ok() {
             .unwrap()
             .as_ref()
             .unwrap()
+            .signed_data
             .data,
-        transfer_transaction.data
+        transfer_transaction.signed_data.data
     );
 }
 

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -280,6 +280,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         .certified_transaction
         .as_ref()
         .unwrap()
+        .signed_data
         .data
         .kind
         .single_transactions()

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1288,8 +1288,8 @@ impl TryFrom<CertifiedTransaction> for SuiCertifiedTransaction {
     fn try_from(cert: CertifiedTransaction) -> Result<Self, Self::Error> {
         Ok(Self {
             transaction_digest: *cert.digest(),
-            data: cert.data.try_into()?,
-            tx_signature: cert.tx_signature,
+            data: cert.signed_data.data.try_into()?,
+            tx_signature: cert.signed_data.tx_signature,
             auth_sign_info: cert.auth_sign_info,
         })
     }

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -223,18 +223,18 @@ impl SuiClient {
     ) -> anyhow::Result<SuiTransactionResponse> {
         Ok(match &self {
             Self::Http(c) => {
-                let tx_bytes = Base64::from_bytes(&tx.data.to_bytes());
-                let flag = tx.tx_signature.scheme();
-                let signature = Base64::from_bytes(tx.tx_signature.signature_bytes());
-                let pub_key = Base64::from_bytes(tx.tx_signature.public_key_bytes());
+                let tx_bytes = Base64::from_bytes(&tx.signed_data.data.to_bytes());
+                let flag = tx.signed_data.tx_signature.scheme();
+                let signature = Base64::from_bytes(tx.signed_data.tx_signature.signature_bytes());
+                let pub_key = Base64::from_bytes(tx.signed_data.tx_signature.public_key_bytes());
                 c.execute_transaction(tx_bytes, flag, signature, pub_key)
                     .await?
             }
             Self::Ws(c) => {
-                let tx_bytes = Base64::from_bytes(&tx.data.to_bytes());
-                let flag = tx.tx_signature.scheme();
-                let signature = Base64::from_bytes(tx.tx_signature.signature_bytes());
-                let pub_key = Base64::from_bytes(tx.tx_signature.public_key_bytes());
+                let tx_bytes = Base64::from_bytes(&tx.signed_data.data.to_bytes());
+                let flag = tx.signed_data.tx_signature.scheme();
+                let signature = Base64::from_bytes(tx.signed_data.tx_signature.signature_bytes());
+                let pub_key = Base64::from_bytes(tx.signed_data.tx_signature.public_key_bytes());
                 c.execute_transaction(tx_bytes, flag, signature, pub_key)
                     .await?
             }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -466,6 +466,7 @@ impl<'a> SuiTestAdapter<'a> {
         let gas_status = gas::start_gas_metering(gas_budget, 1, 1).unwrap();
         let transaction_digest = TransactionDigest::new(self.rng.gen());
         let objects_by_kind = transaction
+            .signed_data
             .data
             .input_objects()
             .unwrap()
@@ -501,7 +502,7 @@ impl<'a> SuiTestAdapter<'a> {
         ) = execution_engine::execute_transaction_to_effects(
             shared_object_refs,
             temporary_store,
-            transaction.data,
+            transaction.signed_data.data,
             transaction_digest,
             transaction_dependencies,
             &self.vm,

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -239,7 +239,7 @@ where
 
 // Enums for Signatures
 #[enum_dispatch]
-#[derive(Clone, JsonSchema)]
+#[derive(Clone, JsonSchema, PartialEq, Eq, Hash)]
 pub enum Signature {
     Ed25519SuiSignature,
 }
@@ -327,7 +327,7 @@ impl std::fmt::Debug for Signature {
 //
 
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 pub struct Ed25519SuiSignature(
     #[schemars(with = "Base64")]
     #[serde_as(as = "Readable<Base64, Bytes>")]
@@ -374,7 +374,7 @@ impl signature::Signer<Signature> for Ed25519KeyPair {
 // Secp256k1 Sui Signature port
 //
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash)]
 pub struct Secp256k1SuiSignature(
     #[schemars(with = "Base64")]
     #[serde_as(as = "Readable<Base64, Bytes>")]
@@ -424,7 +424,7 @@ impl signature::Signature for Secp256k1SuiSignature {
 //
 // This struct exists due to the limitations of the `enum_dispatch` library.
 //
-pub trait SuiSignatureInner: Sized + signature::Signature {
+pub trait SuiSignatureInner: Sized + signature::Signature + PartialEq + Eq + Hash {
     type Sig: Authenticator<PubKey = Self::PubKey> + ToObligationSignature;
     type PubKey: VerifyingKey<Sig = Self::Sig> + SuiPublicKey;
     type KeyPair: KeypairTraits<PubKey = Self::PubKey, Sig = Self::Sig>;
@@ -860,6 +860,7 @@ mod bcs_signable {
     impl BcsSignable for crate::messages_checkpoint::CheckpointProposalSummary {}
     impl BcsSignable for crate::messages::TransactionEffects {}
     impl BcsSignable for crate::messages::TransactionData {}
+    impl BcsSignable for crate::messages::SenderSignedData {}
     impl BcsSignable for crate::messages::EpochInfo {}
     impl BcsSignable for crate::object::Object {}
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -513,17 +513,25 @@ pub struct TransactionEnvelope<S> {
     #[serde(skip)]
     pub is_verified: bool,
 
-    pub data: TransactionData,
-    /// tx_signature is signed by the transaction sender, applied on `data`.
-    pub tx_signature: Signature,
-    /// authority signature information, if available, is signed by an authority, applied on `data`.
+    // The packet of data that authorities will sign on. Stores the tx data and the sender signature.
+    pub signed_data: SenderSignedData,
+
+    /// authority signature information, if available, is signed by an authority, applied on `tx_signature` || `data`.
     pub auth_sign_info: S,
     // Note: If any new field is added here, make sure the Hash and PartialEq
     // implementation are adjusted to include that new field (unless the new field
     // does not participate in the hash and comparison).
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SenderSignedData {
+    pub data: TransactionData,
+    /// tx_signature is signed by the transaction sender, applied on `data`.
+    pub tx_signature: Signature,
+}
+
 impl<S> TransactionEnvelope<S> {
+    #[allow(dead_code)]
     fn add_sender_sig_to_verification_obligation(
         &self,
         obligation: &mut VerificationObligation,
@@ -533,30 +541,30 @@ impl<S> TransactionEnvelope<S> {
         // and therefore we can skip the check. Note that the flag has
         // to be set to true manually, and is not set by calling this
         // "check" function.
-        if self.is_verified || self.data.kind.is_system_tx() {
+        if self.is_verified || self.signed_data.data.kind.is_system_tx() {
             return Ok(());
         }
 
-        self.tx_signature.add_to_verification_obligation_or_verify(
-            self.data.sender,
-            obligation,
-            idx,
-        )
+        self.signed_data
+            .tx_signature
+            .add_to_verification_obligation_or_verify(self.signed_data.data.sender, obligation, idx)
     }
 
     pub fn verify_sender_signature(&self) -> SuiResult<()> {
-        if self.is_verified || self.data.kind.is_system_tx() {
+        if self.is_verified || self.signed_data.data.kind.is_system_tx() {
             return Ok(());
         }
-        self.tx_signature.verify(&self.data, self.data.sender)
+        self.signed_data
+            .tx_signature
+            .verify(&self.signed_data.data, self.signed_data.data.sender)
     }
 
     pub fn sender_address(&self) -> SuiAddress {
-        self.data.sender
+        self.signed_data.data.sender
     }
 
     pub fn gas_payment_object_ref(&self) -> &ObjectRef {
-        self.data.gas_payment_object_ref()
+        self.signed_data.data.gas_payment_object_ref()
     }
 
     pub fn contains_shared_object(&self) -> bool {
@@ -564,7 +572,7 @@ impl<S> TransactionEnvelope<S> {
     }
 
     pub fn shared_input_objects(&self) -> impl Iterator<Item = &ObjectID> {
-        match &self.data.kind {
+        match &self.signed_data.data.kind {
             TransactionKind::Single(s) => Either::Left(s.shared_input_objects()),
             TransactionKind::Batch(b) => {
                 Either::Right(b.iter().flat_map(|kind| kind.shared_input_objects()))
@@ -575,7 +583,7 @@ impl<S> TransactionEnvelope<S> {
     /// Get the transaction digest and write it to the cache
     pub fn digest(&self) -> &TransactionDigest {
         self.transaction_digest
-            .get_or_init(|| TransactionDigest::new(sha3_hash(&self.data)))
+            .get_or_init(|| TransactionDigest::new(sha3_hash(&self.signed_data)))
     }
 
     pub fn input_objects_in_compiled_modules(
@@ -652,8 +660,10 @@ impl Transaction {
         Self {
             transaction_digest: OnceCell::new(),
             is_verified: false,
-            data,
-            tx_signature: signature,
+            signed_data: SenderSignedData {
+                data,
+                tx_signature: signature,
+            },
             auth_sign_info: EmptySignInfo {},
         }
     }
@@ -665,13 +675,13 @@ impl Transaction {
 
 impl Hash for Transaction {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.data.hash(state);
+        self.signed_data.hash(state);
     }
 }
 
 impl PartialEq for Transaction {
     fn eq(&self, other: &Self) -> bool {
-        self.data == other.data
+        self.signed_data == other.signed_data
     }
 }
 impl Eq for Transaction {}
@@ -687,12 +697,11 @@ impl SignedTransaction {
         authority: AuthorityName,
         secret: &dyn signature::Signer<AuthoritySignature>,
     ) -> Self {
-        let signature = AuthoritySignature::new(&transaction.data, secret);
+        let signature = AuthoritySignature::new(&transaction.signed_data, secret);
         Self {
             transaction_digest: OnceCell::new(),
             is_verified: transaction.is_verified,
-            data: transaction.data,
-            tx_signature: transaction.tx_signature,
+            signed_data: transaction.signed_data,
             auth_sign_info: AuthoritySignInfo {
                 epoch,
                 authority,
@@ -720,15 +729,18 @@ impl SignedTransaction {
             (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
             0,
         );
-        let signature = AuthoritySignature::new(&data, secret);
-        Self {
-            transaction_digest: OnceCell::new(),
-            is_verified: false,
+        let signed_data = SenderSignedData {
             data,
             // Arbitrary keypair
             tx_signature: Ed25519SuiSignature::from_bytes(&[0; Ed25519SuiSignature::LENGTH])
                 .unwrap()
                 .into(),
+        };
+        let signature = AuthoritySignature::new(&signed_data, secret);
+        Self {
+            transaction_digest: OnceCell::new(),
+            is_verified: false,
+            signed_data,
             auth_sign_info: AuthoritySignInfo {
                 epoch: next_epoch,
                 authority,
@@ -739,17 +751,10 @@ impl SignedTransaction {
 
     /// Verify the signature and return the non-zero voting right of the authority.
     pub fn verify(&self, committee: &Committee) -> SuiResult {
+        self.verify_sender_signature()?;
+
         let mut obligation = VerificationObligation::default();
-
-        let idx = obligation.add_message(&self.data);
-
-        if self
-            .add_sender_sig_to_verification_obligation(&mut obligation, idx)
-            .is_err()
-        {
-            self.verify_sender_signature()?;
-        }
-
+        let idx = obligation.add_message(&self.signed_data);
         self.auth_sign_info
             .add_to_verification_obligation(committee, &mut obligation, idx)?;
 
@@ -761,13 +766,13 @@ impl SignedTransaction {
     // forming a CertifiedTransaction, where each transaction's authority signature
     // is taking out to form an aggregated signature.
     pub fn to_transaction(self) -> Transaction {
-        Transaction::new(self.data, self.tx_signature)
+        Transaction::new(self.signed_data.data, self.signed_data.tx_signature)
     }
 }
 
 impl Hash for SignedTransaction {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.data.hash(state);
+        self.signed_data.hash(state);
         self.auth_sign_info.hash(state);
     }
 }
@@ -776,7 +781,7 @@ impl PartialEq for SignedTransaction {
     fn eq(&self, other: &Self) -> bool {
         // We do not compare the tx_signature, because there can be multiple
         // valid signatures for the same data and signer.
-        self.data == other.data && self.auth_sign_info == other.auth_sign_info
+        self.signed_data == other.signed_data && self.auth_sign_info == other.auth_sign_info
     }
 }
 
@@ -1680,7 +1685,8 @@ impl<'a> SignatureAggregator<'a> {
         authority: AuthorityName,
         signature: AuthoritySignature,
     ) -> Result<Option<CertifiedTransaction>, SuiError> {
-        signature.verify(&self.partial.data, authority)?;
+        signature.verify(&self.partial.signed_data, authority)?;
+
         // Check that each authority only appears once.
         fp_ensure!(
             !self.used_authorities.contains(&authority),
@@ -1712,8 +1718,7 @@ impl CertifiedTransaction {
         CertifiedTransaction {
             transaction_digest: transaction.transaction_digest,
             is_verified: false,
-            data: transaction.data,
-            tx_signature: transaction.tx_signature,
+            signed_data: transaction.signed_data,
             auth_sign_info: AuthorityStrongQuorumSignInfo::new(epoch),
         }
     }
@@ -1726,8 +1731,7 @@ impl CertifiedTransaction {
         Ok(CertifiedTransaction {
             transaction_digest: transaction.transaction_digest,
             is_verified: false,
-            data: transaction.data,
-            tx_signature: transaction.tx_signature,
+            signed_data: transaction.signed_data,
             auth_sign_info: AuthorityStrongQuorumSignInfo::new_with_signatures(
                 signatures, committee,
             )?,
@@ -1735,7 +1739,7 @@ impl CertifiedTransaction {
     }
 
     pub fn to_transaction(self) -> Transaction {
-        Transaction::new(self.data, self.tx_signature)
+        Transaction::new(self.signed_data.data, self.signed_data.tx_signature)
     }
 
     /// Verify the certificate.
@@ -1748,18 +1752,12 @@ impl CertifiedTransaction {
             return Ok(());
         }
 
+        // Add the obligation of the sender signature verification.
+        self.verify_sender_signature()?;
+
         let mut obligation = VerificationObligation::default();
         // Add the obligation of the authority signature verifications.
-        let idx = obligation.add_message(&self.data);
-
-        // Add the obligation of the sender signature verification.
-        if self
-            .add_sender_sig_to_verification_obligation(&mut obligation, idx)
-            .is_err()
-        {
-            self.verify_sender_signature()?;
-        }
-
+        let idx = obligation.add_message(&self.signed_data);
         self.auth_sign_info
             .add_to_verification_obligation(committee, &mut obligation, idx)?;
 
@@ -1776,7 +1774,7 @@ impl Display for CertifiedTransaction {
             "Signed Authorities Bitmap : {:?}",
             self.auth_sign_info.signers_map
         )?;
-        write!(writer, "{}", &self.data.kind)?;
+        write!(writer, "{}", &self.signed_data.data.kind)?;
         write!(f, "{}", writer)
     }
 }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 
 use narwhal_crypto::traits::AggregateAuthenticator;
@@ -10,6 +11,8 @@ use roaring::RoaringBitmap;
 
 use crate::crypto::bcs_signable_test::{get_obligation_input, Foo};
 use crate::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes};
+use crate::messages_checkpoint::CheckpointContents;
+use crate::messages_checkpoint::CheckpointSummary;
 use crate::object::Owner;
 
 use super::*;
@@ -384,7 +387,7 @@ fn test_digest_caching() {
 
     let initial_digest = *signed_tx.digest();
 
-    signed_tx.data.gas_budget += 1;
+    signed_tx.signed_data.data.gas_budget += 1;
 
     // digest is cached
     assert_eq!(initial_digest, *signed_tx.digest());
@@ -434,4 +437,165 @@ fn test_digest_caching() {
 
     // cached digest was not serialized/deserialized
     assert_ne!(initial_effects_digest, *deserialized_effects.digest());
+}
+
+#[test]
+fn test_user_signature_committed_in_transactions() {
+    // TODO: refactor this test to not reuse the same keys for user and authority signing
+    let (a_sender, sender_sec): (_, AccountKeyPair) = get_key_pair();
+    let (a_sender2, sender_sec2): (_, AccountKeyPair) = get_key_pair();
+
+    let tx_data = TransactionData::new_transfer(
+        a_sender2,
+        random_object_ref(),
+        a_sender,
+        random_object_ref(),
+        10000,
+    );
+    let transaction_a = Transaction::from_data(tx_data.clone(), &sender_sec);
+    let transaction_b = Transaction::from_data(tx_data, &sender_sec2);
+    let tx_digest_a = transaction_a.digest();
+    let tx_digest_b = transaction_b.digest();
+    assert_ne!(tx_digest_a, tx_digest_b);
+
+    // Test hash non-equality
+    let mut hasher = DefaultHasher::new();
+    transaction_a.hash(&mut hasher);
+    let hash_a = hasher.finish();
+    let mut hasher = DefaultHasher::new();
+    transaction_b.hash(&mut hasher);
+    let hash_b = hasher.finish();
+    assert_ne!(hash_a, hash_b);
+
+    // test equality
+    assert_ne!(transaction_a, transaction_b)
+}
+
+#[test]
+fn test_user_signature_committed_in_signed_transactions() {
+    // TODO: refactor this test to not reuse the same keys for user and authority signing
+    let (_a1, sec1): (_, AuthorityKeyPair) = get_key_pair();
+    let (a_sender, sender_sec): (_, AccountKeyPair) = get_key_pair();
+    let (a_sender2, sender_sec2): (_, AccountKeyPair) = get_key_pair();
+
+    let tx_data = TransactionData::new_transfer(
+        a_sender2,
+        random_object_ref(),
+        a_sender,
+        random_object_ref(),
+        10000,
+    );
+    let transaction_a = Transaction::from_data(tx_data.clone(), &sender_sec);
+    let transaction_b = Transaction::from_data(tx_data, &sender_sec2);
+    let signed_tx_a = SignedTransaction::new(
+        0,
+        transaction_a.clone(),
+        AuthorityPublicKeyBytes::from(sec1.public()),
+        &sec1,
+    );
+    let signed_tx_b = SignedTransaction::new(
+        0,
+        transaction_b.clone(),
+        AuthorityPublicKeyBytes::from(sec1.public()),
+        &sec1,
+    );
+
+    let tx_digest_a = signed_tx_a.digest();
+    let tx_digest_b = signed_tx_b.digest();
+    assert_ne!(tx_digest_a, tx_digest_b);
+
+    // Ensure that signed tx verifies against the transaction with a correct user signature.
+    let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
+    authorities.insert(AuthorityPublicKeyBytes::from(sec1.public()), 1);
+    let committee = Committee::new(0, authorities.clone()).unwrap();
+    assert!(signed_tx_a
+        .auth_sign_info
+        .verify(&transaction_a.signed_data, &committee)
+        .is_ok());
+    assert!(signed_tx_a
+        .auth_sign_info
+        .verify(&transaction_b.signed_data, &committee)
+        .is_err());
+
+    // Test hash non-equality
+    let mut hasher = DefaultHasher::new();
+    signed_tx_a.hash(&mut hasher);
+    let hash_a = hasher.finish();
+    let mut hasher = DefaultHasher::new();
+    signed_tx_b.hash(&mut hasher);
+    let hash_b = hasher.finish();
+    assert_ne!(hash_a, hash_b);
+
+    // test equality
+    assert_ne!(signed_tx_a, signed_tx_b)
+}
+
+#[test]
+fn test_user_signature_committed_in_checkpoints() {
+    let (a1, _sec1): (_, AuthorityKeyPair) = get_key_pair();
+    let (a_sender, sender_sec): (_, AccountKeyPair) = get_key_pair();
+    let (a_sender2, sender_sec2): (_, AccountKeyPair) = get_key_pair();
+
+    let tx_data = TransactionData::new_transfer(
+        a_sender2,
+        random_object_ref(),
+        a_sender,
+        random_object_ref(),
+        10000,
+    );
+
+    let transaction_a = Transaction::from_data(tx_data.clone(), &sender_sec);
+    let transaction_b = Transaction::from_data(tx_data, &sender_sec2);
+
+    let tx_digest_a = transaction_a.digest();
+    let tx_digest_b = transaction_b.digest();
+
+    let effects_a = TransactionEffects {
+        status: ExecutionStatus::Success,
+        gas_used: GasCostSummary {
+            computation_cost: 0,
+            storage_cost: 0,
+            storage_rebate: 0,
+        },
+        shared_objects: Vec::new(),
+        transaction_digest: *tx_digest_a,
+        created: Vec::new(),
+
+        mutated: Vec::new(),
+        unwrapped: Vec::new(),
+        deleted: Vec::new(),
+        wrapped: Vec::new(),
+        gas_object: (random_object_ref(), Owner::AddressOwner(a1)),
+        events: Vec::new(),
+        dependencies: Vec::new(),
+    };
+
+    let mut effects_b = effects_a.clone();
+    effects_b.transaction_digest = *tx_digest_b;
+
+    let execution_digest_a = ExecutionDigests::new(*tx_digest_a, effects_a.digest());
+
+    let execution_digest_b = ExecutionDigests::new(*tx_digest_b, effects_b.digest());
+
+    let checkpoint_summary_a = CheckpointSummary::new(
+        0,
+        1,
+        &CheckpointContents {
+            transactions: vec![execution_digest_a],
+        },
+        None,
+    );
+    let checkpoint_summary_b = CheckpointSummary::new(
+        0,
+        1,
+        &CheckpointContents {
+            transactions: vec![execution_digest_b],
+        },
+        None,
+    );
+
+    assert_ne!(checkpoint_summary_a.digest(), checkpoint_summary_b.digest());
+
+    // test non equality
+    assert_ne!(checkpoint_summary_a, checkpoint_summary_b)
 }


### PR DESCRIPTION
### Problem
Currently, authorities do not sign over user signatures. This means that certain types of transactions are not agreed upon. For example, a threshold multi-signature transaction would not be able to record which users out of the multi-sig set have signed the transaction.

Currently, our only two sources of commitments are Checkpoints, and SignedTransactions.

### Solution
1. Introduce a `SignedData` object to the transaction envelope. The authority will instead sign this object. In this PR, `SignedData` will include `TransactionData` and the user's signature.
3. Change `TransactionDigest` to be a digest of `SignedData` instead of just `TransactionData`. The TransactionDigest is included in Checkpoints - therefore, this commits the user's signatures into checkpoints.