### PR TITLE
Query signed epoch to form epoch cert during reconfiguration

### DIFF
--- a/crates/sui-benchmark/src/benchmark/transaction_creator.rs
+++ b/crates/sui-benchmark/src/benchmark/transaction_creator.rs
@@ -73,8 +73,7 @@ fn make_cert(network_config: &NetworkConfig, tx: &Transaction) -> CertifiedTrans
         sigs.push((pubx, sig));
     }
     let mut certificate =
-        CertifiedTransaction::new_with_signatures(committee.epoch(), tx.clone(), sigs, &committee)
-            .unwrap();
+        CertifiedTransaction::new_with_signatures(tx.clone(), sigs, &committee).unwrap();
     certificate.auth_sign_info.epoch = committee.epoch();
     certificate
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1187,6 +1187,10 @@ impl AuthorityState {
         Ok(())
     }
 
+    pub(crate) fn promote_signed_epoch_to_cert(&self, cert: CertifiedEpoch) -> SuiResult {
+        self.database.store_epoch_cert(cert)
+    }
+
     #[cfg(test)]
     pub(crate) fn is_halted(&self) -> bool {
         self.halted.load(Ordering::Relaxed)

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1360,6 +1360,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(())
     }
 
+    pub fn store_epoch_cert(&self, cert: CertifiedEpoch) -> SuiResult {
+        Ok(self.tables.epochs.insert(
+            &cert.epoch_info.epoch(),
+            &AuthenticatedEpoch::Certified(cert),
+        )?)
+    }
+
     pub fn get_authenticated_epoch(
         &self,
         epoch_id: &EpochId,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1347,7 +1347,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             SuiError::from("Unexpected new epoch number")
         );
 
-        let signed_epoch = SignedEpoch::new(new_committee, authority, secret, next_checkpoint);
+        let signed_epoch = SignedEpoch::new(
+            new_committee,
+            authority,
+            secret,
+            next_checkpoint,
+            latest_epoch.epoch_info(),
+        );
         self.tables
             .epochs
             .insert(&cur_epoch, &AuthenticatedEpoch::Signed(signed_epoch))?;

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1265,7 +1265,6 @@ where
                                     self.metrics.num_bad_stake.observe(state.bad_stake as f64);
                                     state.certificate =
                                         Some(CertifiedTransaction::new_with_signatures(
-                                            self.committee.epoch(),
                                             transaction_ref.clone(),
                                             state.signatures.clone(),
                                             &self.committee,
@@ -1536,12 +1535,7 @@ where
                     good_stake = stake,
                     "Found an effect with good stake over threshold"
                 );
-                return CertifiedTransactionEffects::new(
-                    certificate.auth_sign_info.epoch,
-                    effects,
-                    signatures,
-                    &self.committee,
-                );
+                return CertifiedTransactionEffects::new(effects, signatures, &self.committee);
             }
         }
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -20,7 +20,7 @@ use sui_types::messages::{
     SignedTransaction,
 };
 use sui_types::sui_system_state::SuiSystemState;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 use typed_store::Map;
 
 #[async_trait]
@@ -141,6 +141,8 @@ where
                 ?epoch,
                 "Failed to obtain certificate for the next epoch: {:?}", err
             );
+            // TODO: Instead of actively waiting in a loop, we could instead use a notification
+            // pattern.
             tokio::time::sleep(WAIT_BETWEEN_EPOCH_QUERY_RETRY).await;
         }
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority_active::ActiveAuthority;
-use crate::authority_aggregator::AuthorityAggregator;
+use crate::authority_aggregator::{AuthorityAggregator, ReduceOutput};
 use crate::authority_client::AuthorityAPI;
 use async_trait::async_trait;
 use multiaddr::Multiaddr;
