### PR TITLE
A basic implementation of tally rule

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -78,6 +78,8 @@ pub use sui_adapter::temporary_store::TemporaryStore;
 
 pub mod authority_store_tables;
 
+pub mod tally_rule;
+
 mod authority_store;
 pub use authority_store::{
     AuthorityStore, GatewayStore, ResolverWrapper, SuiDataStore, UpdateType,

--- a/crates/sui-core/src/authority/tally_rule.rs
+++ b/crates/sui-core/src/authority/tally_rule.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use rocksdb::{DBWithThreadMode, MultiThreaded, Options};
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use sui_types::base_types::{AuthorityName, ExecutionDigests};
+use sui_types::error::SuiResult;
+use typed_store::rocks::DBMap;
+use typed_store::{reopen, Map};
+
+const TX_EFFECTS_GOSSIP_ORDER: &str = "tx_effects_gossip_order";
+const TALLY_SCORES: &str = "tally_scores";
+
+pub type GossipSequenceNumber = u64;
+
+pub struct TallyRecord {
+    next_seq: AtomicU64,
+    /// Stores the names of validators that sent us execution digests through gossip.
+    /// The key of this table is a tuple of the execution digest and the name of the validator.
+    /// The value is a sequence number obtained from an atomic counter that increase each time
+    /// we receive an item from gossip. It can be used to determine the order we received from
+    /// each validator for each transaction.
+    /// At the end of each checkpoint, we go through each digest executed in the checkpoint,
+    /// update the score of validators based on the order we received from them. We also remove
+    /// all the digests processed.
+    /// In case there are leaks (i.e. digests added back after processing), at the end of epoch,
+    /// we clear this table.
+    tx_effects_gossip_order: DBMap<(ExecutionDigests, AuthorityName), GossipSequenceNumber>,
+
+    /// Tracks the current accumulated total score of each validator.
+    tally_scores: DBMap<AuthorityName, u64>,
+}
+
+impl TallyRecord {
+    pub fn new(db: &Arc<DBWithThreadMode<MultiThreaded>>) -> Self {
+        let (tx_effects_gossip_order, tally_scores) = reopen! (
+            db,
+            TX_EFFECTS_GOSSIP_ORDER;<(ExecutionDigests, AuthorityName), GossipSequenceNumber>,
+            TALLY_SCORES;<AuthorityName, u64>
+        );
+        Self {
+            next_seq: AtomicU64::new(0),
+            tx_effects_gossip_order,
+            tally_scores,
+        }
+    }
+
+    pub fn get_tables_options<'a>(
+        options: &'a Options,
+        point_lookup: &'a Options,
+    ) -> Vec<(&'static str, &'a Options)> {
+        vec![
+            (TX_EFFECTS_GOSSIP_ORDER, options),
+            (TALLY_SCORES, point_lookup),
+        ]
+    }
+
+    pub fn is_table(table_name: &str) -> bool {
+        table_name == TX_EFFECTS_GOSSIP_ORDER || table_name == TALLY_SCORES
+    }
+
+    pub fn dump(&self, table_name: &str) -> anyhow::Result<BTreeMap<String, String>> {
+        match table_name {
+            TX_EFFECTS_GOSSIP_ORDER => {
+                self.tx_effects_gossip_order.try_catch_up_with_primary()?;
+                Ok(self
+                    .tx_effects_gossip_order
+                    .iter()
+                    .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+                    .collect::<BTreeMap<_, _>>())
+            }
+            TALLY_SCORES => {
+                self.tally_scores.try_catch_up_with_primary()?;
+                Ok(self
+                    .tally_scores
+                    .iter()
+                    .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+                    .collect::<BTreeMap<_, _>>())
+            }
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+
+    pub fn add_record(&self, digests: ExecutionDigests, validator: AuthorityName) -> SuiResult {
+        let seq = self.next_seq();
+        self.tx_effects_gossip_order
+            .insert(&(digests, validator), &seq)?;
+        Ok(())
+    }
+
+    /// Given a list of effects digests, for each of these digests, we look at our record and see
+    /// for each digest what is the order we received it from different validators through gossip.
+    /// We then give them score based on the order.
+    pub fn update_score<'a>(
+        &self,
+        digests: impl Iterator<Item = &'a ExecutionDigests>,
+    ) -> SuiResult {
+        let mut to_be_deleted = Vec::new();
+        for digest in digests {
+            let records: BTreeMap<_, _> = self
+                .tx_effects_gossip_order
+                .iter()
+                .skip_to(&(*digest, AuthorityName::ZERO))?
+                .take_while(|((d, _name), _seq)| d == digest)
+                .map(|((_, name), seq)| (seq, name))
+                .collect();
+            to_be_deleted.extend(records.iter().map(|(_, name)| (*digest, *name)));
+            let gossip_size = records.len();
+            for (order, (_, name)) in records.into_iter().enumerate() {
+                self.give_score(name, order, gossip_size)?;
+            }
+        }
+        self.tx_effects_gossip_order.multi_remove(to_be_deleted)?;
+        Ok(())
+    }
+
+    fn next_seq(&self) -> GossipSequenceNumber {
+        self.next_seq.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn give_score(&self, name: AuthorityName, order: usize, gossip_size: usize) -> SuiResult {
+        let cur_score = self.tally_scores.get(&name)?.unwrap_or_default();
+        let to_add = Self::compute_score_for_order(order, gossip_size);
+        self.tally_scores.insert(&name, &(cur_score + to_add))?;
+        Ok(())
+    }
+
+    fn compute_score_for_order(order: usize, gossip_size: usize) -> u64 {
+        (gossip_size - order) as u64
+    }
+}

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -330,6 +330,11 @@ where
         let aggregator = follower.aggregator.clone();
         let name = follower.peer_name;
         Ok(Box::pin(async move {
+            state
+                .database
+                .tables
+                .tally_record
+                .add_record(digest, name)?;
             if !state.database.effects_exists(&digest.transaction)? {
                 // Download the certificate
                 let response = client

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -359,7 +359,7 @@ impl CheckpointStore {
         candidate_contents: &CheckpointContents,
         previous_digest: Option<CheckpointDigest>,
         effects_store: impl CausalOrder + PendCertificateForExecution,
-    ) -> SuiResult {
+    ) -> SuiResult<CheckpointContents> {
         // The checkpoint content is constructed using all fragments received.
         // When receiving the fragments, we have verified that all certs are valid.
         // However, we did not verify that all transactions have not been checkpointed.
@@ -392,7 +392,8 @@ impl CheckpointStore {
         let checkpoint = AuthenticatedCheckpoint::Signed(
             SignedCheckpointSummary::new_from_summary(summary, self.name, &*self.secret),
         );
-        self.handle_internal_set_checkpoint(&checkpoint, &ordered_contents, effects_store)
+        self.handle_internal_set_checkpoint(&checkpoint, &ordered_contents, effects_store)?;
+        Ok(ordered_contents)
     }
 
     /// Call this function internally to update the latest checkpoint.
@@ -612,7 +613,7 @@ impl CheckpointStore {
         &mut self,
         effects_store: impl CausalOrder + PendCertificateForExecution,
         committee: &Committee,
-    ) -> SuiResult {
+    ) -> SuiResult<CheckpointContents> {
         // We have a proposal so lets try to re-construct the checkpoint.
         let next_sequence_number = self.next_checkpoint();
         let locals = self.get_locals();

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -110,6 +110,8 @@ impl ToFromBytes for AuthorityPublicKeyBytes {
 }
 
 impl AuthorityPublicKeyBytes {
+    pub const ZERO: Self = Self([0u8; AuthorityPublicKey::LENGTH]);
+
     /// This ensures it's impossible to construct an instance with other than registered lengths
     pub fn new(bytes: [u8; AuthorityPublicKey::LENGTH]) -> AuthorityPublicKeyBytes
 where {


### PR DESCRIPTION
The tally rule works as follows:
1. For every digest we received from gossip, we assign a unique (incrementing) sequence number, and add the digest and validator name along with the sequence number to the a record table
2. At the end of each checkpoint, for each digest included in the checkpoint, we go over all validators that sent us this digest  in the order we received them (provided by the sequence number), and give them score based on the order.

It's very basic at the moment, and the score calculation is also very rough. We can tune and iterate on it.
TODO: Will add tests.