### PR TITLE
Sync sender address state before txns

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -21,6 +21,7 @@ import {
 } from '../types';
 
 const isNumber = (val: any): val is number => typeof val === 'number';
+const isAny = (_val: any): _val is any => true;
 
 export class JsonRpcProvider extends Provider {
   private client: JsonRpcClient;
@@ -242,6 +243,20 @@ export class JsonRpcProvider extends Provider {
     } catch (err) {
       throw new Error(
         `Error fetching recent transactions: ${err} for count ${count}`
+      );
+    }
+  }
+
+  async syncAccountState(address: string): Promise<any> {
+    try {
+      return await this.client.requestWithType(
+        'sui_syncAccountState',
+        [address],
+        isAny,
+      );
+    } catch (err) {
+      throw new Error(
+        `Error sync account address for address: ${address} with error: ${err}`,
       );
     }
   }

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -56,5 +56,6 @@ export abstract class Provider {
     pubkey: string
   ): Promise<TransactionResponse>;
 
+  abstract syncAccountState(address: string): Promise<any>
   // TODO: add more interface methods
 }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -53,6 +53,10 @@ export class VoidProvider extends Provider {
     throw this.newError('getRecentTransactions');
   }
 
+  async syncAccountState(_address: string): Promise<any> {
+    throw this.newError('syncAccountState');
+  }
+
   private newError(operation: string): Error {
     return new Error(`Please use a valid provider for ${operation}`);
   }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -69,6 +69,15 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * Trigger gateway to sync account state related to the address,
+   * based on the account state on validators.
+   */
+  async syncAccountState(): Promise<any> {
+    const address = await this.getAddress();
+    return await this.provider.syncAccountState(address);
+  }
+
+  /**
    * Serialize and Sign a `TransferObject` transaction and submit to the Gateway for execution
    */
   async transferObject(

--- a/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -76,6 +76,7 @@ export class Coin {
         amount: bigint,
         recipient: SuiAddress
     ): Promise<TransactionResponse> {
+        await signer.syncAccountState();
         const coin = await Coin.selectCoin(signer, coins, amount);
         return await signer.transferObject({
             objectId: coin,
@@ -98,6 +99,7 @@ export class Coin {
         amount: bigint,
         recipient: SuiAddress
     ): Promise<TransactionResponse> {
+        await signer.syncAccountState();
         const coin = await Coin.prepareCoinWithEnoughBalance(
             signer,
             coins,
@@ -127,6 +129,7 @@ export class Coin {
         validator: SuiAddress
     ): Promise<TransactionResponse> {
         const coin = await Coin.selectCoin(signer, coins, amount);
+        await signer.syncAccountState();
         return await signer.executeMoveCall({
             packageObjectId: '0x2',
             module: 'sui_system',

--- a/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -16,6 +16,7 @@ export class ExampleNFT {
         description?: string,
         imageUrl?: string
     ): Promise<TransactionResponse> {
+        await signer.syncAccountState();
         return await signer.executeMoveCall({
             packageObjectId: '0x2',
             module: 'devnet_nft',
@@ -39,6 +40,7 @@ export class ExampleNFT {
         recipientID: string,
         transferCost: number
     ): Promise<TransactionResponse> {
+        await signer.syncAccountState();
         return await signer.transferObject({
             objectId: nftId,
             gasBudget: transferCost,


### PR DESCRIPTION
Trigger the state sync for gateway on the sender address, the specific endpoints that trigger this include:
- transfer coin
- transfer Sui coin
- transfer NFT
- mint NFT
- stake coin

make sure that with console.log, the states are indeed synced

![Screen Shot 2022-08-02 at 10 02 19 AM](https://user-images.githubusercontent.com/106119108/182394201-0ea320d8-714d-4a08-b8e9-eaae50d03b25.png)

![Screen Shot 2022-08-02 at 10 02 30 AM](https://user-images.githubusercontent.com/106119108/182394237-be49bc1c-c2ba-4c51-8db3-67491615fe15.png)

![Screen Shot 2022-08-02 at 10 02 42 AM](https://user-images.githubusercontent.com/106119108/182394253-7e42b9c6-6c1d-4454-a6a8-bbb30a512f48.png)


