### PR TITLE
[refactor] remove proof of possession from public configs

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -120,26 +120,29 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                 let network_key: PublicKey = validator.network_key_pair.public();
                 let stake = validator.stake;
                 let network_address = validator.network_address.clone();
+                let pop = generate_proof_of_possession(
+                    &validator.key_pair,
+                    (&validator.account_key_pair.public()).into(),
+                );
 
-                ValidatorInfo {
-                    name,
-                    protocol_key,
-                    network_key,
-                    proof_of_possession: generate_proof_of_possession(
-                        &validator.key_pair,
-                        (&account_key).into(),
-                    ),
-                    account_key,
-                    stake,
-                    delegation: 0, // no delegation yet at genesis
-                    gas_price: validator.gas_price,
-                    network_address,
-                    narwhal_primary_to_primary: validator.narwhal_primary_to_primary.clone(),
-                    narwhal_worker_to_primary: validator.narwhal_worker_to_primary.clone(),
-                    narwhal_primary_to_worker: validator.narwhal_primary_to_worker.clone(),
-                    narwhal_worker_to_worker: validator.narwhal_worker_to_worker.clone(),
-                    narwhal_consensus_address: validator.narwhal_consensus_address.clone(),
-                }
+                (
+                    ValidatorInfo {
+                        name,
+                        protocol_key,
+                        network_key,
+                        account_key,
+                        stake,
+                        delegation: 0, // no delegation yet at genesis
+                        gas_price: validator.gas_price,
+                        network_address,
+                        narwhal_primary_to_primary: validator.narwhal_primary_to_primary.clone(),
+                        narwhal_worker_to_primary: validator.narwhal_worker_to_primary.clone(),
+                        narwhal_primary_to_worker: validator.narwhal_primary_to_worker.clone(),
+                        narwhal_worker_to_worker: validator.narwhal_worker_to_worker.clone(),
+                        narwhal_consensus_address: validator.narwhal_consensus_address.clone(),
+                    },
+                    pop,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -153,8 +156,8 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
         let genesis = {
             let mut builder = genesis::Builder::new().add_objects(objects);
 
-            for validator in validator_set {
-                builder = builder.add_validator(validator);
+            for (validator, proof_of_possession) in validator_set {
+                builder = builder.add_validator(validator, proof_of_possession);
             }
 
             builder.build()

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -17,11 +17,10 @@ use sui_types::committee::StakeUnit;
 use sui_types::crypto::AccountKeyPair;
 use sui_types::crypto::AuthorityKeyPair;
 use sui_types::crypto::AuthorityPublicKeyBytes;
-use sui_types::crypto::AuthoritySignature;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::PublicKey as AccountsPublicKey;
 use sui_types::crypto::SuiKeyPair;
-use sui_types::sui_serde::{AuthSignature, KeyPairBase64};
+use sui_types::sui_serde::KeyPairBase64;
 
 // Default max number of concurrent requests served
 pub const DEFAULT_GRPC_CONCURRENCY_LIMIT: usize = 20000;
@@ -181,8 +180,6 @@ pub struct ValidatorInfo {
     pub account_key: AccountsPublicKey,
     pub protocol_key: AuthorityPublicKeyBytes,
     pub network_key: AccountsPublicKey,
-    #[serde_as(as = "AuthSignature")]
-    pub proof_of_possession: AuthoritySignature,
     pub stake: StakeUnit,
     pub delegation: StakeUnit,
     pub gas_price: u64,
@@ -215,10 +212,6 @@ impl ValidatorInfo {
 
     pub fn account_key(&self) -> &AccountsPublicKey {
         &self.account_key
-    }
-
-    pub fn proof_of_possession(&self) -> &AuthoritySignature {
-        &self.proof_of_possession
     }
 
     pub fn stake(&self) -> StakeUnit {

--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -74,7 +74,6 @@ fn populated_genesis_snapshot_matches() {
         protocol_key: key.public().into(),
         account_key: account_key.public().clone().into(),
         network_key: network_key.public().clone().into(),
-        proof_of_possession: generate_proof_of_possession(&key, account_key.public().into()),
         stake: 1,
         delegation: 0,
         gas_price: 1,
@@ -85,10 +84,11 @@ fn populated_genesis_snapshot_matches() {
         narwhal_worker_to_worker: Multiaddr::empty(),
         narwhal_consensus_address: Multiaddr::empty(),
     };
+    let pop = generate_proof_of_possession(&key, account_key.public().into());
 
     let genesis = Builder::new()
         .add_objects(objects)
-        .add_validator(validator)
+        .add_validator(validator, pop)
         .build();
     assert_yaml_snapshot!(genesis.validator_set());
     assert_yaml_snapshot!(genesis.committee().unwrap());

--- a/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches.snap
@@ -6,7 +6,6 @@ expression: genesis.validator_set()
   account-key: ALnG7hYw7z5xEUSmSNsGu7IoT3J0z77lP/zuUDzBpJIA
   protocol-key: ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=
   network-key: ALnG7hYw7z5xEUSmSNsGu7IoT3J0z77lP/zuUDzBpJIA
-  proof-of-possession: CfQef5b5XFCJJcZeyEhS5x+4zK4Q3d/Py3Tg0f0pS8fJrkK9vnPPQrB2K8y4wQbnhbXz5eEP3iNnfut6fzOyCg==
   stake: 1
   delegation: 0
   gas-price: 1

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -57,10 +57,6 @@ pub async fn init_local_authorities(
             protocol_key: authority_name,
             account_key: account_key_pair.public(),
             network_key: network_key_pair.public(),
-            proof_of_possession: generate_proof_of_possession(
-                &key_pair,
-                (&account_key_pair.public()).into(),
-            ),
             stake: 1,
             delegation: 0,
             gas_price: 1,
@@ -71,7 +67,8 @@ pub async fn init_local_authorities(
             narwhal_worker_to_worker: sui_config::utils::new_network_address(),
             narwhal_consensus_address: sui_config::utils::new_network_address(),
         };
-        builder = builder.add_validator(validator_info);
+        let pop = generate_proof_of_possession(&key_pair, (&account_key_pair.public()).into());
+        builder = builder.add_validator(validator_info, pop);
         key_pairs.push((authority_name, key_pair));
     }
     let genesis = builder.build();

--- a/crates/sui/src/genesis_ceremony.rs
+++ b/crates/sui/src/genesis_ceremony.rs
@@ -115,25 +115,25 @@ pub fn run(cmd: Ceremony) -> Result<()> {
             let keypair: AuthorityKeyPair = read_authority_keypair_from_file(validator_key_file)?;
             let account_keypair: SuiKeyPair = read_keypair_from_file(account_key_file)?;
             let network_keypair: SuiKeyPair = read_keypair_from_file(network_key_file)?;
-            builder = builder.add_validator(sui_config::ValidatorInfo {
-                name,
-                protocol_key: keypair.public().into(),
-                account_key: account_keypair.public(),
-                network_key: network_keypair.public(),
-                proof_of_possession: generate_proof_of_possession(
-                    &keypair,
-                    (&account_keypair.public()).into(),
-                ),
-                stake: 1,
-                delegation: 0,
-                gas_price: 1,
-                network_address,
-                narwhal_primary_to_primary,
-                narwhal_worker_to_primary,
-                narwhal_primary_to_worker,
-                narwhal_worker_to_worker,
-                narwhal_consensus_address,
-            });
+            let pop = generate_proof_of_possession(&keypair, (&account_keypair.public()).into());
+            builder = builder.add_validator(
+                sui_config::ValidatorInfo {
+                    name,
+                    protocol_key: keypair.public().into(),
+                    account_key: account_keypair.public(),
+                    network_key: network_keypair.public(),
+                    stake: 1,
+                    delegation: 0,
+                    gas_price: 1,
+                    network_address,
+                    narwhal_primary_to_primary,
+                    narwhal_worker_to_primary,
+                    narwhal_primary_to_worker,
+                    narwhal_worker_to_worker,
+                    narwhal_consensus_address,
+                },
+                pop,
+            );
             builder.save(dir)?;
         }
 
@@ -287,10 +287,6 @@ mod test {
                     protocol_key: keypair.public().into(),
                     account_key: account_keypair.public().clone().into(),
                     network_key: network_keypair.public().clone().into(),
-                    proof_of_possession: generate_proof_of_possession(
-                        &keypair,
-                        account_keypair.public().into(),
-                    ),
                     stake: 1,
                     delegation: 0,
                     gas_price: 1,

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -24,8 +24,8 @@ use sui_json_rpc_types::{GetObjectDataResponse, SuiData, SuiParsedObject, SuiTra
 use sui_sdk::crypto::KeystoreType;
 use sui_sdk::ClientType;
 use sui_types::crypto::{
-    generate_proof_of_possession, AccountKeyPair, AuthorityKeyPair, Ed25519SuiSignature,
-    KeypairTraits, Secp256k1SuiSignature, SuiKeyPair, SuiSignatureInner,
+    AccountKeyPair, AuthorityKeyPair, Ed25519SuiSignature, KeypairTraits, Secp256k1SuiSignature,
+    SuiKeyPair, SuiSignatureInner,
 };
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
 use sui_types::{sui_framework_address_concat_string, SUI_FRAMEWORK_ADDRESS};
@@ -119,10 +119,6 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
                 protocol_key: keypair.public().into(),
                 account_key: account_keypair.public(),
                 network_key: get_key_pair::<AccountKeyPair>().1.public().clone().into(),
-                proof_of_possession: generate_proof_of_possession(
-                    &keypair,
-                    (&account_keypair.public()).into(),
-                ),
                 stake: 1,
                 delegation: 1,
                 gas_price: 1,


### PR DESCRIPTION
In #3884, we required that proof of possessions of the consensus key (#4033) be submitted during genesis and reconfigurations. However, it is unnecessary to have proof of possessions in `gateway.yaml`, as this is already stored in the ledger. Full nodes should be able to communicate with validators regardless of whether they can confirm that the validators know of the public key.