### PR TITLE
ci: add release binary publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -162,7 +162,7 @@ jobs:
 
   release-build:
     needs: release
-    if: needs.diff.outputs.isRelease == 'true'
+    if: needs.release.outputs.isRelease == 'true'
     timeout-minutes: 45
     runs-on: [ubuntu-ghcloud]
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,3 +145,54 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
+
+  release-build:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    timeout-minutes: 45
+    runs-on: [ubuntu-ghcloud]
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+      - name: cargo build (release)
+        run: |
+          cargo build --release
+
+          echo ::set-output name=BIN_SUI::"target/release/sui"
+          echo ::set-output name=BIN_SUI_NODE::"target/release/sui-node"
+          echo ::set-output name=BIN_SUI_TOOL::"target/release/sui-tool"
+          echo ::set-output name=BIN_SUI_FAUCET::"target/release/sui-faucet"
+          echo ::set-output name=BIN_RPC_SERVER::"target/release/rpc-server"
+
+    - name: Upload release artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: sui-binaries
+        path: |
+          ${{ steps.package.outputs.BIN_SUI }}
+          ${{ steps.package.outputs.BIN_SUI_NODE }}
+          ${{ steps.package.outputs.BIN_SUI_TOOL }}
+          ${{ steps.package.outputs.BIN_SUI_FAUCET }}
+          ${{ steps.package.outputs.BIN_RPC_SERVER }}
+
+    - name: Check for release
+      id: is-release
+      shell: bash
+      run: |
+        unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/devnet-[0-9].* ]]; then IS_RELEASE='true' ; fi
+        echo ::set-output name=IS_RELEASE::${IS_RELEASE}
+
+    - name: Publish binaries
+      uses: softprops/action-gh-release@v1
+      if: steps.is-release.outputs.IS_RELEASE
+      with:
+        files: |
+          ${{ steps.package.outputs.BIN_SUI }}
+          ${{ steps.package.outputs.BIN_SUI_NODE }}
+          ${{ steps.package.outputs.BIN_SUI_TOOL }}
+          ${{ steps.package.outputs.BIN_SUI_FAUCET }}
+          ${{ steps.package.outputs.BIN_RPC_SERVER }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,9 +146,23 @@ jobs:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
 
-  release-build:
+  release:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
+    runs-on: [ubuntu-ghcloud]
+    outputs:
+      isRelease: ${{ steps.release.outputs.isRelease }}
+    steps:
+      - name: Check for release
+        id: release
+        shell: bash
+        run: |
+          IS_RELEASE='false' ; if [[ $GITHUB_REF =~ ^refs/tags/devnet-[0-9].* ]]; then IS_RELEASE='true' ; fi
+          echo ::set-output name=isRelease::${IS_RELEASE}
+
+  release-build:
+    needs: release
+    if: needs.diff.outputs.isRelease == 'true'
     timeout-minutes: 45
     runs-on: [ubuntu-ghcloud]
     strategy:
@@ -157,15 +171,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
 
-      - name: Check for release
-        id: is-release
-        shell: bash
-        run: |
-          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/devnet-[0-9].* ]]; then IS_RELEASE='true' ; fi
-          echo ::set-output name=IS_RELEASE::${IS_RELEASE}
-
       - name: cargo build (release)
-        if: steps.is-release.outputs.IS_RELEASE
         run: |
           cargo build --release
 
@@ -177,7 +183,6 @@ jobs:
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@master
-        if: steps.is-release.outputs.IS_RELEASE
         with:
           name: sui-binaries
           path: |
@@ -189,7 +194,6 @@ jobs:
 
       - name: Publish binaries
         uses: softprops/action-gh-release@v1
-        if: steps.is-release.outputs.IS_RELEASE
         with:
           files: |
             ${{ steps.package.outputs.BIN_SUI }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -187,7 +187,6 @@ jobs:
             ${{ steps.package.outputs.BIN_SUI_FAUCET }}
             ${{ steps.package.outputs.BIN_RPC_SERVER }}
 
-
       - name: Publish binaries
         uses: softprops/action-gh-release@v1
         if: steps.is-release.outputs.IS_RELEASE

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -156,7 +156,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
+
+      - name: Check for release
+        id: is-release
+        shell: bash
+        run: |
+          unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/devnet-[0-9].* ]]; then IS_RELEASE='true' ; fi
+          echo ::set-output name=IS_RELEASE::${IS_RELEASE}
+
       - name: cargo build (release)
+        if: steps.is-release.outputs.IS_RELEASE
         run: |
           cargo build --release
 
@@ -166,33 +175,28 @@ jobs:
           echo ::set-output name=BIN_SUI_FAUCET::"target/release/sui-faucet"
           echo ::set-output name=BIN_RPC_SERVER::"target/release/rpc-server"
 
-    - name: Upload release artifacts
-      uses: actions/upload-artifact@master
-      with:
-        name: sui-binaries
-        path: |
-          ${{ steps.package.outputs.BIN_SUI }}
-          ${{ steps.package.outputs.BIN_SUI_NODE }}
-          ${{ steps.package.outputs.BIN_SUI_TOOL }}
-          ${{ steps.package.outputs.BIN_SUI_FAUCET }}
-          ${{ steps.package.outputs.BIN_RPC_SERVER }}
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@master
+        if: steps.is-release.outputs.IS_RELEASE
+        with:
+          name: sui-binaries
+          path: |
+            ${{ steps.package.outputs.BIN_SUI }}
+            ${{ steps.package.outputs.BIN_SUI_NODE }}
+            ${{ steps.package.outputs.BIN_SUI_TOOL }}
+            ${{ steps.package.outputs.BIN_SUI_FAUCET }}
+            ${{ steps.package.outputs.BIN_RPC_SERVER }}
 
-    - name: Check for release
-      id: is-release
-      shell: bash
-      run: |
-        unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/devnet-[0-9].* ]]; then IS_RELEASE='true' ; fi
-        echo ::set-output name=IS_RELEASE::${IS_RELEASE}
 
-    - name: Publish binaries
-      uses: softprops/action-gh-release@v1
-      if: steps.is-release.outputs.IS_RELEASE
-      with:
-        files: |
-          ${{ steps.package.outputs.BIN_SUI }}
-          ${{ steps.package.outputs.BIN_SUI_NODE }}
-          ${{ steps.package.outputs.BIN_SUI_TOOL }}
-          ${{ steps.package.outputs.BIN_SUI_FAUCET }}
-          ${{ steps.package.outputs.BIN_RPC_SERVER }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish binaries
+        uses: softprops/action-gh-release@v1
+        if: steps.is-release.outputs.IS_RELEASE
+        with:
+          files: |
+            ${{ steps.package.outputs.BIN_SUI }}
+            ${{ steps.package.outputs.BIN_SUI_NODE }}
+            ${{ steps.package.outputs.BIN_SUI_TOOL }}
+            ${{ steps.package.outputs.BIN_SUI_FAUCET }}
+            ${{ steps.package.outputs.BIN_RPC_SERVER }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will publish artifacts for any release build (e.g. ref contains the devnet-* tag) and also create a release. We'll probably have to change our workflow a bit to make sure we change/push the version change before pushing the tag (or at the same time).