### PR TITLE
[Quorum Driver 5/n] Sui Client and CLI tool can execute transaction via fullnode

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -288,6 +288,7 @@ pub async fn new_wallet_context_from_cluster(
         keystore,
         gateway: ClientType::RPC(rpc_url.into(), None),
         active_address: Some(address),
+        fullnode: None,
     }
     .persisted(&wallet_config_path)
     .save()

--- a/crates/sui-quorum-driver/src/lib.rs
+++ b/crates/sui-quorum-driver/src/lib.rs
@@ -74,6 +74,8 @@ where
         &self,
         request: ExecuteTransactionRequest,
     ) -> SuiResult<ExecuteTransactionResponse> {
+        let tx_digest = request.transaction.digest();
+        debug!("Receive tranasction execution request {tx_digest:?}");
         self.metrics.current_requests_in_flight.inc();
         let _metrics_guard = scopeguard::guard(self.metrics.clone(), |metrics| {
             metrics.current_requests_in_flight.dec();

--- a/crates/sui/src/config/mod.rs
+++ b/crates/sui/src/config/mod.rs
@@ -20,6 +20,8 @@ pub struct SuiClientConfig {
     pub keystore: KeystoreType,
     pub gateway: ClientType,
     pub active_address: Option<SuiAddress>,
+    // Temporarily make this optional, until we fully deprecate gateway
+    pub fullnode: Option<ClientType>,
 }
 
 impl Config for SuiClientConfig {}
@@ -40,6 +42,10 @@ impl Display for SuiClientConfig {
         };
         writeln!(writer, "{}", self.keystore)?;
         write!(writer, "{}", self.gateway)?;
+
+        if let Some(fullnode_type) = &self.fullnode {
+            write!(writer, "{}", fullnode_type)?;
+        }
 
         write!(f, "{}", writer)
     }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -284,6 +284,7 @@ impl SuiCommand {
                     keystore: KeystoreType::File(keystore_path),
                     gateway: ClientType::Embedded(wallet_gateway_config),
                     active_address,
+                    fullnode: None,
                 };
 
                 wallet_config.save(&client_path)?;
@@ -406,6 +407,7 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
                 keystore,
                 gateway: client,
                 active_address: Some(new_address),
+                fullnode: None,
             }
             .persisted(wallet_conf_path)
             .save()?;

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -126,6 +126,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
             ..Default::default()
         }),
         active_address: None,
+        fullnode: None,
     };
     let wallet_conf_path = working_dir.join(SUI_CLIENT_CONFIG);
     let wallet_config = wallet_config.persisted(&wallet_conf_path);
@@ -710,6 +711,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     let resp = SuiClientCommands::Switch {
         address: Some(addr2),
         gateway: None,
+        fullnode: None,
     }
     .execute(&mut context)
     .await?;
@@ -721,7 +723,8 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
             "{}",
             SuiClientCommandResult::Switch(SwitchResponse {
                 address: Some(addr2),
-                gateway: None
+                gateway: None,
+                fullnode: None,
             })
         )
     );
@@ -744,6 +747,7 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     let resp = SuiClientCommands::Switch {
         address: Some(new_addr),
         gateway: None,
+        fullnode: None,
     }
     .execute(&mut context)
     .await?;
@@ -754,7 +758,8 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
             "{}",
             SuiClientCommandResult::Switch(SwitchResponse {
                 address: Some(new_addr),
-                gateway: None
+                gateway: None,
+                fullnode: None,
             })
         )
     );
@@ -797,6 +802,7 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
     let resp = SuiClientCommands::Switch {
         address: Some(addr2),
         gateway: None,
+        fullnode: None,
     }
     .execute(&mut context)
     .await?;
@@ -806,7 +812,8 @@ async fn test_active_address_command() -> Result<(), anyhow::Error> {
             "{}",
             SuiClientCommandResult::Switch(SwitchResponse {
                 address: Some(addr2),
-                gateway: None
+                gateway: None,
+                fullnode: None
             })
         )
     );

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -96,6 +96,7 @@ pub async fn start_test_network_with_fullnodes(
             ..Default::default()
         }),
         active_address,
+        fullnode: None,
     }
     .save(&wallet_path)?;
 


### PR DESCRIPTION
one of the first steps to replace gateway by fullnode. With this we can at least perform local tests easily.

`./sui client switch --fullnode "http://127.0.0.1:9000"` will configure fullnode in `client.yaml` file. If fullnode is set on `WalletContext`, it will try to execute transaction via fullnode rather than gateway. 

By default this field is empty from genesis, so for now this feature is very hidden, which is on purpose until we stabilize it.

Test plan: tested locally pointing to a local fullnode