### PR TITLE
[crypto] optimize verification through referring pre-computed deserialized keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,9 +4937,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4957,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "b3c567e5702efdc79fb18859ea74c3eb36e14c43da7b8c1f098a4ed6514ec7a0"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4970,9 +4970,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "5eb32be5ee3bbdafa8c7a18b0a8a8d962b66cfa2ceee4037f49267a50ee821fe"
 dependencies = [
  "once_cell",
  "pest",
@@ -6994,6 +6994,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64",
+ "base64ct",
  "bcs",
  "clap 3.2.17",
  "crossterm 0.23.2",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -29,6 +29,7 @@ multiaddr = "0.14.0"
 crossterm = "0.23.2"
 rand = "0.8.5"
 base64 = "0.13.0"
+base64ct = "1.5.2"
 rand_distr = "0.4.3"
 
 bcs = "0.1.3"

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -7,4 +7,6 @@ voting_rights:
   - - ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=
     - 1
 total_votes: 1
+expanded_keys:
+  ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=: ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=
 

--- a/crates/sui-types/src/batch.rs
+++ b/crates/sui-types/src/batch.rs
@@ -111,7 +111,7 @@ impl Message for AuthorityBatch {
         Ok(())
     }
 
-    fn add_to_verification_obligation(&self, _: &mut VerificationObligation) -> SuiResult<()> {
+    fn add_to_verification_obligation(&self, _: &mut VerificationObligation<'_>) -> SuiResult<()> {
         Ok(())
     }
 }

--- a/crates/sui-types/src/committee.rs
+++ b/crates/sui-types/src/committee.rs
@@ -22,7 +22,9 @@ pub struct Committee {
     pub epoch: EpochId,
     pub voting_rights: Vec<(AuthorityName, StakeUnit)>,
     pub total_votes: StakeUnit,
-    #[serde(skip)]
+    // TODO: We should find a way to skip serializing this, and instead
+    // recompute it during deserialization. This is not a huge deal for now
+    // as commitees are pretty small in size.
     expanded_keys: HashMap<AuthorityName, AuthorityPublicKey>,
     #[serde(skip)]
     index_map: HashMap<AuthorityName, usize>,
@@ -120,13 +122,14 @@ impl Committee {
         self.epoch
     }
 
-    pub fn public_key(&self, authority: &AuthorityName) -> SuiResult<AuthorityPublicKey> {
+    pub fn public_key(&self, authority: &AuthorityName) -> SuiResult<&AuthorityPublicKey> {
         match self.expanded_keys.get(authority) {
             // TODO: Check if this is unnecessary copying.
-            Some(v) => Ok(v.clone()),
-            None => (*authority).try_into().map_err(|_| {
-                SuiError::InvalidCommittee(format!("Authority #{} not found", authority))
-            }),
+            Some(v) => Ok(v),
+            None => Err(SuiError::InvalidCommittee(format!(
+                "Authority #{} not found",
+                authority
+            ))),
         }
     }
 

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -678,10 +678,6 @@ impl SuiSignatureInner for Secp256k1SuiSignature {
     const LENGTH: usize = Secp256k1PublicKey::LENGTH + Secp256k1Signature::LENGTH + 1;
 }
 
-// impl Default for Secp256k1SuiSignature {
-//     []
-// }
-
 impl SuiPublicKey for Secp256k1PublicKey {
     const SIGNATURE_SCHEME: SignatureScheme = SignatureScheme::Secp256k1;
 }
@@ -775,13 +771,6 @@ pub trait SuiSignature: Sized + signature::Signature {
     fn verify<T>(&self, value: &T, author: SuiAddress) -> SuiResult<()>
     where
         T: Signable<Vec<u8>>;
-
-    fn add_to_verification_obligation_or_verify(
-        &self,
-        author: SuiAddress,
-        obligation: &mut VerificationObligation,
-        idx: usize,
-    ) -> SuiResult<()>;
 }
 
 impl<S: SuiSignatureInner + Sized> SuiSignature for S {
@@ -797,25 +786,6 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
             .map_err(|_| SuiError::InvalidSignature {
                 error: "hello".to_string(),
             })
-    }
-
-    fn add_to_verification_obligation_or_verify(
-        &self,
-        author: SuiAddress,
-        obligation: &mut VerificationObligation,
-        idx: usize,
-    ) -> SuiResult<()> {
-        let (sig, pk) = self.get_verification_inputs(author)?;
-        match obligation.add_signature_and_public_key(sig.clone(), pk.clone(), idx) {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                let msg = &obligation.messages[idx][..];
-                pk.verify(msg, &sig)
-                    .map_err(|_| SuiError::InvalidSignature {
-                        error: err.to_string(),
-                    })
-            }
-        }
     }
 
     fn signature_bytes(&self) -> &[u8] {
@@ -839,10 +809,10 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
 pub trait AuthoritySignInfoTrait: private::SealedAuthoritySignInfoTrait {
     fn verify<T: Signable<Vec<u8>>>(&self, data: &T, committee: &Committee) -> SuiResult;
 
-    fn add_to_verification_obligation(
+    fn add_to_verification_obligation<'a, 'b: 'a>(
         &self,
-        committee: &Committee,
-        obligation: &mut VerificationObligation,
+        committee: &'b Committee,
+        obligation: &mut VerificationObligation<'a>,
         message_index: usize,
     ) -> SuiResult<()>;
 }
@@ -854,10 +824,10 @@ impl AuthoritySignInfoTrait for EmptySignInfo {
         Ok(())
     }
 
-    fn add_to_verification_obligation(
+    fn add_to_verification_obligation<'a, 'b: 'a>(
         &self,
-        _committee: &Committee,
-        _obligation: &mut VerificationObligation,
+        _committee: &'b Committee,
+        _obligation: &mut VerificationObligation<'a>,
         _message_index: usize,
     ) -> SuiResult<()> {
         Ok(())
@@ -891,10 +861,10 @@ impl AuthoritySignInfoTrait for AuthoritySignInfo {
         add_to_verification_obligation_and_verify(self, data, committee)
     }
 
-    fn add_to_verification_obligation(
+    fn add_to_verification_obligation<'a, 'b: 'a>(
         &self,
-        committee: &Committee,
-        obligation: &mut VerificationObligation,
+        committee: &'b Committee,
+        obligation: &mut VerificationObligation<'a>,
         message_index: usize,
     ) -> SuiResult<()> {
         let weight = committee.weight(&self.authority);
@@ -982,10 +952,10 @@ impl<const STRONG_THRESHOLD: bool> AuthoritySignInfoTrait
         add_to_verification_obligation_and_verify(self, data, committee)
     }
 
-    fn add_to_verification_obligation(
+    fn add_to_verification_obligation<'a, 'b: 'a>(
         &self,
-        committee: &Committee,
-        obligation: &mut VerificationObligation,
+        committee: &'b Committee,
+        obligation: &mut VerificationObligation<'a>,
         message_index: usize,
     ) -> SuiResult<()> {
         // Check epoch
@@ -1222,14 +1192,14 @@ impl ToObligationSignature for AuthoritySignature {
 impl ToObligationSignature for Secp256k1Signature {}
 
 #[derive(Default)]
-pub struct VerificationObligation {
+pub struct VerificationObligation<'a> {
     pub messages: Vec<Vec<u8>>,
     pub signatures: Vec<AggregateAuthoritySignature>,
-    pub public_keys: Vec<Vec<AuthorityPublicKey>>,
+    pub public_keys: Vec<Vec<&'a AuthorityPublicKey>>,
 }
 
-impl VerificationObligation {
-    pub fn new() -> VerificationObligation {
+impl<'a> VerificationObligation<'a> {
+    pub fn new() -> VerificationObligation<'a> {
         VerificationObligation {
             ..Default::default()
         }
@@ -1250,44 +1220,12 @@ impl VerificationObligation {
         self.messages.len() - 1
     }
 
-    // Attempts to add signature and public key to the obligation. If this fails, ensure to call `verify` manually.
-    pub fn add_signature_and_public_key<
-        S: ToObligationSignature + Authenticator<PubKey = P>,
-        P: VerifyingKey<Sig = S>,
-    >(
-        &mut self,
-        signature: S,
-        public_key: P,
-        idx: usize,
-    ) -> SuiResult<()> {
-        match signature.to_obligation_signature(&public_key) {
-            ObligationSignature::AuthoritySig((sig, pubkey)) => {
-                self.public_keys
-                    .get_mut(idx)
-                    .ok_or(SuiError::InvalidAuthenticator)?
-                    .push(pubkey.clone());
-                self.signatures
-                    .get_mut(idx)
-                    .ok_or(SuiError::InvalidAuthenticator)?
-                    .add_signature(sig.clone())
-                    .map_err(|_| SuiError::InvalidSignature {
-                        error: "Failed to add signature to obligation".to_string(),
-                    })?;
-                Ok(())
-            }
-            ObligationSignature::None => Err(SuiError::SenderSigUnbatchable),
-        }
-    }
-
     pub fn verify_all(self) -> SuiResult<()> {
         AggregateAuthoritySignature::batch_verify(
-            &self
-                .signatures
-                .iter()
-                .collect::<Vec<&Ed25519AggregateSignature>>(),
+            &self.signatures.iter().collect::<Vec<_>>(),
             self.public_keys
                 .iter()
-                .map(|x| x.iter())
+                .map(|x| x.iter().copied())
                 .collect::<Vec<_>>(),
             &self.messages.iter().map(|x| &x[..]).collect::<Vec<_>>()[..],
         )
@@ -1313,7 +1251,7 @@ pub mod bcs_signable_test {
     use super::VerificationObligation;
 
     #[cfg(test)]
-    pub fn get_obligation_input<T>(value: &T) -> (VerificationObligation, usize)
+    pub fn get_obligation_input<T>(value: &T) -> (VerificationObligation<'_>, usize)
     where
         T: super::bcs_signable::BcsSignable,
     {

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -25,7 +25,7 @@ pub trait Message {
     /// to be verified. In most messages this function can be a noop.
     fn add_to_verification_obligation(
         &self,
-        obligation: &mut VerificationObligation,
+        obligation: &mut VerificationObligation<'_>,
     ) -> SuiResult<()>;
 }
 
@@ -75,10 +75,11 @@ where
     /// Add this message to `obligation` for verification.
     /// This allows batch verification. This message can be
     /// one of the many messages that need to be verified.
-    pub fn add_to_verification_obligation(
+    #[allow(dead_code)]
+    fn add_to_verification_obligation<'a, 'b: 'a>(
         &self,
-        committee: &Committee,
-        obligation: &mut VerificationObligation,
+        committee: &'b Committee,
+        obligation: &mut VerificationObligation<'a>,
     ) -> SuiResult<()> {
         self.data.add_to_verification_obligation(obligation)?;
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -538,25 +538,6 @@ pub struct SenderSignedData {
 }
 
 impl<S> TransactionEnvelope<S> {
-    #[allow(dead_code)]
-    fn add_sender_sig_to_verification_obligation(
-        &self,
-        obligation: &mut VerificationObligation,
-        idx: usize,
-    ) -> SuiResult<()> {
-        // We use this flag to see if someone has checked this before
-        // and therefore we can skip the check. Note that the flag has
-        // to be set to true manually, and is not set by calling this
-        // "check" function.
-        if self.is_verified || self.signed_data.data.kind.is_system_tx() {
-            return Ok(());
-        }
-
-        self.signed_data
-            .tx_signature
-            .add_to_verification_obligation_or_verify(self.signed_data.data.sender, obligation, idx)
-    }
-
     pub fn verify_sender_signature(&self) -> SuiResult<()> {
         if self.is_verified || self.signed_data.data.kind.is_system_tx() {
             return Ok(());


### PR DESCRIPTION
**Problem:** In Sui, we used to:
1. Deserialize Public Keys every time we want to verify a signature
2. Copy a Public Key twice every time we want to verify a signature (once from copying out of the 'committee' struct, the second time copying into the narwhal references function, which does not take in references)

This was probably fine with ed25519, where the public keys were already serialized bytes,  but BLS12381 stores public keys in some other form - which adds extra cost every time we copy/serialize the public keys. Note that this happened 30 times for each certificate.

**Fix:** This PR now instead allows the commitee struct to provide references to previously deserialized public keys. It also relies on another PR on narwhal that lets references of public keys to be passed in for verification.

Relies on: #3586 and https://github.com/MystenLabs/narwhal/pull/662