### PR TITLE
update default grpc connection limit

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -20,7 +20,7 @@ use sui_types::crypto::KeypairTraits;
 use sui_types::sui_serde::KeyPairBase64;
 
 // Default max number of concurrent requests served
-pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 500;
+pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000;
 
 #[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -5,7 +5,7 @@ expression: genesis_config
 validator_genesis_info: ~
 committee_size: 4
 grpc_load_shed: ~
-grpc_concurrency_limit: 500
+grpc_concurrency_limit: 20000
 accounts:
   - address: 375741c9373ae27bde5e6b5f5cc79f074cd84587
     gas_objects:

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -37,7 +37,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
   - key-pair: BWT4edJ648As6Cg0rPqMeTpinyyg3mkZYQvoL0ETJr6u8/SkuOyh38NDNhv45Da9Qt6SWcBLgxTrjiBU3W6Cqw==
@@ -74,7 +74,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
   - key-pair: C9WIQSA+dP6G/HEzjOAXPcYo67cZvcvMFRWFIUzAibSKV2LiGsHNs4cEQsd7TDr1jHztuHedAnDm1PHi9zZ9dA==
@@ -111,7 +111,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
   - key-pair: QiWNzaFM8RHGAriXG4zIQ+keRsqQUVHAJ0SmsBfmkxbMYjMuNLstXNafYO+7KjbLkWx+tFgwHqNmNsTbsBK9iA==
@@ -148,7 +148,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
   - key-pair: sgzWfEvezFOOi+mQwbZCXWi/06b+l2k+SEY1FZbMqKsjjttu6akf3I5xvlDAo/s88pLZAk3brAKqpwkJawqp2g==
@@ -185,7 +185,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
   - key-pair: 9Z/d0Lf1LcwMYKRIy/lRFhCwp0Lx5NI4p6RcrgVOwhydR2FqGN8gOTB/BkIiYCWItSpqrqp7b+jGtNnrqKeHsQ==
@@ -222,7 +222,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
   - key-pair: 4BB+FmG6xjjQpGNs/bv21foY4nMY2jMCltCjhxgNbIzqP8527hCzpkX7MEBRHfq0yc1gWPQZKQFNFkZvXjssKg==
@@ -259,7 +259,7 @@ validator_configs:
     enable-gossip: true
     enable-reconfig: false
     grpc-load-shed: ~
-    grpc-concurrency-limit: 500
+    grpc-concurrency-limit: 20000
     genesis:
       genesis: "[fake genesis]"
 account_keys:


### PR DESCRIPTION
500 is too low. 20k is above our all time high (16k) so far so should be safe. Note this number is just a fallback value in the config in case we forget to fill in this value in config. 