@@ -11,12 +11,16 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_network::tonic;
-use sui_types::committee::Committee;
-use sui_types::crypto::AuthorityPublicKeyBytes;
-use sui_types::error::SuiResult;
-use sui_types::messages::SignedTransaction;
+use sui_types::base_types::AuthorityName;
+use sui_types::committee::{Committee, EpochId, StakeUnit};
+use sui_types::crypto::{AuthorityPublicKeyBytes, AuthoritySignature};
+use sui_types::error::{SuiError, SuiResult};
+use sui_types::messages::{
+    AuthenticatedEpoch, CertifiedEpoch, EpochInfoDigest, EpochRequest, EpochResponse,
+    SignedTransaction,
+};
 use sui_types::sui_system_state::SuiSystemState;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use typed_store::Map;
 
 #[async_trait]
@@ -26,7 +30,9 @@ pub trait Reconfigurable {
     fn recreate(channel: tonic::transport::Channel) -> Self;
 }
 
-const WAIT_BETWEEN_EPOCH_TX_QUERY_RETRY: Duration = Duration::from_millis(300);
+// TODO: Move these constants to a control config.
+const WAIT_BETWEEN_EPOCH_QUERY_RETRY: Duration = Duration::from_millis(300);
+const QUORUM_TIMEOUT: Duration = Duration::from_secs(60);
 
 impl<A> ActiveAuthority<A>
 where
@@ -110,8 +116,33 @@ where
             ?epoch,
             "New committee for the next epoch: {:?}", new_committee
         );
+        let old_committee = self.state.clone_committee();
         self.state
             .sign_new_epoch_and_update_committee(new_committee.clone(), next_checkpoint)?;
+
+        loop {
+            let err = match self
+                .wait_for_epoch_cert(next_epoch, &old_committee, QUORUM_TIMEOUT)
+                .await
+            {
+                Ok(cert) => {
+                    info!(epoch=?next_epoch, "Epoch Certificate Formed");
+                    debug!("Epoch Certificate: {:?}", cert);
+                    match self.state.promote_signed_epoch_to_cert(cert) {
+                        Ok(()) => {
+                            break;
+                        }
+                        Err(err) => err,
+                    }
+                }
+                Err(err) => err,
+            };
+            debug!(
+                ?epoch,
+                "Failed to obtain certificate for the next epoch: {:?}", err
+            );
+            tokio::time::sleep(WAIT_BETWEEN_EPOCH_QUERY_RETRY).await;
+        }
 
         // Reconnect the network if we have an type of AuthorityClient that has a network.
         if A::needs_network_recreation() {
@@ -168,7 +199,7 @@ where
                 ?epoch,
                 "Error when processing advance epoch transaction: {:?}", err
             );
-            tokio::time::sleep(WAIT_BETWEEN_EPOCH_TX_QUERY_RETRY).await;
+            tokio::time::sleep(WAIT_BETWEEN_EPOCH_QUERY_RETRY).await;
         }
 
         // Resume the validator to start accepting transactions for the new epoch.
@@ -254,5 +285,110 @@ where
         ));
         self.net.store(new_net);
         Ok(())
