### PR TITLE
[docs] Fix "programming with objects"

### DIFF
--- a/doc/src/build/programming-with-objects/ch1-object-basics.md
+++ b/doc/src/build/programming-with-objects/ch1-object-basics.md
@@ -159,7 +159,7 @@ This will tell you the current client address.
 
 First, we need to publish the code on-chain. Assuming the path to the root of the repository containing Sui source code is $ROOT:
 ```
-$ sui client publish --path $ROOT/sui/sui_programmability/examples/objects_tutorial --gas-budget 10000
+$ sui client publish --path $ROOT/sui_programmability/examples/objects_tutorial --gas-budget 10000
 ```
 You can find the published package object ID in the **Publish Results** output:
 ```

--- a/doc/src/build/programming-with-objects/ch1-object-basics.md
+++ b/doc/src/build/programming-with-objects/ch1-object-basics.md
@@ -12,12 +12,12 @@ struct Color {
 }
 ```
 The above `struct` defines a data structure that can represent RGB color. `struct`s like this can be used to organize data with complicated semantics. However, instances of `struct`s like `Color` are not Sui objects yet.
-To define a struct that represents a Sui object type, we must add a `key` capability to the definition, and the first field of the struct must be the `id` of the object with type `Info` from the [object library](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/object.move):
+To define a struct that represents a Sui object type, we must add a `key` capability to the definition, and the first field of the struct must be the `id` of the object with type `UID` from the [object module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/object.move):
 ```rust
-use sui::object::Info;
+use sui::object::UID;
 
 struct ColorObject has key {
-    info: Info,
+    id: UID,
     red: u8,
     green: u8,
     blue: u8,
@@ -26,22 +26,22 @@ struct ColorObject has key {
 Now `ColorObject` represents a Sui object type and can be used to create Sui objects that can be eventually stored on the Sui chain.
 > :books: In both core Move and Sui Move, the [key ability](https://github.com/move-language/move/blob/main/language/documentation/book/src/abilities.md#key) denotes a type that can appear as a key in global storage. However, the structure of global storage is a bit different: core Move uses a (type, `address`)-indexed map, whereas Sui Move uses a map keyed by object IDs.
 
-> :bulb: The `Info` type is internal to Sui, and you most likely won't need to deal with it directly. For curious readers, it contains the unique `ID` of the object and the version of the object. Each time a mutable object is used in a transaction, its version will increase by 1.
+> :bulb: The `UID` type is internal to Sui, and you most likely won't need to deal with it directly. For curious readers, it contains the "unique ID" that defines an object. It is unique in the sense that no two values of type `UID` will ever have the same underlying set of bytes.
 
 ### Create Sui object
-Now that we have learned how to define a Sui object type, how do we create/instantiate a Sui object? In order to create a new Sui object from its type, we must assign an initial value to each of the fields, including `info`. The only way to create a new unique `Info` for a Sui object is to call `object::new`. The `new` function takes the current transaction context as an argument to generate unique IDs. The transaction context is of type `&mut TxContext` and should be passed down from an [entry function](../move/index.md#entry-functions) (a function that can be called directly from a transaction). Let's look at how we may define a constructor for `ColorObject`:
+Now that we have learned how to define a Sui object type, how do we create/instantiate a Sui object? In order to create a new Sui object from its type, we must assign an initial value to each of the fields, including `id`. The only way to create a new `UID` for a Sui object is to call `object::new`. The `new` function takes the current transaction context as an argument to generate unique `ID`s. The transaction context is of type `&mut TxContext` and should be passed down from an [entry function](../move/index.md#entry-functions) (a function that can be called directly from a transaction). Let's look at how we may define a constructor for `ColorObject`:
 ```rust
-// object represents the object module, which allows us call
+// object creates an alias to the object module, which allows us call
 // functions in the module, such as the `new` function, without fully
 // qualifying, e.g. `sui::object::new`.
 use sui::object;
