### PR TITLE
[wallet] Add dapp signMessage functionality

### DIFF
--- a/wallet/src/background/Messages.ts
+++ b/wallet/src/background/Messages.ts
@@ -1,0 +1,116 @@
+import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
+import { v4 as uuidV4 } from 'uuid';
+import Browser from 'webextension-polyfill';
+
+import { Window } from './Window';
+
+import type { ContentScriptConnection } from './connections/ContentScriptConnection';
+import type { SignMessageRequest } from '_payloads/messages/SignMessageRequest';
+import type { SignMessageRequestResponse } from '_payloads/messages/ui/SignMessageRequestResponse';
+
+const MESSAGES_STORE_KEY = 'messages';
+
+function openSignMessageWindow(signMessageRequestID: string) {
+    return new Window(
+        Browser.runtime.getURL('ui.html') +
+            `#/sign-message-approval/${encodeURIComponent(
+                signMessageRequestID
+            )}`
+    );
+}
+
+class Messages {
+    private _signMessageResponseMessages =
+        new Subject<SignMessageRequestResponse>();
+
+    async signMessage(
+        message: Uint8Array,
+        connection: ContentScriptConnection
+    ) {
+        const signMessageRequest = this.createSignMessageRequest(
+            message,
+            connection.origin,
+            connection.originFavIcon
+        );
+        await this.storeSignMessageRequest(signMessageRequest);
+        const popUp = openSignMessageWindow(signMessageRequest.id);
+        const popUpClose = (await popUp.show()).pipe(
+            take(1),
+            map<number, false>(() => false)
+        );
+        const signMessageResponseMessage =
+            this._signMessageResponseMessages.pipe(
+                filter(
+                    (msg) => msg.signMessageRequestID === signMessageRequest.id
+                ),
+                take(1)
+            );
+        return lastValueFrom(
+            race(popUpClose, signMessageResponseMessage).pipe(
+                take(1),
+                map(async (response) => {
+                    if (response) {
+                        const { approved, signature } = response;
+                        signMessageRequest.approved = approved;
+                        signMessageRequest.signature = signature;
+                        await this.storeSignMessageRequest(signMessageRequest);
+                        return signature;
+                    }
+                    await this.removeSignMessageRequest(signMessageRequest.id);
+                    throw new Error('Sign Message Request rejected from user');
+                })
+            )
+        );
+    }
+
+    public handleMessage(msg: SignMessageRequestResponse) {
+        this._signMessageResponseMessages.next(msg);
+    }
+
+    private createSignMessageRequest(
+        message: Uint8Array,
+        origin: string,
+        originFavIcon?: string
+    ): SignMessageRequest {
+        return {
+            id: uuidV4(),
+            approved: null,
+            origin,
+            originFavIcon,
+            message,
+            createdDate: new Date().toISOString(),
+        };
+    }
+
+    public async getSignMessageRequests(): Promise<
+        Record<string, SignMessageRequest>
+    > {
+        return (await Browser.storage.local.get({ [MESSAGES_STORE_KEY]: {} }))[
+            MESSAGES_STORE_KEY
+        ];
+    }
+
+    private async saveSignMessageRequests(
+        signMessageRequests: Record<string, SignMessageRequest>
+    ) {
+        await Browser.storage.local.set({
+            [MESSAGES_STORE_KEY]: signMessageRequests,
+        });
+    }
+
+    private async storeSignMessageRequest(
+        signMessageRequest: SignMessageRequest
+    ) {
+        const messages = await this.getSignMessageRequests();
+        messages[signMessageRequest.id] = signMessageRequest;
+        await this.saveSignMessageRequests(messages);
+    }
+
+    private async removeSignMessageRequest(signMessageRequestId: string) {
+        const messages = await this.getSignMessageRequests();
+        delete messages[signMessageRequestId];
+        await this.saveSignMessageRequests(messages);
+    }
+}
+
+export default new Messages();

--- a/wallet/src/background/Messages.ts
+++ b/wallet/src/background/Messages.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
 import { v4 as uuidV4 } from 'uuid';
 import Browser from 'webextension-polyfill';

--- a/wallet/src/background/connections/UiConnection.ts
+++ b/wallet/src/background/connections/UiConnection.ts
@@ -1,8 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import Messages from '../Messages';
 import { Connection } from './Connection';
 import { createMessage } from '_messages';
