### PR TITLE
Add epoch query API to authorityAPI

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -999,6 +999,14 @@ impl AuthorityState {
         }
     }
 
+    pub fn handle_epoch_request(&self, request: &EpochRequest) -> SuiResult<EpochResponse> {
+        let epoch_info = match &request.epoch_id {
+            Some(id) => self.database.get_authenticated_epoch(id)?,
+            None => Some(self.database.get_latest_authenticated_epoch()),
+        };
+        Ok(EpochResponse { epoch_info })
+    }
+
     // TODO: This function takes both committee and genesis as parameter.
     // Technically genesis already contains committee information. Could consider merging them.
     pub async fn new(

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1354,6 +1354,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(())
     }
 
+    pub fn get_authenticated_epoch(
+        &self,
+        epoch_id: &EpochId,
+    ) -> SuiResult<Option<AuthenticatedEpoch>> {
+        Ok(self.tables.epochs.get(epoch_id)?)
+    }
+
     pub fn get_latest_authenticated_epoch(&self) -> AuthenticatedEpoch {
         self.tables
             .epochs

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -22,8 +22,8 @@ use sui_types::crypto::{get_key_pair, AuthorityKeyPair, AuthorityPublicKeyBytes}
 use sui_types::error::SuiError;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    CertifiedTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
-    TransactionInfoRequest, TransactionInfoResponse,
+    CertifiedTransaction, EpochRequest, EpochResponse, ObjectInfoRequest, ObjectInfoResponse,
+    Transaction, TransactionInfoRequest, TransactionInfoResponse,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::Object;
@@ -203,6 +203,10 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
         &self,
         _request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError> {
+        todo!();
+    }
+
+    async fn handle_epoch(&self, _request: EpochRequest) -> Result<EpochResponse, SuiError> {
         todo!();
     }
 }

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -201,13 +201,15 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
 
     async fn handle_checkpoint(
         &self,
-        _request: CheckpointRequest,
+        request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError> {
-        todo!();
+        let state = self.state.clone();
+        state.handle_checkpoint_request(&request)
     }
 
-    async fn handle_epoch(&self, _request: EpochRequest) -> Result<EpochResponse, SuiError> {
-        todo!();
+    async fn handle_epoch(&self, request: EpochRequest) -> Result<EpochResponse, SuiError> {
+        let state = self.state.clone();
+        state.handle_epoch_request(&request)
     }
 }
 

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -67,6 +67,8 @@ pub trait AuthorityAPI {
         &self,
         request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError>;
+
+    async fn handle_epoch(&self, request: EpochRequest) -> Result<EpochResponse, SuiError>;
 }
 
 pub type BatchInfoResponseItemStream = BoxStream<'static, Result<BatchInfoResponseItem, SuiError>>;
@@ -195,6 +197,14 @@ impl AuthorityAPI for NetworkAuthorityClient {
             .map(tonic::Response::into_inner)
             .map_err(Into::into)
     }
+
+    async fn handle_epoch(&self, request: EpochRequest) -> Result<EpochResponse, SuiError> {
+        self.client()
+            .epoch_info(request)
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(Into::into)
+    }
 }
 
 #[derive(Clone, Copy, Default)]
@@ -308,6 +318,12 @@ impl AuthorityAPI for LocalAuthorityClient {
         let state = self.state.clone();
 
         state.handle_checkpoint_request(&request)
+    }
+
+    async fn handle_epoch(&self, request: EpochRequest) -> Result<EpochResponse, SuiError> {
+        let state = self.state.clone();
+
+        state.handle_epoch_request(&request)
     }
 }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -438,4 +438,18 @@ impl Validator for ValidatorService {
 
         return Ok(tonic::Response::new(response));
     }
+
+    async fn epoch_info(
+        &self,
+        request: tonic::Request<EpochRequest>,
+    ) -> Result<tonic::Response<EpochResponse>, tonic::Status> {
+        let request = request.into_inner();
+
+        let response = self
+            .state
+            .handle_epoch_request(&request)
+            .map_err(|e| tonic::Status::internal(e.to_string()))?;
+
+        return Ok(tonic::Response::new(response));
+    }
 }

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -265,6 +265,7 @@ impl<C> SafeClient<C> {
 
     /// This function is used by the higher level authority logic to report an
     /// error that could be due to this authority.
+    /// TODO: Get rid of this. https://github.com/MystenLabs/sui/issues/3740
     pub fn report_client_error(&self, error: &SuiError) {
         info!(?error, authority =? self.address, "Client error");
     }

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -15,6 +15,7 @@ use sui_types::{
     error::{SuiError, SuiResult},
     messages::*,
 };
+use tap::TapFallible;
 use tracing::info;
 
 #[derive(Clone)]
@@ -580,5 +581,57 @@ where
             },
         ));
         Ok(Box::pin(stream))
