### PR TITLE
[TypeScript SDK] Add the option to skip data validation

### DIFF
--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -19,6 +19,11 @@ export type RpcParams = {
   args: Array<any>;
 };
 
+const TYPE_MISMATCH_ERROR =
+  `The response returned from RPC server does not match ` +
+  `the TypeScript definition. This is likely because the SDK version is not ` +
+  `compatible with the RPC server. Please update your SDK version to the latest. `;
+
 export class JsonRpcClient {
   private rpcClient: RpcClient;
 
@@ -90,12 +95,18 @@ export class JsonRpcClient {
     if (isErrorResponse(response)) {
       throw new Error(`RPC Error: ${response.error.message}`);
     } else if (isValidResponse(response)) {
-      if (skipDataValidation || isT(response.result)) return response.result;
-      throw new Error(
-        `RPC Error: result not of expected type. Result received was: ${JSON.stringify(
-          response.result
-        )}`
-      );
+      const expectedSchema = isT(response.result);
+      const errMsg =
+        TYPE_MISMATCH_ERROR +
+        `Result received was: ${JSON.stringify(response.result)}`;
+
+      if (skipDataValidation && !expectedSchema) {
+        console.warn(errMsg);
+        return response.result;
+      } else if (!expectedSchema) {
+        throw new Error(`RPC Error: ${errMsg}`);
+      }
+      return response.result;
     }
     throw new Error(`Unexpected RPC Response: ${response}`);
   }
@@ -124,6 +135,36 @@ export class JsonRpcClient {
         isValidResponse(response) &&
         (skipDataValidation || isT(response.result))
     );
+
+    if (responses.length > validResponses.length) {
+      console.warn(
+        `Batch request contains invalid responses. ${responses.length -
+          validResponses.length} of the ${
+          responses.length
+        } requests has invalid schema.`
+      );
+      const exampleTypeMismatch = responses.find((r: any) => !isT(r.result));
+      const exampleInvalidResponseIndex = responses.findIndex(
+        (r: any) => !isValidResponse(r)
+      );
+      if (exampleTypeMismatch) {
+        console.warn(
+          TYPE_MISMATCH_ERROR +
+            `One example mismatch is: ${JSON.stringify(
+              exampleTypeMismatch.result
+            )}`
+        );
+      }
+      if (exampleInvalidResponseIndex !== -1) {
+        console.warn(
+          `The request ${JSON.stringify(
+            requests[exampleInvalidResponseIndex]
+          )} within a batch request returns an invalid response ${JSON.stringify(
+            responses[exampleInvalidResponseIndex]
+          )}`
+        );
+      }
+    }
 
     return validResponses.map((response: ValidResponse) => response.result);
   }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -45,10 +45,13 @@ export abstract class SignerWithProvider implements Signer {
   constructor(provider?: Provider, serializer?: TxnDataSerializer) {
     this.provider = provider || new VoidProvider();
     let endpoint = '';
+    let skipDataValidation = false;
     if (this.provider instanceof JsonRpcProvider) {
       endpoint = this.provider.endpoint;
+      skipDataValidation = this.provider.skipDataValidation;
     }
-    this.serializer = serializer || new RpcTxnDataSerializer(endpoint);
+    this.serializer =
+      serializer || new RpcTxnDataSerializer(endpoint, skipDataValidation);
   }
 
   /**

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -26,11 +26,18 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
   private client: JsonRpcClient;
 
   /**
-   * Establish a connection to a Sui Gateway endpoint
+   * Establish a connection to a Sui RPC endpoint
    *
-   * @param endpoint URL to the Sui Gateway endpoint
+   * @param endpoint URL to the Sui RPC endpoint
+   * @param skipDataValidation default to `false`. If set to `true`, the rpc
+   * client will not check if the responses from the RPC server conform to the schema
+   * defined in the TypeScript SDK. The mismatches often happen when the SDK
+   * is in a different version than the RPC server. Skipping the validation
+   * can maximize the version compatibility of the SDK, as not all the schema
+   * changes in the RPC response will affect the caller, but the caller needs to
+   * understand that the data may not match the TypeSrcript definitions.
    */
-  constructor(endpoint: string) {
+  constructor(endpoint: string, private skipDataValidation: boolean = false) {
     this.client = new JsonRpcClient(endpoint);
   }
 
@@ -42,7 +49,8 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       const resp = await this.client.requestWithType(
         'sui_transferObject',
         [signerAddress, t.objectId, t.gasPayment, t.gasBudget, t.recipient],
-        isTransactionBytes
+        isTransactionBytes,
+        this.skipDataValidation
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
@@ -58,7 +66,8 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       const resp = await this.client.requestWithType(
         'sui_transferSui',
         [signerAddress, t.suiObjectId, t.gasBudget, t.recipient, t.amount],
-        isTransactionBytes
+        isTransactionBytes,
+        this.skipDataValidation
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
@@ -83,7 +92,8 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
           t.gasPayment,
           t.gasBudget,
         ],
-        isTransactionBytes
+        isTransactionBytes,
+        this.skipDataValidation
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
@@ -105,7 +115,8 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
           t.gasPayment,
           t.gasBudget,
         ],
-        isTransactionBytes
+        isTransactionBytes,
+        this.skipDataValidation
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
@@ -127,7 +138,8 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
           t.gasPayment,
           t.gasBudget,
         ],
-        isTransactionBytes
+        isTransactionBytes,
+        this.skipDataValidation
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
@@ -142,13 +154,9 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
     try {
       const resp = await this.client.requestWithType(
         'sui_publish',
-        [
-          signerAddress,
-          t.compiledModules,
-          t.gasPayment,
-          t.gasBudget,
-        ],
-        isTransactionBytes
+        [signerAddress, t.compiledModules, t.gasPayment, t.gasBudget],
+        isTransactionBytes,
+        this.skipDataValidation
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {

--- a/sdk/typescript/test/rpc/client.test.ts
+++ b/sdk/typescript/test/rpc/client.test.ts
@@ -56,7 +56,18 @@ describe('JSON-RPC Client', () => {
   });
 
   it('requestWithType should succeed if skipDataValidation if true', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     await requestAndValidate(OBJECT_WITH_WRONG_SCHEMA, true);
+    expect(warn).toBeCalledWith(
+      'The response returned from RPC server does not match the TypeScript definition.' +
+        ' This is likely because the SDK version is not compatible with the RPC server.' +
+        ' Please update your SDK version to the latest. Result received was: [{"objectId"' +
+        ':"8dc6a6f70564e29a01c7293a9c03818fda2d049f","version":0,"digest":"CI8Sf+t3Xrt5h9' +
+        'ENlmyR8bbMVfg6df3vSDc08Gbk9/g=","owner":{"AddressOwner1":"0x215592226abfec8d03fb' +
+        'beb8b30eb0d2129c94b0"},"type":"moveObject","previousTransaction":"4RJfkN9SgLYdb0' +
+        'LqxBHh6lfRPicQ8FLJgzi9w2COcTo="}]'
+    );
+    warn.mockReset();
   });
 
   async function requestAndValidate(mockValue: any, skipValidation: boolean) {


### PR DESCRIPTION
The TS-SDK [mirrors](https://github.com/MystenLabs/sui/blob/548564d89992a09a457991c8fa7bbe670e9af60a/sdk/typescript/src/types/objects.ts#L31) the type definitions on the [Rust RPC side](https://github.com/MystenLabs/sui/blob/548564d89992a09a457991c8fa7bbe670e9af60a/crates/sui-json-rpc-types/src/lib.rs#L347), and will do [data validation](https://github.com/MystenLabs/sui/blob/548564d89992a09a457991c8fa7bbe670e9af60a/sdk/typescript/src/providers/json-rpc-provider.ts#L82) to make sure the response received from the RPC server matches what’s defined on the TS side. The pros of data validation is that it will help developers catch the type mismatch at the right layer(e.g., between the SDK and the RPC server), instead of needing to perform type checks themselves again at the application level.


The cons of data validation is that every time we make a change on the RPC server, the old TS-SDK will be incompatible with the new RPC server, e.g., `getObject` request will fail if we change the response schema of `GetObjectResponse`, regardless of whether the DApp uses the changed field or not. Since we are introducing some schema change on a weekly base, the developers need to always make sure they are using the latest version of SDK(for local development), otherwise the SDK would appear to be “unreliable”.


As our API stabilizes, the con will become less of a concern. But in the meanwhile, this PR adds a parameter to disable data validation at the SDK level, which can reduce the impact of breaking changes to the application developers since it’s likely those DApps don’t use the “breaking change” fields at all.