### PR TITLE
[TypeScript SDK] Auto derive call args

### DIFF
--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -14,6 +14,8 @@ import {
   SuiMoveNormalizedStruct,
   SuiMoveNormalizedModule,
   SuiMoveNormalizedModules,
+  ExecuteTransactionRequestType,
+  SuiExecuteTransactionResponse,
 } from '../types';
 
 ///////////////////////////////
@@ -76,6 +78,19 @@ export abstract class Provider {
     pubkey: string
   ): Promise<SuiTransactionResponse>;
 
+  /**
+   * This is under development endpoint on Fullnode that will eventually
+   * replace the other `executeTransaction` that's only available on the
+   * Gateway
+   */
+  abstract executeTransactionWithRequestType(
+    txnBytes: string,
+    signatureScheme: SignatureScheme,
+    signature: string,
+    pubkey: string,
+    requestType: ExecuteTransactionRequestType
+  ): Promise<SuiExecuteTransactionResponse>;
+
   // Move info
   /**
    * Get Move function argument types like read, write and full access
@@ -90,14 +105,16 @@ export abstract class Provider {
    * Get a map from module name to
    * structured representations of Move modules
    */
-  abstract getNormalizedMoveModulesByPackage(objectId: string,): Promise<SuiMoveNormalizedModules>;
+  abstract getNormalizedMoveModulesByPackage(
+    objectId: string
+  ): Promise<SuiMoveNormalizedModules>;
 
   /**
    * Get a structured representation of Move module
    */
   abstract getNormalizedMoveModule(
     objectId: string,
-    moduleName: string,
+    moduleName: string
   ): Promise<SuiMoveNormalizedModule>;
 
   /**
@@ -107,7 +124,7 @@ export abstract class Provider {
     objectId: string,
     moduleName: string,
     functionName: string
-  ): Promise<SuiMoveNormalizedFunction> 
+  ): Promise<SuiMoveNormalizedFunction>;
 
   /**
    * Get a structured representation of Move struct

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -16,6 +16,8 @@ import {
   SuiMoveNormalizedStruct,
   SuiMoveNormalizedModule,
   SuiMoveNormalizedModules,
+  ExecuteTransactionRequestType,
+  SuiExecuteTransactionResponse,
 } from '../types';
 import { Provider } from './provider';
 
@@ -55,6 +57,16 @@ export class VoidProvider extends Provider {
     throw this.newError('executeTransaction');
   }
 
+  async executeTransactionWithRequestType(
+    _txnBytes: string,
+    _signatureScheme: SignatureScheme,
+    _signature: string,
+    _pubkey: string,
+    _requestType: ExecuteTransactionRequestType
+  ): Promise<SuiExecuteTransactionResponse> {
+    throw this.newError('executeTransaction with request Type');
+  }
+
   async getTotalTransactionNumber(): Promise<number> {
     throw this.newError('getTotalTransactionNumber');
   }
@@ -78,13 +90,15 @@ export class VoidProvider extends Provider {
     throw this.newError('getMoveFunctionArgTypes');
   }
 
-  async getNormalizedMoveModulesByPackage(_objectId: string,): Promise<SuiMoveNormalizedModules> {
+  async getNormalizedMoveModulesByPackage(
+    _objectId: string
+  ): Promise<SuiMoveNormalizedModules> {
     throw this.newError('getNormalizedMoveModulesByPackage');
   }
 
   async getNormalizedMoveModule(
     _objectId: string,
-    _moduleName: string,
+    _moduleName: string
   ): Promise<SuiMoveNormalizedModule> {
     throw this.newError('getNormalizedMoveModule');
   }
@@ -104,7 +118,6 @@ export class VoidProvider extends Provider {
   ): Promise<SuiMoveNormalizedStruct> {
     throw this.newError('getNormalizedMoveStruct');
   }
-
 
   async syncAccountState(_address: string): Promise<any> {
     throw this.newError('syncAccountState');

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -5,7 +5,12 @@ import { JsonRpcProvider } from '../providers/json-rpc-provider';
 import { Provider } from '../providers/provider';
 import { VoidProvider } from '../providers/void-provider';
 import { Base64DataBuffer } from '../serialization/base64';
-import { SuiAddress, SuiTransactionResponse } from '../types';
+import {
+  ExecuteTransactionRequestType,
+  SuiAddress,
+  SuiExecuteTransactionResponse,
+  SuiTransactionResponse,
+} from '../types';
 import { SignaturePubkeyPair, Signer } from './signer';
 import { RpcTxnDataSerializer } from './txn-data-serializers/rpc-txn-data-serializer';
 import {
@@ -56,7 +61,7 @@ export abstract class SignerWithProvider implements Signer {
 
   /**
    * Sign a transaction and submit to the Gateway for execution
-   *
+   * @experimental
    * @param txBytes BCS serialised TransactionData bytes
    */
   async signAndExecuteTransaction(
@@ -68,6 +73,25 @@ export abstract class SignerWithProvider implements Signer {
       sig.signatureScheme,
       sig.signature.toString(),
       sig.pubKey.toString()
+    );
+  }
+
+  /**
+   * @experimental Sign a transaction and submit to the Fullnode for execution
+   *
+   * @param txBytes BCS serialised TransactionData bytes
+   */
+  async signAndExecuteTransactionWithRequestType(
+    txBytes: Base64DataBuffer,
+    requestType: ExecuteTransactionRequestType
+  ): Promise<SuiExecuteTransactionResponse> {
+    const sig = await this.signData(txBytes);
+    return await this.provider.executeTransactionWithRequestType(
+      txBytes.toString(),
+      sig.signatureScheme,
+      sig.signature.toString(),
+      sig.pubKey.toString(),
+      requestType
     );
   }
 
