### PR TITLE
[explorer] Migrate to new home page

### DIFF
--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -339,7 +339,7 @@ function LatestTxCard({ ...data }: RecentTx) {
             />
         ) : (
             <TabFooter stats={stats}>
-                <Link className={styles.moretxbtn} to={`/`}>
+                <Link className={styles.moretxbtn} to="/transactions">
                     More Transactions <ContentForwardArrowDark />
                 </Link>
             </TabFooter>

--- a/explorer/client/src/pages/config/AppRoutes.tsx
+++ b/explorer/client/src/pages/config/AppRoutes.tsx
@@ -12,12 +12,11 @@ import TransactionResult from '../transaction-result/TransactionResult';
 import Transactions from '../transactions/Transactions';
 import { ValidatorPageResult } from '../validators/Validators';
 
-// Temporary use Transactions page as the default page.
 const AppRoutes = () => {
     return (
         <Routes>
-            <Route path="/" element={<Transactions />} />
-            <Route path="/home-other" element={<Home />} />
+            <Route path="/" element={<Home />} />
+            <Route path="/transactions" element={<Transactions />} />
             <Route path="/objects/:id" element={<ObjectResult />} />
             <Route path="/transactions/:id" element={<TransactionResult />} />
             <Route path="/addresses/:id" element={<AddressResult />} />


### PR DESCRIPTION
This migrates the `/home-other` route to the index route, and moves the transaction list to `/transactions`. This is in preparation of the release of the new explorer.

Screenshot:
<img width="1550" alt="Screen Shot 2022-08-08 at 3 35 35 PM" src="https://user-images.githubusercontent.com/109986297/183526347-f8483e9a-75cb-42ba-b681-80dda00630a7.png">

Depends on #3851 landing.