### PR TITLE
add script that runs prover on sui framework

### DIFF
--- a/crates/sui-framework/scripts/run_prover.sh
+++ b/crates/sui-framework/scripts/run_prover.sh
@@ -1,0 +1,6 @@
+#  Copyright (c) 2022, Mysten Labs, Inc.
+#  SPDX-License-Identifier: Apache-2.0
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "${SCRIPT_DIR}/../" &&  cargo run -p sui -- move prove


### PR DESCRIPTION
This draft PR contains a script that runs `sui move prove` on sui framework Move code. It would be great if we can run this in CI as a sanity check that the changes in a PR don't break `sui move prove`. 

This script is adapted from the script in Move repo that runs diem framework in CI: 
https://github.com/move-language/move/blob/main/language/documentation/examples/diem-framework/prove_all.sh

In order for `sui move prove` to work, we need to install a few dependencies including dotnet, Boogie, Z3, CVC5. We can probably do something similar to what the move repo does in github actions: 
https://github.com/move-language/move/blob/main/.github/actions/build-setup/action.yml#L45-L60