### PR TITLE
disable stake feature for now

### DIFF
--- a/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
+++ b/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
@@ -7,7 +7,7 @@ import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import { useMiddleEllipsis } from '_hooks';
-import { Coin, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
+import { Coin } from '_redux/slices/sui-objects/Coin';
 import { balanceFormatOptions } from '_shared/formatting';
 
 import st from './CoinBalance.module.scss';
@@ -39,7 +39,9 @@ function CoinBalance({
         () => `/stake?${new URLSearchParams({ type }).toString()}`,
         [type]
     );
-    const showStake = !hideStake && GAS_TYPE_ARG === type;
+    // TODO: turn stake feature back on when fix is ready on next release.
+    // const showStake = !hideStake && GAS_TYPE_ARG === type;
+    const showStake = false;
     const shortenType = useMiddleEllipsis(type, 30);
     return (
         <div className={cl(st.container, st[mode])}>


### PR DESCRIPTION
until the shared objects root cause is figured and fixed, we will keep the stake feature disabled for now.


I will patch this change on tag devnet-0.6.2, build a dist and upload a file based on it, so that it will work with the current devnet because some new breaking changes around signature were introduced.
![Screen Shot 2022-07-29 at 12 46 54 PM](https://user-images.githubusercontent.com/106119108/181807510-167bd7c1-b583-4a3f-9f33-575e99089acd.png)

