### PR TITLE
Use type system to indicate signatures have been verified

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -29,11 +29,7 @@ use crate::ValidatorProxy;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
-use sui_core::authority_client::NetworkAuthorityClient;
-use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
-use sui_types::messages::{
-    QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
-};
+use sui_types::messages::VerifiedTransaction;
 use tokio::sync::Barrier;
 use tokio::time;
 use tokio::time::Instant;
@@ -334,7 +330,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                 let proxy_clone = proxy.clone();
                                 let start = Arc::new(Instant::now());
                                 let res = proxy
-                                    .execute_transaction(b.0.clone())
+                                    .execute_transaction(b.0.clone().into())
                                     .then(|res| async move  {
                                         match res {
                                             Ok((cert, effects)) => {
@@ -390,7 +386,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                 // TODO: clone committee for each request is not ideal.
                                 let committee_cloned = Arc::new(proxy.clone_committee());
                                 let res = proxy
-                                    .execute_transaction(tx.clone())
+                                    .execute_transaction(tx.clone().into())
                                 .then(|res| async move {
                                     match res {
                                         Ok((cert, effects)) => {

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -29,8 +29,11 @@ use crate::ValidatorProxy;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
-use sui_types::crypto::EmptySignInfo;
-use sui_types::messages::TransactionEnvelope;
+use sui_core::authority_client::NetworkAuthorityClient;
+use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
+use sui_types::messages::{
+    QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
+};
 use tokio::sync::Barrier;
 use tokio::time;
 use tokio::time::Instant;
@@ -119,7 +122,7 @@ struct Stats {
     pub bench_stats: BenchmarkStats,
 }
 
-type RetryType = Box<(TransactionEnvelope<EmptySignInfo>, Box<dyn Payload>)>;
+type RetryType = Box<(VerifiedTransaction, Box<dyn Payload>)>;
 enum NextOp {
     Response(Option<(Duration, Box<dyn Payload>)>),
     Retry(RetryType),

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -143,7 +143,7 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
         match self
             .qd
             .execute_transaction(QuorumDriverRequest {
-                transaction: tx,
+                transaction: tx.verify()?,
                 request_type: QuorumDriverRequestType::WaitForEffectsCert,
             })
             .await?
@@ -261,7 +261,7 @@ impl ValidatorProxy for FullNodeProxy {
             .quorum_driver()
             // We need to use WaitForLocalExecution to make sure objects are updated on FN
             .execute_transaction(
-                tx,
+                tx.verify()?,
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -11,8 +11,8 @@ use futures::future::join_all;
 use std::{path::PathBuf, sync::Arc};
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress},
-    crypto::{get_key_pair, AccountKeyPair, EmptySignInfo},
-    messages::TransactionEnvelope,
+    crypto::{get_key_pair, AccountKeyPair},
+    messages::VerifiedTransaction,
     object::Owner,
 };
 use test_utils::messages::{make_counter_create_transaction, make_counter_increment_transaction};
@@ -40,7 +40,7 @@ impl Payload for SharedCounterTestPayload {
             keypair: self.keypair.clone(),
         })
     }
-    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo> {
+    fn make_transaction(&self) -> VerifiedTransaction {
         make_counter_increment_transaction(
             self.gas.0,
             self.package_ref,

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -90,7 +90,7 @@ pub async fn publish_basics_package(
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("../../sui_programmability/examples/basics");
     let transaction = create_publish_move_package_transaction(gas, path, sender, keypair);
-    let (_, effects) = proxy.execute_transaction(transaction).await.unwrap();
+    let (_, effects) = proxy.execute_transaction(transaction.into()).await.unwrap();
     parse_package_ref(&effects.created()).unwrap()
 }
 
@@ -166,7 +166,7 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
                     sender,
                     &keypair,
                 );
-                if let Ok((_, effects)) = proxy_ref.execute_transaction(transaction).await {
+                if let Ok((_, effects)) = proxy_ref.execute_transaction(transaction.into()).await {
                     let counter_ref = effects.created()[0].0;
                     Box::new(SharedCounterTestPayload {
                         package_ref: self.basics_package_ref.unwrap(),

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -8,8 +8,8 @@ use rand::seq::IteratorRandom;
 
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SuiAddress},
-    crypto::{get_key_pair, AccountKeyPair, EmptySignInfo},
-    messages::TransactionEnvelope,
+    crypto::{get_key_pair, AccountKeyPair},
+    messages::VerifiedTransaction,
     object::Owner,
 };
 
@@ -59,7 +59,7 @@ impl Payload for TransferObjectTestPayload {
             keypairs: self.keypairs.clone(),
         })
     }
-    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo> {
+    fn make_transaction(&self) -> VerifiedTransaction {
         let (gas_obj, _) = self
             .gas
             .iter()

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -7,18 +7,11 @@ use std::{collections::HashMap, fmt};
 
 use sui_types::{
     base_types::{ObjectID, ObjectRef},
-    messages::TransactionEffects,
-    object::{Object, ObjectRead, Owner},
+    object::Owner,
 };
 
 use futures::FutureExt;
-use sui_types::{
-    base_types::SuiAddress,
-    crypto::AccountKeyPair,
-    messages::{
-        QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
-    },
-};
+use sui_types::{base_types::SuiAddress, crypto::AccountKeyPair, messages::VerifiedTransaction};
 use test_utils::messages::make_transfer_sui_transaction;
 use tracing::error;
 
@@ -50,7 +43,7 @@ pub async fn transfer_sui_for_testing(
         keypair,
     );
     proxy
-        .execute_transaction(tx)
+        .execute_transaction(tx.into())
         .map(move |res| match res {
             Ok((_, effects)) => {
                 let minted = effects.created().get(0).unwrap().0;

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -7,13 +7,18 @@ use std::{collections::HashMap, fmt};
 
 use sui_types::{
     base_types::{ObjectID, ObjectRef},
-    crypto::EmptySignInfo,
-    messages::TransactionEnvelope,
-    object::Owner,
+    messages::TransactionEffects,
+    object::{Object, ObjectRead, Owner},
 };
 
 use futures::FutureExt;
-use sui_types::{base_types::SuiAddress, crypto::AccountKeyPair};
+use sui_types::{
+    base_types::SuiAddress,
+    crypto::AccountKeyPair,
+    messages::{
+        QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
+    },
+};
 use test_utils::messages::make_transfer_sui_transaction;
 use tracing::error;
 
@@ -71,7 +76,7 @@ pub trait Payload: Send + Sync {
         new_object: ObjectRef,
         new_gas: ObjectRef,
     ) -> Box<dyn Payload>;
-    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo>;
+    fn make_transaction(&self) -> VerifiedTransaction;
     fn get_object_id(&self) -> ObjectID;
     fn get_workload_type(&self) -> WorkloadType;
 }
@@ -107,7 +112,7 @@ impl Payload for CombinationPayload {
             rng: self.rng,
         })
     }
-    fn make_transaction(&self) -> TransactionEnvelope<EmptySignInfo> {
+    fn make_transaction(&self) -> VerifiedTransaction {
         let curr = self.payloads.get(self.curr_index).unwrap();
         curr.make_transaction()
     }

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -24,7 +24,7 @@ use sui_sdk::SuiClient;
 use sui_types::gas_coin::GasCoin;
 use sui_types::{
     base_types::SuiAddress,
-    messages::{Transaction, TransactionData},
+    messages::{Transaction, TransactionData, VerifiedTransaction},
 };
 use test_case::{
     call_contract_test::CallContractTest, coin_merge_split_test::CoinMergeSplitTest,
@@ -108,7 +108,7 @@ impl TestContext {
 
     /// See `make_transactions_with_wallet_context` for potential caveats
     /// of this helper function.
-    pub async fn make_transactions(&mut self, max_txn_num: usize) -> Vec<Transaction> {
+    pub async fn make_transactions(&mut self, max_txn_num: usize) -> Vec<VerifiedTransaction> {
         make_transactions_with_wallet_context(self.get_wallet_mut(), max_txn_num).await
     }
 
@@ -134,7 +134,7 @@ impl TestContext {
             .get_fullnode_client()
             .quorum_driver()
             .execute_transaction(
-                Transaction::new(txn_data, signature),
+                Transaction::new(txn_data, signature).verify().unwrap(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -140,7 +140,6 @@ pub struct AuthorityMetrics {
     total_certs: IntCounter,
     total_cert_attempts: IntCounter,
     total_effects: IntCounter,
-    signature_errors: IntCounter,
     pub shared_obj_tx: IntCounter,
     tx_already_processed: IntCounter,
     num_input_objs: Histogram,
@@ -229,12 +228,6 @@ impl AuthorityMetrics {
             )
             .unwrap(),
 
-            signature_errors: register_int_counter_with_registry!(
-                "total_signature_errors",
-                "Number of transaction signature errors",
-                registry,
-            )
-            .unwrap(),
             shared_obj_tx: register_int_counter_with_registry!(
                 "num_shared_obj_tx",
                 "Number of transactions involving shared objects",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -59,7 +59,7 @@ use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair};
 use sui_types::messages_checkpoint::{
     AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointRequest, CheckpointRequestType,
-    CheckpointResponse, CheckpointSequenceNumber,
+    CheckpointResponse, CheckpointSequenceNumber, VerifiedCheckpointFragment,
 };
 use sui_types::object::{Owner, PastObjectRead};
 use sui_types::query::TransactionQuery;
@@ -124,7 +124,7 @@ pub const MAX_ITEMS_LIMIT: u64 = 1_000;
 const BROADCAST_CAPACITY: usize = 10_000;
 
 pub(crate) const MAX_TX_RECOVERY_RETRY: u32 = 3;
-type CertTxGuard<'a> = DBTxGuard<'a, CertifiedTransaction>;
+type CertTxGuard<'a> = DBTxGuard<'a, VerifiedCertificate>;
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,
@@ -536,8 +536,8 @@ impl AuthorityState {
 
     async fn handle_transaction_impl(
         &self,
-        transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+        transaction: VerifiedTransaction,
+    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
         let transaction_digest = *transaction.digest();
         // Ensure an idempotent answer.
         // If a transaction was signed in a previous epoch, we should no longer reuse it.
@@ -568,7 +568,7 @@ impl AuthorityState {
         let owned_objects = input_objects.filter_owned_objects();
 
         let signed_transaction =
-            SignedTransaction::new(self.epoch(), transaction, self.name, &*self.secret);
+            VerifiedSignedTransaction::new(self.epoch(), transaction, self.name, &*self.secret);
 
         // Check and write locks, to signed transaction, into the database
         // The call to self.set_transaction_lock checks the lock is not conflicting,
@@ -584,18 +584,13 @@ impl AuthorityState {
     /// Initiate a new transaction.
     pub async fn handle_transaction(
         &self,
-        transaction: Transaction,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+        transaction: VerifiedTransaction,
+    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
         let transaction_digest = *transaction.digest();
         debug!(tx_digest=?transaction_digest, "handle_transaction. Tx data: {:?}", transaction.signed_data.data);
         let _metrics_guard = start_timer(self.metrics.handle_transaction_latency.clone());
 
         self.metrics.tx_orders.inc();
-        // Check the sender's signature.
-        transaction.verify().map_err(|e| {
-            self.metrics.signature_errors.inc();
-            e
-        })?;
 
         let response = self.handle_transaction_impl(transaction).await;
         match response {
@@ -623,7 +618,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub async fn handle_certificate_with_effects<S>(
         &self,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         // NOTE: the caller of this (node_sync) must promise to wait until it
         // knows for sure this tx is finalized, namely, it has seen a
         // CertifiedTransactionEffects or at least f+1 identifical effects
@@ -675,8 +670,8 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub async fn handle_certificate(
         &self,
-        certificate: &CertifiedTransaction,
-    ) -> SuiResult<TransactionInfoResponse> {
+        certificate: &VerifiedCertificate,
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
         let _metrics_guard = start_timer(self.metrics.handle_certificate_latency.clone());
         self.handle_certificate_impl(certificate, false).await
     }
@@ -684,17 +679,17 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub async fn handle_certificate_bypass_validator_halt(
         &self,
-        certificate: &CertifiedTransaction,
-    ) -> SuiResult<TransactionInfoResponse> {
+        certificate: &VerifiedCertificate,
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
         self.handle_certificate_impl(certificate, true).await
     }
 
     #[instrument(level = "trace", skip_all)]
     async fn handle_certificate_impl(
         &self,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         bypass_validator_halt: bool,
-    ) -> SuiResult<TransactionInfoResponse> {
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
         self.metrics.total_cert_attempts.inc();
         if self.is_fullnode() {
             return Err(SuiError::GenericStorageError(
@@ -702,7 +697,7 @@ impl AuthorityState {
             ));
         }
 
-        let tx_digest = certificate.digest();
+        let tx_digest = *certificate.digest();
         debug!(?tx_digest, "handle_confirmation_transaction");
 
         if !certificate.is_system_tx() && self.is_cert_awaiting_sequencing(certificate)? {
@@ -797,9 +792,9 @@ impl AuthorityState {
     async fn process_certificate(
         &self,
         tx_guard: CertTxGuard<'_>,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         mut bypass_validator_halt: bool,
-    ) -> SuiResult<TransactionInfoResponse> {
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
         let digest = *certificate.digest();
         // The cert could have been processed by a concurrent attempt of the same cert, so check if
         // the effects have already been written.
@@ -816,15 +811,6 @@ impl AuthorityState {
             tx_guard.release();
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
-
-        // Check the certificate signatures.
-        let committee = &self.committee.load();
-        tracing::trace_span!("cert_check_signature")
-            .in_scope(|| certificate.verify(committee))
-            .map_err(|e| {
-                self.metrics.signature_errors.inc();
-                e
-            })?;
 
         // Errors originating from prepare_certificate may be transient (failure to read locks) or
         // non-transient (transaction input is invalid, move vm errors). However, all errors from
@@ -900,7 +886,7 @@ impl AuthorityState {
             .batch_size
             .observe(certificate.signed_data.data.kind.batch_size() as f64);
 
-        Ok(TransactionInfoResponse {
+        Ok(VerifiedTransactionInfoResponse {
             signed_transaction: self.database.get_transaction(&digest)?,
             certified_transaction: Some(certificate.clone()),
             signed_effects: Some(signed_effects),
@@ -919,7 +905,7 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     async fn prepare_certificate(
         &self,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         transaction_digest: TransactionDigest,
     ) -> SuiResult<(InnerTemporaryStore, SignedTransactionEffects)> {
         let _metrics_guard = start_timer(self.metrics.prepare_certificate_latency.clone());
@@ -969,12 +955,12 @@ impl AuthorityState {
 
     pub async fn dry_run_transaction(
         &self,
-        transaction: &Transaction,
+        transaction: VerifiedTransaction,
         transaction_digest: TransactionDigest,
     ) -> Result<SuiTransactionEffects, anyhow::Error> {
-        transaction.verify()?;
         let (gas_status, input_objects) =
-            transaction_input_checker::check_transaction_input(&self.database, transaction).await?;
+            transaction_input_checker::check_transaction_input(&self.database, &transaction)
+                .await?;
         let shared_object_refs = input_objects.filter_shared_objects();
 
         let transaction_dependencies = input_objects.transaction_dependencies();
@@ -1002,7 +988,7 @@ impl AuthorityState {
     pub async fn get_tx_info_already_executed(
         &self,
         digest: &TransactionDigest,
-    ) -> SuiResult<Option<TransactionInfoResponse>> {
+    ) -> SuiResult<Option<VerifiedTransactionInfoResponse>> {
         if self.database.effects_exists(digest)? {
             debug!("Transaction {digest:?} already executed");
             Ok(Some(self.make_transaction_info(digest).await?))
@@ -1017,7 +1003,7 @@ impl AuthorityState {
         indexes: &IndexStore,
         seq: TxSequenceNumber,
         digest: &TransactionDigest,
-        cert: &CertifiedTransaction,
+        cert: &VerifiedCertificate,
         effects: &SignedTransactionEffects,
         timestamp_ms: u64,
     ) -> SuiResult {
@@ -1059,7 +1045,7 @@ impl AuthorityState {
         // Load cert and effects.
         let info = self.make_transaction_info(digest).await?;
         let (cert, effects) = match info {
-            TransactionInfoResponse {
+            VerifiedTransactionInfoResponse {
                 certified_transaction: Some(cert),
                 signed_effects: Some(effects),
                 ..
@@ -1083,7 +1069,9 @@ impl AuthorityState {
 
         // Stream transaction
         if let Some(transaction_streamer) = &self.transaction_streamer {
-            transaction_streamer.enqueue((cert, effects.clone())).await;
+            transaction_streamer
+                .enqueue((cert.into(), effects.clone()))
+                .await;
             self.metrics
                 .post_processing_total_tx_added_to_streamer
                 .inc();
@@ -1166,7 +1154,7 @@ impl AuthorityState {
     pub async fn handle_transaction_info_request(
         &self,
         request: TransactionInfoRequest,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
         self.make_transaction_info(&request.transaction_digest)
             .await
     }
@@ -1181,7 +1169,7 @@ impl AuthorityState {
     pub async fn handle_object_info_request(
         &self,
         request: ObjectInfoRequest,
-    ) -> Result<ObjectInfoResponse, SuiError> {
+    ) -> Result<VerifiedObjectInfoResponse, SuiError> {
         let ref_and_digest = match request.request_kind {
             ObjectInfoRequestKind::PastObjectInfo(seq)
             | ObjectInfoRequestKind::PastObjectInfoDebug(seq, _) => {
@@ -1639,7 +1627,7 @@ impl AuthorityState {
     /// downloaded in the execution driver.
     pub fn add_pending_certificates(
         &self,
-        certs: Vec<(TransactionDigest, Option<CertifiedTransaction>)>,
+        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
     ) -> SuiResult<()> {
         self.node_sync_store
             .batch_store_certs(certs.iter().filter_map(|(_, cert_opt)| cert_opt.clone()))?;
@@ -1855,7 +1843,7 @@ impl AuthorityState {
     pub async fn get_transaction(
         &self,
         digest: TransactionDigest,
-    ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
+    ) -> Result<(VerifiedCertificate, TransactionEffects), anyhow::Error> {
         QueryHelpers::get_transaction(&self.database, &digest)
     }
 
@@ -2077,7 +2065,7 @@ impl AuthorityState {
     async fn make_transaction_info(
         &self,
         transaction_digest: &TransactionDigest,
-    ) -> Result<TransactionInfoResponse, SuiError> {
+    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
         self.database
             .get_signed_transaction_info(transaction_digest)
     }
@@ -2098,7 +2086,7 @@ impl AuthorityState {
     pub async fn set_transaction_lock(
         &self,
         mutable_input_objects: &[ObjectRef],
-        signed_transaction: SignedTransaction,
+        signed_transaction: VerifiedSignedTransaction,
     ) -> Result<(), SuiError> {
         self.database
             .lock_and_write_transaction(self.epoch(), mutable_input_objects, signed_transaction)
@@ -2111,7 +2099,7 @@ impl AuthorityState {
     pub(crate) async fn commit_certificate(
         &self,
         inner_temporary_store: InnerTemporaryStore,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         signed_effects: &SignedTransactionEffects,
         notifier_ticket: TransactionNotifierTicket,
     ) -> SuiResult<TxSequenceNumber> {
@@ -2156,7 +2144,7 @@ impl AuthorityState {
     /// Check whether a shared-object certificate has already been given shared-locks.
     pub async fn transaction_shared_locks_exist(
         &self,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
     ) -> SuiResult<bool> {
         let digest = certificate.digest();
         let shared_inputs = certificate.shared_input_objects().map(|(id, _)| id);
@@ -2170,7 +2158,7 @@ impl AuthorityState {
     pub async fn get_transaction_lock(
         &self,
         object_ref: &ObjectRef,
-    ) -> Result<Option<SignedTransaction>, SuiError> {
+    ) -> Result<Option<VerifiedSignedTransaction>, SuiError> {
         self.database
             .get_object_locking_transaction(object_ref)
             .await
@@ -2182,7 +2170,7 @@ impl AuthorityState {
     pub async fn read_certificate(
         &self,
         digest: &TransactionDigest,
-    ) -> Result<Option<CertifiedTransaction>, SuiError> {
+    ) -> Result<Option<VerifiedCertificate>, SuiError> {
         self.database.read_certificate(digest)
     }
 
@@ -2228,7 +2216,7 @@ impl AuthorityState {
 
         // Check the certificate. Remember that Byzantine authorities may input anything into
         // consensus.
-        certificate.verify(&self.committee.load())
+        certificate.verify_signatures(&self.committee.load())
     }
 
     /// Verifies transaction signatures and other data
@@ -2269,7 +2257,7 @@ impl AuthorityState {
                     })?;
             }
             ConsensusTransactionKind::Checkpoint(fragment) => {
-                fragment.verify(&committee).map_err(|err| {
+                fragment.verify_signatures(&committee).map_err(|err| {
                     warn!(
                         "Ignoring malformed fragment (failed to verify) from {}: {:?}",
                         transaction.consensus_output.certificate.header.author, err
@@ -2300,6 +2288,10 @@ impl AuthorityState {
         let tracking_id = transaction.get_tracking_id();
         match transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
+                // Safe because signatures are verified when VerifiedSequencedConsensusTransaction
+                // is constructed.
+                let certificate = VerifiedCertificate::new_unchecked(*certificate);
+
                 if self
                     .checkpoints
                     .lock()
@@ -2318,16 +2310,20 @@ impl AuthorityState {
                 // Schedule the certificate for execution
                 self.add_pending_certificates(vec![(
                     *certificate.digest(),
-                    Some(*certificate.clone()),
+                    Some(certificate.clone()),
                 )])?;
 
                 self.database
-                    .lock_shared_objects(*certificate, consensus_index)
+                    .lock_shared_objects(&certificate, consensus_index)
                     .await?;
 
                 Ok(())
             }
             ConsensusTransactionKind::Checkpoint(fragment) => {
+                // Safe because signatures are verified when VerifiedSequencedConsensusTransaction
+                // is constructed.
+                let fragment = VerifiedCheckpointFragment::new_unchecked(*fragment);
+
                 let cp_seq = fragment.proposer_sequence_number();
                 debug!(
                     ?consensus_index,
@@ -2340,7 +2336,7 @@ impl AuthorityState {
                 let mut checkpoint = self.checkpoints.lock();
                 checkpoint.handle_internal_fragment(
                     consensus_index.index,
-                    *fragment,
+                    fragment,
                     self,
                     &self.committee.load(),
                 )?;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -124,7 +124,7 @@ pub const MAX_ITEMS_LIMIT: u64 = 1_000;
 const BROADCAST_CAPACITY: usize = 10_000;
 
 pub(crate) const MAX_TX_RECOVERY_RETRY: u32 = 3;
-type CertTxGuard<'a> = DBTxGuard<'a, VerifiedCertificate>;
+type CertTxGuard<'a> = DBTxGuard<'a, TrustedCertificate>;
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,
@@ -1654,7 +1654,10 @@ impl AuthorityState {
                     continue;
                 }
 
-                if let Err(e) = self.process_certificate(tx_guard, &cert, false).await {
+                if let Err(e) = self
+                    .process_certificate(tx_guard, &cert.into(), false)
+                    .await
+                {
                     warn!(?digest, "Failed to process in-progress certificate: {e}");
                 }
             } else {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -55,7 +55,7 @@ const LAST_CONSENSUS_INDEX_ADDR: u64 = 0;
 pub struct SuiDataStore<S> {
     /// A write-ahead/recovery log used to ensure we finish fully processing certs after errors or
     /// crashes.
-    pub wal: Arc<DBWriteAheadLog<CertifiedTransaction>>,
+    pub wal: Arc<DBWriteAheadLog<VerifiedCertificate>>,
 
     /// The LockService this store depends on for locking functionality
     lock_service: LockService,
@@ -135,7 +135,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         self.epoch_tables.load()
     }
 
-    pub async fn acquire_tx_guard(&self, cert: &CertifiedTransaction) -> SuiResult<CertTxGuard> {
+    pub async fn acquire_tx_guard(&self, cert: &VerifiedCertificate) -> SuiResult<CertTxGuard> {
         let digest = cert.digest();
         let guard = self.wal.begin_tx(digest, cert).await?;
 
@@ -395,7 +395,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub async fn get_object_locking_transaction(
         &self,
         object_ref: &ObjectRef,
-    ) -> SuiResult<Option<TransactionEnvelope<S>>> {
+    ) -> SuiResult<Option<VerifiedTransactionEnvelope<S>>> {
         let tx_lock = self.lock_service.get_lock(*object_ref).await?.ok_or(
             SuiError::ObjectLockUninitialized {
                 obj_ref: *object_ref,
@@ -434,7 +434,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn read_certificate(
         &self,
         digest: &TransactionDigest,
-    ) -> Result<Option<CertifiedTransaction>, SuiError> {
+    ) -> Result<Option<VerifiedCertificate>, SuiError> {
         self.perpetual_tables
             .certificates
             .get(digest)
@@ -602,7 +602,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         epoch: EpochId,
         owned_input_objects: &[ObjectRef],
-        transaction: TransactionEnvelope<S>,
+        transaction: VerifiedTransactionEnvelope<S>,
     ) -> Result<(), SuiError> {
         let tx_digest = *transaction.digest();
 
@@ -639,7 +639,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub async fn update_state(
         &self,
         inner_temporary_store: InnerTemporaryStore,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         proposed_seq: TxSequenceNumber,
         effects: &TransactionEffectsEnvelope<S>,
         effects_digest: &TransactionEffectsDigest,
@@ -699,7 +699,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         input_objects: InputObjects,
         mutated_objects: BTreeMap<ObjectRef, (Object, WriteKind)>,
-        certificate: CertifiedTransaction,
+        certificate: VerifiedCertificate,
         proposed_seq: TxSequenceNumber,
         effects: TransactionEffectsEnvelope<S>,
         effects_digest: &TransactionEffectsDigest,
@@ -1066,7 +1066,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn remove_shared_objects_locks(
         &self,
         transaction_digest: &TransactionDigest,
-        transaction: &CertifiedTransaction,
+        transaction: &VerifiedCertificate,
     ) -> SuiResult {
         let mut sequenced_to_delete = Vec::new();
         let mut schedule_to_delete = Vec::new();
@@ -1093,7 +1093,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// of that transaction. Used by the nodes, which don't listen to consensus.
     pub fn acquire_shared_locks_from_effects(
         &self,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         effects: &TransactionEffects,
         // Do not remove unused arg - ensures that this function is not called without holding a
         // lock.
@@ -1133,7 +1133,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// Caller is responsible to call consensus_message_processed before this method
     pub async fn lock_shared_objects(
         &self,
-        certificate: CertifiedTransaction,
+        certificate: &VerifiedCertificate,
         consensus_index: ExecutionIndicesWithHash,
     ) -> Result<(), SuiError> {
         // Make an iterator to save the certificate.
@@ -1354,7 +1354,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn get_transaction(
         &self,
         transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<TransactionEnvelope<S>>> {
+    ) -> SuiResult<Option<VerifiedTransactionEnvelope<S>>> {
         let transaction = self.epoch_tables().transactions.get(transaction_digest)?;
         Ok(transaction)
     }
@@ -1362,7 +1362,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn get_certified_transaction(
         &self,
         transaction_digest: &TransactionDigest,
-    ) -> SuiResult<Option<CertifiedTransaction>> {
+    ) -> SuiResult<Option<VerifiedCertificate>> {
         let transaction = self.perpetual_tables.certificates.get(transaction_digest)?;
         Ok(transaction)
     }
@@ -1370,7 +1370,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn multi_get_certified_transaction(
         &self,
         transaction_digests: &[TransactionDigest],
-    ) -> SuiResult<Vec<Option<CertifiedTransaction>>> {
+    ) -> SuiResult<Vec<Option<VerifiedCertificate>>> {
         Ok(self
             .perpetual_tables
             .certificates
@@ -1403,8 +1403,8 @@ impl SuiDataStore<AuthoritySignInfo> {
     pub fn get_signed_transaction_info(
         &self,
         transaction_digest: &TransactionDigest,
-    ) -> Result<TransactionInfoResponse, SuiError> {
-        Ok(TransactionInfoResponse {
+    ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
+        Ok(VerifiedTransactionInfoResponse {
             signed_transaction: self.epoch_tables().transactions.get(transaction_digest)?,
             certified_transaction: self.perpetual_tables.certificates.get(transaction_digest)?,
             signed_effects: self.perpetual_tables.effects.get(transaction_digest)?,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -22,7 +22,7 @@ use typed_store_derive::DBMapUtils;
 pub struct AuthorityEpochTables<S> {
     /// This is map between the transaction digest and transactions found in the `transaction_lock`.
     #[default_options_override_fn = "transactions_table_default_config"]
-    pub(crate) transactions: DBMap<TransactionDigest, TransactionEnvelope<S>>,
+    pub(crate) transactions: DBMap<TransactionDigest, VerifiedTransactionEnvelope<S>>,
 
     /// The pending execution table holds a sequence of transactions that are present
     /// in the certificates table, but may not have yet been executed, and should be executed.
@@ -102,7 +102,7 @@ pub struct AuthorityPerpetualTables<S> {
     /// along with the genesis allows the reconstruction of all other state, and a full sync to this
     /// authority.
     #[default_options_override_fn = "certificates_table_default_config"]
-    pub(crate) certificates: DBMap<TransactionDigest, CertifiedTransaction>,
+    pub(crate) certificates: DBMap<TransactionDigest, VerifiedCertificate>,
 
     /// The map between the object ref of objects processed at all versions and the transaction
     /// digest of the certificate that lead to the creation of this version of the object.

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use sui_storage::default_db_options;
 use sui_types::base_types::{ExecutionDigests, SequenceNumber};
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
+use sui_types::messages::{TrustedCertificate, TrustedTransactionEnvelope};
 use typed_store::rocks::DBMap;
 use typed_store::traits::TypedStoreDebug;
 
@@ -22,7 +23,7 @@ use typed_store_derive::DBMapUtils;
 pub struct AuthorityEpochTables<S> {
     /// This is map between the transaction digest and transactions found in the `transaction_lock`.
     #[default_options_override_fn = "transactions_table_default_config"]
-    pub(crate) transactions: DBMap<TransactionDigest, VerifiedTransactionEnvelope<S>>,
+    pub(crate) transactions: DBMap<TransactionDigest, TrustedTransactionEnvelope<S>>,
 
     /// The pending execution table holds a sequence of transactions that are present
     /// in the certificates table, but may not have yet been executed, and should be executed.
@@ -102,7 +103,7 @@ pub struct AuthorityPerpetualTables<S> {
     /// along with the genesis allows the reconstruction of all other state, and a full sync to this
     /// authority.
     #[default_options_override_fn = "certificates_table_default_config"]
-    pub(crate) certificates: DBMap<TransactionDigest, VerifiedCertificate>,
+    pub(crate) certificates: DBMap<TransactionDigest, TrustedCertificate>,
 
     /// The map between the object ref of objects processed at all versions and the transaction
     /// digest of the certificate that lead to the creation of this version of the object.

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -1000,7 +1000,7 @@ where
     diff_certs.extend(
         existing
             .into_iter()
-            .map(|(digests, cert_opt)| (*digests, cert_opt.unwrap())),
+            .map(|(digests, cert_opt)| (*digests, cert_opt.unwrap().into())),
     );
 
     let downloads: Vec<_> = missing
@@ -1014,7 +1014,8 @@ where
                     .handle_cert_info_request(&digests.transaction, Some(Duration::from_secs(5)))
                     .await?
                     .certified_transaction
-                    .unwrap();
+                    .unwrap()
+                    .into_inner();
                 // TODO: Should we insert the cert to the db?
                 Ok((*digests, cert)) as SuiResult<_>
             }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -968,7 +968,7 @@ where
             .ok_or(SuiError::CertificateNotfound {
                 certificate_digest: tx_digest.transaction,
             })?;
-        diff_certs.insert(*tx_digest, cert);
+        diff_certs.insert(*tx_digest, cert.into());
     }
 
     // These are the transactions that the other node has, so we have to potentially

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashSet, sync::Arc};
-use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::CertifiedTransaction};
+use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::VerifiedCertificate};
 use tracing::{debug, info};
 
 use crate::authority::AuthorityState;
@@ -20,14 +20,14 @@ pub(crate) mod tests;
 pub trait PendCertificateForExecution {
     fn add_pending_certificates(
         &self,
-        certs: Vec<(TransactionDigest, Option<CertifiedTransaction>)>,
+        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
     ) -> SuiResult<()>;
 }
 
 impl PendCertificateForExecution for &AuthorityState {
     fn add_pending_certificates(
         &self,
-        certs: Vec<(TransactionDigest, Option<CertifiedTransaction>)>,
+        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
     ) -> SuiResult<()> {
         AuthorityState::add_pending_certificates(self, certs)
     }
@@ -39,7 +39,7 @@ pub struct PendCertificateForExecutionNoop;
 impl PendCertificateForExecution for PendCertificateForExecutionNoop {
     fn add_pending_certificates(
         &self,
-        _certs: Vec<(TransactionDigest, Option<CertifiedTransaction>)>,
+        _certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
     ) -> SuiResult<()> {
         Ok(())
     }

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -95,7 +95,10 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
         transaction: Transaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let state = self.state.clone();
-        state.handle_transaction(transaction).await
+        state
+            .handle_transaction(transaction.verify().unwrap())
+            .await
+            .map(|r| r.into())
     }
 
     async fn handle_certificate(
@@ -103,7 +106,11 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
         certificate: CertifiedTransaction,
     ) -> Result<TransactionInfoResponse, SuiError> {
         let state = self.state.clone();
-        state.handle_certificate(&certificate).await
+        let certificate = certificate.verify(&self.state.committee.load()).unwrap();
+        state
+            .handle_certificate(&certificate)
+            .await
+            .map(|r| r.into())
     }
 
     async fn handle_account_info_request(
@@ -121,7 +128,10 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
         request: ObjectInfoRequest,
     ) -> Result<ObjectInfoResponse, SuiError> {
         let state = self.state.clone();
-        state.handle_object_info_request(request).await
+        state
+            .handle_object_info_request(request)
+            .await
+            .map(|r| r.into())
     }
 
     /// Handle Object information requests for this account.
@@ -129,7 +139,10 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
         &self,
         request: TransactionInfoRequest,
     ) -> Result<TransactionInfoResponse, SuiError> {
-        self.state.handle_transaction_info_request(request).await
+        self.state
+            .handle_transaction_info_request(request)
+            .await
+            .map(|r| r.into())
     }
 
     /// Handle Batch information requests for this authority.

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -21,7 +21,8 @@ use sui_types::{
     batch::{TxSequenceNumber, UpdateItem},
     error::{SuiError, SuiResult},
     messages::{
-        BatchInfoRequest, BatchInfoResponseItem, TransactionInfoRequest, TransactionInfoResponse,
+        BatchInfoRequest, BatchInfoResponseItem, TransactionInfoRequest,
+        VerifiedTransactionInfoResponse,
     },
 };
 use tap::TapFallible;
@@ -320,7 +321,7 @@ impl GossipDigestHandler {
     async fn process_response(
         state: Arc<AuthorityState>,
         peer_name: AuthorityName,
-        response: TransactionInfoResponse,
+        response: VerifiedTransactionInfoResponse,
     ) -> Result<(), SuiError> {
         if let Some(certificate) = response.certified_transaction {
             let digest = *certificate.digest();

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -13,7 +13,7 @@ use sui_types::{
     base_types::AuthorityName,
     committee::Committee,
     messages::CertifiedTransaction,
-    messages_checkpoint::CheckpointFragment,
+    messages_checkpoint::VerifiedCheckpointFragment,
     waypoint::{GlobalCheckpoint, WaypointError},
 };
 
@@ -50,7 +50,7 @@ pub struct InProgressSpanGraph {
     next_checkpoint: CheckpointSequenceNumber,
 
     /// Fragments that have been used so far.
-    fragments_used: Vec<CheckpointFragment>,
+    fragments_used: Vec<VerifiedCheckpointFragment>,
 
     /// Proposals from each validator seen so far. This is needed to detect potential conflicting
     /// fragments.
@@ -99,14 +99,14 @@ impl InProgressSpanGraph {
 
 #[derive(Clone, Debug)]
 pub struct CompletedSpanGraph {
-    active_links: VecDeque<CheckpointFragment>,
+    active_links: VecDeque<VerifiedCheckpointFragment>,
 }
 
 impl SpanGraph {
     pub fn mew(
         committee: &Committee,
         next_checkpoint: CheckpointSequenceNumber,
-        fragments: &[CheckpointFragment],
+        fragments: &[VerifiedCheckpointFragment],
     ) -> Self {
         let mut span = Self::default();
         for frag in fragments {
@@ -135,7 +135,7 @@ impl SpanGraph {
         &mut self,
         committee: &Committee,
         next_checkpoint: CheckpointSequenceNumber,
-        frag: &CheckpointFragment,
+        frag: &VerifiedCheckpointFragment,
     ) {
         if matches!(&self, Self::Uninitialized) {
             self.initialize(committee, next_checkpoint);

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1230,13 +1230,13 @@ fn set_fragment_reconstruct() {
     let p3 = cps3.set_proposal(committee.epoch).unwrap();
     let p4 = cps4.set_proposal(committee.epoch).unwrap();
 
-    let fragment12 = p1.fragment_with(&p2);
-    let fragment34 = p3.fragment_with(&p4);
+    let fragment12 = p1.fragment_with(&p2).verify(&committee).unwrap();
+    let fragment34 = p3.fragment_with(&p4).verify(&committee).unwrap();
 
     let span = SpanGraph::mew(&committee, 0, &[fragment12.clone(), fragment34.clone()]);
     assert!(!span.is_completed());
 
-    let fragment41 = p4.fragment_with(&p1);
+    let fragment41 = p4.fragment_with(&p1).verify(&committee).unwrap();
     let span = SpanGraph::mew(&committee, 0, &[fragment12, fragment34, fragment41]);
     let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 4);
@@ -1264,7 +1264,7 @@ fn set_fragment_reconstruct_two_components() {
     let p_x = proposals.pop().unwrap();
     let p_y = proposals.pop().unwrap();
 
-    let fragment_xy = p_x.fragment_with(&p_y);
+    let fragment_xy = p_x.fragment_with(&p_y).verify(&committee).unwrap();
 
     let span = SpanGraph::mew(&committee, 0, &[fragment_xy.clone()]);
     assert!(!span.is_completed());
@@ -1274,7 +1274,10 @@ fn set_fragment_reconstruct_two_components() {
 
     while let Some(proposal) = proposals.pop() {
         if !proposals.is_empty() {
-            let fragment_xy = proposal.fragment_with(&proposals[0]);
+            let fragment_xy = proposal
+                .fragment_with(&proposals[0])
+                .verify(&committee)
+                .unwrap();
             fragments.push(fragment_xy);
         }
 
@@ -1314,8 +1317,8 @@ fn set_fragment_reconstruct_two_mutual() {
     let p_x = proposals.pop().unwrap();
     let p_y = proposals.pop().unwrap();
 
-    let fragment_xy = p_x.fragment_with(&p_y);
-    let fragment_yx = p_y.fragment_with(&p_x);
+    let fragment_xy = p_x.fragment_with(&p_y).verify(&committee).unwrap();
+    let fragment_yx = p_y.fragment_with(&p_x).verify(&committee).unwrap();
 
     let span = SpanGraph::mew(&committee, 0, &[fragment_xy, fragment_yx]);
     assert!(!span.is_completed());
@@ -1425,6 +1428,7 @@ fn test_fragment_full_flow() {
     let cps0 = &mut test_objects[0].1;
     let mut all_fragments = Vec::new();
     while let Ok(fragment) = rx.try_recv() {
+        let fragment = fragment.verify(&committee).unwrap();
         all_fragments.push(fragment.clone());
         assert!(cps0
             .handle_internal_fragment(
@@ -1716,7 +1720,7 @@ pub struct TestAuthority {
 pub struct TestSetup {
     pub committee: Committee,
     pub authorities: Vec<TestAuthority>,
-    pub transactions: Vec<sui_types::messages::Transaction>,
+    pub transactions: Vec<sui_types::messages::VerifiedTransaction>,
     pub aggregator: AuthorityAggregator<LocalAuthorityClient>,
 }
 
@@ -1817,6 +1821,7 @@ pub async fn checkpoint_tests_setup(
     let _join = tokio::task::spawn(async move {
         let mut seq = ExecutionIndices::default();
         while let Some(msg) = _rx.recv().await {
+            let msg = msg.verify(&c).unwrap();
             for (authority, cps) in &checkpoint_stores {
                 if notify_noop {
                     if let Err(err) = cps.lock().handle_internal_fragment(

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -26,16 +26,14 @@ use std::{
 use sui_types::messages_checkpoint::CheckpointFragment;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::{
-    committee::Committee,
     error::{SuiError, SuiResult},
-    messages::ConsensusTransaction,
+    messages::{ConsensusTransaction, VerifiedCertificate},
 };
 
 use tap::prelude::*;
 use tokio::time::Instant;
 
 use sui_types::base_types::AuthorityName;
-use sui_types::messages::CertifiedTransaction;
 use tokio::{
     sync::{
         mpsc::{Receiver, Sender},
@@ -208,8 +206,6 @@ impl ConsensusWaiter {
 pub struct ConsensusAdapter {
     /// The network client connecting to the consensus node of this authority.
     consensus_client: TransactionsClient<sui_network::tonic::transport::Channel>,
-    /// The Sui committee information.
-    committee: Committee,
     /// A channel to notify the consensus listener to take action for a transactions.
     tx_consensus_listener: Sender<ConsensusListenerMessage>,
     /// Retries sending a transaction to consensus after this timeout.
@@ -224,7 +220,6 @@ impl ConsensusAdapter {
     /// Make a new Consensus adapter instance.
     pub fn new(
         consensus_address: Multiaddr,
-        committee: Committee,
         tx_consensus_listener: Sender<ConsensusListenerMessage>,
         timeout: Duration,
         opt_metrics: OptArcConsensusAdapterMetrics,
@@ -236,7 +231,6 @@ impl ConsensusAdapter {
         let num_inflight_transactions = Default::default();
         Self {
             consensus_client,
-            committee,
             tx_consensus_listener,
             timeout,
             num_inflight_transactions,
@@ -249,7 +243,7 @@ impl ConsensusAdapter {
     }
 
     /// Check if this authority should submit the transaction to consensus.
-    fn should_submit(_certificate: &CertifiedTransaction) -> bool {
+    fn should_submit(_certificate: &VerifiedCertificate) -> bool {
         // TODO [issue #1647]: Right now every authority submits the transaction to consensus.
         true
     }
@@ -260,15 +254,12 @@ impl ConsensusAdapter {
     pub async fn submit(
         &self,
         authority: &AuthorityName,
-        certificate: &CertifiedTransaction,
+        certificate: &VerifiedCertificate,
     ) -> SuiResult {
-        // Check the Sui certificate (submitted by the user).
-        certificate.verify(&self.committee)?;
-
         // Serialize the certificate in a way that is understandable to consensus (i.e., using
         // bincode) and it certificate to consensus.
         let transaction =
-            ConsensusTransaction::new_certificate_message(authority, certificate.clone());
+            ConsensusTransaction::new_certificate_message(authority, certificate.clone().into());
         let tracking_id = transaction.get_tracking_id();
         let tx_digest = certificate.digest();
         debug!(

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -129,6 +129,8 @@ async fn test_start_epoch_change() {
         sigs,
         &genesis_committee,
     )
+    .unwrap()
+    .verify(&genesis_committee)
     .unwrap();
     assert_eq!(
         state.handle_certificate(&certificate).await.unwrap_err(),

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -14,6 +14,7 @@ use sui_types::crypto::AuthoritySignInfo;
 use sui_types::messages::CertifiedTransaction;
 use sui_types::messages_checkpoint::{
     AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents,
+    VerifiedCheckpointFragment,
 };
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -256,8 +257,10 @@ async fn test_consensus_pause_after_last_fragment() {
             state.checkpoints.lock().set_proposal(0).unwrap()
         })
         .collect();
-    let fragment01 = proposals[0].fragment_with(&proposals[1]);
-    let fragment12 = proposals[1].fragment_with(&proposals[2]);
+    let fragment01 =
+        VerifiedCheckpointFragment::new_unchecked(proposals[0].fragment_with(&proposals[1]));
+    let fragment12 =
+        VerifiedCheckpointFragment::new_unchecked(proposals[1].fragment_with(&proposals[2]));
     let mut index = ExecutionIndices::default();
     states.iter().for_each(|state| {
         // Send the first fragment to every validator, and make sure ater this, none of them

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -5,7 +5,9 @@
 use futures::future::join_all;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -182,6 +184,8 @@ pub struct GatewayState<A> {
     metrics: GatewayMetrics,
     module_cache: SyncModuleCache<ResolverWrapper<GatewayStore>>,
 }
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 impl<A> GatewayState<A> {
     /// Create a new manager which stores its managed addresses at `path`
@@ -608,7 +612,7 @@ where
     async fn set_transaction_lock(
         &self,
         mutable_input_objects: &[ObjectRef],
-        transaction: Transaction,
+        transaction: VerifiedTransaction,
     ) -> Result<(), SuiError> {
         debug!(
             ?mutable_input_objects,
@@ -647,8 +651,8 @@ where
     async fn execute_transaction_impl_inner(
         &self,
         input_objects: InputObjects,
-        transaction: Transaction,
-    ) -> Result<(CertifiedTransaction, CertifiedTransactionEffects), anyhow::Error> {
+        transaction: VerifiedTransaction,
+    ) -> Result<(VerifiedCertificate, CertifiedTransactionEffects), anyhow::Error> {
         // If execute_transaction ever fails due to panic, we should fix the panic and make sure it doesn't.
         // If execute_transaction fails, we should retry the same transaction, and it will
         // properly unlock the objects used in this transaction. In the short term, we will ask the wallet to retry failed transactions.
@@ -721,10 +725,8 @@ where
     /// If success, returns the input objects and owned objects in the input.
     async fn prepare_transaction(
         &self,
-        transaction: &Transaction,
+        transaction: &VerifiedTransaction,
     ) -> SuiResult<(InputObjects, Vec<ObjectRef>)> {
-        transaction.verify()?;
-
         self.sync_input_objects_with_authorities(transaction)
             .await?;
 
@@ -776,9 +778,9 @@ where
     /// Update local object states using newly created certificate and ObjectInfoResponse from the Confirmation step.
     async fn execute_transaction_impl(
         &self,
-        transaction: Transaction,
+        transaction: VerifiedTransaction,
         is_last_retry: bool,
-    ) -> Result<(CertifiedTransaction, CertifiedTransactionEffects), anyhow::Error> {
+    ) -> Result<(VerifiedCertificate, CertifiedTransactionEffects), anyhow::Error> {
         let (input_objects, owned_objects) =
             self.prepare_transaction(&transaction)
                 .await
@@ -808,7 +810,7 @@ where
         let tx = self.store.get_transaction(&digest)?;
         match tx {
             Some(tx) => {
-                self.execute_transaction(tx).await?;
+                self.execute_verified_transaction(tx).await?;
                 Ok(())
             }
             None => {
@@ -1309,6 +1311,97 @@ where
                 version: None,
             })
     }
+
+    fn execute_verified_transaction(
+        &self,
+        tx: VerifiedTransaction,
+    ) -> BoxFuture<'_, Result<SuiTransactionResponse, anyhow::Error>> {
+        async fn inner<A>(
+            _self: &GatewayState<A>,
+            tx: VerifiedTransaction,
+        ) -> Result<SuiTransactionResponse, anyhow::Error>
+        where
+            A: AuthorityAPI + Send + Sync + 'static + Clone,
+        {
+            let tx_kind = tx.signed_data.data.kind.clone();
+            let tx_digest = tx.digest();
+
+            debug!(tx_digest = ?tx_digest, "Received execute_transaction request");
+
+            // Ensure idempotency.
+            let (certificate, effects) =
+                match QueryHelpers::get_transaction(&_self.store, tx_digest) {
+                    Ok((cert, effects)) => (cert, effects),
+                    _ => {
+                        let span = tracing::debug_span!(
+                            "gateway_execute_transaction",
+                            ?tx_digest,
+                            tx_kind = tx.signed_data.data.kind_as_str()
+                        );
+
+                        // Use start_coarse_time() if the below turns out to have a perf impact
+                        let timer = _self.metrics.transaction_latency.start_timer();
+                        let mut res = _self
+                            .execute_transaction_impl(tx.clone(), false)
+                            .instrument(span.clone())
+                            .await;
+                        // NOTE: below only records latency if this completes.
+                        timer.stop_and_record();
+
+                        let mut remaining_retries = MAX_NUM_TX_RETRIES;
+                        while res.is_err() {
+                            if remaining_retries == 0 {
+                                error!(
+                                    num_retries = MAX_NUM_TX_RETRIES,
+                                    ?tx_digest,
+                                    "All transaction retries failed"
+                                );
+                                // Okay to unwrap since we checked that this is an error
+                                return Err(res.unwrap_err());
+                            }
+                            remaining_retries -= 1;
+                            _self.metrics.total_tx_retries.inc();
+
+                            debug!(
+                                remaining_retries,
+                                ?tx_digest,
+                                ?res,
+                                "Retrying failed transaction"
+                            );
+
+                            res = _self
+                                .execute_transaction_impl(tx.clone(), remaining_retries == 0)
+                                .instrument(span.clone())
+                                .await;
+                        }
+
+                        // Okay to unwrap() since we checked that this is Ok
+                        let (certificate, effects) = res.unwrap();
+                        let effects = effects.effects;
+
+                        debug!(?tx_digest, "Transaction succeeded");
+                        (certificate, effects)
+                    }
+                };
+
+            // Create custom response base on the request type
+            let parsed_data = _self
+                .create_parsed_transaction_response(
+                    tx_kind,
+                    certificate.clone().into(),
+                    effects.clone(),
+                )
+                .await?;
+
+            Ok(SuiTransactionResponse {
+                certificate: certificate.try_into()?,
+                effects: SuiTransactionEffects::try_from(effects, &_self.module_cache)?,
+                timestamp_ms: None,
+                parsed_data,
+            })
+        }
+        Box::pin(inner(self, tx))
+    }
 }
 
 #[async_trait]
@@ -1320,77 +1413,8 @@ where
         &self,
         tx: Transaction,
     ) -> Result<SuiTransactionResponse, anyhow::Error> {
-        let tx_kind = tx.signed_data.data.kind.clone();
-        let tx_digest = tx.digest();
-
-        debug!(tx_digest = ?tx_digest, "Received execute_transaction request");
-
-        // Ensure idempotency.
-        let (certificate, effects) = match QueryHelpers::get_transaction(&self.store, tx_digest) {
-            Ok((cert, effects)) => (cert, effects),
-            _ => {
-                let span = tracing::debug_span!(
-                    "gateway_execute_transaction",
-                    ?tx_digest,
-                    tx_kind = tx.signed_data.data.kind_as_str()
-                );
-
-                // Use start_coarse_time() if the below turns out to have a perf impact
-                let timer = self.metrics.transaction_latency.start_timer();
-                let mut res = self
-                    .execute_transaction_impl(tx.clone(), false)
-                    .instrument(span.clone())
-                    .await;
-                // NOTE: below only records latency if this completes.
-                timer.stop_and_record();
-
-                let mut remaining_retries = MAX_NUM_TX_RETRIES;
-                while res.is_err() {
-                    if remaining_retries == 0 {
-                        error!(
-                            num_retries = MAX_NUM_TX_RETRIES,
-                            ?tx_digest,
-                            "All transaction retries failed"
-                        );
-                        // Okay to unwrap since we checked that this is an error
-                        return Err(res.unwrap_err());
-                    }
-                    remaining_retries -= 1;
-                    self.metrics.total_tx_retries.inc();
-
-                    debug!(
-                        remaining_retries,
-                        ?tx_digest,
-                        ?res,
-                        "Retrying failed transaction"
-                    );
-
-                    res = self
-                        .execute_transaction_impl(tx.clone(), remaining_retries == 0)
-                        .instrument(span.clone())
-                        .await;
-                }
-
-                // Okay to unwrap() since we checked that this is Ok
-                let (certificate, effects) = res.unwrap();
-                let effects = effects.effects;
-
-                debug!(?tx_digest, "Transaction succeeded");
-                (certificate, effects)
-            }
-        };
-
-        // Create custom response base on the request type
-        let parsed_data = self
-            .create_parsed_transaction_response(tx_kind, certificate.clone(), effects.clone())
-            .await?;
-
-        return Ok(SuiTransactionResponse {
-            certificate: certificate.try_into()?,
-            effects: SuiTransactionEffects::try_from(effects, &self.module_cache)?,
-            timestamp_ms: None,
-            parsed_data,
-        });
+        let tx = tx.verify()?;
+        self.execute_verified_transaction(tx).await
     }
 
     async fn public_transfer_object(

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -5,9 +5,7 @@
 use futures::future::join_all;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::future::Future;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -184,8 +182,6 @@ pub struct GatewayState<A> {
     metrics: GatewayMetrics,
     module_cache: SyncModuleCache<ResolverWrapper<GatewayStore>>,
 }
-
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 impl<A> GatewayState<A> {
     /// Create a new manager which stores its managed addresses at `path`
@@ -1315,7 +1311,7 @@ where
     fn execute_verified_transaction(
         &self,
         tx: VerifiedTransaction,
-    ) -> BoxFuture<'_, Result<SuiTransactionResponse, anyhow::Error>> {
+    ) -> future::BoxFuture<'_, Result<SuiTransactionResponse, anyhow::Error>> {
         async fn inner<A>(
             _self: &GatewayState<A>,
             tx: VerifiedTransaction,

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -332,7 +332,7 @@ mod test {
     use sui_types::{
         base_types::ObjectID,
         crypto::get_account_key_pair,
-        messages::{ExecutionStatus, Transaction},
+        messages::{ExecutionStatus, VerifiedTransaction},
         object::Object,
     };
     use test_utils::{
@@ -405,7 +405,7 @@ mod test {
 
     async fn execute_transactions(
         aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
-        transactions: &[Transaction],
+        transactions: &[VerifiedTransaction],
     ) {
         for transaction in transactions {
             let (_, effects) = aggregator

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -17,7 +17,8 @@ use sui_types::{
     },
     error::{SuiError, SuiResult},
     messages::{
-        CertifiedTransaction, SignedTransactionEffects, TransactionEffects, TransactionInfoResponse,
+        CertifiedTransaction, SignedTransactionEffects, TransactionEffects,
+        TransactionInfoResponse, VerifiedCertificate,
     },
     messages_checkpoint::CheckpointContents,
 };
@@ -508,7 +509,7 @@ where
         &self,
         epoch_id: EpochId,
         digest: &TransactionDigest,
-    ) -> SuiResult<CertifiedTransaction> {
+    ) -> SuiResult<VerifiedCertificate> {
         if let Some(cert) = self.store().get_cert(epoch_id, digest)? {
             assert_eq!(epoch_id, cert.epoch());
             return Ok(cert);
@@ -860,7 +861,7 @@ where
         epoch_id: EpochId,
         authorities_with_cert: Option<BTreeSet<AuthorityName>>,
         req: &DownloadRequest,
-    ) -> SuiResult<(CertifiedTransaction, Option<SignedTransactionEffects>)> {
+    ) -> SuiResult<(VerifiedCertificate, Option<SignedTransactionEffects>)> {
         let tx_digest = *req.transaction_digest();
 
         match (

--- a/crates/sui-core/src/query_helpers.rs
+++ b/crates/sui-core/src/query_helpers.rs
@@ -5,7 +5,7 @@ use crate::authority::SuiDataStore;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use sui_types::messages::{CertifiedTransaction, TransactionEffects};
+use sui_types::messages::{TransactionEffects, VerifiedCertificate};
 use sui_types::{base_types::*, batch::TxSequenceNumber, error::SuiError, fp_ensure};
 use tracing::debug;
 
@@ -82,7 +82,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> QueryHelpers<S> {
     pub fn get_transaction(
         database: &SuiDataStore<S>,
         digest: &TransactionDigest,
-    ) -> Result<(CertifiedTransaction, TransactionEffects), anyhow::Error> {
+    ) -> Result<(VerifiedCertificate, TransactionEffects), anyhow::Error> {
         let opt = database.get_certified_transaction(digest)?;
         match opt {
             Some(certificate) => Ok((certificate, database.get_effects(digest)?)),

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -18,13 +18,13 @@ use crate::authority_client::AuthorityAPI;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     CertifiedTransaction, CertifiedTransactionEffects, QuorumDriverRequest,
-    QuorumDriverRequestType, QuorumDriverResponse, Transaction,
+    QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
 };
 
 const TASK_QUEUE_SIZE: usize = 5000;
 
 pub enum QuorumTask {
-    ProcessTransaction(Transaction),
+    ProcessTransaction(VerifiedTransaction),
     ProcessCertificate(CertifiedTransaction),
 }
 
@@ -138,7 +138,7 @@ where
 
     async fn execute_transaction_immediate_return(
         &self,
-        transaction: Transaction,
+        transaction: VerifiedTransaction,
     ) -> SuiResult<QuorumDriverResponse> {
         self.task_sender
             .send(QuorumTask::ProcessTransaction(transaction))
@@ -151,7 +151,7 @@ where
 
     async fn execute_transaction_wait_for_tx_cert(
         &self,
-        transaction: Transaction,
+        transaction: VerifiedTransaction,
     ) -> SuiResult<QuorumDriverResponse> {
         let certificate = self
             .process_transaction(transaction)
@@ -168,7 +168,7 @@ where
 
     async fn execute_transaction_wait_for_effects_cert(
         &self,
-        transaction: Transaction,
+        transaction: VerifiedTransaction,
     ) -> SuiResult<QuorumDriverResponse> {
         let certificate = self
             .process_transaction(transaction)
@@ -183,7 +183,7 @@ where
 
     pub async fn process_transaction(
         &self,
-        transaction: Transaction,
+        transaction: VerifiedTransaction,
     ) -> SuiResult<CertifiedTransaction> {
         let tx_digest = *transaction.digest();
         self.validators

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -11,7 +11,9 @@ use sui_types::{
     base_types::{dbg_addr, ObjectID, TransactionDigest},
     batch::UpdateItem,
     crypto::{get_key_pair, AccountKeyPair, Signature},
-    messages::{BatchInfoRequest, BatchInfoResponseItem, Transaction, TransactionData},
+    messages::{
+        BatchInfoRequest, BatchInfoResponseItem, Transaction, TransactionData, VerifiedTransaction,
+    },
     object::Object,
 };
 
@@ -86,7 +88,7 @@ pub async fn wait_for_all_txes(wait_digests: Vec<TransactionDigest>, state: Arc<
 
 // Creates a fake sender-signed transaction for testing. This transaction will
 // not actually work.
-pub fn create_fake_transaction() -> Transaction {
+pub fn create_fake_transaction() -> VerifiedTransaction {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);
     let object_id = ObjectID::random();
@@ -105,8 +107,9 @@ pub fn create_fake_transaction() -> Transaction {
 pub fn to_sender_signed_transaction(
     data: TransactionData,
     signer: &dyn Signer<Signature>,
-) -> Transaction {
+) -> VerifiedTransaction {
     let signature = Signature::new_temp(&data.to_bytes(), signer);
     // let signature = Signature::new_secure(&data, Intent::default(), signer).unwrap();
-    Transaction::new(data, signature)
+    let tx = Transaction::new(data, signature);
+    VerifiedTransaction::new_unchecked(tx)
 }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -111,5 +111,5 @@ pub fn to_sender_signed_transaction(
     let signature = Signature::new_temp(&data.to_bytes(), signer);
     // let signature = Signature::new_secure(&data, Intent::default(), signer).unwrap();
     let tx = Transaction::new(data, signature);
-    VerifiedTransaction::new_unchecked(tx)
+    tx.verify().unwrap()
 }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -110,6 +110,5 @@ pub fn to_sender_signed_transaction(
 ) -> VerifiedTransaction {
     let signature = Signature::new_temp(&data.to_bytes(), signer);
     // let signature = Signature::new_secure(&data, Intent::default(), signer).unwrap();
-    let tx = Transaction::new(data, signature);
-    tx.verify().unwrap()
+    VerifiedTransaction::new_unchecked(Transaction::new(data, signature))
 }

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -13,8 +13,8 @@ use sui_types::{
     fp_ensure,
     gas::{self, SuiGasStatus},
     messages::{
-        CertifiedTransaction, InputObjectKind, InputObjects, SingleTransactionKind,
-        TransactionData, TransactionEnvelope,
+        InputObjectKind, InputObjects, SingleTransactionKind, TransactionData, VerifiedCertificate,
+        VerifiedTransactionEnvelope,
     },
     object::{Object, Owner},
 };
@@ -22,7 +22,7 @@ use tracing::instrument;
 
 async fn get_gas_status<S, T>(
     store: &SuiDataStore<S>,
-    transaction: &TransactionEnvelope<T>,
+    transaction: &VerifiedTransactionEnvelope<T>,
 ) -> SuiResult<SuiGasStatus<'static>>
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
@@ -58,7 +58,7 @@ where
 #[instrument(level = "trace", skip_all)]
 pub async fn check_transaction_input<S, T>(
     store: &SuiDataStore<S>,
-    transaction: &TransactionEnvelope<T>,
+    transaction: &VerifiedTransactionEnvelope<T>,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)>
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
@@ -74,7 +74,7 @@ where
 
 pub async fn check_certificate_input<S>(
     store: &SuiDataStore<S>,
-    cert: &CertifiedTransaction,
+    cert: &VerifiedCertificate,
 ) -> SuiResult<(SuiGasStatus<'static>, InputObjects)>
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -24,7 +24,7 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     CertifiedTransaction, CertifiedTransactionEffects, ExecuteTransactionRequest,
     ExecuteTransactionRequestType, ExecuteTransactionResponse, QuorumDriverRequest,
-    QuorumDriverRequestType, QuorumDriverResponse,
+    QuorumDriverRequestType, QuorumDriverResponse, VerifiedCertificate,
 };
 use tap::TapFallible;
 use tokio::sync::broadcast::error::RecvError;
@@ -135,9 +135,10 @@ where
             }
             QuorumDriverResponse::EffectsCert(result) => {
                 let (tx_cert, effects_cert) = *result;
+                let tx_cert = tx_cert.verify(&self.validator_state.committee.load())?;
                 if !wait_for_local_execution {
                     return Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        tx_cert,
+                        tx_cert.into(),
                         effects_cert,
                         false,
                     ))));
@@ -152,12 +153,12 @@ where
                 .await
                 {
                     Ok(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        tx_cert,
+                        tx_cert.into(),
                         effects_cert,
                         true,
                     )))),
                     Err(_) => Ok(ExecuteTransactionResponse::EffectsCert(Box::new((
-                        tx_cert,
+                        tx_cert.into(),
                         effects_cert,
                         false,
                     )))),
@@ -170,7 +171,7 @@ where
     async fn execute_finalized_tx_locally_with_timeout(
         validator_state: &Arc<AuthorityState>,
         node_sync_handle: &NodeSyncHandle,
-        tx_cert: &CertifiedTransaction,
+        tx_cert: &VerifiedCertificate,
         effects_cert: &CertifiedTransactionEffects,
         metrics: &TransactionOrchestratorMetrics,
     ) -> SuiResult {
@@ -238,6 +239,16 @@ where
         loop {
             match effects_receiver.recv().await {
                 Ok((tx_cert, effects_cert)) => {
+                    let tx_cert = match tx_cert.verify(&validator_state.committee.load()) {
+                        Err(err) => {
+                            error!(
+                                "received certificate from quorum driver with bad signatures! {}",
+                                err
+                            );
+                            continue;
+                        }
+                        Ok(c) => c,
+                    };
                     let _ = Self::execute_finalized_tx_locally_with_timeout(
                         &validator_state,
                         &node_sync_handle,
@@ -274,7 +285,7 @@ where
     async fn execute_impl(
         state: &Arc<AuthorityState>,
         node_sync_handle: &NodeSyncHandle,
-        tx_cert: &CertifiedTransaction,
+        tx_cert: &VerifiedCertificate,
         effects_cert: &CertifiedTransactionEffects,
         metrics: &TransactionOrchestratorMetrics,
     ) -> SuiResult {

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -99,7 +99,7 @@ where
             request.request_type,
             ExecuteTransactionRequestType::WaitForLocalExecution
         );
-        let transaction = request.transaction;
+        let transaction = request.transaction.verify()?;
         let tx_digest = *transaction.digest();
         let request_type = match request.request_type {
             ExecuteTransactionRequestType::ImmediateReturn => {

--- a/crates/sui-core/src/transaction_streamer.rs
+++ b/crates/sui-core/src/transaction_streamer.rs
@@ -63,7 +63,9 @@ mod tests {
         let tx_cert = tx_certs.swap_remove(0);
         let tx_digest = *tx_cert.digest();
         let signed_effects = signed_effects.swap_remove(0);
-        let result = streamer.enqueue((tx_cert, signed_effects.clone())).await;
+        let result = streamer
+            .enqueue((tx_cert.into(), signed_effects.clone()))
+            .await;
 
         assert!(result);
         if let Some((cert, effects)) = stream.next().await {

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -181,7 +181,7 @@ pub fn transfer_coin_transaction(
     dest: SuiAddress,
     object_ref: ObjectRef,
     gas_object_ref: ObjectRef,
-) -> Transaction {
+) -> VerifiedTransaction {
     to_sender_signed_transaction(
         TransactionData::new_transfer(
             dest,
@@ -201,7 +201,7 @@ pub fn transfer_object_move_transaction(
     object_ref: ObjectRef,
     framework_obj_ref: ObjectRef,
     gas_object_ref: ObjectRef,
-) -> Transaction {
+) -> VerifiedTransaction {
     let args = vec![
         CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref)),
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(dest)).unwrap()),
@@ -229,7 +229,7 @@ pub fn crate_object_move_transaction(
     value: u64,
     framework_obj_ref: ObjectRef,
     gas_object_ref: ObjectRef,
-) -> Transaction {
+) -> VerifiedTransaction {
     // When creating an object_basics object, we provide the value (u64) and address which will own the object
     let arguments = vec![
         CallArg::Pure(value.to_le_bytes().to_vec()),
@@ -257,7 +257,7 @@ pub fn delete_object_move_transaction(
     object_ref: ObjectRef,
     framework_obj_ref: ObjectRef,
     gas_object_ref: ObjectRef,
-) -> Transaction {
+) -> VerifiedTransaction {
     to_sender_signed_transaction(
         TransactionData::new_move_call(
             src,
@@ -280,7 +280,7 @@ pub fn set_object_move_transaction(
     value: u64,
     framework_obj_ref: ObjectRef,
     gas_object_ref: ObjectRef,
-) -> Transaction {
+) -> VerifiedTransaction {
     let args = vec![
         CallArg::Object(ObjectArg::ImmOrOwnedObject(object_ref)),
         CallArg::Pure(bcs::to_bytes(&value).unwrap()),
@@ -301,7 +301,7 @@ pub fn set_object_move_transaction(
     )
 }
 
-pub async fn do_transaction<A>(authority: &SafeClient<A>, transaction: &Transaction)
+pub async fn do_transaction<A>(authority: &SafeClient<A>, transaction: &VerifiedTransaction)
 where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
@@ -320,9 +320,9 @@ where
     A: AuthorityAPI + Send + Sync + Clone + 'static,
 {
     let mut votes = vec![];
-    let mut transaction: Option<SignedTransaction> = None;
+    let mut transaction: Option<VerifiedSignedTransaction> = None;
     for authority in authorities {
-        if let Ok(TransactionInfoResponse {
+        if let Ok(VerifiedTransactionInfoResponse {
             signed_transaction: Some(signed),
             ..
         }) = authority
@@ -1397,9 +1397,7 @@ pub fn make_response_from_sui_system_state(
     system_state: SuiSystemState,
 ) -> SuiResult<ObjectInfoResponse> {
     let move_content = to_bytes(&system_state).unwrap();
-    let mut tx_cert = make_random_certified_transaction();
-    // A trick to bypass the check in safe client to make the test setup simpler
-    tx_cert.is_verified = true;
+    let tx_cert = make_random_certified_transaction();
     let move_object = unsafe {
         MoveObject::new_from_execution(
             SuiSystemState::type_(),

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1416,7 +1416,7 @@ pub fn make_response_from_sui_system_state(
     );
     let obj_digest = object.compute_object_reference();
     Ok(ObjectInfoResponse {
-        parent_certificate: Some(tx_cert),
+        parent_certificate: Some(tx_cert.into()),
         requested_object_reference: Some(obj_digest),
         object_and_lock: Some(ObjectResponse {
             object,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2136,7 +2136,7 @@ fn init_certified_transaction(
     let committee = authority_state.committee.load();
     CertifiedTransaction::new_with_auth_sign_infos(
         transaction,
-        vec![vote.auth_sign_info],
+        vec![vote.auth_sign_info.clone()],
         &committee,
     )
     .unwrap()

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -86,7 +86,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         let vote = response.signed_transaction.unwrap();
         let certificate = CertifiedTransaction::new_with_auth_sign_infos(
             transaction,
-            vec![vote.auth_sign_info],
+            vec![vote.auth_sign_info.clone()],
             &authority.committee.load(),
         )
         .unwrap();

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -159,7 +159,6 @@ async fn submit_transaction_to_consensus() {
     // Make a new consensus submitter instance.
     let submitter = ConsensusAdapter::new(
         consensus_address.clone(),
-        committee,
         tx_consensus_listener,
         /* timeout */ Duration::from_secs(5),
         metrics,
@@ -196,6 +195,8 @@ async fn submit_transaction_to_consensus() {
             replier.0.send(result).unwrap();
         }
     });
+
+    let certificate = certificate.verify(&committee).unwrap();
 
     // Submit the transaction and ensure the submitter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -518,7 +518,7 @@ struct TransferResult {
     pub authority_state: AuthorityState,
     pub object_id: ObjectID,
     pub gas_object_id: ObjectID,
-    pub response: SuiResult<TransactionInfoResponse>,
+    pub response: SuiResult<VerifiedTransactionInfoResponse>,
 }
 
 async fn execute_transfer(gas_balance: u64, gas_budget: u64, run_confirm: bool) -> TransferResult {

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -123,7 +123,11 @@ async fn test_move_call() {
         gas_object.compute_object_reference(),
     );
 
-    let effects = gateway.execute_transaction(tx).await.unwrap().effects;
+    let effects = gateway
+        .execute_transaction(tx.into_inner())
+        .await
+        .unwrap()
+        .effects;
     assert!(effects.status.is_ok());
     assert_eq!(effects.mutated.len(), 1);
     assert_eq!(effects.created.len(), 1);
@@ -443,7 +447,11 @@ async fn test_public_transfer_object_with_retry() {
         .fail_after_handle_confirmation = false;
 
     // Retry transaction, and this time it should succeed.
-    let effects = gateway.execute_transaction(tx).await.unwrap().effects;
+    let effects = gateway
+        .execute_transaction(tx.into_inner())
+        .await
+        .unwrap()
+        .effects;
     let oref = effects.mutated_excluding_gas().next().unwrap();
     let updated_obj_ref = &oref.reference;
     let new_owner = &oref.owner;

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1831,7 +1831,7 @@ pub async fn build_and_try_publish_test_package(
     gas_object_id: &ObjectID,
     test_dir: &str,
     gas_budget: u64,
-) -> TransactionInfoResponse {
+) -> VerifiedTransactionInfoResponse {
     let build_config = BuildConfig::default();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src/unit_tests/data/");

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -450,8 +450,10 @@ async fn execute_pay_sui(
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
 
     let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
-    let txn_result = send_and_confirm_transaction(&authority_state, tx).await;
+    let tx = Transaction::new(data, signature).verify().unwrap();
+    let txn_result = send_and_confirm_transaction(&authority_state, tx)
+        .await
+        .map(|t| t.into());
 
     PaySuiTransactionExecutionResult {
         authority_state,
@@ -483,9 +485,12 @@ async fn execute_pay_all_sui(
     }));
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
     let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+    let tx = Transaction::new(data, signature).verify().unwrap();
 
-    let txn_result = send_and_confirm_transaction(&authority_state, tx).await;
+    let txn_result = send_and_confirm_transaction(&authority_state, tx)
+        .await
+        .map(|t| t.into());
+
     PaySuiTransactionExecutionResult {
         authority_state,
         txn_result,

--- a/crates/sui-cost/src/estimator.rs
+++ b/crates/sui-cost/src/estimator.rs
@@ -145,7 +145,7 @@ pub async fn estimate_transaction_computation_cost(
         TemporaryStore::new(state.db(), input_objects, TransactionDigest::random());
 
     estimate_transaction_inner(
-        tx.signed_data.data.kind,
+        tx.into_inner().signed_data.data.kind,
         computation_gas_unit_price,
         storage_gas_unit_price,
         mutated_object_sizes_after,

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -12,7 +12,7 @@ use sui_types::coin::PAY_JOIN_FUNC_NAME;
 use sui_types::coin::PAY_MODULE_NAME;
 use sui_types::coin::PAY_SPLIT_VEC_FUNC_NAME;
 use sui_types::crypto::AccountKeyPair;
-use sui_types::messages::Transaction;
+use sui_types::messages::VerifiedTransaction;
 use sui_types::object::Object;
 use sui_types::{
     gas::GasCostSummary,
@@ -64,7 +64,7 @@ async fn split_n_tx(
     coin: &Object,
     gas: &Object,
     validator_info: &[ValidatorInfo],
-) -> Transaction {
+) -> VerifiedTransaction {
     let split_amounts = vec![10u64; n as usize];
     let type_args = vec![coin.get_move_template_type().unwrap()];
 
@@ -88,7 +88,7 @@ async fn create_txes(
     keypair: &AccountKeyPair,
     gas_objects: &[Object],
     configs: &NetworkConfig,
-) -> BTreeMap<CommonTransactionCosts, Transaction> {
+) -> BTreeMap<CommonTransactionCosts, VerifiedTransaction> {
     let mut ret = BTreeMap::new();
     let mut gas_objects = gas_objects.to_vec().clone();
     // let _handles = spawn_test_authorities(gas_objects.clone(), configs).await;
@@ -274,7 +274,7 @@ async fn run_actual_and_estimate_costs(
             .with_async(|node| async move {
                 let state = node.state();
                 estimate_transaction_computation_cost(
-                    tx.signed_data.data,
+                    tx.into_inner().signed_data.data,
                     state.clone(),
                     None,
                     None,

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -351,7 +351,7 @@ impl SimpleFaucet {
 
         let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
 
-        let tx = Transaction::new(data, signature);
+        let tx = Transaction::new(data, signature).verify()?;
         let tx_digest = *tx.digest();
         info!(
             ?tx_digest,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -45,6 +45,7 @@ use sui_types::messages::{
     CallArg, CertifiedTransaction, CertifiedTransactionEffects, ExecuteTransactionResponse,
     ExecutionStatus, InputObjectKind, MoveModulePublish, ObjectArg, Pay, PayAllSui, PaySui,
     SingleTransactionKind, TransactionData, TransactionEffects, TransactionKind,
+    VerifiedCertificate,
 };
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::move_package::{disassemble_modules, MovePackage};
@@ -1719,6 +1720,14 @@ impl TryFrom<CertifiedTransaction> for SuiCertifiedTransaction {
             tx_signature: cert.signed_data.tx_signature,
             auth_sign_info: cert.auth_sign_info,
         })
+    }
+}
+
+impl TryFrom<VerifiedCertificate> for SuiCertifiedTransaction {
+    type Error = anyhow::Error;
+    fn try_from(cert: VerifiedCertificate) -> Result<Self, Self::Error> {
+        let cert: CertifiedTransaction = cert.into();
+        cert.try_into()
     }
 }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -159,10 +159,12 @@ impl RpcFullNodeReadApiServer for FullNodeApi {
         let signature =
             Signature::from_bytes(&[&*flag, &*signature.to_vec()?, &pub_key.to_vec()?].concat())
                 .map_err(|e| anyhow!(e))?;
-        let txn = Transaction::new(data, signature);
+        let txn = Transaction::new(data, signature)
+            .verify()
+            .map_err(|e| anyhow!(e))?;
         let txn_digest = *txn.digest();
 
-        Ok(self.state.dry_run_transaction(&txn, txn_digest).await?)
+        Ok(self.state.dry_run_transaction(txn, txn_digest).await?)
     }
 
     async fn get_normalized_move_modules_by_package(

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -21,7 +21,7 @@ use sui_types::sui_serde::Base64;
 use sui_types::{
     crypto,
     crypto::SignableBytes,
-    messages::{Transaction, TransactionData},
+    messages::{Transaction, TransactionData, VerifiedTransaction},
 };
 
 pub struct FullNodeTransactionExecutionApi {
@@ -57,7 +57,7 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
             &[&*flag, &*signature.to_vec()?, &pub_key.to_vec()?].concat(),
         )
         .map_err(|e| anyhow!(e))?;
-        let txn = Transaction::new(data, signature);
+        let txn = VerifiedTransaction::new_unchecked(Transaction::new(data, signature));
         let txn_digest = *txn.digest();
 
         let response = self

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -21,7 +21,7 @@ use sui_types::sui_serde::Base64;
 use sui_types::{
     crypto,
     crypto::SignableBytes,
-    messages::{Transaction, TransactionData, VerifiedTransaction},
+    messages::{Transaction, TransactionData},
 };
 
 pub struct FullNodeTransactionExecutionApi {
@@ -57,7 +57,7 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
             &[&*flag, &*signature.to_vec()?, &pub_key.to_vec()?].concat(),
         )
         .map_err(|e| anyhow!(e))?;
-        let txn = VerifiedTransaction::new_unchecked(Transaction::new(data, signature));
+        let txn = Transaction::new(data, signature);
         let txn_digest = *txn.digest();
 
         let response = self

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -433,7 +433,7 @@ impl RpcExampleProvider {
 
         let tx = to_sender_signed_transaction(data, &kp);
         let tx1 = tx.clone();
-        let signature = tx.signed_data.tx_signature;
+        let signature = tx.into_inner().signed_data.tx_signature;
 
         let tx_digest = tx1.digest();
         let sui_event = SuiEvent::TransferObject {

--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -47,7 +47,7 @@ pub async fn transaction(
     let digest = request.transaction_identifier.hash;
     let (cert, effects) = context.state.get_transaction(digest).await?;
     let hash = *cert.digest();
-    let data = cert.signed_data.data;
+    let data = &cert.signed_data.data;
 
     let mut new_coins = vec![];
     for ((id, version, _), _) in &effects.created {
@@ -60,7 +60,7 @@ pub async fn transaction(
         }
     }
 
-    let operations = Operation::from_data_and_effect(&data, &effects, &new_coins)?;
+    let operations = Operation::from_data_and_effect(data, &effects, &new_coins)?;
 
     let transaction = Transaction {
         transaction_identifier: TransactionIdentifier { hash },

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -116,7 +116,7 @@ pub async fn submit(
 ) -> Result<TransactionIdentifierResponse, Error> {
     env.check_network_identifier(&request.network_identifier)?;
     let signed_tx: Transaction = bcs::from_bytes(&request.signed_transaction.to_vec()?)?;
-    signed_tx.verify_sender_signature()?;
+    let signed_tx = signed_tx.verify()?;
     let hash = *signed_tx.digest();
 
     let response = context

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -99,7 +99,7 @@ impl TicTacToe {
             .client
             .quorum_driver()
             .execute_transaction(
-                Transaction::new(create_game_call, signature),
+                Transaction::new(create_game_call, signature).verify()?,
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -195,7 +195,7 @@ impl TicTacToe {
                 .client
                 .quorum_driver()
                 .execute_transaction(
-                    Transaction::new(place_mark_call, signature),
+                    Transaction::new(place_mark_call, signature).verify()?,
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await?;

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let transaction_response = sui
         .quorum_driver()
         .execute_transaction(
-            Transaction::new(transfer_tx, signature),
+            Transaction::new(transfer_tx, signature).verify()?,
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -38,7 +38,7 @@ use sui_json_rpc_types::{
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
-use sui_types::messages::Transaction;
+use sui_types::messages::VerifiedTransaction;
 use sui_types::query::{Ordering, TransactionQuery};
 use types::base_types::SequenceNumber;
 use types::committee::EpochId;
@@ -393,7 +393,7 @@ impl QuorumDriver {
     /// error is returned from this call.
     pub async fn execute_transaction(
         &self,
-        tx: Transaction,
+        tx: VerifiedTransaction,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> anyhow::Result<TransactionExecutionResult> {
         Ok(match &*self.api {
@@ -481,7 +481,7 @@ impl QuorumDriver {
             }
             // TODO do we want to support an embedded quorum driver?
             SuiClientApi::Embedded(c) => {
-                let resp = c.execute_transaction(tx).await?;
+                let resp = c.execute_transaction(tx.into_inner()).await?;
                 TransactionExecutionResult {
                     tx_digest: resp.certificate.transaction_digest,
                     tx_cert: Some(resp.certificate),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1130,6 +1130,8 @@ where
 // An empty marker struct that can't be serialized.
 #[derive(Clone)]
 struct NoSer;
+// Never remove this assert!
+static_assertions::assert_not_impl_any!(NoSer: Serialize, DeserializeOwned);
 
 /// VerifiedTransactionEnvelope models a TransactionEnvelope that no longer requires signature
 /// verification. It can only be constructed in 3 ways:
@@ -1142,9 +1144,6 @@ struct NoSer;
 ///   that all uses can be audited easily.
 #[derive(Clone)]
 pub struct VerifiedTransactionEnvelope<T>(TrustedTransactionEnvelope<T>, NoSer);
-
-// Never remove this assert!
-static_assertions::assert_not_impl_any!(VerifiedTransactionEnvelope: Serialize, DeserializeOwned);
 
 impl<T> Debug for VerifiedTransactionEnvelope<T>
 where

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1104,9 +1104,8 @@ pub type TxCertAndSignedEffects = (CertifiedTransaction, SignedTransactionEffect
 ///
 /// DO NOT USE in networked APIs.
 ///
-/// Because it is used very sparingly, it can be audited easily: Use rust-analyzer, or run:
-///
-///      $ git grep -E 'TrustedTransactionEnvelope|TrustedCertificate'
+/// Because it is used very sparingly, it can be audited easily: Use rust-analyzer,
+/// or run: git grep -E 'TrustedTransactionEnvelope|TrustedCertificate'
 ///
 /// And verify that none of the uses appear in any network APIs.
 #[derive(Clone, Serialize, Deserialize)]

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -57,7 +57,9 @@ fn test_signed_values() {
             10000,
         ),
         &sender_sec,
-    );
+    )
+    .verify()
+    .unwrap();
     let bad_transaction = Transaction::from_data(
         TransactionData::new_transfer(
             _a2,
@@ -67,7 +69,9 @@ fn test_signed_values() {
             10000,
         ),
         &sender_sec2,
-    );
+    )
+    .verify()
+    .unwrap();
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -129,7 +133,9 @@ fn test_certificates() {
             10000,
         ),
         &sender_sec,
-    );
+    )
+    .verify()
+    .unwrap();
 
     let v1 = SignedTransaction::new(
         committee.epoch(),
@@ -160,7 +166,7 @@ fn test_certificates() {
     sigs.push(v2.auth_sign_info);
     let c = CertifiedTransaction::new_with_auth_sign_infos(transaction.clone(), sigs, &committee)
         .unwrap();
-    assert!(c.verify(&committee).is_ok());
+    assert!(c.verify_signatures(&committee).is_ok());
 
     let sigs = vec![v1.auth_sign_info, v3.auth_sign_info];
 
@@ -394,7 +400,9 @@ fn test_digest_caching() {
     let transaction = Transaction::from_data(
         TransactionData::new_transfer(sa1, random_object_ref(), sa2, random_object_ref(), 10000),
         &ssec2,
-    );
+    )
+    .verify()
+    .unwrap();
 
     let mut signed_tx = SignedTransaction::new(
         committee.epoch(),
@@ -402,7 +410,7 @@ fn test_digest_caching() {
         AuthorityPublicKeyBytes::from(sec1.public()),
         &sec1,
     );
-    assert!(signed_tx.verify(&committee).is_ok());
+    assert!(signed_tx.verify_signatures(&committee).is_ok());
 
     let initial_digest = *signed_tx.digest();
 
@@ -491,8 +499,12 @@ fn test_user_signature_committed_in_signed_transactions() {
         random_object_ref(),
         10000,
     );
-    let transaction_a = Transaction::from_data(tx_data.clone(), &sender_sec);
-    let transaction_b = Transaction::from_data(tx_data, &sender_sec2);
+    let transaction_a = Transaction::from_data(tx_data.clone(), &sender_sec)
+        .verify()
+        .unwrap();
+    let transaction_b = Transaction::from_data(tx_data, &sender_sec2)
+        .verify()
+        .unwrap();
     let signed_tx_a = SignedTransaction::new(
         0,
         transaction_a.clone(),
@@ -625,7 +637,9 @@ fn verify_sender_signature_correctly_with_flag() {
         10000,
     );
 
-    let transaction = Transaction::from_data(tx_data, &sender_kp);
+    let transaction = Transaction::from_data(tx_data, &sender_kp)
+        .verify()
+        .unwrap();
 
     // create tx also signed by authority
     let signed_tx = SignedTransaction::new(
@@ -657,7 +671,9 @@ fn verify_sender_signature_correctly_with_flag() {
             10000,
         ),
         &sender_kp_2,
-    );
+    )
+    .verify()
+    .unwrap();
 
     let signed_tx_1 = SignedTransaction::new(
         committee.epoch(),

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -60,7 +60,8 @@ fn test_signed_values() {
     )
     .verify()
     .unwrap();
-    let bad_transaction = Transaction::from_data(
+
+    let bad_transaction = VerifiedTransaction::new_unchecked(Transaction::from_data(
         TransactionData::new_transfer(
             _a2,
             random_object_ref(),
@@ -69,9 +70,7 @@ fn test_signed_values() {
             10000,
         ),
         &sender_sec2,
-    )
-    .verify()
-    .unwrap();
+    ));
 
     let v = SignedTransaction::new(
         committee.epoch(),
@@ -502,9 +501,10 @@ fn test_user_signature_committed_in_signed_transactions() {
     let transaction_a = Transaction::from_data(tx_data.clone(), &sender_sec)
         .verify()
         .unwrap();
-    let transaction_b = Transaction::from_data(tx_data, &sender_sec2)
-        .verify()
-        .unwrap();
+    // transaction_b intentionally invalid (sender does not match signer).
+    let transaction_b =
+        VerifiedTransaction::new_unchecked(Transaction::from_data(tx_data, &sender_sec2));
+
     let signed_tx_a = SignedTransaction::new(
         0,
         transaction_a.clone(),

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -34,7 +34,7 @@ use sui_sdk::{ClientType, SuiClient};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
-    messages::Transaction,
+    messages::{Transaction, VerifiedTransaction},
     object::Owner,
     parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS,
 };
@@ -411,7 +411,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&sender, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
 
                 SuiClientCommandResult::Publish(response)
@@ -454,7 +454,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -481,7 +481,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -523,7 +523,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -696,7 +696,7 @@ impl SuiClientCommands {
                 };
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
                 SuiClientCommandResult::SplitCoin(response)
             }
@@ -714,7 +714,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
 
                 SuiClientCommandResult::MergeCoin(response)
@@ -811,8 +811,8 @@ impl SuiClientCommands {
                         ]
                         .concat(),
                     )?,
-                );
-                signed_tx.verify_sender_signature()?;
+                )
+                .verify()?;
 
                 let response = context.execute_transaction(signed_tx).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)
@@ -966,7 +966,7 @@ impl WalletContext {
     /// This function is compatible with both fullnode and an embedded gateway
     pub async fn execute_transaction(
         &self,
-        tx: Transaction,
+        tx: VerifiedTransaction,
     ) -> anyhow::Result<SuiTransactionResponse> {
         let tx_digest = *tx.digest();
 
@@ -1178,7 +1178,7 @@ pub async fn call_move(
         )
         .await?;
     let signature = context.config.keystore.sign(&sender, &data.to_bytes())?;
-    let transaction = Transaction::new(data, signature);
+    let transaction = Transaction::new(data, signature).verify()?;
 
     let response = context.execute_transaction(transaction).await?;
     let cert = response.certificate;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -566,7 +566,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
 
                 let cert = response.certificate;
@@ -598,7 +598,7 @@ impl SuiClientCommands {
 
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::new(data, signature).verify()?)
                     .await?;
 
                 let cert = response.certificate;

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -17,7 +17,7 @@ use sui_types::{
     base_types::{ExecutionDigests, TransactionDigest},
     messages::{
         CallArg, CheckpointStreamRequest, CheckpointStreamResponseItem, ExecutionStatus, ObjectArg,
-        Transaction,
+        VerifiedTransaction,
     },
     messages_checkpoint::AuthenticatedCheckpoint,
 };
@@ -51,7 +51,7 @@ fn transactions_in_checkpoint(authority: &AuthorityState) -> HashSet<Transaction
 
 async fn execute_transactions(
     aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
-    transactions: &[Transaction],
+    transactions: &[VerifiedTransaction],
 ) {
     for transaction in transactions {
         let (_, effects) = aggregator

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -768,7 +768,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
+            transaction: txn.into(),
             request_type: ExecuteTransactionRequestType::WaitForLocalExecution,
         })
         .await
@@ -799,7 +799,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
+            transaction: txn.into(),
             request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
         })
         .await
@@ -830,7 +830,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
+            transaction: txn.into(),
             request_type: ExecuteTransactionRequestType::WaitForTxCert,
         })
         .await
@@ -856,7 +856,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     let digest = *txn.digest();
     let res = transaction_orchestrator
         .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
+            transaction: txn.into(),
             request_type: ExecuteTransactionRequestType::ImmediateReturn,
         })
         .await

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -9,7 +9,7 @@ use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::SuiAddress;
 use sui_types::messages::{
-    QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, Transaction,
+    QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
 };
 use test_utils::authority::{spawn_test_authorities, test_authority_configs};
 use test_utils::messages::make_transfer_sui_transaction;
@@ -19,7 +19,7 @@ use test_utils::test_account_keys;
 async fn setup() -> (
     Vec<SuiNodeHandle>,
     AuthorityAggregator<NetworkAuthorityClient>,
-    Transaction,
+    VerifiedTransaction,
 ) {
     let mut gas_objects = test_gas_objects();
     let configs = test_authority_configs();

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -392,7 +392,7 @@ async fn shared_object_on_gateway() {
         /* arguments */ Vec::default(),
     );
     let resp = gateway
-        .execute_transaction(create_counter_transaction)
+        .execute_transaction(create_counter_transaction.into_inner())
         .await
         .unwrap();
     let effects = resp.effects;
@@ -425,7 +425,10 @@ async fn shared_object_on_gateway() {
                     /* arguments */
                     vec![CallArg::Object(shared_object_arg)],
                 );
-                async move { g.execute_transaction(increment_counter_transaction).await }
+                async move {
+                    g.execute_transaction(increment_counter_transaction.into_inner())
+                        .await
+                }
             })
             .collect();
 
@@ -458,7 +461,7 @@ async fn shared_object_on_gateway() {
     loop {
         let result = gateway
             .clone()
-            .execute_transaction(assert_value_transaction.clone())
+            .execute_transaction(assert_value_transaction.clone().into_inner())
             .await;
         if let Ok(response) = result {
             let effects = response.effects;

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -10,7 +10,7 @@ use sui_node::SuiNode;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    QuorumDriverRequest, QuorumDriverRequestType, Transaction,
+    QuorumDriverRequest, QuorumDriverRequestType, VerifiedTransaction,
 };
 use test_utils::messages::{
     make_counter_increment_transaction_with_wallet_context, make_transactions_with_wallet_context,
@@ -285,7 +285,7 @@ async fn node_does_not_know_txes(node: &SuiNode, digests: &Vec<TransactionDigest
 
 async fn execute_with_orchestrator(
     orchestrator: &TransactiondOrchestrator<NetworkAuthorityClient>,
-    txn: Transaction,
+    txn: VerifiedTransaction,
     request_type: ExecuteTransactionRequestType,
 ) -> ExecuteTransactionResponse {
     let digest = *txn.digest();

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -291,7 +291,7 @@ async fn execute_with_orchestrator(
     let digest = *txn.digest();
     orchestrator
         .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
+            transaction: txn.into(),
             request_type,
         })
         .await

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -28,7 +28,7 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::messages::SignedTransactionEffects;
 use sui_types::messages::{CallArg, ExecutionStatus, TransactionEffects};
 use sui_types::messages::{
-    CertifiedTransaction, ObjectArg, SignedTransaction, Transaction, TransactionData,
+    CertifiedTransaction, ObjectArg, SignedTransaction, TransactionData, VerifiedTransaction,
 };
 use sui_types::object::Object;
 use sui_types::object::Owner;
@@ -131,7 +131,7 @@ pub async fn get_account_and_gas_objects(
 pub async fn make_transactions_with_wallet_context(
     context: &mut WalletContext,
     max_txn_num: usize,
-) -> Vec<Transaction> {
+) -> Vec<VerifiedTransaction> {
     let recipient = get_key_pair::<AuthorityKeyPair>().0;
     let accounts_and_objs = get_account_and_gas_objects(context).await;
     let mut res = Vec::with_capacity(max_txn_num);
@@ -163,7 +163,7 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
     counter_id: ObjectID,
     counter_initial_shared_version: SequenceNumber,
     gas_object_ref: Option<ObjectRef>,
-) -> Transaction {
+) -> VerifiedTransaction {
     let package_object_ref = genesis::get_framework_object_ref();
     let gas_object_ref = match gas_object_ref {
         Some(obj_ref) => obj_ref,
@@ -190,7 +190,7 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
 /// Make a few different single-writer test transactions owned by specific addresses.
 pub fn make_transactions_with_pre_genesis_objects(
     keys: Keystore,
-) -> (Vec<Transaction>, Vec<Object>) {
+) -> (Vec<VerifiedTransaction>, Vec<Object>) {
     // The key pair of the recipient of the transaction.
     let recipient = get_key_pair::<AuthorityKeyPair>().0;
 
@@ -227,7 +227,7 @@ pub fn make_transactions_with_pre_genesis_objects(
 }
 
 /// Make a few different test transaction containing the same shared object.
-pub fn test_shared_object_transactions() -> Vec<Transaction> {
+pub fn test_shared_object_transactions() -> Vec<VerifiedTransaction> {
     // The key pair of the sender of the transaction.
     let (sender, keypair) = test_account_keys().pop().unwrap();
 
@@ -270,7 +270,7 @@ pub fn create_publish_move_package_transaction(
     path: PathBuf,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
-) -> Transaction {
+) -> VerifiedTransaction {
     let build_config = BuildConfig::default();
     let modules = sui_framework::build_move_package(&path, build_config).unwrap();
 
@@ -292,7 +292,7 @@ pub fn make_transfer_sui_transaction(
     amount: Option<u64>,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
-) -> Transaction {
+) -> VerifiedTransaction {
     let data = TransactionData::new_transfer_sui(recipient, sender, amount, gas_object, MAX_GAS);
     to_sender_signed_transaction(data, keypair)
 }
@@ -303,7 +303,7 @@ pub fn make_transfer_object_transaction(
     sender: SuiAddress,
     keypair: &AccountKeyPair,
     recipient: SuiAddress,
-) -> Transaction {
+) -> VerifiedTransaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
     to_sender_signed_transaction(data, keypair)
 }
@@ -314,12 +314,12 @@ pub fn make_transfer_object_transaction_with_wallet_context(
     context: &WalletContext,
     sender: SuiAddress,
     recipient: SuiAddress,
-) -> Transaction {
+) -> VerifiedTransaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
     to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
-pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> Transaction {
+pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransaction {
     let (sender, keypair) = test_account_keys().pop().unwrap();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("../../sui_programmability/examples/basics");
@@ -357,7 +357,7 @@ pub fn make_counter_create_transaction(
     package_ref: ObjectRef,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
-) -> Transaction {
+) -> VerifiedTransaction {
     let data = TransactionData::new_move_call(
         sender,
         package_ref,
@@ -378,7 +378,7 @@ pub fn make_counter_increment_transaction(
     counter_initial_shared_version: SequenceNumber,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
-) -> Transaction {
+) -> VerifiedTransaction {
     let data = TransactionData::new_move_call(
         sender,
         package_ref,
@@ -402,7 +402,7 @@ pub fn move_transaction(
     function: &'static str,
     package_ref: ObjectRef,
     arguments: Vec<CallArg>,
-) -> Transaction {
+) -> VerifiedTransaction {
     move_transaction_with_type_tags(gas_object, module, function, package_ref, &[], arguments)
 }
 
@@ -414,7 +414,7 @@ pub fn move_transaction_with_type_tags(
     package_ref: ObjectRef,
     type_args: &[TypeTag],
     arguments: Vec<CallArg>,
-) -> Transaction {
+) -> VerifiedTransaction {
     let (sender, keypair) = test_account_keys().pop().unwrap();
 
     // Make the transaction.
@@ -433,7 +433,7 @@ pub fn move_transaction_with_type_tags(
 
 /// Make a test certificates for each input transaction.
 pub fn make_tx_certs_and_signed_effects(
-    transactions: Vec<Transaction>,
+    transactions: Vec<VerifiedTransaction>,
 ) -> (Vec<CertifiedTransaction>, Vec<SignedTransactionEffects>) {
     let committee = test_committee();
     make_tx_certs_and_signed_effects_with_committee(transactions, &committee)
@@ -441,7 +441,7 @@ pub fn make_tx_certs_and_signed_effects(
 
 /// Make a test certificates for each input transaction.
 pub fn make_tx_certs_and_signed_effects_with_committee(
-    transactions: Vec<Transaction>,
+    transactions: Vec<VerifiedTransaction>,
     committee: &Committee,
 ) -> (Vec<CertifiedTransaction>, Vec<SignedTransactionEffects>) {
     let mut tx_certs = Vec::new();
@@ -472,7 +472,7 @@ pub fn make_tx_certs_and_signed_effects_with_committee(
     (tx_certs, effect_sigs)
 }
 
-fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
+fn dummy_transaction_effects(tx: &VerifiedTransaction) -> TransactionEffects {
     TransactionEffects {
         status: ExecutionStatus::Success,
         gas_used: GasCostSummary {

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -399,7 +399,7 @@ pub async fn submit_single_owner_transaction(
     for config in configs {
         let client = get_client(config);
         let reply = client
-            .handle_certificate(certificate.clone())
+            .handle_certificate(certificate.clone().into())
             .await
             .unwrap();
         responses.push(reply);
@@ -437,7 +437,7 @@ pub async fn submit_shared_object_transaction_with_committee(
             .map(|config| {
                 let client = get_client(config);
                 let cert = certificate.clone();
-                async move { client.handle_certificate(cert).await }
+                async move { client.handle_certificate(cert.into()).await }
             })
             .collect();
 


### PR DESCRIPTION
The goal of this PR is to safely support optimizations that reduce unnecessary signature verifications. For instance, before this PR, we would verify signatures after loading a cert from the DB, even though that cert was almost certainly verified before it was written to the db. This change makes it much easier to trust that nothing unverified gets in to the db.

The overall design is:
- VerifiedTransactionEnvelope is added as a wrapper around TransactionEnvelope.
    - normally VerifiedTransactionEnvelope is only created by `fn verify(self)` methods.
    - there are a few exceptions which require a `new_unchecked` method - these can be carefully audited.
- VerifiedTransactionEnvelope cannot be serialized. However, it wraps a TrustedTransactionEnvelope which can be serialized, and is `Into<VerifiedTransactionEnvelope>`
   - The purpose of this design is to make the very few places where we trust a serialized transaction auditable in less than 5 minutes.
- The network APIs are unchanged, to indicate that everything arriving via the network must be verified.
- AuthorityState accepts only VerifiedCertificate, VerifiedTransaction, etc.
- Databases store TrustedTransactionEnvelope, meaning that you cannot write unverified data to the db, and you don't need to verify signatures after reading from the db.

This is a huge PR, obviously. I recommend focusing the review in sui-core, especially:
- messages.rs
- authority.rs
- safe_client.rs
- authority_aggregator.rs