-// tx_context::TxContext represents the TxContext struct in tx_context module.
+// tx_context::TxContext creates an alias to the the TxContext struct in tx_context module.
 use sui::tx_context::TxContext;
 
 
 fun new(red: u8, green: u8, blue: u8, ctx: &mut TxContext): ColorObject {
     ColorObject {
-        info: object::new(ctx),
+        id: object::new(ctx),
         red,
         green,
         blue,
@@ -53,7 +53,7 @@ fun new(red: u8, green: u8, blue: u8, ctx: &mut TxContext): ColorObject {
 ### Store Sui object
 We have defined a constructor for the `ColorObject`. Calling this constructor will put the value in a local variable where it can be returned from the current function, passed to other functions, or stored inside another struct. And of course, the object can be placed in persistent global storage so it can be read by the outside world and accessed in subsequent transactions.
 
-All of the APIs for adding objects to persistent storage live in the [`Transfer`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/transfer.move) module. One key API is:
+All of the APIs for adding objects to persistent storage live in the [`transfer`](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/transfer.move) module. One key API is:
 ```rust
 public fun transfer<T: key>(obj: T, recipient: address)
 ```
@@ -111,19 +111,19 @@ let scenario = &mut test_scenario::begin(&owner);
     color_object::create(255, 0, 255, ctx);
 };
 ```
->:books: Note there is a "`;`" after "`}`". This is required except for the last statement in the function. Refer to the [Move book](https://move-book.com/syntax-basics/expression-and-scope.html) for a detailed explanation.
+>:books: Note there is a "`;`" after "`}`". `;` is required to sequence a series of expressions, and even the block `{ ... }` is an expression! Refer to the [Move book](https://move-book.com/syntax-basics/expression-and-scope.html) for a detailed explanation.
 
 Now account `@0x1` should own the object. Let's first make sure it's not owned by anyone else:
 ```rust
 let not_owner = @0x2;
-// Check that @not_owner does not own the just-created ColorObject.
+// Check that not_owner does not own the just-created ColorObject.
 test_scenario::next_tx(scenario, &not_owner);
 {
     assert!(!test_scenario::can_take_owned<ColorObject>(scenario), 0);
 };
 ```
 
-`test_scenario::next_tx` switches the transaction sender to `@0x2`, which is a new address than the previous one.
+`test_scenario::next_tx` switches the transaction sender to `@0x2`, which is a new address different from the previous one.
 `test_scenario::can_take_owned` checks whether an object with the given type actually exists in the global storage owned by the current sender of the transaction. In this code, we assert that we should not be able to remove such an object, because `@0x2` does not own any object.
 > :bulb: The second parameter of `assert!` is the error code. In non-test code, we usually define a list of dedicated error code constants for each type of error that could happen in production. For unit tests though, it's usually unnecessary because there will be way too many assetions and the stacktrace upon error is sufficient to tell where the error happened. Hence we recommend just putting `0` there in unit tests for assertions.
 
@@ -159,7 +159,7 @@ This will tell you the current client address.
 
 First, we need to publish the code on-chain. Assuming the path to the root of the repository containing Sui source code is $ROOT:
 ```
-$ sui client publish --path $ROOT/sui_programmability/examples/objects_tutorial --gas-budget 10000
+$ sui client publish --path $ROOT/sui/sui_programmability/examples/objects_tutorial --gas-budget 10000
 ```
 You can find the published package object ID in the **Publish Results** output:
 ```

