### PR TITLE
[Typescript SDK] construct MoveCall without gateway

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,7 @@
 # we don't want an equality to fail because of line endings.
 crates/sui-core/tests/staged/sui.yaml text eol=lf
 crates/sui-open-rpc/spec/openrpc.json text eol=lf
+sui_core/tests/staged/sui.yaml text eol=lf
+
+# These files is auto generated
+sdk/typescript/src/index.guard.ts linguist-generated=true

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -336,6 +336,7 @@ impl TransactionData {
         TransactionData {
             kind,
             sender,
+            // TODO: Update local-txn-data-serializer.ts if `gas_price` is changed
             gas_price: 1,
             gas_payment,
             gas_budget,

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -66,6 +66,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
+    "@mysten/bcs": "^0.2.0",
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.5",

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, TransferObjectTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 import { BN } from "bn.js";
 import { Base64DataBuffer } from "./serialization/base64";
 import { PublicKey } from "./cryptography/publickey";
@@ -123,14 +123,22 @@ export function isMoveCallTransaction(obj: any, _argumentName?: string): obj is 
         isTransactionDigest(obj.packageObjectId) as boolean &&
         isTransactionDigest(obj.module) as boolean &&
         isTransactionDigest(obj.function) as boolean &&
-        Array.isArray(obj.typeArguments) &&
-        obj.typeArguments.every((e: any) =>
-            isTransactionDigest(e) as boolean
-        ) &&
-        Array.isArray(obj.arguments) &&
-        obj.arguments.every((e: any) =>
-            isSuiJsonValue(e) as boolean
-        ) &&
+        (Array.isArray(obj.typeArguments) &&
+            obj.typeArguments.every((e: any) =>
+                isTransactionDigest(e) as boolean
+            ) ||
+            Array.isArray(obj.typeArguments) &&
+            obj.typeArguments.every((e: any) =>
+                isTypeTag(e) as boolean
+            )) &&
+        (Array.isArray(obj.arguments) &&
+            obj.arguments.every((e: any) =>
+                isSuiJsonValue(e) as boolean
+            ) ||
+            Array.isArray(obj.arguments) &&
+            obj.arguments.every((e: any) =>
+                isCallArg(e) as boolean
+            )) &&
         (typeof obj.gasPayment === "undefined" ||
             isTransactionDigest(obj.gasPayment) as boolean) &&
         isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean
@@ -1032,5 +1040,174 @@ export function isSuiParsedTransactionResponse(obj: any, _argumentName?: string)
                 typeof obj === "object" ||
                 typeof obj === "function") &&
             isSuiParsedPublishResponse(obj.Publish) as boolean)
+    )
+}
+
+export function isTransferObjectTx(obj: any, _argumentName?: string): obj is TransferObjectTx {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.TransferObject !== null &&
+            typeof obj.TransferObject === "object" ||
+            typeof obj.TransferObject === "function") &&
+        isTransactionDigest(obj.TransferObject.recipient) as boolean &&
+        isSuiObjectRef(obj.TransferObject.object_ref) as boolean
+    )
+}
+
+export function isPublishTx(obj: any, _argumentName?: string): obj is PublishTx {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.Publish !== null &&
+            typeof obj.Publish === "object" ||
+            typeof obj.Publish === "function") &&
+        (obj.Publish.modules !== null &&
+            typeof obj.Publish.modules === "object" ||
+            typeof obj.Publish.modules === "function") &&
+        typeof obj.Publish.modules["__@iterator"] === "function"
+    )
+}
+
+export function isObjectArg(obj: any, _argumentName?: string): obj is ObjectArg {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            isSuiObjectRef(obj.ImmOrOwned) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isTransactionDigest(obj.Shared) as boolean)
+    )
+}
+
+export function isCallArg(obj: any, _argumentName?: string): obj is CallArg {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            (obj.Pure !== null &&
+                typeof obj.Pure === "object" ||
+                typeof obj.Pure === "function") &&
+            typeof obj.Pure["__@iterator"] === "function" ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isObjectArg(obj.Object) as boolean)
+    )
+}
+
+export function isStructTag(obj: any, _argumentName?: string): obj is StructTag {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isTransactionDigest(obj.address) as boolean &&
+        isTransactionDigest(obj.module) as boolean &&
+        isTransactionDigest(obj.name) as boolean &&
+        Array.isArray(obj.typeParams) &&
+        obj.typeParams.every((e: any) =>
+            isTypeTag(e) as boolean
+        )
+    )
+}
+
+export function isTypeTag(obj: any, _argumentName?: string): obj is TypeTag {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            obj.bool === null ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            obj.u8 === null ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            obj.u64 === null ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            obj.u128 === null ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            obj.address === null ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            obj.signer === null ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isTypeTag(obj.vector) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            isStructTag(obj.struct) as boolean)
+    )
+}
+
+export function isMoveCallTx(obj: any, _argumentName?: string): obj is MoveCallTx {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.Call !== null &&
+            typeof obj.Call === "object" ||
+            typeof obj.Call === "function") &&
+        isSuiObjectRef(obj.Call.package) as boolean &&
+        isTransactionDigest(obj.Call.module) as boolean &&
+        isTransactionDigest(obj.Call.function) as boolean &&
+        Array.isArray(obj.Call.typeArguments) &&
+        obj.Call.typeArguments.every((e: any) =>
+            isTypeTag(e) as boolean
+        ) &&
+        Array.isArray(obj.Call.arguments) &&
+        obj.Call.arguments.every((e: any) =>
+            isCallArg(e) as boolean
+        )
+    )
+}
+
+export function isTransaction(obj: any, _argumentName?: string): obj is Transaction {
+    return (
+        (isTransferObjectTx(obj) as boolean ||
+            isPublishTx(obj) as boolean ||
+            isMoveCallTx(obj) as boolean)
+    )
+}
+
+export function isTransactionKind(obj: any, _argumentName?: string): obj is TransactionKind {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            isTransaction(obj.Single) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            Array.isArray(obj.Batch) &&
+            obj.Batch.every((e: any) =>
+                isTransaction(e) as boolean
+            ))
+    )
+}
+
+export function isTransactionData(obj: any, _argumentName?: string): obj is TransactionData {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (typeof obj.sender === "undefined" ||
+            isTransactionDigest(obj.sender) as boolean) &&
+        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean &&
+        isSuiMoveTypeParameterIndex(obj.gasPrice) as boolean &&
+        isTransactionKind(obj.kind) as boolean &&
+        isSuiObjectRef(obj.gasPayment) as boolean
     )
 }

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse } from "./index";
 import { BN } from "bn.js";
 import { Base64DataBuffer } from "./serialization/base64";
 import { PublicKey } from "./cryptography/publickey";
