### PR TITLE
crypto: switch to enum SuiKeyPair from type AccountKeyPair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7439,6 +7439,7 @@ dependencies = [
  "digest 0.10.3",
  "enum_dispatch",
  "executor",
+ "eyre",
  "hex",
  "hkdf",
  "itertools",

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -20,6 +20,7 @@ use sui_node::metrics;
 use sui_node::SuiNode;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
+use sui_types::crypto::AccountKeyPair;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -34,9 +35,7 @@ use sui_benchmark::workloads::workload::Payload;
 use sui_benchmark::workloads::workload::Workload;
 use sui_core::epoch::epoch_store::EpochStore;
 use sui_sdk::crypto::FileBasedKeystore;
-use sui_types::crypto::AccountKeyPair;
 use sui_types::crypto::EncodeDecodeBase64;
-use sui_types::crypto::KeypairTraits;
 
 use test_utils::authority::spawn_test_authorities;
 use test_utils::authority::test_and_configure_authority_configs;
@@ -303,7 +302,7 @@ async fn main() -> Result<()> {
             .key_pairs()
             .iter()
             .find(|x| {
-                let address: SuiAddress = Into::<SuiAddress>::into(x.public());
+                let address: SuiAddress = Into::<SuiAddress>::into(&x.public());
                 address == primary_gas_account
             })
             .map(|x| x.encode_base64())

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -15,6 +15,7 @@ use sui_swarm::memory::Node;
 use sui_swarm::memory::Swarm;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
+use sui_types::crypto::SuiKeyPair;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
 use test_utils::network::{start_rpc_test_network_with_fullnode, TestNetwork};
 use tracing::info;
@@ -246,7 +247,11 @@ pub async fn new_wallet_context_from_cluster(
     let keystore_path = temp_dir.path().join(SUI_KEYSTORE_FILENAME);
     let keystore = KeystoreType::File(keystore_path);
     let address: SuiAddress = key_pair.public().into();
-    keystore.init().unwrap().add_key(key_pair).unwrap();
+    keystore
+        .init()
+        .unwrap()
+        .add_key(SuiKeyPair::Ed25519SuiKeyPair(key_pair))
+        .unwrap();
     SuiClientConfig {
         keystore,
         gateway: ClientType::RPC(rpc_url.into()),

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3037,6 +3037,9 @@
           }
         }
       },
+      "Secp256k1SuiSignature": {
+        "$ref": "#/components/schemas/Base64"
+      },
       "SequenceNumber": {
         "type": "integer",
         "format": "uint64",
@@ -3052,6 +3055,18 @@
             "properties": {
               "Ed25519SuiSignature": {
                 "$ref": "#/components/schemas/Ed25519SuiSignature"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Secp256k1SuiSignature"
+            ],
+            "properties": {
+              "Secp256k1SuiSignature": {
+                "$ref": "#/components/schemas/Secp256k1SuiSignature"
               }
             },
             "additionalProperties": false

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -36,6 +36,7 @@ strum = "^0.24"
 strum_macros = "^0.24"
 roaring = "0.9.0"
 enum_dispatch = "^0.3"
+eyre = "0.6.8"
 
 # This version is incompatible with ed25519-dalek
 rand_latest = { version = "0.8.5", package = "rand" }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -26,7 +26,9 @@ use sha2::Sha512;
 use sha3::Sha3_256;
 
 use crate::committee::EpochId;
-use crate::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, SuiPublicKey};
+use crate::crypto::{
+    AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, PublicKey, SuiPublicKey,
+};
 use crate::error::ExecutionError;
 use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
@@ -199,6 +201,19 @@ impl<T: SuiPublicKey> From<&T> for SuiAddress {
     fn from(pk: &T) -> Self {
         let mut hasher = Sha3_256::default();
         hasher.update(&[T::SIGNATURE_SCHEME.flag()]);
+        hasher.update(pk);
+        let g_arr = hasher.finalize();
+
+        let mut res = [0u8; SUI_ADDRESS_LENGTH];
+        res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);
+        SuiAddress(res)
+    }
+}
+
+impl From<&PublicKey> for SuiAddress {
+    fn from(pk: &PublicKey) -> Self {
+        let mut hasher = Sha3_256::default();
+        hasher.update(&[pk.flag()]);
         hasher.update(pk);
         let g_arr = hasher.finalize();
 

--- a/crates/sui-types/src/unit_tests/signature_seed_tests.rs
+++ b/crates/sui-types/src/unit_tests/signature_seed_tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use narwhal_crypto::secp256k1::Secp256k1KeyPair;
+
 use crate::crypto::AccountKeyPair;
 use crate::crypto::SuiSignature;
 use crate::{crypto::bcs_signable_test::Foo, signature_seed::SignatureSeed};
@@ -131,4 +133,22 @@ fn seed_zeroize_on_drop() {
 
     let memory: &[u8] = unsafe { ::std::slice::from_raw_parts(secret_ptr, 32) };
     assert!(!memory.contains(&0x15));
+}
+
+#[test]
+fn test_sign_verify_with_secp256k1() {
+    let seed = SignatureSeed::default();
+    let id_0 = [0u8; 32];
+    let msg0 = Foo("test0".to_string());
+
+    let sui_address_0 = seed
+        .new_deterministic_address::<Secp256k1KeyPair>(&id_0, Some(&TEST_DOMAIN))
+        .unwrap();
+
+    let sig_0 = seed.sign::<_, Secp256k1KeyPair>(&id_0, Some(&TEST_DOMAIN), &msg0);
+    assert!(sig_0.is_ok());
+    let sig_0_ok = sig_0.unwrap();
+
+    let ver_0 = sig_0_ok.verify(&msg0, sui_address_0);
+    assert!(ver_0.is_ok());
 }

--- a/crates/sui/src/genesis_ceremony.rs
+++ b/crates/sui/src/genesis_ceremony.rs
@@ -20,7 +20,7 @@ use sui_types::{
     object::Object,
 };
 
-use crate::keytool::read_keypair_from_file;
+use crate::keytool::read_authority_keypair_from_file;
 
 const GENESIS_BUILDER_SIGNATURE_DIR: &str = "signatures";
 
@@ -106,7 +106,7 @@ pub fn run(cmd: Ceremony) -> Result<()> {
             narwhal_consensus_address,
         } => {
             let mut builder = Builder::load(&dir)?;
-            let keypair: AuthorityKeyPair = read_keypair_from_file(key_file)?;
+            let keypair: AuthorityKeyPair = read_authority_keypair_from_file(key_file)?;
             builder = builder.add_validator(sui_config::ValidatorInfo {
                 name,
                 public_key: keypair.public().into(),
@@ -151,7 +151,7 @@ pub fn run(cmd: Ceremony) -> Result<()> {
         }
 
         CeremonyCommand::VerifyAndSign { key_file } => {
-            let keypair: AuthorityKeyPair = read_keypair_from_file(key_file)?;
+            let keypair: AuthorityKeyPair = read_authority_keypair_from_file(key_file)?;
             let loaded_genesis = Genesis::load(dir.join(SUI_GENESIS_FILENAME))?;
             let loaded_genesis_bytes = loaded_genesis.to_bytes();
 
@@ -252,7 +252,7 @@ mod test {
     use crate::keytool::write_keypair_to_file;
     use anyhow::Result;
     use sui_config::{utils, ValidatorInfo};
-    use sui_types::crypto::{get_key_pair_from_rng, AuthorityKeyPair};
+    use sui_types::crypto::{get_key_pair_from_rng, AuthorityKeyPair, SuiKeyPair};
 
     #[test]
     fn ceremony() -> Result<()> {
@@ -274,7 +274,8 @@ mod test {
                     narwhal_consensus_address: utils::new_network_address(),
                 };
                 let key_file = dir.path().join(format!("{}.key", info.name));
-                write_keypair_to_file(&keypair, &key_file).unwrap();
+                write_keypair_to_file(&SuiKeyPair::Ed25519SuiKeyPair(keypair), &key_file).unwrap();
+
                 (key_file, info)
             })
             .collect::<Vec<_>>();

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -24,7 +24,7 @@ use sui_config::{
 use sui_sdk::crypto::KeystoreType;
 use sui_sdk::{ClientType, SuiClient};
 use sui_swarm::memory::Swarm;
-use sui_types::crypto::KeypairTraits;
+use sui_types::crypto::{KeypairTraits, SuiKeyPair};
 use tracing::info;
 
 #[derive(Parser)]
@@ -246,7 +246,7 @@ impl SuiCommand {
                 let mut keystore = KeystoreType::File(keystore_path.clone()).init().unwrap();
 
                 for key in &network_config.account_keys {
-                    keystore.add_key(key.copy())?;
+                    keystore.add_key(SuiKeyPair::Ed25519SuiKeyPair(key.copy()))?;
                 }
 
                 network_config.genesis.save(&genesis_path)?;

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -23,7 +23,7 @@ use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{GetObjectDataResponse, SuiParsedObject, SuiTransactionEffects};
 use sui_sdk::crypto::KeystoreType;
 use sui_sdk::ClientType;
-use sui_types::crypto::{AuthorityKeyPair, KeypairTraits};
+use sui_types::crypto::{AuthorityKeyPair, KeypairTraits, SuiKeyPair};
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
 use sui_types::{sui_framework_address_concat_string, SUI_FRAMEWORK_OBJECT_ID};
 
@@ -133,7 +133,9 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
     // Add 3 accounts
     for _ in 0..3 {
-        context.keystore.add_key(get_key_pair().1)?;
+        context
+            .keystore
+            .add_key(SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1))?;
     }
 
     // Print all addresses

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::keytool::read_authority_keypair_from_file;
+use crate::keytool::read_keypair_from_file;
+
+use super::write_keypair_to_file;
+use super::KeyToolCommand;
+use sui_sdk::crypto::KeystoreType;
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::get_key_pair;
+use sui_types::crypto::Ed25519SuiSignature;
+use sui_types::crypto::KeypairTraits;
+use sui_types::crypto::Secp256k1SuiSignature;
+use sui_types::crypto::Signature;
+use sui_types::crypto::SuiKeyPair;
+use sui_types::crypto::SuiSignatureInner;
+
+#[test]
+fn test_addresses_command() -> Result<(), anyhow::Error> {
+    // Add 3 Ed25519 KeyPairs as default
+    let mut keystore = KeystoreType::InMem(3).init().unwrap();
+
+    // Add another 3 Secp256k1 KeyPairs
+    for _ in 0..3 {
+        keystore.add_key(SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1))?;
+    }
+
+    // List all addresses with flag
+    KeyToolCommand::List.execute(&mut keystore).unwrap();
+    Ok(())
+}
+
+#[test]
+fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
+    let mut keystore = KeystoreType::InMem(0).init().unwrap();
+
+    keystore.add_key(SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1))?;
+    keystore.add_key(SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1))?;
+
+    for pk in keystore.keys() {
+        let pk1 = pk.clone();
+        let sig = keystore.sign(&(&pk).into(), b"hello")?;
+        match sig {
+            Signature::Ed25519SuiSignature(_) => {
+                // signature contains corresponding flag
+                assert_eq!(
+                    *sig.as_ref().first().unwrap(),
+                    Ed25519SuiSignature::SCHEME.flag()
+                );
+                // keystore stores pubkey with corresponding flag
+                assert!(pk1.flag() == Ed25519SuiSignature::SCHEME.flag())
+            }
+            Signature::Secp256k1SuiSignature(_) => {
+                assert_eq!(
+                    *sig.as_ref().first().unwrap(),
+                    Secp256k1SuiSignature::SCHEME.flag()
+                );
+                assert!(pk1.flag() == Secp256k1SuiSignature::SCHEME.flag())
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_read_write_keystore_with_flag() {
+    let dir = tempfile::TempDir::new().unwrap();
+
+    // create Secp256k1 keypair
+    let kp_secp = SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1);
+    let addr_secp: SuiAddress = (&kp_secp.public()).into();
+    let fp_secp = dir.path().join(format!("{}.key", addr_secp));
+    let fp_secp_2 = fp_secp.clone();
+
+    // write Secp256k1 keypair to file
+    let res = write_keypair_to_file(&kp_secp, &fp_secp);
+    assert!(res.is_ok());
+
+    // read from file as enum KeyPair success
+    let kp_secp_read = read_keypair_from_file(fp_secp);
+    assert!(kp_secp_read.is_ok());
+
+    // KeyPair wrote into file is the same as read
+    assert_eq!(
+        kp_secp_read.unwrap().public().as_ref(),
+        kp_secp.public().as_ref()
+    );
+
+    // read as AuthorityKeyPair fails
+    let kp_secp_read = read_authority_keypair_from_file(fp_secp_2);
+    assert!(kp_secp_read.is_err());
+
+    // create Ed25519 keypair
+    let kp_ed = SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1);
+    let addr_ed: SuiAddress = (&kp_ed.public()).into();
+    let fp_ed = dir.path().join(format!("{}.key", addr_ed));
+    let fp_ed_2 = fp_ed.clone();
+
+    // write Ed25519 keypair to file
+    let res = write_keypair_to_file(&kp_ed, &fp_ed);
+    assert!(res.is_ok());
+
+    // read from file as enum KeyPair success
+    let kp_ed_read = read_keypair_from_file(fp_ed);
+    assert!(kp_ed_read.is_ok());
+
+    // KeyPair wrote into file is the same as read
+    assert_eq!(
+        kp_ed_read.unwrap().public().as_ref(),
+        kp_ed.public().as_ref()
+    );
+
+    // read from file as AuthorityKeyPair success
+    let kp_ed_read = read_authority_keypair_from_file(fp_ed_2);
+    assert!(kp_ed_read.is_ok());
+
+    // AuthorityKeyPair wrote into file is the same as read
+    assert_eq!(
+        kp_ed_read.unwrap().public().as_ref(),
+        kp_ed.public().as_ref()
+    );
+}

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -27,6 +27,7 @@ use sui_sdk::{ClientType, SuiClient};
 use sui_swarm::memory::{Swarm, SwarmBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
+use sui_types::crypto::SuiKeyPair::Ed25519SuiKeyPair;
 const NUM_VALIDAOTR: usize = 4;
 
 pub async fn start_test_network(
@@ -60,7 +61,7 @@ pub async fn start_test_network_with_fullnodes(
     swarm.config().save(&network_path)?;
     let mut keystore = KeystoreType::File(keystore_path.clone()).init()?;
     for key in &swarm.config().account_keys {
-        keystore.add_key(key.copy())?;
+        keystore.add_key(Ed25519SuiKeyPair(key.copy()))?;
     }
 
     let validators = swarm.config().validator_set().to_owned();


### PR DESCRIPTION
https://github.com/MystenLabs/sui/issues/3684
https://github.com/MystenLabs/sui/issues/3846
- SuiKeyPair is added as an enum that has: Ed25519KeyPair and Secp256k1KeyPair
- AccountKeyPair is unchanged, still fixed to type Ed25519KeyPair (perhaps should rename to DefaultAccountKeyPair to avoid confusion)
- All existing unit tests and benchmarks are untouched as they are still ran against Ed25519
- All callers to `KeyStore.add_key` needs to wrap the specific type to KeyPair
- Keypair stores as `encode_base64{flag || pubkey || privkey}` in file
- See test cases in `messages_tests` `keytool_tests`

left some todos:
- a rename only PR to point 2
- add ability to generate KeyPair with a type flag {Ed25519, Sepc256k1}
- add ability to import mnemonics with type flag {Ed25519, Sepc256k1}

this should not contain any breaking changes (to configs and wallet), but FYI if I can add anymore new tests to ensure it works.