### PR TITLE
[sui-test-validator] Add websocket support to test validator

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -52,6 +52,7 @@ pub trait Cluster {
 
     fn rpc_url(&self) -> &str;
     fn fullnode_url(&self) -> &str;
+    fn websocket_url(&self) -> Option<&str>;
     fn user_key(&self) -> AccountKeyPair;
 
     /// Returns faucet url in a remote cluster.
@@ -118,6 +119,9 @@ impl Cluster for RemoteRunningCluster {
     fn fullnode_url(&self) -> &str {
         &self.fullnode_url
     }
+    fn websocket_url(&self) -> Option<&str> {
+        None
+    }
     fn user_key(&self) -> AccountKeyPair {
         get_key_pair().1
     }
@@ -134,6 +138,7 @@ pub struct LocalNewCluster {
     test_network: TestNetwork,
     fullnode_url: String,
     faucet_key: AccountKeyPair,
+    websocket_url: Option<String>,
 }
 
 impl LocalNewCluster {
@@ -201,6 +206,7 @@ impl Cluster for LocalNewCluster {
             test_network,
             fullnode_url,
             faucet_key,
+            websocket_url: options.websocket_address.clone(),
         })
     }
 
@@ -210,6 +216,10 @@ impl Cluster for LocalNewCluster {
 
     fn fullnode_url(&self) -> &str {
         &self.fullnode_url
+    }
+
+    fn websocket_url(&self) -> Option<&str> {
+        self.websocket_url.as_deref()
     }
 
     fn user_key(&self) -> AccountKeyPair {
@@ -239,6 +249,10 @@ impl Cluster for Box<dyn Cluster + Send + Sync> {
 
     fn fullnode_url(&self) -> &str {
         (**self).fullnode_url()
+    }
+
+    fn websocket_url(&self) -> Option<&str> {
+        (**self).websocket_url()
     }
 
     fn user_key(&self) -> AccountKeyPair {

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -161,11 +161,18 @@ impl Cluster for LocalNewCluster {
                 .port()
         });
 
+        let websocket_port = options.websocket_address.as_ref().map(|addr| {
+            addr.parse::<SocketAddr>()
+                .expect("Unable to parse fullnode address")
+                .port()
+        });
+
         let mut test_network = start_rpc_test_network_with_fullnode(
             Some(genesis_config),
             1,
             gateway_port,
             fullnode_port,
+            websocket_port,
         )
         .await
         .unwrap_or_else(|e| panic!("Failed to start a local network, e: {e}"));

--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -22,6 +22,8 @@ pub struct ClusterTestOpt {
     pub faucet_address: Option<String>,
     #[clap(long)]
     pub fullnode_address: Option<String>,
+    #[clap(long)]
+    pub websocket_address: Option<String>,
 }
 
 impl ClusterTestOpt {
@@ -31,6 +33,7 @@ impl ClusterTestOpt {
             gateway_address: None,
             faucet_address: None,
             fullnode_address: None,
+            websocket_address: None,
         }
     }
 }

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -26,6 +26,7 @@ pub struct SwarmBuilder<R = OsRng> {
     initial_accounts_config: Option<GenesisConfig>,
     fullnode_count: usize,
     fullnode_rpc_addr: Option<SocketAddr>,
+    websocket_rpc_addr: Option<SocketAddr>,
 }
 
 impl SwarmBuilder {
@@ -38,6 +39,7 @@ impl SwarmBuilder {
             initial_accounts_config: None,
             fullnode_count: 0,
             fullnode_rpc_addr: None,
+            websocket_rpc_addr: None,
         }
     }
 }
@@ -51,6 +53,7 @@ impl<R> SwarmBuilder<R> {
             initial_accounts_config: self.initial_accounts_config,
             fullnode_count: self.fullnode_count,
             fullnode_rpc_addr: self.fullnode_rpc_addr,
+            websocket_rpc_addr: self.websocket_rpc_addr,
         }
     }
 
@@ -84,6 +87,11 @@ impl<R> SwarmBuilder<R> {
 
     pub fn with_fullnode_rpc_addr(mut self, fullnode_rpc_addr: SocketAddr) -> Self {
         self.fullnode_rpc_addr = Some(fullnode_rpc_addr);
+        self
+    }
+
+    pub fn with_websocket_rpc_addr(mut self, websocket_rpc_addr: SocketAddr) -> Self {
+        self.websocket_rpc_addr = Some(websocket_rpc_addr);
         self
     }
 }
@@ -122,6 +130,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> SwarmBuilder<R> {
                 if let Some(fullnode_rpc_addr) = self.fullnode_rpc_addr {
                     config.json_rpc_address = fullnode_rpc_addr;
                 }
+                config.websocket_address = self.websocket_rpc_addr;
                 fullnodes.insert(config.sui_address(), Node::new(config));
             });
         }

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -33,6 +33,10 @@ struct Args {
     #[clap(long, default_value = "9000")]
     fullnode_rpc_port: u16,
 
+    /// Port to start the fullnode websocket RPC server on
+    #[clap(long, default_value = "9001")]
+    websocket_rpc_port: u16,
+
     /// Port to start the Sui faucet on
     #[clap(long, default_value = "9123")]
     faucet_port: u16,
@@ -46,11 +50,13 @@ async fn main() -> Result<()> {
         env: Env::NewLocal,
         gateway_address: Some(format!("127.0.0.1:{}", args.gateway_rpc_port)),
         fullnode_address: Some(format!("127.0.0.1:{}", args.fullnode_rpc_port)),
+        websocket_address: Some(format!("127.0.0.1:{}", args.websocket_rpc_port)),
         faucet_address: None,
     })
     .await?;
 
     println!("Fullnode RPC URL: {}", cluster.fullnode_url());
