### PR TITLE
[Explorer] Transaction Table Links should show link Color by Default

### DIFF
--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -12,6 +12,10 @@
     @apply pr-5 text-sui-grey-75 text-sm;
 }
 
+.table td section {
+    @apply py-2;
+}
+
 .table tbody tr {
     @apply space-y-10 mt-10 hover:bg-sui-grey-40;
 }
@@ -28,16 +32,16 @@ td:nth-child(1) {
     @apply flex flex-wrap;
 }
 
+.table tbody tr td:hover .addresses {
+    @apply bg-[#6fbcf014];
+}
+
 .addresses svg {
     @apply mr-2;
 }
 
 .addresses a {
     @apply font-mono;
-}
-
-.tablespacing {
-    @apply pb-2 pt-2;
 }
 
 .longtextwrapper {

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -1,5 +1,9 @@
+.container {
+    @apply w-full overflow-x-auto;
+}
+
 .table {
-    @apply w-full text-sm text-left overflow-x-auto min-w-max border-collapse;
+    @apply text-sm text-left min-w-max border-collapse;
 
     border-bottom: 1px solid #f0f1f2;
 }

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -5,15 +5,15 @@
 }
 
 .table th {
-    @apply text-left font-semibold uppercase text-[#767A81] text-xs;
+    @apply text-left font-semibold uppercase text-[#767A81] text-xs px-2.5;
 }
 
 .table td {
-    @apply pr-5 text-sui-grey-75 text-sm;
+    @apply text-sui-grey-75 text-sm;
 }
 
 .table td section {
-    @apply py-2;
+    @apply py-2 px-2.5;
 }
 
 .table tbody tr {

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -16,6 +16,14 @@
     @apply text-sui-grey-75 text-sm;
 }
 
+.table abbr {
+    @apply text-sui-grey-60;
+}
+
+.table tr:hover abbr {
+    @apply text-sui-grey-90;
+}
+
 .table td section {
     @apply py-2 px-2.5;
 }

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -45,7 +45,7 @@ td:nth-child(1) {
 }
 
 .table tbody tr td:hover .addresses {
-    @apply bg-[#6fbcf014] rounded-[4px];
+    @apply bg-sui-light rounded-[4px];
 }
 
 .addresses svg {

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -1,9 +1,5 @@
-.content {
-    @apply w-full overflow-x-auto text-left text-[#4E555D];
-}
-
 .table {
-    @apply w-full text-sm text-left text-[#4E555D]  overflow-x-auto min-w-max border-collapse;
+    @apply w-full text-sm text-left overflow-x-auto min-w-max border-collapse;
 
     border-bottom: 1px solid #f0f1f2;
 }
@@ -13,11 +9,11 @@
 }
 
 .table td {
-    @apply pr-5 text-[#767A81] text-sm;
+    @apply pr-5 text-sui-grey-75 text-sm;
 }
 
 .table tbody tr {
-    @apply space-y-10 mt-10 hover:bg-sui-grey-45;
+    @apply space-y-10 mt-10 hover:bg-sui-grey-40;
 }
 
 td:nth-child(1) {
@@ -25,7 +21,7 @@ td:nth-child(1) {
 }
 
 .table tbody tr:hover td {
-    @apply text-black;
+    @apply text-sui-grey-90;
 }
 
 .addresses {
@@ -38,10 +34,6 @@ td:nth-child(1) {
 
 .tablespacing {
     @apply pb-2 pt-2;
-}
-
-td a {
-    @apply font-mono text-[#4E555D];
 }
 
 .longtextwrapper {

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -21,7 +21,7 @@
 }
 
 .table tbody tr {
-    @apply space-y-10 mt-10 hover:bg-sui-grey-40;
+    @apply space-y-10 mt-10;
 }
 
 td:nth-child(1) {
@@ -29,7 +29,15 @@ td:nth-child(1) {
 }
 
 .table tbody tr:hover td {
-    @apply text-sui-grey-90;
+    @apply text-sui-grey-90 bg-sui-grey-40;
+}
+
+.table tbody tr:hover td:first-child {
+    @apply rounded-l-[4px];
+}
+
+.table tbody tr:hover td:last-child {
+    @apply rounded-r-[4px];
 }
 
 .addresses {
@@ -37,7 +45,7 @@ td:nth-child(1) {
 }
 
 .table tbody tr td:hover .addresses {
-    @apply bg-[#6fbcf014];
+    @apply bg-[#6fbcf014] rounded-[4px];
 }
 
 .addresses svg {

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -32,6 +32,10 @@ td:nth-child(1) {
     @apply mr-2;
 }
 
+.addresses a {
+    @apply font-mono;
+}
+
 .tablespacing {
     @apply pb-2 pt-2;
 }

--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -17,7 +17,7 @@
 }
 
 .table tbody tr {
-    @apply space-y-10 mt-10 hover:bg-[#6fbcf014];
+    @apply space-y-10 mt-10 hover:bg-sui-grey-45;
 }
 
 td:nth-child(1) {

--- a/explorer/client/src/components/table/TableCard.tsx
+++ b/explorer/client/src/components/table/TableCard.tsx
@@ -83,9 +83,9 @@ function TxStatusType({ content }: { content: TxStatus }) {
     const TxResultStatus =
         content.status === 'success' ? TxStatus.success : TxStatus.fail;
     return (
-        <>
+        <section>
             <TxResultStatus /> {content.txTypeName}
-        </>
+        </section>
     );
 }
 
@@ -111,7 +111,7 @@ function columnsContent(columns: TableColumn[]) {
                 return <TxStatusType content={content} />;
             }
             // handle most common types
-            return content;
+            return <section>{content}</section>;
         },
     }));
 }
@@ -162,7 +162,7 @@ function TableCard({
                 {table.getRowModel().rows.map((row: any) => (
                     <tr key={row.id}>
                         {row.getVisibleCells().map((cell: any) => (
-                            <td key={cell.id} className={styles.tablespacing}>
+                            <td key={cell.id}>
                                 {flexRender(
                                     cell.column.columnDef.cell,
                                     cell.getContext()

--- a/explorer/client/src/components/table/TableCard.tsx
+++ b/explorer/client/src/components/table/TableCard.tsx
@@ -137,47 +137,42 @@ function TableCard({
     });
 
     return (
-        <div className={styles.content}>
-            <table className={styles.table}>
-                <thead>
-                    {table.getHeaderGroups().map((headerGroup: any) => (
-                        <tr key={headerGroup.id}>
-                            {headerGroup.headers.map((header: any) => (
-                                <th
-                                    key={header.id}
-                                    colSpan={header.colSpan}
-                                    scope="col"
-                                >
-                                    {header.isPlaceholder
-                                        ? null
-                                        : flexRender(
-                                              header.column.columnDef.header,
-                                              header.getContext()
-                                          )}
-                                </th>
-                            ))}
-                        </tr>
-                    ))}
-                </thead>
-                <tbody>
-                    {table.getRowModel().rows.map((row: any) => (
-                        <tr key={row.id}>
-                            {row.getVisibleCells().map((cell: any) => (
-                                <td
-                                    key={cell.id}
-                                    className={styles.tablespacing}
-                                >
-                                    {flexRender(
-                                        cell.column.columnDef.cell,
-                                        cell.getContext()
-                                    )}
-                                </td>
-                            ))}
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-        </div>
+        <table className={styles.table}>
+            <thead>
+                {table.getHeaderGroups().map((headerGroup: any) => (
+                    <tr key={headerGroup.id}>
+                        {headerGroup.headers.map((header: any) => (
+                            <th
+                                key={header.id}
+                                colSpan={header.colSpan}
+                                scope="col"
+                            >
+                                {header.isPlaceholder
+                                    ? null
+                                    : flexRender(
+                                          header.column.columnDef.header,
+                                          header.getContext()
+                                      )}
+                            </th>
+                        ))}
+                    </tr>
+                ))}
+            </thead>
+            <tbody>
+                {table.getRowModel().rows.map((row: any) => (
+                    <tr key={row.id}>
+                        {row.getVisibleCells().map((cell: any) => (
+                            <td key={cell.id} className={styles.tablespacing}>
+                                {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext()
+                                )}
+                            </td>
+                        ))}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
 

--- a/explorer/client/src/components/table/TableCard.tsx
+++ b/explorer/client/src/components/table/TableCard.tsx
@@ -137,42 +137,44 @@ function TableCard({
     });
 
     return (
-        <table className={styles.table}>
-            <thead>
-                {table.getHeaderGroups().map((headerGroup: any) => (
-                    <tr key={headerGroup.id}>
-                        {headerGroup.headers.map((header: any) => (
-                            <th
-                                key={header.id}
-                                colSpan={header.colSpan}
-                                scope="col"
-                            >
-                                {header.isPlaceholder
-                                    ? null
-                                    : flexRender(
-                                          header.column.columnDef.header,
-                                          header.getContext()
-                                      )}
-                            </th>
-                        ))}
-                    </tr>
-                ))}
-            </thead>
-            <tbody>
-                {table.getRowModel().rows.map((row: any) => (
-                    <tr key={row.id}>
-                        {row.getVisibleCells().map((cell: any) => (
-                            <td key={cell.id}>
-                                {flexRender(
-                                    cell.column.columnDef.cell,
-                                    cell.getContext()
-                                )}
-                            </td>
-                        ))}
-                    </tr>
-                ))}
-            </tbody>
-        </table>
+        <div className={styles.container}>
+            <table className={styles.table}>
+                <thead>
+                    {table.getHeaderGroups().map((headerGroup: any) => (
+                        <tr key={headerGroup.id}>
+                            {headerGroup.headers.map((header: any) => (
+                                <th
+                                    key={header.id}
+                                    colSpan={header.colSpan}
+                                    scope="col"
+                                >
+                                    {header.isPlaceholder
+                                        ? null
+                                        : flexRender(
+                                              header.column.columnDef.header,
+                                              header.getContext()
+                                          )}
+                                </th>
+                            ))}
+                        </tr>
+                    ))}
+                </thead>
+                <tbody>
+                    {table.getRowModel().rows.map((row: any) => (
+                        <tr key={row.id}>
+                            {row.getVisibleCells().map((cell: any) => (
+                                <td key={cell.id}>
+                                    {flexRender(
+                                        cell.column.columnDef.cell,
+                                        cell.getContext()
+                                    )}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
     );
 }
 

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -85,5 +85,5 @@ div.txadd {
 }
 
 .suisuffix {
-    @apply text-[10px] text-sui-grey-60 ml-[2px];
+    @apply text-[10px] ml-[2px];
 }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -80,10 +80,6 @@ div.txadd {
     text-decoration: none;
 }
 
-.txlatestresults td a {
-    @apply font-mono text-[#4E555D];
-}
-
 .txlatestresults td:nth-child(1) {
     @apply text-xs;
 }

--- a/explorer/client/src/components/transaction-card/RecentTxCard.module.css
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.module.css
@@ -87,7 +87,3 @@ div.txadd {
 .suisuffix {
     @apply text-[10px] text-sui-grey-60 ml-[2px];
 }
-
-.suiamount {
-    @apply text-sui-grey-80;
-}

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -146,7 +146,7 @@ function SuiAmount({ amount }: { amount: BN | string | undefined }) {
 
         if (BN.isBN(amount)) {
             return (
-                <span className={styles.suiamount}>
+                <span>
                     {presentBN(amount)}
                     {SuiSuffix}
                 </span>

--- a/explorer/client/src/components/transaction-card/RecentTxCard.tsx
+++ b/explorer/client/src/components/transaction-card/RecentTxCard.tsx
@@ -142,7 +142,7 @@ type RecentTx = {
 
 function SuiAmount({ amount }: { amount: BN | string | undefined }) {
     if (amount) {
-        const SuiSuffix = <span className={styles.suisuffix}>SUI</span>;
+        const SuiSuffix = <abbr className={styles.suisuffix}>SUI</abbr>;
 
         if (BN.isBN(amount)) {
             return (

--- a/explorer/client/src/pages/transactions/Transactions.module.css
+++ b/explorer/client/src/pages/transactions/Transactions.module.css
@@ -5,7 +5,3 @@ div.container {
 .title {
     @apply text-2xl font-[700];
 }
-
-.container td a {
-    @apply text-sui-grey-85;
-}

--- a/explorer/client/tailwind.config.js
+++ b/explorer/client/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
             sui: {
                 dark: '#1F6493',
                 DEFAULT: '#6fbcf0',
-                light: '#F4FBFF',
+                light: '#E1F3FF',
                 grey: {
                     100: '#182435',
                     95: '#2A3645',


### PR DESCRIPTION
In the currently deployed Recent Transactions and Transactions for ID Tables, the hover effect has square edges, highlights the entire row in blue and displays all text in grey except for the address links that change to blue when hovered over.

Video showing PR in action:

https://user-images.githubusercontent.com/11377188/186140649-fda6d4ea-7414-4502-b666-b4852ef93530.mp4

Showing how this will work with the deployment of the new Home Page:

https://user-images.githubusercontent.com/11377188/186141105-c81bf463-c675-4934-ba3a-7b4c00fe17a4.mp4



