### PR TITLE
[tiny] Print more details when receiving checkpoint that has content digest mismatch

### DIFF
--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -288,9 +288,10 @@ impl SignedCheckpointSummary {
         self.auth_signature.verify(&self.summary, committee)?;
 
         if let Some(contents) = contents {
+            let content_digest = contents.digest();
             fp_ensure!(
-                contents.digest() == self.summary.content_digest,
-                SuiError::from("Checkpoint contents digest mismatch")
+                content_digest == self.summary.content_digest,
+                SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, received content digest {:?}, received {} transactions", self.summary, content_digest, contents.transactions.len())}
             );
         }
 
@@ -375,9 +376,10 @@ impl CertifiedCheckpointSummary {
         obligation.verify_all()?;
 
         if let Some(contents) = contents {
+            let content_digest = contents.digest();
             fp_ensure!(
-                contents.digest() == self.summary.content_digest,
-                SuiError::from("Checkpoint contents digest mismatch")
+                content_digest == self.summary.content_digest,
+                SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, content digest = {:?}, transactions {}", self.summary, content_digest, contents.transactions.len())}
             );
         }
 


### PR DESCRIPTION
I've seen this error few times, adding more details allows to better understand what is going on (for example know the checkpoint sequence number).

Example on devnet:

```
2022-08-23T18:31:15.736369Z  INFO sui_core::safe_client: Client error error=GenericAuthorityError { error: "Checkpoint contents digest mismatch: summary=CheckpointSummary { epoch: 0, sequence_number: 237, content_digest: [41, 158, 121, 40, 255, 163, 10, 217, 12, 44, 18, 232, 184, 4, 215, 28, 118, 129, 2, 70, 163, 34, 114, 137, 189, 151, 146, 138, 221, 89, 207, 168], previous_digest: Some([69, 60, 32, 63, 170, 240, 243, 153, 228, 129, 233, 17, 43, 74, 111, 197, 124, 206, 191, 83, 126, 57, 253, 2, 253, 52, 184, 54, 110, 106, 97, 95]) }, content digest = [241, 128, 151, 98, 53, 182, 10, 243, 207, 158, 109, 123, 78, 143, 100, 178, 123, 83, 207, 191, 62, 147, 105, 14, 81, 252, 196, 60, 68, 191, 255, 238], transactions 31" } authority=k#89cafd721eeb1b13483d5fb0968500e78103e8146b45edb30d93781d946d0aeb
```