### PR TITLE
Update jsonrpsee to forked version to fix the tracing span bug in jsonrpsee codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,15 +2955,32 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d966710cd10f992b87107c3b54f9301738892cf5692a5730a362957cc927e3c"
 dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-http-server",
- "jsonrpsee-proc-macros",
- "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
- "jsonrpsee-ws-server",
+ "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-http-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-http-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-proc-macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-wasm-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-ws-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-ws-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "jsonrpsee-client-transport 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-http-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-http-server 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-proc-macros 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-wasm-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-ws-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-ws-server 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "tracing",
 ]
 
@@ -2979,8 +2996,32 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 0.22.3",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "anyhow",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "gloo-net",
+ "http",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -3009,7 +3050,39 @@ dependencies = [
  "globset",
  "http",
  "hyper",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde 1.0.140",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "unicase",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.2",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "globset",
+ "http",
+ "hyper",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "lazy_static 1.4.0",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -3034,8 +3107,27 @@ dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash",
+ "serde 1.0.140",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "rustc-hash",
  "serde 1.0.140",
  "serde_json",
@@ -3054,8 +3146,25 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.140",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-server"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "serde 1.0.140",
  "serde_json",
  "tokio",
@@ -3068,6 +3177,17 @@ name = "jsonrpsee-proc-macros"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a29584096bd0d78576f5649deac29701257cabee28cb5fa68b0afb3459ba7c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.42",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.42",
@@ -3090,14 +3210,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde 1.0.140",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d69d7f38b9e1664a4a20872033d5da608dc4e7b5964046add82da8eb9baa53"
 dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "jsonrpsee-client-transport 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
 ]
 
 [[package]]
@@ -3107,9 +3250,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2eb1980ee67ecbc150d9bf4be734c3a548480af186fe1f170100cde222f76ad"
 dependencies = [
  "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
 ]
 
 [[package]]
@@ -3121,8 +3275,27 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "jsonrpsee-ws-server"
+version = "0.15.0"
+source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "serde_json",
  "soketto",
  "tokio",
