### PR TITLE
[Typescript SDK] Implement client side transaction data construction for remaining Transaction Kinds

### DIFF
--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -151,10 +151,14 @@ export function isPublishTransaction(obj: any, _argumentName?: string): obj is P
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
-        Array.isArray(obj.compiledModules) &&
-        obj.compiledModules.every((e: any) =>
-            e instanceof Buffer
-        ) &&
+        ((obj.compiledModules !== null &&
+            typeof obj.compiledModules === "object" ||
+            typeof obj.compiledModules === "function") &&
+            typeof obj.compiledModules["__@iterator"] === "function" ||
+            (obj.compiledModules !== null &&
+                typeof obj.compiledModules === "object" ||
+                typeof obj.compiledModules === "function") &&
+            typeof obj.compiledModules["__@iterator"] === "function") &&
         (typeof obj.gasPayment === "undefined" ||
             isTransactionDigest(obj.gasPayment) as boolean) &&
         isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -153,7 +153,7 @@ export function isPublishTransaction(obj: any, _argumentName?: string): obj is P
             typeof obj === "function") &&
         Array.isArray(obj.compiledModules) &&
         obj.compiledModules.every((e: any) =>
-            isTransactionDigest(e) as boolean
+            e instanceof Buffer
         ) &&
         (typeof obj.gasPayment === "undefined" ||
             isTransactionDigest(obj.gasPayment) as boolean) &&

--- a/sdk/typescript/src/index.guard.ts
+++ b/sdk/typescript/src/index.guard.ts
@@ -5,7 +5,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 import { BN } from "bn.js";
 import { Buffer } from "buffer";
 import { Base64DataBuffer } from "./serialization/base64";
@@ -82,7 +82,7 @@ export function isTransferSuiTransaction(obj: any, _argumentName?: string): obj 
         isTransactionDigest(obj.suiObjectId) as boolean &&
         isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean &&
         isTransactionDigest(obj.recipient) as boolean &&
-        (typeof obj.amount === "undefined" ||
+        (obj.amount === null ||
             isSuiMoveTypeParameterIndex(obj.amount) as boolean)
     )
 }
@@ -1125,6 +1125,26 @@ export function isTransferObjectTx(obj: any, _argumentName?: string): obj is Tra
     )
 }
 
