### PR TITLE
[checkpoint] Restructure checkpoint loop to allow fine control on progress and timing

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -193,6 +193,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                     consensus_config: Some(consensus_config),
                     enable_event_processing: false,
                     enable_gossip: true,
+                    enable_checkpoint: true,
                     enable_reconfig: false,
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -61,6 +61,9 @@ pub struct NodeConfig {
     #[serde(default)]
     pub enable_gossip: bool,
 
+    #[serde(default = "bool_true")]
+    pub enable_checkpoint: bool,
+
     #[serde(default)]
     pub enable_reconfig: bool,
 
@@ -107,6 +110,10 @@ pub fn default_websocket_address() -> Option<SocketAddr> {
 
 pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
+}
+
+pub fn bool_true() -> bool {
+    true
 }
 
 impl Config for NodeConfig {}

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -90,6 +90,7 @@ impl NetworkConfig {
             consensus_config: None,
             enable_event_processing: true,
             enable_gossip: true,
+            enable_checkpoint: true,
             enable_reconfig: false,
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -37,6 +37,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000
@@ -76,6 +77,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000
@@ -115,6 +117,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000
@@ -154,6 +157,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000
@@ -193,6 +197,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000
@@ -232,6 +237,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000
@@ -271,6 +277,7 @@ validator_configs:
           socket_addr: /ip4/127.0.0.1/tcp/1234
     enable-event-processing: false
     enable-gossip: true
+    enable-checkpoint: true
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -288,14 +288,13 @@ where
             .clone()
     }
 
-    pub async fn sync_to_latest_checkpoint(&self, metrics: &CheckpointMetrics) -> SuiResult {
-        self.sync_to_latest_checkpoint_with_config(metrics, Default::default())
+    pub async fn sync_to_latest_checkpoint(&self) -> SuiResult {
+        self.sync_to_latest_checkpoint_with_config(Default::default())
             .await
     }
 
     pub async fn sync_to_latest_checkpoint_with_config(
         &self,
-        metrics: &CheckpointMetrics,
         checkpoint_process_control: CheckpointProcessControl,
     ) -> SuiResult {
         let checkpoint_store =
@@ -324,7 +323,7 @@ where
             }
         };
 
-        sync_to_checkpoint(self, checkpoint_store, checkpoint_summary, metrics).await
+        sync_to_checkpoint(self, checkpoint_store, checkpoint_summary).await
     }
 
     /// Spawn gossip process

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -246,7 +246,10 @@ pub async fn checkpoint_process<A>(
                         tokio::time::sleep(timing.consensus_delay_estimate).await;
                     }
                     CheckpointStepError::CheckpointSignBlocked(err) => {
-                        error!(?next_cp_seq, "Failed to sync and sign new checkpoint: {:?}", err);
+                        error!(
+                            ?next_cp_seq,
+                            "Failed to sync and sign new checkpoint: {:?}", err
+                        );
                     }
                     CheckpointStepError::ProposalFailed(err) => {
                         warn!(
@@ -353,7 +356,7 @@ where
         &my_proposal,
         committee,
     )
-        .await
+    .await
     {
         Some(contents) => contents,
         None => {
@@ -367,7 +370,9 @@ where
         my_proposal.signed_summary.auth_signature.epoch,
         *my_proposal.sequence_number(),
         transactions,
-    ).await.map_err(|err| Err(CheckpointStepError::CheckpointSignBlocked(Box::new(err))))?;
+    )
+    .await
+    .map_err(|err| CheckpointStepError::CheckpointSignBlocked(Box::new(err)))?;
 
     Ok(CheckpointStepResult::CheckpointSigned)
 }
@@ -790,7 +795,7 @@ where
 
     let result = checkpoint_db
         .lock()
