### PR TITLE
[explorer] Fix browser history getting reset when navigating to the home page

### DIFF
--- a/explorer/client/src/components/pagination/Pagination.tsx
+++ b/explorer/client/src/components/pagination/Pagination.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { memo, useState, useCallback, useEffect } from 'react';
+import { memo, useState, useCallback, useEffect, useRef } from 'react';
 
 import { numberSuffix } from '../../utils/numberUtil';
 
@@ -30,14 +30,16 @@ function Pagination({
     // Connects pageIndex to input page value
 
     const [pageIndex, setPageIndex] = useState(currentPage - 1);
+    const previousPageIndex = useRef(pageIndex);
 
     useEffect(() => {
         setPageIndex(currentPage - 1);
     }, [currentPage]);
 
     useEffect(() => {
-        if (onPagiChangeFn) {
-            onPagiChangeFn(pageIndex + 1);
+        if (pageIndex !== previousPageIndex.current) {
+            previousPageIndex.current = pageIndex;
+            onPagiChangeFn?.(pageIndex + 1);
         }
     }, [pageIndex, onPagiChangeFn]);
 

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -3,7 +3,7 @@
 
 import * as Sentry from '@sentry/react';
 import cl from 'classnames';
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useCallback } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 
 import { ReactComponent as ContentForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
@@ -221,9 +221,15 @@ function LatestTxCard({ ...data }: RecentTx) {
     const [network] = useContext(NetworkContext);
     const [searchParams, setSearchParams] = useSearchParams();
 
-    const [pageIndex, setpageIndex] = useState(
+    const [pageIndex, setPageIndex] = useState(
         parseInt(searchParams.get('p') || '1', 10) || 1
     );
+
+    const handlePageChange = useCallback((newPage: number) => {
+        console.log('HANDLING PAGE CHANGE');
+        setPageIndex(newPage);
+        setSearchParams({ p: newPage.toString() })
+    }, [setSearchParams]);
 
     // update the page index when the user clicks on the pagination buttons
     useEffect(() => {
@@ -231,10 +237,6 @@ function LatestTxCard({ ...data }: RecentTx) {
         // If pageIndex is greater than maxTxPage, set to maxTxPage
         const maxTxPage = Math.ceil(count / txPerPage);
         const pg = pageIndex > maxTxPage ? maxTxPage : pageIndex;
-        setpageIndex(pg);
-        pageIndex > 1
-            ? setSearchParams({ p: pg.toString() })
-            : setSearchParams({});
 
         getRecentTransactions(network, count, txPerPage, pg)
             .then(async (resp: any) => {
@@ -299,7 +301,7 @@ function LatestTxCard({ ...data }: RecentTx) {
                 totalItems={count}
                 itemsPerPage={txPerPage}
                 updateItemsPerPage={setTxPerPage}
-                onPagiChangeFn={setpageIndex}
+                onPagiChangeFn={handlePageChange}
                 currentPage={pageIndex}
                 stats={stats}
             />

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -226,7 +226,6 @@ function LatestTxCard({ ...data }: RecentTx) {
     );
 
     const handlePageChange = useCallback((newPage: number) => {
-        console.log('HANDLING PAGE CHANGE');
         setPageIndex(newPage);
         setSearchParams({ p: newPage.toString() })
     }, [setSearchParams]);

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -225,10 +225,13 @@ function LatestTxCard({ ...data }: RecentTx) {
         parseInt(searchParams.get('p') || '1', 10) || 1
     );
 
-    const handlePageChange = useCallback((newPage: number) => {
-        setPageIndex(newPage);
-        setSearchParams({ p: newPage.toString() })
-    }, [setSearchParams]);
+    const handlePageChange = useCallback(
+        (newPage: number) => {
+            setPageIndex(newPage);
+            setSearchParams({ p: newPage.toString() });
+        },
+        [setSearchParams]
+    );
 
     // update the page index when the user clicks on the pagination buttons
     useEffect(() => {


### PR DESCRIPTION
Whenever navigating to the home page, the browser history would get reset, which preventing navigating backwards and forwards through the home page (other pages work fine). This was being caused by a call to `setSearchParams`, which created a new browser history branch whenever the home page was loaded. The fix here was to update the `Pagination` component to only invoke the `onPagiChangeFn` method when the page index has actually changed.