### PR TITLE
Reconfigure consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 dependencies = [
  "backtrace",
 ]
@@ -67,7 +67,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -358,7 +358,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -436,7 +436,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510fd83e3eaf7263b06182f3550b4c0af2af42cb36ab8024969ff5ea7fcb2833"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
 ]
 
@@ -446,7 +446,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -481,7 +481,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -696,7 +696,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -705,7 +705,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -717,7 +717,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.9",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
 ]
 
@@ -791,7 +791,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.141",
+ "serde 1.0.142",
  "time 0.1.43",
  "winapi",
 ]
@@ -919,7 +919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -928,7 +928,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
  "termcolor",
  "unicode-width",
 ]
@@ -977,13 +977,28 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916#259a37b487570763575e6b28f8b8057b16b3e916"
 dependencies = [
  "arc-swap",
- "crypto",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "multiaddr",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "thiserror",
  "tracing",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "config"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "arc-swap",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "multiaddr",
+ "serde 1.0.142",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -995,7 +1010,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -1011,21 +1026,47 @@ dependencies = [
  "bincode",
  "blake2",
  "bytes",
- "config 0.1.0",
- "crypto",
- "dag",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "dag 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "match_opt",
  "prometheus",
  "rand 0.7.3",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_bytes",
  "thiserror",
  "tokio",
  "tracing",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "consensus"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "arc-swap",
+ "bincode",
+ "blake2",
+ "bytes",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "dag 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "match_opt",
+ "prometheus",
+ "rand 0.7.3",
+ "rocksdb",
+ "serde 1.0.142",
+ "serde_bytes",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -1120,7 +1161,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -1307,12 +1348,39 @@ dependencies = [
  "rand 0.7.3",
  "readonly",
  "secp256k1",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_bytes",
  "serde_with 2.0.0",
  "signature",
  "tokio",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "anyhow",
+ "base64ct",
+ "blake2",
+ "blst",
+ "digest 0.10.3",
+ "ed25519-dalek",
+ "eyre",
+ "hex",
+ "hkdf",
+ "once_cell",
+ "rand 0.7.3",
+ "readonly",
+ "secp256k1",
+ "serde 1.0.142",
+ "serde_bytes",
+ "serde_with 2.0.0",
+ "signature",
+ "tokio",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "zeroize",
 ]
 
@@ -1358,7 +1426,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -1389,7 +1457,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "serde 1.0.141",
+ "serde 1.0.142",
  "subtle",
  "zeroize",
 ]
@@ -1414,15 +1482,32 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916#259a37b487570763575e6b28f8b8057b16b3e916"
 dependencies = [
  "arc-swap",
- "crypto",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "dashmap",
  "either",
  "itertools",
  "once_cell",
  "rayon",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "dag"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "arc-swap",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "dashmap",
+ "either",
+ "itertools",
+ "once_cell",
+ "rayon",
+ "serde 1.0.142",
+ "thiserror",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -1606,7 +1691,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.6.2",
  "rayon",
- "serde 1.0.141",
+ "serde 1.0.142",
  "toml",
 ]
 
@@ -1626,7 +1711,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "parking_lot 0.11.2",
  "rustc-hash",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "thousands",
 ]
@@ -1779,7 +1864,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
  "signature",
 ]
 
