### PR TITLE
[Typescript SDK] add provider with cache

### DIFF
--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -7,6 +7,7 @@ export * from './cryptography/publickey';
 
 export * from './providers/provider';
 export * from './providers/json-rpc-provider';
+export * from './providers/json-rpc-provider-with-cache';
 
 export * from './serialization/base64';
 export * from './serialization/hex';

--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SignatureScheme } from '../cryptography/publickey';
+import { isSuiObjectRef } from '../index.guard';
+import {
+  GetObjectDataResponse,
+  SuiObjectInfo,
+  SuiTransactionResponse,
+  SuiObjectRef,
+  getObjectReference,
+  TransactionEffects,
+  normalizeSuiObjectId,
+} from '../types';
+import { JsonRpcProvider } from './json-rpc-provider';
+
+export class JsonRpcProviderWithCache extends JsonRpcProvider {
+  /**
+   * A list of object references which are being tracked.
+   *
+   * Whenever an object is fetched or updated within the transaction,
+   * its record gets updated.
+   */
+  private objectRefs: Map<string, SuiObjectRef> = new Map();
+
+  // Objects
+  async getObjectsOwnedByAddress(address: string): Promise<SuiObjectInfo[]> {
+    const resp = await super.getObjectsOwnedByAddress(address);
+    resp.forEach(r => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {
+    const resp = await super.getObjectsOwnedByObject(objectId);
+    resp.forEach(r => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  async getObject(objectId: string): Promise<GetObjectDataResponse> {
+    const resp = await super.getObject(objectId);
+    this.updateObjectRefCache(resp);
+    return resp;
+  }
+
+  async getObjectRef(
+    objectId: string,
+    skipCache = false
+  ): Promise<SuiObjectRef | undefined> {
+    const normalizedId = normalizeSuiObjectId(objectId);
+    if (!skipCache && this.objectRefs.has(normalizedId)) {
+      return this.objectRefs.get(normalizedId);
+    }
+
+    const ref = await super.getObjectRef(objectId);
+    this.updateObjectRefCache(ref);
+    return ref;
+  }
+
+  async getObjectBatch(objectIds: string[]): Promise<GetObjectDataResponse[]> {
+    const resp = await super.getObjectBatch(objectIds);
+    resp.forEach(r => this.updateObjectRefCache(r));
+    return resp;
+  }
+
+  // Transactions
+  async executeTransaction(
+    txnBytes: string,
+    signatureScheme: SignatureScheme,
+    signature: string,
+    pubkey: string
+  ): Promise<SuiTransactionResponse> {
+    const resp = await super.executeTransaction(
+      txnBytes,
+      signatureScheme,
+      signature,
+      pubkey
+    );
+
+    this.updateObjectRefCacheFromTransactionEffects(resp.effects);
+    return resp;
+  }
+
+  private updateObjectRefCache(
+    newData: GetObjectDataResponse | SuiObjectRef | undefined
+  ) {
+    if (newData == null) {
+      return;
+    }
+    const ref = isSuiObjectRef(newData) ? newData : getObjectReference(newData);
+    if (ref != null) {
+      this.objectRefs.set(ref.objectId, ref);
+    }
+  }
+
+  private updateObjectRefCacheFromTransactionEffects(
+    effects: TransactionEffects
+  ) {
+    effects.created?.forEach(r => this.updateObjectRefCache(r.reference));
+    effects.mutated?.forEach(r => this.updateObjectRefCache(r.reference));
+    effects.unwrapped?.forEach(r => this.updateObjectRefCache(r.reference));
+    effects.wrapped?.forEach(r => this.updateObjectRefCache(r));
+    effects.deleted?.forEach(r => this.objectRefs.delete(r.objectId));
+  }
+}

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -36,7 +36,7 @@ const isNumber = (val: any): val is number => typeof val === 'number';
 const isAny = (_val: any): _val is any => true;
 
 export class JsonRpcProvider extends Provider {
-  private client: JsonRpcClient;
+  protected client: JsonRpcClient;
 
   /**
    * Establish a connection to a Sui Gateway endpoint

--- a/sdk/typescript/src/types/common.ts
+++ b/sdk/typescript/src/types/common.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Base64DataBuffer } from "../serialization/base64";
+import { Base64DataBuffer } from '../serialization/base64';
+import { ObjectId } from './objects';
 
 /** Base64 string representing the object digest */
 export type TransactionDigest = string;
@@ -13,17 +14,19 @@ export type ObjectOwner =
   | 'Shared'
   | 'Immutable';
 
-
 // source of truth is
 // https://github.com/MystenLabs/sui/blob/acb2b97ae21f47600e05b0d28127d88d0725561d/crates/sui-types/src/base_types.rs#L171
 const TX_DIGEST_LENGTH = 32;
 // taken from https://rgxdb.com/r/1NUN74O6
-const VALID_BASE64_REGEX =
-  /^(?:[a-zA-Z0-9+\/]{4})*(?:|(?:[a-zA-Z0-9+\/]{3}=)|(?:[a-zA-Z0-9+\/]{2}==)|(?:[a-zA-Z0-9+\/]{1}===))$/;
+const VALID_BASE64_REGEX = /^(?:[a-zA-Z0-9+\/]{4})*(?:|(?:[a-zA-Z0-9+\/]{3}=)|(?:[a-zA-Z0-9+\/]{2}==)|(?:[a-zA-Z0-9+\/]{1}===))$/;
 
-export function isValidTransactionDigest(value: string): value is TransactionDigest {
-  return new Base64DataBuffer(value).getLength() === TX_DIGEST_LENGTH
-    && VALID_BASE64_REGEX.test(value);
+export function isValidTransactionDigest(
+  value: string
+): value is TransactionDigest {
+  return (
+    new Base64DataBuffer(value).getLength() === TX_DIGEST_LENGTH &&
+    VALID_BASE64_REGEX.test(value)
+  );
 }
 
 // TODO - can we automatically sync this with rust length definition?
@@ -32,14 +35,42 @@ export function isValidTransactionDigest(value: string): value is TransactionDig
 // which uses the Move account address length
 // https://github.com/move-language/move/blob/67ec40dc50c66c34fd73512fcc412f3b68d67235/language/move-core/types/src/account_address.rs#L23 .
 
-const SUI_ADDRESS_LENGTH = 20;
+export const SUI_ADDRESS_LENGTH = 20;
 export function isValidSuiAddress(value: string): value is SuiAddress {
-  return isHex(value) &&
-    getHexByteLength(value) === SUI_ADDRESS_LENGTH;
+  return isHex(value) && getHexByteLength(value) === SUI_ADDRESS_LENGTH;
 }
 
 export function isValidSuiObjectId(value: string): boolean {
   return isValidSuiAddress(value);
+}
+
+/**
+ * Perform the following operations:
+ * 1. Make the address lower case
+ * 2. Prepend `0x` if the string does not start with `0x`.
+ * 3. Add more zeros if the length of the address(excluding `0x`) is less than `SUI_ADDRESS_LENGTH`
+ *
+ * WARNING: if the address value itself starts with `0x`, e.g., `0x0x`, the default behavior
+ * is to treat the first `0x` not as part of the address. The default behavior can be overridden by
+ * setting `forceAdd0x` to true
+ *
+ */
+export function normalizeSuiAddress(
+  value: string,
+  forceAdd0x: boolean = false
+): SuiAddress {
+  let address = value.toLowerCase();
+  if (!forceAdd0x && address.startsWith('0x')) {
+    address = address.slice(2);
+  }
+  return `0x${address.padStart(SUI_ADDRESS_LENGTH * 2, '0')}`;
+}
+
+export function normalizeSuiObjectId(
+  value: string,
+  forceAdd0x: boolean = false
+): ObjectId {
+  return normalizeSuiAddress(value, forceAdd0x);
 }
 
 function isHex(value: string): boolean {
@@ -47,7 +78,5 @@ function isHex(value: string): boolean {
 }
 
 function getHexByteLength(value: string): number {
-  return /^(0x|0X)/.test(value)
-    ? (value.length - 2) / 2
-    : value.length / 2;
+  return /^(0x|0X)/.test(value) ? (value.length - 2) / 2 : value.length / 2;
 }

--- a/sdk/typescript/test/types/stringTypes.test.ts
+++ b/sdk/typescript/test/types/stringTypes.test.ts
@@ -1,65 +1,105 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidTransactionDigest, isValidSuiAddress } from '../../src/index';
+import {
+  isValidTransactionDigest,
+  isValidSuiAddress,
+  normalizeSuiAddress,
+} from '../../src/index';
 
 describe('String type guards', () => {
-
-  function expectAll<T>(data: T[], check: (value: T) => boolean, expected: boolean) {
-    data.forEach(d=> expect(check(d)).toBe(expected));
+  function expectAll<T>(data: T[], check: (value: T) => any, expected: any) {
+    data.forEach(d => expect(check(d)).toBe(expected));
   }
 
   describe('isValidTransactionDigest()', () => {
-
     it('rejects non base64 strings', () => {
-      expectAll([
-        'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
-        'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  '
-      ], isValidTransactionDigest, false);
+      expectAll(
+        [
+          'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
+          'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  ',
+        ],
+        isValidTransactionDigest,
+        false
+      );
     });
 
     it('rejects base64 strings of the wrong length', () => {
-      expectAll([
-        'ZVteaEsxe0Q6XU53UExxWEFjKy98UD5qfmM+',
-        'J3pwOz9GdS5JSEB8Lz9ILGxdJi9sXTxbdFU2OHpP',
-        'UUQmaXAmQiYxSERrQH5VWEJmQm8pMXMiYEQzJ2wpPnkuYg=='
-      ], isValidTransactionDigest, false);
+      expectAll(
+        [
+          'ZVteaEsxe0Q6XU53UExxWEFjKy98UD5qfmM+',
+          'J3pwOz9GdS5JSEB8Lz9ILGxdJi9sXTxbdFU2OHpP',
+          'UUQmaXAmQiYxSERrQH5VWEJmQm8pMXMiYEQzJ2wpPnkuYg==',
+        ],
+        isValidTransactionDigest,
+        false
+      );
     });
 
     it('accepts base64 strings of the correct length', () => {
-      expectAll([
-        'UYKbz61ny/+E+r07JatGyrtrv/FyjNeqUEQisJJXPHM=',
-        'obGrcB0a+aMJXyRMGQ+7to5GaJ6a1Kfd6tS+sAM0d/8=',
-        'pMmQoBeSSErk96hKMtkilwCZub3FaOF3IIdii16/DBo='
-      ], isValidTransactionDigest, true);
+      expectAll(
+        [
+          'UYKbz61ny/+E+r07JatGyrtrv/FyjNeqUEQisJJXPHM=',
+          'obGrcB0a+aMJXyRMGQ+7to5GaJ6a1Kfd6tS+sAM0d/8=',
+          'pMmQoBeSSErk96hKMtkilwCZub3FaOF3IIdii16/DBo=',
+        ],
+        isValidTransactionDigest,
+        true
+      );
     });
   });
 
   describe('isValidSuiAddress() / isValidObjectID()', () => {
-
     it('rejects non-hex strings', () => {
-      expectAll([
-        'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
-        'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  ',
-      ], isValidSuiAddress, false);
+      expectAll(
+        [
+          'MDpQc 1IIzkie1dJdj nfm85XmRCJmk KHVUU05Abg==',
+          'X09wJFxwQDdTU1tzMy5NJXdSTnknPCh9J0tNUCdmIw  ',
+        ],
+        isValidSuiAddress,
+        false
+      );
     });
 
     it('rejects hex strings of the wrong length', () => {
-      expectAll([
-        '5f713bef531629b47dd1bdbb382a',
-        'f1e2a6d12cd5e62a3ce9b2c12e9e2d37d81c',
-        '0X5f713bef531629b47dd1bdbb382acec5224fc9abc16133e3',
-        '0x503ff67d9291215ffccafddbd08d86e86b3425c6356c9679'
-      ], isValidSuiAddress, false);
+      expectAll(
+        [
+          '5f713bef531629b47dd1bdbb382a',
+          'f1e2a6d12cd5e62a3ce9b2c12e9e2d37d81c',
+          '0X5f713bef531629b47dd1bdbb382acec5224fc9abc16133e3',
+          '0x503ff67d9291215ffccafddbd08d86e86b3425c6356c9679',
+        ],
+        isValidSuiAddress,
+        false
+      );
     });
 
     it('accepts hex strings of the correct length, regardless of 0x prefix', () => {
-      expectAll([
-        '9edd26f2ef1c1796f9feaa703c8628e5a70618c8',
-        '5f713bef531629b47dd1bdbb382acec5224fc9ab',
-        '0Xdce47e3e523b5e52a36d74295c0d83d91f80b47c',
-        '0x4288ba9932cc115784794fcfb709213f30d40a54'
-      ], isValidSuiAddress, true);
+      expectAll(
+        [
+          '9edd26f2ef1c1796f9feaa703c8628e5a70618c8',
+          '5f713bef531629b47dd1bdbb382acec5224fc9ab',
+          '0Xdce47e3e523b5e52a36d74295c0d83d91f80b47c',
+          '0x4288ba9932cc115784794fcfb709213f30d40a54',
+        ],
+        isValidSuiAddress,
+        true
+      );
+    });
+
+    it('normalize hex strings to the correct length', () => {
+      expectAll(
+        [
+          '0x2',
+          '2',
+          '02',
+          '0X02',
+          '0x0000000000000000000000000000000000000002',
+          '0X000000000000000000000000000000000000002',
+        ],
+        normalizeSuiAddress,
+        '0x0000000000000000000000000000000000000002'
+      );
     });
   });
 });


### PR DESCRIPTION
Depends on #3735

This PR implements the the first follow up items as mentioned in #3735. `JsonRpcProviderWithCache` caches the object references locally such that `LocalTxnDataSerializer` can use the object reference in cache instead of fetching the latest object from gateway/fullnode, which might not always have the latest data.


## Testing

Running the script below and observe that cache is hit for the package object
```
const provider = new JsonRpcProviderWithCache(endpoint);
const signerWithProvider = new RawSigner(
  config.defaultKeypair,
  provider,
  new LocalTxnDataSerializer(provider)
);

const coins = await getCoins(
      signerWithProvider.provider,
      config.defaultAddress
    );
await moveCall(signerWithProvider, coins[0].objectId);
await moveCall(signerWithProvider, coins[0].objectId);

async function moveCall(signerWithProvider: RawSigner, gasPayment: string) {
  const txn = await signerWithProvider.executeMoveCall({
    packageObjectId: "0x2",
    module: "devnet_nft",
    function: "mint",
    typeArguments: [],
    arguments: [
      { Pure: bcs.ser(bcs.STRING, "Example NFT").toBytes() },
      {
        Pure: bcs
          .ser(bcs.STRING, "An NFT created by the wallet Command Line Tool")
          .toBytes(),
      },
      {
        Pure: bcs
          .ser(
            bcs.STRING,
            "ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty"
          )
          .toBytes(),
      },
    ],
    gasBudget: 10000,
    gasPayment: gasPayment,
  });
  console.log("move call txn", txn);
}

async function getCoins(
  provider: Provider,
  address: SuiAddress
): Promise<SuiObjectInfo[]> {
  const objectInfos = await provider.getObjectsOwnedByAddress(address);
  return objectInfos.filter((o) => o.type.startsWith("0x2::coin::Coin"));
}

```