--- a/doc/src/build/programming-with-objects/ch3-immutable-objects.md
+++ b/doc/src/build/programming-with-objects/ch3-immutable-objects.md
@@ -8,13 +8,13 @@ Objects in Sui can have different types of [ownership](../objects.md#object-owne
 
 ### Create immutable object
 
-Regardless of whether an object was just created or already owned by an account, to turn this object into an immutable object, we need to call the following API in the [Transfer Library](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/transfer.move):
+Regardless of whether an object was just created or already owned by an account, to turn this object into an immutable object, we need to call the following API in the [transfer module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/transfer.move):
 ```rust
 public native fun freeze_object<T: key>(obj: T);
 ```
 After this call, the specified object will become permanently immutable. This is a non-reversible operation; hence, freeze an object only when you are certain that it will never need to be mutated.
 
-Let's add an entry function to the [ColorObject](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/objects_tutorial/sources/color_object.move) module to turn an existing (owned) `ColorObject` into an immutable object:
+Let's add an entry function to the [color_object module](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/objects_tutorial/sources/color_object.move) to turn an existing (owned) `ColorObject` into an immutable object:
 ```rust
 public entry fun freeze_object(object: ColorObject) {
     transfer::freeze_object(object)
@@ -34,7 +34,7 @@ In this function, a fresh new `ColorObject` is created and immediately turned in
 
 ### Use immutable object
 Once an object becomes immutable, the rules of who could use this object in Move calls change:
-1. An immutable object can be passed only as a read-only reference to Move entry functions as `&T`.
+1. An immutable object can be passed only as a read-only, immutable reference to Move entry functions as `&T`.
 2. Anyone can use immutable objects.
 
 Recall that we defined a function that copies the value of one object to another:
@@ -108,7 +108,7 @@ $ sui client objects --address=$ADDR
 
 Let's publish the `ColorObject` code on-chain using the Sui CLI client:
 ```
-$ sui client publish --path $ROOT/sui_programmability/examples/objects_tutorial --gas-budget 10000
+$ sui client publish --path $ROOT/sui/sui_programmability/examples/objects_tutorial --gas-budget 10000
 ```
 Set the package object ID to the `$PACKAGE` environment variable as we did in previous chapters.
 

--- a/doc/src/build/programming-with-objects/ch3-immutable-objects.md
+++ b/doc/src/build/programming-with-objects/ch3-immutable-objects.md
@@ -108,7 +108,7 @@ $ sui client objects --address=$ADDR
 
 Let's publish the `ColorObject` code on-chain using the Sui CLI client:
 ```
-$ sui client publish --path $ROOT/sui/sui_programmability/examples/objects_tutorial --gas-budget 10000
+$ sui client publish --path $ROOT/sui_programmability/examples/objects_tutorial --gas-budget 10000
 ```
 Set the package object ID to the `$PACKAGE` environment variable as we did in previous chapters.
 

--- a/doc/src/build/programming-with-objects/ch5-child-objects.md
+++ b/doc/src/build/programming-with-objects/ch5-child-objects.md
@@ -119,7 +119,7 @@ Both functions will compile successfully, because object ownership relationships
 
 Let's try to interact with these two entry functions on-chain and see what happens. First we publish the sample code:
 ```
-$ sui client publish --path $ROOT/sui/sui-core/src/unit_tests/data/object_owner --gas-budget 5000
+$ sui client publish --path $ROOT/sui-core/src/unit_tests/data/object_owner --gas-budget 5000
 ```
 ```
 ----- Publish Results ----
@@ -243,4 +243,4 @@ After we unpacked the `Parent` object we are able to extract the parent's `id` (
 
 ### Delete Parent Objects
 
-TODO
+(This section is still in development)

--- a/doc/src/build/programming-with-objects/ch5-child-objects.md
+++ b/doc/src/build/programming-with-objects/ch5-child-objects.md
@@ -5,7 +5,7 @@ title: Chapter 5 - Child Objects
 In the previous chapter, we walked through various ways of wrapping an object in another object. There are a few limitations in object wrapping:
 1. A wrapped object can be accessed only via its wrapper. It cannot be used directly in a transaction or queried by its ID (e.g., in the explorer).
 2. An object can become very large if it wraps several other objects. Larger objects can lead to higher gas fees in transactions. In addition, there is an upper bound on object size.
-3. As we will see in future chapters when we introduce the `Bag` library, there will be use cases where we need to store a collection of objects of heterogeneous types. Since the Move `vector` type must be templated on one single type `T`, it is not suitable for this.
+3. As we will see in future chapters, there will be use cases where we need to store a collection of objects of heterogeneous types. Since the Move `vector` type must be templated on one single type `T`, it is not suitable for this.
 
 Fortunately, Sui provides another way to represent object relationships: *an object can own other objects*. In the first chapter, we introduced libraries for transferring objects to an account address. In this chapter, we will introduce libraries that allow you transfer objects to other objects.
 
@@ -19,25 +19,23 @@ Assume we own two objects in our account address. To make one object own the oth
 public fun transfer_to_object<T: key, R: key>(
     obj: T,
     owner: &mut R,
-): ChildRef<T>;
+)
 ```
 The first argument `obj` will become a child object of the second argument `owner`. `obj` must be passed by value, i.e. it will be fully consumed and cannot be accessed again within the same transaction (similar to `transfer` function). After calling this function, the on-chain owner metadata of `obj` will change to the ID of the `owner` object.
 
-The function returns a special struct `ChildRef<T>` where `T` matches the type of the child object. It represents a reference to the child object. Since `ChildRef` is a struct type without `drop` ability, Move ensures the return value cannot be dropped. This ensures the caller of the function must put the reference somewhere and cannot forget about it.
-
-This is very important because later on if we attempt to delete the parent object, the existence of the child references forces us to take care of them. Otherwise, we may end up in a situation where we deleted the parent object, but there are still some child objects; and these child objects will be locked forever, as we will explain in latter sections. In the last section, we will also see how this reference is used to move around child objects and to prevent making mistakes.
+This begs the question, what happens if we attempt to delete the parent object? In the metadata for an object, Sui maintains a count of how many child objects a parent has. The parent object cannot be deleted, wrapped, or frozen while it still has children. Why? Without this limitation, we may end up in a situation where we deleted the parent object, but there are still some child objects; and these child objects will be locked forever, as we will explain in latter sections.
 
 Let's look at some code. The full source code can be found in [object_owner.move](https://github.com/MystenLabs/sui/blob/main/crates/sui-core/src/unit_tests/data/object_owner/sources/object_owner.move).
 
 First we define two object types for the parent and the child:
 ```rust
 struct Parent has key {
-    info: Info,
-    child: Option<ChildRef<Child>>,
+    id: UID,
+    child: Option<ID>,
 }
 
 struct Child has key {
-    info: Info,
+    id: UID,
 }
 ```
 `Parent` type contains a `child` field that is an optional child reference to an object of `Child` type.
@@ -45,7 +43,7 @@ First we define an API to create an object of `Child` type:
 ```rust
 public entry fun create_child(ctx: &mut TxContext) {
     transfer::transfer(
-        Child { info: object::new(ctx) },
+        Child { id: object::new(ctx) },
         tx_context::sender(ctx),
     );
 }
