### PR TITLE
Add more logging to batch and checkpoint

### DIFF
--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -210,7 +210,7 @@ impl crate::authority::AuthorityState {
                     .tables
                     .batches
                     .insert(&new_batch.data().next_sequence_number, &new_batch)?;
-                debug!(next_sequence_number=?new_batch.data().next_sequence_number, "New batch created");
+                debug!(next_sequence_number=?new_batch.data().next_sequence_number, "New batch created. Transactions: {:?}", current_batch);
 
                 // If a checkpointing service is present, register the batch with it
                 // to insert the transactions into future checkpoint candidates

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -844,6 +844,12 @@ impl CheckpointStore {
 
         let transactions = CheckpointContents::new(self.tables.extra_transactions.keys());
         let size = transactions.transactions.len();
+        info!(cp_seq=?checkpoint_sequence, ?size, "A new checkpoint proposal is created");
+        debug!(
+            "Transactions included in the checkpoint: {:?}",
+            transactions.transactions
+        );
+
         let checkpoint_proposal = CheckpointProposal::new(
             epoch,
             checkpoint_sequence,
@@ -858,7 +864,6 @@ impl CheckpointStore {
         new_locals.proposal_next_transaction = Some(next_local_tx_sequence);
         self.set_locals(locals, new_locals)?;
 
-        info!(cp_seq=?checkpoint_sequence, ?size, "A new checkpoint proposal is created");
         Ok(checkpoint_proposal)
     }
 
@@ -1032,19 +1037,19 @@ impl CheckpointStore {
 
         // If the transactions processed did not belong to a checkpoint yet, we add them to the list
         // of `extra` transactions, that we should be actively propagating to others.
-        let batch = batch.insert_batch(
-            &self.tables.extra_transactions,
-            transactions
-                .iter()
-                .zip(&in_checkpoint)
-                .filter_map(|((seq, tx), in_chk)| {
-                    if in_chk.is_none() {
-                        Some((tx, seq))
-                    } else {
-                        None
-                    }
-                }),
-        )?;
+        let new_extra: Vec<_> = transactions
+            .iter()
+            .zip(&in_checkpoint)
+            .filter_map(|((seq, tx), in_chk)| {
+                if in_chk.is_none() {
+                    Some((tx, seq))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        debug!("Transactions added to extra_transactions: {:?}", new_extra);
+        let batch = batch.insert_batch(&self.tables.extra_transactions, new_extra)?;
 
         // Write to the database.
         batch.write()?;


### PR DESCRIPTION
There is a gap from after a tx is executed to when it's included in a checkpoint in our logs.
This PR closes that gap:
1. Log the list of tx when they are picked up by a batch.
2. Log the list of tx when they are added to extra_transactions for checkpoint
3. Log the list of tx when they are included in a checkpoint.
