### PR TITLE
ci: use uncached install for huniq

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,11 +50,10 @@ jobs:
     # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
     #   with:
     #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
-    - name: Install huniq, and cache the binary
-      uses: baptiste0928/cargo-install@v1
+    - name: Install huniq
+      uses: actions-rs/install@v0.1
       with:
         crate: huniq
-        locked: true
     - name: prepare artifact directory
       run: |
         mkdir -p artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,16 +41,25 @@ jobs:
 
   license-check:
     name: license-check
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-ghcloud]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+
       - name: Install cargo-hakari, and cache the binary
-        uses: baptiste0928/cargo-install@v1
+
+        uses: actions-rs/install@v0.1
         with:
           crate: cargo-hakari
-          locked: true
+          version: latest
+          use-tool-cache: true
+
+      #  uses: baptiste0928/cargo-install@v1
+      #  with:
+      #    crate: cargo-hakari
+      #    locked: true
+
       - run: scripts/license_check.sh
       - run: cargo xlint
       - run: |
@@ -74,7 +83,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: cargo test
         run: |
-         cargo nextest run --all-features --profile ci
+          cargo nextest run --all-features --profile ci
       - name: Doctests
         run: |
           cargo test --doc --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,9 +72,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
-      - name: cargo test
+      - name: testing
         run: |
-          cargo nextest run --all-features --profile ci
+          id && ls -la $HOME && ls -la $PWD
+      # TODO(bradh): uncomment this before committing
+      # - name: cargo test
+      #   run: |
+      #    cargo nextest run --all-features --profile ci
       - name: Doctests
         run: |
           cargo test --doc --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,21 +72,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
-
-      - name: testing
+      - name: cargo test
         run: |
-          id && ls -la $HOME && ls -la $PWD
-
-      - name: Install huniq, and cache the binary
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: huniq
-          locked: true
-
-      # TODO(bradh): uncomment this before committing
-      # - name: cargo test
-      #   run: |
-      #    cargo nextest run --all-features --profile ci
+         cargo nextest run --all-features --profile ci
       - name: Doctests
         run: |
           cargo test --doc --all-features
@@ -123,12 +111,11 @@ jobs:
         with:
           components: clippy
 
-      # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo
-      # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-      #   with:
-      #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
+      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+        with:
+          path: ~/.cargo/registry/src/**/librocksdb-sys-*
 
       # See '.cargo/config' for list of enabled/disappled clippy lints
       - name: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
 
   license-check:
     name: license-check
-    runs-on: [ubuntu-ghcloud]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -113,9 +113,9 @@ jobs:
 
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo
-      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-        with:
-          path: ~/.cargo/registry/src/**/librocksdb-sys-*
+      # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+      #   with:
+      #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
 
       # See '.cargo/config' for list of enabled/disappled clippy lints
       - name: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,20 +46,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-
       - name: Install cargo-hakari, and cache the binary
-
-        uses: actions-rs/install@v0.1
+        uses: baptiste0928/cargo-install@v1
         with:
           crate: cargo-hakari
-          version: latest
-          use-tool-cache: true
-
-      #  uses: baptiste0928/cargo-install@v1
-      #  with:
-      #    crate: cargo-hakari
-      #    locked: true
-
+          locked: true
       - run: scripts/license_check.sh
       - run: cargo xlint
       - run: |
@@ -81,11 +72,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
-      - name: Install huniq
-        uses: actions-rs/install@v0.1
-        with:
-          crate: huniq
-
       - name: cargo test
         run: |
           cargo nextest run --all-features --profile ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
+      - name: Install huniq
+        uses: actions-rs/install@v0.1
+        with:
+          crate: huniq
+
       - name: cargo test
         run: |
           cargo nextest run --all-features --profile ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           components: clippy
 
+      # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo
       # - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,9 +72,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
+
       - name: testing
         run: |
           id && ls -la $HOME && ls -la $PWD
+
+      - name: Install huniq, and cache the binary
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: huniq
+          locked: true
+
       # TODO(bradh): uncomment this before committing
       # - name: cargo test
       #   run: |


### PR DESCRIPTION
This works around the current permission issue of pulling the cached huniq. It's not ideal but it only takes 41 seconds to build it so I'm not too worried about it, and it will allow us to have working benchmark builds again.