@@ -55,56 +53,58 @@ Similarly, we can define an API to create an object of `Parent` type:
 ```rust
 public entry fun create_parent(ctx: &mut TxContext) {
     let parent = Parent {
-        info: object::new(ctx),
+        id: object::new(ctx),
         child: option::none(),
     };
     transfer::transfer(parent, tx_context::sender(ctx));
 }
 ```
-Since the `child` field is `Option` type, we can start with `Option::none()`.
+Since the `child` field is `Option` type, we can start with `option::none()`.
 Now we can define an API that makes an object of `Child` a child of an object of `Parent`:
 ```rust
 public entry fun add_child(parent: &mut Parent, child: Child) {
-    let child_ref = transfer::transfer_to_object(child, parent);
-    option::fill(&mut parent.child, child_ref);
+    option::fill(&mut parent.child, object::id(&child));
+    transfer::transfer_to_object(child, parent);
 }
 ```
-This function takes `child` by value, calls `transfer_to_object` to transfer the `child` object to the `parent`, and returns a `child_ref`.
-After that, we can fill the `child` field of `parent` with `child_ref`.
-If we comment out the second line, the Move compiler will complain that we cannot drop `child_ref`.
+This function takes `child` by value, fills the `child` field of `parent` with the `ID` of the `Child` object, and calls `transfer_to_object` to transfer the `child` object to the `parent`.
 At the end of the `add_child` call, we have the following ownership relationship:
-1. Sender account address owns a `Parent` object.
+1. Sender account address (still) owns a `Parent` object.
 2. The `Parent` object owns a `Child` object.
 
 #### transfer_to_object_id
-In the above example, `Parent` has an optional child field. What if the field is not optional? We must construct `Parent` with a `ChildRef`. However, in order to have a `ChildRef`, we have to transfer the child object to the parent object first. This creates a paradox. We cannot create the parent unless we have a `ChildRef`, and we cannot have a `ChildRef` unless we already have the parent object. To solve this exact problem and be able to construct a non-optional `ChildRef` field, we provide another API that allows you to transfer an object to object ID, instead of to object:
+In the above example, `Parent` has an optional child field. What if the field is not optional? We must construct `Parent` with a `ID`. However, in order to have a valid `ID`, we have to transfer the child object to the parent object first. This creates a somewhat paradoxical situation. We cannot create the parent unless we have a valid `ID`, and we cannot have a valid `ID` unless we already have the parent object. To solve this problem, we can use a different API that allows you to transfer an object to an object ID, instead of to the object itself:
 ```rust
 public fun transfer_to_object_id<T: key>(
     obj: T,
-    owner_id: VersionedID,
-): (VersionedID, ChildRef<T>);
+    owner_id: &mut UID,
+);
 ```
