### PR TITLE
[Explorer] Removes the gaps in the transaction tables

### DIFF
--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -3,7 +3,7 @@
 }
 
 .table {
-    @apply w-full text-sm text-left text-[#4E555D]  overflow-x-auto min-w-max;
+    @apply w-full text-sm text-left text-[#4E555D]  overflow-x-auto min-w-max border-collapse;
 
     border-bottom: 1px solid #f0f1f2;
 }


### PR DESCRIPTION
A small change that removes the appearance of gaps between the columns in the transaction tables when you hover over a row. This follows the Figma Design.

Before:
![image](https://user-images.githubusercontent.com/11377188/183976207-ab18d814-3aed-49e8-b91e-7664abd96680.png)

After:
![image](https://user-images.githubusercontent.com/11377188/183976405-db6b54d3-af2f-4f32-b95d-56eb80828dbb.png)
