### PR TITLE
Add epoch store to SafeClient

### DIFF
--- a/crates/sui-benchmark/src/benchmark/validator_preparer.rs
+++ b/crates/sui-benchmark/src/benchmark/validator_preparer.rs
@@ -279,11 +279,10 @@ fn make_authority_state(
     // opts.set_manual_wal_flush(true);
 
     let store = Arc::new(AuthorityStore::open(&path.join("store"), Some(opts)));
-    let epoch_store = Arc::new(EpochStore::new(path.join("epochs")));
+    let epoch_store = Arc::new(EpochStore::new(path.join("epochs"), committee));
     (
         Runtime::new().unwrap().block_on(async {
             AuthorityState::new(
-                committee.clone(),
                 *pubx,
                 Arc::pin(secx),
                 store.clone(),

--- a/crates/sui-benchmark/src/benchmark/validator_preparer.rs
+++ b/crates/sui-benchmark/src/benchmark/validator_preparer.rs
@@ -278,8 +278,11 @@ fn make_authority_state(
     // manually.
     // opts.set_manual_wal_flush(true);
 
-    let store = Arc::new(AuthorityStore::open(&path.join("store"), Some(opts)));
-    let epoch_store = Arc::new(EpochStore::new(path.join("epochs"), committee));
+    let store = Arc::new(AuthorityStore::open(
+        &path.join("store"),
+        Some(opts.clone()),
+    ));
+    let epoch_store = Arc::new(EpochStore::new(path.join("epochs"), committee, Some(opts)));
     (
         Runtime::new().unwrap().block_on(async {
             AuthorityState::new(

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -43,6 +43,7 @@ use sui_benchmark::workloads::workload::CombinationWorkload;
 use sui_benchmark::workloads::workload::Payload;
 use sui_benchmark::workloads::workload::Workload;
 use sui_core::authority_client::NetworkAuthorityClient;
+use sui_core::epoch::epoch_store::EpochStore;
 use sui_quorum_driver::QuorumDriverHandler;
 use sui_sdk::crypto::FileBasedKeystore;
 use sui_types::crypto::EncodeDecodeBase64;
@@ -118,7 +119,7 @@ struct Opts {
     pub client_metric_port: u16,
     /// Number of followers to run. This also  stresses the follower logic in validators
     #[clap(long, default_value = "0", global = true)]
-    pub num_folowers: u64,
+    pub num_followers: u64,
     /// Whether or no to download TXes during follow
     #[clap(long, global = true)]
     pub download_txes: bool,
@@ -131,7 +132,7 @@ pub enum OptWorkloadSpec {
     // Allow the ability to mix shared object and
     // single owner transactions in the benchmarking
     // framework. Currently, only shared counter
-    // and transfer obejct transaction types are
+    // and transfer object transaction types are
     // supported but there will be more in future. Also
     // there is no dependency between individual
     // transactions such that they can all be executed
@@ -559,7 +560,7 @@ async fn main() -> Result<()> {
                 let mut follower_handles = vec![];
 
                 // Start the followers if any
-                for idx in 0..opts.num_folowers {
+                for idx in 0..opts.num_followers {
                     // Kick off a task which follows all authorities and discards the data
                     for (name, auth_client) in auth_clients.clone() {
                         follower_handles.push(tokio::task::spawn(async move {
@@ -601,6 +602,7 @@ async fn main() -> Result<()> {
         let registry = prometheus::Registry::new();
         let aggregator = AuthorityAggregator::new(
             committee,
+            Arc::new(EpochStore::new_for_testing(&committee))
             authority_clients,
             AuthAggMetrics::new(&registry),
             SafeClientMetrics::new(&registry),
@@ -660,6 +662,7 @@ async fn main() -> Result<()> {
             );
             let aggregator = AuthorityAggregator::new(
                 committee,
+                Arc::new(EpochStore::new_for_testing(&committee))
                 authority_clients,
                 AuthAggMetrics::new(&registry),
                 SafeClientMetrics::new(&registry),

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -600,9 +600,10 @@ async fn main() -> Result<()> {
         let committee = GatewayState::make_committee(&config)?;
         let authority_clients = GatewayState::make_authority_clients(&config);
         let registry = prometheus::Registry::new();
+        let epoch_store = Arc::new(EpochStore::new_for_testing(&committee));
         let aggregator = AuthorityAggregator::new(
             committee,
-            Arc::new(EpochStore::new_for_testing(&committee))
+            epoch_store,
             authority_clients,
             AuthAggMetrics::new(&registry),
             SafeClientMetrics::new(&registry),
@@ -660,9 +661,10 @@ async fn main() -> Result<()> {
                     .parse()
                     .unwrap(),
             );
+            let epoch_store = Arc::new(EpochStore::new_for_testing(&committee));
             let aggregator = AuthorityAggregator::new(
                 committee,
-                Arc::new(EpochStore::new_for_testing(&committee))
+                epoch_store,
                 authority_clients,
                 AuthAggMetrics::new(&registry),
                 SafeClientMetrics::new(&registry),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -346,8 +346,8 @@ impl AuthorityState {
         self.committee.load().epoch
     }
 
-    pub fn clone_epoch_store(&self) -> Arc<EpochStore> {
-        self.epoch_store.clone()
+    pub fn epoch_store(&self) -> &Arc<EpochStore> {
+        &self.epoch_store
     }
 
     async fn handle_transaction_impl(
@@ -1169,7 +1169,11 @@ impl AuthorityState {
                 .expect("No issues");
         }
 
-        let epochs = Arc::new(EpochStore::new(path.join("epochs"), &genesis_committee));
+        let epochs = Arc::new(EpochStore::new(
+            path.join("epochs"),
+            &genesis_committee,
+            None,
+        ));
 
         AuthorityState::new(
             secret.public().into(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -306,7 +306,7 @@ pub struct AuthorityState {
     /// The checkpoint store
     pub checkpoints: Option<Arc<Mutex<CheckpointStore>>>,
 
-    pub(crate) epoch_store: Arc<EpochStore>,
+    epoch_store: Arc<EpochStore>,
 
     // Structures needed for handling batching and notifications.
     /// The sender to notify of new transactions
@@ -344,6 +344,10 @@ impl AuthorityState {
 
     pub fn epoch(&self) -> EpochId {
         self.committee.load().epoch
+    }
+
+    pub fn clone_epoch_store(&self) -> Arc<EpochStore> {
+        self.epoch_store.clone()
     }
 
     async fn handle_transaction_impl(
@@ -1017,7 +1021,6 @@ impl AuthorityState {
     // TODO: This function takes both committee and genesis as parameter.
     // Technically genesis already contains committee information. Could consider merging them.
     pub async fn new(
-        genesis_committee: Committee,
         name: AuthorityName,
         secret: StableSyncAuthoritySigner,
         store: Arc<AuthorityStore>,
@@ -1046,18 +1049,11 @@ impl AuthorityState {
                 .expect("Cannot bulk insert genesis objects");
         }
 
-        let committee = if epoch_store.database_is_empty() {
-            epoch_store
-                .init_genesis_epoch(genesis_committee.clone())
-                .expect("Init genesis epoch data must not fail");
-            genesis_committee
-        } else {
-            epoch_store
-                .get_latest_authenticated_epoch()
-                .epoch_info()
-                .committee()
-                .clone()
-        };
+        let committee = epoch_store
+            .get_latest_authenticated_epoch()
+            .epoch_info()
+            .committee()
+            .clone();
 
         let event_handler = event_store.map(|es| Arc::new(EventHandler::new(store.clone(), es)));
 
@@ -1134,6 +1130,7 @@ impl AuthorityState {
         state
     }
 
+    // TODO: Technically genesis_committee can be derived from genesis.
     pub async fn new_for_testing(
         genesis_committee: Committee,
         key: &AuthorityKeyPair,
@@ -1172,10 +1169,9 @@ impl AuthorityState {
                 .expect("No issues");
         }
 
-        let epochs = Arc::new(EpochStore::new(path.join("epochs")));
+        let epochs = Arc::new(EpochStore::new(path.join("epochs"), &genesis_committee));
 
         AuthorityState::new(
-            genesis_committee.clone(),
             secret.public().into(),
             secret.clone(),
             store,

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -239,7 +239,7 @@ pub async fn init_configurable_authorities(
         }
         states.push(client.state.clone());
         names.push(authority_name);
-        let epoch_store = client.state.clone_epoch_store();
+        let epoch_store = client.state.epoch_store().clone();
         clients.push(SafeClient::new(
             client,
             epoch_store,

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -6,6 +6,7 @@ use crate::authority::AuthorityState;
 use crate::authority_aggregator::authority_aggregator_tests::*;
 use crate::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use crate::authority_client::{AuthorityAPI, BatchInfoResponseItemStream};
+use crate::epoch::epoch_store::EpochStore;
 use crate::safe_client::SafeClient;
 use async_trait::async_trait;
 use std::borrow::Borrow;
@@ -238,9 +239,10 @@ pub async fn init_configurable_authorities(
         }
         states.push(client.state.clone());
         names.push(authority_name);
+        let epoch_store = client.state.clone_epoch_store();
         clients.push(SafeClient::new(
             client,
-            committee.clone(),
+            epoch_store,
             authority_name,
             SafeClientMetrics::new_for_tests(),
         ));
@@ -319,8 +321,10 @@ pub async fn init_configurable_authorities(
         .into_iter()
         .map(|(name, client)| (name, client.authority_client().clone()))
         .collect();
+    let epoch_store = Arc::new(EpochStore::new_for_testing(&committee));
     let net = AuthorityAggregator::new(
         committee,
+        epoch_store,
         authority_clients,
         AuthAggMetrics::new_for_tests(),
         SafeClientMetrics::new_for_tests(),

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -189,7 +189,12 @@ impl<A> AuthorityAggregator<A> {
                 .map(|(name, api)| {
                     (
                         name,
-                        SafeClient::new(api, epoch_store.clone(), name, safe_client_metrics.clone()),
+                        SafeClient::new(
+                            api,
+                            epoch_store.clone(),
+                            name,
+                            safe_client_metrics.clone(),
+                        ),
                     )
                 })
                 .collect(),

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -27,11 +27,13 @@ use prometheus::{
 };
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::string::ToString;
+use std::sync::Arc;
 use std::time::Duration;
 use sui_types::committee::StakeUnit;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::{sleep, timeout};
 
+use crate::epoch::epoch_store::EpochStore;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use tap::TapFallible;
 
@@ -157,12 +159,14 @@ pub struct AuthorityAggregator<A> {
 impl<A> AuthorityAggregator<A> {
     pub fn new(
         committee: Committee,
+        epoch_store: Arc<EpochStore>,
         authority_clients: BTreeMap<AuthorityName, A>,
         metrics: AuthAggMetrics,
         safe_client_metrics: SafeClientMetrics,
     ) -> Self {
         Self::new_with_timeouts(
             committee,
+            epoch_store,
             authority_clients,
             metrics,
             safe_client_metrics,
@@ -172,19 +176,20 @@ impl<A> AuthorityAggregator<A> {
 
     pub fn new_with_timeouts(
         committee: Committee,
+        epoch_store: Arc<EpochStore>,
         authority_clients: BTreeMap<AuthorityName, A>,
         metrics: AuthAggMetrics,
         safe_client_metrics: SafeClientMetrics,
         timeouts: TimeoutConfig,
     ) -> Self {
         Self {
-            committee: committee.clone(),
+            committee,
             authority_clients: authority_clients
                 .into_iter()
                 .map(|(name, api)| {
                     (
                         name,
-                        SafeClient::new(api, committee.clone(), name, safe_client_metrics.clone()),
+                        SafeClient::new(api, epoch_store.clone(), name, safe_client_metrics.clone()),
                     )
                 })
                 .collect(),

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -27,6 +27,7 @@ use sui_types::{
 };
 
 use crate::authority_aggregator::AuthAggMetrics;
+use crate::epoch::epoch_store::EpochStore;
 use parking_lot::Mutex;
 
 pub struct TestCausalOrderPendCertNoop;
@@ -1668,6 +1669,7 @@ pub async fn checkpoint_tests_setup(
     // Now make an authority aggregator
     let aggregator = AuthorityAggregator::new(
         committee.clone(),
+        Arc::new(EpochStore::new_for_testing(&committee)),
         authorities
             .iter()
             .map(|a| {

--- a/crates/sui-core/src/epoch/epoch_store.rs
+++ b/crates/sui-core/src/epoch/epoch_store.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
+use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, EpochId};
 use sui_types::error::SuiResult;
 use sui_types::messages::{AuthenticatedEpoch, GenesisEpoch};
@@ -19,12 +20,21 @@ pub struct EpochStore {
 }
 
 impl EpochStore {
-    pub fn new(path: PathBuf) -> Self {
-        Self::open_tables_read_write(path, None)
+    pub fn new(path: PathBuf, genesis_committee: &Committee) -> Self {
+        let epoch_store = Self::open_tables_read_write(path, None);
+        if epoch_store.database_is_empty() {
+            epoch_store
+                .init_genesis_epoch(genesis_committee.clone())
+                .expect("Init genesis epoch data must not fail");
+        }
+        epoch_store
     }
 
-    pub fn database_is_empty(&self) -> bool {
-        self.epochs.iter().next().is_none()
+    pub fn new_for_testing(genesis_committee: &Committee) -> Self {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("DB_{:?}", ObjectID::random()));
+        std::fs::create_dir(&path).unwrap();
+        Self::new(path, genesis_committee)
     }
 
     pub fn init_genesis_epoch(&self, genesis_committee: Committee) -> SuiResult {
@@ -50,5 +60,9 @@ impl EpochStore {
             // when initializing the store.
             .unwrap()
             .1
+    }
+
+    fn database_is_empty(&self) -> bool {
+        self.epochs.iter().next().is_none()
     }
 }

--- a/crates/sui-core/src/epoch/epoch_store.rs
+++ b/crates/sui-core/src/epoch/epoch_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use rocksdb::Options;
 use std::path::PathBuf;
 use sui_types::base_types::ObjectID;
 use sui_types::committee::{Committee, EpochId};
@@ -20,8 +21,8 @@ pub struct EpochStore {
 }
 
 impl EpochStore {
-    pub fn new(path: PathBuf, genesis_committee: &Committee) -> Self {
-        let epoch_store = Self::open_tables_read_write(path, None);
+    pub fn new(path: PathBuf, genesis_committee: &Committee, db_options: Option<Options>) -> Self {
+        let epoch_store = Self::open_tables_read_write(path, db_options);
         if epoch_store.database_is_empty() {
             epoch_store
                 .init_genesis_epoch(genesis_committee.clone())
@@ -34,7 +35,7 @@ impl EpochStore {
         let dir = std::env::temp_dir();
         let path = dir.join(format!("DB_{:?}", ObjectID::random()));
         std::fs::create_dir(&path).unwrap();
-        Self::new(path, genesis_committee)
+        Self::new(path, genesis_committee, None)
     }
 
     pub fn init_genesis_epoch(&self, genesis_committee: Committee) -> SuiResult {

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -142,7 +142,7 @@ where
         // Replace the clients in the authority aggregator with new clients.
         let new_net = Arc::new(AuthorityAggregator::new(
             new_committee,
-            self.state.clone_epoch_store(),
+            self.state.epoch_store().clone(),
             new_clients,
             self.net.load().metrics.clone(),
             self.net.load().safe_client_metrics.clone(),

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -134,18 +134,20 @@ where
         }
 
         // Reconnect the network if we have an type of AuthorityClient that has a network.
-        if A::needs_network_recreation() {
-            self.recreate_network(sui_system_state, new_committee)?;
+        let new_clients = if A::needs_network_recreation() {
+            self.recreate_network(sui_system_state)?
         } else {
-            // update the authorities with the new committee
-            let new_net = Arc::new(AuthorityAggregator::new(
-                new_committee,
-                self.net.load().clone_inner_clients(),
-                self.net.load().metrics.clone(),
-                self.net.load().safe_client_metrics.clone(),
-            ));
-            self.net.store(new_net);
-        }
+            self.net.load().clone_inner_clients()
+        };
+        // Replace the clients in the authority aggregator with new clients.
+        let new_net = Arc::new(AuthorityAggregator::new(
+            new_committee,
+            self.state.clone_epoch_store(),
+            new_clients,
+            self.net.load().metrics.clone(),
+            self.net.load().safe_client_metrics.clone(),
+        ));
+        self.net.store(new_net);
 
         // TODO: Update all committee in all components safely,
         // potentially restart narwhal committee/consensus adapter,
@@ -207,8 +209,7 @@ where
     pub fn recreate_network(
         &self,
         sui_system_state: SuiSystemState,
-        new_committee: Committee,
-    ) -> SuiResult {
+    ) -> SuiResult<BTreeMap<AuthorityName, A>> {
         let mut new_clients = BTreeMap::new();
         let next_epoch_validators = sui_system_state.validators.next_epoch_validators;
 
@@ -266,16 +267,7 @@ where
             );
             new_clients.insert(public_key_bytes, client);
         }
-
-        // Replace the clients in the authority aggregator with new clients.
-        let new_net = Arc::new(AuthorityAggregator::new(
-            new_committee,
-            new_clients,
-            self.net.load().metrics.clone(),
-            self.net.load().safe_client_metrics.clone(),
-        ));
-        self.net.store(new_net);
-        Ok(())
+        Ok(new_clients)
     }
 
     async fn wait_for_epoch_cert(

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -42,7 +42,7 @@ async fn test_start_epoch_change() {
     let state = states[0].clone();
 
     // Check that we initialized the genesis epoch.
-    let init_epoch = state.epoch_store.get_latest_authenticated_epoch();
+    let init_epoch = state.clone_epoch_store().get_latest_authenticated_epoch();
     assert!(matches!(init_epoch, AuthenticatedEpoch::Genesis(..)));
     assert_eq!(init_epoch.epoch(), 0);
 
@@ -220,7 +220,10 @@ async fn test_finish_epoch_change() {
     for active in actives {
         assert_eq!(active.state.epoch(), 1);
         assert_eq!(active.net.load().committee.epoch, 1);
-        let latest_epoch = active.state.epoch_store.get_latest_authenticated_epoch();
+        let latest_epoch = active
+            .state
+            .clone_epoch_store()
+            .get_latest_authenticated_epoch();
         assert_eq!(latest_epoch.epoch(), 1);
         assert!(matches!(latest_epoch, AuthenticatedEpoch::Certified(..)));
         assert_eq!(latest_epoch.epoch_info().epoch(), 1);

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -42,7 +42,7 @@ async fn test_start_epoch_change() {
     let state = states[0].clone();
 
     // Check that we initialized the genesis epoch.
-    let init_epoch = state.clone_epoch_store().get_latest_authenticated_epoch();
+    let init_epoch = state.epoch_store().get_latest_authenticated_epoch();
     assert!(matches!(init_epoch, AuthenticatedEpoch::Genesis(..)));
     assert_eq!(init_epoch.epoch(), 0);
 
@@ -220,10 +220,7 @@ async fn test_finish_epoch_change() {
     for active in actives {
         assert_eq!(active.state.epoch(), 1);
         assert_eq!(active.net.load().committee.epoch, 1);
-        let latest_epoch = active
-            .state
-            .clone_epoch_store()
-            .get_latest_authenticated_epoch();
+        let latest_epoch = active.state.epoch_store().get_latest_authenticated_epoch();
         assert_eq!(latest_epoch.epoch(), 1);
         assert!(matches!(latest_epoch, AuthenticatedEpoch::Certified(..)));
         assert_eq!(latest_epoch.epoch_info().epoch(), 1);

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -185,8 +185,10 @@ impl<A> GatewayState<A> {
         let gateway_metrics = GatewayMetrics::new(prometheus_registry);
         let auth_agg_metrics = AuthAggMetrics::new(prometheus_registry);
         let safe_client_metrics = SafeClientMetrics::new(&prometheus::Registry::new());
+        let gateway_store = Arc::new(GatewayStore::open(&base_path.join("store"), None));
+        let epoch_store = Arc::new(EpochStore::new(base_path.join("epochs"), &committee, None));
         Self::new_with_authorities(
-            path,
+            gateway_store,
             AuthorityAggregator::new(
                 committee,
                 epoch_store,

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority_client::{AuthorityAPI, BatchInfoResponseItemStream};
+use crate::epoch::epoch_store::EpochStore;
 use futures::StreamExt;
 use prometheus::core::{GenericCounter, GenericGauge};
 use prometheus::{
     register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
     IntGaugeVec,
 };
+use std::sync::Arc;
 use sui_types::batch::{AuthorityBatch, SignedBatch, TxSequenceNumber, UpdateItem};
 use sui_types::crypto::AuthorityPublicKeyBytes;
 use sui_types::messages_checkpoint::{
@@ -77,7 +79,7 @@ impl SafeClientMetrics {
 #[derive(Clone)]
 pub struct SafeClient<C> {
     authority_client: C,
-    committee: Committee,
+    epoch_store: Arc<EpochStore>,
     address: AuthorityPublicKeyBytes,
 
     metrics_total_requests_handle_transaction_and_effects_info_request:
@@ -101,7 +103,7 @@ pub struct SafeClient<C> {
 impl<C> SafeClient<C> {
     pub fn new(
         authority_client: C,
-        committee: Committee,
+        epoch_store: Arc<EpochStore>,
         address: AuthorityPublicKeyBytes,
         safe_client_metrics: SafeClientMetrics,
     ) -> Self {
@@ -145,7 +147,7 @@ impl<C> SafeClient<C> {
 
         Self {
             authority_client,
-            committee,
+            epoch_store,
             address,
 
             metrics_total_requests_handle_transaction_and_effects_info_request,
@@ -170,6 +172,16 @@ impl<C> SafeClient<C> {
         &mut self.authority_client
     }
 
+    fn get_committee(&self, epoch_id: &EpochId) -> SuiResult<Committee> {
+        match self.epoch_store.get_authenticated_epoch(epoch_id)? {
+            Some(epoch_info) => Ok(epoch_info.into_epoch_info().into_committee()),
+            None => Err(SuiError::InvalidAuthenticatedEpoch(format!(
+                "Epoch info not found in the store for epoch {:?}",
+                epoch_id
+            ))),
+        }
+    }
+
     // Here we centralize all checks for transaction info responses
     fn check_transaction_response(
         &self,
@@ -179,7 +191,8 @@ impl<C> SafeClient<C> {
     ) -> SuiResult {
         if let Some(signed_transaction) = &response.signed_transaction {
             // Check the transaction signature
-            signed_transaction.verify(&self.committee)?;
+            signed_transaction
+                .verify(&self.get_committee(&signed_transaction.auth_sign_info.epoch)?)?;
             // Check it has the right signer
             fp_ensure!(
                 signed_transaction.auth_sign_info.authority == self.address,
@@ -200,7 +213,7 @@ impl<C> SafeClient<C> {
 
         if let Some(certificate) = &response.certified_transaction {
             // Check signatures and quorum
-            certificate.verify(&self.committee)?;
+            certificate.verify(&self.get_committee(&certificate.auth_sign_info.epoch)?)?;
             // Check it's the right transaction
             fp_ensure!(
                 certificate.digest() == digest,
@@ -213,7 +226,7 @@ impl<C> SafeClient<C> {
 
         if let Some(signed_effects) = &response.signed_effects {
             // Check signature
-            signed_effects.verify(&self.committee)?;
+            signed_effects.verify(&self.get_committee(&signed_effects.auth_signature.epoch)?)?;
             // Check it has the right signer
             fp_ensure!(
                 signed_effects.auth_signature.authority == self.address,
@@ -253,7 +266,7 @@ impl<C> SafeClient<C> {
     ) -> SuiResult {
         // If we get a certificate make sure it is a valid certificate
         if let Some(certificate) = &response.parent_certificate {
-            certificate.verify(&self.committee)?;
+            certificate.verify(&self.get_committee(&certificate.auth_sign_info.epoch)?)?;
         }
 
         // Check the right object ID and version is returned
@@ -318,7 +331,8 @@ impl<C> SafeClient<C> {
             };
 
             if let Some(signed_transaction) = &object_and_lock.lock {
-                signed_transaction.verify(&self.committee)?;
+                signed_transaction
+                    .verify(&self.get_committee(&signed_transaction.auth_sign_info.epoch)?)?;
                 // Check it has the right signer
                 fp_ensure!(
                     signed_transaction.auth_sign_info.authority == self.address,
@@ -344,7 +358,7 @@ impl<C> SafeClient<C> {
         )>,
     ) -> SuiResult {
         // check the signature of the batch
-        signed_batch.verify(&self.committee)?;
+        signed_batch.verify(&self.get_committee(&signed_batch.auth_signature.epoch)?)?;
 
         // ensure transactions enclosed match requested range
 
@@ -562,9 +576,6 @@ where
         request: &CheckpointRequest,
         response: &CheckpointResponse,
     ) -> SuiResult {
-        // Verify signatures
-        response.verify(&self.committee)?;
-
         // Verify response data was correct for request
         match &request.request_type {
             CheckpointRequestType::AuthenticatedCheckpoint(seq) => {
@@ -572,7 +583,15 @@ where
                 {
                     // Checks that the sequence number is correct.
                     self.verify_checkpoint_sequence(*seq, checkpoint)?;
-                    self.verify_contents_exist(request.detail, checkpoint, &response.detail)
+                    self.verify_contents_exist(request.detail, checkpoint, &response.detail)?;
+                    // Verify signature.
+                    match checkpoint {
+                        Some(c) => {
+                            let epoch_id = c.summary().epoch;
+                            c.verify(&self.get_committee(&epoch_id)?, response.detail.as_ref())
+                        }
+                        None => Ok(()),
+                    }
                 } else {
                     Err(SuiError::from(
                         "Invalid AuthorityCheckpointInfo type in the response",
@@ -582,9 +601,25 @@ where
             CheckpointRequestType::CheckpointProposal => {
                 if let AuthorityCheckpointInfo::CheckpointProposal {
                     proposal,
-                    prev_cert: _,
+                    prev_cert,
                 } = &response.info
                 {
+                    // Verify signature.
+                    if let Some(signed_proposal) = proposal {
+                        let committee =
+                            self.get_committee(&signed_proposal.auth_signature.epoch)?;
+                        signed_proposal.verify(&committee, response.detail.as_ref())?;
+                        if signed_proposal.summary.sequence_number > 0 {
+                            let cert = prev_cert.as_ref().ok_or_else(|| {
+                                SuiError::from("No checkpoint cert provided along with proposal")
+                            })?;
+                            cert.verify(&committee, None)?;
+                            fp_ensure!(
+                                signed_proposal.summary.sequence_number - 1 == cert.summary.sequence_number,
+                                SuiError::from("Checkpoint proposal sequence number inconsistent with previous cert")
+                            );
+                        }
+                    }
                     self.verify_contents_exist(request.detail, proposal, &response.detail)
                 } else {
                     Err(SuiError::from(
@@ -704,17 +739,12 @@ where
                 );
                 Ok(())
             }
-            (_, Some(AuthenticatedEpoch::Genesis(_))) => {
-                // TODO: Verify the epoch data using genesis committee
-                Ok(())
+            (_, Some(AuthenticatedEpoch::Genesis(g))) => g.verify(&self.get_committee(&0)?),
+            (_, Some(AuthenticatedEpoch::Signed(s))) => {
+                s.verify(&self.get_committee(&s.auth_sign_info.epoch)?)
             }
-            (_, Some(AuthenticatedEpoch::Signed(_))) => {
-                // TODO: Verify the epoch data using previous committee
-                Ok(())
-            }
-            (_, Some(AuthenticatedEpoch::Certified(_))) => {
-                // TODO: Verify the epoch data using previous committee
-                Ok(())
+            (_, Some(AuthenticatedEpoch::Certified(c))) => {
+                c.verify(&self.get_committee(&c.auth_sign_info.epoch)?)
             }
         }
     }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -85,9 +85,11 @@ pub async fn init_local_authorities_with_genesis(
         serial_authority_request_timeout: Duration::from_secs(1),
         serial_authority_request_interval: Duration::from_secs(1),
     };
+    let epoch_store = Arc::new(EpochStore::new_for_testing(&committee));
     (
         AuthorityAggregator::new_with_timeouts(
             committee,
+            epoch_store,
             clients,
             AuthAggMetrics::new_for_tests(),
             SafeClientMetrics::new_for_tests(),
@@ -983,9 +985,11 @@ async fn test_quorum_once_with_timeout() {
     }
 
     let committee = Committee::new(0, authorities).unwrap();
+    let epoch_store = Arc::new(EpochStore::new_for_testing(&committee));
 
     let agg = AuthorityAggregator::new_with_timeouts(
         committee,
+        epoch_store,
         clients,
         AuthAggMetrics::new_for_tests(),
         SafeClientMetrics::new_for_tests(),

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -59,7 +59,7 @@ pub(crate) async fn init_state(
     let dir = env::temp_dir();
     let epoch_path = dir.join(format!("DB_{:?}", ObjectID::random()));
     fs::create_dir(&epoch_path).unwrap();
-    let epoch_store = Arc::new(EpochStore::new(epoch_path, &committee));
+    let epoch_store = Arc::new(EpochStore::new(epoch_path, &committee, None));
     AuthorityState::new(
         authority_key.public().into(),
         Arc::pin(authority_key),
@@ -766,7 +766,7 @@ async fn test_safe_batch_stream() {
     // Create an authority
     let store = Arc::new(AuthorityStore::open(&path.join("store"), None));
     let state = init_state(committee.clone(), authority_key, store).await;
-    let epoch_store = state.clone_epoch_store();
+    let epoch_store = state.epoch_store().clone();
 
     // Happy path:
     let auth_client = TrustworthyAuthorityClient::new(state);
@@ -808,7 +808,7 @@ async fn test_safe_batch_stream() {
     let (_, authority_key): (_, AuthorityKeyPair) = get_key_pair();
     let state_b =
         AuthorityState::new_for_testing(committee.clone(), &authority_key, None, None, None).await;
-    let epoch_store = state_b.clone_epoch_store();
+    let epoch_store = state_b.epoch_store().clone();
     let auth_client_from_byzantine = ByzantineAuthorityClient::new(state_b);
     let public_key_bytes_b = authority_key.public().into();
     let safe_client_from_byzantine = SafeClient::new(

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -59,9 +59,8 @@ pub(crate) async fn init_state(
     let dir = env::temp_dir();
     let epoch_path = dir.join(format!("DB_{:?}", ObjectID::random()));
     fs::create_dir(&epoch_path).unwrap();
-    let epoch_store = Arc::new(EpochStore::new(epoch_path));
+    let epoch_store = Arc::new(EpochStore::new(epoch_path, &committee));
     AuthorityState::new(
-        committee,
         authority_key.public().into(),
         Arc::pin(authority_key),
         store,
@@ -767,12 +766,13 @@ async fn test_safe_batch_stream() {
     // Create an authority
     let store = Arc::new(AuthorityStore::open(&path.join("store"), None));
     let state = init_state(committee.clone(), authority_key, store).await;
+    let epoch_store = state.clone_epoch_store();
 
     // Happy path:
     let auth_client = TrustworthyAuthorityClient::new(state);
     let safe_client = SafeClient::new(
         auth_client,
-        committee.clone(),
+        epoch_store,
         public_key_bytes,
         SafeClientMetrics::new_for_tests(),
     );
@@ -808,11 +808,12 @@ async fn test_safe_batch_stream() {
     let (_, authority_key): (_, AuthorityKeyPair) = get_key_pair();
     let state_b =
         AuthorityState::new_for_testing(committee.clone(), &authority_key, None, None, None).await;
+    let epoch_store = state_b.clone_epoch_store();
     let auth_client_from_byzantine = ByzantineAuthorityClient::new(state_b);
     let public_key_bytes_b = authority_key.public().into();
     let safe_client_from_byzantine = SafeClient::new(
         auth_client_from_byzantine,
-        committee.clone(),
+        epoch_store,
         public_key_bytes_b,
         SafeClientMetrics::new_for_tests(),
     );

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -307,7 +307,7 @@ async fn test_subscription_safe_client() {
             state: state.clone(),
             fault_config: LocalAuthorityClientFaultConfig::default(),
         },
-        state.clone_committee(),
+        state.clone_epoch_store(),
         state.name,
         SafeClientMetrics::new_for_tests(),
     );

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -307,7 +307,7 @@ async fn test_subscription_safe_client() {
             state: state.clone(),
             fault_config: LocalAuthorityClientFaultConfig::default(),
         },
-        state.clone_epoch_store(),
+        state.epoch_store().clone(),
         state.name,
         SafeClientMetrics::new_for_tests(),
     );

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -81,7 +81,11 @@ impl SuiNode {
         let secret = Arc::pin(config.key_pair().copy());
         let committee = genesis.committee()?;
         let store = Arc::new(AuthorityStore::open(&config.db_path().join("store"), None));
-        let epoch_store = Arc::new(EpochStore::new(config.db_path().join("epochs"), &committee));
+        let epoch_store = Arc::new(EpochStore::new(
+            config.db_path().join("epochs"),
+            &committee,
+            None,
+        ));
 
         let checkpoint_store = Arc::new(Mutex::new(CheckpointStore::open(
             &config.db_path().join("checkpoints"),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1824,6 +1824,10 @@ impl EpochInfo {
         &self.committee
     }
 
+    pub fn into_committee(self) -> Committee {
+        self.committee
+    }
+
     pub fn first_checkpoint(&self) -> &CheckpointSequenceNumber {
         &self.first_checkpoint
     }
@@ -1857,7 +1861,7 @@ impl GenesisEpoch {
         }
     }
 
-    pub fn verify(&self, genesis_committee: Committee) -> SuiResult {
+    pub fn verify(&self, genesis_committee: &Committee) -> SuiResult {
         fp_ensure!(
             self.epoch_info.first_checkpoint == 0,
             SuiError::InvalidAuthenticatedEpoch(
@@ -1869,7 +1873,7 @@ impl GenesisEpoch {
             SuiError::InvalidAuthenticatedEpoch("Genesis epoch must be epoch 0".to_string())
         );
         fp_ensure!(
-            self.epoch_info.committee == genesis_committee,
+            &self.epoch_info.committee == genesis_committee,
             SuiError::InvalidAuthenticatedEpoch("Genesis epoch committee mismatch".to_string())
         );
         Ok(())
@@ -1976,6 +1980,14 @@ impl AuthenticatedEpoch {
             Self::Signed(s) => &s.epoch_info,
             Self::Certified(c) => &c.epoch_info,
             Self::Genesis(g) => &g.epoch_info,
+        }
+    }
+
+    pub fn into_epoch_info(self) -> EpochInfo {
+        match self {
+            Self::Signed(s) => s.epoch_info,
+            Self::Certified(c) => c.epoch_info,
+            Self::Genesis(g) => g.epoch_info,
         }
     }
 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -123,38 +123,6 @@ pub struct CheckpointResponse {
     pub detail: Option<CheckpointContents>,
 }
 
-impl CheckpointResponse {
-    pub fn verify(&self, committee: &Committee) -> SuiResult {
-        match &self.info {
-            AuthorityCheckpointInfo::AuthenticatedCheckpoint(ckpt) => {
-                if let Some(ckpt) = ckpt {
-                    ckpt.verify(committee, self.detail.as_ref())?;
-                }
-                Ok(())
-            }
-            AuthorityCheckpointInfo::CheckpointProposal {
-                proposal,
-                prev_cert,
-            } => {
-                if let Some(p) = proposal {
-                    p.verify(committee, self.detail.as_ref())?;
-                    if p.summary.sequence_number > 0 {
-                        let cert = prev_cert.as_ref().ok_or_else(|| {
-                            SuiError::from("No checkpoint cert provided along with proposal")
-                        })?;
-                        cert.verify(committee, None)?;
-                        fp_ensure!(
-                            p.summary.sequence_number - 1 == cert.summary.sequence_number,
-                            SuiError::from("Checkpoint proposal sequence number inconsistent with previous cert")
-                        );
-                    }
-                }
-                Ok(())
-            }
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AuthorityCheckpointInfo {
     AuthenticatedCheckpoint(Option<AuthenticatedCheckpoint>),

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -195,7 +195,7 @@ async fn end_to_end() {
     let handles = spawn_test_authorities(input_objects, &configs).await;
 
     // Make an authority's aggregator.
-    let aggregator = test_authority_aggregator(&configs);
+    let aggregator = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
 
     spawn_checkpoint_processes(&aggregator, &handles).await;
 
@@ -219,7 +219,7 @@ async fn end_to_end_with_one_byzantine() {
     let (_first, rest) = handles[..].split_at(1);
 
     // Make an authority's aggregator.
-    let aggregator = test_authority_aggregator(&configs);
+    let aggregator = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
 
     // one authority does not participate in checkpointing
     spawn_checkpoint_processes(&aggregator, rest).await;
@@ -248,7 +248,7 @@ async fn checkpoint_with_shared_objects() {
     let handles = spawn_test_authorities(initialization_objects, &configs).await;
 
     // Make an authority's aggregator.
-    let aggregator = test_authority_aggregator(&configs);
+    let aggregator = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
 
     spawn_checkpoint_processes(&aggregator, &handles).await;
 

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -195,7 +195,7 @@ async fn end_to_end() {
     let handles = spawn_test_authorities(input_objects, &configs).await;
 
     // Make an authority's aggregator.
-    let aggregator = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
+    let aggregator = test_authority_aggregator(&configs, handles[0].state().epoch_store().clone());
 
     spawn_checkpoint_processes(&aggregator, &handles).await;
 
@@ -219,7 +219,7 @@ async fn end_to_end_with_one_byzantine() {
     let (_first, rest) = handles[..].split_at(1);
 
     // Make an authority's aggregator.
-    let aggregator = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
+    let aggregator = test_authority_aggregator(&configs, handles[0].state().epoch_store().clone());
 
     // one authority does not participate in checkpointing
     spawn_checkpoint_processes(&aggregator, rest).await;
@@ -248,7 +248,7 @@ async fn checkpoint_with_shared_objects() {
     let handles = spawn_test_authorities(initialization_objects, &configs).await;
 
     // Make an authority's aggregator.
-    let aggregator = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
+    let aggregator = test_authority_aggregator(&configs, handles[0].state().epoch_store().clone());
 
     spawn_checkpoint_processes(&aggregator, &handles).await;
 

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -26,7 +26,7 @@ async fn setup() -> (
     let mut gas_objects = test_gas_objects();
     let configs = test_authority_configs();
     let handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
-    let clients = test_authority_aggregator(&configs);
+    let clients = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
     let (sender, keypair) = test_account_keys().pop().unwrap();
     let tx = make_transfer_sui_transaction(
         gas_objects.pop().unwrap().compute_object_reference(),

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -26,7 +26,7 @@ async fn setup() -> (
     let mut gas_objects = test_gas_objects();
     let configs = test_authority_configs();
     let handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
-    let clients = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
+    let clients = test_authority_aggregator(&configs, handles[0].state().epoch_store().clone());
     let (sender, keypair) = test_account_keys().pop().unwrap();
     let tx = make_transfer_sui_transaction(
         gas_objects.pop().unwrap().compute_object_reference(),

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use sui_core::authority::GatewayStore;
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::gateway_state::{GatewayAPI, GatewayMetrics, GatewayState};
 use sui_types::messages::{
@@ -366,11 +367,12 @@ async fn shared_object_on_gateway() {
     // Get the authority configs and spawn them. Note that it is important to not drop
     // the handles (or the authorities will stop).
     let configs = test_authority_configs();
-    let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
-    let clients = test_authority_aggregator(&configs);
+    let handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
+    let clients = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
     let path = tempfile::tempdir().unwrap().into_path();
+    let gateway_store = Arc::new(GatewayStore::open(&path.join("store"), None));
     let gateway = Arc::new(
-        GatewayState::new_with_authorities(&path, clients, GatewayMetrics::new_for_tests())
+        GatewayState::new_with_authorities(gateway_store, clients, GatewayMetrics::new_for_tests())
             .unwrap(),
     );
 

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -368,7 +368,7 @@ async fn shared_object_on_gateway() {
     // the handles (or the authorities will stop).
     let configs = test_authority_configs();
     let handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
-    let clients = test_authority_aggregator(&configs, handles[0].state().clone_epoch_store());
+    let clients = test_authority_aggregator(&configs, handles[0].state().epoch_store().clone());
     let path = tempfile::tempdir().unwrap().into_path();
     let gateway_store = Arc::new(GatewayStore::open(&path.join("store"), None));
     let gateway = Arc::new(

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{NetworkConfig, ValidatorInfo};
+use sui_core::epoch::epoch_store::EpochStore;
 use sui_core::{
     authority_active::{
         checkpoint_driver::{CheckpointMetrics, CheckpointProcessControl},
@@ -96,6 +97,7 @@ pub async fn spawn_checkpoint_processes(
 /// Create a test authority aggregator.
 pub fn test_authority_aggregator(
     config: &NetworkConfig,
+    epoch_store: Arc<EpochStore>,
 ) -> AuthorityAggregator<NetworkAuthorityClient> {
     let validators_info = config.validator_set();
     let committee = Committee::new(0, ValidatorInfo::voting_rights(validators_info)).unwrap();
@@ -111,6 +113,7 @@ pub fn test_authority_aggregator(
     let registry = prometheus::Registry::new();
     AuthorityAggregator::new(
         committee,
+        epoch_store,
         clients,
         AuthAggMetrics::new(&registry),
         SafeClientMetrics::new(&registry),


### PR DESCRIPTION
This PR adds `Arc<EpochStore>` to SafeClient. This allows us to read the corresponding committee from the right epoch, when we try to verify an authenticated data structure (based on the epoch from the signature).
A large part of this PR is due to the refactoring needed in order to be able to pass through the epoch store into SafeClient through AuthorityAggregator.