-        .attempt_to_construct_checkpoint(active_authority.state.database.clone(), committee);
+        .attempt_to_construct_checkpoint(committee);
 
     match result {
         Err(err) => {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -531,7 +531,7 @@ fn latest_proposal() {
     .collect();
     // We only need f+1 to make a cert. 2 is sufficient.
     let cert = CertifiedCheckpointSummary::aggregate(signed, &committee).unwrap();
-    cps1.promote_signed_checkpoint_to_cert(&cert, &committee, &CheckpointMetrics::new_for_tests())
+    cps1.promote_signed_checkpoint_to_cert(&cert, &committee)
         .unwrap();
 
     let response = cps1.handle_proposal(false).expect("no errors");
@@ -578,7 +578,6 @@ fn latest_proposal() {
 #[test]
 fn set_get_checkpoint() {
     let (committee, _keys, mut stores) = random_ckpoint_store();
-    let metrics = CheckpointMetrics::new_for_tests();
     let (_, mut cps1) = stores.pop().unwrap();
     let (_, mut cps2) = stores.pop().unwrap();
     let (_, mut cps3) = stores.pop().unwrap();
@@ -702,7 +701,7 @@ fn set_get_checkpoint() {
         CertifiedCheckpointSummary::aggregate(signed_checkpoint, &committee).unwrap();
 
     // Send the certificate to a party that has the data
-    cps1.promote_signed_checkpoint_to_cert(&checkpoint_cert, &committee, &metrics)
+    cps1.promote_signed_checkpoint_to_cert(&checkpoint_cert, &committee)
         .unwrap();
 
     // Now we have a certified checkpoint
@@ -725,7 +724,6 @@ fn set_get_checkpoint() {
         &contents,
         &committee,
         TestCausalOrderPendCertNoop,
-        &metrics,
     );
     assert!(response_ckp.is_err());
 
@@ -736,7 +734,6 @@ fn set_get_checkpoint() {
         &contents,
         &committee,
         TestCausalOrderPendCertNoop,
-        &metrics,
     )
     .unwrap();
 
@@ -828,12 +825,8 @@ fn checkpoint_integration() {
                 })
                 .collect();
             let cert = CertifiedCheckpointSummary::aggregate(signatures, &committee).unwrap();
-            cps.promote_signed_checkpoint_to_cert(
-                &cert,
-                &committee,
-                &CheckpointMetrics::new_for_tests(),
-            )
-            .unwrap();
+            cps.promote_signed_checkpoint_to_cert(&cert, &committee)
+                .unwrap();
 
             // Loop invariant to ensure termination or error
             assert_eq!(cps.get_locals().next_checkpoint, old_checkpoint + 1);
@@ -1657,7 +1650,6 @@ async fn checkpoint_messaging_flow_bug() {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn checkpoint_messaging_flow() {
     let mut setup = checkpoint_tests_setup(5, Duration::from_millis(500), true).await;
-    let metrics = CheckpointMetrics::new_for_tests();
 
     // Check that the system is running.
     let t = setup.transactions.pop().unwrap();
@@ -1794,13 +1786,12 @@ async fn checkpoint_messaging_flow() {
                     &contents,
                     &setup.committee,
                     TestCausalOrderPendCertNoop,
-                    &metrics,
                 )
                 .unwrap();
         } else {
             auth.checkpoint
                 .lock()
-                .promote_signed_checkpoint_to_cert(&checkpoint_cert, &setup.committee, &metrics)
+                .promote_signed_checkpoint_to_cert(&checkpoint_cert, &setup.committee)
                 .unwrap();
         }
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -58,10 +58,10 @@ pub struct SuiNode {
     _batch_subsystem_handle: tokio::task::JoinHandle<Result<()>>,
     _post_processing_subsystem_handle: Option<tokio::task::JoinHandle<Result<()>>>,
     _gossip_handle: Option<tokio::task::JoinHandle<()>>,
-    _execute_driver_handle: Option<tokio::task::JoinHandle<()>>,
+    _execute_driver_handle: tokio::task::JoinHandle<()>,
     _checkpoint_process_handle: Option<tokio::task::JoinHandle<()>>,
     state: Arc<AuthorityState>,
-    active: Option<Arc<ActiveAuthority<NetworkAuthorityClient>>>,
+    active: Arc<ActiveAuthority<NetworkAuthorityClient>>,
     quorum_driver_handler: Option<QuorumDriverHandler<NetworkAuthorityClient>>,
 }
 
@@ -175,64 +175,60 @@ impl SuiNode {
         } else {
             None
         };
-        let should_start_follower = is_full_node || config.enable_gossip;
 
-        let mut active = None;
+        let pending_store = Arc::new(NodeSyncStore::open_tables_read_write(
+            config.db_path().join("node_sync_db"),
+            None,
+            None,
+        ));
+        let active_authority = Arc::new(ActiveAuthority::new(
+            state.clone(),
+            pending_store,
+            net,
+            GossipMetrics::new(&prometheus_registry),
+            network_metrics.clone(),
+        )?);
 
-        let (gossip_handle, execute_driver_handle, checkpoint_process_handle) =
-            if should_start_follower {
-                let pending_store = Arc::new(NodeSyncStore::open_tables_read_write(
-                    config.db_path().join("node_sync_db"),
-                    None,
-                    None,
-                ));
-
-                let active_authority = Arc::new(ActiveAuthority::new(
-                    state.clone(),
-                    pending_store,
-                    net,
-                    GossipMetrics::new(&prometheus_registry),
-                    network_metrics.clone(),
-                )?);
-                active = Some(Arc::clone(&active_authority));
-
-                if is_validator {
-                    // TODO: get degree from config file.
-                    let degree = 4;
-                    (
-                        Some(active_authority.clone().spawn_gossip_process(degree).await),
-                        Some(active_authority.clone().spawn_execute_process().await),
-                        Some(
-                            active_authority
-                                .spawn_checkpoint_process(
-                                    CheckpointMetrics::new(&prometheus_registry),
-                                    config.enable_reconfig,
-                                )
-                                .await,
-                        ),
-                    )
-                } else {
-                    info!("Starting full node sync to latest checkpoint (this may take a while)");
-                    let metrics = CheckpointMetrics::new(&prometheus_registry);
-                    let now = Instant::now();
-                    if let Err(err) = active_authority.sync_to_latest_checkpoint(&metrics).await {
-                        error!(
+        let gossip_handle = if is_full_node {
+            info!("Starting full node sync to latest checkpoint (this may take a while)");
+            let metrics = CheckpointMetrics::new(&prometheus_registry);
+            let now = Instant::now();
+            if let Err(err) = active_authority.sync_to_latest_checkpoint(&metrics).await {
+                error!(
                             "Full node failed to catch up to latest checkpoint: {:?}",
                             err
                         );
-                    } else {
-                        info!(
+            } else {
+                info!(
                             "Full node caught up to latest checkpoint in {:?}",
                             now.elapsed()
                         );
-                    }
-                    active_authority.spawn_node_sync_process().await;
-                    (None, None, None)
-                }
-            } else {
-                (None, None, None)
-            };
+            }
+            active_authority.clone().spawn_node_sync_process().await;
+            None
+        } else if config.enable_gossip {
+            // TODO: get degree from config file.
+            let degree = 4;
+            Some(active_authority.clone().spawn_gossip_process(degree).await)
+        } else {
+            None
+        };
+        let execute_driver_handle = active_authority.clone().spawn_execute_process().await;
+        let checkpoint_process_handle = if config.enable_checkpoint {
+            Some(
+                active_authority
+                    .clone()
+                    .spawn_checkpoint_process(
+                        CheckpointMetrics::new(&prometheus_registry),
+                        config.enable_reconfig,
+                    )
+                    .await,
+            )
+        } else {
+            None
+        };
 
+        // TODO: Do not enable batch for fullnode.
         let batch_subsystem_handle = {
             // Start batch system so that this node can be followed
             let batch_state = state.clone();
@@ -301,7 +297,7 @@ impl SuiNode {
             _batch_subsystem_handle: batch_subsystem_handle,
             _post_processing_subsystem_handle: post_processing_subsystem_handle,
             state,
-            active,
+            active: active_authority,
             quorum_driver_handler,
         };
 
@@ -314,8 +310,8 @@ impl SuiNode {
         self.state.clone()
     }
 
-    pub fn active(&self) -> Option<Arc<ActiveAuthority<NetworkAuthorityClient>>> {
-        self.active.clone()
+    pub fn active(&self) -> &Arc<ActiveAuthority<NetworkAuthorityClient>> {
+        &self.active
     }
 
     pub fn quorum_driver(&self) -> Option<Arc<QuorumDriver<NetworkAuthorityClient>>> {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -227,7 +227,6 @@ impl SuiNode {
             None
         };
 
-        // TODO: Do not enable batch for fullnode.
         let batch_subsystem_handle = {
             // Start batch system so that this node can be followed
             let batch_state = state.clone();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -191,18 +191,17 @@ impl SuiNode {
 
         let gossip_handle = if is_full_node {
             info!("Starting full node sync to latest checkpoint (this may take a while)");
-            let metrics = CheckpointMetrics::new(&prometheus_registry);
             let now = Instant::now();
-            if let Err(err) = active_authority.sync_to_latest_checkpoint(&metrics).await {
+            if let Err(err) = active_authority.sync_to_latest_checkpoint().await {
                 error!(
-                            "Full node failed to catch up to latest checkpoint: {:?}",
-                            err
-                        );
+                    "Full node failed to catch up to latest checkpoint: {:?}",
+                    err
+                );
             } else {
                 info!(
-                            "Full node caught up to latest checkpoint in {:?}",
-                            now.elapsed()
-                        );
+                    "Full node caught up to latest checkpoint in {:?}",
+                    now.elapsed()
+                );
             }
             active_authority.clone().spawn_node_sync_process().await;
             None

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -121,7 +121,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     wait_for_tx(digest, node.state().clone()).await;
 
     // verify that the intermediate sync data is cleared.
-    let sync_store = node.active().unwrap().node_sync_state.store();
+    let sync_store = node.active().node_sync_state.store();
     assert!(sync_store.get_cert(&digest).unwrap().is_none());
     assert!(sync_store.get_effects(&digest).unwrap().is_none());
 
@@ -589,13 +589,13 @@ async fn test_full_node_sub_and_query_move_event_ok() -> Result<(), anyhow::Erro
 async fn test_full_node_event_read_api_ok() -> Result<(), anyhow::Error> {
     let (swarm, mut context, _address) = setup_network_and_wallet().await?;
     let (node, jsonrpc_client) = set_up_jsonrpc(&swarm).await?;
-    let (transfered_object, sender, receiver, digest) = transfer_coin(&mut context).await?;
+    let (transferred_object, sender, receiver, digest) = transfer_coin(&mut context).await?;
 
     wait_for_tx(digest, node.state().clone()).await;
 
     let txes = node
         .state()
-        .get_transactions_by_input_object(transfered_object)
+        .get_transactions_by_input_object(transferred_object)
         .await?;
 
     assert_eq!(txes.len(), 1);
@@ -613,7 +613,7 @@ async fn test_full_node_event_read_api_ok() -> Result<(), anyhow::Error> {
         transaction_module: "native".into(),
         sender,
         recipient: Owner::AddressOwner(receiver),
-        object_id: transfered_object,
+        object_id: transferred_object,
         version: SequenceNumber::from_u64(1),
         type_: TransferType::Coin,
     };
@@ -655,7 +655,7 @@ async fn test_full_node_event_read_api_ok() -> Result<(), anyhow::Error> {
 
     // query by object
     let params = rpc_params![
-        transfered_object,
+        transferred_object,
         10,
         ts.unwrap() - HOUR_MS,
         ts.unwrap() + HOUR_MS

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -1,11 +1,14 @@
+use futures::future::join_all;
 use std::sync::Arc;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use multiaddr::Multiaddr;
 use sui_config::ValidatorInfo;
 use sui_core::authority::AuthorityState;
+use sui_core::authority_active::checkpoint_driver::{
+    checkpoint_process_step, CheckpointProcessControl,
+};
 use sui_core::authority_client::AuthorityAPI;
-use sui_core::checkpoints::CHECKPOINT_COUNT_PER_EPOCH;
 use sui_core::safe_client::SafeClient;
 use sui_node::SuiNode;
 use sui_types::base_types::{ExecutionDigests, ObjectID, ObjectRef};
@@ -33,25 +36,17 @@ async fn reconfig_end_to_end_tests() {
 
     let mut configs = test_authority_configs();
     for c in configs.validator_configs.iter_mut() {
-        c.enable_gossip = true;
+        // Turn off checkpoint process so that we can have fine control over it in the test.
+        c.enable_checkpoint = false;
     }
     let validator_info = configs.validator_set();
     let mut gas_objects = test_gas_objects();
     let validator_stake = generate_gas_object_with_balance(100000000000000);
     let mut states = Vec::new();
     let mut nodes = Vec::new();
-    let mut prev_signed_checkpoints = Vec::new();
     for validator in configs.validator_configs() {
         let node = SuiNode::start(validator).await.unwrap();
         let state = node.state();
-
-        // Make sure that every validator just finished checkpoint CHECKPOINT_COUNT_PER_EPOCH - 1,
-        // and is ready for checkpoint CHECKPOINT_COUNT_PER_EPOCH.
-        prev_signed_checkpoints.push(sign_checkpoint(
-            &state,
-            CHECKPOINT_COUNT_PER_EPOCH - 1,
-            std::iter::empty(),
-        ));
 
         for gas in gas_objects.clone() {
             state.insert_genesis_object(gas).await;
@@ -60,8 +55,6 @@ async fn reconfig_end_to_end_tests() {
         states.push(state);
         nodes.push(node);
     }
-
-    update_checkpoint_cert_for_all(&states, prev_signed_checkpoints.clone());
 
     // get sui system state and confirm it matches network info
     let sui_system_state = states[0].get_sui_system_state_object().await.unwrap();
@@ -96,21 +89,48 @@ async fn reconfig_end_to_end_tests() {
     let new_committee_size = sui_system_state.validators.next_epoch_validators.len();
     assert_eq!(old_committee_size + 1, new_committee_size);
 
-    let mut last_signed_checkpoints = Vec::new();
+    let mut checkpoint_processes = vec![];
     for node in &nodes {
-        node.active().start_epoch_change().await.unwrap();
-        last_signed_checkpoints.push(sign_checkpoint(
-            &node.state(),
-            CHECKPOINT_COUNT_PER_EPOCH,
-            // The transaction that registered the new validator must be included in the checkpoint
-            std::iter::once(&ExecutionDigests::new(
-                effects.transaction_digest,
-                effects.digest(),
-            )),
-        ));
+        let active = node.active().clone();
+        let handle = tokio::spawn(async move {
+            while !active
+                .state
+                .checkpoints
+                .as_ref()
+                .unwrap()
+                .lock()
+                .is_ready_to_start_epoch_change()
+            {
+                let _ =
+                    checkpoint_process_step(&active, &CheckpointProcessControl::default()).await;
+            }
+        });
+        checkpoint_processes.push(handle);
     }
+    // Wait for all validators to be ready for epoch change.
+    join_all(checkpoint_processes).await;
 
-    update_checkpoint_cert_for_all(&states, last_signed_checkpoints.clone());
+    let results: Vec<_> = nodes
+        .iter()
+        .map(|node| async {
+            let active = node.active().clone();
+            active.start_epoch_change().await.unwrap();
+            while !active
+                .state
+                .checkpoints
+                .as_ref()
+                .unwrap()
+                .lock()
+                .is_ready_to_finish_epoch_change()
+            {
+                let _ =
+                    checkpoint_process_step(&active, &CheckpointProcessControl::default()).await;
+            }
+        })
+        .collect();
+
+    join_all(results).await;
+
     let results: Vec<_> = nodes
         .iter()
         .map(|node| async {
@@ -125,46 +145,6 @@ async fn reconfig_end_to_end_tests() {
     assert_eq!(sui_system_state.epoch, 1);
     // We should now have one more active validator.
     assert_eq!(sui_system_state.validators.active_validators.len(), 5);
-}
-
-fn sign_checkpoint<'a>(
-    state: &Arc<AuthorityState>,
-    seq: CheckpointSequenceNumber,
-    transactions: impl Iterator<Item = &'a ExecutionDigests> + Clone,
-) -> SignedCheckpointSummary {
-    let mut checkpoints = state.checkpoints.as_ref().unwrap().lock();
-
-    let mut cur_locals = (*checkpoints.get_locals()).clone();
-    cur_locals.next_checkpoint = seq;
-    checkpoints.set_locals_for_testing(cur_locals).unwrap();
-
-    checkpoints
-        .sign_new_checkpoint(0, seq, transactions, state.db())
-        .unwrap();
-    match checkpoints.get_checkpoint(seq).unwrap().unwrap() {
-        AuthenticatedCheckpoint::Signed(s) => s,
-        _ => {
-            unreachable!()
-        }
-    }
-}
-
-fn update_checkpoint_cert_for_all(
-    states: &[Arc<AuthorityState>],
-    signed_checkpoints: Vec<SignedCheckpointSummary>,
-) {
-    let committee = states[0].clone_committee();
-    let checkpoint_cert =
-        CertifiedCheckpointSummary::aggregate(signed_checkpoints, &committee).unwrap();
-    for state in states {
-        state
-            .checkpoints
-            .as_ref()
-            .unwrap()
-            .lock()
-            .promote_signed_checkpoint_to_cert(&checkpoint_cert, &committee)
-            .unwrap();
-    }
 }
 
 pub async fn create_and_register_new_validator(

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -1,27 +1,22 @@
-use futures::future::join_all;
-use std::sync::Arc;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+use futures::future::join_all;
 use multiaddr::Multiaddr;
 use sui_config::ValidatorInfo;
-use sui_core::authority::AuthorityState;
 use sui_core::authority_active::checkpoint_driver::{
     checkpoint_process_step, CheckpointProcessControl,
 };
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::safe_client::SafeClient;
 use sui_node::SuiNode;
-use sui_types::base_types::{ExecutionDigests, ObjectID, ObjectRef};
+use sui_types::base_types::{ObjectID, ObjectRef};
 use sui_types::crypto::{
     generate_proof_of_possession, get_key_pair, AccountKeyPair, AuthorityKeyPair, KeypairTraits,
 };
 use sui_types::error::SuiResult;
 use sui_types::messages::ObjectInfoResponse;
 use sui_types::messages::{CallArg, ObjectArg, ObjectInfoRequest, TransactionEffects};
-use sui_types::messages_checkpoint::{
-    AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointSequenceNumber,
-    SignedCheckpointSummary,
-};
 use sui_types::object::Object;
 use sui_types::SUI_SYSTEM_STATE_OBJECT_ID;
 use test_utils::authority::test_authority_configs;

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use multiaddr::Multiaddr;
 use sui_config::ValidatorInfo;
 use sui_core::authority::AuthorityState;
-use sui_core::authority_active::checkpoint_driver::CheckpointMetrics;
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::checkpoints::CHECKPOINT_COUNT_PER_EPOCH;
 use sui_core::safe_client::SafeClient;
@@ -163,11 +162,7 @@ fn update_checkpoint_cert_for_all(
             .as_ref()
             .unwrap()
             .lock()
-            .promote_signed_checkpoint_to_cert(
-                &checkpoint_cert,
-                &committee,
-                &CheckpointMetrics::new_for_tests(),
-            )
+            .promote_signed_checkpoint_to_cert(&checkpoint_cert, &committee)
             .unwrap();
     }
 }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -99,7 +99,7 @@ async fn reconfig_end_to_end_tests() {
 
     let mut last_signed_checkpoints = Vec::new();
     for node in &nodes {
-        node.active().unwrap().start_epoch_change().await.unwrap();
+        node.active().start_epoch_change().await.unwrap();
         last_signed_checkpoints.push(sign_checkpoint(
             &node.state(),
             CHECKPOINT_COUNT_PER_EPOCH,
@@ -115,7 +115,7 @@ async fn reconfig_end_to_end_tests() {
     let results: Vec<_> = nodes
         .iter()
         .map(|node| async {
-            node.active().unwrap().finish_epoch_change().await.unwrap();
+            node.active().finish_epoch_change().await.unwrap();
         })
         .collect();
 


### PR DESCRIPTION
This PR restructures the checkpoint main loop into two functions:
- A step loop that makes one step progress in checkpoint
- A main loop that decides how long to sleep based on the result after a step is made.

Doing so allows us to make checkpoint progress explicitly, and can decide arbitrarily on how long to delay after each step.
This will be extremely useful for testing: it will allow us to generate all kinds of edge cases. As an example, this PR allows us significantly simplify the reconfiguration test.

A few side changes to enable this PR:
- Added "enable_checkpoint" to sui-node config. This allows us to disable checkpoint when needed. It's enabled by default.
- Cleans up the sui-node creation process: gossip process is created separately; execution driver process is always created unconditionally; checkpoint process is created based on the config.
- No longer doing linear backoff after sequencing fragments. Instead, we always go back to the main loop to gain control on timing. Since we go through the checkpoint quorum process at the beginning of the loop, it essentially gives enough time for fragments to be sequenced. In the long run, we may want something more proactive.