### PR TITLE
[explorer] Fix node map on small devices

### DIFF
--- a/explorer/client/src/components/validator-map/ValidatorMap.module.css
+++ b/explorer/client/src/components/validator-map/ValidatorMap.module.css
@@ -27,7 +27,7 @@
 }
 
 .map {
-    @apply absolute top-0 bottom-0 right-0 md:left-32 pointer-events-none md:pointer-events-auto;
+    @apply absolute inset-0 md:left-32 pointer-events-none md:pointer-events-auto;
 }
 
 .map svg {


### PR DESCRIPTION
I missed a `left-0`, which was causing the map to be width 0 on small devices, but only with some layout engines. Moved to` inset-0` because it's the same things as `left-0 right-0 top-0 bottom-0`.