### PR TITLE
[explorer] Add custom RPC validation and localStorage persistence

### DIFF
--- a/explorer/client/src/components/network/Network.module.css
+++ b/explorer/client/src/components/network/Network.module.css
@@ -39,6 +39,10 @@ div.active {
     @apply bg-offblack text-offwhite border-green-500 border-solid font-mono;
 }
 
+.opennetworkdetails > div > input.invalid {
+    @apply border-red-500;
+}
+
 .remove {
     @apply hidden;
 }

--- a/explorer/client/src/components/network/Network.tsx
+++ b/explorer/client/src/components/network/Network.tsx
@@ -29,8 +29,10 @@ export default function NetworkSelect() {
 
     const openInput = useCallback(() => {
         setIsOpenInput(true);
-        setNetwork(customRPC);
-    }, [setIsOpenInput, setNetwork, customRPC]);
+        if (customRPCIsValid) {
+            setNetwork(customRPC);
+        }
+    }, [setIsOpenInput, setNetwork, customRPC, customRPCIsValid]);
 
     const chooseNetwork = useCallback(
         (specified: Network | string) => () => {

--- a/explorer/client/src/components/network/Network.tsx
+++ b/explorer/client/src/components/network/Network.tsx
@@ -4,8 +4,8 @@
 import { useCallback, useContext, useState } from 'react';
 
 import { ReactComponent as DownSVG } from '../../assets/Down.svg';
-import { NetworkContext } from '../../context';
-import { Network, getEndpoint } from '../../utils/api/DefaultRpcClient';
+import { NetworkContext, useCustomRPC } from '../../context';
+import { Network } from '../../utils/api/DefaultRpcClient';
 import {
     IS_STATIC_ENV,
     IS_LOCAL_ENV,
@@ -19,6 +19,8 @@ export default function NetworkSelect() {
     const [isModuleOpen, setModuleOpen] = useState(false);
     const [isOpenInput, setIsOpenInput] = useState(false);
 
+    const { customRPC, setCustomRPC, customRPCIsValid } = useCustomRPC();
+
     const openModal = useCallback(
         () => (isModuleOpen ? setModuleOpen(false) : setModuleOpen(true)),
         [isModuleOpen, setModuleOpen]
@@ -27,8 +29,8 @@ export default function NetworkSelect() {
 
     const openInput = useCallback(() => {
         setIsOpenInput(true);
-        setNetwork(getEndpoint(Network.Local));
-    }, [setIsOpenInput, setNetwork]);
+        setNetwork(customRPC);
+    }, [setIsOpenInput, setNetwork, customRPC]);
 
     const chooseNetwork = useCallback(
         (specified: Network | string) => () => {
@@ -41,9 +43,13 @@ export default function NetworkSelect() {
     );
 
     const handleTextChange = useCallback(
-        (e: React.ChangeEvent<HTMLInputElement>) =>
-            setNetwork(e.currentTarget.value),
-        [setNetwork]
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            setCustomRPC(e.currentTarget.value);
+            if (customRPCIsValid) {
+                setNetwork(e.currentTarget.value);
+            }
+        },
+        [customRPCIsValid, setNetwork, setCustomRPC]
     );
     const networkStyle = (iconNetwork: Network | 'other') =>
         // Button text matches network or
@@ -116,8 +122,11 @@ export default function NetworkSelect() {
                         {isOpenInput && (
                             <input
                                 type="text"
-                                value={network}
+                                value={customRPC}
                                 onChange={handleTextChange}
+                                className={
+                                    !customRPCIsValid ? styles.invalid : ''
+                                }
                             />
                         )}
                     </div>

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -90,11 +90,11 @@ export async function genFileTypeMsg(
         });
 }
 
-/* Currently unused but potentially useful:
- *
- * export const isValidHttpUrl = (url: string) => {
- *     try { new URL(url) }
- *         catch (e) { return false }
- *             return /^https?/.test(url);
- *             };
- */
+export function isValidHttpUrl(url: string) {
+    try {
+        new URL(url);
+    } catch (e) {
+        return false;
+    }
+    return /^https?/.test(url);
+}


### PR DESCRIPTION
Currently, the Custom RPC URL interaction is a bit awkward after a page refresh. When a Custom RPC URL is currently selected and a page refresh happens, the last URL is pulled from localStorage as expected. 

If you then navigate to Custom RPC URL again, this is reset to localhost and the previously entered Custom RPC URL is cleared out. I feel like a better behavior would be for the previously entered Custom RPC URL to be populated.

I also added validation to the Custom RPC URL field. 