### PR TITLE
tiny: add context to genesis parsing errors

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -122,7 +122,8 @@ impl Genesis {
         trace!("Reading Genesis from {}", path.display());
         let bytes = fs::read(path)
             .with_context(|| format!("Unable to load Genesis from {}", path.display()))?;
-        Ok(bcs::from_bytes(&bytes)?)
+        bcs::from_bytes(&bytes)
+            .with_context(|| format!("Unable to parse Genesis from {}", path.display()))
     }
 
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
Currently if genesis parsing fails the node exists with ambiguous error message:

```
Error: invalid length 0, expected an byte array of size 32
```

This PR adds some context to the error so that user understands which part of node startup has failed