### PR TITLE
[explorer] #3902 display type arguments on transaction details page

### DIFF
--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -112,6 +112,10 @@ function formatByTransactionKind(
                     value: moveCall.arguments,
                     list: true,
                 },
+                typeArguments: {
+                    value: moveCall.typeArguments,
+                    list: true,
+                },
             };
         case 'Publish':
             const publish = getPublishTransaction(data)!;
@@ -286,6 +290,15 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                   ],
               }
             : false;
+
+    if (typearguments && txKindData.typeArguments?.value) {
+        typearguments.content.push({
+            label: 'Type Arguments',
+            monotypeClass: true,
+            value: JSON.stringify(txKindData.typeArguments.value),
+        });
+    }
+
     const defaultActiveTab = 0;
 
     const modules =


### PR DESCRIPTION
**Problem**

Type Arguments aren't displayed under Call transactions on the transaction details pages

**Summary of Changes**

Conditionally display type arguments on transaction detail pages

![image](https://user-images.githubusercontent.com/188792/184556043-3c36c356-d7d0-44c1-993f-165bac4d8def.png)

Fixes #3902 