### PR TITLE
use linked hash map for object inventory to preserve insertion order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6895,6 +6895,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "linked-hash-map",
  "move-binary-format",
  "move-cli",
  "move-core-types",

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
+linked-hash-map = "0.5.6"
 smallvec = "1.9.0"
 num_enum = "0.5.7"
 once_cell = "1.11.0"

--- a/crates/sui-framework/src/natives/test_scenario.rs
+++ b/crates/sui-framework/src/natives/test_scenario.rs
@@ -3,6 +3,7 @@
 
 use crate::EventType;
 use core::panic;
+use linked_hash_map::LinkedHashMap;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, value::MoveTypeLayout};
 use move_vm_runtime::native_functions::NativeContext;
@@ -52,7 +53,7 @@ struct OwnedObj {
 // This will require extending NativeContext with a function to map `Type` (which is just an index
 // into the module's StructHandle table for structs) to something human-readable like `TypeTag`.
 // TODO: add a native function that prints the log of transfers, deletes, wraps for debugging purposes
-type Inventory = BTreeMap<ObjectID, OwnedObj>;
+type Inventory = LinkedHashMap<ObjectID, OwnedObj>;
 
 /// Return the object ID involved in an event.
 /// This depends on the value format for each event type.

--- a/crates/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/tests/test_scenario_tests.move
@@ -275,6 +275,33 @@ module sui::test_scenarioTests {
     }
 
     #[test]
+    fun test_get_last_created_owned_object() {
+        let sender = @0x0;
+        let scenario = &mut test_scenario::begin(&sender);
+		create_and_transfer_object(scenario, 1);
+		test_scenario::next_tx(scenario, &sender);
+		{
+			let obj = test_scenario::take_last_created_owned<Object>(scenario);
+			assert!(obj.value == 1, VALUE_MISMATCH);
+			test_scenario::return_owned(scenario, obj);
+		};
+		create_and_transfer_object(scenario, 2);
+		test_scenario::next_tx(scenario, &sender);
+		{
+			let obj = test_scenario::take_last_created_owned<Object>(scenario);
+			assert!(obj.value == 2, VALUE_MISMATCH);
+			test_scenario::return_owned(scenario, obj);
+		};
+		create_and_transfer_object(scenario, 3);
+		test_scenario::next_tx(scenario, &sender);
+		{
+			let obj = test_scenario::take_last_created_owned<Object>(scenario);
+			assert!(obj.value == 3, VALUE_MISMATCH);
+			test_scenario::return_owned(scenario, obj);
+		};
+    }
+
+    #[test]
     fun test_take_child_object() {
         let sender = @0x0;
         let scenario = test_scenario::begin(&sender);
@@ -369,5 +396,14 @@ module sui::test_scenarioTests {
             child: child_id,
         };
         transfer::transfer(parent, test_scenario::sender(scenario));
+    }
+
+    /// Create an object and transfer it to the sender of `scenario`.
+    fun create_and_transfer_object(scenario: &mut Scenario, value: u64) {
+        let object = Object {
+            info: test_scenario::new_object(scenario),
+            value,
+        };
+        transfer::transfer(object, test_scenario::sender(scenario));
     }
 }


### PR DESCRIPTION
Before this PR we use `BTreeMap` got object inventory in the implementation of `test_scenario`. But `BTreeMap` does not preserve the order of entry insertions, causing a bug in `test_scenario:: take_last_created_owned`, as described in issue #3567. This PR fixes that and adds the missing unit test for `take_last_created_owned`.