+    }
+
+    async fn wait_for_epoch_cert(
+        &self,
+        epoch_id: EpochId,
+        old_committee: &Committee,
+        timeout_until_quorum: Duration,
+    ) -> SuiResult<CertifiedEpoch> {
+        #[derive(Default)]
+        struct Signatures {
+            total_stake: StakeUnit,
+            sigs: Vec<(AuthorityName, AuthoritySignature)>,
+        }
+        #[derive(Default)]
+        struct Summaries {
+            bad_weight: StakeUnit,
+            signed: BTreeMap<EpochInfoDigest, Signatures>,
+            cert: Option<CertifiedEpoch>,
+            errors: Vec<(AuthorityName, SuiError)>,
+        }
+        let initial_state = Summaries::default();
+        let net = self.net.load();
+        let threshold = net.committee.quorum_threshold();
+        let validity = net.committee.validity_threshold();
+        let final_state = net
+            .quorum_map_then_reduce_with_timeout(
+                initial_state,
+                |_name, client| {
+                    Box::pin(async move {
+                        client
+                            .handle_epoch(EpochRequest { epoch_id: Some(epoch_id) })
+                            .await
+                    })
+                },
+                |mut state, name, weight, result| {
+                    Box::pin(async move {
+                        if let Ok(EpochResponse {
+                                      epoch_info: Some(epoch_info)
+                                  }) = result
+                        {
+                            match epoch_info {
+                                AuthenticatedEpoch::Signed(s) => {
+                                    let entry = state.signed.entry(s.epoch_info.digest()).or_default();
+                                    entry.total_stake += weight;
+                                    entry.sigs.push((name, s.auth_sign_info.signature));
+                                    if entry.total_stake >= threshold {
+                                        let maybe_cert = CertifiedEpoch::new(
+                                            &s.epoch_info,
+                                            entry.sigs.clone(),
+                                            old_committee
+                                        );
+                                        match maybe_cert {
+                                            Ok(cert) => {
+                                                state.cert = Some(cert);
+                                                return Ok(ReduceOutput::End(state));
+                                            },
+                                            Err(err) => {
+                                                error!("Unexpected error when creating epoch cert: {:?}", err);
+                                                state.errors.push((name, err));
+                                            }
+                                        }
+                                    }
+                                }
+                                AuthenticatedEpoch::Certified(c) => {
+                                    state.cert = Some(c);
+                                    return Ok(ReduceOutput::End(state));
+                                }
+                                AuthenticatedEpoch::Genesis(_) => {
+                                    unreachable!();
+                                }
+                            }
+                        } else {
+                            state.bad_weight += weight;
+
+                            // Add to the list of errors.
+                            match result {
+                                Err(err) => state.errors.push((name, err)),
+                                Ok(_) => state.errors.push((
+                                    name,
+                                    SuiError::from("Epoch info not yet available"),
+                                )),
+                            }
+
+                            // Return all errors if a quorum is not possible.
+                            if state.bad_weight > validity {
+                                return Err(SuiError::TooManyIncorrectAuthorities {
+                                    errors: state.errors,
+                                });
+                            }
+                        }
+
+                        Ok(ReduceOutput::Continue(state))
+                    })
+                },
+                // A long timeout before we hear back from a quorum
+                timeout_until_quorum,
+            )
+            .await?;
+        if let Some(cert) = final_state.cert {
+            Ok(cert)
+        } else {
+            Err(SuiError::TooManyIncorrectAuthorities {
+                errors: final_state.errors,
+            })
+        }
     }
 }

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -216,7 +216,7 @@ async fn test_finish_epoch_change() {
         assert_eq!(active.net.load().committee.epoch, 1);
         let latest_epoch = active.state.db().get_latest_authenticated_epoch();
         assert_eq!(latest_epoch.epoch(), 1);
-        assert!(matches!(latest_epoch, AuthenticatedEpoch::Signed(..)));
+        assert!(matches!(latest_epoch, AuthenticatedEpoch::Certified(..)));
         assert_eq!(latest_epoch.epoch_info().epoch(), 1);
         // Verify that validator is no longer halted.
         assert!(!active.state.is_halted());

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -285,7 +285,6 @@ where
     assert!(stake >= quorum_threshold);
 
     CertifiedTransaction::new_with_signatures(
-        committee.epoch(),
         transaction.unwrap().to_transaction(),
         votes,
         committee,

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -758,7 +758,6 @@ impl<const STRONG_THRESHOLD: bool> AuthorityQuorumSignInfo<STRONG_THRESHOLD> {
     }
 
     pub fn new_with_signatures(
-        epoch: EpochId,
         mut signatures: Vec<(AuthorityPublicKeyBytes, AuthoritySignature)>,
         committee: &Committee,
     ) -> SuiResult<Self> {
@@ -775,7 +774,7 @@ impl<const STRONG_THRESHOLD: bool> AuthorityQuorumSignInfo<STRONG_THRESHOLD> {
         let sigs: Vec<AuthoritySignature> = signatures.into_iter().map(|(_, sig)| sig).collect();
 
         Ok(AuthorityQuorumSignInfo {
-            epoch,
+            epoch: committee.epoch,
             signature: AggregateAuthoritySignature::aggregate(sigs).map_err(|e| {
                 SuiError::InvalidSignature {
                     error: e.to_string(),

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -124,7 +124,6 @@ where
             digest: OnceCell::new(),
             data,
             auth_signature: AuthorityQuorumSignInfo::<S>::new_with_signatures(
-                committee.epoch,
                 signatures
                     .into_iter()
                     .map(|v| (v.authority, v.signature))

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1921,18 +1921,15 @@ impl SignedEpoch {
 
 impl CertifiedEpoch {
     pub fn new(
-        committee: Committee,
+        epoch_info: &EpochInfo,
         signatures: Vec<(AuthorityName, AuthoritySignature)>,
-        first_checkpoint: CheckpointSequenceNumber,
-        prev_epoch_info: &EpochInfo,
+        prev_epoch_committee: &Committee,
     ) -> SuiResult<Self> {
-        debug_assert_eq!(prev_epoch_info.epoch() + 1, committee.epoch);
-        let epoch_info = EpochInfo::new(committee, first_checkpoint, prev_epoch_info.digest());
         Ok(Self {
-            epoch_info,
+            epoch_info: epoch_info.clone(),
             auth_sign_info: AuthorityStrongQuorumSignInfo::new_with_signatures(
                 signatures,
-                &prev_epoch_info.committee,
+                prev_epoch_committee,
             )?,
         })
     }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1468,7 +1468,6 @@ pub type CertifiedTransactionEffects = TransactionEffectsEnvelope<AuthorityStron
 
 impl CertifiedTransactionEffects {
     pub fn new(
-        epoch: EpochId,
         effects: TransactionEffects,
         signatures: Vec<(AuthorityName, AuthoritySignature)>,
         committee: &Committee,
@@ -1682,7 +1681,6 @@ impl CertifiedTransaction {
     }
 
     pub fn new_with_signatures(
-        epoch: EpochId,
         transaction: Transaction,
         signatures: Vec<(AuthorityName, AuthoritySignature)>,
         committee: &Committee,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1921,6 +1921,24 @@ impl SignedEpoch {
 }
 
 impl CertifiedEpoch {
+    pub fn new(
+        committee: Committee,
+        signatures: Vec<(AuthorityName, AuthoritySignature)>,
+        first_checkpoint: CheckpointSequenceNumber,
+        prev_epoch_info: &EpochInfo,
+    ) -> SuiResult<Self> {
+        let epoch = committee.epoch;
+        let epoch_info = EpochInfo::new(committee, first_checkpoint, prev_epoch_info.digest());
+        Ok(Self {
+            epoch_info,
+            auth_sign_info: AuthorityStrongQuorumSignInfo::new_with_signatures(
+                epoch - 1,
+                signatures,
+                &prev_epoch_info.committee,
+            )?,
+        })
+    }
+
     /// Verify the signature of this certified epoch. The committee to verify this must be the
     /// committee from the previous epoch, as this is signed by a quorum from the previous epoch.
     pub fn verify(&self, committee: &Committee) -> SuiResult {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1477,7 +1477,7 @@ impl CertifiedTransactionEffects {
             transaction_effects_digest: OnceCell::from(effects.digest()),
             effects,
             auth_signature: AuthorityStrongQuorumSignInfo::new_with_signatures(
-                epoch, signatures, committee,
+                signatures, committee,
             )?,
         })
     }
@@ -1660,7 +1660,6 @@ impl<'a> SignatureAggregator<'a> {
 
         if self.weight >= self.committee.quorum_threshold() {
             self.partial.auth_sign_info = AuthorityStrongQuorumSignInfo::new_with_signatures(
-                self.partial.auth_sign_info.epoch,
                 self.signature_stash.clone(),
                 self.committee,
             )?;
@@ -1694,7 +1693,7 @@ impl CertifiedTransaction {
             data: transaction.data,
             tx_signature: transaction.tx_signature,
             auth_sign_info: AuthorityStrongQuorumSignInfo::new_with_signatures(
-                epoch, signatures, committee,
+                signatures, committee,
             )?,
         })
     }
@@ -1927,12 +1926,11 @@ impl CertifiedEpoch {
         first_checkpoint: CheckpointSequenceNumber,
         prev_epoch_info: &EpochInfo,
     ) -> SuiResult<Self> {
-        let epoch = committee.epoch;
+        debug_assert_eq!(prev_epoch_info.epoch() + 1, committee.epoch);
         let epoch_info = EpochInfo::new(committee, first_checkpoint, prev_epoch_info.digest());
         Ok(Self {
             epoch_info,
             auth_sign_info: AuthorityStrongQuorumSignInfo::new_with_signatures(
-                epoch - 1,
                 signatures,
                 &prev_epoch_info.committee,
             )?,

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -370,7 +370,6 @@ impl CertifiedCheckpointSummary {
         let certified_checkpoint = CertifiedCheckpointSummary {
             summary: signed_checkpoints[0].summary.clone(),
             auth_signature: AuthorityWeakQuorumSignInfo::new_with_signatures(
-                committee.epoch,
                 signed_checkpoints
                     .into_iter()
                     .map(|v| (v.auth_signature.authority, v.auth_signature.signature))

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -197,8 +197,7 @@ fn test_new_with_signatures() {
 
     let committee = Committee::new(0, authorities.clone()).unwrap();
     let quorum =
-        AuthorityStrongQuorumSignInfo::new_with_signatures(0, signatures.clone(), &committee)
-            .unwrap();
+        AuthorityStrongQuorumSignInfo::new_with_signatures(signatures.clone(), &committee).unwrap();
 
     let sig_clone = signatures.clone();
     let mut alphabetical_authorities = sig_clone
@@ -232,7 +231,7 @@ fn test_handle_reject_malicious_signature() {
 
     let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
-        AuthorityStrongQuorumSignInfo::new_with_signatures(0, signatures, &committee).unwrap();
+        AuthorityStrongQuorumSignInfo::new_with_signatures(signatures, &committee).unwrap();
     {
         let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
         let sig = AuthoritySignature::new(&message, &sec);
@@ -259,7 +258,7 @@ fn test_bitmap_out_of_range() {
 
     let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
-        AuthorityStrongQuorumSignInfo::new_with_signatures(0, signatures, &committee).unwrap();
+        AuthorityStrongQuorumSignInfo::new_with_signatures(signatures, &committee).unwrap();
 
     // Insert outside of range
     quorum.signers_map.insert(10);
@@ -293,7 +292,7 @@ fn test_reject_extra_public_key() {
 
     let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
-        AuthorityStrongQuorumSignInfo::new_with_signatures(0, used_signatures, &committee).unwrap();
+        AuthorityStrongQuorumSignInfo::new_with_signatures(used_signatures, &committee).unwrap();
 
     quorum.signers_map.insert(3);
 
@@ -324,7 +323,7 @@ fn test_reject_reuse_signatures() {
 
     let committee = Committee::new(0, authorities.clone()).unwrap();
     let quorum =
-        AuthorityStrongQuorumSignInfo::new_with_signatures(0, used_signatures, &committee).unwrap();
+        AuthorityStrongQuorumSignInfo::new_with_signatures(used_signatures, &committee).unwrap();
 
     let (mut obligation, idx) = get_obligation_input(&message);
     assert!(quorum
@@ -346,7 +345,7 @@ fn test_empty_bitmap() {
 
     let committee = Committee::new(0, authorities.clone()).unwrap();
     let mut quorum =
-        AuthorityStrongQuorumSignInfo::new_with_signatures(0, signatures, &committee).unwrap();
+        AuthorityStrongQuorumSignInfo::new_with_signatures(signatures, &committee).unwrap();
     quorum.signers_map = RoaringBitmap::new();
 
     let (mut obligation, idx) = get_obligation_input(&message);


### PR DESCRIPTION
This PR adds the following:
1. Adds a digest to EpochInfo, and an epoch info would always commit to the digest of the previous epoch info.
2. At epoch boundaries, we query a quorum of validators to form a epoch cert and store locally
3. Cleanups