### PR TITLE
[Explorer] Swaps 'Mutated' label for 'Updated'

### DIFF
--- a/explorer/client/src/pages/transaction-result/TransactionView.tsx
+++ b/explorer/client/src/pages/transaction-result/TransactionView.tsx
@@ -55,7 +55,7 @@ function generateMutatedCreated(tx: TxDataProps) {
         ...(tx.mutated?.length
             ? [
                   {
-                      label: 'Mutated',
+                      label: 'Updated',
                       links: tx.mutated.map((obj) => obj.objectId),
                   },
               ]

--- a/explorer/client/yarn.lock
+++ b/explorer/client/yarn.lock
@@ -1504,9 +1504,17 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@mysten/bcs@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mysten/bcs/-/bcs-0.2.0.tgz#d259b526e7a1b71538603bb51c3d670d571ec4cd"
+  integrity sha512-vSTaazqLo40yQKiTPVMrUdc66CLSlm/nX/l0ip8rtuZk7NCbYV3OhlxQ44rRXbodf+67osAAZyeTmUfkpzNsfQ==
+  dependencies:
+    bn.js "^5.2.1"
+
 "@mysten/sui.js@file:../../sdk/typescript":
   version "0.8.0"
   dependencies:
+    "@mysten/bcs" "^0.2.0"
     bn.js "^5.2.0"
     buffer "^6.0.3"
     cross-fetch "^3.1.5"
@@ -3114,7 +3122,7 @@ bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-bn.js@^5.2.0:
+bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==


### PR DESCRIPTION
This is a quick fix to swap the label 'Mutated' for the preferred label of 'Updated'.

Before:
![image](https://user-images.githubusercontent.com/11377188/185084620-0864a696-930d-41b4-93f5-5fee833d254d.png)

After:
![image](https://user-images.githubusercontent.com/11377188/185084700-67bd26ee-8007-4c6d-80d7-3ac05880da7a.png)
