### PR TITLE
Update documentation to remove sui::object::Info

### DIFF
--- a/doc/src/build/move/write-package.md
+++ b/doc/src/build/move/write-package.md
@@ -75,7 +75,7 @@ definitions in the `m1.move` file:
 
 ``` rust
 module my_first_package::m1 {
-    use sui::object::UID;
+    use sui::object::{Self, UID};
     use sui::tx_context::TxContext;
 
     struct Sword has key, store {

--- a/doc/src/build/move/write-package.md
+++ b/doc/src/build/move/write-package.md
@@ -75,11 +75,11 @@ definitions in the `m1.move` file:
 
 ``` rust
 module my_first_package::m1 {
-    use sui::object::Info;
+    use sui::object::UID;
     use sui::tx_context::TxContext;
 
     struct Sword has key, store {
-        info: Info,
+        id: UID,
         magic: u64,
         strength: u64,
     }


### PR DESCRIPTION
If I understand correctly sui::object::Info is being removed. Updating the documentation with the code that allowed the project to build. Including Self in the import as it is necessary later in the example even though it throws a warning. If any of this is incorrect please ignore this PR.