### PR TITLE
[temporary-storage] Add API to access last known ObjectRef from parent sync

### DIFF
--- a/crates/sui-adapter/src/temporary_store.rs
+++ b/crates/sui-adapter/src/temporary_store.rs
@@ -8,35 +8,37 @@ use std::collections::{BTreeMap, HashSet};
 use sui_types::base_types::{
     ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
 };
-use sui_types::error::{ExecutionError, SuiError};
+use sui_types::error::{ExecutionError, SuiError, SuiResult};
 use sui_types::fp_bail;
 use sui_types::messages::{ExecutionStatus, InputObjects, TransactionEffects};
 use sui_types::object::{Data, Object};
-use sui_types::storage::{BackingPackageStore, DeleteKind, Storage};
+use sui_types::storage::{BackingPackageStore, DeleteKind, ParentSync, Storage};
 use sui_types::{
     event::Event,
     gas::{GasCostSummary, SuiGasStatus},
     object::Owner,
 };
 
-pub type InnerTemporaryStore = (
-    BTreeMap<ObjectID, Object>,
-    Vec<ObjectRef>,
-    BTreeMap<ObjectID, (ObjectRef, Object)>,
-    BTreeMap<ObjectID, (SequenceNumber, DeleteKind)>,
-    Vec<Event>,
-);
+pub struct InnerTemporaryStore {
+    pub objects: BTreeMap<ObjectID, Object>,
+    pub mutable_inputs: Vec<ObjectRef>,
+    pub written: BTreeMap<ObjectID, (ObjectRef, Object)>,
+    pub deleted: BTreeMap<ObjectID, (SequenceNumber, DeleteKind)>,
+}
 
 pub struct TemporaryStore<S> {
     // The backing store for retrieving Move packages onchain.
     // When executing a Move call, the dependent packages are not going to be
-    // in the input objects. They will be feteched from the backing store.
-    package_store: S,
+    // in the input objects. They will be fetched from the backing store.
+    // Also used for fetching the backing parent_sync to get the last known version for wrapped
+    // objects
+    store: S,
     tx_digest: TransactionDigest,
     objects: BTreeMap<ObjectID, Object>,
-    mutable_inputs: Vec<ObjectRef>, // Inputs that are mutable
-    written: BTreeMap<ObjectID, (ObjectRef, Object)>, // Objects written
+    mutable_inputs: Vec<ObjectRef>,      // Inputs that are mutable
+    written: BTreeMap<ObjectID, Object>, // Objects written
     /// Objects actively deleted.
+    /// Child count is Some for Normal/UnwrapThenDelete events, and is None for wraps
     deleted: BTreeMap<ObjectID, (SequenceNumber, DeleteKind)>,
     /// Ordered sequence of events emitted by execution
     events: Vec<Event>,
@@ -45,18 +47,30 @@ pub struct TemporaryStore<S> {
     created_object_ids: HashSet<ObjectID>,
 }
 
+macro_rules! into_inner {
+    ($store:ident) => {{
+        let written = $store
+            .written
+            .into_iter()
+            .map(|(id, obj)| (id, (obj.compute_object_reference(), obj)))
+            .collect();
+        InnerTemporaryStore {
+            objects: $store.objects,
+            mutable_inputs: $store.mutable_inputs,
+            written,
+            deleted: $store.deleted,
+        }
+    }};
+}
+
 impl<S> TemporaryStore<S> {
     /// Creates a new store associated with an authority store, and populates it with
     /// initial objects.
-    pub fn new(
-        package_store: S,
-        input_objects: InputObjects,
-        tx_digest: TransactionDigest,
-    ) -> Self {
+    pub fn new(store: S, input_objects: InputObjects, tx_digest: TransactionDigest) -> Self {
         let mutable_inputs = input_objects.mutable_inputs();
         let objects = input_objects.into_object_map();
         Self {
-            package_store,
+            store,
             tx_digest,
             objects,
             mutable_inputs,
@@ -72,7 +86,7 @@ impl<S> TemporaryStore<S> {
         &self.objects
     }
 
-    pub fn written(&self) -> &BTreeMap<ObjectID, (ObjectRef, Object)> {
+    pub fn written(&self) -> &BTreeMap<ObjectID, Object> {
         &self.written
     }
 
@@ -86,13 +100,7 @@ impl<S> TemporaryStore<S> {
         {
             self.check_invariants();
         }
-        (
-            self.objects,
-            self.mutable_inputs,
-            self.written,
-            self.deleted,
-            self.events,
-        )
+        into_inner!(self)
     }
 
     /// For every object from active_inputs (i.e. all mutable objects), if they are not
@@ -108,8 +116,7 @@ impl<S> TemporaryStore<S> {
                 let mut object = self.objects[id].clone();
                 // Active input object must be Move object.
                 object.data.try_as_move_mut().unwrap().increment_version();
-                self.written
-                    .insert(*id, (object.compute_object_reference(), object));
+                self.written.insert(*id, object);
             }
         }
     }
@@ -132,7 +139,7 @@ impl<S> TemporaryStore<S> {
         )?;
         objects_to_update.push(gas_object.clone());
 
-        for (object_id, (_object_ref, object)) in &mut self.written {
+        for (object_id, object) in &mut self.written {
             let (old_object_size, storage_rebate) =
                 if let Some(old_object) = self.objects.get(object_id) {
                     (
@@ -179,73 +186,75 @@ impl<S> TemporaryStore<S> {
     }
 
     pub fn to_effects(
-        &self,
+        self,
         shared_object_refs: Vec<ObjectRef>,
         transaction_digest: &TransactionDigest,
         transaction_dependencies: Vec<TransactionDigest>,
         gas_cost_summary: GasCostSummary,
         status: ExecutionStatus,
         gas_object_ref: ObjectRef,
-    ) -> TransactionEffects {
+    ) -> (InnerTemporaryStore, TransactionEffects) {
+        let written = self
+            .written
+            .iter()
+            .map(|(id, obj)| (*id, (obj.compute_object_reference(), obj.owner)))
+            .collect::<BTreeMap<_, _>>();
+
         // In the case of special transactions that don't require a gas object,
         // we don't really care about the effects to gas, just use the input for it.
         let updated_gas_object_info = if gas_object_ref.0 == ObjectID::ZERO {
             (gas_object_ref, Owner::AddressOwner(SuiAddress::default()))
         } else {
-            let (gas_reference, gas_object) = &self.written[&gas_object_ref.0];
-            (*gas_reference, gas_object.owner)
+            written[&gas_object_ref.0]
         };
-        TransactionEffects {
+        let mut created = vec![];
+        let mut mutated = vec![];
+        let mut unwrapped = vec![];
+        for (id, object_ref_and_owner) in written {
+            match (
+                self.created_object_ids.contains(&id),
+                self.objects.contains_key(&id),
+            ) {
+                (true, _) => created.push(object_ref_and_owner),
+                (false, true) => mutated.push(object_ref_and_owner),
+                (false, false) => {
+                    // wrapped objects must have their version set to 1 + the last known version in
+                    // the `parent_sync`
+                    debug_assert!(object_ref_and_owner.0 .1.value() > 1);
+                    unwrapped.push(object_ref_and_owner)
+                }
+            }
+        }
+
+        let mut deleted = vec![];
+        let mut wrapped = vec![];
+        for (id, (version, kind)) in &self.deleted {
+            match kind {
+                DeleteKind::Normal | DeleteKind::UnwrapThenDelete => {
+                    deleted.push((*id, *version, ObjectDigest::OBJECT_DIGEST_DELETED))
+                }
+                DeleteKind::Wrap => {
+                    wrapped.push((*id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED))
+                }
+            }
+        }
+        let inner = into_inner!(self);
+
+        let effects = TransactionEffects {
             status,
             gas_used: gas_cost_summary,
             shared_objects: shared_object_refs,
             transaction_digest: *transaction_digest,
-            created: self
-                .written
-                .iter()
-                .filter(|(id, _)| self.created_object_ids.contains(*id))
-                .map(|(_, (object_ref, object))| (*object_ref, object.owner))
-                .collect(),
-            mutated: self
-                .written
-                .iter()
-                .filter(|(id, _)| self.objects.contains_key(*id))
-                .map(|(_, (object_ref, object))| (*object_ref, object.owner))
-                .collect(),
-            unwrapped: self
-                .written
-                .iter()
-                .filter(|(id, _)| {
-                    !self.objects.contains_key(*id) && !self.created_object_ids.contains(*id)
-                })
-                .map(|(_, (object_ref, object))| (*object_ref, object.owner))
-                .collect(),
-            deleted: self
-                .deleted
-                .iter()
-                .filter_map(|(id, (version, kind))| {
-                    if kind != &DeleteKind::Wrap {
-                        Some((*id, *version, ObjectDigest::OBJECT_DIGEST_DELETED))
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            wrapped: self
-                .deleted
-                .iter()
-                .filter_map(|(id, (version, kind))| {
-                    if kind == &DeleteKind::Wrap {
-                        Some((*id, *version, ObjectDigest::OBJECT_DIGEST_WRAPPED))
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
+            created,
+            mutated,
+            unwrapped,
+            deleted,
+            wrapped,
             gas_object: updated_gas_object_info,
-            events: self.events.clone(),
+            events: self.events,
             dependencies: transaction_dependencies,
-        }
+        };
+        (inner, effects)
     }
 
     /// An internal check of the invariants (will only fire in debug)
@@ -295,10 +304,7 @@ impl<S> Storage for TemporaryStore<S> {
     fn read_object(&self, id: &ObjectID) -> Option<&Object> {
         // there should be no read after delete
         debug_assert!(self.deleted.get(id) == None);
-        match self.written.get(id) {
-            Some((_, obj)) => Some(obj),
-            None => self.objects.get(id),
-        }
+        self.written.get(id).or_else(|| self.objects.get(id))
     }
 
     fn set_create_object_ids(&mut self, ids: HashSet<ObjectID>) {
@@ -325,8 +331,7 @@ impl<S> Storage for TemporaryStore<S> {
         // The adapter is not very disciplined at filling in the correct
         // previous transaction digest, so we ensure it is correct here.
         object.previous_transaction = self.tx_digest;
-        self.written
-            .insert(object.id(), (object.compute_object_reference(), object));
+        self.written.insert(object.id(), object);
     }
 
     fn delete_object(&mut self, id: &ObjectID, version: SequenceNumber, kind: DeleteKind) {
@@ -359,7 +364,7 @@ impl<S: BackingPackageStore> ModuleResolver for TemporaryStore<S> {
         let package_obj;
         let package = match self.read_object(package_id) {
             Some(object) => object,
-            None => match self.package_store.get_package(package_id)? {
+            None => match self.store.get_package(package_id)? {
                 Some(object) => {
                     package_obj = object;
                     &package_obj
@@ -413,5 +418,11 @@ impl<S> ResourceResolver for TemporaryStore<S> {
                 other
             ),
         }
+    }
+}
+
+impl<S: ParentSync> ParentSync for TemporaryStore<S> {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+        self.store.get_latest_parent_entry_ref(object_id)
     }
 }

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -14,7 +14,7 @@ use std::{fs, path::Path};
 use sui_adapter::adapter;
 use sui_adapter::adapter::MoveVM;
 use sui_adapter::in_memory_storage::InMemoryStorage;
-use sui_adapter::temporary_store::TemporaryStore;
+use sui_adapter::temporary_store::{InnerTemporaryStore, TemporaryStore};
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::TransactionDigest;
 use sui_types::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes};
@@ -451,7 +451,9 @@ fn process_package(
         &mut gas_status,
     )?;
 
-    let (_objects, _mutable_inputs, written, deleted, _events) = temporary_store.into_inner();
+    let InnerTemporaryStore {
+        written, deleted, ..
+    } = temporary_store.into_inner();
 
     store.finish(written, deleted);
 
@@ -499,7 +501,9 @@ pub fn generate_genesis_system_object(
         genesis_ctx,
     )?;
 
-    let (_objects, _mutable_inputs, written, deleted, _events) = temporary_store.into_inner();
+    let InnerTemporaryStore {
+        written, deleted, ..
+    } = temporary_store.into_inner();
 
     store.finish(written, deleted);
 

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -432,7 +432,7 @@ fn process_package(
 
     debug_assert!(ctx.digest() == TransactionDigest::genesis());
     let mut temporary_store =
-        TemporaryStore::new(&store, InputObjects::new(filtered), ctx.digest());
+        TemporaryStore::new(&*store, InputObjects::new(filtered), ctx.digest());
     let package_id = ObjectID::from(*modules[0].self_id().address());
     let natives = native_functions.clone();
     let mut gas_status = SuiGasStatus::new_unmetered();
@@ -468,7 +468,7 @@ pub fn generate_genesis_system_object(
 ) -> Result<()> {
     let genesis_digest = genesis_ctx.digest();
     let mut temporary_store =
-        TemporaryStore::new(&store, InputObjects::new(vec![]), genesis_digest);
+        TemporaryStore::new(&*store, InputObjects::new(vec![]), genesis_digest);
 
     let mut pubkeys = Vec::new();
     let mut sui_addresses = Vec::new();

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -34,6 +34,7 @@ use std::{
     },
 };
 use sui_adapter::adapter;
+use sui_adapter::temporary_store::InnerTemporaryStore;
 use sui_config::genesis::Genesis;
 use sui_storage::{
     event_store::{EventStore, EventStoreType, StoredEvent},
@@ -583,7 +584,7 @@ impl AuthorityState {
         // non-transient (transaction input is invalid, move vm errors). However, all errors from
         // this function occur before we have written anything to the db, so we commit the tx
         // guard and rely on the client to retry the tx (if it was transient).
-        let (temporary_store, signed_effects) =
+        let (inner_temporary_store, signed_effects) =
             match self.prepare_certificate(certificate, digest).await {
                 Err(e) => {
                     debug!(name = ?self.name, ?digest, "Error preparing transaction: {}", e);
@@ -593,12 +594,12 @@ impl AuthorityState {
                 Ok(res) => res,
             };
 
-        let input_object_count = temporary_store.objects().len();
+        let input_object_count = inner_temporary_store.objects.len();
         let shared_object_count = signed_effects.effects.shared_objects.len();
 
         // If commit_certificate returns an error, tx_guard will be dropped and the certificate
         // will be persisted in the log for later recovery.
-        self.commit_certificate(temporary_store, certificate, &signed_effects)
+        self.commit_certificate(inner_temporary_store, certificate, &signed_effects)
             .await
             .tap_err(|e| error!(?digest, "commit_certificate failed: {}", e))?;
 
@@ -644,10 +645,7 @@ impl AuthorityState {
         &self,
         certificate: &CertifiedTransaction,
         transaction_digest: TransactionDigest,
-    ) -> SuiResult<(
-        TemporaryStore<Arc<AuthorityStore>>,
-        SignedTransactionEffects,
-    )> {
+    ) -> SuiResult<(InnerTemporaryStore, SignedTransactionEffects)> {
         let (gas_status, input_objects) =
             transaction_input_checker::check_transaction_input(&self.database, certificate).await?;
 
@@ -670,24 +668,25 @@ impl AuthorityState {
         );
 
         let transaction_dependencies = input_objects.transaction_dependencies();
-        let mut temporary_store =
+        let temporary_store =
             TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
-        let (effects, _execution_error) = execution_engine::execute_transaction_to_effects(
-            shared_object_refs,
-            &mut temporary_store,
-            certificate.data.clone(),
-            transaction_digest,
-            transaction_dependencies,
-            &self.move_vm,
-            &self._native_functions,
-            gas_status,
-            self.epoch(),
-        );
+        let (inner_temp_store, effects, _execution_error) =
+            execution_engine::execute_transaction_to_effects(
+                shared_object_refs,
+                temporary_store,
+                certificate.data.clone(),
+                transaction_digest,
+                transaction_dependencies,
+                &self.move_vm,
+                &self._native_functions,
+                gas_status,
+                self.epoch(),
+            );
 
         // TODO: Distribute gas charge and rebate, which can be retrieved from effects.
         let signed_effects = effects.to_sign_effects(self.epoch(), &self.name, &*self.secret);
 
-        Ok((temporary_store, signed_effects))
+        Ok((inner_temp_store, signed_effects))
     }
 
     pub async fn check_tx_already_executed(
@@ -1400,7 +1399,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub(crate) async fn commit_certificate(
         &self,
-        temporary_store: TemporaryStore<Arc<AuthorityStore>>,
+        inner_temporary_store: InnerTemporaryStore,
         certificate: &CertifiedTransaction,
         signed_effects: &SignedTransactionEffects,
     ) -> SuiResult {
@@ -1417,7 +1416,7 @@ impl AuthorityState {
         let effects_digest = &signed_effects.digest();
         self.database
             .update_state(
-                temporary_store,
+                inner_temporary_store,
                 certificate,
                 seq,
                 signed_effects,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -16,12 +16,12 @@ use sui_storage::{
     write_ahead_log::{DBWriteAheadLog, WriteAheadLog},
     LockService,
 };
-use sui_types::base_types::SequenceNumber;
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
 use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthoritySignInfo, EmptySignInfo};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::{Owner, OBJECT_START_VERSION};
+use sui_types::{base_types::SequenceNumber, storage::ParentSync};
 use tokio::sync::Notify;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{debug, error, info, trace};
@@ -607,9 +607,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     ///
     /// Internally it checks that all locks for active inputs are at the correct
     /// version, and then writes locks, objects, certificates, parents atomically.
-    pub async fn update_state<BackingPackageStore>(
+    pub async fn update_state(
         &self,
-        temporary_store: TemporaryStore<BackingPackageStore>,
+        inner_temporary_store: InnerTemporaryStore,
         certificate: &CertifiedTransaction,
         proposed_seq: TxSequenceNumber,
         effects: &TransactionEffectsEnvelope<S>,
@@ -628,7 +628,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         self.sequence_tx(
             write_batch,
-            temporary_store,
+            inner_temporary_store,
             transaction_digest,
             proposed_seq,
             effects,
@@ -643,16 +643,16 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Persist temporary storage to DB for genesis modules
-    pub async fn update_objects_state_for_genesis<BackingPackageStore>(
+    pub async fn update_objects_state_for_genesis(
         &self,
-        temporary_store: TemporaryStore<BackingPackageStore>,
+        inner_temporary_store: InnerTemporaryStore,
         transaction_digest: TransactionDigest,
     ) -> Result<(), SuiError> {
         debug_assert_eq!(transaction_digest, TransactionDigest::genesis());
         let write_batch = self.tables.certificates.batch();
         self.batch_update_objects(
             write_batch,
-            temporary_store,
+            inner_temporary_store,
             transaction_digest,
             UpdateType::Genesis,
         )
@@ -693,9 +693,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             std::iter::once((transaction_digest, &certificate)),
         )?;
 
+        let inner_temporary_store = temporary_store.into_inner();
         self.sequence_tx(
             write_batch,
-            temporary_store,
+            inner_temporary_store,
             transaction_digest,
             proposed_seq,
             &effects,
@@ -704,10 +705,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         .await
     }
 
-    async fn sequence_tx<BackingPackageStore>(
+    async fn sequence_tx(
         &self,
         write_batch: DBBatch,
-        temporary_store: TemporaryStore<BackingPackageStore>,
+        inner_temporary_store: InnerTemporaryStore,
         transaction_digest: &TransactionDigest,
         proposed_seq: TxSequenceNumber,
         effects: &TransactionEffectsEnvelope<S>,
@@ -717,7 +718,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         let assigned_seq = self
             .batch_update_objects(
                 write_batch,
-                temporary_store,
+                inner_temporary_store,
                 *transaction_digest,
                 UpdateType::Transaction(proposed_seq, *effects_digest),
             )
@@ -753,14 +754,19 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Helper function for updating the objects in the state
-    async fn batch_update_objects<BackingPackageStore>(
+    async fn batch_update_objects(
         &self,
         mut write_batch: DBBatch,
-        temporary_store: TemporaryStore<BackingPackageStore>,
+        inner_temporary_store: InnerTemporaryStore,
         transaction_digest: TransactionDigest,
         update_type: UpdateType,
     ) -> SuiResult<Option<TxSequenceNumber>> {
-        let (objects, active_inputs, written, deleted, _events) = temporary_store.into_inner();
+        let InnerTemporaryStore {
+            objects,
+            mutable_inputs: active_inputs,
+            written,
+            deleted,
+        } = inner_temporary_store;
         trace!(written =? written.values().map(|((obj_id, ver, _), _)| (obj_id, ver)).collect::<Vec<_>>(),
                "batch_update_objects: temp store written");
 
@@ -1426,6 +1432,14 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> BackingPackageStore
             );
         }
         Ok(package)
+    }
+}
+
+impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> ParentSync for SuiDataStore<S> {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+        Ok(self
+            .get_latest_parent_entry(object_id)?
+            .map(|(obj_ref, _)| obj_ref))
     }
 }
 

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -118,7 +118,7 @@ async fn test_start_epoch_change() {
     // Test that for certificates that have finished execution and is about to write effects,
     // they will also fail to get a ticket for the commit.
     let tx_digest = *transaction.digest();
-    let mut temporary_store = TemporaryStore::new(
+    let temporary_store = TemporaryStore::new(
         state.database.clone(),
         InputObjects::new(
             transaction
@@ -131,9 +131,9 @@ async fn test_start_epoch_change() {
         ),
         tx_digest,
     );
-    let (effects, _) = execution_engine::execute_transaction_to_effects(
+    let (inner_temporary_store, effects, _) = execution_engine::execute_transaction_to_effects(
         vec![],
-        &mut temporary_store,
+        temporary_store,
         transaction.data.clone(),
         tx_digest,
         BTreeSet::new(),
@@ -145,7 +145,7 @@ async fn test_start_epoch_change() {
     let signed_effects = effects.to_sign_effects(0, &state.name, &*state.secret);
     assert_eq!(
         state
-            .commit_certificate(temporary_store, &certificate, &signed_effects)
+            .commit_certificate(inner_temporary_store, &certificate, &signed_effects)
             .await
             .unwrap_err(),
         SuiError::ValidatorHaltedAtEpochEnd

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -376,10 +376,8 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
                         let move_struct =
                             MoveStruct::simple_deserialize(move_obj.contents(), &layout).unwrap();
                         self.stabilize_str(format!(
-                            "Owner: {}\nVersion: {}\nContents: {}",
-                            &obj.owner,
-                            obj.version().value(),
-                            move_struct
+                            "Owner: {}\nContents: {}",
+                            &obj.owner, move_struct
                         ))
                     }
                     object::Data::Package(package) => {

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    base_types::{ObjectID, SequenceNumber},
+    base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::SuiResult,
     event::Event,
     object::Object,
@@ -52,5 +52,33 @@ impl<S: BackingPackageStore> BackingPackageStore for std::sync::Arc<S> {
 impl<S: BackingPackageStore> BackingPackageStore for &S {
     fn get_package(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
         BackingPackageStore::get_package(*self, package_id)
+    }
+}
+
+impl<S: BackingPackageStore> BackingPackageStore for &mut S {
+    fn get_package(&self, package_id: &ObjectID) -> SuiResult<Option<Object>> {
+        BackingPackageStore::get_package(*self, package_id)
+    }
+}
+
+pub trait ParentSync {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>>;
+}
+
+impl<S: ParentSync> ParentSync for std::sync::Arc<S> {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+        ParentSync::get_latest_parent_entry_ref(self.as_ref(), object_id)
+    }
+}
+
+impl<S: ParentSync> ParentSync for &S {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+        ParentSync::get_latest_parent_entry_ref(*self, object_id)
+    }
+}
+
+impl<S: ParentSync> ParentSync for &mut S {
+    fn get_latest_parent_entry_ref(&self, object_id: ObjectID) -> SuiResult<Option<ObjectRef>> {
+        ParentSync::get_latest_parent_entry_ref(*self, object_id)
     }
 }


### PR DESCRIPTION
- In an effort to move the version info out of Move, we will need to be able to query the last known version when unwrapping objects
- Next PR will use this in the adapter

More background:

- We were going to add a `child_count` alongside the version in `VersionedID` in Move, this motivated the `object::Info` renaming
- After attempting to do `child_count`, we realized that neither version nor child count can  be exposed in Move due to cases where they are inaccurate. So we are moving them into the Rust layer in order to reduce the gas cost of Move txns and to reduce the complexity for Move devs
- However, when unwrapping wrapped objects, to either delete them or transfer them, you need to know the previous version. Before removing the `version` from Move, we can essentially just double increment the version. But after it is moved into the Rust layer, we don’t know the version in the Move data after unwrapping. So we will grab the last version from the `parent_sync` for these unwrapped objects.
- `parent_sync` will need to maintain the information for deleted objects to at least handle the shared object case. It will now also now be needed for the unwrapping case. In the long term, everything except deleted shared or wrapped objects can be removed from `parent_sync` after the epoch that they are deleted. 