### PR TITLE
call transferSui for Sui token sending

### DIFF
--- a/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -57,13 +57,6 @@ export function createValidationSchema(
                     }
                 }
             )
-            .test(
-                'num-gas-coins-check',
-                `Need at least 2 ${GAS_SYMBOL} coins to transfer a ${GAS_SYMBOL} coin`,
-                () => {
-                    return coinType !== GAS_TYPE_ARG || totalGasCoins >= 2;
-                }
-            )
             .label('Amount'),
     });
 }

--- a/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -48,12 +48,20 @@ export const sendTokens = createAsyncThunk<
                     isSuiMoveObject(anObj.data) && anObj.data.type === coinType
             )
             .map(({ data }) => data as SuiMoveObject);
-        const response = await Coin.transferCoin(
-            api.getSignerInstance(keypairVault.getKeyPair()),
-            coins,
-            amount,
-            recipientAddress
-        );
+        const response =
+            Coin.getCoinSymbol(tokenTypeArg) === 'SUI'
+                ? await Coin.transferSui(
+                      api.getSignerInstance(keypairVault.getKeyPair()),
+                      coins,
+                      amount,
+                      recipientAddress
+                  )
+                : await Coin.transferCoin(
+                      api.getSignerInstance(keypairVault.getKeyPair()),
+                      coins,
+                      amount,
+                      recipientAddress
+                  );
 
         // TODO: better way to sync latest objects
         dispatch(fetchAllOwnedObjects());


### PR DESCRIPTION
RT.

also removed the validation of at least 2 Sui coins because now transferSui just takes one.

tests:
- on local server (devnet is now not compatible with local main), transfer one coin from gas object and transfer to another address
- verify that indeed the transferSui is triggered and the no split is triggered.

![Screen Shot 2022-08-01 at 11 49 45 AM](https://user-images.githubusercontent.com/106119108/182189378-1d2f0781-f732-4418-9404-26b54ad11a74.png)

![Screen Shot 2022-08-01 at 11 46 08 AM](https://user-images.githubusercontent.com/106119108/182189309-91872912-bb57-4e2b-8d45-81d5a7651ea9.png)
