### PR TITLE
Use address input component on tranferNFTform

### DIFF
--- a/wallet/src/ui/app/components/nft-display/NFTDisplay.module.scss
+++ b/wallet/src/ui/app/components/nft-display/NFTDisplay.module.scss
@@ -46,9 +46,9 @@
         font-size: 13px;
         padding-top: 10px;
         color: colors.$gray-100;
-        width: 140px;
         text-overflow: ellipsis;
         overflow: hidden;
+        width: 100%;
         white-space: nowrap;
     }
 

--- a/wallet/src/ui/app/components/nft-display/NFTDisplay.module.scss
+++ b/wallet/src/ui/app/components/nft-display/NFTDisplay.module.scss
@@ -6,6 +6,7 @@
     flex-direction: column;
     align-items: center;
     width: 100%;
+    margin: auto;
 
     img {
         width: 100%;
@@ -14,19 +15,28 @@
         height: 100%;
     }
 
-    .small {
-        height: 98px;
+    &.small {
         width: 98px;
+
+        img {
+            height: 98px;
+        }
     }
 
-    .medium {
-        height: 150px;
+    &.medium {
         width: 150px;
+
+        img {
+            height: 150px;
+        }
     }
 
-    .large {
-        height: 180px;
+    &.large {
         width: 180px;
+
+        img {
+            height: 180px;
+        }
     }
 
     .nftfields {

--- a/wallet/src/ui/app/components/nft-display/index.tsx
+++ b/wallet/src/ui/app/components/nft-display/index.tsx
@@ -58,10 +58,10 @@ function NFTDisplayCard({
     );
 
     return (
-        <div className={cl(st.nftimage, wideview && st.wideview)}>
+        <div className={cl(st.nftimage, wideview && st.wideview, st[size])}>
             {filePath && (
                 <img
-                    className={cl(st.img, st[size])}
+                    className={cl(st.img)}
                     src={filePath}
                     alt={fileExtentionType?.name || 'NFT'}
                 />

--- a/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.module.scss
+++ b/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.module.scss
@@ -28,69 +28,7 @@
 }
 
 .group {
-    display: flex;
     width: 100%;
-
-    .input-group-append,
-    .textarea {
-        padding: 5px 12px;
-        border: 1px solid colors.$gray-50;
-        box-shadow: 0 1px 2px #1018280d;
-        border-radius: 10px;
-    }
-
-    .textarea {
-        width: 90%;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-
-        .input {
-            width: 100%;
-            border: 0;
-            resize: none;
-            padding: 5px 0;
-            vertical-align: bottom;
-            height: 40px;
-
-            &::placeholder {
-                color: colors.$gray-65;
-            }
-        }
-    }
-
-    .input-group-append {
-        padding: 0 10px;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        border-left: 0;
-        background-color: colors.$gray-40;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
-
-    .qr-code {
-        background-image: url('_assets/images/qr-code.svg');
-        padding: 0 18px;
-        background-repeat: no-repeat;
-        background-position: center;
-    }
-
-    &.invalid-addr {
-        .input-group-append,
-        .textarea {
-            border-color: colors.$error;
-        }
-    }
-
-    .change-addr-icon {
-        cursor: pointer;
-
-        &::before {
-            font-size: 16px;
-            color: colors.$gray-75;
-        }
-    }
 }
 
 .label-info {
@@ -141,8 +79,11 @@
     }
 
     .send-nft-btn {
+        color: colors.$white;
+
         &:visited,
-        &:active {
+        &:active,
+        &:disabled {
             color: colors.$gray-50;
         }
     }

--- a/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.tsx
+++ b/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.tsx
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { ErrorMessage, Form, Field, useFormikContext } from 'formik';
-import { useEffect, useRef, memo, useCallback } from 'react';
-import TextareaAutosize from 'react-textarea-autosize';
+import { Form, Field, useFormikContext } from 'formik';
+import { useEffect, useRef, memo } from 'react';
 
 import { Content } from '_app/shared/bottom-menu-layout';
 import Button from '_app/shared/button';
+import AddressInput from '_components/address-input';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
 import { DEFAULT_NFT_TRANSFER_GAS_FEE } from '_redux/slices/sui-objects/Coin';
@@ -30,9 +30,7 @@ function TransferNFTForm({
     const {
         isSubmitting,
         isValid,
-        dirty,
         values: { to, amount },
-        setFieldValue,
     } = useFormikContext<FormValues>();
 
     const onClearRef = useRef(onClearSubmitError);
@@ -40,11 +38,6 @@ function TransferNFTForm({
     useEffect(() => {
         onClearRef.current();
     }, [to, amount]);
-
-    // TODO: add QR code scanner
-    const clearAddress = useCallback(() => {
-        setFieldValue('to', '');
-    }, [setFieldValue]);
 
     return (
         <div className={st.sendNft}>
@@ -58,48 +51,17 @@ function TransferNFTForm({
                         Enter the address of the recipient to start sending the
                         NFT
                     </label>
-                    <div
-                        className={cl(
-                            st.group,
-                            dirty && to !== '' && !isValid ? st.invalidAddr : ''
-                        )}
-                    >
-                        <div className={st.textarea}>
-                            <Field as="div" id="to" placeholder="Enter Address">
-                                <TextareaAutosize
-                                    maxRows={2}
-                                    minRows={1}
-                                    name="to"
-                                    value={to}
-                                    placeholder="Enter Address"
-                                    className={st.input}
-                                />
-                            </Field>
-                        </div>
-                        <div
-                            onClick={clearAddress}
-                            className={cl(
-                                st.inputGroupAppend,
-                                dirty && to !== ''
-                                    ? st.changeAddrIcon + ' sui-icons-close'
-                                    : st.qrCode
-                            )}
-                        ></div>
+                    <div className={st.group}>
+                        <Field
+                            component={AddressInput}
+                            name="to"
+                            as="div"
+                            id="to"
+                            placeholder="Enter Address"
+                            className={st.input}
+                        />
                     </div>
 
-                    <ErrorMessage
-                        className={st.error}
-                        name="to"
-                        component="div"
-                    />
-                    {isValid && (
-                        <div className={st.validAddress}>
-                            <Icon
-                                icon={SuiIcons.Checkmark}
-                                className={st.checkmark}
-                            />
-                        </div>
-                    )}
                     {BigInt(gasBalance) < DEFAULT_NFT_TRANSFER_GAS_FEE && (
                         <div className={st.error}>
                             * Insufficient balance to cover transfer cost


### PR DESCRIPTION
- Update the Transfer NFT form to use the Address Input component. 
- Remove styles related to the old input field. 
- Set the parent element of an NFT image to a fixed width to prevent text overflow.