### PR TITLE
[FE] Add diffs based on pnpm

### DIFF
--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -26,6 +26,9 @@ runs:
     - name: Pnpm list
       shell: bash
       run: pnpm list --filter "...[${{ inputs.baseSha }}]" --depth -1 --json > changes.json
+    - name: Debug
+      shell: bash
+      run: cat ./changes.json
     - id: changes
       shell: bash
       run: |

--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -1,5 +1,9 @@
 name: Detect Changes in Pnpm Workspace
 description: Defines variables indicating the parts of the pnpm workspace have changed
+inputs:
+  baseSha:
+    description: "The base git SHA that will be used to perform the diff"
+    required: true
 outputs:
   isExplorerClient:
     description: True when there are changes to files related to explorer client
@@ -21,10 +25,10 @@ runs:
         version: 7
     - name: Pnpm list
       shell: bash
-      run: pnpm list --filter "...[origin/main]" --depth -1 --json > changes.json
+      run: pnpm list --filter "...[${{ inputs.baseSha }}]" --depth -1 --json > changes.json
     - id: changes
       shell: bash
       run: |
         echo "::set-output name=explorer::$(jq 'any(.[]; .name == "sui-explorer")' changes.json)"
         echo "::set-output name=sdk::$(jq 'any(.[]; .name == "@mysten/sui.js")' changes.json)"
-        echo "::set-output name=walletAdapter::$(jq 'any(.[]; .name == "sui-wallet-adapter")' changes.json)"
+        echo "::set-output name=walletAdapter::$(jq 'any(.[]; .name | startswith("@mysten/wallet-adapter"))' changes.json)"

--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -25,7 +25,10 @@ runs:
         version: 7
     - name: Pnpm list
       shell: bash
-      run: pnpm list --filter "...[${{ inputs.baseSha }}]" --depth -1 --json > changes.json
+      run: pnpm list --filter "...[origin/main]" --depth -1 --json > changes.json
+    - name: Debug
+      shell: bash
+      run: cat ./changes.json
     - name: Debug
       shell: bash
       run: cat ./changes.json

--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -8,7 +8,7 @@ outputs:
     description: True when there are changes to files related to TypeScript SDK
     value: "${{ steps.changes.outputs.sdk }}"
   isWalletAdapter:
-    description: True when there are changes to files related to TypeScript SDK
+    description: True when there are changes to files related to wallet adapter
     value: "${{ steps.changes.outputs.walletAdapter }}"
 runs:
   using: composite

--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -1,9 +1,5 @@
 name: Detect Changes in Pnpm Workspace
 description: Defines variables indicating the parts of the pnpm workspace have changed
-inputs:
-  baseSha:
-    description: "The base git SHA that will be used to perform the diff"
-    required: true
 outputs:
   isExplorerClient:
     description: True when there are changes to files related to explorer client
@@ -26,10 +22,7 @@ runs:
     - name: Pnpm list
       shell: bash
       run: pnpm list --filter "...[origin/main]" --depth -1 --json > changes.json
-    - name: Debug
-      shell: bash
-      run: cat ./changes.json
-    - name: Debug
+    - name: Print changes for easy debugging
       shell: bash
       run: cat ./changes.json
     - id: changes

--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -1,0 +1,30 @@
+name: Detect Changes in Pnpm Workspace
+description: Defines variables indicating the parts of the pnpm workspace have changed
+outputs:
+  isExplorerClient:
+    description: True when there are changes to files related to explorer client
+    value: "${{ steps.changes.outputs.explorer }}"
+  isTypeScriptSDK:
+    description: True when there are changes to files related to TypeScript SDK
+    value: "${{ steps.changes.outputs.sdk }}"
+  isWalletAdapter:
+    description: True when there are changes to files related to TypeScript SDK
+    value: "${{ steps.changes.outputs.walletAdapter }}"
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: pnpm/action-setup@v2.2.2
+      with:
+        version: 7
+    - name: Pnpm list
+      shell: bash
+      run: pnpm list --filter "...[origin/main]" --depth -1 --json > changes.json
+    - id: changes
+      shell: bash
+      run: |
+        echo "::set-output name=explorer::$(jq 'any(.[]; .name == "sui-explorer")' changes.json)"
+        echo "::set-output name=sdk::$(jq 'any(.[]; .name == "@mysten/sui.js")' changes.json)"
+        echo "::set-output name=walletAdapter::$(jq 'any(.[]; .name == "sui-wallet-adapter")' changes.json)"

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes
-        uses: "./.github/actions/diffs"
+        uses: "./.github/actions/pnpm-diffs"
         id: diff
   client_checks:
     name: Lint, Test & Build

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -6,6 +6,7 @@ jobs:
     outputs:
       isClient: ${{ steps.diff.outputs.isExplorerClient }}
     steps:
+      - uses: actions/checkout@v3
       - name: Detect Changes
         uses: "./.github/actions/pnpm-diffs"
         id: diff

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -6,12 +6,9 @@ jobs:
     outputs:
       isClient: ${{ steps.diff.outputs.isExplorerClient }}
     steps:
-      - uses: actions/checkout@v3
       - name: Detect Changes
         uses: "./.github/actions/pnpm-diffs"
         id: diff
-        with:
-          baseSha: ${{ github.event.pull_request.base.sha }}
   client_checks:
     name: Lint, Test & Build
     needs: diff

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -10,6 +10,8 @@ jobs:
       - name: Detect Changes
         uses: "./.github/actions/pnpm-diffs"
         id: diff
+        with:
+          baseSha: ${{ github.event.pull_request.base.sha }}
   client_checks:
     name: Lint, Test & Build
     needs: diff


### PR DESCRIPTION
Our current diff-based test runs will only run when files within a project have changed, but this misses cross-package dependencies, which can break any dependent project. This adds a new diff approach, which is based on the `pnpm list` command, which can list packages that have changed since main, including dependencies.