### PR TITLE
[adapter] Fix bug for unwrapped but never stored object

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.exp
@@ -1,0 +1,16 @@
+processed 4 tasks
+
+init:
+A: object(100), B: object(101)
+
+task 1 'publish'. lines 8-38:
+created: object(105)
+written: object(104)
+
+task 2 'run'. lines 40-40:
+created: object(107)
+written: object(106)
+
+task 3 'run'. lines 42-42:
+written: object(108)
+deleted: object(107)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored.move
@@ -1,0 +1,42 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests deleting a wrapped object that has never been in storage
+
+//# init --addresses test=0x0 --accounts A B
+
+//# publish
+
+module test::m {
+    use sui::tx_context::{Self, TxContext};
+
+    struct S has key, store {
+        id: sui::object::UID,
+    }
+
+    struct R has key {
+        id: sui::object::UID,
+        s: S,
+    }
+
+    public entry fun create(ctx: &mut TxContext) {
+        let parent = sui::object::new(ctx);
+        let child = S { id: sui::object::new(ctx) };
+        sui::transfer::transfer(R { id: parent, s: child }, tx_context::sender(ctx))
+    }
+
+    public entry fun delete(r: R) {
+        let R { id, s } = r;
+        sui::object::delete(id);
+        let S { id } = s;
+        sui::object::delete(id);
+    }
+}
+
+//
+// Test sharing
+//
+
+//# run test::m::create --sender A
+
+//# run test::m::delete --args object(107) --sender A

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.exp
@@ -1,0 +1,17 @@
+processed 4 tasks
+
+init:
+A: object(100), B: object(101)
+
+task 1 'publish'. lines 8-37:
+created: object(105)
+written: object(104)
+
+task 2 'run'. lines 39-39:
+created: object(107)
+written: object(106)
+
+task 3 'run'. lines 41-41:
+created: object(109)
+written: object(108)
+deleted: object(107)

--- a/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.move
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/unwrap_never_stored_transfer.move
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests transferring a wrapped object that has never previously been in storage
+
+//# init --addresses test=0x0 --accounts A B
+
+//# publish
+
+module test::m {
+    use sui::tx_context::{Self, TxContext};
+
+    struct S has key, store {
+        id: sui::object::UID,
+    }
+
+    struct R has key {
+        id: sui::object::UID,
+        s: S,
+    }
+
+    public entry fun create(ctx: &mut TxContext) {
+        let parent = sui::object::new(ctx);
+        let child = S { id: sui::object::new(ctx) };
+        sui::transfer::transfer(R { id: parent, s: child }, tx_context::sender(ctx))
+    }
+
+    public entry fun unwrap_and_transfer(r: R, ctx: &mut TxContext) {
+        let R { id, s } = r;
+        sui::object::delete(id);
+        sui::transfer::transfer(s, tx_context::sender(ctx));
+    }
+}
+
+//
+// Test sharing
+//
+
+//# run test::m::create --sender A
+
+//# run test::m::unwrap_and_transfer --args object(107) --sender A


### PR DESCRIPTION
- Fixed a bug where objects where an invariant violation was thrown for unwrapped objects that did not have a last known version
- For deleted unwrapped, we no longer emit a deleted event
- For transferred unwrapped, we now mark it as newly created