@@ -159,5 +183,120 @@ export abstract class SignerWithProvider implements Signer {
       transaction
     );
     return await this.signAndExecuteTransaction(txBytes);
+  }
+
+  /* ---------------------------- Experimental API ---------------------------- */
+  /**
+   * @experimental Serialize and sign a `TransferObject` transaction and submit to the Fullnode
+   * for execution
+   */
+  async transferObjectWithRequestType(
+    transaction: TransferObjectTransaction,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
+  ): Promise<SuiExecuteTransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newTransferObject(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransactionWithRequestType(
+      txBytes,
+      requestType
+    );
+  }
+
+  /**
+   * @experimental Serialize and sign a `TransferSui` transaction and submit to the Fullnode
+   * for execution
+   */
+  async transferSuiWithRequestType(
+    transaction: TransferSuiTransaction,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
+  ): Promise<SuiExecuteTransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newTransferSui(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransactionWithRequestType(
+      txBytes,
+      requestType
+    );
+  }
+
+  /**
+   * @experimental Serialize and sign a `MergeCoin` transaction and submit to the Fullnode
+   * for execution
+   */
+  async mergeCoinWithRequestType(
+    transaction: MergeCoinTransaction,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
+  ): Promise<SuiExecuteTransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newMergeCoin(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransactionWithRequestType(
+      txBytes,
+      requestType
+    );
+  }
+
+  /**
+   * @experimental Serialize and sign a `SplitCoin` transaction and submit to the Fullnode
+   * for execution
+   */
+  async splitCoinWithRequestType(
+    transaction: SplitCoinTransaction,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
+  ): Promise<SuiExecuteTransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newSplitCoin(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransactionWithRequestType(
+      txBytes,
+      requestType
+    );
+  }
+
+  /**
+   * @experimental Serialize and sign a `MoveCall` transaction and submit to the Fullnode
+   * for execution
+   */
+  async executeMoveCallWithRequestType(
+    transaction: MoveCallTransaction,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
+  ): Promise<SuiExecuteTransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newMoveCall(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransactionWithRequestType(
+      txBytes,
+      requestType
+    );
+  }
+
+  /**
+   * @experimental Serialize and sign a `Publish` transaction and submit to the Fullnode
+   * for execution
+   */
+  async publishWithRequestType(
+    transaction: PublishTransaction,
+    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
+  ): Promise<SuiExecuteTransactionResponse> {
+    const signerAddress = await this.getAddress();
+    const txBytes = await this.serializer.newPublish(
+      signerAddress,
+      transaction
+    );
+    return await this.signAndExecuteTransactionWithRequestType(
+      txBytes,
+      requestType
+    );
   }
 }

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -34,20 +34,20 @@ export class CallArgSerializer {
     // Entry functions can have a mutable reference to an instance of the TxContext
     // struct defined in the TxContext module as the last parameter. The caller of
     // the function does not need to pass it in as an argument.
-    if (params.length > 0 && this.isTxContext(params[params.length - 1])) {
-      params.pop();
-    }
+    const hasTxContext = params.length > 0 && this.isTxContext(params.at(-1)!);
+    const userParams = hasTxContext
+      ? params.slice(0, params.length - 1)
+      : params;
 
-    if (params.length !== txn.arguments.length) {
+    if (userParams.length !== txn.arguments.length) {
       throw new Error(
-        `${MOVE_CALL_SER_ERROR} expect ${params.length} ` +
+        `${MOVE_CALL_SER_ERROR} expect ${userParams.length} ` +
           `arguments, received ${txn.arguments.length} arguments`
       );
     }
-
-    return await Promise.all(
-      params.map(
-        async (param, i) => await this.newCallArg(param, txn.arguments[i])
+    return Promise.all(
+      userParams.map(async (param, i) =>
+        this.newCallArg(param, txn.arguments[i])
       )
     );
   }

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Provider } from '../../providers/provider';
+import {
+  extractMutableReference,
+  extractStructTag,
+  getObjectReference,
+  isSharedObject,
+  isValidSuiAddress,
+  normalizeSuiObjectId,
+  SuiJsonValue,
+  SuiMoveNormalizedType,
+} from '../../types';
+import { bcs, CallArg, ObjectArg } from '../../types/sui-bcs';
+import { MoveCallTransaction } from './txn-data-serializer';
+
+const MOVE_CALL_SER_ERROR = 'Move call argument serialization error:';
+
+const isTypeFunc = (type: string) => (t: any) => typeof t === type;
+
+export class CallArgSerializer {
+  constructor(private provider: Provider) {}
+
+  async serializeMoveCallArguments(
+    txn: MoveCallTransaction
+  ): Promise<CallArg[]> {
+    const normalized = await this.provider.getNormalizedMoveFunction(
+      normalizeSuiObjectId(txn.packageObjectId),
+      txn.module,
+      txn.function
+    );
+    const params = normalized.parameters;
+    // Entry functions can have a mutable reference to an instance of the TxContext
+    // struct defined in the TxContext module as the last parameter. The caller of
+    // the function does not need to pass it in as an argument.
+    if (params.length > 0 && this.isTxContext(params[params.length - 1])) {
+      params.pop();
+    }
+
+    if (params.length !== txn.arguments.length) {
+      throw new Error(
+        `${MOVE_CALL_SER_ERROR} expect ${params.length} ` +
+          `arguments, received ${txn.arguments.length} arguments`
+      );
+    }
+
+    return await Promise.all(
+      params.map(
+        async (param, i) => await this.newCallArg(param, txn.arguments[i])
+      )
+    );
+  }
+
+  async newObjectArg(objectId: string): Promise<ObjectArg> {
+    const object = await this.provider.getObject(objectId);
+    if (isSharedObject(object)) {
+      return { Shared: objectId };
+    }
+
+    return { ImmOrOwned: getObjectReference(object)! };
+  }
+
+  private async newCallArg(
+    expectedType: SuiMoveNormalizedType,
+    argVal: SuiJsonValue
+  ): Promise<CallArg> {
+    const structVal = extractStructTag(expectedType);
+    if (structVal != null) {
+      if (typeof argVal !== 'string') {
+        throw new Error(
+          `${MOVE_CALL_SER_ERROR} expect the argument to be an object id string, got ${argVal}`
+        );
+      }
+      return { Object: await this.newObjectArg(argVal) };
+    }
+
+    let serType = this.getPureSerializationType(expectedType, argVal);
+
+    return {
+      Pure: bcs.ser(serType, argVal).toBytes(),
+    };
+  }
+
+  /**
+   *
+   * @param argVal used to do additional data validation to make sure the argVal
+   * matches the normalized Move types. If `argVal === undefined`, the data validation
+   * will be skipped. This is useful in the case where `normalizedType` is a vector<T>
+   * and `argVal` is an empty array, the data validation for the inner types will be skipped.
+   */
+  private getPureSerializationType(
+    normalizedType: SuiMoveNormalizedType,
+    argVal: SuiJsonValue | undefined
+  ): string {
+    const allowedTypes = ['Address', 'Bool', 'U8', 'U32', 'U64', 'U128'];
+    if (
+      typeof normalizedType === 'string' &&
+      allowedTypes.includes(normalizedType)
+    ) {
+      if (normalizedType in ['U8', 'U32', 'U64', 'U128']) {
+        this.checkArgVal(isTypeFunc('number'), argVal, 'number');
+      } else if (normalizedType === 'Bool') {
+        this.checkArgVal(isTypeFunc('boolean'), argVal, 'boolean');
+      } else if (normalizedType === 'Address') {
+        this.checkArgVal(
+          (t: any) => typeof t === 'string' && isValidSuiAddress(t),
+          argVal,
+          'valid SUI address'
+        );
+      }
+      return normalizedType.toLowerCase();
+    } else if (typeof normalizedType === 'string') {
+      throw new Error(
+        `${MOVE_CALL_SER_ERROR} unknown pure normalized type ${normalizedType}`
+      );
+    }
+
+    if ('Vector' in normalizedType) {
+      if (typeof argVal === 'string' && normalizedType.Vector === 'U8') {
+        return 'string';
+      }
+
+      if (!Array.isArray(argVal)) {
+        throw new Error(
+          `Expect ${argVal} to be a array, received ${typeof argVal}`
+        );
+      }
+      const innerType = this.getPureSerializationType(
+        normalizedType.Vector,
+        // undefined when argVal is empty
+        argVal[0]
+      );
+      const res = `vector<${innerType}>`;
+      // TODO: can we get rid of this call and make it happen automatically?
+      bcs.registerVectorType(res, innerType);
+      return res;
+    }
+
+    // TODO: update this once we support vector of object ids
+    throw new Error(
+      `${MOVE_CALL_SER_ERROR} unknown normalized type ${normalizedType}`
+    );
+  }
+
+  private checkArgVal(
+    check: (t: any) => boolean,
+    argVal: SuiJsonValue | undefined,
+    expectedType: string
+  ) {
+    if (argVal === undefined) {
+      return;
+    }
+    if (!check(argVal)) {
+      throw new Error(
+        `Expect ${argVal} to be ${expectedType}, received ${typeof argVal}`
+      );
+    }
+  }
+
+  private isTxContext(param: SuiMoveNormalizedType): boolean {
+    const struct = extractMutableReference(param)?.Struct;
+    return (
+      struct?.address === '0x2' &&
+      struct?.module === 'tx_context' &&
+      struct?.name === 'TxContext'
+    );
+  }
+}

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -26,7 +26,7 @@ import {
 import { Provider } from '../../providers/provider';
 import { CallArgSerializer } from './call-arg-serializer';
 
-const TYPE_TAG = Array.from('TransactionData::').map(e => e.charCodeAt(0));
+const TYPE_TAG = Array.from('TransactionData::').map((e) => e.charCodeAt(0));
 
 export class LocalTxnDataSerializer implements TxnDataSerializer {
   /**
@@ -106,8 +106,6 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
           ).serializeMoveCallArguments(t),
         },
       };
-
-      console.log('movecall', tx);
 
       return await this.constructTransactionData(
         tx,

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -4,7 +4,6 @@
 import { Base64DataBuffer } from '../../serialization/base64';
 import {
   bcs,
-  CallArg,
   Coin,
   COIN_JOIN_FUNC_NAME,
   COIN_MODULE_NAME,
@@ -25,6 +24,7 @@ import {
   TxnDataSerializer,
 } from './txn-data-serializer';
 import { Provider } from '../../providers/provider';
+import { CallArgSerializer } from './call-arg-serializer';
 
 const TYPE_TAG = Array.from('TransactionData::').map(e => e.charCodeAt(0));
 
@@ -101,9 +101,13 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
           module: t.module,
           function: t.function,
           typeArguments: t.typeArguments as TypeTag[],
-          arguments: t.arguments as CallArg[],
+          arguments: await new CallArgSerializer(
+            this.provider
+          ).serializeMoveCallArguments(t),
         },
       };
+
+      console.log('movecall', tx);
 
       return await this.constructTransactionData(
         tx,
@@ -124,34 +128,15 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     t: MergeCoinTransaction
   ): Promise<Base64DataBuffer> {
     try {
-      const coinToMergeRef = await this.provider.getObjectRef(t.coinToMerge);
-      const primaryCoinRef = await this.provider.getObjectRef(t.primaryCoin);
-      const pkg = await this.provider.getObjectRef(COIN_PACKAGE_ID);
-
-      const tx = {
-        Call: {
-          package: pkg!,
-          module: COIN_MODULE_NAME,
-          function: COIN_JOIN_FUNC_NAME,
-          typeArguments: [await this.getCoinStructTag(t.coinToMerge)],
-          arguments: [
-            {
-              Object: { ImmOrOwned: primaryCoinRef! },
-            },
-            {
-              Object: { ImmOrOwned: coinToMergeRef! },
-            },
-          ],
-        },
-      };
-
-      return await this.constructTransactionData(
-        tx,
-        // TODO: make `gasPayment` a required field in `MoveCallTransaction`
-        t.gasPayment!,
-        t.gasBudget,
-        signerAddress
-      );
+      return await this.newMoveCall(signerAddress, {
+        packageObjectId: COIN_PACKAGE_ID,
+        module: COIN_MODULE_NAME,
+        function: COIN_JOIN_FUNC_NAME,
+        typeArguments: [await this.getCoinStructTag(t.coinToMerge)],
+        arguments: [t.primaryCoin, t.coinToMerge],
+        gasPayment: t.gasPayment,
+        gasBudget: t.gasBudget,
+      });
     } catch (err) {
       throw new Error(
         `Error constructing a MergeCoin Transaction: ${err} args ${JSON.stringify(
@@ -166,33 +151,15 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     t: SplitCoinTransaction
   ): Promise<Base64DataBuffer> {
     try {
-      const coinRef = await this.provider.getObjectRef(t.coinObjectId);
-      const pkg = await this.provider.getObjectRef(COIN_PACKAGE_ID);
-
-      const tx = {
-        Call: {
-          package: pkg!,
-          module: COIN_MODULE_NAME,
-          function: COIN_SPLIT_VEC_FUNC_NAME,
-          typeArguments: [await this.getCoinStructTag(t.coinObjectId)],
-          arguments: [
-            {
-              Object: { ImmOrOwned: coinRef! },
-            },
-            {
-              Pure: bcs.ser('vector<u64>', t.splitAmounts).toBytes(),
-            },
-          ],
-        },
-      };
-
-      return await this.constructTransactionData(
-        tx,
-        // TODO: make `gasPayment` a required field in `MoveCallTransaction`
-        t.gasPayment!,
-        t.gasBudget,
-        signerAddress
-      );
+      return await this.newMoveCall(signerAddress, {
+        packageObjectId: COIN_PACKAGE_ID,
+        module: COIN_MODULE_NAME,
+        function: COIN_SPLIT_VEC_FUNC_NAME,
+        typeArguments: [await this.getCoinStructTag(t.coinObjectId)],
+        arguments: [t.coinObjectId, t.splitAmounts],
+        gasPayment: t.gasPayment,
+        gasBudget: t.gasBudget,
+      });
     } catch (err) {
       throw new Error(
         `Error constructing a SplitCoin Transaction: ${err} args ${JSON.stringify(
@@ -221,7 +188,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
       );
     } catch (err) {
       throw new Error(
-        `Error constructing a newPublishi transaction: ${err} with args ${JSON.stringify(
+        `Error constructing a newPublish transaction: ${err} with args ${JSON.stringify(
           t
         )}`
       );
@@ -257,6 +224,8 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
       gasBudget: gasBudget,
       sender: signerAddress,
     };
+
+    console.log('transactiondata', txData);
 
     return this.serializeTransactionData(txData);
   }

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -2,13 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Base64DataBuffer } from '../../serialization/base64';
-import {
-  CallArg,
-  ObjectId,
-  SuiAddress,
-  SuiJsonValue,
-  TypeTag,
-} from '../../types';
+import { ObjectId, SuiAddress, SuiJsonValue, TypeTag } from '../../types';
 
 ///////////////////////////////
 // Exported Types
@@ -50,11 +44,7 @@ export interface MoveCallTransaction {
    * RpcTxnDataSerializer soon.
    */
   typeArguments: string[] | TypeTag[];
-  /**
-   * Usage: pass in SuiJsonValue[] if you use RpcTxnDataSerializer,
-   * Otherwise you need to pass in CallArg[].
-   */
-  arguments: SuiJsonValue[] | CallArg[];
+  arguments: SuiJsonValue[];
   gasPayment?: ObjectId;
   gasBudget: number;
 }

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -285,35 +285,47 @@ export function isSuiMoveAbilitySet(obj: any, _argumentName?: string): obj is Su
 export function isSuiMoveNormalizedType(obj: any, _argumentName?: string): obj is SuiMoveNormalizedType {
     return (
         (isTransactionDigest(obj) as boolean ||
+            isSuiMoveNormalizedTypeParameterType(obj) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&
-            isSuiMoveTypeParameterIndex(obj.TypeParameter) as boolean ||
+            isSuiMoveNormalizedStructType(obj.Reference) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&
-            isSuiMoveNormalizedType(obj.Reference) as boolean ||
-            (obj !== null &&
-                typeof obj === "object" ||
-                typeof obj === "function") &&
-            isSuiMoveNormalizedType(obj.MutableReference) as boolean ||
+            isSuiMoveNormalizedStructType(obj.MutableReference) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&
             isSuiMoveNormalizedType(obj.Vector) as boolean ||
-            (obj !== null &&
-                typeof obj === "object" ||
-                typeof obj === "function") &&
-            (obj.Struct !== null &&
-                typeof obj.Struct === "object" ||
-                typeof obj.Struct === "function") &&
-            isTransactionDigest(obj.Struct.address) as boolean &&
-            isTransactionDigest(obj.Struct.module) as boolean &&
-            isTransactionDigest(obj.Struct.name) as boolean &&
-            Array.isArray(obj.Struct.type_arguments) &&
-            obj.Struct.type_arguments.every((e: any) =>
-                isSuiMoveNormalizedType(e) as boolean
-            ))
+            isSuiMoveNormalizedStructType(obj) as boolean)
+    )
+}
+
+export function isSuiMoveNormalizedTypeParameterType(obj: any, _argumentName?: string): obj is SuiMoveNormalizedTypeParameterType {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isSuiMoveTypeParameterIndex(obj.TypeParameter) as boolean
+    )
+}
+
+export function isSuiMoveNormalizedStructType(obj: any, _argumentName?: string): obj is SuiMoveNormalizedStructType {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.Struct !== null &&
+            typeof obj.Struct === "object" ||
+            typeof obj.Struct === "function") &&
+        isTransactionDigest(obj.Struct.address) as boolean &&
+        isTransactionDigest(obj.Struct.module) as boolean &&
+        isTransactionDigest(obj.Struct.name) as boolean &&
+        Array.isArray(obj.Struct.type_arguments) &&
+        obj.Struct.type_arguments.every((e: any) =>
+            isSuiMoveNormalizedTypeParameterType(e) as boolean
+        )
     )
 }
 
