### PR TITLE
[cluster test] allow to test faucet locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6940,6 +6940,7 @@ dependencies = [
  "bcs",
  "clap 3.1.18",
  "futures",
+ "prometheus",
  "reqwest",
  "serde 1.0.141",
  "serde_json",
@@ -6957,6 +6958,7 @@ dependencies = [
  "test-utils",
  "tokio",
  "tracing",
+ "uuid",
  "workspace-hack 0.1.0",
 ]
 

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -19,6 +19,8 @@ telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", re
 async-trait = "0.1.57"
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
+uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
+prometheus = "0.13.1"
 
 sui-faucet = { path = "../sui-faucet" }
 sui-swarm = { path = "../sui-swarm" }

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -83,12 +83,12 @@ impl TestContext {
 
     pub async fn setup(options: ClusterTestOpt) -> Result<Self, anyhow::Error> {
         let cluster = ClusterFactory::start(&options).await?;
-        let faucet_url = cluster.faucet_url().map(String::from);
         let wallet_client = WalletClient::new_from_cluster(&cluster).await;
+        let faucet = FaucetClientFactory::new_from_cluster(&cluster).await;
         Ok(Self {
             cluster,
             client: wallet_client,
-            faucet: FaucetClientFactory::create(&options, faucet_url),
+            faucet,
         })
     }
 
@@ -96,7 +96,7 @@ impl TestContext {
     // A potential way to do this is to subscribe to txns from fullnode
     // when the feature is ready
     pub async fn let_fullnode_sync(&self) {
-        let duration = Duration::from_secs(10);
+        let duration = Duration::from_secs(5);
         sleep(duration).await;
     }
 }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 
 use crate::metrics::FaucetMetrics;
 use prometheus::Registry;
-use sui::client_commands::WalletContext;
+use sui::client_commands::{SuiClientCommands, WalletContext};
 use sui_json_rpc_types::{
     SuiExecutionStatus, SuiTransactionKind, SuiTransferSui, TransactionEffectsResponse,
 };
@@ -47,6 +47,14 @@ impl SimpleFaucet {
             .active_address()
             .map_err(|err| FaucetError::Wallet(err.to_string()))?;
         info!("SimpleFaucet::new with active address: {active_address}");
+
+        // Sync to have the latest status
+        SuiClientCommands::SyncClientState {
+            address: Some(active_address),
+        }
+        .execute(&mut wallet)
+        .await
+        .map_err(|err| FaucetError::Wallet(format!("Fail to sync client state: {}", err)))?;
 
         let coins = wallet
             .gas_objects(active_address)

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -17,7 +17,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use sui::client_commands::{SuiClientCommands, WalletContext};
+use sui::client_commands::WalletContext;
 use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
 use sui_faucet::{Faucet, FaucetRequest, FaucetResponse, SimpleFaucet};
 use tower::ServiceBuilder;
@@ -166,26 +166,9 @@ async fn request_gas(
 }
 
 async fn create_wallet_context() -> Result<WalletContext, anyhow::Error> {
-    // Create Wallet context.
     let wallet_conf = sui_config_dir()?.join(SUI_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {:?}", wallet_conf);
-    let mut context = WalletContext::new(&wallet_conf).await?;
-    let address = context
-        .keystore
-        .addresses()
-        .first()
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Empty wallet context!"))?;
-
-    info!(?address, "Sync client states");
-    // Sync client to retrieve objects from the network.
-    SuiClientCommands::SyncClientState {
-        address: Some(address),
-    }
-    .execute(&mut context)
-    .await
-    .map_err(|err| anyhow::anyhow!("Fail to sync client state: {}", err))?;
-    Ok(context)
+    WalletContext::new(&wallet_conf).await
 }
 
 async fn handle_error(error: BoxError) -> impl IntoResponse {

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -185,6 +185,11 @@ impl Swarm {
         &self.network_config
     }
 
+    /// Return a mutable reference to this Swarm's `NetworkConfig`.
+    pub fn config_mut(&mut self) -> &mut NetworkConfig {
+        &mut self.network_config
+    }
+
     /// Attempt to lookup and return a shared reference to the Validator with the provided `name`.
     pub fn validator(&self, name: SuiAddress) -> Option<&Node> {
         self.validators.get(&name)


### PR DESCRIPTION
We implement a `LocalFaucetClient` that starts an in-process faucet server instance (without the http server) for the local cluster test. This faucet holds the key and the wealth that is created during genesis. 

This PR only has a bunch of refactoring to reuse code.