### PR TITLE
Do not double-check transaction effects when catching up to checkpoint

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -618,11 +618,10 @@ where
             return Err(SuiError::CheckpointingError { error });
         }
 
-        checkpoint_db.lock().process_new_checkpoint_certificate(
+        checkpoint_db.lock().process_synced_checkpoint_certificate(
             &past,
             &contents,
             &net.committee,
-            active_authority.state.database.clone(),
             metrics,
         )?;
     }


### PR DESCRIPTION
When syncing to checkpoint we download effects and insert them in DB. If this fails we abort checkpoint sync process.

As such catching up to check point does not need to double-check that just inserted effects exist in DB, so this check can be skipped in this particular place.

Other places where new checkpoint is set still perform the check.

**Why do we need this PR?**

This will fix frequent "Checkpoint blocked by pending certificates" that we can see in devnet validator logs. In fact, currently any attempt to catch up to checkpoint by validator will fail first with this error and only will succeed on second attempt, this PR fixed this unfortunate behaviour.

This will also unblock full node being able to catch up to checkpoint during startup (in the future PR).

This PR is somewhat related to the #4168 - we remove redundant check when catching up to checkpoint. We still need another PR for that issue to check effects instead of batch service inclusion for other use cases.