### PR TITLE
[explorer] Implement updated designs for validator table

### DIFF
--- a/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -100,8 +100,18 @@ function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
                     alttext={truncate(validator.address, 14)}
                     category={'addresses'}
                     isLink={true}
+                    isCopyButton={false}
                 />
             ),
+            pubkeyBytes: (
+                <Longtext
+                    text={validator.pubkeyBytes}
+                    alttext={truncate(validator.pubkeyBytes, 14)}
+                    category={'addresses'}
+                    isLink={false}
+                    isCopyButton={false}
+                />
+            )
         })),
         columns: [
             {
@@ -116,6 +126,10 @@ function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
                 headerLabel: 'Address',
                 accessorKey: 'address',
             },
+            {
+                headerLabel: 'Pubkey Bytes',
+                accessorKey: 'pubkeyBytes',
+            },
         ],
     };
 
@@ -126,16 +140,15 @@ function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
             <Tabs selected={0}>
                 <div title="Top Validators">
                     <TableCard tabledata={tableData} />
-                    <TabFooter stats={tabsFooter.stats}>
+                    {/* <TabFooter stats={tabsFooter.stats}>
                         <Longtext
                             text=""
                             category="validators"
                             isLink={true}
                             isCopyButton={false}
-                            /*showIconButton={true}*/
                             alttext="More Validators"
                         />
-                    </TabFooter>
+                    </TabFooter> */}
                 </div>
             </Tabs>
         </div>

--- a/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -5,11 +5,9 @@ import { useContext, useEffect, useState } from 'react';
 
 import Longtext from '../../components/longtext/Longtext';
 import TableCard from '../../components/table/TableCard';
-import TabFooter from '../../components/tabs/TabFooter';
 import Tabs from '../../components/tabs/Tabs';
 import { NetworkContext } from '../../context';
 import {
-    getTabFooter,
     getValidatorState,
     processValidators,
     ValidatorLoadFail,
@@ -132,8 +130,6 @@ function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
             },
         ],
     };
-
-    const tabsFooter = getTabFooter(validatorsData.length);
 
     return (
         <div className={styles.validators}>

--- a/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/explorer/client/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -109,7 +109,7 @@ function TopValidatorsCard({ state }: { state: ValidatorState }): JSX.Element {
                     isLink={false}
                     isCopyButton={false}
                 />
-            )
+            ),
         })),
         columns: [
             {

--- a/explorer/client/src/components/validator-map/ValidatorMap.tsx
+++ b/explorer/client/src/components/validator-map/ValidatorMap.tsx
@@ -32,6 +32,10 @@ export default function ValidatorMap() {
             method: 'GET',
         });
 
+        if (!res.ok) {
+            return [];
+        }
+
         return res.json() as Promise<NodeList>;
     });
 

--- a/explorer/client/src/pages/validators/Validators.tsx
+++ b/explorer/client/src/pages/validators/Validators.tsx
@@ -187,7 +187,7 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
                         isLink={false}
                         isCopyButton={false}
                     />
-                )
+                ),
             };
         }),
         columns: [

--- a/explorer/client/src/pages/validators/Validators.tsx
+++ b/explorer/client/src/pages/validators/Validators.tsx
@@ -146,6 +146,7 @@ export function processValidators(set: Validator[]) {
         return {
             name: name,
             address: av.fields.metadata.fields.sui_address,
+            pubkeyBytes: av.fields.metadata.fields.pubkey_bytes,
             position: i + 1,
         };
     });
@@ -169,6 +170,7 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
         data: validatorsData.map((validator) => {
             return {
                 name: validator.name,
+                position: validator.position,
                 address: (
                     <Longtext
                         text={validator.address}
@@ -177,7 +179,15 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
                         isLink={true}
                     />
                 ),
-                position: validator.position,
+                pubkeyBytes: (
+                    <Longtext
+                        text={validator.pubkeyBytes}
+                        alttext={truncate(validator.pubkeyBytes, 14)}
+                        category={'addresses'}
+                        isLink={false}
+                        isCopyButton={false}
+                    />
+                )
             };
         }),
         columns: [
@@ -192,6 +202,10 @@ function ValidatorsPage({ state }: { state: ValidatorState }): JSX.Element {
             {
                 headerLabel: 'Address',
                 accessorKey: 'address',
+            },
+            {
+                headerLabel: 'Pubkey Bytes',
+                accessorKey: 'pubkeyBytes',
             },
         ],
     };


### PR DESCRIPTION
This updates the validator table to also display the pubkey bytes. We also are opting to remove the "More Validators" link for now. I also made a small tweak to the validator map to check for 200 responses before parsing the response.

On the dedicated validators page:

<img width="773" alt="Screen Shot 2022-08-10 at 12 20 28 PM" src="https://user-images.githubusercontent.com/109986297/184005187-5c07a280-31fe-4bb1-9033-1e705188ed79.png">

On the new homepage:

<img width="749" alt="Screen Shot 2022-08-10 at 12 34 27 PM" src="https://user-images.githubusercontent.com/109986297/184005213-06339867-57f1-4c3e-8f38-35b9ac911f6f.png">