@@ -1793,7 +1878,7 @@ dependencies = [
  "ed25519",
  "merlin",
  "rand 0.7.3",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -1808,7 +1893,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand 0.8.5",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -1938,24 +2023,53 @@ dependencies = [
  "bincode",
  "blake2",
  "bytes",
- "config 0.1.0",
- "consensus",
- "crypto",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "futures",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "primary",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
  "tokio",
  "tokio-util",
  "tonic",
  "tracing",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "types",
- "worker",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "worker 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "executor"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "blake2",
+ "bytes",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "futures",
+ "multiaddr",
+ "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "rocksdb",
+ "serde 1.0.142",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tracing",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "worker 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -2309,7 +2423,7 @@ dependencies = [
  "gloo-utils",
  "js-sys",
  "pin-project",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "thiserror",
  "wasm-bindgen",
@@ -2372,7 +2486,7 @@ dependencies = [
  "petgraph 0.6.2",
  "rayon",
  "semver 1.0.9",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "smallvec",
  "static_assertions",
@@ -2391,7 +2505,7 @@ dependencies = [
  "diffus",
  "guppy-workspace-hack",
  "semver 1.0.9",
- "serde 1.0.141",
+ "serde 1.0.142",
  "toml",
 ]
 
@@ -2440,7 +2554,7 @@ dependencies = [
  "owo-colors",
  "pathdiff",
  "rayon",
- "serde 1.0.141",
+ "serde 1.0.142",
  "tabular",
  "target-spec",
  "toml",
@@ -2763,7 +2877,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.1",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -2776,7 +2890,7 @@ dependencies = [
  "once_cell",
  "pest",
  "pest_derive",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_yaml",
  "similar",
@@ -2964,7 +3078,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "soketto",
  "thiserror",
@@ -2987,7 +3101,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustc-hash",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "thiserror",
  "tokio",
@@ -3006,7 +3120,7 @@ dependencies = [
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "tokio",
  "tracing",
@@ -3033,7 +3147,7 @@ checksum = "e290bba767401b646812f608c099b922d8142603c9e73a50fb192d3ac86f4a0d"
 dependencies = [
  "anyhow",
  "beef",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "thiserror",
  "tracing",
@@ -3107,7 +3221,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3250,7 +3364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3411,7 +3525,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3423,7 +3537,7 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "ref-cast",
- "serde 1.0.141",
+ "serde 1.0.142",
  "variant_count",
 ]
 
@@ -3444,7 +3558,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3523,7 +3637,7 @@ dependencies = [
  "once_cell",
  "read-write-set",
  "read-write-set-dynamic",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_yaml",
  "tempfile",
  "walkdir",
@@ -3539,7 +3653,7 @@ dependencies = [
  "hex",
  "move-core-types",
  "num-bigint",
- "serde 1.0.141",
+ "serde 1.0.142",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -3584,7 +3698,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_bytes",
 ]
 
@@ -3605,7 +3719,7 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3641,7 +3755,7 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3655,7 +3769,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3720,7 +3834,7 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3746,7 +3860,7 @@ dependencies = [
  "num",
  "once_cell",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3774,7 +3888,7 @@ dependencies = [
  "petgraph 0.5.1",
  "ptree",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -3812,7 +3926,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "simplelog",
  "tokio",
@@ -3841,7 +3955,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "tera",
  "tokio",
@@ -3855,7 +3969,7 @@ dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3870,7 +3984,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3897,7 +4011,7 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3915,7 +4029,7 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -3946,7 +4060,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=79071528524f08b12e9abb84c1094d8e976aa17a#79071528524f08b12e9abb84c1094d8e976aa17a"
 dependencies = [
  "once_cell",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -4063,7 +4177,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "once_cell",
- "serde 1.0.141",
+ "serde 1.0.142",
  "smallvec",
 ]
 
@@ -4079,7 +4193,7 @@ dependencies = [
  "data-encoding",
  "multihash",
  "percent-encoding",
- "serde 1.0.141",
+ "serde 1.0.142",
  "static_assertions",
  "unsigned-varint",
  "url",
@@ -4127,7 +4241,28 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
- "serde 1.0.141",
+ "serde 1.0.142",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "mysten-network"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=20ef52a00135114eb361e28673cfaa9bf4560f6f#20ef52a00135114eb361e28673cfaa9bf4560f6f"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "futures",
+ "http",
+ "multiaddr",
+ "serde 1.0.142",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4148,7 +4283,7 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
- "serde 1.0.141",
+ "serde 1.0.142",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4169,7 +4304,7 @@ dependencies = [
  "futures",
  "http",
  "multiaddr",
- "serde 1.0.141",
+ "serde 1.0.142",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4236,20 +4371,45 @@ dependencies = [
  "async-trait",
  "backoff",
  "bytes",
- "crypto",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "futures",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
  "prometheus",
  "rand 0.7.3",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
  "tokio",
  "tokio-util",
  "tonic",
  "tracing",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "network"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backoff",
+ "bytes",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "futures",
+ "multiaddr",
+ "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "prometheus",
+ "rand 0.7.3",
+ "serde 1.0.142",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tracing",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -4264,7 +4424,7 @@ dependencies = [
  "hakari",
  "hex",
  "once_cell",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -4279,7 +4439,7 @@ dependencies = [
  "guppy",
  "nexlint",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
  "toml",
 ]
 
@@ -4318,13 +4478,13 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "clap 2.34.0",
- "config 0.1.0",
- "consensus",
- "crypto",
- "executor",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "futures",
- "network",
- "primary",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "prometheus",
  "rand 0.7.3",
  "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
@@ -4336,10 +4496,49 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber 0.3.15",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "url",
- "worker",
+ "worker 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "node"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "axum",
+ "bincode",
+ "bytes",
+ "cfg-if 1.0.0",
+ "clap 2.34.0",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "futures",
+ "multiaddr",
+ "mysten-network 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=20ef52a00135114eb361e28673cfaa9bf4560f6f)",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "prometheus",
+ "rand 0.7.3",
+ "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber 0.3.15",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "url",
+ "worker 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -5085,9 +5284,9 @@ dependencies = [
  "bincode",
  "blake2",
  "bytes",
- "config 0.1.0",
- "consensus",
- "crypto",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "dashmap",
  "derive_builder",
  "ed25519-dalek",
@@ -5095,12 +5294,12 @@ dependencies = [
  "itertools",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "network",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "once_cell",
  "prometheus",
  "prost",
  "rand 0.7.3",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -5108,8 +5307,46 @@ dependencies = [
  "tower",
  "tracing",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "primary"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "base64",
+ "bincode",
+ "blake2",
+ "bytes",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "dashmap",
+ "derive_builder",
+ "ed25519-dalek",
+ "futures",
+ "itertools",
+ "multiaddr",
+ "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "once_cell",
+ "prometheus",
+ "prost",
+ "rand 0.7.3",
+ "serde 1.0.142",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tower",
+ "tracing",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -5291,7 +5528,7 @@ dependencies = [
  "config 0.11.0",
  "directories",
  "petgraph 0.6.2",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde-value",
  "tint",
 ]
@@ -5612,7 +5849,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -5785,9 +6022,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "rusty-fork"
@@ -5870,7 +6107,7 @@ dependencies = [
  "dyn-clone",
  "either",
  "schemars_derive",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
 ]
 
@@ -5993,7 +6230,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -6025,9 +6262,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af873f2c95b99fcb0bd0fe622a43e29514658873c8ceba88c4cb88833a22500"
+checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
 dependencies = [
  "serde_derive",
 ]
@@ -6050,7 +6287,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
 ]
 
@@ -6061,7 +6298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
 ]
 
@@ -6072,7 +6309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.0",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -6081,7 +6318,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -6091,14 +6328,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75743a150d003dd863b51dc809bcad0d73f2102c53632f1e954e738192a3413f"
+checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
 dependencies = [
  "proc-macro2 1.0.42",
  "quote 1.0.20",
@@ -6118,13 +6355,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -6133,7 +6370,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b0651a2f427e4a4d74d458947aa5ca36c62c1b503344d143763ec06216a975"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -6145,7 +6382,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.2",
  "ryu",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -6155,7 +6392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "hex",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_with_macros 1.5.2",
 ]
 
@@ -6169,7 +6406,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_with_macros 2.0.0",
  "time 0.3.9",
@@ -6207,7 +6444,7 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.141",
+ "serde 1.0.142",
  "yaml-rust",
 ]
 
@@ -6671,7 +6908,7 @@ dependencies = [
  "camino",
  "clap 3.1.18",
  "colored",
- "executor",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "futures",
  "jemalloc-ctl",
  "jemallocator",
@@ -6687,7 +6924,7 @@ dependencies = [
  "rocksdb",
  "rustyline",
  "rustyline-derive",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_with 1.14.0",
  "shell-words",
@@ -6754,14 +6991,14 @@ dependencies = [
  "jemallocator",
  "move-core-types",
  "multiaddr",
- "node",
+ "node 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "num_cpus",
  "prometheus",
  "rand 0.8.5",
  "rand_distr",
  "rayon",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_with 1.14.0",
  "strum",
@@ -6793,7 +7030,7 @@ dependencies = [
  "clap 3.1.18",
  "futures",
  "reqwest",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "sui",
  "sui-config",
@@ -6820,8 +7057,8 @@ dependencies = [
  "arc-swap",
  "bcs",
  "camino",
- "config 0.1.0",
- "crypto",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "dirs",
  "insta",
  "move-binary-format",
@@ -6831,7 +7068,7 @@ dependencies = [
  "multiaddr",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_with 1.14.0",
  "serde_yaml",
  "sui-adapter",
@@ -6854,10 +7091,10 @@ dependencies = [
  "bytes",
  "chrono",
  "clap 3.1.18",
- "config 0.1.0",
- "consensus",
- "crypto",
- "executor",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "futures",
  "move-binary-format",
  "move-bytecode-utils",
@@ -6866,7 +7103,7 @@ dependencies = [
  "move-vm-runtime",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=a4c2cae59d823533061a5d8fe28771629819c43f)",
- "node",
+ "node 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions",
@@ -6874,7 +7111,7 @@ dependencies = [
  "rand 0.7.3",
  "rocksdb",
  "scopeguard",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde-reflection",
  "serde_json",
  "serde_with 1.14.0",
@@ -6899,7 +7136,7 @@ dependencies = [
  "tracing",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=a4c2cae59d823533061a5d8fe28771629819c43f)",
  "typed-store-macros",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "workspace-hack 0.1.0",
 ]
 
@@ -6912,7 +7149,7 @@ dependencies = [
  "axum",
  "clap 3.1.18",
  "http",
- "serde 1.0.141",
+ "serde 1.0.142",
  "sui",
  "sui-config",
  "sui-json-rpc-types",
@@ -6976,7 +7213,7 @@ dependencies = [
  "move-package",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=a4c2cae59d823533061a5d8fe28771629819c43f)",
  "prometheus",
- "serde 1.0.141",
+ "serde 1.0.142",
  "sui-config",
  "sui-core",
  "sui-framework",
@@ -7004,7 +7241,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "schemars",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "sui-adapter",
  "sui-framework",
@@ -7025,7 +7262,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-proc-macros",
  "prometheus",
- "serde 1.0.141",
+ "serde 1.0.142",
  "signature",
  "sui-core",
  "sui-json",
@@ -7050,7 +7287,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "schemars",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "serde_with 1.14.0",
  "sui-json",
@@ -7111,7 +7348,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.7.3",
  "schemars",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "sui",
  "sui-config",
@@ -7162,7 +7399,7 @@ dependencies = [
  "futures",
  "futures-core",
  "jsonrpsee",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "signature",
  "sui-config",
@@ -7190,7 +7427,7 @@ dependencies = [
  "num_cpus",
  "pretty_assertions",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "sqlx",
  "strum",
@@ -7231,7 +7468,7 @@ name = "sui-telemetry"
 version = "0.1.0"
 dependencies = [
  "reqwest",
- "serde 1.0.141",
+ "serde 1.0.142",
  "tokio",
  "tracing",
  "workspace-hack 0.1.0",
@@ -7244,11 +7481,11 @@ dependencies = [
  "anyhow",
  "clap 3.1.18",
  "colored",
- "executor",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "futures",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=a4c2cae59d823533061a5d8fe28771629819c43f)",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_with 1.14.0",
  "strum",
  "strum_macros",
@@ -7298,11 +7535,11 @@ dependencies = [
  "base64ct",
  "bcs",
  "bincode",
- "crypto",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "curve25519-dalek",
  "digest 0.10.3",
  "enum_dispatch",
- "executor",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
  "hex",
  "hkdf",
  "itertools",
@@ -7319,7 +7556,7 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "schemars",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde-name",
  "serde_bytes",
  "serde_json",
@@ -7429,7 +7666,7 @@ checksum = "462215968f204588ef2d3499333d07729b692aa01f79f9b0925071127b3b353f"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
- "serde 1.0.141",
+ "serde 1.0.142",
  "target-lexicon",
 ]
 
@@ -7499,7 +7736,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "slug",
  "unic-segment",
@@ -7536,7 +7773,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03298404c433dd9e5bb84e2d6e587e80aa98a01a818c45150327d06c3ae1c72"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -7551,7 +7788,7 @@ dependencies = [
  "cargo_metadata",
  "proc-macro2 1.0.42",
  "quote 1.0.20",
- "serde 1.0.141",
+ "serde 1.0.142",
  "strum_macros",
 ]
 
@@ -7582,7 +7819,7 @@ dependencies = [
  "bincode",
  "hex",
  "num-traits 0.2.15",
- "serde 1.0.141",
+ "serde 1.0.142",
  "sha-1 0.10.0",
  "test-fuzz-internal",
 ]
@@ -7714,7 +7951,7 @@ dependencies = [
  "itoa 1.0.2",
  "libc",
  "num_threads",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -7732,7 +7969,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
 ]
 
@@ -7871,7 +8108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "indexmap",
- "serde 1.0.141",
+ "serde 1.0.142",
 ]
 
 [[package]]
@@ -8068,7 +8305,7 @@ checksum = "a788f2119fde477cd33823330c14004fa8cdac6892fd6f12181bbda9dbf14fc9"
 dependencies = [
  "gethostname",
  "log",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "time 0.3.9",
  "tracing",
@@ -8230,7 +8467,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
  "tokio",
  "tracing",
@@ -8248,7 +8485,7 @@ dependencies = [
  "fdlimit",
  "pre",
  "rocksdb",
- "serde 1.0.141",
+ "serde 1.0.142",
  "thiserror",
  "tokio",
  "tracing",
@@ -8286,9 +8523,9 @@ dependencies = [
  "bincode",
  "blake2",
  "bytes",
- "config 0.1.0",
- "crypto",
- "dag",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "dag 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "derive_builder",
  "ed25519-dalek",
  "proptest",
@@ -8296,7 +8533,7 @@ dependencies = [
  "prost",
  "rand 0.7.3",
  "rustversion",
- "serde 1.0.141",
+ "serde 1.0.142",
  "signature",
  "thiserror",
  "tokio",
@@ -8304,6 +8541,38 @@ dependencies = [
  "tonic",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "types"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "base64",
+ "bincode",
+ "blake2",
+ "bytes",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "dag 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "derive_builder",
+ "ed25519-dalek",
+ "indexmap",
+ "proptest",
+ "proptest-derive",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "rustversion",
+ "serde 1.0.142",
+ "signature",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-build 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -8607,7 +8876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde_json",
  "wasm-bindgen-macro",
 ]
@@ -8869,16 +9138,16 @@ dependencies = [
  "bincode",
  "blake2",
  "bytes",
- "config 0.1.0",
- "crypto",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "ed25519-dalek",
  "futures",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "network",
- "primary",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "prometheus",
- "serde 1.0.141",
+ "serde 1.0.142",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8886,8 +9155,39 @@ dependencies = [
  "tower",
  "tracing",
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
+]
+
+[[package]]
+name = "worker"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "blake2",
+ "bytes",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "ed25519-dalek",
+ "futures",
+ "multiaddr",
+ "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "prometheus",
+ "serde 1.0.142",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower",
+ "tracing",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd)",
 ]
 
 [[package]]
@@ -8987,9 +9287,9 @@ dependencies = [
  "colored",
  "colored-diff",
  "combine",
- "config 0.1.0",
+ "config 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "config 0.11.0",
- "consensus",
+ "consensus 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "console",
  "const-oid",
  "constant_time_eq",
@@ -9008,7 +9308,7 @@ dependencies = [
  "crossterm 0.22.1",
  "crossterm 0.23.2",
  "crossterm 0.24.0",
- "crypto",
+ "crypto 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "crypto-bigint",
  "crypto-common",
  "crypto-mac",
@@ -9016,7 +9316,7 @@ dependencies = [
  "csv-core",
  "curve25519-dalek",
  "curve25519-dalek-fiat",
- "dag",
+ "dag 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "darling 0.13.4",
  "darling 0.14.1",
  "darling_core 0.13.4",
@@ -9063,7 +9363,7 @@ dependencies = [
  "env_logger",
  "ethnum",
  "event-listener",
- "executor",
+ "executor 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "eyre",
  "fail",
  "fastrand",
@@ -9235,11 +9535,11 @@ dependencies = [
  "name-variant",
  "named-lock",
  "nested",
- "network",
+ "network 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "nexlint",
  "nexlint-lints",
  "nibble_vec",
- "node",
+ "node 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "nom 5.1.2",
  "nom 7.1.1",
  "normalize-line-endings",
@@ -9307,7 +9607,7 @@ dependencies = [
  "pretty",
  "pretty_assertions",
  "prettyplease",
- "primary",
+ "primary 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "proc-macro-crate 0.1.5",
  "proc-macro-crate 1.1.3",
  "proc-macro-error",
@@ -9385,7 +9685,7 @@ dependencies = [
  "semver-parser 0.7.0",
  "send_wrapper",
  "serde 0.8.23",
- "serde 1.0.141",
+ "serde 1.0.142",
  "serde-hjson",
  "serde-name",
  "serde-reflection",
@@ -9514,7 +9814,7 @@ dependencies = [
  "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=a4c2cae59d823533061a5d8fe28771629819c43f)",
  "typed-store-macros",
  "typenum",
- "types",
+ "types 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "ucd-trie",
  "uncased",
  "unescape",
@@ -9561,7 +9861,7 @@ dependencies = [
  "webpki-roots 0.21.1",
  "webpki-roots 0.22.3",
  "which",
- "worker",
+ "worker 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=259a37b487570763575e6b28f8b8057b16b3e916)",
  "yaml-rust",
  "zeroize",
@@ -9852,7 +10152,393 @@ dependencies = [
  "secp256k1-sys",
  "semver 0.11.0",
  "semver-parser 0.10.2",
- "serde 1.0.141",
+ "serde 1.0.142",
+ "serde-reflection",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "serde_test",
+ "serde_urlencoded",
+ "serde_with 2.0.0",
+ "serde_with_macros 2.0.0",
+ "serde_yaml",
+ "sha2 0.10.2",
+ "sha2 0.9.9",
+ "sha3 0.10.2",
+ "sharded-slab",
+ "shlex",
+ "signature",
+ "similar",
+ "slab",
+ "smallvec",
+ "socket2",
+ "spki",
+ "static_assertions",
+ "strsim 0.10.0",
+ "strsim 0.8.0",
+ "structopt",
+ "structopt-derive",
+ "subtle",
+ "syn 0.15.44",
+ "syn 1.0.98",
+ "sync_wrapper",
+ "synstructure",
+ "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "tempfile",
+ "termcolor",
+ "terminal_size",
+ "termtree",
+ "textwrap 0.11.0",
+ "textwrap 0.15.0",
+ "thiserror",
+ "thiserror-impl",
+ "thousands",
+ "thread_local",
+ "threadpool",
+ "thrift",
+ "time 0.3.9",
+ "tinytemplate",
+ "tinyvec",
+ "tinyvec_macros",
+ "tokio",
+ "tokio-io-timeout",
+ "tokio-macros",
+ "tokio-rustls 0.23.4",
+ "tokio-stream",
+ "tokio-util",
+ "toml",
+ "tonic",
+ "tonic-build 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic-health",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-appender",
+ "tracing-attributes",
+ "tracing-bunyan-formatter",
+ "tracing-chrome",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-log",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.15",
+ "tracing-test",
+ "tracing-test-macro",
+ "try-lock",
+ "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "typenum",
+ "ucd-trie",
+ "unicode-bidi",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "unicode-width",
+ "unicode-xid 0.1.0",
+ "unicode-xid 0.2.3",
+ "unsigned-varint",
+ "untrusted",
+ "url",
+ "vec_map",
+ "version_check",
+ "wait-timeout",
+ "walkdir",
+ "want",
+ "webpki 0.22.0",
+ "which",
+ "yaml-rust",
+ "zeroize",
+ "zeroize_derive",
+ "zstd-sys",
+]
+
+[[package]]
+name = "workspace-hack"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/narwhal?rev=32b5298b60d410620f2c0e80eec4b6c12e4f9bdd#32b5298b60d410620f2c0e80eec4b6c12e4f9bdd"
+dependencies = [
+ "addr2line",
+ "adler",
+ "ahash",
+ "aho-corasick",
+ "ansi_term",
+ "anyhow",
+ "arc-swap",
+ "ark-bls12-377",
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ed-on-bw6-761",
+ "ark-ed-on-cp6-782",
+ "ark-ff",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-relations",
+ "ark-serialize",
+ "ark-serialize-derive",
+ "ark-snark",
+ "ark-std",
+ "arrayref",
+ "arrayvec 0.7.2",
+ "async-recursion",
+ "async-stream",
+ "async-stream-impl",
+ "async-trait",
+ "atty",
+ "autocfg",
+ "axum",
+ "axum-core",
+ "backoff",
+ "backtrace",
+ "base16ct",
+ "base64",
+ "base64ct",
+ "bincode",
+ "bindgen",
+ "bit-set",
+ "bit-vec",
+ "bitcoin_hashes",
+ "bitflags",
+ "blake2",
+ "blake2s_simd",
+ "block-buffer 0.10.2",
+ "block-buffer 0.9.0",
+ "bls-crypto",
+ "blst",
+ "bs58",
+ "bstr",
+ "byteorder",
+ "bytes",
+ "bzip2-sys",
+ "cast 0.3.0",
+ "cc",
+ "cexpr",
+ "cfg-if 1.0.0",
+ "clang-sys",
+ "clap 2.34.0",
+ "clap 3.1.18",
+ "clap_lex",
+ "cmake",
+ "collectable",
+ "console",
+ "const-oid",
+ "constant_time_eq",
+ "core2",
+ "criterion",
+ "criterion-plot",
+ "crossbeam",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "crossterm 0.24.0",
+ "crypto-bigint",
+ "crypto-common",
+ "crypto-mac",
+ "csv",
+ "csv-core",
+ "curve25519-dalek",
+ "darling 0.14.1",
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
+ "dashmap",
+ "data-encoding",
+ "der",
+ "derivative",
+ "derive_builder",
+ "derive_builder_core",
+ "derive_builder_macro",
+ "dhat",
+ "diff",
+ "difflib",
+ "digest 0.10.3",
+ "digest 0.9.0",
+ "downcast",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "either",
+ "elliptic-curve",
+ "env_logger",
+ "eyre",
+ "fastrand",
+ "fdlimit",
+ "ff",
+ "fixedbitset 0.4.1",
+ "float-cmp",
+ "fnv",
+ "form_urlencoded",
+ "fragile",
+ "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "generic-array",
+ "gethostname",
+ "getrandom 0.1.16",
+ "getrandom 0.2.6",
+ "gimli",
+ "glob",
+ "group",
+ "h2",
+ "half",
+ "hashbrown 0.12.1",
+ "hdrhistogram",
+ "heck 0.3.3",
+ "heck 0.4.0",
+ "hex",
+ "hex-literal",
+ "hkdf",
+ "hmac",
+ "http",
+ "http-body",
+ "http-range-header",
+ "httparse",
+ "httpdate",
+ "humantime",
+ "hyper",
+ "hyper-timeout",
+ "ident_case",
+ "idna",
+ "indenter",
+ "indexmap",
+ "insta",
+ "instant",
+ "integer-encoding",
+ "itertools",
+ "itoa 0.4.8",
+ "itoa 1.0.2",
+ "jobserver",
+ "json",
+ "k256",
+ "keccak",
+ "lazy_static 1.4.0",
+ "lazycell",
+ "libc",
+ "libloading",
+ "librocksdb-sys",
+ "libz-sys",
+ "linked-hash-map",
+ "lock_api 0.4.7",
+ "log",
+ "lru",
+ "match_opt",
+ "matchers",
+ "matches",
+ "matchit",
+ "memchr",
+ "memoffset",
+ "merlin",
+ "mime",
+ "minimal-lexical",
+ "miniz_oxide",
+ "mio 0.8.3",
+ "mockall",
+ "mockall_derive",
+ "multiaddr",
+ "multihash",
+ "multihash-derive",
+ "multimap",
+ "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "mysten-network 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=20ef52a00135114eb361e28673cfaa9bf4560f6f)",
+ "nom 7.1.1",
+ "normalize-line-endings",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+ "num_cpus",
+ "object 0.29.0",
+ "once_cell",
+ "oorandom",
+ "opaque-debug",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "opentelemetry-semantic-conventions",
+ "ordered-float 1.1.1",
+ "os_str_bytes",
+ "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
+ "parking_lot_core 0.8.5",
+ "parking_lot_core 0.9.3",
+ "paste",
+ "peeking_take_while",
+ "percent-encoding",
+ "pest",
+ "petgraph 0.6.2",
+ "pin-project",
+ "pin-project-internal",
+ "pin-project-lite",
+ "pin-utils",
+ "pkcs8",
+ "pkg-config",
+ "plotters",
+ "plotters-backend",
+ "plotters-svg",
+ "ppv-lite86",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "pretty_assertions",
+ "prettyplease",
+ "proc-macro-crate 1.1.3",
+ "proc-macro-error",
+ "proc-macro-error-attr",
+ "proc-macro2 0.4.30",
+ "proc-macro2 1.0.42",
+ "prometheus",
+ "proptest",
+ "proptest-derive",
+ "prost",
+ "prost-build",
+ "prost-derive",
+ "prost-types",
+ "protobuf",
+ "quick-error 1.2.3",
+ "quick-error 2.0.1",
+ "quote 0.6.13",
+ "quote 1.0.20",
+ "rand 0.7.3",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.5.1",
+ "rand_core 0.6.3",
+ "rand_pcg",
+ "rand_xorshift",
+ "rayon",
+ "rayon-core",
+ "readonly",
+ "regex",
+ "regex-automata",
+ "regex-syntax",
+ "remove_dir_all",
+ "rfc6979",
+ "ring",
+ "rocksdb",
+ "rustc-demangle",
+ "rustc-hash",
+ "rustc_version 0.3.3",
+ "rustls 0.20.6",
+ "rustls-pemfile",
+ "rustversion",
+ "rusty-fork",
+ "ryu",
+ "same-file",
+ "scopeguard",
+ "sct 0.7.0",
+ "sec1",
+ "secp256k1",
+ "secp256k1-sys",
+ "semver 0.11.0",
+ "semver-parser 0.10.2",
+ "serde 1.0.142",
  "serde-reflection",
  "serde_bytes",
  "serde_cbor",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.57"
 rayon = "1.5.3"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 futures = "0.3.21"
-serde = { version = "1.0.141", features = ["derive"] }
+serde = { version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.80"
 tempfile = "3.3.0"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/crates/sui-benchmark/src/benchmark/validator_preparer.rs
+++ b/crates/sui-benchmark/src/benchmark/validator_preparer.rs
@@ -280,6 +280,7 @@ fn make_authority_state(
     // opts.set_manual_wal_flush(true);
 
     let store = Arc::new(AuthorityStore::open(store_path, Some(opts)));
+    let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = tokio::sync::mpsc::channel(10);
     (
         Runtime::new().unwrap().block_on(async {
             AuthorityState::new(
@@ -292,6 +293,7 @@ fn make_authority_state(
                 None,
                 &sui_config::genesis::Genesis::get_default_genesis(),
                 &prometheus::Registry::new(),
+                tx_reconfigure_consensus,
             )
             .await
         }),

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0.141", features = ["derive"] }
+serde = { version = "1.0.142", features = ["derive"] }
 futures = "0.3.21"
 serde_json = "1.0.80"
 tempfile = "3.3.0"

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -20,8 +20,9 @@ multiaddr = "0.14.0"
 once_cell = "1.11.0"
 tracing = "0.1.36"
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "config" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "crypto" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "config" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "crypto" }
+
 move-binary-format = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-package = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a", features = ["address20"] }

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -75,7 +75,7 @@ impl Genesis {
                 };
                 let workers = [(
                     0, // worker_id
-                    narwhal_config::WorkerAddresses {
+                    narwhal_config::WorkerInfo {
                         primary_to_worker: validator.narwhal_primary_to_worker.clone(),
                         transactions: validator.narwhal_consensus_address.clone(),
                         worker_to_worker: validator.narwhal_worker_to_worker.clone(),

--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -108,7 +108,7 @@ fn network_config_snapshot_matches() {
             consensus_config
                 .narwhal_config
                 .prometheus_metrics
-                .socket_addr = fake_socket;
+                .socket_addr = Multiaddr::empty();
         }
     }
     assert_yaml_snapshot!(network_config, {

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -32,7 +32,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false
@@ -67,7 +67,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false
@@ -102,7 +102,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false
@@ -137,7 +137,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false
@@ -172,7 +172,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false
@@ -207,7 +207,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false
@@ -242,7 +242,7 @@ validator_configs:
           remove_collections_timeout: 5000ms
         max_concurrent_requests: 500000
         prometheus_metrics:
-          socket_addr: "0.0.0.0:1"
+          socket_addr: ""
     enable-event-processing: false
     enable-gossip: true
     enable-reconfig: false

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -13,7 +13,7 @@ bcs = "0.1.3"
 chrono = "0.4.0"
 futures = "0.3.21"
 bytes = "1.2.1"
-serde = { version = "1.0.141", features = ["derive"] }
+serde = { version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.79"
 serde_with = "1.14.0"
 tokio = { version = "1.20.1", features = ["full", "tracing", "test-util"] }
@@ -50,12 +50,12 @@ typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a4c2c
 typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a4c2cae59d823533061a5d8fe28771629819c43f"} 
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a4c2cae59d823533061a5d8fe28771629819c43f" }
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "config" }
-narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "consensus" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "crypto", features=["copy_key"]}
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "executor" }
-narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "types" }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "node" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "config" }
+narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "consensus" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "crypto", features=["copy_key"]}
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "executor" }
+narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "types" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "node" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -27,6 +27,7 @@ use sui_types::messages::{
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::Object;
+use tokio::sync::mpsc::channel;
 
 static mut SHOULD_FAIL: bool = true;
 static FIXER: Once = Once::new();
@@ -73,6 +74,7 @@ impl ConfigurableBatchActionClient {
         fs::create_dir(&path).unwrap();
 
         let store = Arc::new(AuthorityStore::open(&path, None));
+        let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = channel(1);
         let state = AuthorityState::new(
             committee.clone(),
             address,
@@ -83,6 +85,7 @@ impl ConfigurableBatchActionClient {
             None,
             &sui_config::genesis::Genesis::get_default_genesis(),
             &prometheus::Registry::new(),
+            tx_reconfigure_consensus,
         )
         .await;
 

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -339,6 +339,7 @@ impl LocalAuthorityClient {
         use crate::checkpoints::CheckpointStore;
         use parking_lot::Mutex;
         use std::{env, fs};
+        use tokio::sync::mpsc::channel;
 
         // Random directory
         let dir = env::temp_dir();
@@ -361,6 +362,7 @@ impl LocalAuthorityClient {
         )
         .expect("Should not fail to open local checkpoint DB");
 
+        let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = channel(1);
         let state = AuthorityState::new(
             committee.clone(),
             address,
@@ -371,6 +373,7 @@ impl LocalAuthorityClient {
             Some(Arc::new(Mutex::new(checkpoints))),
             genesis,
             &prometheus::Registry::new(),
+            tx_reconfigure_consensus,
         )
         .await;
         Self {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -14,7 +14,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::{stream::BoxStream, TryStreamExt};
 use multiaddr::Multiaddr;
-use narwhal_crypto::traits::KeyPair;
+use narwhal_config::Committee as ConsensusCommittee;
+use narwhal_crypto::{traits::KeyPair as _, KeyPair as ConsensusKeyPair};
 use prometheus::Registry;
 use std::{io, sync::Arc, time::Duration};
 use sui_config::NodeConfig;
@@ -22,6 +23,7 @@ use sui_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
+use tokio::sync::mpsc::Receiver;
 
 use sui_types::{error::*, messages::*};
 use tokio::{
@@ -166,7 +168,8 @@ impl ValidatorService {
     pub async fn new(
         config: &NodeConfig,
         state: Arc<AuthorityState>,
-        prometheus_registry: &Registry,
+        _prometheus_registry: &Registry,
+        rx_reconfigure_consensus: Receiver<(ConsensusKeyPair, ConsensusCommittee)>,
     ) -> Result<Self> {
         let (tx_consensus_to_sui, rx_consensus_to_sui) = channel(1_000);
         let (tx_sui_to_consensus, rx_sui_to_consensus) = channel(1_000);
@@ -176,27 +179,45 @@ impl ValidatorService {
             .consensus_config()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
         let consensus_keypair = config.key_pair().copy();
-        let consensus_name = consensus_keypair.public().clone();
-        let consensus_store = narwhal_node::NodeStorage::reopen(consensus_config.db_path());
-        narwhal_node::Node::spawn_primary(
-            consensus_keypair,
-            config.genesis()?.narwhal_committee(),
-            &consensus_store,
-            consensus_config.narwhal_config().to_owned(),
-            /* consensus */ true, // Indicate that we want to run consensus.
-            /* execution_state */ state.clone(),
-            /* tx_confirmation */ tx_consensus_to_sui,
-            prometheus_registry,
-        )
-        .await?;
-        narwhal_node::Node::spawn_workers(
-            consensus_name,
-            /* ids */ vec![0], // We run a single worker with id '0'.
-            config.genesis()?.narwhal_committee(),
-            &consensus_store,
-            consensus_config.narwhal_config().to_owned(),
-            prometheus_registry,
-        );
+        // let consensus_name = consensus_keypair.public().clone();
+        let consensus_committee = config.genesis()?.narwhal_committee().load();
+        let consensus_storage_base_path = consensus_config.db_path().to_path_buf();
+        // let consensus_store = narwhal_node::NodeStorage::reopen(consensus_config.db_path());
+        let consensus_execution_state = state.clone();
+        let consensus_parameters = consensus_config.narwhal_config().to_owned();
+
+        tokio::spawn(async move {
+            narwhal_node::restarter::NodeRestarter::watch(
+                consensus_keypair,
+                &(&*consensus_committee).clone(),
+                consensus_storage_base_path,
+                consensus_execution_state,
+                consensus_parameters,
+                rx_reconfigure_consensus,
+                /* tx_output */ tx_consensus_to_sui,
+            )
+            .await
+        });
+
+        // narwhal_node::Node::spawn_primary(
+        //     consensus_keypair,
+        //     config.genesis()?.narwhal_committee(),
+        //     &consensus_store,
+        //     consensus_config.narwhal_config().to_owned(),
+        //     /* consensus */ true, // Indicate that we want to run consensus.
+        //     /* execution_state */ state.clone(),
+        //     /* tx_confirmation */ tx_consensus_to_sui,
+        //     prometheus_registry,
+        // )
+        // .await?;
+        // narwhal_node::Node::spawn_workers(
+        //     consensus_name,
+        //     /* ids */ vec![0], // We run a single worker with id '0'.
+        //     config.genesis()?.narwhal_committee(),
+        //     &consensus_store,
+        //     consensus_config.narwhal_config().to_owned(),
+        //     prometheus_registry,
+        // );
 
         // Spawn a consensus listener. It listen for consensus outputs and notifies the
         // authority server when a sequenced transaction is ready for execution.

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -179,10 +179,8 @@ impl ValidatorService {
             .consensus_config()
             .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
         let consensus_keypair = config.key_pair().copy();
-        // let consensus_name = consensus_keypair.public().clone();
         let consensus_committee = config.genesis()?.narwhal_committee().load();
         let consensus_storage_base_path = consensus_config.db_path().to_path_buf();
-        // let consensus_store = narwhal_node::NodeStorage::reopen(consensus_config.db_path());
         let consensus_execution_state = state.clone();
         let consensus_parameters = consensus_config.narwhal_config().to_owned();
 
@@ -198,26 +196,6 @@ impl ValidatorService {
             )
             .await
         });
-
-        // narwhal_node::Node::spawn_primary(
-        //     consensus_keypair,
-        //     config.genesis()?.narwhal_committee(),
-        //     &consensus_store,
-        //     consensus_config.narwhal_config().to_owned(),
-        //     /* consensus */ true, // Indicate that we want to run consensus.
-        //     /* execution_state */ state.clone(),
-        //     /* tx_confirmation */ tx_consensus_to_sui,
-        //     prometheus_registry,
-        // )
-        // .await?;
-        // narwhal_node::Node::spawn_workers(
-        //     consensus_name,
-        //     /* ids */ vec![0], // We run a single worker with id '0'.
-        //     config.genesis()?.narwhal_committee(),
-        //     &consensus_store,
-        //     consensus_config.narwhal_config().to_owned(),
-        //     prometheus_registry,
-        // );
 
         // Spawn a consensus listener. It listen for consensus outputs and notifies the
         // authority server when a sequenced transaction is ready for execution.

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -31,6 +31,7 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use sui_types::{crypto::AuthorityPublicKeyBytes, object::Data};
+use tokio::sync::mpsc::channel;
 
 pub enum TestCallArg {
     Object(ObjectID),
@@ -1613,7 +1614,7 @@ pub async fn init_state_with_committee(
     };
 
     let store = init_store();
-
+    let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = channel(1);
     AuthorityState::new(
         committee,
         authority_key.public().into(),
@@ -1624,6 +1625,7 @@ pub async fn init_state_with_committee(
         None,
         &sui_config::genesis::Genesis::get_default_genesis(),
         &prometheus::Registry::new(),
+        tx_reconfigure_consensus,
     )
     .await
 }

--- a/crates/sui-gateway/Cargo.toml
+++ b/crates/sui-gateway/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 async-trait = "0.1.57"
-serde = { version = "1.0.141", features = ["derive"] }
+serde = { version = "1.0.142", features = ["derive"] }
 tracing = "0.1.36"
 tokio = { version = "1.20.1", features = ["full"] }
 futures = "0.3.21"

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -51,8 +51,9 @@ move-disassembler = { git = "https://github.com/move-language/move", rev = "7907
 move-ir-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "executor" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "crypto" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "executor" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "crypto" }
+
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
-serde = { version = "1.0.141", features = ["derive"] }
+serde = { version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.80"
 signature = "1.5.0"
 camino = "1.0.9"
@@ -39,7 +39,7 @@ rocksdb = "0.18.0"
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a4c2cae59d823533061a5d8fe28771629819c43f"}
 typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "a4c2cae59d823533061a5d8fe28771629819c43f"} 
 tempfile = "3.3.0"
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "259a37b487570763575e6b28f8b8057b16b3e916", package = "executor" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "32b5298b60d410620f2c0e80eec4b6c12e4f9bdd", package = "executor" }
 
 move-core-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a", features = ["address20"] }
 move-prover = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }


### PR DESCRIPTION
Allow the AuthorityState to make decide when to reconfigure consensus. In a nutshell, this is how we plan to reconfigure consensus in Sui:
* We have a watcher that lists for consensus updates, gracefully shutdowns all tasks, and then gracefully reboots them: https://github.com/MystenLabs/narwhal/blob/32b5298b60d410620f2c0e80eec4b6c12e4f9bdd/node/src/restarter.rs#L20
* Here is an end-to-end test where SimpleExecutionError is supposed to represent AuthorityState in Sui: https://github.com/MystenLabs/narwhal/blob/32b5298b60d410620f2c0e80eec4b6c12e4f9bdd/node/tests/reconfigure.rs#L162

Note that this strategy will not work for our external partners (Celo, Somelier) so the Narwhal codebase has other ways to change epoch/reconfigure.
