### PR TITLE
[Typescript SDK] Add getObjectRef and getGasObjectsOwnedByAddress

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -73,9 +73,9 @@ export function isTransferSuiTransaction(obj: any, _argumentName?: string): obj 
             typeof obj === "function") &&
         isTransactionDigest(obj.suiObjectId) as boolean &&
         isSequenceNumber(obj.gasBudget) as boolean &&
-        isTransactionDigest(obj.recipient) as boolean && 
-        (typeof obj.amount === "undefined" || 
-            isSequenceNumber(obj.amount))
+        isTransactionDigest(obj.recipient) as boolean &&
+        (typeof obj.amount === "undefined" ||
+            isSequenceNumber(obj.amount) as boolean)
     )
 }
 
@@ -151,6 +151,7 @@ export function isTxnDataSerializer(obj: any, _argumentName?: string): obj is Tx
             typeof obj === "object" ||
             typeof obj === "function") &&
         typeof obj.newTransferObject === "function" &&
+        typeof obj.newTransferSui === "function" &&
         typeof obj.newMoveCall === "function" &&
         typeof obj.newMergeCoin === "function" &&
         typeof obj.newSplitCoin === "function" &&

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -20,6 +20,7 @@ import {
   TransactionResponse,
   SuiObjectRef,
   getObjectReference,
+  Coin,
 } from '../types';
 
 const isNumber = (val: any): val is number => typeof val === 'number';
@@ -61,6 +62,11 @@ export class JsonRpcProvider extends Provider {
       acc[type] ? acc[type].push(val) : (acc[type] = [val]);
       return acc;
     }, {});
+  }
+
+  async getGasObjectsOwnedByAddress(address: string): Promise<SuiObjectInfo[]> {
+    const objects = await this.getObjectsOwnedByAddress(address);
+    return objects.filter((obj: SuiObjectInfo) => Coin.isSUI(obj));
   }
 
   async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -52,6 +52,17 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
