### PR TITLE
[TypeScript SDK] Add note about building SDK with all deps

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -33,6 +33,12 @@ cd <your project directory>
 npm link @mysten/sui.js
 ```
 
+If you wish to rebuild all dependencies of the TypeScript SDK, or if you're encountering issues with the `@mysten/bcs` module not being found, you can re-build the SDK module and all of it's local dependencies using the following command:
+
+```bash
+pnpm --filter @mysten/sui.js... build
+```
+
 Refer to the [JSON RPC doc](https://github.com/MystenLabs/sui/blob/main/doc/src/build/json-rpc.md) for instructions about how to start a local network and local RPC server
 
 ## Type Doc


### PR DESCRIPTION
Sometimes, you can end up in a state where the `@mysten/bcs` module isn't built when you're trying to build the TypeScript SDK, causing an error. This adds a note to the readme about how to invoke the build including all dependencies of the project.

I'm planning on resolving this at a more fundamental level as I migrate projects off of TSDX (#4143), but for now this note should be sufficient.