### PR TITLE
Use well-defined signature scheme enum instead of arbitrary byte flag

### DIFF
--- a/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
@@ -59,12 +59,12 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let signature = keystore.sign(address, &tx_bytes)?;
 
     let tx_bytes = Base64::from_bytes(&tx_bytes);
-    let flag_bytes = Base64::from_bytes(&[signature.flag_byte()]);
+    let sig_scheme = signature.scheme();
     let signature_bytes = Base64::from_bytes(signature.signature_bytes());
     let pub_key = Base64::from_bytes(signature.public_key_bytes());
 
     let tx_response: TransactionResponse = http_client
-        .execute_transaction(tx_bytes, flag_bytes, signature_bytes, pub_key)
+        .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
         .await?;
 
     let effect = tx_response.to_effect_response()?.effects;
@@ -100,12 +100,12 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let signature = keystore.sign(address, &tx_bytes)?;
 
     let tx_bytes = Base64::from_bytes(&tx_bytes);
-    let flag_bytes = Base64::from_bytes(&[signature.flag_byte()]);
+    let sig_scheme = signature.scheme();
     let signature_bytes = Base64::from_bytes(signature.signature_bytes());
     let pub_key = Base64::from_bytes(signature.public_key_bytes());
 
     let tx_response: TransactionResponse = http_client
-        .execute_transaction(tx_bytes, flag_bytes, signature_bytes, pub_key)
+        .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
         .await?;
 
     let response = tx_response.to_publish_response()?;
@@ -150,12 +150,12 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let signature = keystore.sign(address, &tx_bytes)?;
 
     let tx_bytes = Base64::from_bytes(&tx_bytes);
-    let flag_bytes = Base64::from_bytes(&[signature.flag_byte()]);
+    let sig_scheme = signature.scheme();
     let signature_bytes = Base64::from_bytes(signature.signature_bytes());
     let pub_key = Base64::from_bytes(signature.public_key_bytes());
 
     let tx_response: TransactionResponse = http_client
-        .execute_transaction(tx_bytes, flag_bytes, signature_bytes, pub_key)
+        .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
         .await?;
 
     let effect = tx_response.to_effect_response()?.effects;
@@ -204,12 +204,12 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
         let signature = keystore.sign(address, &tx_bytes)?;
 
         let tx_bytes = Base64::from_bytes(&tx_bytes);
-        let flag_bytes = Base64::from_bytes(&[signature.flag_byte()]);
+        let sig_scheme = signature.scheme();
         let signature_bytes = Base64::from_bytes(signature.signature_bytes());
         let pub_key = Base64::from_bytes(signature.public_key_bytes());
 
         let response: TransactionResponse = http_client
