### PR TITLE
[Explorer] Stylises scrollbars across the website following Figma

### DIFF
--- a/explorer/client/src/index.css
+++ b/explorer/client/src/index.css
@@ -15,22 +15,28 @@ body {
     @apply m-0 text-offblack;
 }
 
+html {
+    scrollbar-color: #4e555d #fefefe;
+    scrollbar-width: 6px;
+}
+
 /* Improves scrollbar look on Chromium browsers */
 
-body::-webkit-scrollbar {
-    width: 10px;
+::-webkit-scrollbar {
+    width: 6px;
 }
 
-body::-webkit-scrollbar-track {
-    background: transparent;
+::-webkit-scrollbar-track {
+    @apply bg-inherit;
 }
 
-body::-webkit-scrollbar-thumb {
-    background: #898d93;
+::-webkit-scrollbar-thumb {
+    @apply bg-sui-grey-50;
+
     border-radius: 5px;
 }
 
-body::-webkit-scrollbar-thumb:hover {
+::-webkit-scrollbar-thumb:hover {
     background: #4e555d;
 }
 

--- a/explorer/client/src/index.css
+++ b/explorer/client/src/index.css
@@ -16,14 +16,14 @@ body {
 }
 
 html {
-    scrollbar-color: #4e555d #fefefe;
+    scrollbar-color: #182435 #fefefe;
     scrollbar-width: 6px;
 }
 
 /* Improves scrollbar look on Chromium browsers */
 
 ::-webkit-scrollbar {
-    width: 6px;
+    @apply w-[6px];
 }
 
 ::-webkit-scrollbar-track {
@@ -31,13 +31,11 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-    @apply bg-sui-grey-50;
-
-    border-radius: 5px;
+    @apply bg-sui-grey-50 rounded-[10px];
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: #4e555d;
+    @apply bg-sui-grey-100;
 }
 
 input:focus,


### PR DESCRIPTION
A CSS change that should update the scrollbars to match Figma.

### Before (Chrome / Windows OS)

![image](https://user-images.githubusercontent.com/11377188/184200829-94c55aa7-cc6a-4fa6-8a87-ffa42d053bfa.png)


### After 

#### Chrome (Windows OS)
https://user-images.githubusercontent.com/11377188/184202443-702e956a-3355-4ca9-a48d-476137d0ffe6.mp4

#### Firefox (Windows OS)
https://user-images.githubusercontent.com/11377188/184203348-c47fb8bd-9adf-44a7-8e0f-8d4099aaeddc.mp4

#### Safari (Mac OS)
This follows the same look as Chrome.