### PR TITLE
[reconfig] Do not wait for batch to pick up tx in the last checkpoint

### DIFF
--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -51,16 +51,21 @@ impl TransactionNotifier {
         self.low_watermark.load(Ordering::SeqCst)
     }
 
-    /// Check that we have drained all tickets (i.e. low watermark reached high watermark),
-    /// and that the issued tickets ends before `end`.
-    pub fn ticket_drained_til(&self, end: TxSequenceNumber) -> bool {
-        let high_watermark = self.inner.lock().high_watermark;
+    /// Check that we have drained all tickets (i.e. low watermark reached high watermark).
+    /// Return the watermark if we have drained.
+    pub fn ticket_drained(&self) -> Option<u64> {
+        // Hold the lock till the end of the function to ensure there is no data race.
+        // This is just to be safe, high_watermark is not expected to be changing when this function
+        // is being called.
+        let lock = self.inner.lock();
+        let high_watermark = lock.high_watermark;
         let low_watermark = self.low_watermark.load(Ordering::SeqCst);
-        let result = high_watermark == low_watermark && high_watermark == end;
-        if !result {
-            debug!(?high_watermark, ?low_watermark, checkpoint_end_tx=?end, "Ticket not drained yet.");
+        if high_watermark == low_watermark {
+            Some(high_watermark)
+        } else {
+            debug!(?high_watermark, ?low_watermark, "Ticket not drained yet.");
+            None
         }
-        result
     }
 
     /// Get a ticket with a sequence number

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authority_store_tables::AuthorityStoreTables, *};
-use crate::gateway_state::GatewayTxSeqNumber;
 use narwhal_executor::ExecutionIndices;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
@@ -1162,16 +1161,15 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     pub fn transactions_in_seq_range(
         &self,
-        start: GatewayTxSeqNumber,
-        end: GatewayTxSeqNumber,
-    ) -> SuiResult<Vec<(GatewayTxSeqNumber, TransactionDigest)>> {
+        start: u64,
+        end: u64,
+    ) -> SuiResult<Vec<(u64, ExecutionDigests)>> {
         Ok(self
             .tables
             .executed_sequence
             .iter()
             .skip_to(&start)?
             .take_while(|(seq, _tx)| *seq < end)
-            .map(|(seq, exec)| (seq, exec.transaction))
             .collect())
     }
 

--- a/crates/sui-core/src/query_helpers.rs
+++ b/crates/sui-core/src/query_helpers.rs
@@ -50,7 +50,11 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> QueryHelpers<S> {
             }
             .into()
         );
-        let res = database.transactions_in_seq_range(start, end)?;
+        let res = database
+            .transactions_in_seq_range(start, end)?
+            .into_iter()
+            .map(|(seq, digests)| (seq, digests.transaction))
+            .collect();
         debug!(?start, ?end, ?res, "Fetched transactions");
         Ok(res)
     }


### PR DESCRIPTION
Previously we wait for the batch to pick up the newly committed transactions so that we can include them in the last checkpoint proposal in the epoch. That's wasteful and can lead to unacceptable delays when the validator is halted.
This PR makes this process proactive: we simply take care of the last step of the batch service actively and add all newly committed transactions to `extra_transactions` table.