+  async getObjectsOwnedByAddressGroupByType(
+    address: string
+  ): Promise<{ [key: string]: SuiObjectInfo[] }> {
+    const objects = await this.getObjectsOwnedByAddress(address);
+    return objects.reduce((acc: any, val: SuiObjectInfo) => {
+      let type = val.type;
+      acc[type] ? acc[type].push(val) : (acc[type] = [val]);
+      return acc;
+    }, {});
+  }
+
   async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {
     try {
       return await this.client.requestWithType(

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -18,6 +18,8 @@ import {
   TransactionDigest,
   TransactionEffectsResponse,
   TransactionResponse,
+  SuiObjectRef,
+  getObjectReference,
 } from '../types';
 
 const isNumber = (val: any): val is number => typeof val === 'number';
@@ -74,6 +76,11 @@ export class JsonRpcProvider extends Provider {
     } catch (err) {
       throw new Error(`Error fetching object info: ${err} for id ${objectId}`);
     }
+  }
+
+  async getObjectRef(objectId: string): Promise<SuiObjectRef | undefined> {
+    const resp = await this.getObject(objectId);
+    return getObjectReference(resp);
   }
 
   async getObjectBatch(objectIds: string[]): Promise<GetObjectDataResponse[]> {

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -53,17 +53,6 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async getObjectsOwnedByAddressGroupByType(
-    address: string
-  ): Promise<{ [key: string]: SuiObjectInfo[] }> {
-    const objects = await this.getObjectsOwnedByAddress(address);
-    return objects.reduce((acc: any, val: SuiObjectInfo) => {
-      let type = val.type;
-      acc[type] ? acc[type].push(val) : (acc[type] = [val]);
-      return acc;
-    }, {});
-  }
-
   async getGasObjectsOwnedByAddress(address: string): Promise<SuiObjectInfo[]> {
     const objects = await this.getObjectsOwnedByAddress(address);
     return objects.filter((obj: SuiObjectInfo) => Coin.isSUI(obj));

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -22,6 +22,13 @@ export abstract class Provider {
   ): Promise<SuiObjectInfo[]>;
 
   /**
+   * Get all objects owned by an address and grouped by object type
+   */
+  abstract getObjectsOwnedByAddressGroupByType(
+    address: string
+  ): Promise<{ [key: string]: SuiObjectInfo[] }>;
+
+  /**
    * Get details about an object
    */
   abstract getObject(objectId: string): Promise<GetObjectDataResponse>;

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -29,6 +29,13 @@ export abstract class Provider {
   ): Promise<{ [key: string]: SuiObjectInfo[] }>;
 
   /**
+   * Convenience method for getting all gas objects(SUI Tokens) owned by an address
+   */
+  abstract getGasObjectsOwnedByAddress(
+    _address: string
+  ): Promise<SuiObjectInfo[]>;
+
+  /**
    * Get details about an object
    */
   abstract getObject(objectId: string): Promise<GetObjectDataResponse>;

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -22,13 +22,6 @@ export abstract class Provider {
   ): Promise<SuiObjectInfo[]>;
 
   /**
-   * Get all objects owned by an address and grouped by object type
-   */
-  abstract getObjectsOwnedByAddressGroupByType(
-    address: string
-  ): Promise<{ [key: string]: SuiObjectInfo[] }>;
-
-  /**
    * Convenience method for getting all gas objects(SUI Tokens) owned by an address
    */
   abstract getGasObjectsOwnedByAddress(

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -7,6 +7,7 @@ import {
   GatewayTxSeqNumber,
   GetTxnDigestsResponse,
   TransactionResponse,
+  SuiObjectRef,
 } from '../types';
 
 ///////////////////////////////
@@ -24,6 +25,12 @@ export abstract class Provider {
    * Get details about an object
    */
   abstract getObject(objectId: string): Promise<GetObjectDataResponse>;
+
+  /**
+   * Get object reference(id, tx digest, version id)
+   * @param objectId
+   */
+  abstract getObjectRef(objectId: string): Promise<SuiObjectRef | undefined>;
 
   // Transactions
   /**

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -16,7 +16,13 @@ import { Provider } from './provider';
 export class VoidProvider extends Provider {
   // Objects
   async getObjectsOwnedByAddress(_address: string): Promise<SuiObjectInfo[]> {
-    throw this.newError('getOwnedObjects');
+    throw this.newError('getObjectsOwnedByAddress');
+  }
+
+  async getObjectsOwnedByAddressGroupByType(
+    _address: string
+  ): Promise<{ [key: string]: SuiObjectInfo[] }> {
+    throw this.newError('getObjectsOwnedByAddressGroupByType');
   }
 
   async getObject(_objectId: string): Promise<GetObjectDataResponse> {

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -25,6 +25,12 @@ export class VoidProvider extends Provider {
     throw this.newError('getObjectsOwnedByAddressGroupByType');
   }
 
+  async getGasObjectsOwnedByAddress(
+    _address: string
+  ): Promise<SuiObjectInfo[]> {
+    throw this.newError('getGasObjectsOwnedByAddress');
+  }
+
   async getObject(_objectId: string): Promise<GetObjectDataResponse> {
     throw this.newError('getObject');
   }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -19,12 +19,6 @@ export class VoidProvider extends Provider {
     throw this.newError('getObjectsOwnedByAddress');
   }
 
-  async getObjectsOwnedByAddressGroupByType(
-    _address: string
-  ): Promise<{ [key: string]: SuiObjectInfo[] }> {
-    throw this.newError('getObjectsOwnedByAddressGroupByType');
-  }
-
   async getGasObjectsOwnedByAddress(
     _address: string
   ): Promise<SuiObjectInfo[]> {

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -9,6 +9,7 @@ import {
   SuiObjectInfo,
   GetObjectDataResponse,
   TransactionResponse,
+  SuiObjectRef,
 } from '../types';
 import { Provider } from './provider';
 
@@ -20,6 +21,10 @@ export class VoidProvider extends Provider {
 
   async getObject(_objectId: string): Promise<GetObjectDataResponse> {
     throw this.newError('getObject');
+  }
+
+  async getObjectRef(_objectId: string): Promise<SuiObjectRef | undefined> {
+    throw this.newError('getObjectRef');
   }
 
   // Transactions

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -1,22 +1,48 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getObjectFields, GetObjectDataResponse } from './objects';
+import {
+  getObjectFields,
+  GetObjectDataResponse,
+  SuiMoveObject,
+  SuiObjectInfo,
+} from './objects';
 
 import { getMoveObjectType } from './objects';
 
 import BN from 'bn.js';
+
+const COIN_TYPE = '0x2::coin::Coin';
+const COIN_TYPE_ARG_REGEX = /^0x2::coin::Coin<(.+)>$/;
+
+type ObjectData = GetObjectDataResponse | SuiMoveObject | SuiObjectInfo;
 
 /**
  * Utility class for 0x2::coin
  * as defined in https://github.com/MystenLabs/sui/blob/ca9046fd8b1a9e8634a4b74b0e7dabdc7ea54475/sui_programmability/framework/sources/Coin.move#L4
  */
 export class Coin {
-  static isCoin(data: GetObjectDataResponse): boolean {
-    return getMoveObjectType(data)?.startsWith('0x2::coin::Coin') ?? false;
+  static isCoin(data: ObjectData): boolean {
+    return Coin.getType(data)?.startsWith(COIN_TYPE) ?? false;
   }
 
-  static getBalance(data: GetObjectDataResponse): BN | undefined {
+  static getCoinTypeArg(obj: ObjectData) {
+    const res = Coin.getType(obj)?.match(COIN_TYPE_ARG_REGEX);
+    return res ? res[1] : null;
+  }
+
+  static isSUI(obj: ObjectData) {
+    const arg = Coin.getCoinTypeArg(obj);
+    return arg ? Coin.getCoinSymbol(arg) === 'SUI' : false;
+  }
+
+  static getCoinSymbol(coinTypeArg: string) {
+    return coinTypeArg.substring(coinTypeArg.lastIndexOf(':') + 1);
+  }
+
+  static getBalance(
+    data: GetObjectDataResponse | SuiMoveObject
+  ): BN | undefined {
     if (!Coin.isCoin(data)) {
       return undefined;
     }
@@ -26,5 +52,12 @@ export class Coin {
 
   static getZero(): BN {
     return new BN.BN('0', 10);
+  }
+
+  private static getType(data: ObjectData): string | undefined {
+    if ('status' in data) {
+      return getMoveObjectType(data);
+    }
+    return data.type;
   }
 }

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -152,8 +152,11 @@ export function getMoveObjectType(
 }
 
 export function getObjectFields(
-  resp: GetObjectDataResponse
+  resp: GetObjectDataResponse | SuiMoveObject
 ): ObjectContentFields | undefined {
+  if ('fields' in resp) {
+    return resp.fields;
+  }
   return getMoveObject(resp)?.fields;
 }
 

--- a/sdk/typescript/test/types/transactions.test.ts
+++ b/sdk/typescript/test/types/transactions.test.ts
@@ -8,10 +8,11 @@ import { isTransactionResponse } from '../../src/index.guard';
 describe('Test Transaction Definition', () => {
   it('Test against different transaction definitions', () => {
     const txns = mockTransactionData;
-    
+
     expect(isTransactionResponse(txns['move_call'])).toBeTruthy();
     expect(isTransactionResponse(txns['transfer'])).toBeTruthy();
     expect(isTransactionResponse(txns['coin_split'])).toBeTruthy();
+    expect(isTransactionResponse(txns['transfer_sui'])).toBeTruthy();
     // TODO: add mock data for failed transaction
     // expect(
     //   isTransactionEffectsResponse(txns['fail'])


### PR DESCRIPTION
Adding a few util methods to the TS-SDK
- getObjectRef
- getGasObjectsOwnedByAddress
- Coin.isSUI

These methods will be useful for client side transaction construction. But they are quite inefficient as they require a roundtrip to the RPC server, regardless of whether the data exists locally, I will implement a new provider that caches the data in a subsequent PR.