### PR TITLE
[checkpoint][refactor] Sync pending checkpoint transactions in checkpoint driver

### DIFF
--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -423,9 +423,11 @@ fn latest_proposal() {
 
     // ---
 
-    let p1 = cps1.set_proposal(committee.epoch).unwrap();
-    let p2 = cps2.set_proposal(committee.epoch).unwrap();
-    let p3 = cps3.set_proposal(committee.epoch).unwrap();
+    let epoch = committee.epoch;
+
+    let p1 = cps1.set_proposal(epoch).unwrap();
+    let p2 = cps2.set_proposal(epoch).unwrap();
+    let p3 = cps3.set_proposal(epoch).unwrap();
 
     // --- TEST 1 ---
 
@@ -479,29 +481,20 @@ fn latest_proposal() {
 
     // ---
 
-    let ckp_items = p1
+    let ckp_items: Vec<_> = p1
         .transactions()
         .chain(p2.transactions())
         .chain(p3.transactions())
-        .cloned();
-
-    let transactions = CheckpointContents::new(ckp_items);
-    let summary = CheckpointSummary::new(committee.epoch, 0, &transactions, None);
+        .cloned()
+        .collect();
 
     // Fail to set if transactions not processed.
     assert!(cps1
-        .sign_new_checkpoint(
-            summary.epoch,
-            summary.sequence_number,
-            &transactions,
-            summary.previous_digest,
-            TestCausalOrderPendCertNoop,
-        )
+        .sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop,)
         .is_err());
 
     // Set the transactions as executed.
-    let batch: Vec<_> = transactions
-        .transactions
+    let batch: Vec<_> = ckp_items
         .iter()
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
@@ -512,38 +505,14 @@ fn latest_proposal() {
     cps4.handle_internal_batch(0, &batch).unwrap();
 
     // Try to get checkpoint
-    cps1.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
-    cps2.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
-    cps3.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
-    cps4.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
+    cps1.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
+    cps2.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
+    cps3.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
+    cps4.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
 
     // --- TEST3 ---
 
@@ -634,9 +603,11 @@ fn set_get_checkpoint() {
     cps4.update_processed_transactions(&[(1, t4), (2, t5)])
         .unwrap();
 
-    let p1 = cps1.set_proposal(committee.epoch).unwrap();
-    let p2 = cps2.set_proposal(committee.epoch).unwrap();
-    let p3 = cps3.set_proposal(committee.epoch).unwrap();
+    let epoch = committee.epoch;
+
+    let p1 = cps1.set_proposal(epoch).unwrap();
+    let p2 = cps2.set_proposal(epoch).unwrap();
+    let p3 = cps3.set_proposal(epoch).unwrap();
 
     // --- TEST 0 ---
 
@@ -662,27 +633,18 @@ fn set_get_checkpoint() {
 
     // ---
 
-    let ckp_items = p1
+    let ckp_items: BTreeSet<_> = p1
         .transactions()
         .chain(p2.transactions())
         .chain(p3.transactions())
-        .cloned();
-
-    let transactions = CheckpointContents::new(ckp_items);
-    let summary = CheckpointSummary::new(committee.epoch, 0, &transactions, None);
+        .cloned()
+        .collect();
 
     // Need to load the transactions as processed, before getting a checkpoint.
     assert!(cps1
-        .sign_new_checkpoint(
-            summary.epoch,
-            summary.sequence_number,
-            &transactions,
-            summary.previous_digest,
-            TestCausalOrderPendCertNoop,
-        )
+        .sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop,)
         .is_err());
-    let batch: Vec<_> = transactions
-        .transactions
+    let batch: Vec<_> = ckp_items
         .iter()
         .enumerate()
         .map(|(u, c)| (u as u64, *c))
@@ -691,30 +653,12 @@ fn set_get_checkpoint() {
     cps2.handle_internal_batch(0, &batch).unwrap();
     cps3.handle_internal_batch(0, &batch).unwrap();
 
-    cps1.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
-    cps2.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
-    cps3.sign_new_checkpoint(
-        summary.epoch,
-        summary.sequence_number,
-        &transactions,
-        summary.previous_digest,
-        TestCausalOrderPendCertNoop,
-    )
-    .unwrap();
+    cps1.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
+    cps2.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
+    cps3.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
+        .unwrap();
     // cps4.handle_internal_set_checkpoint(summary, &transactions)
     //     .unwrap();
 
@@ -775,9 +719,10 @@ fn set_get_checkpoint() {
     // --- TEST 3 ---
 
     // Setting with contents succeeds BUT has not processed transactions
+    let contents = CheckpointContents::new(ckp_items.into_iter());
     let response_ckp = cps4.process_new_checkpoint_certificate(
         &checkpoint_cert,
-        &transactions.clone(),
+        &contents,
         &committee,
         TestCausalOrderPendCertNoop,
         &metrics,
@@ -788,7 +733,7 @@ fn set_get_checkpoint() {
     cps4.handle_internal_batch(0, &batch).unwrap();
     cps4.process_new_checkpoint_certificate(
         &checkpoint_cert,
-        &transactions,
+        &contents,
         &committee,
         TestCausalOrderPendCertNoop,
         &metrics,
@@ -835,7 +780,7 @@ fn checkpoint_integration() {
 
     let mut next_tx_num: TxSequenceNumber = 0;
     let mut unprocessed = Vec::new();
-    let mut checkpoint_contents_opt: Option<CheckpointContents> = None;
+    let mut checkpoint_contents_opt: Option<Vec<_>> = None;
     const N: u64 = 7;
     while cps.get_locals().next_checkpoint < 10 {
         let old_checkpoint = cps.get_locals().next_checkpoint;
@@ -861,16 +806,15 @@ fn checkpoint_integration() {
 
         // If we have a previous checkpoint, now lets try to process again?
         if let Some(transactions) = checkpoint_contents_opt.take() {
-            let prev_digest = cps.get_prev_checkpoint_digest(old_checkpoint).unwrap();
             assert!(cps
                 .sign_new_checkpoint(
                     committee.epoch,
                     old_checkpoint,
-                    &transactions,
-                    prev_digest,
+                    transactions.iter(),
                     TestCausalOrderPendCertNoop,
                 )
                 .is_ok());
+
             // Turn the signed checkpoint to a cert. This is required to make progress.
             let checkpoint = match cps.latest_stored_checkpoint().unwrap() {
                 AuthenticatedCheckpoint::Signed(s) => s.summary,
@@ -905,21 +849,18 @@ fn checkpoint_integration() {
             .collect();
 
         // Checkpoint contains both locally executed transactions as well as unprocessed ones.
-        let transactions = CheckpointContents::new(
-            some_fresh_transactions
-                .into_iter()
-                .chain(unprocessed.clone().into_iter()),
-        );
+        let transactions: Vec<_> = some_fresh_transactions
+            .into_iter()
+            .chain(unprocessed.clone().into_iter())
+            .collect();
         let next_checkpoint = cps.get_locals().next_checkpoint;
 
         // Cannot register the checkpoint while there are unprocessed transactions.
-        let prev_digest = cps.get_prev_checkpoint_digest(next_checkpoint).unwrap();
         assert!(cps
             .sign_new_checkpoint(
                 committee.epoch,
                 next_checkpoint,
-                &transactions,
-                prev_digest,
+                transactions.iter(),
                 TestCausalOrderPendCertNoop
             )
             .is_err());
@@ -1447,7 +1388,8 @@ fn test_fragment_full_flow() {
             /* total_batches */ 100, /* total_transactions */ 100,
         );
     }
-    cps0.attempt_to_construct_checkpoint(TestCausalOrderPendCertNoop, &committee)
+    let transactions = cps0.attempt_to_construct_checkpoint(&committee).unwrap();
+    cps0.sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop)
         .unwrap();
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
@@ -1648,7 +1590,6 @@ pub async fn checkpoint_tests_setup(
     let _join = tokio::task::spawn(async move {
         let mut seq = ExecutionIndices::default();
         while let Some(msg) = _rx.recv().await {
-            println!("Deliver fragment seq={:?}", seq);
             for (authority, cps) in &checkpoint_stores {
                 if notify_noop {
                     if let Err(err) = cps.lock().handle_internal_fragment(
@@ -1796,9 +1737,14 @@ async fn checkpoint_messaging_flow() {
 
     // Now make sure each authority makes some progress to create a checkpoint.
     for auth in &setup.authorities {
+        let transactions = auth
+            .checkpoint
+            .lock()
+            .attempt_to_construct_checkpoint(&setup.committee)
+            .unwrap();
         auth.checkpoint
             .lock()
-            .attempt_to_construct_checkpoint(TestCausalOrderPendCertNoop, &setup.committee)
+            .sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop)
             .unwrap();
     }
 
@@ -1939,7 +1885,7 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[0]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(TestCausalOrderPendCertNoop, &setup.committee)
+        .attempt_to_construct_checkpoint(&setup.committee)
         .is_ok());
 
     // Expecting more fragments
@@ -1955,7 +1901,7 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(TestCausalOrderPendCertNoop, &setup.committee)
+        .attempt_to_construct_checkpoint(&setup.committee)
         .is_err());
 
     // Expecting more fragments
@@ -1977,6 +1923,6 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(TestCausalOrderPendCertNoop, &setup.committee)
+        .attempt_to_construct_checkpoint(&setup.committee)
         .is_ok());
 }


### PR DESCRIPTION
This is a non-functional change refactoring. Previously we sync the upcoming checkpoint transactions within checkpoint driver by scheduling them. This PR changes it such that they are synced synchronously in checkpoint driver by sending messages to the node sync component.
This sets it ready for the next PR where we can change reconfiguration to use only one checkpoint, which would require us to be able to execute transactions even when the validator is halted.