+import { isGetSignMessageRequests } from '_payloads/messages/ui/GetSignMessageRequests';
+import { isSignMessageRequestResponse } from '_payloads/messages/ui/SignMessageRequestResponse';
 import {
     isGetPermissionRequests,
     isPermissionResponse,
@@ -14,6 +17,8 @@ import Transactions from '_src/background/Transactions';
 
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
+import type { SignMessageRequest } from '_payloads/messages/SignMessageRequest';
+import type { GetSignMessageRequestsResponse } from '_payloads/messages/ui/GetSignMessageRequestsResponse';
 import type { Permission, PermissionRequests } from '_payloads/permissions';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { GetTransactionRequestsResponse } from '_payloads/transactions/ui/GetTransactionRequestsResponse';
@@ -32,9 +37,16 @@ export class UiConnection extends Connection {
             Permissions.handlePermissionResponse(payload);
         } else if (isTransactionRequestResponse(payload)) {
             Transactions.handleMessage(payload);
+        } else if (isSignMessageRequestResponse(payload)) {
+            Messages.handleMessage(payload);
         } else if (isGetTransactionRequests(payload)) {
             this.sendTransactionRequests(
                 Object.values(await Transactions.getTransactionRequests()),
+                id
+            );
+        } else if (isGetSignMessageRequests(payload)) {
+            this.sendSignMessageRequests(
+                Object.values(await Messages.getSignMessageRequests()),
                 id
             );
         }
@@ -61,6 +73,21 @@ export class UiConnection extends Connection {
                 {
                     type: 'get-transaction-requests-response',
                     txRequests,
+                },
+                requestID
+            )
+        );
+    }
+
+    private sendSignMessageRequests(
+        signMessageRequests: SignMessageRequest[],
+        requestID: string
+    ) {
+        this.send(
+            createMessage<GetSignMessageRequestsResponse>(
+                {
+                    type: 'get-sign-message-requests-response',
+                    signMessageRequests,
                 },
                 requestID
             )

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -12,6 +12,8 @@ import type { SuiAddress, MoveCallTransaction } from '@mysten/sui.js';
 import type { Payload } from '_payloads';
 import type { GetAccount } from '_payloads/account/GetAccount';
 import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
+import type { ExecuteSignMessageRequest } from '_payloads/messages/ExecuteSignMessageRequest';
+import type { ExecuteSignMessageResponse } from '_payloads/messages/ExecuteSignMessageResponse';
 import type {
     PermissionType,
     HasPermissionsRequest,
@@ -103,6 +105,16 @@ export class DAppInterface {
                 transactionBytes,
             }),
             (response) => response.result
+        );
+    }
+
+    public signMessage(message: Uint8Array) {
+        return mapToPromise(
+            this.send<ExecuteSignMessageRequest, ExecuteSignMessageResponse>({
+                type: 'execute-sign-message-request',
+                message,
+            }),
+            (response) => response.signature
         );
     }
 

--- a/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -17,7 +17,12 @@ export type PayloadType =
     | 'execute-transaction-response'
     | 'get-transaction-requests'
     | 'get-transaction-requests-response'
