### PR TITLE
[explorer] format addresses as links in arguments details (prototype)

### DIFF
--- a/explorer/client/src/pages/transaction-result/TransactionResult.module.css
+++ b/explorer/client/src/pages/transaction-result/TransactionResult.module.css
@@ -62,6 +62,10 @@
     @apply break-all font-mono text-sm text-sui-dark;
 }
 
+.itemviewcontent .itemviewcontentitem span.formattedArguments {
+    @apply text-sui-grey-100;
+}
+
 @media (min-width: 40em) {
     .itemviewcontent .itemviewcontentitem {
         grid-template-columns: 1fr 5fr;

--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -13,6 +13,7 @@ import {
     getTransferSuiTransaction,
 } from '@mysten/sui.js';
 import cl from 'classnames';
+import { Link } from 'react-router-dom';
 
 import Longtext from '../../components/longtext/Longtext';
 import ModulesWrapper from '../../components/module/ModulesWrapper';
@@ -111,6 +112,7 @@ function formatByTransactionKind(
                 arguments: {
                     value: moveCall.arguments,
                     list: true,
+                    formatArguments: true,
                 },
             };
         case 'Publish':
@@ -142,10 +144,31 @@ type TxItemView = {
         label?: string | number | any;
         value: string | number;
         link?: boolean;
+        formatArguments?: boolean;
         category?: string;
         monotypeClass?: boolean;
     }[];
 };
+
+function FormatArguments({ value }: { value: string }): JSX.Element {
+    const matchAddress = /(0x[a-f0-9]*)/;
+    const split = value.split(matchAddress);
+    return (
+        <>
+            {split.map((value, index) =>
+                value.match(matchAddress) ? (
+                    <Link to={`/addresses/${value}`} key={index}>
+                        {value}
+                    </Link>
+                ) : (
+                    <span key={index} className={styles.formattedArguments}>
+                        {value}
+                    </span>
+                )
+            )}
+        </>
+    );
+}
 
 function ItemView({ data }: { data: TxItemView }) {
     return (
@@ -177,6 +200,10 @@ function ItemView({ data }: { data: TxItemView }) {
                                         text={item.value as string}
                                         category={item.category as Category}
                                         isLink={true}
+                                    />
+                                ) : item.formatArguments ? (
+                                    <FormatArguments
+                                        value={item.value as string}
                                     />
                                 ) : (
                                     item.value
@@ -281,6 +308,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                       {
                           label: 'Argument',
                           monotypeClass: true,
+                          formatArguments: true,
                           value: JSON.stringify(txKindData.arguments.value),
                       },
                   ],

--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -151,7 +151,7 @@ type TxItemView = {
 };
 
 function FormatArguments({ value }: { value: string }): JSX.Element {
-    const matchAddress = /(0x[a-f0-9]*)/;
+    const matchAddress = /(0x[a-f0-9]{40})/;
     const split = value.split(matchAddress);
     return (
         <>


### PR DESCRIPTION
**Problem**
It would be cool if addresses in arguments were links. This could also be applied to other link categories too.

**Summary of Changes**
Format addresses as links in stringified arguments list.

![image](https://user-images.githubusercontent.com/188792/184557762-7aa5149e-6ab5-4015-9a56-1a143e7db2c0.png)
