### PR TITLE
[explorer] Implement go-to-definition within modules

### DIFF
--- a/explorer/client/src/components/module/ModuleView.tsx
+++ b/explorer/client/src/components/module/ModuleView.tsx
@@ -1,27 +1,90 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import { useQuery } from '@tanstack/react-query';
 import cl from 'classnames';
 import Highlight, { defaultProps, Prism } from 'prism-react-renderer';
 import 'prism-themes/themes/prism-one-light.css';
+import { useContext } from 'react';
 
+import { NetworkContext } from '../../context';
 import codestyle from '../../styles/bytecode.module.css';
+import { DefaultRpcClient as rpc } from '../../utils/api/DefaultRpcClient';
 
+import type { SuiMoveNormalizedType } from '@mysten/sui.js';
 import type { Language } from 'prism-react-renderer';
 
 import styles from './ModuleView.module.css';
+
 // inclue Rust language.
 // @ts-ignore
 (typeof global !== 'undefined' ? global : window).Prism = Prism;
 require('prismjs/components/prism-rust');
 
-function ModuleView({ itm }: { itm: any }) {
+interface Props {
+    id?: string;
+    name: string;
+    code: string;
+}
+
+/** Takes a normalized move type and returns the address information contained within it */
+function unwrapTypeReference(type: SuiMoveNormalizedType): null | {
+    address: string;
+    module: string;
+    name: string;
+} {
+    if (typeof type === 'object') {
+        if ('Struct' in type) {
+            return type.Struct;
+        }
+        if ('Reference' in type) {
+            return unwrapTypeReference(type.Reference);
+        }
+        if ('MutableReference' in type) {
+            return unwrapTypeReference(type.MutableReference);
+        }
+        if ('Vector' in type) {
+            return unwrapTypeReference(type.Vector);
+        }
+    }
+    return null;
+}
+
+function ModuleView({ id, name, code }: Props) {
+    const [network] = useContext(NetworkContext);
+    const { data: normalizedModuleReferences } = useQuery(
+        ['normalized-module', id, name],
+        async () => {
+            const normalizedModule = await rpc(network).getNormalizedMoveModule(
+                id!,
+                name
+            );
+
+            const typeReferences: Record<string, any> = {};
+            Object.values(normalizedModule.exposed_functions).forEach(
+                (exposedFunction) => {
+                    exposedFunction.parameters.forEach((param) => {
+                        const unwrappedType = unwrapTypeReference(param);
+                        if (!unwrappedType) return;
+                        typeReferences[unwrappedType.name] =
+                            unwrappedType.address;
+                    });
+                }
+            );
+
+            return typeReferences;
+        },
+        {
+            enabled: !!id,
+        }
+    );
+
     return (
         <section className={styles.modulewrapper}>
-            <div className={styles.moduletitle}>{itm[0]}</div>
+            <div className={styles.moduletitle}>{name}</div>
             <div className={cl(codestyle.code, styles.codeview)}>
                 <Highlight
                     {...defaultProps}
-                    code={itm[1]}
+                    code={code}
                     language={'rust' as Language}
                     theme={undefined}
                 >
@@ -42,12 +105,43 @@ function ModuleView({ itm }: { itm: any }) {
                                     <div className={styles.codelinenumbers}>
                                         {i + 1}
                                     </div>
-                                    {line.map((token, key) => (
-                                        <span
-                                            {...getTokenProps({ token, key })}
-                                            key={key}
-                                        />
-                                    ))}
+                                    {line.map((token, key) => {
+                                        if (
+                                            token.types.includes(
+                                                'class-name'
+                                            ) &&
+                                            normalizedModuleReferences?.[
+                                                token.content
+                                            ]
+                                        ) {
+                                            return (
+                                                // eslint-disable-next-line jsx-a11y/anchor-has-content, react/jsx-no-target-blank
+                                                <a
+                                                    key={key}
+                                                    {...getTokenProps({
+                                                        token,
+                                                        key,
+                                                    })}
+                                                    target="_blank"
+                                                    href={`/objects/${
+                                                        normalizedModuleReferences?.[
+                                                            token.content
+                                                        ]
+                                                    }`}
+                                                />
+                                            );
+                                        }
+
+                                        return (
+                                            <span
+                                                {...getTokenProps({
+                                                    token,
+                                                    key,
+                                                })}
+                                                key={key}
+                                            />
+                                        );
+                                    })}
                                 </div>
                             ))}
                         </pre>

--- a/explorer/client/src/components/module/ModuleView.tsx
+++ b/explorer/client/src/components/module/ModuleView.tsx
@@ -5,17 +5,17 @@ import cl from 'classnames';
 import Highlight, { defaultProps, Prism } from 'prism-react-renderer';
 import 'prism-themes/themes/prism-one-light.css';
 import { useContext } from 'react';
+import { Link } from 'react-router-dom';
 
 import { NetworkContext } from '../../context';
 import codestyle from '../../styles/bytecode.module.css';
 import { DefaultRpcClient as rpc } from '../../utils/api/DefaultRpcClient';
+import { normalizeSuiAddress } from './util';
 
 import type { SuiMoveNormalizedType } from '@mysten/sui.js';
 import type { Language } from 'prism-react-renderer';
 
 import styles from './ModuleView.module.css';
-import { Link } from 'react-router-dom';
-import { normalizeSuiAddress } from './util';
 
 // inclue Rust language.
 // @ts-ignore

--- a/explorer/client/src/components/module/ModulesWrapper.tsx
+++ b/explorer/client/src/components/module/ModulesWrapper.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import Pagination from '../../components/pagination/Pagination';
 import ModuleView from './ModuleView';
@@ -10,7 +11,7 @@ import styles from './ModuleView.module.css';
 
 type Modules = {
     title: string;
-    content: any[];
+    content: [moduleName: string, code: string][];
 };
 
 interface Props {
@@ -21,13 +22,20 @@ interface Props {
 const MODULES_PER_PAGE = 3;
 // TODO: Include Pagination for now use viewMore and viewLess
 function ModuleViewWrapper({ id, data }: Props) {
+    const [searchParams] = useSearchParams();
     const [modulesPageNumber, setModulesPageNumber] = useState(1);
     const totalModulesCount = data.content.length;
     const numOfMudulesToShow = MODULES_PER_PAGE;
 
     useEffect(() => {
-        setModulesPageNumber(modulesPageNumber);
-    }, [modulesPageNumber]);
+        if (searchParams.get('module')) {
+            const moduleIndex = data.content.findIndex(([moduleName]) => {
+                return moduleName === searchParams.get('module');
+            });
+
+            setModulesPageNumber(Math.floor(moduleIndex / MODULES_PER_PAGE) + 1);
+        }
+    }, [searchParams, data.content]);
 
     const stats = {
         stats_text: 'total modules',

--- a/explorer/client/src/components/module/ModulesWrapper.tsx
+++ b/explorer/client/src/components/module/ModulesWrapper.tsx
@@ -33,7 +33,9 @@ function ModuleViewWrapper({ id, data }: Props) {
                 return moduleName === searchParams.get('module');
             });
 
-            setModulesPageNumber(Math.floor(moduleIndex / MODULES_PER_PAGE) + 1);
+            setModulesPageNumber(
+                Math.floor(moduleIndex / MODULES_PER_PAGE) + 1
+            );
         }
     }, [searchParams, data.content]);
 