-    | 'transaction-request-response';
+    | 'transaction-request-response'
+    | 'execute-sign-message-request'
+    | 'execute-sign-message-response'
+    | 'sign-message-request-response'
+    | 'get-sign-message-requests'
+    | 'get-sign-message-requests-response';
 
 export interface BasePayload {
     type: PayloadType;

--- a/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageRequest.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface ExecuteSignMessageRequest extends BasePayload {
+    type: 'execute-sign-message-request';
+    message: Uint8Array;
+}
+
+export function isExecuteSignMessageRequest(
+    payload: Payload
+): payload is ExecuteSignMessageRequest {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'execute-sign-message-request'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageResponse.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SignaturePubkeyPair } from '@mysten/sui.js';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface ExecuteSignMessageResponse extends BasePayload {
+    type: 'execute-sign-message-response';
+    signature?: SignaturePubkeyPair;
+}
+
+export function isExecuteSignMessageResponse(
+    payload: Payload
+): payload is ExecuteSignMessageResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'execute-sign-message-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { SignaturePubkeyPair } from '@mysten/sui.js';
 
 export type SignMessageRequest = {

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -1,0 +1,11 @@
+import type { SignaturePubkeyPair } from '@mysten/sui.js';
+
+export type SignMessageRequest = {
+    id: string;
+    approved: boolean | null;
+    origin: string;
+    originFavIcon?: string;
+    message: Uint8Array;
+    createdDate: string;
+    signature?: SignaturePubkeyPair;
+};

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequests.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequests.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface GetSignMessageRequests extends BasePayload {
+    type: 'get-sign-message-requests';
+}
+
+export function isGetSignMessageRequests(
+    payload: Payload
+): payload is GetSignMessageRequests {
+    return (
+        isBasePayload(payload) && payload.type === 'get-sign-message-requests'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequestsResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequestsResponse.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SignMessageRequest } from '../SignMessageRequest';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface GetSignMessageRequestsResponse extends BasePayload {
+    type: 'get-sign-message-requests-response';
+    signMessageRequests: SignMessageRequest[];
+}
+
+export function isGetSignMessageRequestsResponse(
+    payload: Payload
+): payload is GetSignMessageRequestsResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'get-sign-message-requests-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/SignMessageRequestResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/SignMessageRequestResponse.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SignaturePubkeyPair } from '@mysten/sui.js';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface SignMessageRequestResponse extends BasePayload {
+    type: 'sign-message-request-response';
+    signMessageRequestID: string;
+    approved: boolean;
+    signature?: SignaturePubkeyPair;
+    error?: string;
+}
+
+export function isSignMessageRequestResponse(
+    payload: Payload
+): payload is SignMessageRequestResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'sign-message-request-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
@@ -4,6 +4,7 @@
 export const ALL_PERMISSION_TYPES = [
     'viewAccount',
     'suggestTransactions',
+    'suggestSignMessages',
 ] as const;
 type AllPermissionsType = typeof ALL_PERMISSION_TYPES;
 export type PermissionType = AllPermissionsType[number];

--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -4,6 +4,7 @@
 import { useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
+import { DappSignMessageApprovalPage } from './pages/dapp-sign-message-approval';
 import { AppType } from './redux/slices/app/AppType';
 import { routes as stakeRoutes } from './staking';
 import { useAppDispatch, useAppSelector } from '_hooks';
@@ -73,6 +74,10 @@ const App = () => {
             </Route>
             <Route path="/connect/:requestID" element={<SiteConnectPage />} />
             <Route path="/tx-approval/:txID" element={<DappTxApprovalPage />} />
+            <Route
+                path="/sign-message-approval/:signMessageRequestID"
+                element={<DappSignMessageApprovalPage />}
+            />
         </Routes>
     );
 };

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
@@ -1,0 +1,10 @@
+.title {
+    align-self: flex-start;
+}
+
+.message {
+    align-self: flex-start;
+    max-width: 320px;
+    overflow-wrap: break-word;
+    overflow-x: auto;
+}

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import Loading from '_components/loading';
+import UserApproveContainer from '_components/user-approve-container';
+import { useAppDispatch, useAppSelector, useInitializedGuard } from '_hooks';
+import {
+    respondToSignMessageRequest,
+    signMessageRequestsSelectors,
+} from '_redux/slices/sign-message-requests';
+
+import type { RootState } from '_redux/RootReducer';
+
+import st from './DappSignMessageApprovalPage.module.scss';
+
+export function DappSignMessageApprovalPage() {
+    const { signMessageRequestID } = useParams();
+    const guardLoading = useInitializedGuard(true);
+    const signMessageRequestLoading = useAppSelector(
+        ({ signMessageRequests }) => !signMessageRequests.initialized
+    );
+    const signMessageRequestSelector = useMemo(
+        () => (state: RootState) =>
+            (signMessageRequestID &&
+                signMessageRequestsSelectors.selectById(
+                    state,
+                    signMessageRequestID
+                )) ||
+            null,
+        [signMessageRequestID]
+    );
+    const signMessageRequest = useAppSelector(signMessageRequestSelector);
+    const loading = guardLoading || signMessageRequestLoading;
+    const dispatch = useAppDispatch();
+
+    const handleOnSubmit = useCallback(
+        async (approved: boolean) => {
+            if (signMessageRequest) {
+                await dispatch(
+                    respondToSignMessageRequest({
+                        approved,
+                        id: signMessageRequest.id,
+                    })
+                );
+            }
+
+            return true;
+        },
+        [dispatch, signMessageRequest]
+    );
+
+    useEffect(() => {
+        if (
+            !loading &&
+            (!signMessageRequest ||
+                (signMessageRequest && signMessageRequest.approved !== null))
+        ) {
+            window.close();
+        }
+    }, [loading, signMessageRequest]);
+
+    return (
+        <Loading loading={loading}>
+            {signMessageRequest && (
+                <UserApproveContainer
+                    title="Sign Message"
+                    approveTitle="Sign Message"
+                    rejectTitle="Reject"
+                    origin={signMessageRequest.origin}
+                    originFavIcon={signMessageRequest.originFavIcon}
+                    onSubmit={handleOnSubmit}
+                >
+                    <h4 className={st.title}>Message</h4>
+                    <pre className={st.message}>
+                        {signMessageRequest.message}
+                    </pre>
+                </UserApproveContainer>
+            )}
+        </Loading>
+    );
+}

--- a/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -21,6 +21,7 @@ import stUserApprove from '_components/user-approve-container/UserApproveContain
 const permissionTypeToTxt: Record<PermissionType, string> = {
     viewAccount: 'View Account',
     suggestTransactions: 'Propose transactions',
+    suggestSignMessages: 'Propose signing of messages',
 };
 
 function SiteConnectPage() {

--- a/wallet/src/ui/app/redux/RootReducer.ts
+++ b/wallet/src/ui/app/redux/RootReducer.ts
@@ -6,6 +6,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import account from './slices/account';
 import app from './slices/app';
 import permissions from './slices/permissions';
+import signMessageRequests from './slices/sign-message-requests';
 import suiObjects from './slices/sui-objects';
 import transactionRequests from './slices/transaction-requests';
 import transactions from './slices/transactions';
@@ -19,6 +20,7 @@ const rootReducer = combineReducers({
     txresults,
     permissions,
     transactionRequests,
+    signMessageRequests,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
+++ b/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Base64DataBuffer, type SignaturePubkeyPair } from '@mysten/sui.js';
+import {
+    createAsyncThunk,
+    createEntityAdapter,
+    createSlice,
+    type EntityState,
+} from '@reduxjs/toolkit';
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { SignMessageRequest } from '_payloads/messages/SignMessageRequest';
+import type { RootState } from '_redux/RootReducer';
+import type { AppThunkConfig } from '_store/thunk-extras';
+
+const signMessageRequestsAdapter = createEntityAdapter<SignMessageRequest>({
+    sortComparer: (a, b) => {
+        const aDate: Date = new Date(a.createdDate);
+        const bDate: Date = new Date(b.createdDate);
+        return aDate.getTime() - bDate.getTime();
+    },
+});
+
+export const respondToSignMessageRequest = createAsyncThunk<
+    {
+        id: string;
+        approved: boolean;
+        signature: SignaturePubkeyPair | null;
+    },
+    { id: string; approved: boolean },
+    AppThunkConfig
+>(
+    'respond-to-sign-message-request',
+    async (
+        { id, approved },
+        { extra: { background, api, keypairVault }, getState }
+    ) => {
+        const state = getState();
+        const signMessageRequest = signMessageRequestsSelectors.selectById(
+            state,
+            id
+        );
+        if (!signMessageRequest) {
+            throw new Error(`SignMessageRequest ${id} not found`);
+        }
+        let signMessageResult: SignaturePubkeyPair | undefined = undefined;
+        let signMessageResultError: string | undefined;
+        if (approved) {
+            const signer = api.getSignerInstance(keypairVault.getKeyPair());
+            try {
+                signMessageResult = await signer.signData(
+                    new Base64DataBuffer(signMessageRequest.message)
+                );
+            } catch (e) {
+                signMessageResultError = (e as Error).message;
+            }
+        }
+        background.sendSignMessageRequestResponse(
+            id,
+            approved,
+            signMessageResult,
+            signMessageResultError
+        );
+        return { id, approved: approved, signature: null };
+    }
+);
+
+type State = EntityState<SignMessageRequest> & {
+    initialized: boolean;
+};
+
+const slice = createSlice({
+    name: 'sign-message-requests',
+    initialState: signMessageRequestsAdapter.getInitialState({
+        initialized: false,
+    }),
+    reducers: {
+        setSignMessageRequests: (
+            state,
+            { payload }: PayloadAction<SignMessageRequest[]>
+        ) => {
+            signMessageRequestsAdapter.setAll(state as State, payload);
+            state.initialized = true;
+        },
+    },
+    extraReducers: (build) => {
+        build.addCase(
+            respondToSignMessageRequest.fulfilled,
+            (state, { payload }) => {
+                const { id, signature, approved: allowed } = payload;
+                signMessageRequestsAdapter.updateOne(state as State, {
+                    id,
+                    changes: {
+                        approved: allowed,
+                        signature: signature || undefined,
+                    },
+                });
+            }
+        );
+    },
+});
+
+export default slice.reducer;
+
+export const { setSignMessageRequests } = slice.actions;
+
+export const signMessageRequestsSelectors =
+    signMessageRequestsAdapter.getSelectors(
+        (state: RootState) => state.signMessageRequests
+    );


### PR DESCRIPTION
**Problem**

Sui Wallet doesn't yet support the signing of messages sent from a dapp. 

**Summary of Changes**

- Added `signMessage` method to DAppInterface
- Created Sign Message Approval page for popup
- Added message passing flow and redux integration
- Adds additional permission `suggestSignMessages`

![Screenshot from 2022-08-16 20-47-32](https://user-images.githubusercontent.com/188792/185025433-be13ce46-6a1c-45f7-a47e-a15945fbe7d1.png)

![Screenshot from 2022-08-16 20-49-59](https://user-images.githubusercontent.com/188792/185025440-498dd71e-2993-471f-bd4c-9efe4cbf1dc0.png)

Fixes https://github.com/MystenLabs/sui/issues/3832