### PR TITLE
crypto: Add keytool generate with flag

### DIFF
--- a/crates/sui-sdk/src/crypto.rs
+++ b/crates/sui-sdk/src/crypto.rs
@@ -4,6 +4,7 @@
 // TODO: Remove usage of rand::rngs::adapter::ReadRng.
 #![allow(deprecated)]
 
+use anyhow::anyhow;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use signature::Signer;
@@ -21,7 +22,8 @@ use rand::rngs::adapter::ReadRng;
 
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
-    get_key_pair_from_rng, EncodeDecodeBase64, PublicKey, Signature, SuiKeyPair,
+    get_key_pair_from_rng, random_key_pair_by_type_from_rng, EncodeDecodeBase64, PublicKey,
+    Signature, SuiKeyPair,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -106,7 +108,7 @@ impl FileBasedKeystore {
                     key.map(|k| (Into::<SuiAddress>::into(&k.public()), k))
                 })
                 .collect::<Result<BTreeMap<_, _>, _>>()
-                .map_err(|_| anyhow::anyhow!("Invalid Keypair file"))?
+                .map_err(|e| anyhow::anyhow!("Invalid Keypair file {:#?} {:?}", e, path))?
         } else {
             BTreeMap::new()
         };
@@ -152,14 +154,21 @@ impl SuiKeystore {
         self.0.add_key(keypair)
     }
 
