### PR TITLE
Fix a bug in verifying checkpoint

### DIFF
--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -198,7 +198,7 @@ where
         self.state.unhalt_validator();
         info!(?epoch, "Validator unhalted.");
         info!(
-            "Epoch change finished. We are now at epoch {:?}",
+            "===== Epoch change finished. We are now at epoch {:?} =====",
             next_epoch
         );
         Ok(())

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -281,7 +281,7 @@ impl SignedCheckpointSummary {
         contents: Option<&CheckpointContents>,
     ) -> Result<(), SuiError> {
         fp_ensure!(
-            self.summary.epoch == self.auth_signature.epoch,
+            self.summary.epoch == committee.epoch,
             SuiError::from("Epoch in the summary doesn't match with the signature")
         );
 


### PR DESCRIPTION
In a checkpoint proposal response, the proposal and the previous cert may be from different epochs (if we are at epoch boundary). This PR fixes it.