### PR TITLE
Clean up checkpoint_integration test

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -883,7 +883,7 @@ impl CheckpointStore {
         let size = transactions.transactions.len();
         info!(cp_seq=?checkpoint_sequence, ?size, "A new checkpoint proposal is created");
         debug!(
-            "Transactions included in the checkpoint: {:?}",
+            "Transactions included in the checkpoint proposal: {:?}",
             transactions.transactions
         );
 


### PR DESCRIPTION
The test is very confusing. It generates random transactions that were thrown away.
This PR cleans it up slightly.