### PR TITLE
chore: Update the Narwhal pointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "arc-swap",
  "crypto",
@@ -983,7 +983,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "consensus"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1025,7 +1025,7 @@ dependencies = [
  "tracing",
  "typed-store",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "anyhow",
  "base64ct",
@@ -1312,7 +1312,7 @@ dependencies = [
  "serde_with 2.0.0",
  "signature",
  "tokio",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
  "zeroize",
 ]
 
@@ -1411,7 +1411,7 @@ dependencies = [
 [[package]]
 name = "dag"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "arc-swap",
  "crypto",
@@ -1422,7 +1422,7 @@ dependencies = [
  "rayon",
  "serde 1.0.141",
  "thiserror",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -1932,7 +1932,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1955,7 +1955,7 @@ dependencies = [
  "typed-store",
  "types",
  "worker",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -4203,7 +4203,7 @@ checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 [[package]]
 name = "network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4222,7 +4222,7 @@ dependencies = [
  "tonic",
  "tracing",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "node"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4312,7 +4312,7 @@ dependencies = [
  "types",
  "url",
  "worker",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -5022,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "primary"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -5054,7 +5054,7 @@ dependencies = [
  "tracing",
  "typed-store",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -8115,7 +8115,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "base64",
  "bincode",
@@ -8126,9 +8126,13 @@ dependencies = [
  "dag",
  "derive_builder",
  "ed25519-dalek",
+ "futures",
+ "indexmap",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "prost",
+ "prost-build",
  "rand 0.7.3",
  "rustversion",
  "serde 1.0.141",
@@ -8137,8 +8141,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "tonic-build 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -8697,7 +8702,7 @@ dependencies = [
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8722,7 +8727,7 @@ dependencies = [
  "tracing",
  "typed-store",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
 ]
 
 [[package]]
@@ -9385,7 +9390,7 @@ dependencies = [
  "webpki-roots 0.22.3",
  "which",
  "worker",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08)",
  "yaml-rust",
  "zeroize",
  "zeroize_derive",
@@ -9395,7 +9400,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=cdf44079efc2ced6125f6a2ee7827680be3cbd0a#cdf44079efc2ced6125f6a2ee7827680be3cbd0a"
+source = "git+https://github.com/MystenLabs/narwhal?rev=e2231eb858d985a6ddedfcc64cc422893090be08#e2231eb858d985a6ddedfcc64cc422893090be08"
 dependencies = [
  "addr2line",
  "adler",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -37,7 +37,7 @@ sui-types = { path = "../sui-types" }
 sui-sdk = { path = "../sui-sdk" }
 
 move-core-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a", features = ["address20"] }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "node" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "node" }
 sui-quorum-driver = { path = "../sui-quorum-driver" }
 sui-node = { path = "../sui-node" }
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -20,8 +20,8 @@ multiaddr = "0.14.0"
 once_cell = "1.11.0"
 tracing = "0.1.36"
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "config" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "crypto" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "config" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "crypto" }
 move-binary-format = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-package = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a", features = ["address20"] }

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -75,7 +75,7 @@ impl Genesis {
                 };
                 let workers = [(
                     0, // worker_id
-                    narwhal_config::WorkerAddresses {
+                    narwhal_config::WorkerInfo {
                         primary_to_worker: validator.narwhal_primary_to_worker.clone(),
                         transactions: validator.narwhal_consensus_address.clone(),
                         worker_to_worker: validator.narwhal_worker_to_worker.clone(),

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -49,12 +49,12 @@ move-vm-runtime = { git = "https://github.com/move-language/move", rev = "790715
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c"}
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "config" }
-narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "consensus" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "crypto", features=["copy_key"]}
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "executor" }
-narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "types" }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "node" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "config" }
+narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "consensus" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "crypto", features=["copy_key"]}
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "executor" }
+narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "types" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "node" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.21"
 rocksdb = "0.18.0"
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c"}
 tempfile = "3.3.0"
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "executor" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "executor" }
 serde_with = { version = "1.14.0", features = ["hex"] }
 sui-storage = { path = "../sui-storage" }
 serde = { version = "1.0.141", features = ["derive"] }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -49,8 +49,8 @@ move-disassembler = { git = "https://github.com/move-language/move", rev = "7907
 move-ir-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "executor" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", package = "crypto" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "executor" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", package = "crypto" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -91,9 +91,9 @@ collectable = { version = "0.0.2", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4", features = ["alloc", "bytes", "std"] }
-config-c3e9345e8dfd2b77 = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+config-e01da1b25acb9a3f = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 config-a6292c17cd707f01 = { package = "config", version = "0.11", features = ["hjson", "ini", "json", "rust-ini", "serde-hjson", "serde_json", "toml", "yaml", "yaml-rust"] }
-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", features = ["benchmark", "rand"] }
+consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", features = ["benchmark", "rand"] }
 console = { version = "0.15", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
@@ -112,7 +112,7 @@ crossterm-647d43efb71741da = { package = "crossterm", version = "0.21" }
 crossterm-3c51e837cfc5589a = { package = "crossterm", version = "0.22" }
 crossterm-2b5c6dc72f624058 = { package = "crossterm", version = "0.23" }
 crossterm-adf3d7031871b0af = { package = "crossterm", version = "0.24" }
-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", features = ["copy_key"] }
+crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", features = ["copy_key"] }
 crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 crypto-mac = { version = "0.8", default-features = false, features = ["std"] }
@@ -120,7 +120,7 @@ csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
 curve25519-dalek = { version = "3", default-features = false, features = ["alloc", "serde", "std", "u64_backend"] }
 curve25519-dalek-fiat = { version = "0.1", default-features = false, features = ["alloc", "fiat-crypto", "fiat_u64_backend", "std"] }
-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+dag = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2", features = ["alloc", "std"] }
 datatest-stable = { version = "0.1", default-features = false }
@@ -155,7 +155,7 @@ endian-type = { version = "0.1", default-features = false }
 env_logger = { version = "0.9", features = ["atty", "humantime", "regex", "termcolor"] }
 ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+executor = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail = { version = "0.4", default-features = false }
 fastrand = { version = "1", default-features = false }
@@ -204,7 +204,6 @@ hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", features
 hashlink = { version = "0.7", default-features = false }
 hdrhistogram = { version = "7", default-features = false }
 heck-468e82937335b1c9 = { package = "heck", version = "0.3", default-features = false }
-heck-9fbad63c4bcf4a8f = { package = "heck", version = "0.4", features = ["unicode", "unicode-segmentation"] }
 hex = { version = "0.4", features = ["alloc", "std"] }
 hkdf = { version = "0.12", default-features = false, features = ["std"] }
 hmac = { version = "0.12", default-features = false, features = ["reset", "std"] }
@@ -223,7 +222,7 @@ ignore = { version = "0.4", default-features = false }
 im = { version = "15", default-features = false }
 include_dir = { version = "0.7", features = ["glob"] }
 indenter = { version = "0.3" }
-indexmap = { version = "1", default-features = false, features = ["std"] }
+indexmap = { version = "1", default-features = false, features = ["serde", "std"] }
 insta = { version = "1", features = ["colors", "console", "pest", "pest_derive", "redactions"] }
 instant = { version = "0.1", default-features = false }
 integer-encoding = { version = "3", default-features = false }
@@ -307,16 +306,15 @@ move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "790
 move-vm-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
-multimap = { version = "0.8", default-features = false }
 mysten-network-68692745110bd6f4 = { package = "mysten-network", git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c", default-features = false }
 mysten-network-a2655ef8805d82bb = { package = "mysten-network", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "c6dc7a23a40b3517f138d122a76d3bc15f844f67", default-features = false }
 named-lock = { version = "0.1", default-features = false }
 nested = { version = "0.1", default-features = false }
-network = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+network = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
-node = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false, features = ["benchmark"] }
+node = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false, features = ["benchmark"] }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5", features = ["alloc", "lexical", "lexical-core", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
@@ -369,14 +367,11 @@ predicates-core = { version = "1", default-features = false }
 predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1", features = ["std"] }
-prettyplease = { version = "0.1", default-features = false }
-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false, features = ["benchmark"] }
+primary = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false, features = ["benchmark"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro", "span-locations"] }
 prometheus = { version = "0.13", features = ["protobuf"] }
 proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 prost = { version = "0.10", features = ["prost-derive", "std"] }
-prost-build = { version = "0.10" }
-prost-types = { version = "0.10", default-features = false }
 protobuf = { version = "2", default-features = false }
 ptree = { version = "0.4", features = ["ansi", "ansi_term", "atty", "conf", "config", "directories", "petgraph", "serde-value", "tint", "value"] }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
@@ -474,7 +469,6 @@ strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-feature
 structopt = { version = "0.3" }
 strum = { version = "0.24", features = ["std"] }
 subtle = { version = "2", default-features = false, features = ["i128", "std"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 tabular = { version = "0.2", features = ["ansi-cell", "strip-ansi-escapes", "unicode-width"] }
 tap = { version = "1", default-features = false }
@@ -512,7 +506,6 @@ tokio-util = { version = "0.7", features = ["codec", "compat", "futures-io", "tr
 toml = { version = "0.5", features = ["indexmap", "preserve_order"] }
 toml_edit = { version = "0.13" }
 tonic = { version = "0.7", features = ["async-trait", "axum", "channel", "codegen", "h2", "hyper", "hyper-timeout", "prost", "prost-derive", "prost1", "rustls-pemfile", "tls", "tokio", "tokio-rustls", "tower", "tracing-futures", "transport"] }
-tonic-build-ca01ad9e24f5d932 = { package = "tonic-build", version = "0.7", features = ["prost", "prost-build", "transport"] }
 tonic-health = { version = "0.6", features = ["transport"] }
 tower = { version = "0.4", features = ["__common", "balance", "buffer", "discover", "filter", "full", "futures-core", "futures-util", "hdrhistogram", "hedge", "indexmap", "limit", "load", "load-shed", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "reconnect", "retry", "slab", "spawn-ready", "steer", "timeout", "tokio", "tokio-util", "tracing", "util"] }
 tower-http = { version = "0.3", features = ["cors", "map-response-body", "propagate-header", "set-header", "tower", "trace", "tracing", "util"] }
@@ -535,7 +528,7 @@ twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c", default-features = false }
 typenum = { version = "1", default-features = false }
-types = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a" }
+types = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08" }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
 uncased = { version = "0.9", default-features = false }
 unescape = { version = "0.1", default-features = false }
@@ -570,8 +563,8 @@ webpki-647d43efb71741da = { package = "webpki", version = "0.21", features = ["s
 webpki-3c51e837cfc5589a = { package = "webpki", version = "0.22", default-features = false, features = ["alloc", "std"] }
 webpki-roots-647d43efb71741da = { package = "webpki-roots", version = "0.21", default-features = false }
 webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false, features = ["benchmark"] }
-workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+worker = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false, features = ["benchmark"] }
+workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 zeroize = { version = "1", features = ["alloc", "zeroize_derive"] }
 zstd-sys = { version = "1", default-features = false }
@@ -670,9 +663,9 @@ collectable = { version = "0.0.2", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4", features = ["alloc", "bytes", "std"] }
-config-c3e9345e8dfd2b77 = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+config-e01da1b25acb9a3f = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 config-a6292c17cd707f01 = { package = "config", version = "0.11", features = ["hjson", "ini", "json", "rust-ini", "serde-hjson", "serde_json", "toml", "yaml", "yaml-rust"] }
-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", features = ["benchmark", "rand"] }
+consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", features = ["benchmark", "rand"] }
 console = { version = "0.15", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
@@ -691,7 +684,7 @@ crossterm-647d43efb71741da = { package = "crossterm", version = "0.21" }
 crossterm-3c51e837cfc5589a = { package = "crossterm", version = "0.22" }
 crossterm-2b5c6dc72f624058 = { package = "crossterm", version = "0.23" }
 crossterm-adf3d7031871b0af = { package = "crossterm", version = "0.24" }
-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", features = ["copy_key"] }
+crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", features = ["copy_key"] }
 crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 crypto-mac = { version = "0.8", default-features = false, features = ["std"] }
@@ -699,7 +692,7 @@ csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
 curve25519-dalek = { version = "3", default-features = false, features = ["alloc", "serde", "std", "u64_backend"] }
 curve25519-dalek-fiat = { version = "0.1", default-features = false, features = ["alloc", "fiat-crypto", "fiat_u64_backend", "std"] }
-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+dag = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 darling-594e8ee84c453af0 = { package = "darling", version = "0.13", features = ["suggestions"] }
 darling-582f2526e08bb6a0 = { package = "darling", version = "0.14", features = ["suggestions"] }
 darling_core-594e8ee84c453af0 = { package = "darling_core", version = "0.13", default-features = false, features = ["strsim", "suggestions"] }
@@ -746,7 +739,7 @@ enum_dispatch = { version = "0.3", default-features = false }
 env_logger = { version = "0.9", features = ["atty", "humantime", "regex", "termcolor"] }
 ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+executor = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail = { version = "0.4", default-features = false }
 fastrand = { version = "1", default-features = false }
@@ -820,7 +813,7 @@ im = { version = "15", default-features = false }
 include_dir = { version = "0.7", features = ["glob"] }
 include_dir_macros = { version = "0.7", default-features = false }
 indenter = { version = "0.3" }
-indexmap = { version = "1", default-features = false, features = ["std"] }
+indexmap = { version = "1", default-features = false, features = ["serde", "std"] }
 insta = { version = "1", features = ["colors", "console", "pest", "pest_derive", "redactions"] }
 instant = { version = "0.1", default-features = false }
 integer-encoding = { version = "3", default-features = false }
@@ -916,11 +909,11 @@ mysten-network-a2655ef8805d82bb = { package = "mysten-network", git = "https://g
 name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c", default-features = false }
 named-lock = { version = "0.1", default-features = false }
 nested = { version = "0.1", default-features = false }
-network = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+network = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
-node = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false, features = ["benchmark"] }
+node = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false, features = ["benchmark"] }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5", features = ["alloc", "lexical", "lexical-core", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
@@ -986,7 +979,7 @@ predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1", features = ["std"] }
 prettyplease = { version = "0.1", default-features = false }
-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false, features = ["benchmark"] }
+primary = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false, features = ["benchmark"] }
 proc-macro-crate = { version = "1", default-features = false }
 proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
 proc-macro-error-attr = { version = "1", default-features = false }
@@ -1185,7 +1178,7 @@ twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c", default-features = false }
 typenum = { version = "1", default-features = false }
-types = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a" }
+types = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08" }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
 uncased = { version = "0.9", default-features = false }
 unescape = { version = "0.1", default-features = false }
@@ -1232,8 +1225,8 @@ webpki-3c51e837cfc5589a = { package = "webpki", version = "0.22", default-featur
 webpki-roots-647d43efb71741da = { package = "webpki-roots", version = "0.21", default-features = false }
 webpki-roots-3c51e837cfc5589a = { package = "webpki-roots", version = "0.22", default-features = false }
 which = { version = "4", default-features = false }
-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false, features = ["benchmark"] }
-workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "cdf44079efc2ced6125f6a2ee7827680be3cbd0a", default-features = false }
+worker = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false, features = ["benchmark"] }
+workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "e2231eb858d985a6ddedfcc64cc422893090be08", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 zeroize = { version = "1", features = ["alloc", "zeroize_derive"] }
 zeroize_derive = { version = "1", default-features = false }


### PR DESCRIPTION
re-do of #3790 
Target: devnet
Manifest:
https://github.com/MystenLabs/narwhal/tree/devnet

Which is main at [0a92aa9b](https://github.com/MystenLabs/narwhal/commit/0a92aa9b2c799cdc0cfb29877f7a16e0d6fa4d67) minus:
https://github.com/MystenLabs/narwhal/pull/625
https://github.com/MystenLabs/narwhal/pull/603
https://github.com/MystenLabs/narwhal/pull/633
https://github.com/MystenLabs/narwhal/pull/536
https://github.com/MystenLabs/narwhal/pull/645
https://github.com/MystenLabs/narwhal/pull/673
https://github.com/MystenLabs/narwhal/pull/674
https://github.com/MystenLabs/narwhal/pull/677
https://github.com/MystenLabs/narwhal/pull/679
https://github.com/MystenLabs/narwhal/pull/624
https://github.com/MystenLabs/narwhal/pull/680
https://github.com/MystenLabs/narwhal/pull/683
https://github.com/MystenLabs/narwhal/pull/652
https://github.com/MystenLabs/narwhal/pull/684