### PR TITLE
add retry for TransferSui transaction builder call at faucet

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -4,12 +4,13 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 
+use crate::metrics::FaucetMetrics;
+use prometheus::Registry;
+
 // HashSet is in fact used but linter does not think so
 #[allow(unused_imports)]
 use std::collections::HashSet;
 
-use crate::metrics::FaucetMetrics;
-use prometheus::Registry;
 use sui::client_commands::{SuiClientCommands, WalletContext};
 use sui_json_rpc_types::{
     SuiExecutionStatus, SuiTransactionKind, SuiTransactionResponse, SuiTransferSui,
@@ -17,13 +18,14 @@ use sui_json_rpc_types::{
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     gas_coin::GasCoin,
-    messages::Transaction,
+    messages::{Transaction, TransactionData},
 };
 use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     Mutex,
 };
-use tracing::{debug, error, info};
+use tokio::time::Duration;
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::{CoinInfo, Faucet, FaucetError, FaucetReceipt};
@@ -178,6 +180,60 @@ impl SimpleFaucet {
         Ok(responses)
     }
 
+    async fn construct_transfer_sui_txn_with_retry(
+        &self,
+        coin_id: ObjectID,
+        signer: SuiAddress,
+        recipient: SuiAddress,
+        budget: u64,
+        amount: u64,
+        uuid: Uuid,
+    ) -> Result<TransactionData, anyhow::Error> {
+        // try 3 times in total
+        let retry_intervals_ms = [Duration::from_millis(500), Duration::from_millis(1000)];
+        let mut data = self
+            .construct_transfer_sui_txn(coin_id, signer, recipient, budget, amount)
+            .await;
+        let mut iter = retry_intervals_ms.iter();
+        while data.is_err() {
+            if let Some(duration) = iter.next() {
+                tokio::time::sleep(*duration).await;
+                debug!(?uuid, "Retrying constructing TransferSui txn");
+            } else {
+                warn!(
+                    ?uuid,
+                    "Failed to construct TransferSui txn after attempts: {:?}", &retry_intervals_ms
+                );
+                break;
+            }
+            data = self
+                .construct_transfer_sui_txn(coin_id, signer, recipient, budget, amount)
+                .await;
+        }
+        data
+    }
+
+    async fn construct_transfer_sui_txn(
+        &self,
+        coin_id: ObjectID,
+        signer: SuiAddress,
+        recipient: SuiAddress,
+        budget: u64,
+        amount: u64,
+    ) -> Result<TransactionData, anyhow::Error> {
+        self.wallet
+            .gateway
+            .transfer_sui(signer, coin_id, budget, recipient, Some(amount))
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to construct TransferSui transaction for coin {:?}, {:?}",
+                    coin_id,
+                    e
+                )
+            })
+    }
+
     async fn transfer_sui(
         &self,
         coin_id: ObjectID,
@@ -188,11 +244,10 @@ impl SimpleFaucet {
         uuid: Uuid,
     ) -> Result<SuiTransactionResponse, anyhow::Error> {
         let context = &self.wallet;
-
-        let data = context
-            .gateway
-            .transfer_sui(signer, coin_id, budget, recipient, Some(amount))
+        let data = self
+            .construct_transfer_sui_txn_with_retry(coin_id, signer, recipient, budget, amount, uuid)
             .await?;
+
         let signature = context.keystore.sign(&signer, &data.to_bytes())?;
 
         let tx = Transaction::new(data, signature);

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -203,7 +203,7 @@ impl SimpleFaucet {
             } else {
                 warn!(
                     ?uuid,
-                    "Failed to construct TransferSui txn after {} attempts with interval {:?}",
+                    "Failed to construct TransferSui txn after {} retries with interval {:?}",
                     retry_intervals_ms.len(),
                     &retry_intervals_ms
                 );

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -189,8 +189,9 @@ impl SimpleFaucet {
         amount: u64,
         uuid: Uuid,
     ) -> Result<TransactionData, anyhow::Error> {
-        // try 3 times in total
+        // if needed, retry 2 times with the following interval
         let retry_intervals_ms = [Duration::from_millis(500), Duration::from_millis(1000)];
+
         let mut data = self
             .construct_transfer_sui_txn(coin_id, signer, recipient, budget, amount)
             .await;
@@ -202,7 +203,9 @@ impl SimpleFaucet {
             } else {
                 warn!(
                     ?uuid,
-                    "Failed to construct TransferSui txn after attempts: {:?}", &retry_intervals_ms
+                    "Failed to construct TransferSui txn after {} attempts with interval {:?}",
+                    retry_intervals_ms.len(),
+                    &retry_intervals_ms
                 );
                 break;
             }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -199,9 +199,17 @@ impl SimpleFaucet {
         while data.is_err() {
             if let Some(duration) = iter.next() {
                 tokio::time::sleep(*duration).await;
-                debug!(?uuid, "Retrying constructing TransferSui txn");
+                debug!(
+                    ?recipient,
+                    ?coin_id,
+                    ?uuid,
+                    "Retrying constructing TransferSui txn. Previous error: {:?}",
+                    &data,
+                );
             } else {
                 warn!(
+                    ?recipient,
+                    ?coin_id,
                     ?uuid,
                     "Failed to construct TransferSui txn after {} retries with interval {:?}",
                     retry_intervals_ms.len(),

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -381,8 +381,8 @@ pub enum SuiError {
 
     // These are errors that occur when an RPC fails and is simply the utf8 message sent in a
     // Tonic::Status
-    #[error("{0}")]
-    RpcError(String),
+    #[error("{1} - {0}")]
+    RpcError(String, &'static str),
 
     #[error("Use of disabled feature: {:?}", error)]
     UnsupportedFeatureError { error: String },
@@ -439,7 +439,7 @@ impl std::convert::From<SubscriberError> for SuiError {
 
 impl From<tonic::Status> for SuiError {
     fn from(status: tonic::Status) -> Self {
-        Self::RpcError(status.message().to_owned())
+        Self::RpcError(status.message().to_owned(), status.code().description())
     }
 }
 


### PR DESCRIPTION
This PR adds a simple retry functionality for calling gateway's transaction building api `transfer_sui`. Also it extends the `RpcError` to include the error code for more info. 


## Context
We started to observe a very strange thing recently:
When running the cluster test  on the CI pipeline (aka the runner) against continuous cluster, gateway always fails `get_object` through aggregators, thus faucet errors out when building Transaction for `transferSui`. 

example error msg:
```
2022-08-12T21:06:29.352719Z ERROR sui_faucet::faucet::simple_faucet: Encountered error in transfer sui: Err(RPC call failed: ErrorObject { code: ServerError(-32000), message: "Too many authority errors were detected for get_object_by_id: [(k#839e99f8b03f0f5563d6cd9cc39e10a8cf483ad2775aecbb927031370925ef4e, RpcError(\"transport error\")), (k#89cafd721eeb1b13483d5fb0968500e78103e8146b45edb30d93781d946d0aeb, RpcError(\"transport error\")), (k#e97638a9e10b9cc46d85b81191a60a6a6fcae63dacd811c07502db9c5cfc55b5, RpcError(\"transport error\"))]", data: None }
```

However when triggering the test locally, it does not have this problem at all.. The interesting part is regardless of where the test harness runs, gateway shouldn't behave differently, not to mention faucet is hit in the same way too. 


We don't see this issue in any other apis such as `execution_transaction`, but probably just because they have retries already
