### PR TITLE
Changes to ensure forward progress in fullnode sync

### DIFF
--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -12,7 +12,7 @@ use std::collections::{hash_map, BTreeSet, HashMap};
 use sui_storage::node_sync_store::NodeSyncStore;
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests, TransactionDigest, TransactionEffectsDigest},
-    committee::{Committee, StakeUnit},
+    committee::Committee,
     error::{SuiError, SuiResult},
     messages::{CertifiedTransaction, SignedTransactionEffects, TransactionInfoResponse},
     messages_checkpoint::CheckpointContents,
@@ -35,83 +35,6 @@ const NODE_SYNC_QUEUE_LEN: usize = 500;
 // Process up to 20 digests concurrently.
 const MAX_NODE_SYNC_CONCURRENCY: usize = 20;
 
-/// EffectsStakeMap tracks which effects digests have been attested by a quorum of validators and
-/// are thus final.
-struct EffectsStakeMap {
-    /// Keep track of how much stake has voted for a given effects digest
-    /// any entry in this map with >2f+1 stake can be sequenced locally and
-    /// removed from the map.
-    effects_stake_map: HashMap<TransactionEffectsDigest, StakeUnit>,
-    /// Keep track of stake votes per validator - needed to double check the total stored in
-    /// effects_stake_map, which can otherwise be corrupted by byzantine double-voting.
-    effects_vote_map: HashMap<TransactionEffectsDigest, HashMap<AuthorityName, StakeUnit>>,
-}
-
-impl EffectsStakeMap {
-    pub fn new() -> Self {
-        Self {
-            effects_stake_map: HashMap::new(),
-            effects_vote_map: HashMap::new(),
-        }
-    }
-
-    // Get the set of authorities who voted for a digest.
-    pub fn voters(&self, digest: &TransactionEffectsDigest) -> BTreeSet<AuthorityName> {
-        self.effects_vote_map
-            .get(digest)
-            .unwrap_or(&HashMap::new())
-            .keys()
-            .cloned()
-            .collect()
-    }
-
-    /// Note that a given effects digest has been attested by a validator, and return true if the
-    /// stake that has attested that effects digest has exceeded the quorum threshold.
-    pub fn note_effects_digest(
-        &mut self,
-        source: &AuthorityName,
-        stake: StakeUnit,
-        quorum_threshold: StakeUnit,
-        effects_digest: &TransactionEffectsDigest,
-    ) -> bool {
-        let validator_map = self
-            .effects_vote_map
-            .entry(*effects_digest)
-            .or_insert_with(HashMap::new);
-
-        let vote_entry = validator_map.entry(*source);
-
-        let cur_stake = if let hash_map::Entry::Occupied(_) = &vote_entry {
-            // TODO: report byzantine authority suspciion
-            warn!(peer = ?source, ?effects_digest,
-                "ByzantineAuthoritySuspicion: peer double-voted for effects digest");
-            self.effects_stake_map.entry(*effects_digest).or_insert(0)
-        } else {
-            vote_entry.or_insert(stake);
-
-            self.effects_stake_map
-                .entry(*effects_digest)
-                .and_modify(|cur| *cur += stake)
-                .or_insert(stake)
-        };
-
-        let is_final = *cur_stake >= quorum_threshold;
-        if !is_final {
-            trace!(
-                ?effects_digest,
-                "tx cert/effects not yet final: {} < {}",
-                *cur_stake,
-                quorum_threshold
-            );
-        }
-        is_final
-    }
-
-    pub fn forget_effects(&mut self, digests: &TransactionEffectsDigest) {
-        self.effects_stake_map.remove(digests);
-        self.effects_vote_map.remove(digests);
-    }
-}
 
 /// Waiter is used to single-shot concurrent requests and wait for dependencies to finish.
 struct Waiter<Key, ResultT> {
@@ -247,7 +170,6 @@ impl DownloadRequest {
 /// TXes locally.
 pub struct NodeSyncState<A> {
     committee: Arc<Committee>,
-    effects_stake: Mutex<EffectsStakeMap>,
     state: Arc<AuthorityState>,
     pub(super) node_sync_store: Arc<NodeSyncStore>,
     aggregator: Arc<AuthorityAggregator<A>>,
@@ -277,7 +199,6 @@ impl<A> NodeSyncState<A> {
         let committee = state.committee.load().deref().clone();
         Self {
             committee,
-            effects_stake: Mutex::new(EffectsStakeMap::new()),
             state,
             aggregator,
             node_sync_store,
@@ -437,13 +358,25 @@ where
         }
     }
 
+    pub fn cleanup_cert(
+        &self,
+        digest: &TransactionDigest,
+        effects: Option<&TransactionEffectsDigest>,
+    ) {
+        let _ = self
+            .node_sync_store
+            .cleanup_cert(digest, effects)
+            .tap_err(|e| warn!("cleanup_cert failed: {}", e));
+    }
+
     async fn process_digest(&self, arg: SyncArg, permit: OwnedSemaphorePermit) -> SyncResult {
         trace!(?arg, "process_digest");
 
-        let (digest, _effects_digest) = arg.digests();
+        let (digest, effects_digest) = arg.digests();
 
         // check if the tx is already locally final
         if self.state.database.effects_exists(digest)? {
+            self.cleanup_cert(digest, effects_digest);
             return Ok(SyncStatus::CertExecuted);
         }
 
@@ -468,12 +401,11 @@ where
                 let stake = self.committee.weight(&peer);
                 let quorum_threshold = self.committee.quorum_threshold();
 
-                let is_final = self.effects_stake.lock().unwrap().note_effects_digest(
-                    &peer,
-                    stake,
-                    quorum_threshold,
-                    &digests.effects,
-                );
+                self.node_sync_store
+                    .record_effects_vote(peer, digests.effects, stake)?;
+                let votes = self.node_sync_store.count_effects_votes(digests.effects)?;
+
+                let is_final = votes >= quorum_threshold;
 
                 if !is_final {
                     return Ok(SyncStatus::NotFinal);
@@ -483,7 +415,7 @@ where
 
                 (
                     digests,
-                    Some(self.effects_stake.lock().unwrap().voters(&digests.effects)),
+                    Some(self.node_sync_store.get_voters(digests.effects)?),
                 )
             }
             SyncArg::Checkpoint(digests) => {
@@ -751,48 +683,5 @@ impl NodeSyncHandle {
         let sender = self.sender.clone();
         Self::send_msg_with_tx(sender, DigestsMessage::new(&digests, peer, tx)).await?;
         Ok(Self::map_rx(rx))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    // Note: this code is tested end-to-end in full_node_tests.rs
-
-    use fastcrypto::traits::KeyPair;
-    use sui_types::{
-        base_types::{AuthorityName, TransactionEffectsDigest},
-        crypto::{get_key_pair, AuthorityKeyPair},
-    };
-
-    use super::EffectsStakeMap;
-
-    fn random_authority_name() -> AuthorityName {
-        let key: (_, AuthorityKeyPair) = get_key_pair();
-        key.1.public().into()
-    }
-
-    #[test]
-    fn test_effects_stake() {
-        let mut map = EffectsStakeMap::new();
-
-        let threshold = 3;
-
-        let byzantine = random_authority_name();
-        let validator2 = random_authority_name();
-        let validator3 = random_authority_name();
-
-        let digests = TransactionEffectsDigest::random();
-
-        assert!(!map.note_effects_digest(&byzantine, 1, threshold, &digests));
-        assert!(!map.note_effects_digest(&validator2, 1, threshold, &digests));
-
-        // double voting is rejected
-        assert!(!map.note_effects_digest(&byzantine, 1, threshold, &digests));
-
-        // final vote pushes us over.
-        assert!(map.note_effects_digest(&validator3, 1, threshold, &digests));
-
-        // double vote doesn't result in false if we already exceeded threshold.
-        assert!(map.note_effects_digest(&byzantine, 1, threshold, &digests));
     }
 }

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -159,18 +159,18 @@ where
 
 struct DigestsMessage {
     sync_arg: SyncArg,
-    tx: Option<oneshot::Sender<SuiResult>>,
+    tx: Option<oneshot::Sender<SyncResult>>,
 }
 
 impl DigestsMessage {
-    fn new_for_ckpt(digests: &ExecutionDigests, tx: oneshot::Sender<SuiResult>) -> Self {
+    fn new_for_ckpt(digests: &ExecutionDigests, tx: oneshot::Sender<SyncResult>) -> Self {
         Self {
             sync_arg: SyncArg::Checkpoint(*digests),
             tx: Some(tx),
         }
     }
 
-    fn new_for_exec_driver(digest: &TransactionDigest, tx: oneshot::Sender<SuiResult>) -> Self {
+    fn new_for_exec_driver(digest: &TransactionDigest, tx: oneshot::Sender<SyncResult>) -> Self {
         Self {
             sync_arg: SyncArg::ExecDriver(*digest),
             tx: Some(tx),
@@ -180,7 +180,7 @@ impl DigestsMessage {
     fn new(
         digests: &ExecutionDigests,
         peer: AuthorityName,
-        tx: oneshot::Sender<SuiResult>,
+        tx: oneshot::Sender<SyncResult>,
     ) -> Self {
         Self {
             sync_arg: SyncArg::Follow(peer, *digests),
@@ -290,6 +290,17 @@ impl<A> NodeSyncState<A> {
     }
 }
 
+pub enum SyncStatus {
+    /// The digest has been successfully processed, but there is not yet sufficient stake
+    /// voting for the digest to prove finality.
+    NotFinal,
+
+    /// The digest was executed locally.
+    CertExecuted,
+}
+
+pub type SyncResult = SuiResult<SyncStatus>;
+
 impl<A> NodeSyncState<A>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
@@ -375,7 +386,7 @@ where
         &self,
         permit: OwnedSemaphorePermit,
         digest: &TransactionDigest,
-    ) -> SuiResult {
+    ) -> SyncResult {
         trace!(?digest, "validator pending execution requested");
 
         let cert = match self.state.database.read_certificate(digest)? {
@@ -389,7 +400,7 @@ where
         };
 
         match self.state.handle_certificate(cert.clone()).await {
-            Ok(_) => Ok(()),
+            Ok(_) => Ok(SyncStatus::CertExecuted),
             Err(SuiError::ObjectErrors { .. }) => {
                 debug!(?digest, "cert execution failed due to missing parents");
 
@@ -413,7 +424,7 @@ where
                     // Parents have been executed, so this should now succeed.
                     debug!(?digest, "parents executed, re-attempting cert");
                     self.state.handle_certificate(cert.clone()).await?;
-                    Ok(())
+                    Ok(SyncStatus::CertExecuted)
                 } else {
                     Err(SuiError::ExecutionDriverError {
                         digest: *digest,
@@ -426,14 +437,14 @@ where
         }
     }
 
-    async fn process_digest(&self, arg: SyncArg, permit: OwnedSemaphorePermit) -> SuiResult {
+    async fn process_digest(&self, arg: SyncArg, permit: OwnedSemaphorePermit) -> SyncResult {
         trace!(?arg, "process_digest");
 
         let (digest, _effects_digest) = arg.digests();
 
         // check if the tx is already locally final
         if self.state.database.effects_exists(digest)? {
-            return Ok(());
+            return Ok(SyncStatus::CertExecuted);
         }
 
         // TODO: We could kick off the cert download now, as an optimization. For simplicity
@@ -465,20 +476,7 @@ where
                 );
 
                 if !is_final {
-                    // we won't be downloading anything, so release the permit
-                    std::mem::drop(permit);
-
-                    // wait until the tx becomes final before returning, so that the follower doesn't mark
-                    // this tx as finished prematurely.
-                    let _timer = self.metrics.wait_for_finality_latency_sec.start_timer();
-                    let (_, mut rx) = self.pending_txes.wait(&digests.transaction).await;
-                    let result = rx
-                        .recv()
-                        .await
-                        .map_err(|e| SuiError::GenericAuthorityError {
-                            error: format!("{:?}", e),
-                        });
-                    return result;
+                    return Ok(SyncStatus::NotFinal);
                 }
 
                 debug!(?digests, ?peer, "digests are now final");
@@ -519,7 +517,7 @@ where
             .forget_effects(effects.digest());
         self.node_sync_store.delete_cert_and_effects(digest)?;
 
-        Ok(())
+        Ok(SyncStatus::CertExecuted)
     }
 
     async fn wait_for_parents(
@@ -669,7 +667,7 @@ impl NodeSyncHandle {
         Self { sender, metrics }
     }
 
-    fn map_rx(rx: oneshot::Receiver<SuiResult>) -> BoxFuture<'static, SuiResult> {
+    fn map_rx(rx: oneshot::Receiver<SyncResult>) -> BoxFuture<'static, SyncResult> {
         Box::pin(rx.map(|res| {
             let res = res.map_err(|e| SuiError::GenericAuthorityError {
                 error: e.to_string(),
@@ -698,7 +696,7 @@ impl NodeSyncHandle {
     pub async fn sync_checkpoint_cert_transactions(
         &self,
         checkpoint_contents: &CheckpointContents,
-    ) -> SuiResult<impl Stream<Item = SuiResult>> {
+    ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digests in checkpoint_contents.iter() {
             let (tx, rx) = oneshot::channel();
@@ -732,7 +730,7 @@ impl NodeSyncHandle {
     pub async fn handle_execution_request(
         &self,
         digests: impl Iterator<Item = TransactionDigest>,
-    ) -> SuiResult<impl Stream<Item = SuiResult>> {
+    ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digest in digests {
             let (tx, rx) = oneshot::channel();
@@ -748,7 +746,7 @@ impl NodeSyncHandle {
         &self,
         peer: AuthorityName,
         digests: ExecutionDigests,
-    ) -> SuiResult<BoxFuture<'static, SuiResult>> {
+    ) -> SuiResult<BoxFuture<'static, SyncResult>> {
         let (tx, rx) = oneshot::channel();
         let sender = self.sender.clone();
         Self::send_msg_with_tx(sender, DigestsMessage::new(&digests, peer, tx)).await?;

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -824,7 +824,7 @@ impl NodeSyncHandle {
     pub async fn sync_pending_checkpoint_transactions(
         &self,
         transactions: impl Iterator<Item = &ExecutionDigests>,
-    ) -> SuiResult<impl Stream<Item = SuiResult>> {
+    ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digests in transactions {
             let (tx, rx) = oneshot::channel();

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -154,6 +154,7 @@ impl NodeSyncStore {
         effects_digest: TransactionEffectsDigest,
         stake: StakeUnit,
     ) -> SuiResult {
+        trace!(?effects_digest, ?peer, ?stake, "recording vote");
         Ok(self.effects_votes.insert(&(effects_digest, peer), &stake)?)
     }
 
@@ -187,6 +188,7 @@ impl NodeSyncStore {
     }
 
     pub fn clear_effects_votes(&self, digest: TransactionEffectsDigest) -> SuiResult {
+        trace!(effects_digest = ?digest, "clearing votes");
         Ok(self
             .effects_votes
             .multi_remove(self.iter_fx_digest(digest)?.map(|(k, _)| k))?)

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -248,7 +248,7 @@ mod test {
         db.record_effects_vote(peer1, tx2, digest2, 1).unwrap();
         db.record_effects_vote(peer2, tx2, digest2, 2).unwrap();
 
-        db.clear_effects_votes(digest1).unwrap();
+        db.clear_effects_votes(tx1).unwrap();
         // digest1 is cleared
         assert_eq!(db.count_effects_votes(tx1, digest1).unwrap(), 0);
         // digest2 is not

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -25,8 +25,11 @@ use std::sync::Arc;
 /// not yet been applied to the node's SuiDataStore.
 #[derive(DBMapUtils)]
 pub struct NodeSyncStore {
-    /// Certificates/Effects that have been fetched from remote validators, but not sequenced.
-    certs_and_fx: DBMap<TransactionDigest, (CertifiedTransaction, SignedTransactionEffects)>,
+    /// Certificates that have been fetched from remote validators, but not sequenced.
+    certs: DBMap<TransactionDigest, CertifiedTransaction>,
+
+    /// Verified true effects.
+    effects: DBMap<TransactionDigest, SignedTransactionEffects>,
 
     /// The persisted batch streams (minus the signed batches) from each authority.
     batch_streams: DBMap<(AuthorityName, TxSequenceNumber), ExecutionDigests>,
@@ -46,23 +49,37 @@ impl NodeSyncStore {
         Arc::new(NodeSyncStore::open_tables_read_write(db_path, None, None))
     }
 
-    pub fn has_cert_and_effects(&self, tx: &TransactionDigest) -> SuiResult<bool> {
-        Ok(self.certs_and_fx.contains_key(tx)?)
+    pub fn store_cert(&self, cert: &CertifiedTransaction) -> SuiResult {
+        Ok(self.certs.insert(cert.digest(), cert)?)
     }
 
-    pub fn store_cert_and_effects(
+    pub fn store_effects(
         &self,
         tx: &TransactionDigest,
-        val: &(CertifiedTransaction, SignedTransactionEffects),
+        effects: &SignedTransactionEffects,
     ) -> SuiResult {
-        Ok(self.certs_and_fx.insert(tx, val)?)
+        Ok(self.effects.insert(tx, effects)?)
     }
 
     pub fn get_cert_and_effects(
         &self,
         tx: &TransactionDigest,
-    ) -> SuiResult<Option<(CertifiedTransaction, SignedTransactionEffects)>> {
-        Ok(self.certs_and_fx.get(tx)?)
+    ) -> SuiResult<(
+        Option<CertifiedTransaction>,
+        Option<SignedTransactionEffects>,
+    )> {
+        Ok((self.certs.get(tx)?, self.effects.get(tx)?))
+    }
+
+    pub fn get_cert(&self, tx: &TransactionDigest) -> SuiResult<Option<CertifiedTransaction>> {
+        Ok(self.certs.get(tx)?)
+    }
+
+    pub fn get_effects(
+        &self,
+        tx: &TransactionDigest,
+    ) -> SuiResult<Option<SignedTransactionEffects>> {
+        Ok(self.effects.get(tx)?)
     }
 
     pub fn cleanup_cert(
@@ -70,7 +87,8 @@ impl NodeSyncStore {
         digest: &TransactionDigest,
         effects: Option<&TransactionEffectsDigest>,
     ) -> SuiResult {
-        self.certs_and_fx.remove(digest)?;
+        self.certs.remove(digest)?;
+        self.effects.remove(digest)?;
         if let Some(effects) = effects {
             self.clear_effects_votes(*effects)?;
         }

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -65,8 +65,17 @@ impl NodeSyncStore {
         Ok(self.certs_and_fx.get(tx)?)
     }
 
-    pub fn delete_cert_and_effects(&self, tx: &TransactionDigest) -> SuiResult {
-        Ok(self.certs_and_fx.remove(tx)?)
+    pub fn cleanup_cert(
+        &self,
+        digest: &TransactionDigest,
+        effects: Option<&TransactionEffectsDigest>,
+    ) -> SuiResult {
+        self.certs_and_fx.remove(digest)?;
+        if let Some(effects) = effects {
+            self.clear_effects_votes(*effects)?;
+        }
+
+        Ok(())
     }
 
     pub fn enqueue_execution_digests(

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -276,6 +276,8 @@ pub struct TransactionEffectsDigest(
 );
 
 impl TransactionEffectsDigest {
+    pub const ZERO: Self = TransactionEffectsDigest([0u8; TRANSACTION_DIGEST_LENGTH]);
+
     // for testing
     pub fn random() -> Self {
         let random_bytes = rand::thread_rng().gen::<[u8; TRANSACTION_DIGEST_LENGTH]>();

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -337,8 +337,10 @@ impl ToFromBytes for AuthorityPublicKeyBytes {
 }
 
 impl AuthorityPublicKeyBytes {
+    pub const ZERO: Self = Self::new([0u8; AccountPublicKey::LENGTH]);
+
     /// This ensures it's impossible to construct an instance with other than registered lengths
-    pub fn new(bytes: [u8; AuthorityPublicKey::LENGTH]) -> AuthorityPublicKeyBytes
+    pub const fn new(bytes: [u8; AuthorityPublicKey::LENGTH]) -> AuthorityPublicKeyBytes
 where {
         AuthorityPublicKeyBytes(bytes)
     }
@@ -453,6 +455,10 @@ pub fn random_key_pair_by_type(
 }
 
 pub fn get_account_key_pair() -> (SuiAddress, AccountKeyPair) {
+    get_key_pair()
+}
+
+pub fn get_authority_key_pair() -> (SuiAddress, AuthorityKeyPair) {
     get_key_pair()
 }
 

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -120,6 +120,11 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     let (transferred_object, _, receiver, digest) = transfer_coin(&mut context).await?;
     wait_for_tx(digest, node.state().clone()).await;
 
+    // verify that the intermediate sync data is cleared.
+    let sync_store = node.active().unwrap().node_sync_state.store();
+    assert!(sync_store.get_cert(&digest).unwrap().is_none());
+    assert!(sync_store.get_effects(&digest).unwrap().is_none());
+
     // verify that the node has seen the transfer
     let object_read = node.state().get_object_read(&transferred_object).await?;
     let object = object_read.into_object()?;

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -157,6 +157,7 @@ const HOUR_MS: u64 = 3_600_000;
 
 #[tokio::test]
 async fn test_full_node_move_function_index() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let (swarm, context, _) = setup_network_and_wallet().await?;
 
     let config = swarm.config().generate_fullnode_config();


### PR DESCRIPTION
Stacked on #4154 - top 6 commits are new.

- Store votes in DB instead of memory to further ensure forward progress0
- Early exit instead of waiting forever when a tx is not yet final.
- Actively download parent certs when necessary, to ensure forward progress.
- Time out sync tasks so they can't live forever
- Refactor how we store certs/effects in the NodeSyncStore. The goal of this refactoring was:
   - make sure we never download things multiple times - this is important to allowing us to make progress in light of the timeouts.
   - make sure we never store an un-verified effects to the db. Only effects that we know to be true are written.