--- a/explorer/client/src/components/module/ModulesWrapper.tsx
+++ b/explorer/client/src/components/module/ModulesWrapper.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 import Pagination from '../../components/pagination/Pagination';
 import ModuleView from './ModuleView';
@@ -13,12 +13,16 @@ type Modules = {
     content: any[];
 };
 
+interface Props {
+    id?: string;
+    data: Modules;
+}
+
 const MODULES_PER_PAGE = 3;
 // TODO: Include Pagination for now use viewMore and viewLess
-function ModuleViewWrapper({ data }: { data: Modules }) {
-    const moduleData = useMemo(() => data, [data]);
+function ModuleViewWrapper({ id, data }: Props) {
     const [modulesPageNumber, setModulesPageNumber] = useState(1);
-    const totalModulesCount = moduleData.content.length;
+    const totalModulesCount = data.content.length;
     const numOfMudulesToShow = MODULES_PER_PAGE;
 
     useEffect(() => {
@@ -34,15 +38,15 @@ function ModuleViewWrapper({ data }: { data: Modules }) {
         <div className={styles.modulewraper}>
             <h3 className={styles.title}>{data.title}</h3>
             <div className={styles.module}>
-                {moduleData.content
+                {data.content
                     .filter(
                         (_, index) =>
                             index >=
                                 (modulesPageNumber - 1) * numOfMudulesToShow &&
                             index < modulesPageNumber * numOfMudulesToShow
                     )
-                    .map((item, idx) => (
-                        <ModuleView itm={item} key={idx} />
+                    .map(([name, code], idx) => (
+                        <ModuleView key={idx} id={id} name={name} code={code} />
                     ))}
             </div>
             {totalModulesCount > numOfMudulesToShow && (

--- a/explorer/client/src/components/module/util.ts
+++ b/explorer/client/src/components/module/util.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SuiAddress } from '@mysten/sui.js';
+
+export const SUI_ADDRESS_LENGTH = 20;
+
+// TODO: Use version of this function from the SDK when it is exposed.
+export function normalizeSuiAddress(
+    value: string,
+    forceAdd0x: boolean = false
+): SuiAddress {
+    let address = value.toLowerCase();
+    if (!forceAdd0x && address.startsWith('0x')) {
+        address = address.slice(2);
+    }
+    const numMissingZeros =
+        (SUI_ADDRESS_LENGTH - getHexByteLength(address)) * 2;
+    if (numMissingZeros <= 0) {
+        return '0x' + address;
+    }
+    return '0x' + '0'.repeat(numMissingZeros) + address;
+}
+
+function getHexByteLength(value: string): number {
+    return /^(0x|0X)/.test(value) ? (value.length - 2) / 2 : value.length / 2;
+}

--- a/explorer/client/src/pages/object-result/views/PkgView.tsx
+++ b/explorer/client/src/pages/object-result/views/PkgView.tsx
@@ -75,6 +75,7 @@ function PkgView({ data }: { data: DataType }) {
                     </table>
                 </Tabs>
                 <ModulesWrapper
+                    id={data.id}
                     data={{
                         title: 'Modules',
                         content: properties,

--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -398,7 +398,10 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                                     styles.txgridcolspan3,
                                 ])}
                             >
-                                <ModulesWrapper data={modules} />
+                                <ModulesWrapper
+                                    id={txKindData.objectId?.value}
+                                    data={modules}
+                                />
                             </section>
                         )}
                     </div>


### PR DESCRIPTION
This uses the new normalized move module data to implement basic go-to-definition with the explorer. The approach we're taking now is super basic due to the limitations of Prism. The main issue that's currently observed is that we over-highlight pretty significantly. Any token that matches the normalized data will get highlighted, as opposed to a more granular approach of only typing move function arguments. This is solvable but requires us to either stop using react-prism-renderer, rework the syntax parsing of the move bytecode, or move off of prism for highlighting entirely.

![Screen Shot 2022-08-11 at 10 19 09 AM](https://user-images.githubusercontent.com/109986297/184194519-13e323ea-6a97-461d-bc3f-a6de349cdb9a.png)
