### PR TITLE
[wallet] Add dapp signMessage functionality

### DIFF
--- a/wallet/src/background/Messages.ts
+++ b/wallet/src/background/Messages.ts
@@ -1,0 +1,116 @@
+import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
+import { v4 as uuidV4 } from 'uuid';
+import Browser from 'webextension-polyfill';
+
+import { Window } from './Window';
+
+import type { ContentScriptConnection } from './connections/ContentScriptConnection';
+import type { SignMessageRequest } from '_payloads/messages/SignMessageRequest';
+import type { SignMessageRequestResponse } from '_payloads/messages/ui/SignMessageRequestResponse';
+
+const MESSAGES_STORE_KEY = 'messages';
+
+function openSignMessageWindow(signMessageRequestID: string) {
+    return new Window(
+        Browser.runtime.getURL('ui.html') +
+            `#/sign-message-approval/${encodeURIComponent(
+                signMessageRequestID
+            )}`
+    );
+}
+
+class Messages {
+    private _signMessageResponseMessages =
+        new Subject<SignMessageRequestResponse>();
+
+    async signMessage(
+        message: Uint8Array,
+        connection: ContentScriptConnection
+    ) {
+        const signMessageRequest = this.createSignMessageRequest(
+            message,
+            connection.origin,
+            connection.originFavIcon
+        );
+        await this.storeSignMessageRequest(signMessageRequest);
+        const popUp = openSignMessageWindow(signMessageRequest.id);
+        const popUpClose = (await popUp.show()).pipe(
+            take(1),
+            map<number, false>(() => false)
+        );
+        const signMessageResponseMessage =
+            this._signMessageResponseMessages.pipe(
+                filter(
+                    (msg) => msg.signMessageRequestID === signMessageRequest.id
+                ),
+                take(1)
+            );
+        return lastValueFrom(
+            race(popUpClose, signMessageResponseMessage).pipe(
+                take(1),
+                map(async (response) => {
+                    if (response) {
+                        const { approved, signature } = response;
+                        signMessageRequest.approved = approved;
+                        signMessageRequest.signature = signature;
+                        await this.storeSignMessageRequest(signMessageRequest);
+                        return signature;
+                    }
+                    await this.removeSignMessageRequest(signMessageRequest.id);
+                    throw new Error('Sign Message Request rejected from user');
+                })
+            )
+        );
+    }
+
+    public handleMessage(msg: SignMessageRequestResponse) {
+        this._signMessageResponseMessages.next(msg);
+    }
+
+    private createSignMessageRequest(
+        message: Uint8Array,
+        origin: string,
+        originFavIcon?: string
+    ): SignMessageRequest {
+        return {
+            id: uuidV4(),
+            approved: null,
+            origin,
+            originFavIcon,
+            message,
+            createdDate: new Date().toISOString(),
+        };
+    }
+
+    public async getSignMessageRequests(): Promise<
+        Record<string, SignMessageRequest>
+    > {
+        return (await Browser.storage.local.get({ [MESSAGES_STORE_KEY]: {} }))[
+            MESSAGES_STORE_KEY
+        ];
+    }
+
+    private async saveSignMessageRequests(
+        signMessageRequests: Record<string, SignMessageRequest>
+    ) {
+        await Browser.storage.local.set({
+            [MESSAGES_STORE_KEY]: signMessageRequests,
+        });
+    }
+
+    private async storeSignMessageRequest(
+        signMessageRequest: SignMessageRequest
+    ) {
+        const messages = await this.getSignMessageRequests();
+        messages[signMessageRequest.id] = signMessageRequest;
+        await this.saveSignMessageRequests(messages);
+    }
+
+    private async removeSignMessageRequest(signMessageRequestId: string) {
+        const messages = await this.getSignMessageRequests();
+        delete messages[signMessageRequestId];
+        await this.saveSignMessageRequests(messages);
+    }
+}
+
+export default new Messages();