@@ -421,7 +433,9 @@ export function isTransferObjectEvent(obj: any, _argumentName?: string): obj is 
         isObjectOwner(obj.recipient) as boolean &&
         isTransactionDigest(obj.objectId) as boolean &&
         isSuiMoveTypeParameterIndex(obj.version) as boolean &&
-        isTransactionDigest(obj.type) as boolean
+        isTransactionDigest(obj.type) as boolean &&
+        (obj.amount === null ||
+            isSuiMoveTypeParameterIndex(obj.amount) as boolean)
     )
 }
 
@@ -512,6 +526,14 @@ export function isSuiChangeEpoch(obj: any, _argumentName?: string): obj is SuiCh
         isSuiMoveTypeParameterIndex(obj.epoch) as boolean &&
         isSuiMoveTypeParameterIndex(obj.storage_charge) as boolean &&
         isSuiMoveTypeParameterIndex(obj.computation_charge) as boolean
+    )
+}
+
+export function isExecuteTransactionRequestType(obj: any, _argumentName?: string): obj is ExecuteTransactionRequestType {
+    return (
+        (obj === "ImmediateReturn" ||
+            obj === "WaitForTxCert" ||
+            obj === "WaitForEffectsCert")
     )
 }
 
@@ -709,6 +731,42 @@ export function isSuiTransactionResponse(obj: any, _argumentName?: string): obj 
     )
 }
 
