### PR TITLE
chore(deps): Update the narwhal pointer to devnet branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5607,9 +5607,9 @@ dependencies = [
 
 [[package]]
 name = "readonly"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1195d8cd0ebd43f09af81cbfabd0105419337d13baf2b537ee6788f2c63f825d"
+checksum = "6c0e08c3b00fcae55ee1dac341e1b9b5bc942e7e1931957436ab00b4a5e8dc18"
 dependencies = [
  "proc-macro2 1.0.42",
  "quote 1.0.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "arc-swap",
  "crypto",
@@ -1010,7 +1010,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "consensus"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1045,13 +1045,12 @@ dependencies = [
  "prometheus",
  "rand 0.7.3",
  "serde 1.0.142",
- "serde_bytes",
  "thiserror",
  "tokio",
  "tracing",
  "typed-store",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -1318,9 +1317,8 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
- "anyhow",
  "base64ct",
  "blake2",
  "blst",
@@ -1334,11 +1332,10 @@ dependencies = [
  "readonly",
  "secp256k1",
  "serde 1.0.142",
- "serde_bytes",
  "serde_with 2.0.0",
  "signature",
  "tokio",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
  "zeroize",
 ]
 
@@ -1437,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "dag"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "arc-swap",
  "crypto",
@@ -1448,7 +1445,7 @@ dependencies = [
  "rayon",
  "serde 1.0.142",
  "thiserror",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -1961,7 +1958,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1971,9 +1968,11 @@ dependencies = [
  "consensus",
  "crypto",
  "futures",
+ "match_opt",
  "multiaddr",
  "mysten-network",
  "primary",
+ "prometheus",
  "serde 1.0.142",
  "thiserror",
  "tokio",
@@ -1983,7 +1982,7 @@ dependencies = [
  "typed-store",
  "types",
  "worker",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -4222,13 +4221,13 @@ checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 [[package]]
 name = "network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
- "anyhow",
  "async-trait",
  "backoff",
  "bytes",
  "crypto",
+ "eyre",
  "futures",
  "multiaddr",
  "mysten-network",
@@ -4241,7 +4240,7 @@ dependencies = [
  "tonic",
  "tracing",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -4300,9 +4299,8 @@ dependencies = [
 [[package]]
 name = "node"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
- "anyhow",
  "arc-swap",
  "async-trait",
  "axum",
@@ -4314,6 +4312,7 @@ dependencies = [
  "consensus",
  "crypto",
  "executor",
+ "eyre",
  "futures",
  "multiaddr",
  "mysten-network",
@@ -4333,7 +4332,7 @@ dependencies = [
  "types",
  "url",
  "worker",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -5071,7 +5070,7 @@ dependencies = [
 [[package]]
 name = "primary"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -5084,7 +5083,6 @@ dependencies = [
  "crypto",
  "dashmap",
  "derive_builder",
- "ed25519-dalek",
  "futures",
  "itertools",
  "multiaddr",
@@ -5103,7 +5101,7 @@ dependencies = [
  "tracing",
  "typed-store",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -8371,7 +8369,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "base64",
  "bincode",
@@ -8381,8 +8379,9 @@ dependencies = [
  "crypto",
  "dag",
  "derive_builder",
- "ed25519-dalek",
+ "futures",
  "indexmap",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "prost",
@@ -8397,7 +8396,7 @@ dependencies = [
  "tonic",
  "tonic-build 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -8937,16 +8936,14 @@ dependencies = [
 [[package]]
 name = "worker"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
- "anyhow",
  "async-trait",
  "bincode",
  "blake2",
  "bytes",
  "config 0.1.0",
  "crypto",
- "ed25519-dalek",
  "futures",
  "multiaddr",
  "mysten-network",
@@ -8962,7 +8959,7 @@ dependencies = [
  "tracing",
  "typed-store",
  "types",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
 ]
 
 [[package]]
@@ -9641,7 +9638,7 @@ dependencies = [
  "webpki-roots",
  "which",
  "worker",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2)",
  "yaml-rust",
  "zeroize",
  "zeroize_derive",
@@ -9651,7 +9648,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=ef4536f3db403fda6d6c1c12ccb0ca827974e4fc#ef4536f3db403fda6d6c1c12ccb0ca827974e4fc"
+source = "git+https://github.com/MystenLabs/narwhal?rev=24353f2f1c5df27a8f1b693d78285faf506e36a2#24353f2f1c5df27a8f1b693d78285faf506e36a2"
 dependencies = [
  "addr2line",
  "adler",
@@ -9707,6 +9704,7 @@ dependencies = [
  "cast 0.3.0",
  "cc",
  "cexpr",
+ "cfg-if 0.1.10",
  "cfg-if 1.0.0",
  "clang-sys",
  "clap 2.34.0",
@@ -9874,11 +9872,14 @@ dependencies = [
  "plotters-backend",
  "plotters-svg",
  "ppv-lite86",
+ "pre",
+ "pre-proc-macro",
  "predicates",
  "predicates-core",
  "predicates-tree",
  "pretty_assertions",
  "prettyplease",
+ "proc-macro-crate 0.1.5",
  "proc-macro-crate 1.1.3",
  "proc-macro-error",
  "proc-macro-error-attr",
@@ -9915,6 +9916,7 @@ dependencies = [
  "rocksdb",
  "rustc-demangle",
  "rustc-hash",
+ "rustc_version 0.2.3",
  "rustc_version 0.3.3",
  "rustls",
  "rustls-pemfile",
@@ -9928,7 +9930,9 @@ dependencies = [
  "secp256k1",
  "secp256k1-sys",
  "semver 0.11.0",
+ "semver 0.9.0",
  "semver-parser 0.10.2",
+ "semver-parser 0.7.0",
  "serde 1.0.142",
  "serde-reflection",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6982,6 +6982,7 @@ dependencies = [
  "tempfile",
  "test-fuzz",
  "test-utils",
+ "thiserror",
  "tokio",
  "tokio-retry",
  "tokio-stream",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -41,7 +41,7 @@ sui-node = { path = "../sui-node" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 
 move-core-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a", features = ["address20"] }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "node" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "node" }
 workspace-hack = { path = "../workspace-hack"}
 test-utils = { path = "../test-utils" }
 

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -640,7 +640,7 @@ async fn main() -> Result<()> {
         (
             primary_gas_id,
             primary_gas_account,
-            Arc::new(keypair.parse()?),
+            Arc::new(keypair.parse().map_err(|e| anyhow!("{:#?}", e))?),
             config,
         )
     };

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -20,8 +20,8 @@ multiaddr = "0.14.0"
 once_cell = "1.11.0"
 tracing = "0.1.36"
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "config" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "crypto" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "config" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "crypto" }
 
 move-binary-format = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-package = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -50,12 +50,12 @@ typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa5
 typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e"} 
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e" }
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "config" }
-narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "consensus" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "crypto", features=["copy_key"]}
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "executor" }
-narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "types" }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "node" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "config" }
+narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "consensus" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "crypto", features=["copy_key"]}
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "executor" }
+narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "types" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "node" }
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -57,6 +57,7 @@ narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353
 narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "types" }
 narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "node" }
 workspace-hack = { path = "../workspace-hack"}
+thiserror = "1.0.32"
 
 [dev-dependencies]
 clap = { version = "3.1.17", features = ["derive"] }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1609,7 +1609,7 @@ impl ExecutionState for AuthorityState {
         _consensus_output: &narwhal_consensus::ConsensusOutput,
         consensus_index: ExecutionIndices,
         transaction: Self::Transaction,
-    ) -> Result<(Self::Outcome, Option<narwhal_config::Committee>), Self::Error> {
+    ) -> Result<Self::Outcome, Self::Error> {
         self.metrics.total_consensus_txns.inc();
         match transaction {
             ConsensusTransaction::UserTransaction(certificate) => {
@@ -1632,7 +1632,7 @@ impl ExecutionState for AuthorityState {
 
                 // TODO: This return time is not ideal.
                 // TODO [2533]: edit once integrating Narwhal reconfiguration
-                Ok((Vec::default(), None))
+                Ok(Vec::default())
             }
             ConsensusTransaction::Checkpoint(fragment) => {
                 let seq = consensus_index;
@@ -1661,7 +1661,7 @@ impl ExecutionState for AuthorityState {
                 // TODO: This return time is not ideal. The authority submitting the checkpoint fragment
                 // is not expecting any reply.
                 // TODO [2533]: edit once integrating Narwhal reconfiguration
-                Ok((Vec::default(), None))
+                Ok(Vec::default())
             }
         }
     }
@@ -1688,13 +1688,6 @@ impl ExecutionStateError for FragmentInternalError {
             // Those are errors caused by the authority (eg. storage failure). It is not guaranteed
             // that other validators will also trigger it and they may not be deterministic.
             Self::Retry(..) => true,
-        }
-    }
-
-    fn to_string(&self) -> String {
-        match self {
-            Self::Error(sui_error) => format!("Failed to process checkpoint fragment {sui_error}"),
-            Self::Retry(fragment) => format!("Failed to sequence checkpoint fragment {fragment:?}"),
         }
     }
 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -26,6 +26,7 @@ use sui_types::{
         CheckpointSequenceNumber, CheckpointSummary, SignedCheckpointSummary,
     },
 };
+use thiserror::Error;
 use tracing::{debug, error, info};
 use typed_store::traits::DBMapTableUtil;
 use typed_store::{
@@ -79,9 +80,11 @@ pub trait ConsensusSender: Send + Sync + 'static {
     fn send_to_consensus(&self, fragment: CheckpointFragment) -> Result<(), SuiError>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum FragmentInternalError {
+    #[error("Sui error: {0}")]
     Error(SuiError),
+    #[error("Error processing fragment, retrying")]
     Retry(Box<CheckpointFragment>),
 }
 

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -27,7 +27,7 @@ move-stdlib = { git = "https://github.com/move-language/move", rev = "7907152852
 move-unit-test = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-vm-runtime = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "crypto" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "crypto" }
 workspace-hack = { path = "../workspace-hack"}
 
 [build-dependencies]

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -19,7 +19,7 @@ rocksdb = "0.19.0"
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e"}
 typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e"} 
 tempfile = "3.3.0"
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "executor" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "executor" }
 serde_with = { version = "1.14.0", features = ["hex"] }
 sui-storage = { path = "../sui-storage" }
 strum_macros = "^0.24"

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -50,8 +50,8 @@ move-disassembler = { git = "https://github.com/move-language/move", rev = "7907
 move-ir-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }
 
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "executor" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "crypto" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "executor" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "crypto" }
 
 workspace-hack = { path = "../workspace-hack"}
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -467,10 +467,6 @@ impl ExecutionStateError for SuiError {
                 | Self::GenericAuthorityError { .. }
         )
     }
-
-    fn to_string(&self) -> String {
-        ToString::to_string(&self)
-    }
 }
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -39,7 +39,7 @@ rocksdb = "0.19.0"
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e"}
 typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e"} 
 tempfile = "3.3.0"
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", package = "executor" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", package = "executor" }
 
 move-core-types = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a", features = ["address20"] }
 move-prover = { git = "https://github.com/move-language/move", rev = "79071528524f08b12e9abb84c1094d8e976aa17a" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -93,9 +93,9 @@ collectable = { version = "0.0.2", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4", features = ["alloc", "bytes", "std"] }
-config-2389909a4f862b4e = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+config-d72a4ba35040a3fc = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 config-a6292c17cd707f01 = { package = "config", version = "0.11", features = ["hjson", "ini", "json", "rust-ini", "serde-hjson", "serde_json", "toml", "yaml", "yaml-rust"] }
-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", features = ["benchmark", "rand"] }
+consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", features = ["benchmark", "rand"] }
 console = { version = "0.15", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
@@ -114,7 +114,7 @@ crossterm-647d43efb71741da = { package = "crossterm", version = "0.21" }
 crossterm-3c51e837cfc5589a = { package = "crossterm", version = "0.22" }
 crossterm-2b5c6dc72f624058 = { package = "crossterm", version = "0.23" }
 crossterm-adf3d7031871b0af = { package = "crossterm", version = "0.24" }
-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", features = ["copy_key"] }
+crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", features = ["copy_key"] }
 crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 crypto-mac = { version = "0.8", default-features = false, features = ["std"] }
@@ -122,7 +122,7 @@ csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
 curve25519-dalek = { version = "3", default-features = false, features = ["alloc", "serde", "std", "u64_backend"] }
 curve25519-dalek-fiat = { version = "0.1", default-features = false, features = ["alloc", "fiat-crypto", "fiat_u64_backend", "std"] }
-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+dag = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2", features = ["alloc", "std"] }
 datatest-stable = { version = "0.1", default-features = false }
@@ -158,7 +158,7 @@ endian-type = { version = "0.1", default-features = false }
 env_logger = { version = "0.9", features = ["atty", "humantime", "regex", "termcolor"] }
 ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail = { version = "0.4", default-features = false }
 fastrand = { version = "1", default-features = false }
@@ -313,11 +313,11 @@ multihash = { version = "0.16", default-features = false, features = ["alloc", "
 mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e", default-features = false }
 named-lock = { version = "0.1", default-features = false }
 nested = { version = "0.1", default-features = false }
-network = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+network = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
-node = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false, features = ["benchmark"] }
+node = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false, features = ["benchmark"] }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5", features = ["alloc", "lexical", "lexical-core", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
@@ -371,7 +371,7 @@ predicates-core = { version = "1", default-features = false }
 predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1", features = ["std"] }
-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false, features = ["benchmark"] }
+primary = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false, features = ["benchmark"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro", "span-locations"] }
 prometheus = { version = "0.13", features = ["protobuf"] }
 proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
@@ -540,7 +540,7 @@ twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e", default-features = false }
 typenum = { version = "1", default-features = false }
-types = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc" }
+types = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2" }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
 uncased = { version = "0.9", default-features = false }
 unescape = { version = "0.1", default-features = false }
@@ -573,8 +573,8 @@ wasm-bindgen-futures = { version = "0.4", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["BinaryType", "Blob", "CloseEvent", "Document", "Element", "ErrorEvent", "Event", "EventTarget", "FileReader", "History", "HtmlElement", "HtmlHeadElement", "Location", "MessageEvent", "Node", "ProgressEvent", "WebSocket", "Window"] }
 webpki = { version = "0.22", default-features = false, features = ["alloc", "std"] }
 webpki-roots = { version = "0.22", default-features = false }
-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false, features = ["benchmark"] }
-workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+worker = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false, features = ["benchmark"] }
+workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 zeroize = { version = "1", features = ["alloc", "zeroize_derive"] }
 zstd-sys = { version = "2", features = ["legacy", "zdict_builder"] }
@@ -676,9 +676,9 @@ collectable = { version = "0.0.2", default-features = false }
 colored = { version = "2", default-features = false }
 colored-diff = { version = "0.2", default-features = false }
 combine = { version = "4", features = ["alloc", "bytes", "std"] }
-config-2389909a4f862b4e = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+config-d72a4ba35040a3fc = { package = "config", git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 config-a6292c17cd707f01 = { package = "config", version = "0.11", features = ["hjson", "ini", "json", "rust-ini", "serde-hjson", "serde_json", "toml", "yaml", "yaml-rust"] }
-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", features = ["benchmark", "rand"] }
+consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", features = ["benchmark", "rand"] }
 console = { version = "0.15", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
@@ -697,7 +697,7 @@ crossterm-647d43efb71741da = { package = "crossterm", version = "0.21" }
 crossterm-3c51e837cfc5589a = { package = "crossterm", version = "0.22" }
 crossterm-2b5c6dc72f624058 = { package = "crossterm", version = "0.23" }
 crossterm-adf3d7031871b0af = { package = "crossterm", version = "0.24" }
-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", features = ["copy_key"] }
+crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", features = ["copy_key"] }
 crypto-bigint = { version = "0.4", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 crypto-mac = { version = "0.8", default-features = false, features = ["std"] }
@@ -705,7 +705,7 @@ csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
 curve25519-dalek = { version = "3", default-features = false, features = ["alloc", "serde", "std", "u64_backend"] }
 curve25519-dalek-fiat = { version = "0.1", default-features = false, features = ["alloc", "fiat-crypto", "fiat_u64_backend", "std"] }
-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+dag = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 darling-594e8ee84c453af0 = { package = "darling", version = "0.13", features = ["suggestions"] }
 darling-582f2526e08bb6a0 = { package = "darling", version = "0.14", features = ["suggestions"] }
 darling_core-594e8ee84c453af0 = { package = "darling_core", version = "0.13", default-features = false, features = ["strsim", "suggestions"] }
@@ -752,7 +752,7 @@ enum_dispatch = { version = "0.3", default-features = false }
 env_logger = { version = "0.9", features = ["atty", "humantime", "regex", "termcolor"] }
 ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+executor = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail = { version = "0.4", default-features = false }
 fastrand = { version = "1", default-features = false }
@@ -922,11 +922,11 @@ mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4
 name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e", default-features = false }
 named-lock = { version = "0.1", default-features = false }
 nested = { version = "0.1", default-features = false }
-network = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+network = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nibble_vec = { version = "0.1", default-features = false }
-node = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false, features = ["benchmark"] }
+node = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false, features = ["benchmark"] }
 nom-cdf1610d3e1514e9 = { package = "nom", version = "5", features = ["alloc", "lexical", "lexical-core", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
@@ -994,7 +994,7 @@ predicates-tree = { version = "1", default-features = false }
 pretty = { version = "0.10", default-features = false }
 pretty_assertions = { version = "1", features = ["std"] }
 prettyplease = { version = "0.1", default-features = false }
-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false, features = ["benchmark"] }
+primary = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false, features = ["benchmark"] }
 proc-macro-crate-c65f7effa3be6d31 = { package = "proc-macro-crate", version = "0.1", default-features = false }
 proc-macro-crate-dff4ba8e3ae991db = { package = "proc-macro-crate", version = "1", default-features = false }
 proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
@@ -1206,7 +1206,7 @@ typed-arena = { version = "2", features = ["std"] }
 typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e", default-features = false }
 typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e", default-features = false }
 typenum = { version = "1", default-features = false }
-types = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc" }
+types = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2" }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
 uncased = { version = "0.9", default-features = false }
 unescape = { version = "0.1", default-features = false }
@@ -1251,8 +1251,8 @@ web-sys = { version = "0.3", default-features = false, features = ["BinaryType",
 webpki = { version = "0.22", default-features = false, features = ["alloc", "std"] }
 webpki-roots = { version = "0.22", default-features = false }
 which = { version = "4", default-features = false }
-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false, features = ["benchmark"] }
-workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "ef4536f3db403fda6d6c1c12ccb0ca827974e4fc", default-features = false }
+worker = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false, features = ["benchmark"] }
+workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "24353f2f1c5df27a8f1b693d78285faf506e36a2", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 zeroize = { version = "1", features = ["alloc", "zeroize_derive"] }
 zeroize_derive = { version = "1", default-features = false }


### PR DESCRIPTION
## Context

For release, we should merge the tip of NW main in Sui. However, a recent NW change (https://github.com/MystenLabs/narwhal/pull/624) has created serialization issues that are not resolved for the moment. See efforts to resolve in #3891.

Moreover, a [security advisory](https://rustsec.org/advisories/RUSTSEC-2022-0046) has forced a rapid upgrade to rocksdb 0.19.0, which prompted #3942 in order to also update this dependency as imported through NW.

## The issue

We need to ship a new version of devnet without delay.

## The fix

This imports the tip of the `devnet` branch in NW. This protected branch on the NW repo contains precisely NW main as of https://github.com/MystenLabs/narwhal/commit/9c1862af04e8c5ecf9c7504900e9d5d00a088859 minus the following PRs, which have been removed from the branch:
- https://github.com/MystenLabs/narwhal/pull/624
- https://github.com/MystenLabs/narwhal/pull/689
- https://github.com/MystenLabs/narwhal/pull/750

Please note that we've had to adapt a few files to the latest NW changes (see last commit of this PR).

## Follow-up/see also
- https://github.com/MystenLabs/sui/pull/3891
- https://github.com/MystenLabs/narwhal/pull/756