### PR TITLE
[Explorer] Cleanup validators UI

### DIFF
--- a/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -12,8 +12,6 @@ import {
     getTabFooter,
     getValidatorState,
     processValidators,
-    sortValidatorsByStake,
-    stakeColumn,
     ValidatorLoadFail,
     type ValidatorState,
 } from '../../pages/validators/Validators';
@@ -21,6 +19,7 @@ import { mockState } from '../../pages/validators/mockData';
 import theme from '../../styles/theme.module.css';
 
 import styles from './TopValidatorsCard.module.css';
+import { truncate } from '../../utils/stringUtils';
 
 export const STATE_DEFAULT: ValidatorState = {
     delegation_reward: 0,
@@ -86,22 +85,23 @@ export const TopValidatorsCardAPI = (): JSX.Element => {
 };
 
 function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
-    const totalStake = state.validators.fields.total_validator_stake;
-    // sort by order of descending stake
-    sortValidatorsByStake(state.validators.fields.active_validators);
-
     const validatorsData = processValidators(
-        state.validators.fields.active_validators,
-        totalStake
+        state.validators.fields.active_validators
     );
 
     // map the above data to match the table - combine stake and stake percent
     const tableData = {
         data: validatorsData.map((validator) => ({
             name: validator.name,
-            stake: stakeColumn(validator),
-            delegation: validator.delegation_count,
             position: validator.position,
+            address: (
+                <Longtext
+                    text={validator.address}
+                    alttext={truncate(validator.address, 14)}
+                    category={'addresses'}
+                    isLink={true}
+                />
+            ),
         })),
         columns: [
             {
@@ -113,12 +113,8 @@ function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
                 accessorKey: 'name',
             },
             {
-                headerLabel: 'STAKE',
-                accessorKey: 'stake',
-            },
-            {
-                headerLabel: 'Delegators',
-                accessorKey: 'delegation',
+                headerLabel: 'Address',
+                accessorKey: 'address',
             },
         ],
     };

--- a/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -17,9 +17,9 @@ import {
 } from '../../pages/validators/Validators';
 import { mockState } from '../../pages/validators/mockData';
 import theme from '../../styles/theme.module.css';
+import { truncate } from '../../utils/stringUtils';
 
 import styles from './TopValidatorsCard.module.css';
-import { truncate } from '../../utils/stringUtils';
 
 export const STATE_DEFAULT: ValidatorState = {
     delegation_reward: 0,

--- a/explorer/client/src/pages/validators/Validators.tsx
+++ b/explorer/client/src/pages/validators/Validators.tsx
@@ -123,14 +123,6 @@ export function getValidatorState(network: string): Promise<ValidatorState> {
         });
 }
 
-export function sortValidatorsByStake(validators: Validator[]) {
-    validators.sort((a: Validator, b: Validator): number => {
-        if (a.fields.stake_amount < b.fields.stake_amount) return 1;
-        if (a.fields.stake_amount > b.fields.stake_amount) return -1;
-        return 0;
-    });
-}
-
 const ValidatorPageResult = (): JSX.Element => {
     const { state } = useLocation();
 
@@ -145,26 +137,7 @@ const ValidatorPageResult = (): JSX.Element => {
     );
 };
 
-export function stakeColumn(validator: {
-    stake: BigInt;
-    stakePercent: number;
-}): JSX.Element {
-    return (
-        <div>
-            {' '}
-            {validator.stake.toString()}{' '}
-            <span className={styles.stakepercent}>
-                {' '}
-                {validator.stakePercent.toFixed(2)} %
-            </span>
-        </div>
-    );
-}
-
-export const getStakePercent = (stake: bigint, total: bigint): number =>
-    Number(BigInt(stake) * BigInt(100)) / Number(total);
-
-export function processValidators(set: Validator[], totalStake: bigint) {
+export function processValidators(set: Validator[]) {
     return set.map((av, i) => {
         const rawName = av.fields.metadata.fields.name;
         const name = textDecoder.decode(
@@ -173,9 +146,6 @@ export function processValidators(set: Validator[], totalStake: bigint) {
         return {
             name: name,
             address: av.fields.metadata.fields.sui_address,
-            stake: av.fields.stake_amount,
-            stakePercent: getStakePercent(av.fields.stake_amount, totalStake),
-            delegation_count: av.fields.delegation_count || 0,
             position: i + 1,
         };
     });
@@ -191,19 +161,12 @@ export function getTabFooter(count: number) {
 }
 
 function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
-    const totalStake = state.validators.fields.total_validator_stake;
-    // sort by order of descending stake
-    sortValidatorsByStake(state.validators.fields.active_validators);
-
     const validatorsData = processValidators(
-        state.validators.fields.active_validators,
-        totalStake
+        state.validators.fields.active_validators
     );
 
-    let cumulativeStakePercent = 0;
     const tableData = {
         data: validatorsData.map((validator) => {
-            cumulativeStakePercent += validator.stakePercent;
             return {
                 name: validator.name,
                 address: (
@@ -214,14 +177,6 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
                         isLink={true}
                     />
                 ),
-                stake: stakeColumn(validator),
-                cumulativeStake: (
-                    <span className={styles.stakepercent}>
-                        {' '}
-                        {cumulativeStakePercent.toFixed(2)} %
-                    </span>
-                ),
-                delegation: validator.delegation_count,
                 position: validator.position,
             };
         }),
@@ -233,18 +188,6 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
             {
                 headerLabel: 'Name',
                 accessorKey: 'name',
-            },
-            {
-                headerLabel: 'STAKE',
-                accessorKey: 'stake',
-            },
-            {
-                headerLabel: 'Cumulative Stake',
-                accessorKey: 'cumulativeStake',
-            },
-            {
-                headerLabel: 'Delegators',
-                accessorKey: 'delegation',
             },
             {
                 headerLabel: 'Address',
@@ -266,7 +209,6 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
                             category="validators"
                             isLink={false}
                             isCopyButton={false}
-                            /*showIconButton={true}*/
                             alttext=""
                         />
                     </TabFooter>


### PR DESCRIPTION
Updating the validators UI based on feedback.

On the home page:
<img width="846" alt="Screen Shot 2022-08-08 at 2 05 03 PM" src="https://user-images.githubusercontent.com/109986297/183514431-28c9c31b-6c39-4922-ba16-6da6c017959f.png">

Within the validators card:
<img width="779" alt="Screen Shot 2022-08-08 at 2 04 55 PM" src="https://user-images.githubusercontent.com/109986297/183514451-c73d3b32-d305-4206-9686-b5e149bfaeb0.png">