+export function isSuiCertifiedTransactionEffects(obj: any, _argumentName?: string): obj is SuiCertifiedTransactionEffects {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isTransactionEffects(obj.effects) as boolean
+    )
+}
+
+export function isSuiExecuteTransactionResponse(obj: any, _argumentName?: string): obj is SuiExecuteTransactionResponse {
+    return (
+        ((obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+            (obj.ImmediateReturn !== null &&
+                typeof obj.ImmediateReturn === "object" ||
+                typeof obj.ImmediateReturn === "function") &&
+            isTransactionDigest(obj.ImmediateReturn.tx_digest) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            (obj.TxCert !== null &&
+                typeof obj.TxCert === "object" ||
+                typeof obj.TxCert === "function") &&
+            isCertifiedTransaction(obj.TxCert.certificate) as boolean ||
+            (obj !== null &&
+                typeof obj === "object" ||
+                typeof obj === "function") &&
+            (obj.EffectsCert !== null &&
+                typeof obj.EffectsCert === "object" ||
+                typeof obj.EffectsCert === "function") &&
+            isCertifiedTransaction(obj.EffectsCert.certificate) as boolean &&
+            isSuiCertifiedTransactionEffects(obj.EffectsCert.effects) as boolean)
+    )
+}
+
 export function isGatewayTxSeqNumber(obj: any, _argumentName?: string): obj is GatewayTxSeqNumber {
     return (
         typeof obj === "number"
@@ -755,10 +813,7 @@ export function isSuiJsonValue(obj: any, _argumentName?: string): obj is SuiJson
             obj === true ||
             Array.isArray(obj) &&
             obj.every((e: any) =>
-            (isTransactionDigest(e) as boolean ||
-                isSuiMoveTypeParameterIndex(e) as boolean ||
-                e === false ||
-                e === true)
+                isSuiJsonValue(e) as boolean
             ))
     )
 }

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -12,6 +12,7 @@ bcs
   .registerVectorType('vector<vector<u8>>', 'vector<u8>')
   .registerAddressType('ObjectID', 20)
   .registerAddressType('SuiAddress', 20)
