### PR TITLE
Add recommended extensions for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-		"move.move-analyzer",
+    "move.move-analyzer",
     "rust-lang.rust-analyzer",
     "esbenp.prettier-vscode"
   ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+		"move.move-analyzer",
+    "rust-lang.rust-analyzer",
+    "esbenp.prettier-vscode"
+  ]
+}


### PR DESCRIPTION
VSCode has a feature that allows setting recommended extensions within a workspace. This makes it easier for new people setting the repo up, as it will automatically prompt them to install these extensions.

I started with three extensions to begin with: `rust-analyzer`, `move-analyzer`, and `prettier` (used heavily within the frontend parts of the codebase).

Documentation: https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions