### PR TITLE
[sui-test-validator] Improve sui-test-validator for usage with explorer / wallet

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -149,15 +149,26 @@ impl Cluster for LocalNewCluster {
         // Let the faucet account hold 1000 gas objects on genesis
         let genesis_config = GenesisConfig::custom_genesis(4, 1, 1000);
 
-        let port = options.gateway_address.as_ref().map(|addr| {
+        let gateway_port = options.gateway_address.as_ref().map(|addr| {
             addr.parse::<SocketAddr>()
                 .expect("Unable to parse gateway address")
                 .port()
         });
 
-        let mut test_network = start_rpc_test_network_with_fullnode(Some(genesis_config), 1, port)
-            .await
-            .unwrap_or_else(|e| panic!("Failed to start a local network, e: {e}"));
+        let fullnode_port = options.fullnode_address.as_ref().map(|addr| {
+            addr.parse::<SocketAddr>()
+                .expect("Unable to parse fullnode address")
+                .port()
+        });
+
+        let mut test_network = start_rpc_test_network_with_fullnode(
+            Some(genesis_config),
+            1,
+            gateway_port,
+            fullnode_port,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Failed to start a local network, e: {e}"));
 
         // Use the wealthy account for faucet
         let faucet_key = test_network

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use futures::future::try_join_all;
 use rand::rngs::OsRng;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::{
     mem, ops,
@@ -24,6 +25,7 @@ pub struct SwarmBuilder<R = OsRng> {
     committee_size: NonZeroUsize,
     initial_accounts_config: Option<GenesisConfig>,
     fullnode_count: usize,
+    fullnode_rpc_addr: Option<SocketAddr>
 }
 
 impl SwarmBuilder {
@@ -35,6 +37,7 @@ impl SwarmBuilder {
             committee_size: NonZeroUsize::new(1).unwrap(),
             initial_accounts_config: None,
             fullnode_count: 0,
+            fullnode_rpc_addr: None,
         }
     }
 }
@@ -47,6 +50,7 @@ impl<R> SwarmBuilder<R> {
             committee_size: self.committee_size,
             initial_accounts_config: self.initial_accounts_config,
             fullnode_count: self.fullnode_count,
+            fullnode_rpc_addr: self.fullnode_rpc_addr,
         }
     }
 
@@ -75,6 +79,11 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_fullnode_count(mut self, fullnode_count: usize) -> Self {
         self.fullnode_count = fullnode_count;
+        self
+    }
+
+    pub fn with_fullnode_rpc_addr(mut self, fullnode_rpc_addr: SocketAddr) -> Self {
+        self.fullnode_rpc_addr = Some(fullnode_rpc_addr);
         self
     }
 }
@@ -109,7 +118,10 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> SwarmBuilder<R> {
 
         if self.fullnode_count > 0 {
             (0..self.fullnode_count).for_each(|_| {
-                let config = network_config.generate_fullnode_config();
+                let mut config = network_config.generate_fullnode_config();
+                if let Some(fullnode_rpc_addr) = self.fullnode_rpc_addr {
+                    config.json_rpc_address = fullnode_rpc_addr;
+                }
                 fullnodes.insert(config.sui_address(), Node::new(config));
             });
         }

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -25,7 +25,7 @@ pub struct SwarmBuilder<R = OsRng> {
     committee_size: NonZeroUsize,
     initial_accounts_config: Option<GenesisConfig>,
     fullnode_count: usize,
-    fullnode_rpc_addr: Option<SocketAddr>
+    fullnode_rpc_addr: Option<SocketAddr>,
 }
 
 impl SwarmBuilder {

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -25,13 +25,18 @@ struct Args {
     // /// Config directory that will be used to store network configuration
     // #[clap(short, long, parse(from_os_str), value_hint = ValueHint::DirPath)]
     // config: Option<std::path::PathBuf>,
+
     /// Port to start the Gateway RPC server on
     #[clap(long, default_value = "5001")]
     gateway_rpc_port: u16,
 
-    // Port to start the Sui faucet on
-    #[clap(long)]
-    faucet_port: Option<u16>,
+    /// Port to start the Fullnode RPC server on
+    #[clap(long, default_value = "9000")]
+    fullnode_rpc_port: u16,
+
+    /// Port to start the Sui faucet on
+    #[clap(long, default_value = "9123")]
+    faucet_port: u16,
 }
 
 #[tokio::main]
@@ -41,26 +46,15 @@ async fn main() -> Result<()> {
     let cluster = LocalNewCluster::start(&ClusterTestOpt {
         env: Env::NewLocal,
         gateway_address: Some(format!("127.0.0.1:{}", args.gateway_rpc_port)),
-        fullnode_address: None,
+        fullnode_address: Some(format!("127.0.0.1:{}", args.fullnode_rpc_port)),
         faucet_address: None,
     })
     .await?;
 
+    println!("Fullnode RPC URL: {}", cluster.fullnode_url());
     println!("Gateway RPC URL: {}", cluster.rpc_url());
 
-    if let Some(faucet_port) = args.faucet_port {
-        start_faucet(&cluster, faucet_port).await?;
-    } else {
-        // Perform health checks to keep the service running:
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
-        loop {
-            for node in cluster.swarm().validators() {
-                node.health_check().await.unwrap();
-            }
-
-            interval.tick().await;
-        }
-    }
+    start_faucet(&cluster, args.faucet_port).await?;
 
     Ok(())
 }
@@ -93,7 +87,7 @@ async fn start_faucet(cluster: &LocalNewCluster, port: u16) -> Result<()> {
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
 
-    println!("Faucet listening on http://{}", addr);
+    println!("Faucet URL: http://{}", addr);
 
     axum::Server::bind(&addr)
         .serve(app.into_make_service())

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -25,7 +25,6 @@ struct Args {
     // /// Config directory that will be used to store network configuration
     // #[clap(short, long, parse(from_os_str), value_hint = ValueHint::DirPath)]
     // config: Option<std::path::PathBuf>,
-
     /// Port to start the Gateway RPC server on
     #[clap(long, default_value = "5001")]
     gateway_rpc_port: u16,

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -33,16 +33,21 @@ const NUM_VALIDAOTR: usize = 4;
 pub async fn start_test_network(
     genesis_config: Option<GenesisConfig>,
 ) -> Result<Swarm, anyhow::Error> {
-    start_test_network_with_fullnodes(genesis_config, 0).await
+    start_test_network_with_fullnodes(genesis_config, 0, None).await
 }
 
 pub async fn start_test_network_with_fullnodes(
     genesis_config: Option<GenesisConfig>,
     fullnode_count: usize,
+    fullnode_port: Option<u16>,
 ) -> Result<Swarm, anyhow::Error> {
     let mut builder: SwarmBuilder = Swarm::builder()
         .committee_size(NonZeroUsize::new(NUM_VALIDAOTR).unwrap())
         .with_fullnode_count(fullnode_count);
+    if let Some(fullnode_port) = fullnode_port {
+        builder =
+            builder.with_fullnode_rpc_addr(format!("127.0.0.1:{}", fullnode_port).parse().unwrap());
+    }
     if let Some(genesis_config) = genesis_config {
         builder = builder.initial_accounts_config(genesis_config);
     }
@@ -132,15 +137,17 @@ async fn start_rpc_gateway(
 pub async fn start_rpc_test_network(
     genesis_config: Option<GenesisConfig>,
 ) -> Result<TestNetwork, anyhow::Error> {
-    start_rpc_test_network_with_fullnode(genesis_config, 0, None).await
+    start_rpc_test_network_with_fullnode(genesis_config, 0, None, None).await
 }
 
 pub async fn start_rpc_test_network_with_fullnode(
     genesis_config: Option<GenesisConfig>,
     fullnode_count: usize,
     gateway_port: Option<u16>,
+    fullnode_port: Option<u16>,
 ) -> Result<TestNetwork, anyhow::Error> {
-    let network = start_test_network_with_fullnodes(genesis_config, fullnode_count).await?;
+    let network =
+        start_test_network_with_fullnodes(genesis_config, fullnode_count, fullnode_port).await?;
     let working_dir = network.dir();
     let (server_addr, rpc_server_handle) =
         start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG), gateway_port).await?;


### PR DESCRIPTION
This adds support for configuring the fullnode RPC port when booting the `sui-test-validator`, and defaults it to port `9000` to mirror other local dev environments. I also defaulted the faucet port to `9123`, so that the command is more useful with no configuration needed.