-To use this API, we don't need to create a parent object yet; we need only the object ID of the parent object, which can be created in advance through `object::new(ctx)`. The function returns a tuple: it will return the `owner_id` that was passed in, along with the `ChildRef` representing a reference to the child object `obj`. It may seem strange that we require passing in `owner_id` by value only to return it. This is to ensure that the caller of the function does indeed own a `Info` that hasn't been used in any object yet. Without this, it can be easy to make mistakes.
+To use this API, we don't need to create a parent object yet; we need only the `UID` of the parent object, which can be created in advance through `object::new(ctx)`. The function requres a mutable reference to the parent `UID` for two reasons. (1) it prevents children from being added to immutable objects (more on that later). (2) it gives the module that defines the parent object more control. Namely, it can expose a function to get an immutable reference to the `&UID` without worrying about external caller adding child objects.
+
 Let's see how this is used in action. First we define another object type that has a non-optional child field:
 ```rust
 struct AnotherParent has key {
-    info: Info,
-    child: ChildRef<Child>,
+    id: UID,
+    child: ID,
 }
 ```
 And let's see how we define the API to create `AnotherParent` instance:
 ```rust
 public entry fun create_another_parent(child: Child, ctx: &mut TxContext) {
-    let info = object::new(ctx);
-    let (id, child_ref) = transfer::transfer_to_object_id(child, id);
+    let id = object::new(ctx);
+    let child_id = object::id(&child);
+    transfer::transfer_to_object_id(child, &mut id);
     let parent = AnotherParent {
         id,
-        child: child_ref,
+        child: child_id,
     };
     transfer::transfer(parent, tx_context::sender(ctx));
 }
 ```
 In the above function, we need to first create the ID of the new parent object. With the ID, we can then transfer the child object to it by calling `transfer_to_object_id`, thereby obtaining a reference `child_ref`. With both `id` and `child_ref`, we can create an object of `AnotherParent`, which we would eventually transfer to the sender's account.
+
+> :bulb: If we wanted to ensure that the `ID` in the `child` field of `Parent` or `AnotherParent` actually referred to an object of type `Child`, we could use `TypedID` which is defined in the [typed_id module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/typed_id.move)
 
 ### Use Child Objects
 We have explained in the first chapter that, in order to use an owned object, the object owner must be the transaction sender. What about objects owned by objects? We require that the object's owner object must also be passed as an argument in the Move call. For example, if object A owns object B, and object B owns object C, to be able to use C when calling a Move entry function, one must also pass B as an argument; and since B is an argument, A must also be an argument. This essentially means that to use an object, its entire ownership ancestor chain must be included, and the account owner of the root ancestor must match the sender of the transaction.
@@ -119,7 +119,7 @@ Both functions will compile successfully, because object ownership relationships
 
 Let's try to interact with these two entry functions on-chain and see what happens. First we publish the sample code:
 ```
-$ sui client publish --path sui_core/src/unit_tests/data/object_owner --gas-budget 5000
+$ sui client publish --path $ROOT/sui/sui-core/src/unit_tests/data/object_owner --gas-budget 5000
 ```
 ```
 ----- Publish Results ----
@@ -190,96 +190,57 @@ There are two ways to transfer a child object:
 1. Transfer it to an account address, thus it will no longer be a child object after the transfer.
 2. Transfer it to another object, thus it will still be a child object but with the parent object changed.
 
-#### transfer_child_to_address
-First of all, let's look at how to transfer a child object to an account address. The [Transfer](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/transfer.move) library provides the following API:
+#### transfer
+First of all, let's look at how to transfer a child object to an account address. Recall the `transfer` function as defined in the [transfer module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/transfer.move):
 ```rust
-public fun transfer_child_to_address<T: key>(
-    child: T,
-    child_ref: ChildRef<T>,
-    recipient: address,
-);
+```rust
+public fun transfer<T: key>(obj: T, recipient: address)
 ```