+    }
+
+    fn verify_epoch(
+        &self,
+        requested_epoch_id: Option<EpochId>,
+        response: &EpochResponse,
+    ) -> SuiResult {
+        if let Some(epoch) = &response.epoch_info {
+            fp_ensure!(
+                requested_epoch_id.is_none() || requested_epoch_id == Some(epoch.epoch()),
+                SuiError::InvalidEpochResponse("Responded epoch number mismatch".to_string())
+            );
+        }
+        match (requested_epoch_id, &response.epoch_info) {
+            (None, None) => Err(SuiError::InvalidEpochResponse(
+                "Latest epoch must not be None".to_string(),
+            )),
+            (Some(epoch_id), None) => {
+                fp_ensure!(
+                    epoch_id != 0,
+                    SuiError::InvalidEpochResponse("Genesis epoch must be available".to_string())
+                );
+                Ok(())
+            }
+            (_, Some(AuthenticatedEpoch::Genesis(_))) => {
+                // TODO: Verify the epoch data using genesis committee
+                Ok(())
+            }
+            (_, Some(AuthenticatedEpoch::Signed(_))) => {
+                // TODO: Verify the epoch data using previous committee
+                Ok(())
+            }
+            (_, Some(AuthenticatedEpoch::Certified(_))) => {
+                // TODO: Verify the epoch data using previous committee
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn handle_epoch(&self, request: EpochRequest) -> Result<EpochResponse, SuiError> {
+        let epoch_id = request.epoch_id;
+        let authority = self.address;
+        let response = self.authority_client.handle_epoch(request).await?;
+        self.verify_epoch(epoch_id, &response)
+            .map_err(|err| SuiError::ByzantineAuthoritySuspicion {
+                authority,
+                reason: err.to_string(),
+            })
+            .tap_err(|err| {
+                self.report_client_error(err);
+            })?;
+        Ok(response)
     }
 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -952,6 +952,10 @@ async fn test_quorum_once_with_timeout() {
         ) -> Result<CheckpointResponse, SuiError> {
             unreachable!();
         }
+
+        async fn handle_epoch(&self, _request: EpochRequest) -> Result<EpochResponse, SuiError> {
+            unreachable!()
+        }
     }
 
     let count = Arc::new(Mutex::new(0));

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -681,7 +681,7 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         &self,
         _request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError> {
-        unimplemented!();
+        unimplemented!()
     }
 
     async fn handle_epoch(&self, _request: EpochRequest) -> Result<EpochResponse, SuiError> {

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -27,8 +27,8 @@ use std::fs;
 use std::sync::Arc;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    CertifiedTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
-    TransactionInfoRequest, TransactionInfoResponse,
+    CertifiedTransaction, EpochRequest, EpochResponse, ObjectInfoRequest, ObjectInfoResponse,
+    Transaction, TransactionInfoRequest, TransactionInfoResponse,
 };
 use sui_types::object::Object;
 
@@ -565,6 +565,10 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         unimplemented!();
     }
 
+    async fn handle_epoch(&self, _request: EpochRequest) -> Result<EpochResponse, SuiError> {
+        unimplemented!()
+    }
+
     /// Handle Batch information requests for this authority.
     async fn handle_batch_stream(
         &self,
@@ -678,6 +682,10 @@ impl AuthorityAPI for ByzantineAuthorityClient {
         _request: CheckpointRequest,
     ) -> Result<CheckpointResponse, SuiError> {
         unimplemented!();
+    }
+
+    async fn handle_epoch(&self, _request: EpochRequest) -> Result<EpochResponse, SuiError> {
+        unimplemented!()
     }
 
     /// Handle Batch information requests for this authority.

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -83,6 +83,15 @@ fn main() -> Result<()> {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            Method::builder()
+                .name("epoch_info")
+                .route_name("Epoch")
+                .input_type("sui_types::messages::EpochRequest")
+                .output_type("sui_types::messages::EpochResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     Builder::new()

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -397,6 +397,12 @@ pub enum SuiError {
 
     #[error("Invalid committee composition")]
     InvalidCommittee(String),
+
+    #[error("Invalid authenticated epoch: {0}")]
+    InvalidAuthenticatedEpoch(String),
+
+    #[error("Invalid epoch request response: {0}")]
+    InvalidEpochResponse(String),
 }
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;


### PR DESCRIPTION
Add an API to AuthorityAPI that can request authenticated epoch data structure.
Cannot add the proper verify function in SafeClient yet, because that depends on hooking up the SafeClient and the state store in order to fetch the committee.