### PR TITLE
[explorer] Fix GA through cookieconsent

### DIFF
--- a/explorer/client/src/components/cookies-consent/CookiesConsent.tsx
+++ b/explorer/client/src/components/cookies-consent/CookiesConsent.tsx
@@ -32,11 +32,8 @@ export function CookiesConsent() {
                         transition: 'slide',
                     },
                 },
-                // @ts-expect-error no types
-                onAccept: function (cookie: {
-                    level: ('necessary' | 'analytics')[];
-                }) {
-                    if (cookie?.level?.includes('analytics')) {
+                onAccept(cookie) {
+                    if (cookie.categories.includes('analytics')) {
                         loadAndEnableAnalytics();
                     }
                 },


### PR DESCRIPTION
There was a breaking change in a minor release of `cookieconsent`, which cased a few issues, this being one of them. This unfortunately wasn't caught by TypeScript because of the `ts-expect-error` before the line.