### PR TITLE
[explorer] #3611 show address view by default if object id dne

### DIFF
--- a/explorer/client/src/utils/api/searchUtil.ts
+++ b/explorer/client/src/utils/api/searchUtil.ts
@@ -12,6 +12,8 @@ export const navigateWithUnknown = async (
 ) => {
     let searchPromises = [];
 
+    const isSuiAddress = isValidSuiAddress(input);
+
     if (isValidTransactionDigest(input)) {
         searchPromises.push(
             rpc(network)
@@ -26,7 +28,7 @@ export const navigateWithUnknown = async (
     // object IDs and addresses can't be distinguished just by the string, so search both.
     // allow navigating to the standard Move packages at 0x1 & 0x2 as a convenience
     // Get Search results for a given query from both the object and address index
-    else if (isValidSuiAddress(input) || isGenesisLibAddress(input)) {
+    else if (isSuiAddress || isGenesisLibAddress(input)) {
         const addrObjPromise = Promise.allSettled([
             rpc(network)
                 .getObjectsOwnedByAddress(input)
@@ -95,6 +97,12 @@ export const navigateWithUnknown = async (
             })
             //if none of the queries find a result, show missing page
             .catch((error) => {
+                if (isSuiAddress) {
+                    // navigate to empty address page
+                    navigate(`../addresses/${encodeURIComponent(input)}`);
+                    return;
+                }
+
                 // encode url in
                 navigate(`../error/missing/${encodeURIComponent(input)}`);
             })

--- a/explorer/client/src/utils/static/searchUtil.ts
+++ b/explorer/client/src/utils/static/searchUtil.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isValidSuiAddress } from '@mysten/sui.js';
+
 import latestTxData from './latest_transactions.json';
 import mockData from './mock_data.json';
 import mockOwnedObjectData from './owned_object.json';
@@ -13,6 +15,7 @@ const navigateWithUnknown = async (
 ) => {
     const data = findDataFromID(input, false);
     const ownedObjects = findOwnedObjectsfromID(input);
+    const isSuiAddress = isValidSuiAddress(input);
 
     if (data?.category === 'transaction') {
         navigate(`../transactions/${input}`, { state: data });
@@ -20,6 +23,8 @@ const navigateWithUnknown = async (
         navigate(`../objects/${input}`, { state: data });
     } else if (ownedObjects && ownedObjects.length > 0) {
         navigate(`../addresses/${input}`, { state: data });
+    } else if (isSuiAddress) {
+        navigate(`../addresses/${encodeURIComponent(input)}`);
     } else {
         navigate(`../error/missing/${input}`);
     }


### PR DESCRIPTION
**Problem**
Right now the following is shown if a user searches for a 20 bytes string that does not match with the id of any existing objects or a non-empty address. 

![image](https://user-images.githubusercontent.com/188792/184705755-fbe9056b-f8d6-4208-af00-4b61cd1aa39e.png)

**Summary of Changes**
Navigate to empty address page.

Fixes #3611 

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>


> 
> #### What changed
> - Added a check to see if the input is a valid Sui address
> - Added logic to navigate to the empty address page if the input is a valid Sui address
> - Added logic to navigate to the missing page if none of the queries find a result
> 
> #### Impact
> The diff adds logic to navigate to the empty address page if the input is a valid Sui address.
> 
> #### Testing
> This diff can be tested by providing a valid Sui address as input and verifying that the user is navigated to the empty address page.
</details>