### PR TITLE
[Explorer] Add lint rule for copyright header

### DIFF
--- a/explorer/client/.eslintrc.js
+++ b/explorer/client/.eslintrc.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module.exports = {
+    plugins: ['header'],
     extends: ['react-app', 'react-app/jest', 'prettier'],
     rules: {
         'react/jsx-no-bind': ['error'],
@@ -34,5 +35,13 @@ module.exports = {
             },
         ],
         'react/jsx-key': ['error', {}],
+        'header/header': [
+            2,
+            'line',
+            [
+                ' Copyright (c) 2022, Mysten Labs, Inc.',
+                ' SPDX-License-Identifier: Apache-2.0',
+            ],
+        ],
     },
 };

--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -15,6 +15,7 @@
         "@types/react-dom": "^17.0.11",
         "autoprefixer": "^10.4.2",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-header": "^3.1.1",
         "jest-puppeteer": "^6.1.0",
         "onchange": "^7.1.0",
         "postcss": "^8.4.6",
@@ -30,9 +31,9 @@
     },
     "dependencies": {
         "@mysten/sui.js": "file:../../sdk/typescript",
-        "@tanstack/react-table": "^8.1.4",
         "@sentry/react": "^7.6.0",
         "@sentry/tracing": "^7.6.0",
+        "@tanstack/react-table": "^8.1.4",
         "bn.js": "^5.2.0",
         "classnames": "^2.3.1",
         "prism-react-renderer": "^1.3.5",

--- a/explorer/client/yarn.lock
+++ b/explorer/client/yarn.lock
@@ -1500,7 +1500,7 @@
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
 "@mysten/sui.js@file:../../sdk/typescript":
-  version "0.3.0"
+  version "0.8.0"
   dependencies:
     bn.js "^5.2.0"
     buffer "^6.0.3"
@@ -4290,6 +4290,11 @@ eslint-plugin-flowtype@^8.0.3:
   dependencies:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
+
+eslint-plugin-header@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz#6ce512432d57675265fac47292b50d1eff11acd6"
+  integrity sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==
 
 eslint-plugin-import@^2.25.3:
   version "2.26.0"


### PR DESCRIPTION
I noticed that we had a copyright header on every file, but didn't lint against it. This adds a simple lint rule to ensure that we don't accidentally forget to add it anywhere. It also can be auto-fixed, which makes it easy to author the copyright header to begin with (there are also IDE plugins that do this for you, this is just another option).