### PR TITLE
Fix return issue

### DIFF
--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -49,35 +49,33 @@ pub async fn transfer_sui_for_testing(
     );
     let quorum_driver_handler = QuorumDriverHandler::new(client.clone());
     let qd = quorum_driver_handler.clone_quorum_driver();
-    let new_object = qd
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: tx.clone(),
-            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
-        })
-        .map(move |res| match res {
-            Ok(ExecuteTransactionResponse::EffectsCert(result)) => {
-                let (_, effects) = *result;
-                let minted = effects.effects.created.get(0).unwrap().0;
-                let updated = effects
-                    .effects
-                    .mutated
-                    .iter()
-                    .find(|(k, _)| k.0 == gas.0 .0)
-                    .unwrap()
-                    .0;
-                Some((updated, minted))
-            }
-            Ok(resp) => {
-                error!("Unexpected response while transferring sui: {:?}", resp);
-                None
-            }
-            Err(err) => {
-                error!("Error while transferring sui: {:?}", err);
-                None
-            }
-        })
-        .await;
-    new_object
+    qd.execute_transaction(ExecuteTransactionRequest {
+        transaction: tx.clone(),
+        request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+    })
+    .map(move |res| match res {
+        Ok(ExecuteTransactionResponse::EffectsCert(result)) => {
+            let (_, effects) = *result;
+            let minted = effects.effects.created.get(0).unwrap().0;
+            let updated = effects
+                .effects
+                .mutated
+                .iter()
+                .find(|(k, _)| k.0 == gas.0 .0)
+                .unwrap()
+                .0;
+            Some((updated, minted))
+        }
+        Ok(resp) => {
+            error!("Unexpected response while transferring sui: {:?}", resp);
+            None
+        }
+        Err(err) => {
+            error!("Error while transferring sui: {:?}", err);
+            None
+        }
+    })
+    .await
 }
 
 pub async fn get_latest(


### PR DESCRIPTION
Fixes small issue where extra var assigned and returned

**Issue**
```
error: returning the result of a `let` binding from a block
  --> crates/sui-benchmark/src/workloads/workload.rs:80:5
   |
52 | /     let new_object = qd
53 | |         .execute_transaction(ExecuteTransactionRequest {
54 | |             transaction: tx.clone(),
55 | |             request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
...  |
78 | |         })
79 | |         .await;
   | |_______________- unnecessary `let` binding
80 |       new_object
   |       ^^^^^^^^^^
   |
   = note: `-D clippy::let-and-return` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
help: return the expression directly
```