+    println!("Fullnode Websocket RPC URL: http://127.0.0.1:{}", args.websocket_rpc_port);
     println!("Gateway RPC URL: {}", cluster.rpc_url());
 
     start_faucet(&cluster, args.faucet_port).await?;

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -56,7 +56,10 @@ async fn main() -> Result<()> {
     .await?;
 
     println!("Fullnode RPC URL: {}", cluster.fullnode_url());
-    println!("Fullnode Websocket RPC URL: http://127.0.0.1:{}", args.websocket_rpc_port);
+    println!(
+        "Fullnode Websocket URL: {}",
+        cluster.websocket_url().unwrap()
+    );
     println!("Gateway RPC URL: {}", cluster.rpc_url());
 
     start_faucet(&cluster, args.faucet_port).await?;

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -33,13 +33,14 @@ const NUM_VALIDAOTR: usize = 4;
 pub async fn start_test_network(
     genesis_config: Option<GenesisConfig>,
 ) -> Result<Swarm, anyhow::Error> {
-    start_test_network_with_fullnodes(genesis_config, 0, None).await
+    start_test_network_with_fullnodes(genesis_config, 0, None, None).await
 }
 
 pub async fn start_test_network_with_fullnodes(
     genesis_config: Option<GenesisConfig>,
     fullnode_count: usize,
     fullnode_port: Option<u16>,
+    websocket_port: Option<u16>,
 ) -> Result<Swarm, anyhow::Error> {
     let mut builder: SwarmBuilder = Swarm::builder()
         .committee_size(NonZeroUsize::new(NUM_VALIDAOTR).unwrap())
@@ -47,6 +48,10 @@ pub async fn start_test_network_with_fullnodes(
     if let Some(fullnode_port) = fullnode_port {
         builder =
             builder.with_fullnode_rpc_addr(format!("127.0.0.1:{}", fullnode_port).parse().unwrap());
+    }
+    if let Some(websocket_port) = websocket_port {
+        builder = builder
+            .with_websocket_rpc_addr(format!("127.0.0.1:{}", websocket_port).parse().unwrap())
     }
     if let Some(genesis_config) = genesis_config {
         builder = builder.initial_accounts_config(genesis_config);
@@ -137,7 +142,7 @@ async fn start_rpc_gateway(
 pub async fn start_rpc_test_network(
     genesis_config: Option<GenesisConfig>,
 ) -> Result<TestNetwork, anyhow::Error> {
-    start_rpc_test_network_with_fullnode(genesis_config, 0, None, None).await
+    start_rpc_test_network_with_fullnode(genesis_config, 0, None, None, None).await
 }
 
 pub async fn start_rpc_test_network_with_fullnode(
@@ -145,9 +150,15 @@ pub async fn start_rpc_test_network_with_fullnode(
     fullnode_count: usize,
     gateway_port: Option<u16>,
     fullnode_port: Option<u16>,
+    websocket_port: Option<u16>,
 ) -> Result<TestNetwork, anyhow::Error> {
-    let network =
-        start_test_network_with_fullnodes(genesis_config, fullnode_count, fullnode_port).await?;
+    let network = start_test_network_with_fullnodes(
+        genesis_config,
+        fullnode_count,
+        fullnode_port,
+        websocket_port,
+    )
+    .await?;
     let working_dir = network.dir();
     let (server_addr, rpc_server_handle) =
         start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG), gateway_port).await?;


### PR DESCRIPTION
I noticed that websocket RPC wasn't supported, so I added it.