@@ -6648,7 +6821,7 @@ dependencies = [
  "futures",
  "jemalloc-ctl",
  "jemallocator",
- "jsonrpsee",
+ "jsonrpsee 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-cli",
  "move-core-types",
  "move-package",
@@ -6990,9 +7163,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "jsonrpsee",
- "jsonrpsee-core",
- "jsonrpsee-proc-macros",
+ "jsonrpsee 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-proc-macros 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "prometheus",
  "serde 1.0.140",
  "signature",
@@ -7050,7 +7223,6 @@ dependencies = [
  "futures",
  "jemalloc-ctl",
  "jemallocator",
- "jsonrpsee",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
  "parking_lot 0.12.1",
@@ -7128,7 +7300,7 @@ dependencies = [
  "dirs",
  "futures",
  "futures-core",
- "jsonrpsee",
+ "jsonrpsee 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "serde 1.0.140",
  "serde_json",
  "signature",
@@ -7536,8 +7708,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "futures",
- "jsonrpsee-http-client",
- "jsonrpsee-http-server",
+ "jsonrpsee-http-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
  "move-core-types",
  "move-package",
  "once_cell",
@@ -9057,16 +9228,16 @@ dependencies = [
  "jobserver",
  "js-sys",
  "json",
- "jsonrpsee",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-http-server",
- "jsonrpsee-proc-macros",
- "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
- "jsonrpsee-ws-server",
+ "jsonrpsee 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-http-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-http-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-proc-macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-wasm-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-ws-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-ws-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "k256",
  "keccak",
  "kstring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,61 +2952,18 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 [[package]]
 name = "jsonrpsee"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d966710cd10f992b87107c3b54f9301738892cf5692a5730a362957cc927e3c"
-dependencies = [
- "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-http-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-http-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-proc-macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-wasm-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-ws-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-ws-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "0.15.0"
 source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
 dependencies = [
- "jsonrpsee-client-transport 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-http-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-http-server 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-proc-macros 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-wasm-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-ws-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-ws-server 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-http-server",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
+ "jsonrpsee-ws-server",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bc7b8506b6f313ec2915e2205f72015a55827d6fc4fbf6f485f45c802843a6"
-dependencies = [
- "anyhow",
- "futures-channel",
- "futures-timer",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.23.4",
- "tokio-util",
- "tracing",
- "webpki-roots 0.22.3",
 ]
 
 [[package]]
@@ -3020,8 +2977,8 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -3031,39 +2988,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "webpki-roots 0.22.3",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411236b4379b4d9e252b557ba3a9137c7fad5fdc944f2a29347db7c9edc929ee"
-dependencies = [
- "anyhow",
- "arrayvec 0.7.2",
- "async-lock",
- "async-trait",
- "beef",
- "futures-channel",
- "futures-timer",
- "futures-util",
- "globset",
- "http",
- "hyper",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "rustc-hash",
- "serde 1.0.140",
- "serde_json",
- "soketto",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "unicase",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3082,7 +3006,7 @@ dependencies = [
  "globset",
  "http",
  "hyper",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-types",
  "lazy_static 1.4.0",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -3101,55 +3025,17 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-http-client"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c78311a7686a5397806d362a1c8f7088fa59662dda23b01260d37ad235d682"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hash",
- "serde 1.0.140",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.15.0"
 source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
 dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustc-hash",
  "serde 1.0.140",
  "serde_json",
  "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-server"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80722337131d5a6b3e3928bf70944176ee6af6c31429c18483cad933962d7003"
-dependencies = [
- "futures-channel",
- "futures-util",
- "hyper",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.140",
- "serde_json",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -3163,25 +3049,13 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hyper",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde 1.0.140",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a29584096bd0d78576f5649deac29701257cabee28cb5fa68b0afb3459ba7c"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2 1.0.42",
- "quote 1.0.20",
- "syn 1.0.98",
 ]
 
 [[package]]
@@ -3193,20 +3067,6 @@ dependencies = [
  "proc-macro2 1.0.42",
  "quote 1.0.20",
  "syn 1.0.98",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e88f208ac5004389f0063e87bd7463f5e864ff1ac40484f80e8432976ffa0a"
-dependencies = [
- "anyhow",
- "beef",
- "serde 1.0.140",
- "serde_json",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -3225,34 +3085,11 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d69d7f38b9e1664a4a20872033d5da608dc4e7b5964046add82da8eb9baa53"
-dependencies = [
- "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.15.0"
 source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
 dependencies = [
- "jsonrpsee-client-transport 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2eb1980ee67ecbc150d9bf4be734c3a548480af186fe1f170100cde222f76ad"
-dependencies = [
- "http",
- "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3261,29 +3098,9 @@ version = "0.15.0"
 source = "git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa#76ce4e09537cb58b56e668121c95ea0a760db5fa"
 dependencies = [
  "http",
- "jsonrpsee-client-transport 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
-]
-
-[[package]]
-name = "jsonrpsee-ws-server"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637e02fdb87d2c5b5c518e1a4abc1a664768a2ca0797e5c06f5454ce7e4efe5"
-dependencies = [
- "futures-channel",
- "futures-util",
- "http",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json",
- "soketto",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "tracing-futures",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3294,8 +3111,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-types 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde_json",
  "soketto",
  "tokio",
@@ -6821,7 +6638,7 @@ dependencies = [
  "futures",
  "jemalloc-ctl",
  "jemallocator",
- "jsonrpsee 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee",
  "move-cli",
  "move-core-types",
  "move-package",
@@ -7163,9 +6980,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "jsonrpsee 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-core 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
- "jsonrpsee-proc-macros 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee",
+ "jsonrpsee-core",
+ "jsonrpsee-proc-macros",
  "prometheus",
  "serde 1.0.140",
  "signature",
@@ -7300,7 +7117,7 @@ dependencies = [
  "dirs",
  "futures",
  "futures-core",
- "jsonrpsee 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee",
  "serde 1.0.140",
  "serde_json",
  "signature",
@@ -7708,7 +7525,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "futures",
- "jsonrpsee-http-client 0.15.0 (git+https://github.com/patrickkuo/jsonrpsee?rev=76ce4e09537cb58b56e668121c95ea0a760db5fa)",
+ "jsonrpsee-http-client",
  "move-core-types",
  "move-package",
  "once_cell",
@@ -9228,16 +9045,16 @@ dependencies = [
  "jobserver",
  "js-sys",
  "json",
- "jsonrpsee 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-client-transport 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-core 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-http-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-http-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-proc-macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-wasm-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-ws-client 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-ws-server 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-http-server",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
+ "jsonrpsee-ws-server",
  "k256",
  "keccak",
  "kstring",

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 edition = "2021"
 
 [dependencies]
-jsonrpsee = { version = "0.15.0", features = ["full"] }
-jsonrpsee-core = "0.15.0"
-jsonrpsee-proc-macros = "0.15.0"
+jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee", features = ["full"] , rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa"}
+jsonrpsee-core = { git = "https://github.com/patrickkuo/jsonrpsee" , rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa"}
+jsonrpsee-proc-macros = { git = "https://github.com/patrickkuo/jsonrpsee" , rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa"}
 prometheus = "0.13.1"
 anyhow = "1.0.58"
 tracing = "0.1.35"
@@ -24,5 +24,5 @@ sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }
 sui-open-rpc = { path = "../sui-open-rpc" }
 sui-open-rpc-macros = { path = "../sui-open-rpc-macros" }
-sui-json-rpc-types= { path = "../sui-json-rpc-types" }
-workspace-hack = { path = "../workspace-hack"}
+sui-json-rpc-types = { path = "../sui-json-rpc-types" }
+workspace-hack = { path = "../workspace-hack" }

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use jsonrpsee::http_server::{AccessControlBuilder, HttpServerBuilder, HttpServerHandle};
-use jsonrpsee::ws_server::{WsServerBuilder, WsServerHandle};
+use jsonrpsee_core::server::access_control::AccessControlBuilder;
 use jsonrpsee_core::server::rpc_module::RpcModule;
+
+use crate::http_server::{HttpServerBuilder, HttpServerHandle};
+use crate::ws_server::{WsServerBuilder, WsServerHandle};
 
 use jsonrpsee::types::Params;
 use jsonrpsee_core::middleware::{Headers, HttpMiddleware, MethodKind, WsMiddleware};
@@ -16,6 +18,9 @@ use std::net::SocketAddr;
 use std::time::Instant;
 use sui_open_rpc::{Module, Project};
 use tracing::info;
+
+pub use jsonrpsee::http_server;
+pub use jsonrpsee::ws_server;
 
 pub mod api;
 pub mod bcs_api;

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -16,7 +16,6 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.35"
 parking_lot = "0.12.1"
 futures = "0.3.21"
-jsonrpsee = { version = "0.15.0", features = ["full"] }
 
 sui-config = { path = "../sui-config" }
 sui-core = { path = "../sui-core" }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -3,8 +3,6 @@
 
 use anyhow::Result;
 use futures::TryFutureExt;
-use jsonrpsee::http_server::HttpServerHandle;
-use jsonrpsee::ws_server::WsServerHandle;
 use multiaddr::Multiaddr;
 use parking_lot::Mutex;
 use prometheus::Registry;
@@ -23,7 +21,6 @@ use sui_core::{
     checkpoints::CheckpointStore,
 };
 use sui_json_rpc::bcs_api::BcsApiImpl;
-use sui_json_rpc::JsonRpcServerBuilder;
 use sui_network::api::ValidatorServer;
 use sui_storage::{
     event_store::{EventStoreType, SqlEventStore},
@@ -35,8 +32,11 @@ use sui_types::crypto::ToFromBytes;
 
 use sui_json_rpc::event_api::EventReadApiImpl;
 use sui_json_rpc::event_api::EventStreamingApiImpl;
+use sui_json_rpc::http_server::HttpServerHandle;
 use sui_json_rpc::read_api::FullNodeApi;
 use sui_json_rpc::read_api::ReadApi;
+use sui_json_rpc::ws_server::WsServerHandle;
+use sui_json_rpc::JsonRpcServerBuilder;
 use sui_types::crypto::{AuthorityPublicKeyBytes, KeypairTraits};
 
 pub mod admin;

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.58"
 async-trait = "0.1.56"
-jsonrpsee = { version = "0.15.0", features = ["full"] }
+jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee", features = ["full"] , rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa"}
 serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.80"
 futures-core = "0.3.21"

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -58,7 +58,7 @@ jemalloc-ctl = "^0.5"
 [dev-dependencies]
 tempfile = "3.3.0"
 futures = "0.3.21"
-jsonrpsee = { version = "0.15.0", features = ["full"] }
+jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee", features = ["full"] , rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa"}
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c"}
 test-utils = { path = "../test-utils" }
 sui-quorum-driver = { path = "../sui-quorum-driver" }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -13,8 +13,7 @@ rand = "0.7.3"
 tempfile = "3.3.0"
 tracing = "0.1.35"
 bcs = "0.1.3"
-jsonrpsee-http-server = "0.15.0"
-jsonrpsee-http-client = "0.15.0"
+jsonrpsee-http-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa"}
 prometheus = "0.13.1"
 tokio = { version = "1.20.1", features = ["full", "tracing", "test-util"] }
 serde_json = "1.0.80"

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
-use jsonrpsee_http_server::{HttpServerBuilder, HttpServerHandle, RpcModule};
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -24,6 +23,7 @@ use sui_json_rpc::api::WalletSyncApiServer;
 use sui_json_rpc::gateway_api::{
     GatewayReadApiImpl, GatewayWalletSyncApiImpl, RpcGatewayImpl, TransactionBuilderImpl,
 };
+use sui_json_rpc::http_server::{HttpServerBuilder, HttpServerHandle, RpcModule};
 use sui_sdk::crypto::{KeystoreType, SuiKeystore};
 use sui_swarm::memory::{Swarm, SwarmBuilder};
 use sui_types::base_types::SuiAddress;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -233,15 +233,15 @@ itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4", features = ["std"] 
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
 json = { version = "0.12", default-features = false }
-jsonrpsee = { version = "0.15", default-features = false, features = ["async-client", "client", "client-ws-transport", "full", "http-client", "http-server", "jsonrpsee-client-transport", "jsonrpsee-core", "jsonrpsee-http-client", "jsonrpsee-http-server", "jsonrpsee-proc-macros", "jsonrpsee-types", "jsonrpsee-wasm-client", "jsonrpsee-ws-client", "jsonrpsee-ws-server", "macros", "server", "tracing", "wasm-client", "ws-client", "ws-server"] }
-jsonrpsee-client-transport = { version = "0.15", default-features = false, features = ["anyhow", "futures-channel", "futures-timer", "futures-util", "gloo-net", "http", "jsonrpsee-types", "pin-project", "rustls-native-certs", "soketto", "thiserror", "tls", "tokio", "tokio-rustls", "tokio-util", "web", "webpki-roots", "ws"] }
-jsonrpsee-core = { version = "0.15", features = ["arrayvec", "async-client", "async-lock", "async-wasm-client", "client", "futures-timer", "futures-util", "globset", "http", "http-helpers", "hyper", "lazy_static", "parking_lot", "rand", "rustc-hash", "server", "soketto", "tokio", "tracing-futures", "unicase", "wasm-bindgen-futures"] }
-jsonrpsee-http-client = { version = "0.15", features = ["hyper-rustls", "tls"] }
-jsonrpsee-http-server = { version = "0.15", default-features = false }
-jsonrpsee-types = { version = "0.15", default-features = false }
-jsonrpsee-wasm-client = { version = "0.15", default-features = false }
-jsonrpsee-ws-client = { version = "0.15", features = ["tls"] }
-jsonrpsee-ws-server = { version = "0.15", default-features = false }
+jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false, features = ["async-client", "client", "client-ws-transport", "full", "http-client", "http-server", "jsonrpsee-client-transport", "jsonrpsee-core", "jsonrpsee-http-client", "jsonrpsee-http-server", "jsonrpsee-proc-macros", "jsonrpsee-types", "jsonrpsee-wasm-client", "jsonrpsee-ws-client", "jsonrpsee-ws-server", "macros", "server", "tracing", "wasm-client", "ws-client", "ws-server"] }
+jsonrpsee-client-transport = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false, features = ["anyhow", "futures-channel", "futures-timer", "futures-util", "gloo-net", "http", "jsonrpsee-types", "pin-project", "rustls-native-certs", "soketto", "thiserror", "tls", "tokio", "tokio-rustls", "tokio-util", "web", "webpki-roots", "ws"] }
+jsonrpsee-core = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", features = ["arrayvec", "async-client", "async-lock", "async-wasm-client", "client", "futures-timer", "futures-util", "globset", "http", "http-helpers", "hyper", "lazy_static", "parking_lot", "rand", "rustc-hash", "server", "soketto", "tokio", "tracing-futures", "unicase", "wasm-bindgen-futures"] }
+jsonrpsee-http-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", features = ["hyper-rustls", "tls"] }
+jsonrpsee-http-server = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-types = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-wasm-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-ws-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", features = ["tls"] }
+jsonrpsee-ws-server = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
 k256 = { version = "0.11", features = ["arithmetic", "digest", "ecdsa", "ecdsa-core", "keccak256", "pkcs8", "schnorr", "sha2", "sha256", "sha3", "std"] }
 keccak = { version = "0.1", default-features = false }
 kstring = { version = "1", features = ["max_inline", "serde"] }
@@ -831,16 +831,16 @@ itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = fa
 jobserver = { version = "0.1", default-features = false }
 js-sys = { version = "0.3", default-features = false }
 json = { version = "0.12", default-features = false }
-jsonrpsee = { version = "0.15", default-features = false, features = ["async-client", "client", "client-ws-transport", "full", "http-client", "http-server", "jsonrpsee-client-transport", "jsonrpsee-core", "jsonrpsee-http-client", "jsonrpsee-http-server", "jsonrpsee-proc-macros", "jsonrpsee-types", "jsonrpsee-wasm-client", "jsonrpsee-ws-client", "jsonrpsee-ws-server", "macros", "server", "tracing", "wasm-client", "ws-client", "ws-server"] }
-jsonrpsee-client-transport = { version = "0.15", default-features = false, features = ["anyhow", "futures-channel", "futures-timer", "futures-util", "gloo-net", "http", "jsonrpsee-types", "pin-project", "rustls-native-certs", "soketto", "thiserror", "tls", "tokio", "tokio-rustls", "tokio-util", "web", "webpki-roots", "ws"] }
-jsonrpsee-core = { version = "0.15", features = ["arrayvec", "async-client", "async-lock", "async-wasm-client", "client", "futures-timer", "futures-util", "globset", "http", "http-helpers", "hyper", "lazy_static", "parking_lot", "rand", "rustc-hash", "server", "soketto", "tokio", "tracing-futures", "unicase", "wasm-bindgen-futures"] }
-jsonrpsee-http-client = { version = "0.15", features = ["hyper-rustls", "tls"] }
-jsonrpsee-http-server = { version = "0.15", default-features = false }
-jsonrpsee-proc-macros = { version = "0.15", default-features = false }
-jsonrpsee-types = { version = "0.15", default-features = false }
-jsonrpsee-wasm-client = { version = "0.15", default-features = false }
-jsonrpsee-ws-client = { version = "0.15", features = ["tls"] }
-jsonrpsee-ws-server = { version = "0.15", default-features = false }
+jsonrpsee = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false, features = ["async-client", "client", "client-ws-transport", "full", "http-client", "http-server", "jsonrpsee-client-transport", "jsonrpsee-core", "jsonrpsee-http-client", "jsonrpsee-http-server", "jsonrpsee-proc-macros", "jsonrpsee-types", "jsonrpsee-wasm-client", "jsonrpsee-ws-client", "jsonrpsee-ws-server", "macros", "server", "tracing", "wasm-client", "ws-client", "ws-server"] }
+jsonrpsee-client-transport = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false, features = ["anyhow", "futures-channel", "futures-timer", "futures-util", "gloo-net", "http", "jsonrpsee-types", "pin-project", "rustls-native-certs", "soketto", "thiserror", "tls", "tokio", "tokio-rustls", "tokio-util", "web", "webpki-roots", "ws"] }
+jsonrpsee-core = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", features = ["arrayvec", "async-client", "async-lock", "async-wasm-client", "client", "futures-timer", "futures-util", "globset", "http", "http-helpers", "hyper", "lazy_static", "parking_lot", "rand", "rustc-hash", "server", "soketto", "tokio", "tracing-futures", "unicase", "wasm-bindgen-futures"] }
+jsonrpsee-http-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", features = ["hyper-rustls", "tls"] }
+jsonrpsee-http-server = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-proc-macros = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-types = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-wasm-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
+jsonrpsee-ws-client = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", features = ["tls"] }
+jsonrpsee-ws-server = { git = "https://github.com/patrickkuo/jsonrpsee", rev = "76ce4e09537cb58b56e668121c95ea0a760db5fa", default-features = false }
 k256 = { version = "0.11", features = ["arithmetic", "digest", "ecdsa", "ecdsa-core", "keccak256", "pkcs8", "schnorr", "sha2", "sha256", "sha3", "std"] }
 keccak = { version = "0.1", default-features = false }
 kstring = { version = "1", features = ["max_inline", "serde"] }


### PR DESCRIPTION
jsonrpsee is using `Span::enter()` incorrectly in async function, causing incorrect trace.

Created the fix in this fork https://github.com/patrickkuo/jsonrpsee, will contribute the fix to upstream.