### PR TITLE
wallet-ext: fix route warning

### DIFF
--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -47,7 +47,7 @@ const App = () => {
     }, [location, dispatch]);
     return (
         <Routes>
-            <Route path="/" element={<HomePage />}>
+            <Route path="/*" element={<HomePage />}>
                 <Route
                     index
                     element={<Navigate to="/tokens" replace={true} />}


### PR DESCRIPTION

I noticed the following error in the chrome error details page: 
![CleanShot 2022-08-05 at 17 22 50](https://user-images.githubusercontent.com/76067158/183226140-2397e1ba-4967-4a46-820d-1fd12e453148.png)

see https://stackoverflow.com/questions/70604020/please-change-the-parent-route-path-to-route-path for a detailed explanation