+  .registerAddressType('address', 20)
   .registerType(
     'utf8string',
     (writer, str) => {

--- a/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -112,6 +112,8 @@ const slice = createSlice({
             state,
             { payload }: PayloadAction<TransactionRequest[]>
         ) => {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             txRequestsAdapter.setAll(state, payload);
             state.initialized = true;
         },


### PR DESCRIPTION
## Overview

This PR simplifies the Move call API by removing the need for the caller to serialize arguments into BCS bytes. 

## Problem
Today, to use the local transaction serializer, the user have to serialize the arguments into BCS bytes themselves
```
const txn = await signerWithProvider.executeMoveCall({
    packageObjectId: "0x2",
    module: "devnet_nft",
    function: "mint",
    typeArguments: [],
    arguments: [
      { Pure: bcs.ser(bcs.STRING, "Example NFT").toBytes() },
      {
        Pure: bcs
          .ser(bcs.STRING, "An NFT created by the wallet Command Line Tool")
          .toBytes(),
      },
      {
        Pure: bcs
          .ser(
            bcs.STRING,
            "ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty"
          )
          .toBytes(),
      },
    ],
    gasBudget: 10000,
    gasPayment: gasPayment,
  });
```

The need to pass in serialize the BCS bytes makes the API unergonomic to use. The SDK should be able to derive them by leveraging the exiting `sui_getNormalizedMoveModulesByPackage` endpoint, which return formats like the following

```
// For this Move function

public entry fun transfer<T>(
	 _recipient: address, 
   _coin: &mut Coin<T>,
   _new_description: vector<u8>,
   _nested_vec: vector<vector<u8>>, 
   _is_true: bool, 
   _ctx: &mut TxContext
) {}


[
    "Address",
    {
        "MutableReference": {
            "Struct": {
                "address": "0x2",
                "module": "coin",
                "name": "Coin",
                "type_arguments": [
                    {
                        "TypeParameter": 0
                    }
                ]
            }
        }
    },
    {
        "Vector": "U8"
    },
    {
        "Vector": {
            "Vector": "U8"
        }
    },
    "Bool",
    {
        "MutableReference": {
            "Struct": {
                "address": "0x2",
                "module": "tx_context",
                "name": "TxContext",
                "type_arguments": []
            }
        }
    }
]
```

The caller should be able to just pass in plain string, number, boolean, or array, and the SDK will serialize them into the right types by looking at the normalizedMoveModules definitions for that function. 

```
const txn = await signerWithProvider.executeMoveCall({
    packageObjectId: "0x2",
    module: "devnet_nft",
    function: "mint",
    typeArguments: [],
    arguments: [
     "Example NFT",
      "An NFT created by the wallet Command Line Tool",
      "ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty",
    ],
    gasBudget: 10000,
    gasPayment: gasPayment,
  });

```

## Testing

```
// Move function definition, which contains different argument types
public entry fun transfer<T>(
	 _recipient: address, 
   _coin: &mut Coin<T>,
   _new_description: vector<u8>,
   _nested_vec: vector<vector<u8>>, 
   _is_true: bool, 
   _ctx: &mut TxContext
) {}

// JS code
const txn = await signerWithProvider.executeMoveCallWithRequestType({
    packageObjectId: "0x4c06ef71c1681aa7255cd7c0a906126f97823616",
    module: "m1",
    function: "transfer",
    typeArguments: [
      {
        struct: {
          address: normalizeSuiObjectId("0x2"),
          module: "sui",
          name: "SUI",
          typeParams: [],
        },
      },
    ],
    arguments: [
      "0x1d3d759d976e188e4343bcce37c5a89dbb48ef1b",
      coin,
      "ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty",
      ["ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty"],
      true,
    ],
    gasBudget: 10000,
    gasPayment: gasPayment,
  });

```