-    pub fn generate_new_key(&mut self) -> Result<(SuiAddress, String), anyhow::Error> {
+    pub fn generate_new_key(
+        &mut self,
+        key_scheme: Option<String>,
+    ) -> Result<(SuiAddress, String, u8), anyhow::Error> {
         let mnemonic = Mnemonic::generate(12)?;
         let seed = mnemonic.to_seed("");
         let mut rng = RngWrapper(ReadRng::new(&seed));
-        // TODO(joyqvq): add ability to generate as Secp256k1 keypair
-        let (address, kp) = get_key_pair_from_rng(&mut rng);
-        self.0.add_key(SuiKeyPair::Ed25519SuiKeyPair(kp))?;
-        Ok((address, mnemonic.to_string()))
+        match random_key_pair_by_type_from_rng(key_scheme, &mut rng) {
+            Ok((address, kp)) => {
+                let flag = kp.public().flag();
+                self.0.add_key(kp)?;
+                Ok((address, mnemonic.to_string(), flag))
+            }
+            Err(e) => Err(anyhow!("error generating key {:?}", e)),
+        }
     }
 
     pub fn keys(&self) -> Vec<PublicKey> {
@@ -174,13 +183,20 @@ impl SuiKeystore {
         KeystoreSigner::new(&*self.0, signer)
     }
 
-    pub fn import_from_mnemonic(&mut self, phrase: &str) -> Result<SuiAddress, anyhow::Error> {
+    pub fn import_from_mnemonic(
+        &mut self,
+        phrase: &str,
+        key_scheme: Option<String>,
+    ) -> Result<SuiAddress, anyhow::Error> {
         let seed = &Mnemonic::from_str(phrase).unwrap().to_seed("");
         let mut rng = RngWrapper(ReadRng::new(seed));
-        let (address, kp) = get_key_pair_from_rng(&mut rng);
-        // TODO(joyqvq): add ability to import as Secp256k1 keypair
-        self.0.add_key(SuiKeyPair::Ed25519SuiKeyPair(kp))?;
-        Ok(address)
+        match random_key_pair_by_type_from_rng(key_scheme, &mut rng) {
+            Ok((address, kp)) => {
+                self.0.add_key(kp)?;
+                Ok(address)
+            }
+            Err(e) => Err(anyhow!("error getting keypair {:?}", e)),
+        }
     }
 
     pub fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error> {

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -6,20 +6,23 @@ use sha3::{Digest, Sha3_256};
 use tempfile::TempDir;
 
 use sui_sdk::crypto::KeystoreType;
-use sui_types::base_types::{SuiAddress, SUI_ADDRESS_LENGTH};
-
+use sui_types::crypto::SuiSignatureInner;
+use sui_types::{
+    base_types::{SuiAddress, SUI_ADDRESS_LENGTH},
+    crypto::Ed25519SuiSignature,
+};
 #[test]
 fn mnemonic_test() {
     let temp_dir = TempDir::new().unwrap();
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
 
-    let (address, phrase) = keystore.generate_new_key().unwrap();
+    let (address, phrase, flag) = keystore.generate_new_key(None).unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");
     let mut keystore2 = KeystoreType::File(keystore_path_2).init().unwrap();
-    let imported_address = keystore2.import_from_mnemonic(&phrase).unwrap();
-
+    let imported_address = keystore2.import_from_mnemonic(&phrase, None).unwrap();
+    assert_eq!(flag, Ed25519SuiSignature::SCHEME.flag());
     assert_eq!(address, imported_address);
 }
 
@@ -34,10 +37,11 @@ fn sui_wallet_address_mnemonic_test() -> Result<(), anyhow::Error> {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
 
-    keystore.import_from_mnemonic(phrase).unwrap();
+    keystore.import_from_mnemonic(phrase, None).unwrap();
 
-    // SuiAddress without the key flag.
     let pubkey = keystore.keys()[0].clone();
+    assert_eq!(pubkey.flag(), Ed25519SuiSignature::SCHEME.flag());
+
     let mut hasher = Sha3_256::default();
     hasher.update(pubkey);
     let g_arr = hasher.finalize();

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -188,9 +188,9 @@ pub enum SuiClientCommands {
     #[clap(name = "addresses")]
     Addresses,
 
-    /// Generate new address and keypair.
+    /// Generate new address and keypair, with optional keypair scheme {ed25519 | secp256k1}, default to ed25519.
     #[clap(name = "new-address")]
-    NewAddress,
+    NewAddress { key_scheme: Option<String> },
 
     /// Obtain all objects owned by the address.
     #[clap(name = "objects")]
@@ -407,9 +407,9 @@ impl SuiClientCommands {
                     .await?;
                 SuiClientCommandResult::SyncClientState
             }
-            SuiClientCommands::NewAddress => {
-                let (address, phrase) = context.keystore.generate_new_key()?;
-                SuiClientCommandResult::NewAddress((address, phrase))
+            SuiClientCommands::NewAddress { key_scheme } => {
+                let (address, phrase, flag) = context.keystore.generate_new_key(key_scheme)?;
+                SuiClientCommandResult::NewAddress((address, phrase, flag))
             }
             SuiClientCommands::Gas { address } => {
                 let address = address.unwrap_or(context.active_address()?);
@@ -760,8 +760,11 @@ impl Display for SuiClientCommandResult {
             SuiClientCommandResult::SyncClientState => {
                 writeln!(writer, "Client state sync complete.")?;
             }
-            SuiClientCommandResult::NewAddress((address, recovery_phrase)) => {
-                writeln!(writer, "Created new keypair for address : [{address}]")?;
+            SuiClientCommandResult::NewAddress((address, recovery_phrase, flag)) => {
+                writeln!(
+                    writer,
+                    "Created new keypair for address with flag {flag}: [{address}]"
+                )?;
                 writeln!(writer, "Secret Recovery Phrase : [{recovery_phrase}]")?;
             }
             SuiClientCommandResult::Gas(gases) => {
@@ -929,7 +932,7 @@ pub enum SuiClientCommandResult {
     Addresses(Vec<SuiAddress>),
     Objects(Vec<SuiObjectInfo>),
     SyncClientState,
-    NewAddress((SuiAddress, String)),
+    NewAddress((SuiAddress, String, u8)),
     Gas(Vec<GasCoin>),
     SplitCoin(SuiTransactionResponse),
     MergeCoin(SuiTransactionResponse),

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -400,8 +400,15 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
                 .unwrap_or(&sui_config_dir()?)
                 .join(SUI_KEYSTORE_FILENAME);
             let keystore = KeystoreType::File(keystore_path);
-            let (new_address, phrase) = keystore.init()?.generate_new_key()?;
-            println!("Generated new keypair for address [{new_address}]");
+            println!("Generating keypair ...\n");
+
+            println!("Do you want to generate a secp256k1 keypair instead? [y/N] No will select Ed25519 by default. ");
+            let key_scheme = match read_line()?.trim() {
+                "y" => Some(String::from("secp256k1")),
+                _ => None,
+            };
+            let (new_address, phrase, flag) = keystore.init()?.generate_new_key(key_scheme)?;
+            println!("Generated new keypair for address with flag {flag} [{new_address}]");
             println!("Secret Recovery Phrase : [{phrase}]");
             SuiClientConfig {
                 keystore,


### PR DESCRIPTION
- `sui keytool generate` takes in optional key scheme flag, `sui keytool unpack` should unpack the flag field as well
- `sui client new-address` takes in optional key scheme flag, and store in `sui.keystore`
- import mnemonics can also optionally save the keypair as Secp256k1
![image](https://user-images.githubusercontent.com/108701016/185165110-f1498292-c1e3-4442-b485-a39f023211da.png)

![image](https://user-images.githubusercontent.com/108701016/185174647-a30c01a6-ca91-49ff-a82c-9e3c826a91ea.png)