@@ -728,7 +728,7 @@ export function isSuiTransactionKind(obj: any, _argumentName?: string): obj is S
     )
 }
 
-export function isTransactionData(obj: any, _argumentName?: string): obj is TransactionData {
+export function isSuiTransactionData(obj: any, _argumentName?: string): obj is SuiTransactionData {
     return (
         (obj !== null &&
             typeof obj === "object" ||
@@ -768,7 +768,7 @@ export function isCertifiedTransaction(obj: any, _argumentName?: string): obj is
             typeof obj === "object" ||
             typeof obj === "function") &&
         isTransactionDigest(obj.transactionDigest) as boolean &&
-        isTransactionData(obj.data) as boolean &&
+        isSuiTransactionData(obj.data) as boolean &&
         isTransactionDigest(obj.txSignature) as boolean &&
         isAuthorityQuorumSignInfo(obj.authSignInfo) as boolean
     )

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -13,6 +13,7 @@ export * from './serialization/hex';
 
 export * from './signers/txn-data-serializers/rpc-txn-data-serializer';
 export * from './signers/txn-data-serializers/txn-data-serializer';
+export * from './signers/txn-data-serializers/local-txn-data-serializer';
 
 export * from './signers/signer';
 export * from './signers/raw-signer';

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -7,6 +7,7 @@ export * from './cryptography/publickey';
 
 export * from './providers/provider';
 export * from './providers/json-rpc-provider';
+export * from './providers/json-rpc-provider-with-cache';
 
 export * from './serialization/base64';
 export * from './serialization/hex';

--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SignatureScheme } from '../cryptography/publickey';
+import { isSuiObjectRef } from '../index.guard';
+import {
+  GetObjectDataResponse,
+  SuiObjectInfo,
+  SuiTransactionResponse,
+  SuiObjectRef,
+  getObjectReference,
+  TransactionEffects,
+  normalizeSuiObjectId,
+} from '../types';
+import { JsonRpcProvider } from './json-rpc-provider';
+
+export class JsonRpcProviderWithCache extends JsonRpcProvider {
+  /**
+   * A list of object references which are being tracked.
+   *
+   * Whenever an object is fetched or updated within the transaction,
+   * its record gets updated.
+   */
+  private objectRefs: Map<string, SuiObjectRef> = new Map();
+
+  // Objects
+  async getObjectsOwnedByAddress(address: string): Promise<SuiObjectInfo[]> {
+    const resp = await super.getObjectsOwnedByAddress(address);
+    resp.forEach(r => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {
+    const resp = await super.getObjectsOwnedByObject(objectId);
+    resp.forEach(r => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  async getObject(objectId: string): Promise<GetObjectDataResponse> {
+    const resp = await super.getObject(objectId);
+    this.updateObjectRefCache(resp);
+    return resp;
+  }
+
+  async getObjectRef(
+    objectId: string,
+    skipCache = false
+  ): Promise<SuiObjectRef | undefined> {
+    const normalizedId = normalizeSuiObjectId(objectId);
+    if (!skipCache && this.objectRefs.has(normalizedId)) {
+      return this.objectRefs.get(normalizedId);
+    }
+
+    const ref = await super.getObjectRef(objectId);
+    this.updateObjectRefCache(ref);
+    return ref;
+  }
+
+  async getObjectBatch(objectIds: string[]): Promise<GetObjectDataResponse[]> {
+    const resp = await super.getObjectBatch(objectIds);
+    resp.forEach(r => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  // Transactions
+  async executeTransaction(
+    txnBytes: string,
+    signatureScheme: SignatureScheme,
+    signature: string,
+    pubkey: string
+  ): Promise<SuiTransactionResponse> {
+    const resp = await super.executeTransaction(
+      txnBytes,
+      signatureScheme,
+      signature,
+      pubkey
+    );
+
+    this.updateObjectRefCacheFromTransactionEffects(resp.effects);
+    return resp;
+  }
+
+  private updateObjectRefCache(
+    newData: GetObjectDataResponse | SuiObjectRef | undefined
+  ) {
+    if (newData == null) {
+      return;
+    }
+    const ref = isSuiObjectRef(newData) ? newData : getObjectReference(newData);
+    if (ref != null) {
+      this.objectRefs.set(ref.objectId, ref);
+    }
+  }
+
+  private updateObjectRefCacheFromTransactionEffects(
+    effects: TransactionEffects
+  ) {
+    effects.created?.forEach(r => this.updateObjectRefCache(r.reference));
+    effects.mutated?.forEach(r => this.updateObjectRefCache(r.reference));
+    effects.unwrapped?.forEach(r => this.updateObjectRefCache(r.reference));
+    effects.wrapped?.forEach(r => this.updateObjectRefCache(r));
+    effects.deleted?.forEach(r => this.objectRefs.delete(r.objectId));
+  }
+}

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -36,7 +36,7 @@ const isNumber = (val: any): val is number => typeof val === 'number';
 const isAny = (_val: any): _val is any => true;
 
 export class JsonRpcProvider extends Provider {
-  private client: JsonRpcClient;
+  protected client: JsonRpcClient;
 
   /**
    * Establish a connection to a Sui Gateway endpoint

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Base64DataBuffer } from '../../serialization/base64';
+import {
+  CallArg,
+  MoveCallTx,
+  registerTypes,
+  SuiAddress,
+  TransactionData,
+  TypeTag,
+} from '../../types';
+import { bcs as BCS } from '@mysten/bcs';
+import {
+  MoveCallTransaction,
+  MergeCoinTransaction,
+  SplitCoinTransaction,
+  TransferObjectTransaction,
+  TransferSuiTransaction,
+  PublishTransaction,
+  TxnDataSerializer,
+} from './txn-data-serializer';
+import { Provider } from '../../providers/provider';
+
+// For commonjs scenario need to figure out how to do it differently
+const bcs = registerTypes(BCS);
+export { bcs };
+
+export class LocalTxnDataSerializer implements TxnDataSerializer {
+  /**
+   * Need a provider to fetch the latest object reference. Ideally the provider
+   * should cache the object reference locally
+   */
+  constructor(private provider: Provider) {}
+
+  async newTransferObject(
+    _signerAddress: SuiAddress,
+    _t: TransferObjectTransaction
+  ): Promise<Base64DataBuffer> {
+    throw new Error('Not implemented');
+  }
+
+  async newTransferSui(
+    _signerAddress: SuiAddress,
+    _t: TransferSuiTransaction
+  ): Promise<Base64DataBuffer> {
+    throw new Error('Not implemented');
+  }
+
+  async newMoveCall(
+    signerAddress: SuiAddress,
+    t: MoveCallTransaction
+  ): Promise<Base64DataBuffer> {
+    try {
+      const pkg = await this.provider.getObjectRef(t.packageObjectId);
+      const tx = {
+        Call: {
+          package: pkg!,
+          module: t.module,
+          function: t.function,
+          typeArguments: t.typeArguments as TypeTag[],
+          arguments: t.arguments as CallArg[],
+        },
+      };
+
+      return await this.constructTransactionData(
+        tx,
+        t.gasPayment!,
+        t.gasBudget,
+        signerAddress
+      );
+    } catch (err) {
+      throw new Error(`Error executing a move call: ${err} with args ${t}`);
+    }
+  }
+
+  async newMergeCoin(
+    _signerAddress: SuiAddress,
+    _t: MergeCoinTransaction
+  ): Promise<Base64DataBuffer> {
+    throw new Error('Not implemented');
+  }
+
+  async newSplitCoin(
+    _signerAddress: SuiAddress,
+    _t: SplitCoinTransaction
+  ): Promise<Base64DataBuffer> {
+    throw new Error('Not implemented');
+  }
+
+  async newPublish(
+    _signerAddress: SuiAddress,
+    _t: PublishTransaction
+  ): Promise<Base64DataBuffer> {
+    throw new Error('Not implemented');
+  }
+
+  private async constructTransactionData(
+    tx: MoveCallTx,
+    gasObjectId: string,
+    gasBudget: number,
+    signerAddress: SuiAddress
+  ): Promise<Base64DataBuffer> {
+    // TODO: mark gasPayment as required in `MoveCallTransaction`
+    const gasPayment = await this.provider.getObjectRef(gasObjectId);
+    const txData = {
+      kind: {
+        // TODO: support batch txns
+        Single: tx,
+      },
+      gasPayment: gasPayment!,
+      // Need to keep in sync with
+      // https://github.com/MystenLabs/sui/blob/f32877f2e40d35a008710c232e49b57aab886462/crates/sui-types/src/messages.rs#L338
+      gasPrice: 1,
+      gasBudget: gasBudget,
+      sender: signerAddress,
+    };
+
+    return this.serializeTransactionData(txData);
+  }
+
+  private serializeTransactionData(
+    tx: TransactionData,
+    // TODO: derive the buffer size automatically
+    size: number = 2048
+  ): Base64DataBuffer {
+    const dataBytes = bcs.ser('TransactionData', tx, size).toBytes();
+    const typeTag = Array.from('TransactionData::').map(e => e.charCodeAt(0));
+    const serialized = new Uint8Array(typeTag.length + dataBytes.length);
+    serialized.set(typeTag);
+    serialized.set(dataBytes, typeTag.length);
+    return new Base64DataBuffer(serialized);
+  }
+}

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -65,6 +65,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
 
       return await this.constructTransactionData(
         tx,
+        // TODO: make `gasPayment` a required field in `MoveCallTransaction`
         t.gasPayment!,
         t.gasBudget,
         signerAddress

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -3,14 +3,13 @@
 
 import { Base64DataBuffer } from '../../serialization/base64';
 import {
+  bcs,
   CallArg,
   MoveCallTx,
-  registerTypes,
   SuiAddress,
   TransactionData,
   TypeTag,
 } from '../../types';
-import { bcs as BCS } from '@mysten/bcs';
 import {
   MoveCallTransaction,
   MergeCoinTransaction,
@@ -21,10 +20,6 @@ import {
   TxnDataSerializer,
 } from './txn-data-serializer';
 import { Provider } from '../../providers/provider';
-
-// For commonjs scenario need to figure out how to do it differently
-const bcs = registerTypes(BCS);
-export { bcs };
 
 export class LocalTxnDataSerializer implements TxnDataSerializer {
   /**

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -21,6 +21,8 @@ import {
 } from './txn-data-serializer';
 import { Provider } from '../../providers/provider';
 
+const TYPE_TAG = Array.from('TransactionData::').map(e => e.charCodeAt(0));
+
 export class LocalTxnDataSerializer implements TxnDataSerializer {
   /**
    * Need a provider to fetch the latest object reference. Ideally the provider
@@ -121,10 +123,9 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     size: number = 2048
   ): Base64DataBuffer {
     const dataBytes = bcs.ser('TransactionData', tx, size).toBytes();
-    const typeTag = Array.from('TransactionData::').map(e => e.charCodeAt(0));
-    const serialized = new Uint8Array(typeTag.length + dataBytes.length);
-    serialized.set(typeTag);
-    serialized.set(dataBytes, typeTag.length);
+    const serialized = new Uint8Array(TYPE_TAG.length + dataBytes.length);
+    serialized.set(TYPE_TAG);
+    serialized.set(dataBytes, TYPE_TAG.length);
     return new Base64DataBuffer(serialized);
   }
 }

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Base64DataBuffer } from '../../serialization/base64';
-import { ObjectId, SuiAddress, SuiJsonValue } from '../../types';
+import {
+  CallArg,
+  ObjectId,
+  SuiAddress,
+  SuiJsonValue,
+  TypeTag,
+} from '../../types';
 
 ///////////////////////////////
 // Exported Types
@@ -38,18 +44,17 @@ export interface MoveCallTransaction {
   packageObjectId: ObjectId;
   module: string;
   function: string;
-  typeArguments: string[];
-  arguments: SuiJsonValue[];
+  typeArguments: string[] | TypeTag[];
+  arguments: SuiJsonValue[] | CallArg[];
   gasPayment?: ObjectId;
   gasBudget: number;
 }
 
 export interface PublishTransaction {
-  compiledModules: string[],
+  compiledModules: string[];
   gasPayment?: ObjectId;
   gasBudget: number;
 }
-
 
 ///////////////////////////////
 // Exported Abstracts

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -44,7 +44,12 @@ export interface MoveCallTransaction {
   packageObjectId: ObjectId;
   module: string;
   function: string;
+  // Usage: pass in string[] if you use RpcTxnDataSerializer,
+  // Otherwise you need to pass in TypeTag[]. We will remove
+  // RpcTxnDataSerializer soon.
   typeArguments: string[] | TypeTag[];
+  // Usage: pass in SuiJsonValue[] if you use RpcTxnDataSerializer,
+  // Otherwise you need to pass in CallArg[].
   arguments: SuiJsonValue[] | CallArg[];
   gasPayment?: ObjectId;
   gasBudget: number;

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -44,12 +44,16 @@ export interface MoveCallTransaction {
   packageObjectId: ObjectId;
   module: string;
   function: string;
-  // Usage: pass in string[] if you use RpcTxnDataSerializer,
-  // Otherwise you need to pass in TypeTag[]. We will remove
-  // RpcTxnDataSerializer soon.
+  /**
+   * Usage: pass in string[] if you use RpcTxnDataSerializer,
+   * Otherwise you need to pass in TypeTag[]. We will remove
+   * RpcTxnDataSerializer soon.
+   */
   typeArguments: string[] | TypeTag[];
-  // Usage: pass in SuiJsonValue[] if you use RpcTxnDataSerializer,
-  // Otherwise you need to pass in CallArg[].
+  /**
+   * Usage: pass in SuiJsonValue[] if you use RpcTxnDataSerializer,
+   * Otherwise you need to pass in CallArg[].
+   */
   arguments: SuiJsonValue[] | CallArg[];
   gasPayment?: ObjectId;
   gasBudget: number;

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Base64DataBuffer } from "../serialization/base64";
+import { Base64DataBuffer } from '../serialization/base64';
+import { ObjectId } from './objects';
 
 /** Base64 string representing the object digest */
 export type TransactionDigest = string;
@@ -13,17 +14,19 @@ export type ObjectOwner =
   | 'Shared'
   | 'Immutable';
 
-
 // source of truth is
 // https://github.com/MystenLabs/sui/blob/acb2b97ae21f47600e05b0d28127d88d0725561d/crates/sui-types/src/base_types.rs#L171
 const TX_DIGEST_LENGTH = 32;
 // taken from https://rgxdb.com/r/1NUN74O6
-const VALID_BASE64_REGEX =
-  /^(?:[a-zA-Z0-9+\/]{4})*(?:|(?:[a-zA-Z0-9+\/]{3}=)|(?:[a-zA-Z0-9+\/]{2}==)|(?:[a-zA-Z0-9+\/]{1}===))$/;
+const VALID_BASE64_REGEX = /^(?:[a-zA-Z0-9+\/]{4})*(?:|(?:[a-zA-Z0-9+\/]{3}=)|(?:[a-zA-Z0-9+\/]{2}==)|(?:[a-zA-Z0-9+\/]{1}===))$/;
 
-export function isValidTransactionDigest(value: string): value is TransactionDigest {
-  return new Base64DataBuffer(value).getLength() === TX_DIGEST_LENGTH
-    && VALID_BASE64_REGEX.test(value);
+export function isValidTransactionDigest(
+  value: string
+): value is TransactionDigest {
+  return (
+    new Base64DataBuffer(value).getLength() === TX_DIGEST_LENGTH &&
+    VALID_BASE64_REGEX.test(value)
+  );
 }
 
 // TODO - can we automatically sync this with rust length definition?
@@ -32,14 +35,42 @@ export function isValidTransactionDigest(value: string): value is TransactionDig
 // which uses the Move account address length
 // https://github.com/move-language/move/blob/67ec40dc50c66c34fd73512fcc412f3b68d67235/language/move-core/types/src/account_address.rs#L23 .
 
-const SUI_ADDRESS_LENGTH = 20;
+export const SUI_ADDRESS_LENGTH = 20;
 export function isValidSuiAddress(value: string): value is SuiAddress {
-  return isHex(value) &&
-    getHexByteLength(value) === SUI_ADDRESS_LENGTH;
+  return isHex(value) && getHexByteLength(value) === SUI_ADDRESS_LENGTH;
 }
 
 export function isValidSuiObjectId(value: string): boolean {
   return isValidSuiAddress(value);
+}
+
+/**
+ * Perform the following operations:
+ * 1. Make the address lower case
+ * 2. Prepend `0x` if the string does not start with `0x`.
+ * 3. Add more zeros if the length of the address(excluding `0x`) is less than `SUI_ADDRESS_LENGTH`
+ *
+ * WARNING: if the address value itself starts with `0x`, e.g., `0x0x`, the default behavior
+ * is to treat the first `0x` not as part of the address. The default behavior can be overridden by
+ * setting `forceAdd0x` to true
+ *
+ */
+export function normalizeSuiAddress(
+  value: string,
+  forceAdd0x: boolean = false
+): SuiAddress {
+  let address = value.toLowerCase();
+  if (!forceAdd0x && address.startsWith('0x')) {
+    address = address.slice(2);
+  }
+  return `0x${address.padStart(SUI_ADDRESS_LENGTH * 2, '0')}`;
+}
+
+export function normalizeSuiObjectId(
+  value: string,
+  forceAdd0x: boolean = false
+): ObjectId {
+  return normalizeSuiAddress(value, forceAdd0x);
 }
 
 function isHex(value: string): boolean {
@@ -47,7 +78,5 @@ function isHex(value: string): boolean {
 }
 
 function getHexByteLength(value: string): number {
-  return /^(0x|0X)/.test(value)
-    ? (value.length - 2) / 2
-    : value.length / 2;
+  return /^(0x|0X)/.test(value) ? (value.length - 2) / 2 : value.length / 2;
 }

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -6,3 +6,4 @@ export * from './objects';
 export * from './events';
 export * from './transactions';
 export * from './framework';
+export * from './sui-bcs';

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -1,0 +1,273 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { bcs, decodeStr, encodeStr } from '@mysten/bcs';
+import { SuiObjectRef } from './objects';
+
+// This buddy collects definitions for BCS.
+const initializers: Function[] = [];
+
+initializers.push((b: typeof bcs) =>
+  b
+    .registerVectorType('vector<u8>', 'u8')
+    .registerVectorType('vector<vector<u8>>', 'vector<u8>')
+    .registerAddressType('ObjectID', 20)
+    .registerAddressType('SuiAddress', 20)
+    .registerType(
+      'utf8string',
+      (writer, str) => {
+        let bytes = Array.from(Buffer.from(str));
+        return writer.writeVec(bytes, (writer, el) => writer.write8(el));
+      },
+      reader => {
+        let bytes = reader.readVec(reader => reader.read8());
+        return Buffer.from(bytes).toString('utf-8');
+      }
+    )
+    .registerType(
+      'ObjectDigest',
+      (writer, str) => {
+        let bytes = Array.from(decodeStr(str, 'base64'));
+        return writer.writeVec(bytes, (writer, el) => writer.write8(el));
+      },
+      reader => {
+        let bytes = reader.readVec(reader => reader.read8());
+        return encodeStr(new Uint8Array(bytes), 'base64');
+      }
+    )
+);
+
+initializers.push((b: typeof bcs) =>
+  b.registerStructType('SuiObjectRef', {
+    objectId: 'ObjectID',
+    version: 'u64',
+    digest: 'ObjectDigest',
+  })
+);
+
+/**
+ * Transaction type used for transferring objects.
+ * For this transaction to be executed, and `SuiObjectRef` should be queried
+ * upfront and used as a parameter.
+ */
+export type TransferObjectTx = {
+  TransferObject: {
+    recipient: string;
+    object_ref: SuiObjectRef;
+  };
+};
+
+initializers.push((b: typeof bcs) =>
+  b.registerStructType('TransferObjectTx', {
+    recipient: 'SuiAddress',
+    object_ref: 'SuiObjectRef',
+  })
+);
+
+/**
+ * Transaction type used for publishing Move modules to the Sui.
+ * Should be already compiled using `sui-move`, example:
+ * ```
+ * $ sui-move build
+ * $ cat build/project_name/bytecode_modules/module.mv
+ * ```
+ * In JS:
+ * ```
+ * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv');
+ * let bytes = Array.from(bytes);
+ * let modules = [ bytes ];
+ *
+ * // ... publish logic ...
+ * ```
+ *
+ * Each module should be represented as a sequence of bytes.
+ */
+export type PublishTx = {
+  Publish: {
+    modules: Iterable<Iterable<number>>;
+  };
+};
+
+initializers.push((b: typeof bcs) =>
+  b.registerStructType('PublishTx', {
+    modules: 'vector<vector<u8>>',
+  })
+);
+
+// ========== Move Call Tx ===========
+
+/**
+ * An object argument.
+ */
+export type ObjectArg = { ImmOrOwned: SuiObjectRef } | { Shared: string };
+
+/**
+ * An argument for the transaction. It is a 'meant' enum which expects to have
+ * one of the optional properties. If not, the BCS error will be thrown while
+ * attempting to form a transaction.
+ *
+ * Example:
+ * ```js
+ * let arg1: CallArg = { Object: { Shared: '5460cf92b5e3e7067aaace60d88324095fd22944' } };
+ * let arg2: CallArg = { Pure: bcs.set(bcs.STRING, 100000).toBytes() };
+ * let arg3: CallArg = { Object: { ImmOrOwnedObject: {
+ *   objectId: '4047d2e25211d87922b6650233bd0503a6734279',
+ *   version: 1,
+ *   digest: 'bCiANCht4O9MEUhuYjdRCqRPZjr2rJ8MfqNiwyhmRgA='
+ * } } };
+ * ```
+ *
+ * For `Pure` arguments BCS is required. You must encode the values with BCS according
+ * to the type required by the called function. Pure accepts only serialized values
+ */
+export type CallArg = { Pure: Iterable<number> } | { Object: ObjectArg };
+
+initializers.push((b: typeof bcs) =>
+  b
+    .registerEnumType('ObjectArg', {
+      ImmOrOwned: 'SuiObjectRef',
+      Shared: 'ObjectID',
+    })
+    .registerEnumType('CallArg', {
+      Pure: 'vector<u8>',
+      Object: 'ObjectArg',
+    })
+);
+
+/**
+ * Kind of a TypeTag which is represented by a Move type identifier.
+ */
+export type StructTag = {
+  address: string;
+  module: string;
+  name: string;
+  typeParams: TypeTag[];
+};
+
+/**
+ * Sui TypeTag object. A decoupled `0x...::module::Type<???>` parameter.
+ */
+export type TypeTag =
+  | { bool: null }
+  | { u8: null }
+  | { u64: null }
+  | { u128: null }
+  | { address: null }
+  | { signer: null }
+  | { vector: TypeTag }
+  | { struct: StructTag };
+
+initializers.push((b: typeof bcs) =>
+  b
+    .registerEnumType('TypeTag', {
+      bool: null,
+      u8: null,
+      u64: null,
+      u128: null,
+      address: null,
+      signer: null,
+      vector: 'TypeTag',
+      struct: 'StructTag',
+    })
+    .registerVectorType('vector<TypeTag>', 'TypeTag')
+    .registerStructType('StructTag', {
+      address: 'SuiAddress',
+      module: 'string',
+      name: 'string',
+      typeParams: 'vector<TypeTag>',
+    })
+);
+
+/**
+ * Transaction type used for calling Move modules' functions.
+ * Should be crafted carefully, because the order of type parameters and
+ * arguments matters.
+ */
+export type MoveCallTx = {
+  Call: {
+    package: SuiObjectRef;
+    module: string;
+    function: string;
+    typeArguments: TypeTag[];
+    arguments: CallArg[];
+  };
+};
+
+initializers.push((b: typeof bcs) =>
+  b
+    .registerVectorType('vector<CallArg>', 'CallArg')
+    .registerStructType('MoveCallTx', {
+      package: 'SuiObjectRef',
+      module: 'string',
+      function: 'string',
+      typeArguments: 'vector<TypeTag>',
+      arguments: 'vector<CallArg>',
+    })
+);
+
+// ========== TransactionData ===========
+
+export type Transaction = MoveCallTx | PublishTx | TransferObjectTx;
+
+initializers.push((b: typeof bcs) =>
+  b.registerEnumType('Transaction', {
+    TransferObject: 'TransferObjectTx',
+    Publish: 'PublishTx',
+    Call: 'MoveCallTx',
+  })
+);
+
+/**
+ * Transaction kind - either Batch or Single.
+ *
+ * Can be improved to change serialization automatically based on
+ * the passed value (single Transaction or an array).
+ */
+export type TransactionKind =
+  | { Single: Transaction }
+  | { Batch: Transaction[] };
+
+initializers.push((b: typeof bcs) =>
+  b
+    .registerVectorType('vector<Transaction>', 'Transaction')
+    .registerEnumType('TransactionKind', {
+      Single: 'Transaction',
+      Batch: 'vector<Transaction>',
+    })
+);
+
+/**
+ * The TransactionData to be signed and sent to the Gateway service.
+ *
+ * Field `sender` is made optional as it can be added during the signing
+ * process and there's no need to define it sooner.
+ */
+export type TransactionData = {
+  sender?: string; //
+  gasBudget: number;
+  gasPrice: number;
+  kind: TransactionKind;
+  gasPayment: SuiObjectRef;
+};
+
+initializers.push((b: typeof bcs) =>
+  b.registerStructType('TransactionData', {
+    kind: 'TransactionKind',
+    sender: 'SuiAddress',
+    gasPayment: 'SuiObjectRef',
+    gasPrice: 'u64',
+    gasBudget: 'u64',
+  })
+);
+
+/**
+ * Initialize BCS definitions.
+ * @param {BCS} bcs
+ */
+export function registerTypes(b: typeof bcs): typeof bcs {
+  for (let init of initializers) {
+    init(b);
+  }
+
+  return b;
+}

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -271,3 +271,7 @@ export function registerTypes(b: typeof bcs): typeof bcs {
 
   return b;
 }
+
+// For commonjs scenario need to figure out how to do it differently
+const suiBCS = registerTypes(bcs);
+export { suiBCS as bcs };

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -32,7 +32,7 @@ export type SuiTransactionKind =
   | { Call: MoveCall }
   | { TransferSui: SuiTransferSui }
   | { ChangeEpoch: SuiChangeEpoch };
-export type TransactionData = {
+export type SuiTransactionData = {
   transactions: SuiTransactionKind[];
   sender: SuiAddress;
   gasPayment: SuiObjectRef;
@@ -49,7 +49,7 @@ export type AuthorityQuorumSignInfo = {
 
 export type CertifiedTransaction = {
   transactionDigest: TransactionDigest;
-  data: TransactionData;
+  data: SuiTransactionData;
   txSignature: string;
   authSignInfo: AuthorityQuorumSignInfo;
 };
@@ -196,7 +196,9 @@ export function getTransactionAuthorityQuorumSignInfo(
   return tx.authSignInfo;
 }
 
-export function getTransactionData(tx: CertifiedTransaction): TransactionData {
+export function getTransactionData(
+  tx: CertifiedTransaction
+): SuiTransactionData {
   return tx.data;
 }
 

--- a/sdk/typescript/test/types/stringTypes.test.ts
+++ b/sdk/typescript/test/types/stringTypes.test.ts
@@ -1,65 +1,105 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidTransactionDigest, isValidSuiAddress } from '../../src/index';
+import {
+  isValidTransactionDigest,
+  isValidSuiAddress,
+  normalizeSuiAddress,
+} from '../../src/index';
 
 describe('String type guards', () => {
-
-  function expectAll<T>(data: T[], check: (value: T) => boolean, expected: boolean) {
-    data.forEach(d=> expect(check(d)).toBe(expected));
+  function expectAll<T>(data: T[], check: (value: T) => any, expected: any) {
+    data.forEach(d => expect(check(d)).toBe(expected));
   }
 
   describe('isValidTransactionDigest()', () => {
-
     it('rejects non base64 strings', () => {
-      expectAll([
-        'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
-        'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  '
-      ], isValidTransactionDigest, false);
+      expectAll(
+        [
+          'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
+          'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  ',
+        ],
+        isValidTransactionDigest,
+        false
+      );
     });
 
     it('rejects base64 strings of the wrong length', () => {
-      expectAll([
-        'ZVteaEsxe0Q6XU53UExxWEFjKy98UD5qfmM+',
-        'J3pwOz9GdS5JSEB8Lz9ILGxdJi9sXTxbdFU2OHpP',
-        'UUQmaXAmQiYxSERrQH5VWEJmQm8pMXMiYEQzJ2wpPnkuYg=='
-      ], isValidTransactionDigest, false);
+      expectAll(
+        [
+          'ZVteaEsxe0Q6XU53UExxWEFjKy98UD5qfmM+',
+          'J3pwOz9GdS5JSEB8Lz9ILGxdJi9sXTxbdFU2OHpP',
+          'UUQmaXAmQiYxSERrQH5VWEJmQm8pMXMiYEQzJ2wpPnkuYg==',
+        ],
+        isValidTransactionDigest,
+        false
+      );
     });
 
     it('accepts base64 strings of the correct length', () => {
-      expectAll([
-        'UYKbz61ny/+E+r07JatGyrtrv/FyjNeqUEQisJJXPHM=',
-        'obGrcB0a+aMJXyRMGQ+7to5GaJ6a1Kfd6tS+sAM0d/8=',
-        'pMmQoBeSSErk96hKMtkilwCZub3FaOF3IIdii16/DBo='
-      ], isValidTransactionDigest, true);
+      expectAll(
+        [
+          'UYKbz61ny/+E+r07JatGyrtrv/FyjNeqUEQisJJXPHM=',
+          'obGrcB0a+aMJXyRMGQ+7to5GaJ6a1Kfd6tS+sAM0d/8=',
+          'pMmQoBeSSErk96hKMtkilwCZub3FaOF3IIdii16/DBo=',
+        ],
+        isValidTransactionDigest,
+        true
+      );
     });
   });
 
   describe('isValidSuiAddress() / isValidObjectID()', () => {
-
     it('rejects non-hex strings', () => {
-      expectAll([
-        'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
-        'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  ',
-      ], isValidSuiAddress, false);
+      expectAll(
+        [
+          'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
+          'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  ',
+        ],
+        isValidSuiAddress,
+        false
+      );
     });
 
     it('rejects hex strings of the wrong length', () => {
-      expectAll([
-        '5f713bef531629b47dd1bdbb382a',
-        'f1e2a6d12cd5e62a3ce9b2c12e9e2d37d81c',
-        '0X5f713bef531629b47dd1bdbb382acec5224fc9abc16133e3',
-        '0x503ff67d9291215ffccafddbd08d86e86b3425c6356c9679'
-      ], isValidSuiAddress, false);
+      expectAll(
+        [
+          '5f713bef531629b47dd1bdbb382a',
+          'f1e2a6d12cd5e62a3ce9b2c12e9e2d37d81c',
+          '0X5f713bef531629b47dd1bdbb382acec5224fc9abc16133e3',
+          '0x503ff67d9291215ffccafddbd08d86e86b3425c6356c9679',
+        ],
+        isValidSuiAddress,
+        false
+      );
     });
 
     it('accepts hex strings of the correct length, regardless of 0x prefix', () => {
-      expectAll([
-        '9edd26f2ef1c1796f9feaa703c8628e5a70618c8',
-        '5f713bef531629b47dd1bdbb382acec5224fc9ab',
-        '0Xdce47e3e523b5e52a36d74295c0d83d91f80b47c',
-        '0x4288ba9932cc115784794fcfb709213f30d40a54'
-      ], isValidSuiAddress, true);
+      expectAll(
+        [
+          '9edd26f2ef1c1796f9feaa703c8628e5a70618c8',
+          '5f713bef531629b47dd1bdbb382acec5224fc9ab',
+          '0Xdce47e3e523b5e52a36d74295c0d83d91f80b47c',
+          '0x4288ba9932cc115784794fcfb709213f30d40a54',
+        ],
+        isValidSuiAddress,
+        true
+      );
+    });
+
+    it('normalize hex strings to the correct length', () => {
+      expectAll(
+        [
+          '0x2',
+          '2',
+          '02',
+          '0X02',
+          '0x0000000000000000000000000000000000000002',
+          '0X000000000000000000000000000000000000002',
+        ],
+        normalizeSuiAddress,
+        '0x0000000000000000000000000000000000000002'
+      );
     });
   });
 });

--- a/sdk/typescript/yarn.lock
+++ b/sdk/typescript/yarn.lock
@@ -1234,6 +1234,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@mysten/bcs@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mysten/bcs/-/bcs-0.2.0.tgz#d259b526e7a1b71538603bb51c3d670d571ec4cd"
+  integrity sha512-vSTaazqLo40yQKiTPVMrUdc66CLSlm/nX/l0ip8rtuZk7NCbYV3OhlxQ44rRXbodf+67osAAZyeTmUfkpzNsfQ==
+  dependencies:
+    bn.js "^5.2.1"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -2136,6 +2143,11 @@ bn.js@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@1.19.2:
   version "1.19.2"


### PR DESCRIPTION
This PR is the first step to support client side transaction construction in TS(previously we have been relying on the gateway to construct and serialize transaction data) through merging  the [experimental SDK](https://github.com/MystenLabs/sui/pull/3466). 

## Testing

```
const provider = new JsonRpcProvider(endpoint);
const signerWithProvider = new RawSigner(
      keypair,
      provider,
      new LocalTxnDataSerializer(provider)
);

const moveCallTxn = await signerWithProvider.executeMoveCall({
      packageObjectId: "0x2",
      module: "devnet_nft",
      function: "mint",
      typeArguments: [],
      arguments: [
        { Pure: bcs.ser(bcs.STRING, "Example NFT").toBytes() },
        {
          Pure: bcs
            .ser(bcs.STRING, "An NFT created by the wallet Command Line Tool")
            .toBytes(),
        },
        {
          Pure: bcs
            .ser(
              bcs.STRING,
              "ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty"
            )
            .toBytes(),
        },
      ],
      gasBudget: 10000,
      gasPayment: coins[0].objectId,
    });
console.log("Move call txn to create devnet_nft", moveCallTxn);
```

Verified that the transaction is successful and a proper NFT is created 

## Remaining work(will do in separate PRs to keep this PR small)
1. Implement a provider that maintain an in-memory cache for object references and update the cache for new transactions https://github.com/MystenLabs/sui/pull/3876/files
2. Support other transaction types (TransferObject, TransferSui, MergeCoin, SplitCoin, Publish)
3. Make the argument interface more ergonomic(e.g., get rid of the `Pure`, `bcs.ser`, etc)
4. Address TODOs in the inline comments
5. Update README
6. Get rid of the existing `rpc-txn-data-serializer` and the experimental section