### PR TITLE
[wallet-ext] Remove TxContext from the dapp signing page

### DIFF
--- a/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
+++ b/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
@@ -36,6 +36,8 @@ interface TypeReference {
     type_arguments: SuiMoveNormalizedType[];
 }
 
+const TX_CONTEXT_TYPE = '0x2::tx_context::TxContext';
+
 /** Takes a normalized move type and returns the address information contained within it */
 function unwrapTypeReference(
     type: SuiMoveNormalizedType
@@ -141,6 +143,8 @@ export function DappTxApprovalPage() {
             if ('Struct' in param) {
                 transfer.children.push(groupedParam);
             } else if ('MutableReference' in param) {
+                // Skip TxContext:
+                if (groupedParam.module === TX_CONTEXT_TYPE) return;
                 modify.children.push(groupedParam);
             } else if ('Reference' in param) {
                 read.children.push(groupedParam);


### PR DESCRIPTION
We noticed that `TxContext` was showing up in the request to sign transactions. This removes it.
![Screen Shot 2022-08-19 at 2 27 46 PM](https://user-images.githubusercontent.com/109986297/185709687-0f763a20-9e78-4a92-a5df-f60190387fa3.png)