-`transfer_child_to_address` transfers an object that is currently a child to an account address. This function takes 3 arguments: `child` is the child object we wish to transfer, `child_ref` is the reference to it that was obtained when we previously transferred it to its current parent, and `recipient` is the recipient account address. After the transfer, the `recipient` account address now owns this object.
-There are two important things worth mentioning:
-1. Requiring `child_ref` as an argument ensures that the old parent won't have an out-of-date reference to the child object, and this reference is properly destroyed by the library during the transfer.
-2. This function has no return value. We no longer need a `ChildRef` because the object is no longer a child object.
-
-To demonstrate how to use this API, let's implement a function that removes a child object from a parent object and transfer it back to the account owner:
+`transfer` transfers an object, in this case a child object, to an account address.
+Using this API is no different than a normal transfer! All that is required is that the object's parent was present as an argument to the initial `entry` function. Let's implement a function that removes a child object from a parent object and transfer it back to the account owner:
 ```rust
 public entry fun remove_child(parent: &mut Parent, child: Child, ctx: &mut TxContext) {
-    let child_ref = option::extract(&mut parent.child);
-    transfer::transfer_child_to_address(child, child_ref, tx_context::sender(ctx));
+    option::extract(&mut parent.child); // this sets the option to none
+    transfer::transfer(child, tx_context::sender(ctx));
 }
 ```
-In the above function, the reference to the child is extracted from the `parent` object, which is then passed together with the `child` object to the `transfer_child_to_address`, with recipient as the sender of the transaction. It is important to note that this function must also take the `child` object as an argument. Move is not able to obtain the child object only from the reference. An object must always be explicitly provided in the transaction to make the transfer work. As we explained earlier, the fact that `transfer_child_to_address` requires the child reference as an argument guarantees that the `parent` object no longer holds a reference to the child object.
+In the above function, the `ID` of the child is extracted from the `parent` object. This is not necessary for the code to run, but is necessary to maintain the invariant that our `Parent` contains a valid `ID` of its child. After that, we transfer the `child` like any other object.
 
-#### transfer_child_to_object
-Another way to transfer a child object is to transfer it to another parent. The API is also defined in the Transfer library:
+#### transfer_to_object
+Another way to transfer a child object is to transfer it to another parent. Like we did when transferring to an address, we can use the API we are already familiar with from above:
 ```rust
-public fun transfer_child_to_object<T: key, R: key>(
-    child: T,
-    child_ref: ChildRef<T>,
+public fun transfer_to_object<T: key, R: key>(
+    obj: T,
     owner: &mut R,
-): ChildRef<T>;
+)
 ```
-After this call, the object `child` will become a child object of the object `owner`.
-Comparing to the previous API, there are two primary differences:
-1. Instead of transferring the object to an recipient address, here we need to provide a mutable reference to the new parent object `owner`. Although we are not mutating the new parent object in practice, we require `mut` to make sure the new owner is not an immutable object: child objects cannot be added to an immutable object.
-2. The function returns a new `ChildRef`. This is because we are transferring this object to a new parent, and hence a new reference is created to represent this child relationship, which will be different from the old child reference.
-
-To see how to use this API, let's define a function that could transfer a child object to a new parent:
+After this call, the object `obj` will become a child object of the object `owner`.
+Using this API is straight forward, as the only thing special required is that the object's parent was present as an argument to the initial `entry` function.
 ```rust
 public entry fun transfer_child(parent: &mut Parent, child: Child, new_parent: &mut Parent) {
-    let child_ref = option::extract(&mut parent.child);
-    let new_child_ref = transfer::transfer_child_to_object(child, child_ref, new_parent);
-    option::fill(&mut new_parent.child, new_child_ref);
+    option::fill(&mut new_parent.child,  option::extract(&mut parent.child));
+    transfer::transfer_to_object(child, new_parent);
 }
 ```
-Similar to `remove_child`, the `child` object must be passed explicitly by-value in the arguments. First of all we extract the existing child reference, and pass it to `transfer_child_to_object` along with `child`, and a mutable reference to `new_parent`. This call will return a new child reference. We then fill the `new_parent`'s `child` field with this new reference. Since `ChildRef` type is not droppable, `Option::fill` will fail if `new_parent.child` already contains an existing `ChildRef`. This ensures that we never accidentally drop a `ChildRef` without properly transferring the child.
+Similar to `remove_child`, the `child` object must be passed explicitly by-value in the arguments. First, we extract the existing child `ID` and use it to fill the `child` field of the `new_parent`. Then we use `transfer_to_object` as expected. Note, we can ensure that `new_parent` does not already have a child object. If it did, `option::fill` would abort, thus preventing any change from occurring as a result of this transaction.
 
 ### Delete Child Objects
