### PR TITLE
add a description field in TooManyIncorrectAuthorities

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -374,6 +374,7 @@ where
                         if state.bad_weight > validity {
                             return Err(SuiError::TooManyIncorrectAuthorities {
                                 errors: state.errors,
+                                action: "get_latest_checkpoint_from_all".to_string(),
                             });
                         }
                     }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -374,7 +374,7 @@ where
                         if state.bad_weight > validity {
                             return Err(SuiError::TooManyIncorrectAuthorities {
                                 errors: state.errors,
-                                action: "get_latest_checkpoint_from_all".to_string(),
+                                action: "get_latest_checkpoint_from_all",
                             });
                         }
                     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -768,7 +768,7 @@ where
         // When to give up on the attempt entirely.
         timeout_total: Option<Duration>,
         // The behavior that authorities expect to perform, used for logging and error
-        description: &str,
+        description: &'static str,
     ) -> Result<S, SuiError>
     where
         FMap: Fn(AuthorityName, SafeClient<A>) -> AsyncResult<'a, S, SuiError> + Send + Clone + 'a,
@@ -794,7 +794,7 @@ where
                             .iter()
                             .map(|(a, b)| (*a, b.clone()))
                             .collect(),
-                        action: description.to_string(),
+                        action: description,
                     }
                 }
             })?
@@ -874,7 +874,7 @@ where
                                             response.err().map(|err| (name, err))
                                         })
                                         .collect(),
-                                    action: "get_object_by_id".to_string(),
+                                    action: "get_object_by_id",
                                 });
                             }
                         }
@@ -1031,7 +1031,7 @@ where
                                 if state.bad_weight > validity {
                                     return Err(SuiError::TooManyIncorrectAuthorities {
                                         errors: state.errors,
-                                        action: "get_all_owned_objects".to_string(),
+                                        action: "get_all_owned_objects",
                                     });
                                 }
                             }
@@ -1939,7 +1939,7 @@ where
             .true_effects
             .ok_or(SuiError::TooManyIncorrectAuthorities {
                 errors: final_state.errors,
-                action: "execute_cert_to_true_effects".to_string(),
+                action: "execute_cert_to_true_effects",
             })
             .tap_err(|e| info!(?digest, "execute_cert_to_true_effects failed: {}", e))
     }

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -361,6 +361,7 @@ where
                             if state.bad_weight > validity {
                                 return Err(SuiError::TooManyIncorrectAuthorities {
                                     errors: state.errors,
+                                    action: "wait_for_epoch_cert".to_string(),
                                 });
                             }
                         }
@@ -377,6 +378,7 @@ where
         } else {
             Err(SuiError::TooManyIncorrectAuthorities {
                 errors: final_state.errors,
+                action: "wait_for_epoch_cert".to_string(),
             })
         }
     }

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -361,7 +361,7 @@ where
                             if state.bad_weight > validity {
                                 return Err(SuiError::TooManyIncorrectAuthorities {
                                     errors: state.errors,
-                                    action: "wait_for_epoch_cert".to_string(),
+                                    action: "wait_for_epoch_cert",
                                 });
                             }
                         }
@@ -378,7 +378,7 @@ where
         } else {
             Err(SuiError::TooManyIncorrectAuthorities {
                 errors: final_state.errors,
-                action: "wait_for_epoch_cert".to_string(),
+                action: "wait_for_epoch_cert",
             })
         }
     }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -381,9 +381,12 @@ async fn test_map_reducer() {
             0usize,
             |_name, _client| Box::pin(async move { Ok(()) }),
             |_accumulated_state, _authority_name, _authority_weight, _result| {
-                Box::pin(
-                    async move { Err(SuiError::TooManyIncorrectAuthorities { errors: vec![] }) },
-                )
+                Box::pin(async move {
+                    Err(SuiError::TooManyIncorrectAuthorities {
+                        errors: vec![],
+                        action: String::new(),
+                    })
+                })
             },
             Duration::from_millis(1000),
         )
@@ -399,8 +402,10 @@ async fn test_map_reducer() {
             0usize,
             |_name, _client| {
                 Box::pin(async move {
-                    let res: Result<usize, SuiError> =
-                        Err(SuiError::TooManyIncorrectAuthorities { errors: vec![] });
+                    let res: Result<usize, SuiError> = Err(SuiError::TooManyIncorrectAuthorities {
+                        errors: vec![],
+                        action: String::new(),
+                    });
                     res
                 })
             },
@@ -451,9 +456,12 @@ async fn test_map_reducer() {
                 })
             },
             |_accumulated_state, _authority_name, _authority_weight, _result| {
-                Box::pin(
-                    async move { Err(SuiError::TooManyIncorrectAuthorities { errors: vec![] }) },
-                )
+                Box::pin(async move {
+                    Err(SuiError::TooManyIncorrectAuthorities {
+                        errors: vec![],
+                        action: String::new(),
+                    })
+                })
             },
             Duration::from_millis(10),
         )
@@ -1002,6 +1010,7 @@ async fn test_quorum_once_with_timeout() {
             },
             Duration::from_millis(authority_request_timeout),
             Some(Duration::from_millis(30 * 50)),
+            "test",
         )
         .await
         .unwrap();

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -384,7 +384,7 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     Err(SuiError::TooManyIncorrectAuthorities {
                         errors: vec![],
-                        action: String::new(),
+                        action: "",
                     })
                 })
             },
@@ -404,7 +404,7 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     let res: Result<usize, SuiError> = Err(SuiError::TooManyIncorrectAuthorities {
                         errors: vec![],
-                        action: String::new(),
+                        action: "",
                     });
                     res
                 })
@@ -459,7 +459,7 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     Err(SuiError::TooManyIncorrectAuthorities {
                         errors: vec![],
-                        action: String::new(),
+                        action: "",
                     })
                 })
             },

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -333,9 +333,10 @@ pub enum SuiError {
     ConcurrentTransactionError,
     #[error("Transfer should be received by us.")]
     IncorrectRecipientError,
-    #[error("Too many authority errors were detected: {:?}", errors)]
+    #[error("Too many authority errors were detected for {}: {:?}", action, errors)]
     TooManyIncorrectAuthorities {
         errors: Vec<(AuthorityName, SuiError)>,
+        action: String,
     },
     #[error("Inconsistent results observed in the Gateway. This should not happen and typically means there is a bug in the Sui implementation. Details: {error:?}")]
     InconsistentGatewayResult { error: String },

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -336,7 +336,7 @@ pub enum SuiError {
     #[error("Too many authority errors were detected for {}: {:?}", action, errors)]
     TooManyIncorrectAuthorities {
         errors: Vec<(AuthorityName, SuiError)>,
-        action: String,
+        action: &'static str,
     },
     #[error("Inconsistent results observed in the Gateway. This should not happen and typically means there is a bug in the Sui implementation. Details: {error:?}")]
     InconsistentGatewayResult { error: String },


### PR DESCRIPTION
we see `TooManyIncorrectAuthorities` error here and there but more times than not we don't know for what actions the authority aggregator said so. This PR adds an additional field `action` to describe it