-            .execute_transaction(tx_bytes, flag_bytes, signature_bytes, pub_key)
+            .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
             .await?;
 
         if let TransactionResponse::EffectResponse(effects) = response {

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -11,6 +11,7 @@ use sui_json_rpc_types::{
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
+use sui_types::crypto::SignatureScheme;
 use sui_types::sui_serde::Base64;
 
 #[open_rpc(namespace = "sui", tag = "Gateway Transaction Execution API")]
@@ -23,7 +24,7 @@ pub trait RpcGatewayApi {
         /// transaction data bytes, as base-64 encoded string
         tx_bytes: Base64,
         /// Flag of the signature scheme that is used.
-        flag: Base64,
+        sig_scheme: SignatureScheme,
         /// transaction signature, as base-64 encoded string
         signature: Base64,
         /// signer's public key, as base-64 encoded string

--- a/crates/sui-json-rpc/src/gateway_api.rs
+++ b/crates/sui-json-rpc/src/gateway_api.rs
@@ -19,6 +19,7 @@ use sui_json_rpc_types::{
     TransactionBytes, TransactionEffectsResponse, TransactionResponse,
 };
 use sui_open_rpc::Module;
+use sui_types::crypto::SignatureScheme;
 use sui_types::sui_serde::Base64;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
@@ -71,13 +72,14 @@ impl RpcGatewayApiServer for RpcGatewayImpl {
     async fn execute_transaction(
         &self,
         tx_bytes: Base64,
-        flag: Base64,
+        sig_scheme: SignatureScheme,
         signature: Base64,
         pub_key: Base64,
     ) -> RpcResult<TransactionResponse> {
         let data = TransactionData::from_signable_bytes(&tx_bytes.to_vec()?)?;
+        let flag = vec![sig_scheme.flag()];
         let signature = crypto::Signature::from_bytes(
-            &[&*flag.to_vec()?, &*signature.to_vec()?, &pub_key.to_vec()?].concat(),
+            &[&*flag, &*signature.to_vec()?, &pub_key.to_vec()?].concat(),
         )
         .map_err(|e| anyhow!(e))?;
         let result = self

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -160,11 +160,11 @@
           }
         },
         {
-          "name": "flag",
+          "name": "sig_scheme",
           "description": "Flag of the signature scheme that is used.",
           "required": true,
           "schema": {
-            "$ref": "#/components/schemas/Base64"
+            "$ref": "#/components/schemas/SignatureScheme"
           }
         },
         {
@@ -200,8 +200,8 @@
               "value": "VHJhbnNhY3Rpb25EYXRhOjoAABdY7bkmDSqGyDbvwF8X5cWVJeQExGwtZKelsdk7LYZGgF2NKhIvzNsCAAAAAAAAACA7x9yXWrdfyGV5NTb2bmQYkFA2D2I9yIq7gwAYDN0Kj9BnwzQmQaTOqrLB29rQESsuPkj4xqk9BRZR/i5O764oE0klaDiQqUICAAAAAAAAACD2POST9RLwss+3xCoHzpEwy20FmjiNiGFTbLnFuBqajQEAAAAAAAAA6AMAAAAAAAA="
             },
             {
-              "name": "flag",
-              "value": "AA=="
+              "name": "sig_scheme",
+              "value": "ED25519"
             },
             {
               "name": "signature",
@@ -2922,6 +2922,13 @@
             },
             "additionalProperties": false
           }
+        ]
+      },
+      "SignatureScheme": {
+        "type": "string",
+        "enum": [
+          "ED25519",
+          "Secp256k1"
         ]
       },
       "SplitCoinResponse": {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -169,7 +169,7 @@ impl RpcExampleProvider {
                 "Execute an object transfer transaction",
                 vec![
                     ("tx_bytes", json!(tx_bytes.tx_bytes)),
-                    ("flag", json!(Base64::from_bytes(&[signature.flag_byte()]))),
+                    ("sig_scheme", json!(signature.scheme())),
                     (
                         "signature",
                         json!(Base64::from_bytes(signature.signature_bytes())),

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -224,7 +224,7 @@ impl SuiClient {
         Ok(match &self {
             Self::Http(c) => {
                 let tx_bytes = Base64::from_bytes(&tx.data.to_bytes());
-                let flag = Base64::from_bytes(&[tx.tx_signature.flag_byte()]);
+                let flag = tx.tx_signature.scheme();
                 let signature = Base64::from_bytes(tx.tx_signature.signature_bytes());
                 let pub_key = Base64::from_bytes(tx.tx_signature.public_key_bytes());
                 c.execute_transaction(tx_bytes, flag, signature, pub_key)
@@ -232,7 +232,7 @@ impl SuiClient {
             }
             Self::Ws(c) => {
                 let tx_bytes = Base64::from_bytes(&tx.data.to_bytes());
-                let flag = Base64::from_bytes(&[tx.tx_signature.flag_byte()]);
+                let flag = tx.tx_signature.scheme();
                 let signature = Base64::from_bytes(tx.tx_signature.signature_bytes());
                 let pub_key = Base64::from_bytes(tx.tx_signature.public_key_bytes());
                 c.execute_transaction(tx_bytes, flag, signature, pub_key)

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -185,7 +185,7 @@ impl TryFrom<Vec<u8>> for SuiAddress {
 impl From<&AuthorityPublicKeyBytes> for SuiAddress {
     fn from(pkb: &AuthorityPublicKeyBytes) -> Self {
         let mut hasher = Sha3_256::default();
-        hasher.update(&[AuthorityPublicKey::FLAG]);
+        hasher.update(&[AuthorityPublicKey::SIGNATURE_SCHEME.flag()]);
         hasher.update(pkb);
         let g_arr = hasher.finalize();
 
@@ -198,7 +198,7 @@ impl From<&AuthorityPublicKeyBytes> for SuiAddress {
 impl<T: SuiPublicKey> From<&T> for SuiAddress {
     fn from(pk: &T) -> Self {
         let mut hasher = Sha3_256::default();
-        hasher.update(&[T::FLAG]);
+        hasher.update(&[T::SIGNATURE_SCHEME.flag()]);
         hasher.update(pk);
         let g_arr = hasher.finalize();
 

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -27,6 +27,13 @@ export type PublicKeyData = {
 export const PUBLIC_KEY_SIZE = 32;
 export const TYPE_BYTE = 0x00;
 
+export type SignatureScheme = 'ED25519' | 'Secp256k1';
+
+const SIGNATURE_SCHEME_TO_FLAG = {
+  ED25519: 0x00,
+  Secp256k1: 0x01,
+};
+
 function isPublicKeyData(value: PublicKeyInitData): value is PublicKeyData {
   return (value as PublicKeyData)._bn !== undefined;
 }
@@ -108,9 +115,9 @@ export class PublicKey {
   /**
    * Return the Sui address associated with this public key
    */
-  toSuiAddress(): string {
+  toSuiAddress(scheme: SignatureScheme = 'ED25519'): string {
     let tmp = new Uint8Array(PUBLIC_KEY_SIZE + 1);
-    tmp.set([TYPE_BYTE]);
+    tmp.set([SIGNATURE_SCHEME_TO_FLAG[scheme]]);
     tmp.set(this.toBytes(), 1);
     const hexHash = sha3_256(tmp);
     const publicKeyBytes = new BN(hexHash, 16).toArray(undefined, 32);

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, TransactionEffectsResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, MergeCoinResponse, SplitCoinResponse, PublishResponse, SuiPackage, TransactionResponse } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, TransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, TransactionEffectsResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, MergeCoinResponse, SplitCoinResponse, PublishResponse, SuiPackage, TransactionResponse } from "./index";
 import { BN } from "bn.js";
 import { Base64DataBuffer } from "./serialization/base64";
 import { PublicKey } from "./cryptography/publickey";
@@ -50,6 +50,13 @@ export function isPublicKeyData(obj: any, _argumentName?: string): obj is Public
             typeof obj === "object" ||
             typeof obj === "function") &&
         obj._bn instanceof BN
+    )
+}
+
+export function isSignatureScheme(obj: any, _argumentName?: string): obj is SignatureScheme {
+    return (
+        (obj === "ED25519" ||
+            obj === "Secp256k1")
     )
 }
 
@@ -164,7 +171,7 @@ export function isSignaturePubkeyPair(obj: any, _argumentName?: string): obj is 
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
-        obj.flag instanceof Base64DataBuffer &&
+        isSignatureScheme(obj.signatureScheme) as boolean &&
         obj.signature instanceof Base64DataBuffer &&
         obj.pubKey instanceof PublicKey
     )

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -22,6 +22,7 @@ import {
   getObjectReference,
   Coin,
 } from '../types';
+import { SignatureScheme } from '../cryptography/publickey';
 
 const isNumber = (val: any): val is number => typeof val === 'number';
 const isAny = (_val: any): _val is any => true;
@@ -200,14 +201,14 @@ export class JsonRpcProvider extends Provider {
 
   async executeTransaction(
     txnBytes: string,
-    flag: string,
+    signatureScheme: SignatureScheme,
     signature: string,
     pubkey: string
   ): Promise<TransactionResponse> {
     try {
       const resp = await this.client.requestWithType(
         'sui_executeTransaction',
-        [txnBytes, flag, signature, pubkey],
+        [txnBytes, signatureScheme, signature, pubkey],
         isTransactionResponse
       );
       return resp;
@@ -265,11 +266,11 @@ export class JsonRpcProvider extends Provider {
       return await this.client.requestWithType(
         'sui_syncAccountState',
         [address],
-        isAny,
+        isAny
       );
     } catch (err) {
       throw new Error(
-        `Error sync account address for address: ${address} with error: ${err}`,
+        `Error sync account address for address: ${address} with error: ${err}`
       );
     }
   }

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { SignatureScheme } from '../cryptography/publickey';
 import {
   GetObjectDataResponse,
   SuiObjectInfo,
@@ -65,11 +66,11 @@ export abstract class Provider {
 
   abstract executeTransaction(
     txnBytes: string,
-    flag: string,
+    signatureScheme: SignatureScheme,
     signature: string,
     pubkey: string
   ): Promise<TransactionResponse>;
 
-  abstract syncAccountState(address: string): Promise<any>
+  abstract syncAccountState(address: string): Promise<any>;
   // TODO: add more interface methods
 }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { SignatureScheme } from '../cryptography/publickey';
 import {
   CertifiedTransaction,
   TransactionDigest,
@@ -42,7 +43,7 @@ export class VoidProvider extends Provider {
 
   async executeTransaction(
     _txnBytes: string,
-    _flag: string,
+    _signatureScheme: SignatureScheme,
     _signature: string,
     _pubkey: string
   ): Promise<TransactionResponse> {

--- a/sdk/typescript/src/signers/raw-signer.ts
+++ b/sdk/typescript/src/signers/raw-signer.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Ed25519Keypair } from '../cryptography/ed25519-keypair';
-import { TYPE_BYTE } from '../cryptography/publickey';
 import { Provider } from '../providers/provider';
 import { Base64DataBuffer } from '../serialization/base64';
 import { SuiAddress } from '../types';
@@ -28,7 +27,7 @@ export class RawSigner extends SignerWithProvider {
 
   async signData(data: Base64DataBuffer): Promise<SignaturePubkeyPair> {
     return {
-      flag: new Base64DataBuffer(new Uint8Array([TYPE_BYTE])),
+      signatureScheme: 'ED25519',
       signature: this.keypair.signData(data),
       pubKey: this.keypair.getPublicKey(),
     };

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -62,7 +62,7 @@ export abstract class SignerWithProvider implements Signer {
     const sig = await this.signData(txBytes);
     return await this.provider.executeTransaction(
       txBytes.toString(),
-      sig.flag.toString(),
+      sig.signatureScheme,
       sig.signature.toString(),
       sig.pubKey.toString()
     );
@@ -147,9 +147,7 @@ export abstract class SignerWithProvider implements Signer {
     return await this.signAndExecuteTransaction(txBytes);
   }
 
-  async publish(
-    transaction: PublishTransaction
-  ): Promise<TransactionResponse> {
+  async publish(transaction: PublishTransaction): Promise<TransactionResponse> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newPublish(
       signerAddress,

--- a/sdk/typescript/src/signers/signer.ts
+++ b/sdk/typescript/src/signers/signer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PublicKey } from '../cryptography/publickey';
+import { PublicKey, SignatureScheme } from '../cryptography/publickey';
 import { Base64DataBuffer } from '../serialization/base64';
 
 ///////////////////////////////
@@ -11,7 +11,7 @@ import { Base64DataBuffer } from '../serialization/base64';
  * Pair of signature and corresponding public key
  */
 export type SignaturePubkeyPair = {
-  flag: Base64DataBuffer;
+  signatureScheme: SignatureScheme;
   signature: Base64DataBuffer;
   pubKey: PublicKey;
 };


### PR DESCRIPTION
This PR replaces the signature flag byte with enum.

Somehow TS SDK checks is skipped for this PR... @666lcz @punwai , are there anything needed to be changed in the TS SDK?