-For the same reasons that transferring a child object requires both the child object and the `ChildRef`, deleting child objects directly without taking care of the child reference will lead to a stale reference pointing to a non-existing object after the deletion.
-There are two ways to delete a child object:
+Deleting child objects is similarly straight foward, and no different from deleting normal objects, except that the parent object must be present as an argument to the initial `entry` function.
+With this in mind, we can either:
 1. First transfer this child object to an account address, which makes this object a regular account-owned object instead of a child object, and hence can be deleted normally.
-2. Use a special API to delete the child object directly along with the child reference.
+2. Delete the child object directly
 
-#### Transfer and then delete
-What happens if we try to delete a child directly using what we learned in the first chapter, without taking the child reference? Let's find out. We can define a simple `delete_child` method like this:
-```rust
-public entry fun delete_child(child: Child, _parent: &mut Parent) {
-    let Child { id } = child;
-    id::delete(id);
-}
-```
-If you follow the client interaction above and then try to call the `delete_child` function here on a child object, you will see the following runtime error:
-```
-An object that's owned by another object cannot be deleted or wrapped.
-It must be transferred to an account address first before deletion
-```
-If we follow the suggestion, fist call `remove_child` to turn this child object to an account-owned object, and then call `delete_child` again, it will succeed! This is intuitive, but rather inconvenient: it requires two transactions to achieve the effect.
-
-#### delete_child_object
-The `Transfer` library provides a `delete_child_object` API to delete a child object directly. It is much more convenient than transfer + delete as it can be done in one transaction instead of two.
-The `delete_child_object` API is defined as following:
-```rust
-public fun delete_child_object<T: key>(
-    child_id: VersionedID,
-    child_ref: ChildRef<T>,
-);
-```
-The function takes both the ID of the child object and the child reference as arguments. As explained in chapter 1, to delete an object we must first unpack the object, and upon doing so a non-droppable `id` will need to be deleted explicitly.
-Instead of calling `id::delete` on the `id`, for child object, here we require calling `transfer::delete_child_object` with the `id` and the child reference.
-To demonstrate how to use this API, we define a function that can delete a parent object and a child object altogether:
+The first case is an application of two concepts already covered, i.e. transfering a child object and deleting an account-owned object. So let's look at the second case, deleting the child directly:
 ```rust
 public entry fun delete_parent_and_child(parent: Parent, child: Child) {
-    let Parent { id: parent_id, child: child_ref_opt } = parent;
-    let child_ref = option::extract(&mut child_ref_opt);
-    option::destroy_none(child_ref_opt);
-    id::delete(parent_id);
-
-    let Child { id: child_id } = child;
-    transfer::delete_child_object(child_id, child_ref);
+    let Parent { id: parent_id, child: _ } = parent;
+    object::delete(parent_id);
+    let Child { id } = child;
+    object::delete(id);
 }
 ```
-In the above example, after we unpacked the `parent` object we are able to extract the `child_ref`. We then also unpack the `child` object to obtain the `child_id`.
-Notice that when deleting the `parent` object, we called `id::delete`, while when deleting the `child` object, we called `delete_child_object`.
+After we unpacked the `parent` object we are able to extract the parent's `id` (bound to `parent_id`) and the ID of the child in the option, `child`. Since `ID` has the `drop` ability, the `Option<ID>` also has the `drop` ability. This means we can discard the value and have done so by not binding it to a local variable with `child: _`. We then also unpack the `child` object to obtain the its `id`. We delete `UID`s with `object::delete`. Note that these deletions can happen in any order, but Move's type system ensures that both must be deleted by the end of the function, since `UID` does not have `drop`.
+
+### Delete Parent Objects
+
+TODO


### PR DESCRIPTION
- Fixed after UID to ID renaming
- Fixed references to ChildRef (as it was removed)
- Small other consistency changes

- I did not fill out the section on deleting parent objects, as #3730 has not yet landed