### PR TITLE
[Explorer ] Places space between Modules and Transactions in Package View

### DIFF
--- a/explorer/client/src/components/module/ModuleView.module.css
+++ b/explorer/client/src/components/module/ModuleView.module.css
@@ -51,6 +51,7 @@ section .codeview pre {
 .modulewrapper {
     @apply p-0 pb-2;
 }
+
 @media (min-width: 40em) {
     section .modulewrapper {
         border-right: 1px solid #f0f1f2;

--- a/explorer/client/src/pages/object-result/views/ObjectView.module.css
+++ b/explorer/client/src/pages/object-result/views/ObjectView.module.css
@@ -122,22 +122,8 @@ div.accommodate > h2.header {
     @apply lg:w-[50vw];
 }
 
-/* Bytecode Styling */
+/* Transaction Section Spacing */
 
-div.bytecodebox > div {
-    @apply ml-[5vw];
-}
-
-div.bytecodebox > div > div:first-child {
-    @apply font-sans tracking-tight font-semibold block;
-}
-
-div.bytecodebox > div > div:nth-child(2) {
-    @apply w-[65vw] h-[30vh] mt-[2vh] mb-[5vh];
-}
-
-div.jsondata {
-    @apply border-solid border-stone-300 mb-[5vh] p-5 bg-white whitespace-pre text-lg font-mono;
-
-    overflow-x: scroll;
+.txsection {
+    @apply mt-[68px];
 }

--- a/explorer/client/src/pages/object-result/views/PkgView.tsx
+++ b/explorer/client/src/pages/object-result/views/PkgView.tsx
@@ -80,8 +80,10 @@ function PkgView({ data }: { data: DataType }) {
                         content: properties,
                     }}
                 />
-                <h2 className={styles.header}>Transactions </h2>
-                <TxForID id={viewedData.id} category="object" />
+                <div className={styles.txsection}>
+                    <h2 className={styles.header}>Transactions </h2>
+                    <TxForID id={viewedData.id} category="object" />
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
This also removes the now unused jsondata and bytecode CSS variables which are a legacy from how modules were handled

## Before

![image](https://user-images.githubusercontent.com/11377188/184215444-e00e6285-f456-4dcd-9aef-2ace4900192e.png)

## After

![image](https://user-images.githubusercontent.com/11377188/184215272-6946370f-2784-439b-917a-fcd51951e504.png)

## Figma
https://www.figma.com/file/kSD0qXCIDZA4KQVNepA5hR/02-Explorer?node-id=227%3A94893

This suggests a gap of 68px. 