### PR TITLE
bridge cluster tests into cargo test

### DIFF
--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -23,3 +23,14 @@ pub struct ClusterTestOpt {
     #[clap(long)]
     pub fullnode_address: Option<String>,
 }
+
+impl ClusterTestOpt {
+    pub fn new_local() -> Self {
+        Self {
+            env: Env::NewLocal,
+            gateway_address: None,
+            faucet_address: None,
+            fullnode_address: None,
+        }
+    }
+}

--- a/crates/sui-cluster-test/src/main.rs
+++ b/crates/sui-cluster-test/src/main.rs
@@ -2,15 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::*;
-use sui_cluster_test::{
-    config::ClusterTestOpt,
-    test_case::{
-        call_contract_test::CallContractTest, coin_merge_split_test::CoinMergeSplitTest,
-        native_transfer_test::NativeTransferTest, shared_object_test::SharedCounterTest,
-    },
-    *,
-};
-use tracing::info;
+use sui_cluster_test::{config::ClusterTestOpt, ClusterTest};
 
 #[tokio::main]
 async fn main() {
@@ -19,28 +11,6 @@ async fn main() {
         .init();
 
     let options = ClusterTestOpt::parse();
-    let mut ctx = TestContext::setup(options)
-        .await
-        .unwrap_or_else(|e| panic!("Failed to set up TestContext, e: {e}"));
 
-    let tests = vec![
-        TestCase::new(NativeTransferTest {}),
-        TestCase::new(CoinMergeSplitTest {}),
-        TestCase::new(CallContractTest {}),
-        TestCase::new(SharedCounterTest {}),
-    ];
-
-    // TODO: improve the runner parallelism for efficiency
-    // For now we run tests serially
-    let mut success_cnt = 0;
-    let total_cnt = tests.len() as i32;
-    for t in tests {
-        let is_sucess = t.run(&mut ctx).await as i32;
-        success_cnt += is_sucess;
-    }
-    if success_cnt < total_cnt {
-        // If any test failed, panic to bubble up the signal
-        panic!("{success_cnt} of {total_cnt} tests passed.");
-    }
-    info!("{success_cnt} of {total_cnt} tests passed.");
+    ClusterTest::run(options).await;
 }

--- a/crates/sui-cluster-test/tests/local_cluster_test.rs
+++ b/crates/sui-cluster-test/tests/local_cluster_test.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_cluster_test::{config::ClusterTestOpt, ClusterTest};
+
+#[tokio::test]
+async fn cluster_test() {
+    telemetry_subscribers::init_for_testing();
+
+    ClusterTest::run(ClusterTestOpt::new_local()).await;
+}


### PR DESCRIPTION
Wrap the test body into a lib and make it runnable with `cargo test`