### PR TITLE
SuiKeystore mnemonic support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -509,6 +518,7 @@ version = "1.0.1"
 source = "git+https://github.com/patrickkuo/rust-bip39.git?rev=a76fe8310416555e6383b42b8acc4eb93c7bcc89#a76fe8310416555e6383b42b8acc4eb93c7bcc89"
 dependencies = [
  "bitcoin_hashes 0.9.7",
+ "rand 0.6.5",
  "rand_core 0.4.2",
  "serde 1.0.141",
  "unicode-normalization",
@@ -1196,7 +1206,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static 1.4.0",
@@ -2127,6 +2137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,7 +2794,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.12.1",
  "serde 1.0.141",
 ]
@@ -3256,7 +3272,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -3318,7 +3334,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -4415,7 +4431,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.15",
 ]
@@ -4435,7 +4451,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits 0.2.15",
 ]
 
@@ -4445,7 +4461,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.15",
 ]
@@ -4456,7 +4472,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.15",
@@ -4477,7 +4493,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "libm",
 ]
 
@@ -4595,7 +4611,7 @@ version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -5219,7 +5235,7 @@ dependencies = [
  "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
@@ -5355,6 +5371,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg 0.1.2",
+ "rand_xorshift 0.1.1",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5363,8 +5398,8 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
+ "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -5376,6 +5411,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5396,6 +5441,15 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -5434,11 +5488,64 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -5448,6 +5555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5474,7 +5590,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -5490,6 +5606,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -6405,7 +6530,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -7190,6 +7315,7 @@ dependencies = [
  "rand 0.7.3",
  "serde 1.0.141",
  "serde_json",
+ "sha3 0.10.2",
  "signature",
  "sui-config",
  "sui-core",
@@ -7197,6 +7323,7 @@ dependencies = [
  "sui-json-rpc",
  "sui-json-rpc-types",
  "sui-types",
+ "tempfile",
  "tokio",
  "workspace-hack 0.1.0",
 ]
@@ -7783,7 +7910,7 @@ version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "memchr",
@@ -8952,7 +9079,8 @@ dependencies = [
  "atoi",
  "atomicwrites",
  "atty",
- "autocfg",
+ "autocfg 0.1.8",
+ "autocfg 1.1.0",
  "axum",
  "axum-core",
  "backoff",
@@ -9356,15 +9484,24 @@ dependencies = [
  "quote 0.6.13",
  "quote 1.0.20",
  "radix_trie",
+ "rand 0.6.5",
  "rand 0.7.3",
  "rand 0.8.5",
+ "rand_chacha 0.1.1",
  "rand_chacha 0.3.1",
+ "rand_core 0.3.1",
  "rand_core 0.4.2",
  "rand_core 0.5.1",
  "rand_core 0.6.3",
  "rand_distr",
- "rand_pcg",
- "rand_xorshift",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg 0.1.2",
+ "rand_pcg 0.2.1",
+ "rand_xorshift 0.1.1",
+ "rand_xorshift 0.3.0",
  "rand_xoshiro",
  "rayon",
  "rayon-core",
@@ -9630,7 +9767,7 @@ dependencies = [
  "async-stream-impl",
  "async-trait",
  "atty",
- "autocfg",
+ "autocfg 1.1.0",
  "axum",
  "axum-core",
  "backoff",
@@ -9853,8 +9990,8 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.5.1",
  "rand_core 0.6.3",
- "rand_pcg",
- "rand_xorshift",
+ "rand_pcg 0.2.1",
+ "rand_xorshift 0.3.0",
  "rayon",
  "rayon-core",
  "readonly",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "1.0.1"
+source = "git+https://github.com/patrickkuo/rust-bip39.git?rev=a76fe8310416555e6383b42b8acc4eb93c7bcc89#a76fe8310416555e6383b42b8acc4eb93c7bcc89"
+dependencies = [
+ "bitcoin_hashes 0.9.7",
+ "rand_core 0.4.2",
+ "serde 1.0.141",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +528,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -5383,6 +5400,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -5932,7 +5955,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
@@ -7158,6 +7181,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "bcs",
+ "bip39",
  "clap 3.1.18",
  "dirs",
  "futures",
@@ -8943,9 +8967,11 @@ dependencies = [
  "bimap",
  "bincode",
  "bindgen",
+ "bip39",
  "bit-set",
  "bit-vec",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes 0.9.7",
  "bitflags",
  "bitmaps",
  "blake2",
@@ -9333,6 +9359,7 @@ dependencies = [
  "rand 0.7.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rand_core 0.4.2",
  "rand_core 0.5.1",
  "rand_core 0.6.3",
  "rand_distr",
@@ -9615,7 +9642,7 @@ dependencies = [
  "bindgen",
  "bit-set",
  "bit-vec",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.11.0",
  "bitflags",
  "blake2",
  "blake2s_simd",

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -44,7 +44,7 @@ use sui_benchmark::workloads::workload::Payload;
 use sui_benchmark::workloads::workload::Workload;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_quorum_driver::QuorumDriverHandler;
-use sui_sdk::crypto::SuiKeystore;
+use sui_sdk::crypto::FileBasedKeystore;
 use sui_types::crypto::EncodeDecodeBase64;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::{AccountKeyPair, EmptySignInfo};
@@ -620,7 +620,7 @@ async fn main() -> Result<()> {
                     &opts.keystore_path
                 ))
             })?;
-        let keystore = SuiKeystore::load_or_create(&keystore_path)?;
+        let keystore = FileBasedKeystore::load_or_create(&keystore_path)?;
         let keypair = keystore
             .key_pairs()
             .iter()

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -25,7 +25,6 @@ use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::gateway_state::GatewayState;
 use sui_node::metrics;
 use sui_node::SuiNode;
-use sui_sdk::crypto::Keystore;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 use tokio::sync::OnceCell;

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -31,7 +31,6 @@ impl WalletClient {
         let address: SuiAddress = key_pair.public().into();
         keystore.init().unwrap().add_key(key_pair).unwrap();
         SuiClientConfig {
-            accounts: vec![address],
             keystore,
             gateway: ClientType::RPC(rpc_url.into()),
             active_address: Some(address),

--- a/crates/sui-faucet/src/main.rs
+++ b/crates/sui-faucet/src/main.rs
@@ -157,8 +157,8 @@ async fn create_wallet_context() -> Result<WalletContext, anyhow::Error> {
     info!("Initialize wallet from config path: {:?}", wallet_conf);
     let mut context = WalletContext::new(&wallet_conf).await?;
     let address = context
-        .config
-        .accounts
+        .keystore
+        .addresses()
         .first()
         .cloned()
         .ok_or_else(|| anyhow::anyhow!("Empty wallet context!"))?;

--- a/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
@@ -13,7 +13,7 @@ use sui_json_rpc::api::{
 use sui_json_rpc_types::{
     GetObjectDataResponse, TransactionBytes, TransactionEffectsResponse, TransactionResponse,
 };
-use sui_sdk::crypto::{Keystore, SuiKeystore};
+use sui_sdk::crypto::KeystoreType;
 use sui_types::crypto::SuiSignature;
 use sui_types::sui_serde::Base64;
 use sui_types::{
@@ -53,8 +53,9 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let keystore =
-        SuiKeystore::load_or_create(&test_network.network.dir().join(SUI_KEYSTORE_FILENAME))?;
+    let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = KeystoreType::File(keystore_path).init()?;
+
     let tx_bytes = tx_data.tx_bytes.to_vec()?;
     let signature = keystore.sign(address, &tx_bytes)?;
 
@@ -94,8 +95,9 @@ async fn test_publish() -> Result<(), anyhow::Error> {
         .publish(*address, compiled_modules, Some(gas.object_id), 10000)
         .await?;
 
-    let keystore =
-        SuiKeystore::load_or_create(&test_network.network.dir().join(SUI_KEYSTORE_FILENAME))?;
+    let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = KeystoreType::File(keystore_path).init()?;
+
     let tx_bytes = tx_data.tx_bytes.to_vec()?;
     let signature = keystore.sign(address, &tx_bytes)?;
 
@@ -144,8 +146,9 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
         )
         .await?;
 
-    let keystore =
-        SuiKeystore::load_or_create(&test_network.network.dir().join(SUI_KEYSTORE_FILENAME))?;
+    let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
+    let keystore = KeystoreType::File(keystore_path).init()?;
+
     let tx_bytes = tx_data.tx_bytes.to_vec()?;
     let signature = keystore.sign(address, &tx_bytes)?;
 
@@ -198,8 +201,9 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
             .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
             .await?;
 
-        let keystore =
-            SuiKeystore::load_or_create(&test_network.network.dir().join(SUI_KEYSTORE_FILENAME))?;
+        let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
+        let keystore = KeystoreType::File(keystore_path).init()?;
+
         let tx_bytes = tx_data.tx_bytes.to_vec()?;
         let signature = keystore.sign(address, &tx_bytes)?;
 

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -130,7 +130,7 @@ async fn create_response_sample() -> Result<
     let config = working_dir.join(SUI_CLIENT_CONFIG);
 
     let mut context = WalletContext::new(&config).await?;
-    let address = context.config.accounts.first().cloned().unwrap();
+    let address = context.keystore.addresses().first().cloned().unwrap();
 
     context.gateway.sync_account_state(address).await?;
 

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3.21"
 signature = "1.5.0"
 rand = "0.7.3"
 
-bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git" , rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89"}
+bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git" , rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["rand"]}
 rand = "0.7.3"
 
 sui-json-rpc = { path = "../sui-json-rpc" }
@@ -35,6 +35,8 @@ dirs = "4.0.0"
 tokio = "1.20.1"
 bcs = "0.1.3"
 async-recursion = "1.0.0"
+tempfile = "3.3.0"
+sha3 = "0.10.2"
 
 [[example]]
 name = "tic-tac-toe"

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -18,7 +18,6 @@ signature = "1.5.0"
 rand = "0.7.3"
 
 bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git" , rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["rand"]}
-rand = "0.7.3"
 
 sui-json-rpc = { path = "../sui-json-rpc" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -17,6 +17,9 @@ futures = "0.3.21"
 signature = "1.5.0"
 rand = "0.7.3"
 
+bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git" , rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89"}
+rand = "0.7.3"
+
 sui-json-rpc = { path = "../sui-json-rpc" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
+use sui_sdk::crypto::KeystoreType;
 use sui_sdk::{
     crypto::SuiKeystore,
     json::SuiJsonValue,
@@ -27,7 +28,7 @@ use sui_sdk::{
 async fn main() -> Result<(), anyhow::Error> {
     let opts: TicTacToeOpts = TicTacToeOpts::parse();
     let keystore_path = opts.keystore_path.unwrap_or_else(default_keystore_path);
-    let keystore = SuiKeystore::load_or_create(&keystore_path)?;
+    let keystore = KeystoreType::File(keystore_path).init()?;
 
     let game = TicTacToe {
         game_package_id: opts.game_package_id,

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr;
 use sui_sdk::{
-    crypto::SuiKeystore,
+    crypto::KeystoreType,
     types::{
         base_types::{ObjectID, SuiAddress},
         crypto::Signature,
@@ -31,7 +31,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     // Get signer from keystore
-    let keystore = SuiKeystore::load_or_create(&keystore_path)?;
+    let keystore = KeystoreType::File(keystore_path).init()?;
     let signer = keystore.signer(my_address);
 
     // Sign the transaction

--- a/crates/sui-sdk/src/crypto.rs
+++ b/crates/sui-sdk/src/crypto.rs
@@ -11,11 +11,17 @@ use std::fs;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use bip39::Mnemonic;
+use rand::rngs::adapter::ReadRng;
+use serde::{Deserialize, Serialize};
+use signature::Signer;
 
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
-    get_key_pair, get_key_pair_from_rng, AccountKeyPair, EncodeDecodeBase64, KeypairTraits,
-    Signature,
+    get_key_pair_from_rng, get_key_pair_from_rng, AccountKeyPair, AccountPublicKey,
+    EncodeDecodeBase64, KeypairTraits, Signature, ToFromBytes,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -26,17 +32,16 @@ pub enum KeystoreType {
     InMem,
 }
 
-pub trait Keystore: Send + Sync {
+pub trait AccountKeystore: Send + Sync {
     fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error>;
-    fn add_random_key(&mut self) -> Result<SuiAddress, anyhow::Error>;
     fn add_key(&mut self, keypair: AccountKeyPair) -> Result<(), anyhow::Error>;
-    fn key_pairs(&self) -> Vec<&AccountKeyPair>;
+    fn keys(&self) -> Vec<AccountPublicKey>;
 }
 
 impl KeystoreType {
-    pub fn init(&self) -> Result<Box<dyn Keystore>, anyhow::Error> {
+    pub fn init(&self) -> Result<SuiKeystore, anyhow::Error> {
         Ok(match self {
-            KeystoreType::File(path) => Box::new(SuiKeystore::load_or_create(path)?),
+            KeystoreType::File(path) => SuiKeystore::from(FileBasedKeystore::load_or_create(path)?),
             KeystoreType::InMem => Box::new(InMemKeystore::new(0)),
         })
     }
@@ -60,12 +65,12 @@ impl Display for KeystoreType {
 }
 
 #[derive(Serialize, Deserialize, Default)]
-pub struct SuiKeystore {
+pub struct FileBasedKeystore {
     keys: BTreeMap<SuiAddress, AccountKeyPair>,
     path: Option<PathBuf>,
 }
 
-impl Keystore for SuiKeystore {
+impl AccountKeystore for FileBasedKeystore {
     fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error> {
         self.keys
             .get(address)
@@ -75,13 +80,6 @@ impl Keystore for SuiKeystore {
             .try_sign(msg)
     }
 
-    fn add_random_key(&mut self) -> Result<SuiAddress, anyhow::Error> {
-        let (address, keypair): (_, AccountKeyPair) = get_key_pair();
-        self.keys.insert(address, keypair);
-        self.save()?;
-        Ok(address)
-    }
-
     fn add_key(&mut self, keypair: AccountKeyPair) -> Result<(), anyhow::Error> {
         let address: SuiAddress = keypair.public().into();
         self.keys.insert(address, keypair);
@@ -89,29 +87,27 @@ impl Keystore for SuiKeystore {
         Ok(())
     }
 
-    fn key_pairs(&self) -> Vec<&AccountKeyPair> {
-        self.keys.values().collect()
+    fn keys(&self) -> Vec<AccountPublicKey> {
+        self.keys.values().map(|key| key.public().clone()).collect()
     }
 }
 
-impl SuiKeystore {
+impl FileBasedKeystore {
     pub fn load_or_create(path: &Path) -> Result<Self, anyhow::Error> {
-        let keys: Vec<AccountKeyPair> = if path.exists() {
+        let keys = if path.exists() {
             let reader = BufReader::new(File::open(path)?);
             let kp_strings: Vec<String> = serde_json::from_reader(reader)?;
             kp_strings
                 .iter()
-                .map(|kpstr| AccountKeyPair::decode_base64(kpstr))
-                .collect::<Result<Vec<_>, _>>()
+                .map(|kpstr| {
+                    let key = AccountKeyPair::decode_base64(kpstr);
+                    key.map(|k| (k.public().into(), k))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()
                 .map_err(|_| anyhow::anyhow!("Invalid Keypair file"))?
         } else {
-            Vec::new()
+            BTreeMap::new()
         };
-
-        let keys = keys
-            .into_iter()
-            .map(|key| (key.public().into(), key))
-            .collect();
 
         Ok(Self {
             keys,
@@ -138,31 +134,80 @@ impl SuiKeystore {
         Ok(())
     }
 
-    pub fn add_key(
-        &mut self,
-        address: SuiAddress,
-        keypair: AccountKeyPair,
-    ) -> Result<(), anyhow::Error> {
-        self.keys.insert(address, keypair);
-        Ok(())
+    pub fn key_pairs(&self) -> Vec<&AccountKeyPair> {
+        self.keys.values().collect()
+    }
+}
+
+pub struct SuiKeystore(Box<dyn AccountKeystore>);
+
+impl SuiKeystore {
+    fn from<S: AccountKeystore + 'static>(keystore: S) -> Self {
+        Self(Box::new(keystore))
+    }
+
+    pub fn add_key(&mut self, keypair: AccountKeyPair) -> Result<String, anyhow::Error> {
+        let pk = keypair.private();
+        let phrase = Mnemonic::from_entropy(pk.as_bytes())?.to_string();
+        let keypair = AccountKeyPair::from(pk);
+        self.0.add_key(keypair)?;
+        Ok(phrase)
+    }
+
+    pub fn keys(&self) -> Vec<AccountPublicKey> {
+        self.0.keys()
     }
 
     pub fn addresses(&self) -> Vec<SuiAddress> {
-        self.keys.keys().cloned().collect()
+        self.keys().iter().map(|k| k.into()).collect()
     }
 
     pub fn signer(&self, signer: SuiAddress) -> impl Signer<Signature> + '_ {
-        SuiKeystoreSigner::new(self, signer)
+        KeystoreSigner::new(&*self.0, signer)
+    }
+
+    pub fn import_from_mnemonic(&mut self, phrase: &str) -> Result<SuiAddress, anyhow::Error> {
+        let seed = &Mnemonic::from_str(phrase).unwrap().to_seed("");
+        let mut rng = RngWrapper(ReadRng::new(seed));
+        let (address, kp) = get_key_pair_from_rng(&mut rng);
+        self.0.add_key(kp)?;
+        Ok(address)
+    }
+
+    pub fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error> {
+        self.0.sign(address, msg)
     }
 }
 
-struct SuiKeystoreSigner<'a> {
-    keystore: &'a SuiKeystore,
+/// wrapper for adding CryptoRng and RngCore impl to ReadRng.
+struct RngWrapper<'a>(ReadRng<&'a [u8]>);
+
+impl rand::CryptoRng for RngWrapper<'_> {}
+impl rand::RngCore for RngWrapper<'_> {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+struct KeystoreSigner<'a> {
+    keystore: &'a dyn AccountKeystore,
     address: SuiAddress,
 }
 
-impl<'a> SuiKeystoreSigner<'a> {
-    pub fn new(keystore: &'a SuiKeystore, account: SuiAddress) -> Self {
+impl<'a> KeystoreSigner<'a> {
+    pub fn new(keystore: &'a dyn AccountKeystore, account: SuiAddress) -> Self {
         Self {
             keystore,
             address: account,
@@ -170,8 +215,8 @@ impl<'a> SuiKeystoreSigner<'a> {
     }
 }
 
-impl Signer<Signature> for SuiKeystoreSigner<'_> {
-    fn try_sign(&self, msg: &[u8]) -> Result<Signature, Error> {
+impl Signer<Signature> for KeystoreSigner<'_> {
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {
         self.keystore.sign(&self.address, msg)
     }
 }

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use std::str::FromStr;
+
+use sha3::{Digest, Sha3_256};
+use tempfile::TempDir;
+
+use sui_sdk::crypto::KeystoreType;
+use sui_types::base_types::{SuiAddress, SUI_ADDRESS_LENGTH};
+
+#[test]
+fn mnemonic_test() {
+    let temp_dir = TempDir::new().unwrap();
+    let keystore_path = temp_dir.path().join("sui.keystore");
+    let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
+
+    let (address, phrase) = keystore.generate_new_key().unwrap();
+
+    let keystore_path_2 = temp_dir.path().join("sui2.keystore");
+    let mut keystore2 = KeystoreType::File(keystore_path_2).init().unwrap();
+    let imported_address = keystore2.import_from_mnemonic(&phrase).unwrap();
+
+    assert_eq!(address, imported_address);
+}
+
+/// This test confirms rust's implementation of mnemonic is the same with the Sui Wallet
+#[test]
+fn sui_wallet_address_mnemonic_test() -> Result<(), anyhow::Error> {
+    // Recovery phase and SuiAddress obtained from Sui wallet v0.0.4 (prior key flag changes)
+    let phrase = "oil puzzle immense upon pony govern jelly neck portion laptop laptop wall";
+    let expected_address = SuiAddress::from_str("0x6a06dd564dfb2f0c71f3e167a48f569c705ed34c")?;
+
+    let temp_dir = TempDir::new().unwrap();
+    let keystore_path = temp_dir.path().join("sui.keystore");
+    let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
+
+    keystore.import_from_mnemonic(phrase).unwrap();
+
+    // SuiAddress without the key flag.
+    let pubkey = keystore.keys()[0].clone();
+    let mut hasher = Sha3_256::default();
+    hasher.update(pubkey);
+    let g_arr = hasher.finalize();
+    let mut res = [0u8; SUI_ADDRESS_LENGTH];
+    res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);
+    let address = SuiAddress::try_from(res.as_slice())?;
+
+    assert_eq!(expected_address, address);
+
+    Ok(())
+}

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -27,7 +27,7 @@ sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }
 sui-swarm = { path = "../sui-swarm" }
-sui-json-rpc-types= { path = "../sui-json-rpc-types" }
+sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-sdk = { path = "../sui-sdk" }
 
 rustyline = "9.1.2"
@@ -48,7 +48,7 @@ move-unit-test = { git = "https://github.com/move-language/move", rev = "7907152
 move-cli = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-package = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 
-workspace-hack = { path = "../workspace-hack"}
+workspace-hack = { path = "../workspace-hack" }
 multiaddr = "0.14.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -27,7 +27,6 @@ use sui_json_rpc_types::{
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_sdk::crypto::SuiKeystore;
 use sui_sdk::{ClientType, SuiClient};
-use sui_types::crypto::get_key_pair;
 use sui_types::object::Owner;
 use sui_types::sui_serde::{Base64, Encoding};
 use sui_types::{
@@ -402,8 +401,7 @@ impl SuiClientCommands {
                 SuiClientCommandResult::SyncClientState
             }
             SuiClientCommands::NewAddress => {
-                let (address, keypair) = get_key_pair();
-                let phrase = context.keystore.add_key(keypair)?;
+                let (address, phrase) = context.keystore.generate_new_key()?;
                 SuiClientCommandResult::NewAddress((address, phrase))
             }
             SuiClientCommands::Gas { address } => {

--- a/crates/sui/src/config/mod.rs
+++ b/crates/sui/src/config/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use serde_with::{hex::Hex, serde_as};
+use serde_with::serde_as;
 use std::fmt::{Display, Formatter, Write};
 use sui_sdk::crypto::KeystoreType;
 use sui_types::base_types::*;
@@ -17,8 +17,6 @@ use sui_sdk::ClientType;
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct SuiClientConfig {
-    #[serde_as(as = "Vec<Hex>")]
-    pub accounts: Vec<SuiAddress>,
     pub keystore: KeystoreType,
     pub gateway: ClientType,
     pub active_address: Option<SuiAddress>,
@@ -30,7 +28,11 @@ impl Display for SuiClientConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
 
-        writeln!(writer, "Managed addresses : {}", self.accounts.len())?;
+        writeln!(
+            writer,
+            "Managed addresses : {}",
+            self.keystore.init().unwrap().addresses().len()
+        )?;
         write!(writer, "Active address: ")?;
         match self.active_address {
             Some(r) => writeln!(writer, "{}", r)?,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -24,7 +24,7 @@ use sui_config::{
 use sui_sdk::crypto::{AccountKeystore, FileBasedKeystore, KeystoreType};
 use sui_sdk::{ClientType, SuiClient};
 use sui_swarm::memory::Swarm;
-use sui_types::crypto::{get_key_pair, KeypairTraits};
+use sui_types::crypto::KeypairTraits;
 use tracing::info;
 
 #[derive(Parser)]
@@ -399,9 +399,8 @@ fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Error> {
                 .unwrap_or(&sui_config_dir()?)
                 .join(SUI_KEYSTORE_FILENAME);
             let keystore = KeystoreType::File(keystore_path);
-            let (new_address, keypair) = get_key_pair();
+            let (new_address, phrase) = keystore.init()?.generate_new_key()?;
             println!("Generated new keypair for address [{new_address}]");
-            let phrase = keystore.init()?.add_key(keypair)?;
             println!("Secret Recovery Phrase : [{phrase}]");
             SuiClientConfig {
                 keystore,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -21,7 +21,7 @@ use sui_config::{
     sui_config_dir, Config, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
     SUI_GATEWAY_CONFIG, SUI_NETWORK_CONFIG,
 };
-use sui_sdk::crypto::{AccountKeystore, FileBasedKeystore, KeystoreType};
+use sui_sdk::crypto::KeystoreType;
 use sui_sdk::{ClientType, SuiClient};
 use sui_swarm::memory::Swarm;
 use sui_types::crypto::KeypairTraits;
@@ -243,7 +243,7 @@ impl SuiCommand {
                         .build()
                 };
 
-                let mut keystore = FileBasedKeystore::default();
+                let mut keystore = KeystoreType::File(keystore_path.clone()).init().unwrap();
 
                 for key in &network_config.account_keys {
                     keystore.add_key(key.copy())?;
@@ -258,8 +258,6 @@ impl SuiCommand {
                 network_config.save(&network_path)?;
                 info!("Network config file is stored in {:?}.", network_path);
 
-                keystore.set_path(&keystore_path);
-                keystore.save()?;
                 info!("Client keystore is stored in {:?}.", keystore_path);
 
                 // Use the first address if any

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -339,13 +339,10 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     let obj = object_refs.get(1).unwrap().object_id;
 
     // Create the args
-    let addr1_str = format!("0x{:02x}", address1);
-    let args_json = json!([123u8, addr1_str]);
-
-    let mut args = vec![];
-    for a in args_json.as_array().unwrap() {
-        args.push(SuiJsonValue::new(a.clone()).unwrap());
-    }
+    let args = vec![
+        SuiJsonValue::new(json!(123u8))?,
+        SuiJsonValue::new(json!(address1))?,
+    ];
 
     // Test case with no gas specified
     let resp = SuiClientCommands::Call {
@@ -378,7 +375,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     };
 
     // Try a bad argument: decimal
-    let args_json = json!([0.3f32, addr1_str]);
+    let args_json = json!([0.3f32, address1]);
     assert!(SuiJsonValue::new(args_json.as_array().unwrap().get(0).unwrap().clone()).is_err());
 
     // Try a bad argument: too few args
@@ -407,14 +404,10 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
 
     // Try a transfer
     // This should fail due to mismatch of object being sent
-    let obj_str = format!("0x{:02x}", obj);
-    let addr2_str = format!("0x{:02x}", address2);
-
-    let args_json = json!([obj_str, addr2_str]);
-    let mut args = vec![];
-    for a in args_json.as_array().unwrap() {
-        args.push(SuiJsonValue::new(a.clone()).unwrap());
-    }
+    let args = vec![
+        SuiJsonValue::new(json!(obj))?,
+        SuiJsonValue::new(json!(address2))?,
+    ];
 
     let resp = SuiClientCommands::Call {
         package: SUI_FRAMEWORK_OBJECT_ID,
@@ -435,14 +428,10 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     assert!(err_string.contains(&format!("Expected argument of type {framework_addr}::object_basics::Object, but found type {framework_addr}::coin::Coin<{framework_addr}::sui::SUI>")));
 
     // Try a proper transfer
-    let obj_str = format!("0x{:02x}", created_obj);
-    let addr2_str = format!("0x{:02x}", address2);
-
-    let args_json = json!([obj_str, addr2_str]);
-    let mut args = vec![];
-    for a in args_json.as_array().unwrap() {
-        args.push(SuiJsonValue::new(a.clone()).unwrap());
-    }
+    let args = vec![
+        SuiJsonValue::new(json!(created_obj))?,
+        SuiJsonValue::new(json!(address2))?,
+    ];
 
     SuiClientCommands::Call {
         package: SUI_FRAMEWORK_OBJECT_ID,

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -23,7 +23,7 @@ use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{GetObjectDataResponse, SuiParsedObject, SuiTransactionEffects};
 use sui_sdk::crypto::KeystoreType;
 use sui_sdk::ClientType;
-use sui_types::crypto::{AccountKeyPair, AuthorityKeyPair, KeypairTraits};
+use sui_types::crypto::{AuthorityKeyPair, KeypairTraits};
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
 use sui_types::{sui_framework_address_concat_string, SUI_FRAMEWORK_OBJECT_ID};
 
@@ -84,7 +84,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
         panic!()
     }
 
-    assert_eq!(5, wallet_conf.accounts.len());
+    assert_eq!(5, wallet_conf.keystore.init().unwrap().addresses().len());
 
     // Genesis 2nd time should fail
     let result = SuiCommand::Genesis {
@@ -107,7 +107,6 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
     let working_dir = temp_dir.path();
 
     let wallet_config = SuiClientConfig {
-        accounts: vec![],
         keystore: KeystoreType::File(working_dir.join(SUI_KEYSTORE_FILENAME)),
         gateway: ClientType::Embedded(GatewayConfig {
             db_folder_path: working_dir.join("client_db"),
@@ -128,18 +127,14 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
         active_address: None,
     };
     let wallet_conf_path = working_dir.join(SUI_CLIENT_CONFIG);
-    let mut wallet_config = wallet_config.persisted(&wallet_conf_path);
+    let wallet_config = wallet_config.persisted(&wallet_conf_path);
+    wallet_config.save().unwrap();
+    let mut context = WalletContext::new(&wallet_conf_path).await.unwrap();
 
     // Add 3 accounts
     for _ in 0..3 {
-        wallet_config.accounts.push({
-            let (address, _): (_, AccountKeyPair) = get_key_pair();
-            address
-        });
+        context.keystore.add_key(get_key_pair().1)?;
     }
-    wallet_config.save().unwrap();
-
-    let mut context = WalletContext::new(&wallet_conf_path).await.unwrap();
 
     // Print all addresses
     SuiClientCommands::Addresses
@@ -223,8 +218,8 @@ async fn test_custom_genesis() -> Result<(), anyhow::Error> {
 
     // Wallet config
     let mut context = WalletContext::new(&network.dir().join(SUI_CLIENT_CONFIG)).await?;
-    assert_eq!(1, context.config.accounts.len());
-    let address = context.config.accounts.first().cloned().unwrap();
+    assert_eq!(1, context.keystore.addresses().len());
+    let address = context.keystore.addresses().first().cloned().unwrap();
 
     // Sync client to retrieve objects from the network.
     SuiClientCommands::SyncClientState {
@@ -268,7 +263,7 @@ async fn test_object_info_get_command() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_gas_command() -> Result<(), anyhow::Error> {
     let (_network, mut context, address) = setup_network_and_wallet().await?;
-    let recipient = context.config.accounts.get(1).cloned().unwrap();
+    let recipient = context.keystore.addresses().get(1).cloned().unwrap();
 
     let object_refs = context
         .gateway
@@ -312,7 +307,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     let (_network, mut context, address1) = setup_network_and_wallet().await?;
-    let address2 = context.config.accounts.get(1).cloned().unwrap();
+    let address2 = context.keystore.addresses().get(1).cloned().unwrap();
 
     // Sync client to retrieve objects from the network.
     SuiClientCommands::SyncClientState {
@@ -530,7 +525,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_native_transfer() -> Result<(), anyhow::Error> {
     let (_network, mut context, address) = setup_network_and_wallet().await?;
-    let recipient = context.config.accounts.get(1).cloned().unwrap();
+    let recipient = context.keystore.addresses().get(1).cloned().unwrap();
 
     let object_refs = context
         .gateway
@@ -710,7 +705,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     assert_eq!(cmd_objs, actual_objs);
 
     // Switch the address
-    let addr2 = context.config.accounts.get(1).cloned().unwrap();
+    let addr2 = context.keystore.addresses().get(1).cloned().unwrap();
     let resp = SuiClientCommands::Switch {
         address: Some(addr2),
         gateway: None,
@@ -731,14 +726,13 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     );
 
     // Wipe all the address info
-    context.config.accounts.clear();
     context.config.active_address = None;
 
     // Create a new address
     let os = SuiClientCommands::NewAddress {}
         .execute(&mut context)
         .await?;
-    let new_addr = if let SuiClientCommandResult::NewAddress(a) = os {
+    let new_addr = if let SuiClientCommandResult::NewAddress((a, _)) = os {
         a
     } else {
         panic!("Command failed")
@@ -798,7 +792,7 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
     };
     assert_eq!(a, addr1);
 
-    let addr2 = context.config.accounts.get(1).cloned().unwrap();
+    let addr2 = context.keystore.addresses().get(1).cloned().unwrap();
     let resp = SuiClientCommands::Switch {
         address: Some(addr2),
         gateway: None,

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -6,7 +6,7 @@ use sui_core::{
     authority_client::NetworkAuthorityClient,
 };
 use sui_node::SuiNode;
-use sui_sdk::crypto::InMemKeystore;
+use sui_sdk::crypto::KeystoreType;
 use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest},
     messages::{CallArg, ExecutionStatus, ObjectArg, Transaction},
@@ -186,8 +186,8 @@ async fn end_to_end() {
     telemetry_subscribers::init_for_testing();
     // Make a few test transactions.
     let total_transactions = 3;
-    let keys = InMemKeystore::new(total_transactions);
-    let (transactions, input_objects) = make_transactions_with_pre_genesis_objects(&keys);
+    let keys = KeystoreType::InMem(total_transactions).init().unwrap();
+    let (transactions, input_objects) = make_transactions_with_pre_genesis_objects(keys);
     let transaction_digests: HashSet<_> = transactions.iter().map(|x| *x.digest()).collect();
 
     // Spawn a quorum of authorities.
@@ -209,8 +209,8 @@ async fn end_to_end_with_one_byzantine() {
     telemetry_subscribers::init_for_testing();
     // Make a few test transactions.
     let total_transactions = 3;
-    let keys = InMemKeystore::new(total_transactions);
-    let (transactions, input_objects) = make_transactions_with_pre_genesis_objects(&keys);
+    let keystore = KeystoreType::InMem(total_transactions).init().unwrap();
+    let (transactions, input_objects) = make_transactions_with_pre_genesis_objects(keystore);
     let transaction_digests: HashSet<_> = transactions.iter().map(|x| *x.digest()).collect();
 
     // Spawn a quorum of authorities.
@@ -239,8 +239,8 @@ async fn checkpoint_with_shared_objects() {
 
     // Make a few test transactions.
     let total_transactions = 3;
-    let keys = InMemKeystore::new(total_transactions);
-    let (transactions, input_objects) = make_transactions_with_pre_genesis_objects(&keys);
+    let keystore = KeystoreType::InMem(total_transactions).init().unwrap();
+    let (transactions, input_objects) = make_transactions_with_pre_genesis_objects(keystore);
 
     // Spawn a quorum of authorities.
     let configs = test_authority_configs();

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -52,9 +52,11 @@ beef = { version = "0.5", features = ["impl_serde", "serde"] }
 better_any = { version = "0.1", default-features = false }
 bimap = { version = "0.6", features = ["std"] }
 bincode = { version = "1", default-features = false }
+bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git", rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["serde", "std", "unicode-normalization"] }
 bit-set = { version = "0.5", features = ["std"] }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
-bitcoin_hashes = { version = "0.11", default-features = false }
+bitcoin_hashes-a6292c17cd707f01 = { package = "bitcoin_hashes", version = "0.11", default-features = false }
+bitcoin_hashes-274715c4dabd11b0 = { package = "bitcoin_hashes", version = "0.9", features = ["std"] }
 bitflags = { version = "1" }
 bitmaps = { version = "2", features = ["std"] }
 blake2 = { version = "0.9", features = ["std"] }
@@ -389,6 +391,7 @@ radix_trie = { version = "0.2", default-features = false }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 rand_chacha = { version = "0.3", features = ["std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_distr = { version = "0.4", features = ["alloc", "std"] }
@@ -630,9 +633,11 @@ better_typeid_derive = { version = "0.1", default-features = false }
 bimap = { version = "0.6", features = ["std"] }
 bincode = { version = "1", default-features = false }
 bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
+bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git", rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["serde", "std", "unicode-normalization"] }
 bit-set = { version = "0.5", features = ["std"] }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
-bitcoin_hashes = { version = "0.11", default-features = false }
+bitcoin_hashes-a6292c17cd707f01 = { package = "bitcoin_hashes", version = "0.11", default-features = false }
+bitcoin_hashes-274715c4dabd11b0 = { package = "bitcoin_hashes", version = "0.9", features = ["std"] }
 bitflags = { version = "1" }
 bitmaps = { version = "2", features = ["std"] }
 blake2 = { version = "0.9", features = ["std"] }
@@ -1020,6 +1025,7 @@ radix_trie = { version = "0.2", default-features = false }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 rand_chacha = { version = "0.3", features = ["std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_distr = { version = "0.4", features = ["alloc", "std"] }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -52,7 +52,7 @@ beef = { version = "0.5", features = ["impl_serde", "serde"] }
 better_any = { version = "0.1", default-features = false }
 bimap = { version = "0.6", features = ["std"] }
 bincode = { version = "1", default-features = false }
-bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git", rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["serde", "std", "unicode-normalization"] }
+bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git", rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["rand", "serde", "std", "unicode-normalization"] }
 bit-set = { version = "0.5", features = ["std"] }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bitcoin_hashes-a6292c17cd707f01 = { package = "bitcoin_hashes", version = "0.11", default-features = false }
@@ -388,15 +388,24 @@ quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default
 quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
 radix_trie = { version = "0.2", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
-rand_chacha = { version = "0.3", features = ["std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_distr = { version = "0.4", features = ["alloc", "std"] }
-rand_pcg = { version = "0.2", default-features = false }
-rand_xorshift = { version = "0.3", default-features = false }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
@@ -618,7 +627,8 @@ async-trait = { version = "0.1", default-features = false }
 atoi = { version = "0.4", default-features = false }
 atomicwrites = { version = "0.3", default-features = false }
 atty = { version = "0.2", default-features = false }
-autocfg = { version = "1", default-features = false }
+autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
+autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
 axum = { version = "0.5", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "serde_json", "serde_urlencoded", "tower-log"] }
 axum-core = { version = "0.2", default-features = false }
 backoff = { version = "0.4", features = ["futures", "futures-core", "pin-project-lite", "tokio", "tokio_1"] }
@@ -633,7 +643,7 @@ better_typeid_derive = { version = "0.1", default-features = false }
 bimap = { version = "0.6", features = ["std"] }
 bincode = { version = "1", default-features = false }
 bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
-bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git", rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["serde", "std", "unicode-normalization"] }
+bip39 = { git = "https://github.com/patrickkuo/rust-bip39.git", rev = "a76fe8310416555e6383b42b8acc4eb93c7bcc89", features = ["rand", "serde", "std", "unicode-normalization"] }
 bit-set = { version = "0.5", features = ["std"] }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bitcoin_hashes-a6292c17cd707f01 = { package = "bitcoin_hashes", version = "0.11", default-features = false }
@@ -1022,15 +1032,24 @@ quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
 radix_trie = { version = "0.2", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
-rand_chacha = { version = "0.3", features = ["std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_distr = { version = "0.4", features = ["alloc", "std"] }
-rand_pcg = { version = "0.2", default-features = false }
-rand_xorshift = { version = "0.3", default-features = false }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
 rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }


### PR DESCRIPTION
* implemented mnemonic following the Sui Wallet mnemonic implementation, using bip39 crate.
* add mnemonic support to SuiKeystore
* the Sui CLI now prints recovery phrase when create new address using the `sui client new-address` command
* added `import` functionality to the keytool, it can be used to import keys using the recovery phrase, e.g. `sui keytool import "<recovery phrase>"`
* SuiKeystore refactoring
* Removed list of accounts from `client.yaml`, using `sui.keystore` as the source of the SuiAddresses


** I have [forked](https://github.com/patrickkuo/rust-bip39) rust-bip39 to upgrade it's dependency of `unicode-normalization` to 0.1.21, this is needed to resolve dependency clash. (it was using v0.1.9, please let me know if there are better way to handle this)

*** this is not compatible with the current Sui Wallet (0.0.4) due to the Signature flag changes (it will import the key pair correctly but the SuiAddress will be different).