--- a/wallet/src/background/Messages.ts
+++ b/wallet/src/background/Messages.ts
@@ -27,11 +27,13 @@ class Messages {
         new Subject<SignMessageRequestResponse>();
 
     async signMessage(
-        message: Uint8Array,
+        messageData: string | undefined,
+        messageString: string | undefined,
         connection: ContentScriptConnection
     ) {
         const signMessageRequest = this.createSignMessageRequest(
-            message,
+            messageData,
+            messageString,
             connection.origin,
             connection.originFavIcon
         );
@@ -71,17 +73,19 @@ class Messages {
     }
 
     private createSignMessageRequest(
-        message: Uint8Array | undefined,
+        messageData: string | undefined,
+        messageString: string | undefined,
         origin: string,
         originFavIcon?: string
     ): SignMessageRequest {
-        if (message !== undefined) {
+        if (messageData !== undefined) {
             return {
                 id: uuidV4(),
                 approved: null,
                 origin,
                 originFavIcon,
-                message,
+                messageData,
+                messageString,
                 createdDate: new Date().toISOString(),
             };
         }

--- a/wallet/src/background/Messages.ts
+++ b/wallet/src/background/Messages.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { filter, lastValueFrom, map, race, Subject, take } from 'rxjs';
 import { v4 as uuidV4 } from 'uuid';
 import Browser from 'webextension-polyfill';

--- a/wallet/src/background/connections/ContentScriptConnection.ts
+++ b/wallet/src/background/connections/ContentScriptConnection.ts
@@ -135,7 +135,8 @@ export class ContentScriptConnection extends Connection {
             if (allowed) {
                 try {
                     const signature = await Messages.signMessage(
-                        payload.message,
+                        payload.messageData,
+                        payload.messageString,
                         this
                     );
                     this.send(

--- a/wallet/src/background/connections/UiConnection.ts
+++ b/wallet/src/background/connections/UiConnection.ts
@@ -1,8 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import Messages from '../Messages';
 import { Connection } from './Connection';
 import { createMessage } from '_messages';
+import { isGetSignMessageRequests } from '_payloads/messages/ui/GetSignMessageRequests';
+import { isSignMessageRequestResponse } from '_payloads/messages/ui/SignMessageRequestResponse';
 import {
     isGetPermissionRequests,
     isPermissionResponse,
@@ -14,6 +17,8 @@ import Transactions from '_src/background/Transactions';
 
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
+import type { SignMessageRequest } from '_payloads/messages/SignMessageRequest';
+import type { GetSignMessageRequestsResponse } from '_payloads/messages/ui/GetSignMessageRequestsResponse';
 import type { Permission, PermissionRequests } from '_payloads/permissions';
 import type { TransactionRequest } from '_payloads/transactions';
 import type { GetTransactionRequestsResponse } from '_payloads/transactions/ui/GetTransactionRequestsResponse';
@@ -32,9 +37,16 @@ export class UiConnection extends Connection {
             Permissions.handlePermissionResponse(payload);
         } else if (isTransactionRequestResponse(payload)) {
             Transactions.handleMessage(payload);
+        } else if (isSignMessageRequestResponse(payload)) {
+            Messages.handleMessage(payload);
         } else if (isGetTransactionRequests(payload)) {
             this.sendTransactionRequests(
                 Object.values(await Transactions.getTransactionRequests()),
+                id
+            );
+        } else if (isGetSignMessageRequests(payload)) {
+            this.sendSignMessageRequests(
+                Object.values(await Messages.getSignMessageRequests()),
                 id
             );
         }
@@ -61,6 +73,21 @@ export class UiConnection extends Connection {
                 {
                     type: 'get-transaction-requests-response',
                     txRequests,
+                },
+                requestID
+            )
+        );
+    }
+
+    private sendSignMessageRequests(
+        signMessageRequests: SignMessageRequest[],
+        requestID: string
+    ) {
+        this.send(
+            createMessage<GetSignMessageRequestsResponse>(
+                {
+                    type: 'get-sign-message-requests-response',
+                    signMessageRequests,
                 },
                 requestID
             )

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -116,12 +116,15 @@ export class DAppInterface {
         let messageData;
         let messageString;
 
-        if (message) {
-            const buffer = new Base64DataBuffer(message);
-            messageData = buffer.toString();
-            if (typeof message === 'string') {
-                messageString = message;
-            }
+        // convert utf8 string to Uint8Array
+        if (typeof message === 'string') {
+            messageString = message;
+            message = new Uint8Array(Buffer.from(message, 'utf8'));
+        }
+
+        // convert Uint8Array to base64 string
+        if (message instanceof Uint8Array) {
+            messageData = new Base64DataBuffer(message).toString();
         }
 
         return mapToPromise(

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -1,6 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+    type SuiAddress,
+    type MoveCallTransaction,
+    Base64DataBuffer,
+} from '@mysten/sui.js';
 import { filter, lastValueFrom, map, take } from 'rxjs';
 
 import { createMessage } from '_messages';
@@ -8,7 +13,6 @@ import { WindowMessageStream } from '_messaging/WindowMessageStream';
 import { isErrorPayload } from '_payloads';
 import { ALL_PERMISSION_TYPES } from '_payloads/permissions';
 
-import type { SuiAddress, MoveCallTransaction } from '@mysten/sui.js';
 import type { Payload } from '_payloads';
 import type { GetAccount } from '_payloads/account/GetAccount';
 import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
@@ -108,11 +112,23 @@ export class DAppInterface {
         );
     }
 
-    public signMessage(message: Uint8Array) {
+    public signMessage(message: Uint8Array | string) {
+        let messageData;
+        let messageString;
+
+        if (message) {
+            const buffer = new Base64DataBuffer(message);
+            messageData = buffer.toString();
+            if (typeof message === 'string') {
+                messageString = message;
+            }
+        }
+
         return mapToPromise(
             this.send<ExecuteSignMessageRequest, ExecuteSignMessageResponse>({
                 type: 'execute-sign-message-request',
-                message,
+                messageData,
+                messageString,
             }),
             (response) => response.signature
         );

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -12,6 +12,8 @@ import type { SuiAddress, MoveCallTransaction } from '@mysten/sui.js';
 import type { Payload } from '_payloads';
 import type { GetAccount } from '_payloads/account/GetAccount';
 import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
+import type { ExecuteSignMessageRequest } from '_payloads/messages/ExecuteSignMessageRequest';
+import type { ExecuteSignMessageResponse } from '_payloads/messages/ExecuteSignMessageResponse';
 import type {
     PermissionType,
     HasPermissionsRequest,
@@ -103,6 +105,16 @@ export class DAppInterface {
                 transactionBytes,
             }),
             (response) => response.result
+        );
+    }
+
+    public signMessage(message: Uint8Array) {
+        return mapToPromise(
+            this.send<ExecuteSignMessageRequest, ExecuteSignMessageResponse>({
+                type: 'execute-sign-message-request',
+                message,
+            }),
+            (response) => response.signature
         );
     }
 

--- a/wallet/src/dapp-interface/DAppInterface.ts
+++ b/wallet/src/dapp-interface/DAppInterface.ts
@@ -8,6 +8,7 @@ import {
 } from '@mysten/sui.js';
 import { filter, lastValueFrom, map, take } from 'rxjs';
 
+import { deserializeSignaturePubkeyPair } from '../shared/signature-serialization';
 import { createMessage } from '_messages';
 import { WindowMessageStream } from '_messaging/WindowMessageStream';
 import { isErrorPayload } from '_payloads';
@@ -133,7 +134,10 @@ export class DAppInterface {
                 messageData,
                 messageString,
             }),
-            (response) => response.signature
+            (response) =>
+                response.signature
+                    ? deserializeSignaturePubkeyPair(response.signature)
+                    : undefined
         );
     }
 

--- a/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
+++ b/wallet/src/shared/messaging/messages/payloads/BasePayload.ts
@@ -17,7 +17,12 @@ export type PayloadType =
     | 'execute-transaction-response'
     | 'get-transaction-requests'
     | 'get-transaction-requests-response'
-    | 'transaction-request-response';
+    | 'transaction-request-response'
+    | 'execute-sign-message-request'
+    | 'execute-sign-message-response'
+    | 'sign-message-request-response'
+    | 'get-sign-message-requests'
+    | 'get-sign-message-requests-response';
 
 export interface BasePayload {
     type: PayloadType;

--- a/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageRequest.ts
@@ -7,7 +7,8 @@ import type { BasePayload, Payload } from '_payloads';
 
 export interface ExecuteSignMessageRequest extends BasePayload {
     type: 'execute-sign-message-request';
-    message: Uint8Array;
+    messageData?: string; // base64 encoded string
+    messageString?: string;
 }
 
 export function isExecuteSignMessageRequest(

--- a/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageRequest.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface ExecuteSignMessageRequest extends BasePayload {
+    type: 'execute-sign-message-request';
+    message: Uint8Array;
+}
+
+export function isExecuteSignMessageRequest(
+    payload: Payload
+): payload is ExecuteSignMessageRequest {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'execute-sign-message-request'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageResponse.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SignaturePubkeyPair } from '@mysten/sui.js';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface ExecuteSignMessageResponse extends BasePayload {
+    type: 'execute-sign-message-response';
+    signature?: SignaturePubkeyPair;
+}
+
+export function isExecuteSignMessageResponse(
+    payload: Payload
+): payload is ExecuteSignMessageResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'execute-sign-message-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ExecuteSignMessageResponse.ts
@@ -3,12 +3,12 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SignaturePubkeyPair } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
+import type { SerializedSignaturePubkeyPair } from '_shared/signature-serialization';
 
 export interface ExecuteSignMessageResponse extends BasePayload {
     type: 'execute-sign-message-response';
-    signature?: SignaturePubkeyPair;
+    signature?: SerializedSignaturePubkeyPair;
 }
 
 export function isExecuteSignMessageResponse(

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -8,7 +8,8 @@ export type SignMessageRequest = {
     approved: boolean | null;
     origin: string;
     originFavIcon?: string;
-    message?: Uint8Array;
+    messageData?: string; // base 64 encoded string
+    messageString?: string;
     createdDate: string;
     signature?: SignaturePubkeyPair;
 };

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -8,7 +8,7 @@ export type SignMessageRequest = {
     approved: boolean | null;
     origin: string;
     originFavIcon?: string;
-    message: Uint8Array;
+    message?: Uint8Array;
     createdDate: string;
     signature?: SignaturePubkeyPair;
 };

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -8,7 +8,7 @@ export type SignMessageRequest = {
     approved: boolean | null;
     origin: string;
     originFavIcon?: string;
-    messageData?: string; // base 64 encoded string
+    messageData?: string; // base64 encoded string
     messageString?: string;
     createdDate: string;
     signature?: SignaturePubkeyPair;

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import type { SignaturePubkeyPair } from '@mysten/sui.js';
 
 export type SignMessageRequest = {

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -1,0 +1,11 @@
+import type { SignaturePubkeyPair } from '@mysten/sui.js';
+
+export type SignMessageRequest = {
+    id: string;
+    approved: boolean | null;
+    origin: string;
+    originFavIcon?: string;
+    message: Uint8Array;
+    createdDate: string;
+    signature?: SignaturePubkeyPair;
+};

--- a/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/SignMessageRequest.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SignaturePubkeyPair } from '@mysten/sui.js';
+import type { SerializedSignaturePubkeyPair } from '_shared/signature-serialization';
 
 export type SignMessageRequest = {
     id: string;
@@ -11,5 +11,5 @@ export type SignMessageRequest = {
     messageData?: string; // base64 encoded string
     messageString?: string;
     createdDate: string;
-    signature?: SignaturePubkeyPair;
+    signature?: SerializedSignaturePubkeyPair;
 };

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequests.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequests.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { BasePayload, Payload } from '_payloads';
+
+export interface GetSignMessageRequests extends BasePayload {
+    type: 'get-sign-message-requests';
+}
+
+export function isGetSignMessageRequests(
+    payload: Payload
+): payload is GetSignMessageRequests {
+    return (
+        isBasePayload(payload) && payload.type === 'get-sign-message-requests'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequestsResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/GetSignMessageRequestsResponse.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SignMessageRequest } from '../SignMessageRequest';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface GetSignMessageRequestsResponse extends BasePayload {
+    type: 'get-sign-message-requests-response';
+    signMessageRequests: SignMessageRequest[];
+}
+
+export function isGetSignMessageRequestsResponse(
+    payload: Payload
+): payload is GetSignMessageRequestsResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'get-sign-message-requests-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/SignMessageRequestResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/SignMessageRequestResponse.ts
@@ -3,14 +3,14 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { SignaturePubkeyPair } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
+import type { SerializedSignaturePubkeyPair } from '_shared/signature-serialization';
 
 export interface SignMessageRequestResponse extends BasePayload {
     type: 'sign-message-request-response';
     signMessageRequestID: string;
     approved: boolean;
-    signature?: SignaturePubkeyPair;
+    signature?: SerializedSignaturePubkeyPair;
     error?: string;
 }
 

--- a/wallet/src/shared/messaging/messages/payloads/messages/ui/SignMessageRequestResponse.ts
+++ b/wallet/src/shared/messaging/messages/payloads/messages/ui/SignMessageRequestResponse.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isBasePayload } from '_payloads';
+
+import type { SignaturePubkeyPair } from '@mysten/sui.js';
+import type { BasePayload, Payload } from '_payloads';
+
+export interface SignMessageRequestResponse extends BasePayload {
+    type: 'sign-message-request-response';
+    signMessageRequestID: string;
+    approved: boolean;
+    signature?: SignaturePubkeyPair;
+    error?: string;
+}
+
+export function isSignMessageRequestResponse(
+    payload: Payload
+): payload is SignMessageRequestResponse {
+    return (
+        isBasePayload(payload) &&
+        payload.type === 'sign-message-request-response'
+    );
+}

--- a/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
@@ -4,6 +4,7 @@
 export const ALL_PERMISSION_TYPES = [
     'viewAccount',
     'suggestTransactions',
+    'suggestSignMessages',
 ] as const;
 type AllPermissionsType = typeof ALL_PERMISSION_TYPES;
 export type PermissionType = AllPermissionsType[number];

--- a/wallet/src/shared/signature-serialization.ts
+++ b/wallet/src/shared/signature-serialization.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import {
     Base64DataBuffer,
     PublicKey,

--- a/wallet/src/shared/signature-serialization.ts
+++ b/wallet/src/shared/signature-serialization.ts
@@ -1,0 +1,32 @@
+import {
+    Base64DataBuffer,
+    PublicKey,
+    type SignaturePubkeyPair,
+    type SignatureScheme,
+} from '@mysten/sui.js';
+
+export interface SerializedSignaturePubkeyPair {
+    signatureScheme: string;
+    signature: string;
+    pubKey: string;
+}
+
+export function serializeSignaturePubkeyPair(
+    signature: SignaturePubkeyPair
+): SerializedSignaturePubkeyPair {
+    return {
+        signatureScheme: signature.signatureScheme,
+        signature: signature.signature.toString(),
+        pubKey: signature.pubKey.toBase64(),
+    };
+}
+
+export function deserializeSignaturePubkeyPair(
+    signature: SerializedSignaturePubkeyPair
+): SignaturePubkeyPair {
+    return {
+        signatureScheme: signature.signatureScheme as SignatureScheme,
+        signature: new Base64DataBuffer(signature.signature),
+        pubKey: new PublicKey(signature.pubKey),
+    };
+}

--- a/wallet/src/ui/app/background-client/index.ts
+++ b/wallet/src/ui/app/background-client/index.ts
@@ -12,11 +12,7 @@ import { setPermissions } from '_redux/slices/permissions';
 import { setSignMessageRequests } from '_redux/slices/sign-message-requests';
 import { setTransactionRequests } from '_redux/slices/transaction-requests';
 
-import type {
-    SignaturePubkeyPair,
-    SuiAddress,
-    SuiTransactionResponse,
-} from '@mysten/sui.js';
+import type { SuiAddress, SuiTransactionResponse } from '@mysten/sui.js';
 import type { Message } from '_messages';
 import type { GetSignMessageRequests } from '_payloads/messages/ui/GetSignMessageRequests';
 import type { SignMessageRequestResponse } from '_payloads/messages/ui/SignMessageRequestResponse';
@@ -26,6 +22,7 @@ import type {
 } from '_payloads/permissions';
 import type { GetTransactionRequests } from '_payloads/transactions/ui/GetTransactionRequests';
 import type { TransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
+import type { SerializedSignaturePubkeyPair } from '_shared/signature-serialization';
 import type { AppDispatch } from '_store';
 
 export class BackgroundClient {
@@ -94,7 +91,7 @@ export class BackgroundClient {
     public async sendSignMessageRequestResponse(
         signMessageRequestID: string,
         approved: boolean,
-        signature: SignaturePubkeyPair | undefined,
+        signature: SerializedSignaturePubkeyPair | undefined,
         error: string | undefined
     ) {
         this.sendMessage(

--- a/wallet/src/ui/app/index.tsx
+++ b/wallet/src/ui/app/index.tsx
@@ -4,6 +4,7 @@
 import { useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
+import { DappSignMessageApprovalPage } from './pages/dapp-sign-message-approval';
 import { AppType } from './redux/slices/app/AppType';
 import { routes as stakeRoutes } from './staking';
 import { useAppDispatch, useAppSelector } from '_hooks';
@@ -78,6 +79,10 @@ const App = () => {
                 <Route
                     path="tx-approval/:txID"
                     element={<DappTxApprovalPage />}
+                />
+                <Route
+                    path="sign-message-approval/:signMessageRequestID"
+                    element={<DappSignMessageApprovalPage />}
                 />
             </Route>
 

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
@@ -1,0 +1,10 @@
+.title {
+    align-self: flex-start;
+}
+
+.message {
+    align-self: flex-start;
+    max-width: 320px;
+    overflow-wrap: break-word;
+    overflow-x: auto;
+}

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
@@ -68,3 +68,7 @@
     color: colors.$gray-85;
     font-family: 'Space Mono', ui-monospace, monospace;
 }
+
+.message small {
+    font-size: 9px;
+}

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/DappSignMessageApprovalPage.module.scss
@@ -1,10 +1,70 @@
-.title {
-    align-self: flex-start;
+@use '_values/colors';
+
+.card {
+    background: colors.$gray-40;
+    border-radius: 10px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.content {
+    padding: 15px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.content h2 {
+    display: flex;
+    justify-content: space-between;
+    font-size: 14px;
+    line-height: 13px;
+    color: colors.$gray-80;
+}
+
+.card::after {
+    content: '';
+    background-image: url('_assets/images/CardEdge.svg');
+    background-size: 20px 5px;
+    width: 100%;
+    height: 5px;
+    position: relative;
+    display: block;
+    bottom: 0;
+    right: 0;
+    z-index: 2;
+}
+
+.tabs {
+    margin-top: 20px;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 17px;
+    display: flex;
+    gap: 30px;
+    border-bottom: 1px solid colors.$gray-45;
+
+    .tab {
+        cursor: pointer;
+        background: none;
+        border: none;
+        padding: 8px 0;
+        margin-bottom: -1px;
+        color: colors.$gray-75;
+        border-bottom: 1px solid colors.$gray-45;
+
+        &.active {
+            color: colors.$gray-100;
+            border-color: colors.$gray-65;
+        }
+    }
 }
 
 .message {
-    align-self: flex-start;
-    max-width: 320px;
-    overflow-wrap: break-word;
-    overflow-x: auto;
+    font-weight: 500;
+    font-size: 14px;
+    margin-top: 20px;
+    line-height: 17px;
+    color: colors.$gray-85;
+    font-family: 'Space Mono', ui-monospace, monospace;
 }

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Base64DataBuffer } from '@mysten/sui.js';
 import cl from 'classnames';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
@@ -37,16 +36,6 @@ export function DappSignMessageApprovalPage() {
     const signMessageRequest = useAppSelector(signMessageRequestSelector);
     const loading = guardLoading || signMessageRequestLoading;
     const dispatch = useAppDispatch();
-    const messageContents = useMemo(() => {
-        if (signMessageRequest?.messageString) {
-            return signMessageRequest.messageString;
-        }
-
-        if (signMessageRequest?.messageData) {
-            const b64 = new Base64DataBuffer(signMessageRequest?.messageData);
-            return b64.toString();
-        }
-    }, [signMessageRequest]);
 
     const handleOnSubmit = useCallback(
         async (approved: boolean) => {
@@ -76,7 +65,7 @@ export function DappSignMessageApprovalPage() {
 
     return (
         <Loading loading={loading}>
-            {signMessageRequest && messageContents && (
+            {signMessageRequest && (
                 <UserApproveContainer
                     approveTitle="Sign"
                     rejectTitle="Reject"
@@ -95,7 +84,8 @@ export function DappSignMessageApprovalPage() {
                         </button>
                     </div>
                     <div className={st.message}>
-                        {messageContents}
+                        {signMessageRequest.messageString ||
+                            signMessageRequest.messageData}
                         {!signMessageRequest.messageString && (
                             <small>{' (base64)'}</small>
                         )}

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Base64DataBuffer } from '@mysten/sui.js';
 import cl from 'classnames';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
@@ -36,6 +37,16 @@ export function DappSignMessageApprovalPage() {
     const signMessageRequest = useAppSelector(signMessageRequestSelector);
     const loading = guardLoading || signMessageRequestLoading;
     const dispatch = useAppDispatch();
+    const messageContents = useMemo(() => {
+        if (signMessageRequest?.messageString) {
+            return signMessageRequest.messageString;
+        }
+
+        if (signMessageRequest?.messageData) {
+            const b64 = new Base64DataBuffer(signMessageRequest?.messageData);
+            return b64.toString();
+        }
+    }, [signMessageRequest]);
 
     const handleOnSubmit = useCallback(
         async (approved: boolean) => {
@@ -65,7 +76,7 @@ export function DappSignMessageApprovalPage() {
 
     return (
         <Loading loading={loading}>
-            {signMessageRequest && (
+            {signMessageRequest && messageContents && (
                 <UserApproveContainer
                     approveTitle="Sign"
                     rejectTitle="Reject"
@@ -84,7 +95,10 @@ export function DappSignMessageApprovalPage() {
                         </button>
                     </div>
                     <div className={st.message}>
-                        {signMessageRequest.message}
+                        {messageContents}
+                        {!signMessageRequest.messageString && (
+                            <small>{' (base64)'}</small>
+                        )}
                     </div>
                 </UserApproveContainer>
             )}

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import Loading from '_components/loading';
+import UserApproveContainer from '_components/user-approve-container';
+import { useAppDispatch, useAppSelector, useInitializedGuard } from '_hooks';
+import {
+    respondToSignMessageRequest,
+    signMessageRequestsSelectors,
+} from '_redux/slices/sign-message-requests';
+
+import type { RootState } from '_redux/RootReducer';
+
+import st from './DappSignMessageApprovalPage.module.scss';
+
+export function DappSignMessageApprovalPage() {
+    const { signMessageRequestID } = useParams();
+    const guardLoading = useInitializedGuard(true);
+    const signMessageRequestLoading = useAppSelector(
+        ({ signMessageRequests }) => !signMessageRequests.initialized
+    );
+    const signMessageRequestSelector = useMemo(
+        () => (state: RootState) =>
+            (signMessageRequestID &&
+                signMessageRequestsSelectors.selectById(
+                    state,
+                    signMessageRequestID
+                )) ||
+            null,
+        [signMessageRequestID]
+    );
+    const signMessageRequest = useAppSelector(signMessageRequestSelector);
+    const loading = guardLoading || signMessageRequestLoading;
+    const dispatch = useAppDispatch();
+
+    const handleOnSubmit = useCallback(
+        async (approved: boolean) => {
+            if (signMessageRequest) {
+                await dispatch(
+                    respondToSignMessageRequest({
+                        approved,
+                        id: signMessageRequest.id,
+                    })
+                );
+            }
+
+            return true;
+        },
+        [dispatch, signMessageRequest]
+    );
+
+    useEffect(() => {
+        if (
+            !loading &&
+            (!signMessageRequest ||
+                (signMessageRequest && signMessageRequest.approved !== null))
+        ) {
+            window.close();
+        }
+    }, [loading, signMessageRequest]);
+
+    return (
+        <Loading loading={loading}>
+            {signMessageRequest && (
+                <UserApproveContainer
+                    title="Sign Message"
+                    approveTitle="Sign Message"
+                    rejectTitle="Reject"
+                    origin={signMessageRequest.origin}
+                    originFavIcon={signMessageRequest.originFavIcon}
+                    onSubmit={handleOnSubmit}
+                >
+                    <h4 className={st.title}>Message</h4>
+                    <pre className={st.message}>
+                        {signMessageRequest.message}
+                    </pre>
+                </UserApproveContainer>
+            )}
+        </Loading>
+    );
+}

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -47,8 +47,6 @@ export function DappSignMessageApprovalPage() {
                     })
                 );
             }
-
-            return true;
         },
         [dispatch, signMessageRequest]
     );

--- a/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-sign-message-approval/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import cl from 'classnames';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -66,17 +67,25 @@ export function DappSignMessageApprovalPage() {
         <Loading loading={loading}>
             {signMessageRequest && (
                 <UserApproveContainer
-                    title="Sign Message"
-                    approveTitle="Sign Message"
+                    approveTitle="Sign"
                     rejectTitle="Reject"
                     origin={signMessageRequest.origin}
                     originFavIcon={signMessageRequest.originFavIcon}
                     onSubmit={handleOnSubmit}
                 >
-                    <h4 className={st.title}>Message</h4>
-                    <pre className={st.message}>
+                    <div className={st.card}>
+                        <div className={st.content}>
+                            <h2>Sign Message Request</h2>
+                        </div>
+                    </div>
+                    <div className={st.tabs}>
+                        <button type="button" className={cl(st.tab, st.active)}>
+                            Message Contents
+                        </button>
+                    </div>
+                    <div className={st.message}>
                         {signMessageRequest.message}
-                    </pre>
+                    </div>
                 </UserApproveContainer>
             )}
         </Loading>

--- a/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -21,6 +21,7 @@ import st from './SiteConnectPage.module.scss';
 const permissionTypeToTxt: Record<PermissionType, string> = {
     viewAccount: 'Share wallet address',
     suggestTransactions: 'Suggest transactions to approve',
+    suggestSignMessages: 'Suggest messages to sign'
 };
 
 function SiteConnectPage() {

--- a/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -21,7 +21,7 @@ import st from './SiteConnectPage.module.scss';
 const permissionTypeToTxt: Record<PermissionType, string> = {
     viewAccount: 'Share wallet address',
     suggestTransactions: 'Suggest transactions to approve',
-    suggestSignMessages: 'Suggest messages to sign'
+    suggestSignMessages: 'Suggest messages to sign',
 };
 
 function SiteConnectPage() {

--- a/wallet/src/ui/app/redux/RootReducer.ts
+++ b/wallet/src/ui/app/redux/RootReducer.ts
@@ -6,6 +6,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import account from './slices/account';
 import app from './slices/app';
 import permissions from './slices/permissions';
+import signMessageRequests from './slices/sign-message-requests';
 import suiObjects from './slices/sui-objects';
 import transactionRequests from './slices/transaction-requests';
 import transactions from './slices/transactions';
@@ -19,6 +20,7 @@ const rootReducer = combineReducers({
     txresults,
     permissions,
     transactionRequests,
+    signMessageRequests,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
+++ b/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
@@ -49,9 +49,13 @@ export const respondToSignMessageRequest = createAsyncThunk<
         if (approved) {
             const signer = api.getSignerInstance(keypairVault.getKeyPair());
             try {
-                signMessageResult = await signer.signData(
-                    new Base64DataBuffer(signMessageRequest.message)
-                );
+                if (signMessageRequest.message) {
+                    signMessageResult = await signer.signData(
+                        new Base64DataBuffer(signMessageRequest.message)
+                    );
+                } else {
+                    throw new Error('Message must be defined.');
+                }
             } catch (e) {
                 signMessageResultError = (e as Error).message;
             }

--- a/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
+++ b/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Base64DataBuffer, type SignaturePubkeyPair } from '@mysten/sui.js';
+import {
+    createAsyncThunk,
+    createEntityAdapter,
+    createSlice,
+    type EntityState,
+} from '@reduxjs/toolkit';
+
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { SignMessageRequest } from '_payloads/messages/SignMessageRequest';
+import type { RootState } from '_redux/RootReducer';
+import type { AppThunkConfig } from '_store/thunk-extras';
+
+const signMessageRequestsAdapter = createEntityAdapter<SignMessageRequest>({
+    sortComparer: (a, b) => {
+        const aDate: Date = new Date(a.createdDate);
+        const bDate: Date = new Date(b.createdDate);
+        return aDate.getTime() - bDate.getTime();
+    },
+});
+
+export const respondToSignMessageRequest = createAsyncThunk<
+    {
+        id: string;
+        approved: boolean;
+        signature: SignaturePubkeyPair | null;
+    },
+    { id: string; approved: boolean },
+    AppThunkConfig
+>(
+    'respond-to-sign-message-request',
+    async (
+        { id, approved },
+        { extra: { background, api, keypairVault }, getState }
+    ) => {
+        const state = getState();
+        const signMessageRequest = signMessageRequestsSelectors.selectById(
+            state,
+            id
+        );
+        if (!signMessageRequest) {
+            throw new Error(`SignMessageRequest ${id} not found`);
+        }
+        let signMessageResult: SignaturePubkeyPair | undefined = undefined;
+        let signMessageResultError: string | undefined;
+        if (approved) {
+            const signer = api.getSignerInstance(keypairVault.getKeyPair());
+            try {
+                signMessageResult = await signer.signData(
+                    new Base64DataBuffer(signMessageRequest.message)
+                );
+            } catch (e) {
+                signMessageResultError = (e as Error).message;
+            }
+        }
+        background.sendSignMessageRequestResponse(
+            id,
+            approved,
+            signMessageResult,
+            signMessageResultError
+        );
+        return { id, approved: approved, signature: null };
+    }
+);
+
+type State = EntityState<SignMessageRequest> & {
+    initialized: boolean;
+};
+
+const slice = createSlice({
+    name: 'sign-message-requests',
+    initialState: signMessageRequestsAdapter.getInitialState({
+        initialized: false,
+    }),
+    reducers: {
+        setSignMessageRequests: (
+            state,
+            { payload }: PayloadAction<SignMessageRequest[]>
+        ) => {
+            signMessageRequestsAdapter.setAll(state as State, payload);
+            state.initialized = true;
+        },
+    },
+    extraReducers: (build) => {
+        build.addCase(
+            respondToSignMessageRequest.fulfilled,
+            (state, { payload }) => {
+                const { id, signature, approved: allowed } = payload;
+                signMessageRequestsAdapter.updateOne(state as State, {
+                    id,
+                    changes: {
+                        approved: allowed,
+                        signature: signature || undefined,
+                    },
+                });
+            }
+        );
+    },
+});
+
+export default slice.reducer;
+
+export const { setSignMessageRequests } = slice.actions;
+
+export const signMessageRequestsSelectors =
+    signMessageRequestsAdapter.getSelectors(
+        (state: RootState) => state.signMessageRequests
+    );

--- a/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
+++ b/wallet/src/ui/app/redux/slices/sign-message-requests/index.ts
@@ -49,9 +49,9 @@ export const respondToSignMessageRequest = createAsyncThunk<
         if (approved) {
             const signer = api.getSignerInstance(keypairVault.getKeyPair());
             try {
-                if (signMessageRequest.message) {
+                if (signMessageRequest.messageData) {
                     signMessageResult = await signer.signData(
-                        new Base64DataBuffer(signMessageRequest.message)
+                        new Base64DataBuffer(signMessageRequest.messageData)
                     );
                 } else {
                     throw new Error('Message must be defined.');


### PR DESCRIPTION
**Problem**

Sui Wallet doesn't yet support the signing of messages sent from a dapp. 

**Summary of Changes**

- Added `signMessage` method to DAppInterface
- Created Sign Message Approval page for popup
- Added message passing flow and redux integration
- Adds additional permission `suggestSignMessages`
- Could use some design help

![Screenshot from 2022-08-17 19-11-35](https://user-images.githubusercontent.com/188792/185270372-377aaaa5-4c2a-41ae-9ab5-2202ef742337.png)

![Screenshot from 2022-08-17 21-16-15](https://user-images.githubusercontent.com/188792/185285317-036e458e-7834-4cd7-8a7c-23514450610d.png)

![Screenshot from 2022-08-17 15-17-05](https://user-images.githubusercontent.com/188792/185245612-5132a1fa-3505-4e19-82cc-6ad36e0f5372.png)

Fixes https://github.com/MystenLabs/sui/issues/3832

(Apologies for the duplicate PR, previous got closed upon rebase https://github.com/MystenLabs/sui/pull/4075)