### PR TITLE
Sadhan/fix_blocking_send

### DIFF
--- a/crates/sui-benchmark/src/benchmark/transaction_creator.rs
+++ b/crates/sui-benchmark/src/benchmark/transaction_creator.rs
@@ -62,7 +62,7 @@ fn make_cert(network_config: &NetworkConfig, tx: &Transaction) -> CertifiedTrans
     let committee = network_config.committee();
     let mut sigs: Vec<(AuthorityName, AuthoritySignature)> = Vec::new();
     // TODO: Why iterating from 0 to quorum_threshold??
-    for i in 0..network_config.validator_configs().len() {
+    for i in 0..committee.quorum_threshold() {
         let secx = network_config
             .validator_configs()
             .get(i as usize)

--- a/crates/sui-benchmark/src/benchmark/transaction_creator.rs
+++ b/crates/sui-benchmark/src/benchmark/transaction_creator.rs
@@ -62,7 +62,7 @@ fn make_cert(network_config: &NetworkConfig, tx: &Transaction) -> CertifiedTrans
     let committee = network_config.committee();
     let mut sigs: Vec<(AuthorityName, AuthoritySignature)> = Vec::new();
     // TODO: Why iterating from 0 to quorum_threshold??
-    for i in 0..committee.quorum_threshold() {
+    for i in 0..network_config.validator_configs().len() {
         let secx = network_config
             .validator_configs()
             .get(i as usize)

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -268,7 +268,7 @@ async fn run(
                 tokio::select! {
                     _ = stat_interval.tick() => {
                         if tx_cloned
-                            .send(Stats {
+                            .try_send(Stats {
                                 id: i as usize,
                                 num_success,
                                 num_error,
@@ -279,7 +279,6 @@ async fn run(
                                 num_submitted,
                                 duration: Duration::from_micros(stat_delay_micros),
                             })
-                            .await
                             .is_err()
                         {
                             debug!("Failed to update stat!");


### PR DESCRIPTION
We block the worker threads on send which is not ideal, it should've been non-blocking and hence switching to try_send()