### PR TITLE
[explorer] Removes min space for owned objects in mobile

### DIFF
--- a/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/OwnedObjects.module.css
@@ -25,7 +25,7 @@
 
 .ownedcoins,
 .ownedobjects {
-    @apply w-[100%] min-h-[420px] lg:min-h-[240px] lg:flex lg:flex-wrap lg:justify-between;
+    @apply w-[100%] lg:min-h-[240px] lg:flex lg:flex-wrap lg:justify-between;
 }
 
 .objectbox {


### PR DESCRIPTION
Before 
![image](https://user-images.githubusercontent.com/11377188/181794704-7c231038-67f0-4ee3-a948-c77d79540e47.png)

After
![image](https://user-images.githubusercontent.com/11377188/181794631-a8930906-8fdf-4350-b0cf-1f117295d075.png)
