### PR TITLE
Added comma separated numbers to the activity section and receipt page

### DIFF
--- a/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -10,6 +10,7 @@ import Icon, { SuiIcons } from '_components/icon';
 import { formatDate } from '_helpers';
 import { useFileExtentionType } from '_hooks';
 import { GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
+import { balanceFormatOptions } from '_shared/formatting';
 
 import type { TxResultState } from '_redux/slices/txresults';
 
@@ -99,7 +100,10 @@ function ReceiptCard({ tranferType, txDigest }: TxResponseProps) {
                     {AssetCard}
                     {txDigest.amount && (
                         <div className={st.amount}>
-                            {intl.formatNumber(BigInt(txDigest.amount || 0))}{' '}
+                            {intl.formatNumber(
+                                BigInt(txDigest.amount || 0),
+                                balanceFormatOptions
+                            )}{' '}
                             <span>{GAS_SYMBOL}</span>
                         </div>
                     )}
@@ -135,7 +139,8 @@ function ReceiptCard({ tranferType, txDigest }: TxResponseProps) {
                                 {intl.formatNumber(
                                     BigInt(
                                         txDigest.amount + txDigest.txGas || 0
-                                    )
+                                    ),
+                                    balanceFormatOptions
                                 )}{' '}
                                 {GAS_SYMBOL}
                             </div>

--- a/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
+import { useIntl } from 'react-intl';
 
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
@@ -24,6 +25,8 @@ function ReceiptCard({ tranferType, txDigest }: TxResponseProps) {
     const iconClassName = txDigest.isSender
         ? cl(st.arrowActionIcon, st.angledArrow)
         : cl(st.arrowActionIcon, st.buyIcon);
+
+    const intl = useIntl();
 
     const imgUrl = txDigest?.url
         ? txDigest?.url.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')
@@ -96,7 +99,8 @@ function ReceiptCard({ tranferType, txDigest }: TxResponseProps) {
                     {AssetCard}
                     {txDigest.amount && (
                         <div className={st.amount}>
-                            {txDigest.amount} <span>{GAS_SYMBOL}</span>
+                            {intl.formatNumber(BigInt(txDigest.amount || 0))}{' '}
+                            <span>{GAS_SYMBOL}</span>
                         </div>
                     )}
                     <div
@@ -128,7 +132,12 @@ function ReceiptCard({ tranferType, txDigest }: TxResponseProps) {
                         <div className={st.txFees}>
                             <div className={st.txInfoLabel}>Total Amount</div>
                             <div className={st.walletInfoValue}>
-                                {txDigest.amount + txDigest.txGas} {GAS_SYMBOL}
+                                {intl.formatNumber(
+                                    BigInt(
+                                        txDigest.amount + txDigest.txGas || 0
+                                    )
+                                )}{' '}
+                                {GAS_SYMBOL}
                             </div>
                         </div>
                     )}

--- a/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -3,6 +3,7 @@
 
 import cl from 'classnames';
 import { memo } from 'react';
+import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
 import Icon, { SuiIcons } from '_components/icon';
@@ -28,6 +29,8 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
         TRUNCATE_MAX_LENGTH,
         TRUNCATE_PREFIX_LENGTH
     );
+
+    const intl = useIntl();
 
     const transferStatus = txn.status === 'success' ? 'Checkmark' : 'Close';
 
@@ -90,7 +93,8 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
                     {txn.amount && (
                         <>
                             <div className={st.txAmount}>
-                                {txn.amount} {GAS_SYMBOL}
+                                {intl.formatNumber(BigInt(txn.amount || 0))}{' '}
+                                {GAS_SYMBOL}
                             </div>
                             <div className={st.txFiatValue}></div>
                         </>

--- a/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -10,6 +10,7 @@ import Icon, { SuiIcons } from '_components/icon';
 import { formatDate } from '_helpers';
 import { useMiddleEllipsis } from '_hooks';
 import { GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
+import { balanceFormatOptions } from '_shared/formatting';
 
 import type { TxResultState } from '_redux/slices/txresults';
 
@@ -93,7 +94,10 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
                     {txn.amount && (
                         <>
                             <div className={st.txAmount}>
-                                {intl.formatNumber(BigInt(txn.amount || 0))}{' '}
+                                {intl.formatNumber(
+                                    BigInt(txn.amount || 0),
+                                    balanceFormatOptions
+                                )}{' '}
                                 {GAS_SYMBOL}
                             </div>
                             <div className={st.txFiatValue}></div>

--- a/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
+++ b/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
@@ -4,7 +4,6 @@
 import cl from 'classnames';
 import { memo, useMemo } from 'react';
 import { useIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
 
 import { useMiddleEllipsis } from '_hooks';
 import { Coin } from '_redux/slices/sui-objects/Coin';
@@ -26,10 +25,7 @@ function CoinBalance({ type, balance, mode = 'row-item' }: CoinProps) {
         () => intl.formatNumber(balance, balanceFormatOptions),
         [intl, balance]
     );
-    const sendUrl = useMemo(
-        () => `/send?${new URLSearchParams({ type }).toString()}`,
-        [type]
-    );
+
     const shortenType = useMiddleEllipsis(type, 30);
     return (
         <div className={cl(st.container, st[mode])}>
@@ -45,9 +41,6 @@ function CoinBalance({ type, balance, mode = 'row-item' }: CoinProps) {
                         {shortenType}
                     </span>
                 ) : null}
-                <Link className={cl('btn', st.action)} to={sendUrl}>
-                    Send
-                </Link>
             </div>
         </div>
     );

--- a/wallet/src/ui/app/pages/home/tokens/index.tsx
+++ b/wallet/src/ui/app/pages/home/tokens/index.tsx
@@ -50,8 +50,9 @@ function TokensPage() {
                 />
                 <IconLink
                     icon={SuiIcons.HandCoins}
-                    to="/"
-                    disabled={true}
+                    to={`/send?${new URLSearchParams({
+                        type: GAS_TYPE_ARG,
+                    }).toString()}`}
                     text="Send & Receive"
                 />
                 <IconLink

--- a/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
+++ b/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
@@ -15,6 +15,7 @@ import AddressInput from '_components/address-input';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
 import { DEFAULT_GAS_BUDGET_FOR_TRANSFER } from '_redux/slices/sui-objects/Coin';
+import { balanceFormatOptions } from '_shared/formatting';
 
 import type { FormValues } from '../';
 
@@ -76,7 +77,10 @@ function StepTwo({
 
                     <div className={st.responseCard}>
                         <div className={st.amount}>
-                            {intl.formatNumber(BigInt(amount || 0))}{' '}
+                            {intl.formatNumber(
+                                BigInt(amount || 0),
+                                balanceFormatOptions
+                            )}{' '}
                             <span>{coinSymbol}</span>
                         </div>
 
@@ -95,7 +99,8 @@ function StepTwo({
                                 </div>
                                 <div className={st.walletInfoValue}>
                                     {intl.formatNumber(
-                                        BigInt(totalAmount || 0)
+                                        BigInt(totalAmount || 0),
+                                        balanceFormatOptions
                                     )}{' '}
                                     {coinSymbol}
                                 </div>

--- a/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
+++ b/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
@@ -94,7 +94,10 @@ function StepTwo({
                                     Total Amount
                                 </div>
                                 <div className={st.walletInfoValue}>
-                                    {totalAmount} {coinSymbol}
+                                    {intl.formatNumber(
+                                        BigInt(totalAmount || 0)
+                                    )}{' '}
+                                    {coinSymbol}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
- Added comma-separated numbers to the activity section and receipt page
- Remove the old send coin button and activate the new one


![Screen Shot 2022-08-18 at 10 30 50 AM](https://user-images.githubusercontent.com/8676844/185422835-85391610-37bb-426c-ba87-fde014b8e45c.png)
![Screen Shot 2022-08-18 at 10 10 37 AM](https://user-images.githubusercontent.com/8676844/185422903-891cb7cf-13b2-47a2-838f-43111822faec.png)
![Screen Shot 2022-08-18 at 10 08 17 AM](https://user-images.githubusercontent.com/8676844/185423214-26ea20e3-0f87-4530-95bd-6d0fcded6c5e.png)