+export function isTransferSuiTx(obj: any, _argumentName?: string): obj is TransferSuiTx {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.TransferSui !== null &&
+            typeof obj.TransferSui === "object" ||
+            typeof obj.TransferSui === "function") &&
+        isTransactionDigest(obj.TransferSui.recipient) as boolean &&
+        ((obj.TransferSui.amount !== null &&
+            typeof obj.TransferSui.amount === "object" ||
+            typeof obj.TransferSui.amount === "function") &&
+            isSuiMoveTypeParameterIndex(obj.TransferSui.amount.Some) as boolean ||
+            (obj.TransferSui.amount !== null &&
+                typeof obj.TransferSui.amount === "object" ||
+                typeof obj.TransferSui.amount === "function") &&
+            obj.TransferSui.amount.None === null)
+    )
+}
+
 export function isPublishTx(obj: any, _argumentName?: string): obj is PublishTx {
     return (
         (obj !== null &&
@@ -1246,6 +1266,7 @@ export function isMoveCallTx(obj: any, _argumentName?: string): obj is MoveCallT
 export function isTransaction(obj: any, _argumentName?: string): obj is Transaction {
     return (
         (isTransferObjectTx(obj) as boolean ||
+            isTransferSuiTx(obj) as boolean ||
             isPublishTx(obj) as boolean ||
             isMoveCallTx(obj) as boolean)
     )

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -209,7 +209,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     try {
       const tx = {
         Publish: {
-          modules: t.compiledModules.map(m => Array.from(m)),
+          modules: t.compiledModules as Iterable<Iterable<number>>,
         },
       };
       return await this.constructTransactionData(

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -57,10 +57,27 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
   }
 
   async newTransferSui(
-    _signerAddress: SuiAddress,
-    _t: TransferSuiTransaction
+    signerAddress: SuiAddress,
+    t: TransferSuiTransaction
   ): Promise<Base64DataBuffer> {
-    throw new Error('Not implemented');
+    try {
+      const tx = {
+        TransferSui: {
+          recipient: t.recipient,
+          amount: t.amount == null ? { None: null } : { Some: t.amount },
+        },
+      };
+      return await this.constructTransactionData(
+        tx,
+        t.suiObjectId,
+        t.gasBudget,
+        signerAddress
+      );
+    } catch (err) {
+      throw new Error(
+        `Error constructing a TransferSui transaction: ${err} with args ${t}`
+      );
+    }
   }
 
   async newMoveCall(

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -154,12 +154,7 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
     try {
       const resp = await this.client.requestWithType(
         'sui_publish',
-        [
-          signerAddress,
-          t.compiledModules.map(m => m.toString()),
-          t.gasPayment,
-          t.gasBudget,
-        ],
+        [signerAddress, t.compiledModules, t.gasPayment, t.gasBudget],
         isTransactionBytes,
         this.skipDataValidation
       );

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -154,7 +154,12 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
     try {
       const resp = await this.client.requestWithType(
         'sui_publish',
-        [signerAddress, t.compiledModules, t.gasPayment, t.gasBudget],
+        [
+          signerAddress,
+          t.compiledModules.map(m => m.toString()),
+          t.gasPayment,
+          t.gasBudget,
+        ],
         isTransactionBytes,
         this.skipDataValidation
       );

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -60,7 +60,29 @@ export interface MoveCallTransaction {
 }
 
 export interface PublishTransaction {
-  compiledModules: string[];
+  /**
+   * Transaction type used for publishing Move modules to the Sui.
+   * Should be already compiled using `sui-move`, example:
+   * ```
+   * $ sui move build
+   * $ cat build/project_name/bytecode_modules/module.mv
+   * ```
+   * In JS:
+   *
+   * ```
+   * // If you are using `RpcTxnDataSerializer`, change the following line to
+   * // `let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv', 'base64');`
+   * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv');
+   *
+   * let bytes = Array.from(file);
+   * let modules = [ bytes ];
+   *
+   * // ... publish logic ...
+   * ```
+   *
+   * Each module should be represented as a sequence of bytes.
+   */
+  compiledModules: Buffer[];
   gasPayment?: ObjectId;
   gasBudget: number;
 }

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -23,7 +23,7 @@ export interface TransferSuiTransaction {
   suiObjectId: ObjectId;
   gasBudget: number;
   recipient: SuiAddress;
-  amount?: number;
+  amount: number | null;
 }
 
 export interface MergeCoinTransaction {

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -70,19 +70,20 @@ export interface PublishTransaction {
    * In JS:
    *
    * ```
-   * // If you are using `RpcTxnDataSerializer`, change the following line to
-   * // `let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv', 'base64');`
-   * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv');
+   * // If you are using `RpcTxnDataSerializer`,
+   * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv', 'base64');
+   * let compiledModules = [file.toString()]
    *
-   * let bytes = Array.from(file);
-   * let modules = [ bytes ];
+   * // If you are using `LocalTxnDataSerializer`,
+   * let file = fs.readFileSync('./move/build/project_name/bytecode_modules/module.mv');
+   * let modules = [ Array.from(file) ];
    *
    * // ... publish logic ...
    * ```
    *
    * Each module should be represented as a sequence of bytes.
    */
-  compiledModules: Buffer[];
+  compiledModules: Iterable<string> | Iterable<Iterable<number>>;
   gasPayment?: ObjectId;
   gasBudget: number;
 }

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -7,6 +7,8 @@ import { SuiObjectRef } from './objects';
 
 bcs
   .registerVectorType('vector<u8>', 'u8')
+  .registerVectorType('vector<u64>', 'u64')
+  .registerVectorType('vector<u128>', 'u128')
   .registerVectorType('vector<vector<u8>>', 'vector<u8>')
   .registerAddressType('ObjectID', 20)
   .registerAddressType('SuiAddress', 20)

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -57,6 +57,22 @@ bcs.registerStructType('TransferObjectTx', {
 });
 
 /**
+ * Transaction type used for transferring Sui.
+ */
+export type TransferSuiTx = {
+  TransferSui: {
+    recipient: string;
+    amount: number | null;
+  };
+};
+
+bcs.registerStructType('TransferSuiTx', {
+  recipient: 'SuiAddress',
+  // TODO: figure out how to represent Option<u64> field
+  object_ref: 'u64',
+});
+
+/**
  * Transaction type used for publishing Move modules to the Sui.
  * Should be already compiled using `sui-move`, example:
  * ```

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -62,14 +62,18 @@ bcs.registerStructType('TransferObjectTx', {
 export type TransferSuiTx = {
   TransferSui: {
     recipient: string;
-    amount: number | null;
+    amount: { Some: number } | { None: null };
   };
 };
 
+bcs.registerEnumType('Option<u64>', {
+  None: null,
+  Some: 'u64',
+});
+
 bcs.registerStructType('TransferSuiTx', {
   recipient: 'SuiAddress',
-  // TODO: figure out how to represent Option<u64> field
-  object_ref: 'u64',
+  amount: 'Option<u64>',
 });
 
 /**
@@ -207,12 +211,17 @@ bcs
 
 // ========== TransactionData ===========
 
-export type Transaction = MoveCallTx | PublishTx | TransferObjectTx;
+export type Transaction =
+  | MoveCallTx
+  | PublishTx
+  | TransferObjectTx
+  | TransferSuiTx;
 
 bcs.registerEnumType('Transaction', {
   TransferObject: 'TransferObjectTx',
   Publish: 'PublishTx',
   Call: 'MoveCallTx',
+  TransferSui: 'TransferSuiTx',
 });
 /**
  * Transaction kind - either Batch or Single.


### PR DESCRIPTION
Following https://github.com/MystenLabs/sui/pull/3735, this PR adds local serialization for:
- Publish
- TransferObject
- TransferSui
- SplitCoin
- MergeCoin

## Testing

```
const provider = new JsonRpcProvider(endpoint);
const signerWithProvider = new RawSigner(
      keypair,
      provider,
      new LocalTxnDataSerializer(provider)
);

// Test split coin
const splitTxn = await signerWithProvider.splitCoin({
    coinObjectId: coins[0].objectId,
    splitAmounts: [10],
    gasBudget: 10000,
    gasPayment: coins[1].objectId,
});

console.log("splitTxn", splitTxn);

const coinsAfterSplit = await getCoins(
    signerWithProvider.provider,
    config.defaultAddress
);
console.log("Coins after split/before merge", coinsAfterSplit);

// Test Merge Coin
const mergeTxn = await signerWithProvider.mergeCoin({
    primaryCoin: coins[0].objectId,
    coinToMerge:
    getNewlyCreatedCoinsAfterSplit(splitTxn)![0].reference.objectId,
    gasBudget: 10000,
    gasPayment: coins[1].objectId,
});
console.log("Merge coin txn", mergeTxn);

// Test Transfer Object
const txn = await signerWithProvider.transferObject({
    objectId: coin,
    gasBudget: 10000,
    recipient: config.defaultRecipient,
    gasPayment: gasPayment,
  });
  console.log("Transfer coin txn", txn);

// Test transfer SUI
const txn = await signerWithProvider.transferSui({
    suiObjectId: coin,
    gasBudget: 10000,
    recipient: config.defaultRecipient,
    amount: null,
  });
  console.log("Transfer coin txn", txn);


// Test publish
const bytecode =  await fs.readFile( "/Users/cl/projects/toy-move-packages/simple/build/simple/bytecode_modules/m1.mv" );
const publishTxn = await signer1.publish({compiledModules: [Array.from(bytecode)], gasBudget: 10000, gasPayment:'0x56f6c887069703032242e23d48cf9fd64fc63593' });

```

Verified that transactions are executed successfully