### PR TITLE
Revert "Sync up to the latest checkpoint when full node starts"

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -970,6 +970,10 @@ impl CheckpointStore {
             .extra_transactions
             .multi_get(transactions.iter())?;
 
+        // Debug check that we only make a checkpoint if we have processed all the checkpointed
+        // transactions and their history.
+        debug_assert!(transactions_with_seq.iter().all(|item| item.is_some()));
+
         // Delete the extra transactions now used
         let batch = batch.delete_batch(
             &self.tables.extra_transactions,
@@ -984,9 +988,11 @@ impl CheckpointStore {
         let transactions_to_checkpoint: Vec<_> = transactions
             .iter()
             .zip(transactions_with_seq.iter())
-            .filter_map(|(tx, opt)| {
-                // If iseq is missing here then batch service will update this index in update_processed_transactions
-                opt.as_ref().map(|iseq| (*tx, (seq, *iseq)))
+            .map(|(tx, opt)| {
+                // Unwrap safe since we have checked all transactions are processed
+                // to get to this point.
+                let iseq = opt.as_ref().unwrap();
+                (*tx, (seq, *iseq))
             })
             .collect();
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -7,7 +7,6 @@ use futures::TryFutureExt;
 use parking_lot::Mutex;
 use prometheus::Registry;
 use std::option::Option::None;
-use std::time::Instant;
 use std::{sync::Arc, time::Duration};
 use sui_config::NodeConfig;
 use sui_core::authority_active::checkpoint_driver::CheckpointMetrics;
@@ -34,7 +33,7 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::messages::{CertifiedTransaction, CertifiedTransactionEffects};
-use tracing::{error, info};
+use tracing::info;
 
 use sui_core::authority_client::NetworkAuthorityClientMetrics;
 use sui_core::epoch::epoch_store::EpochStore;
@@ -220,20 +219,9 @@ impl SuiNode {
                         ),
                     )
                 } else {
-                    info!("Starting full node sync to latest checkpoint (this may take a while)");
-                    let metrics = CheckpointMetrics::new(&prometheus_registry);
-                    let now = Instant::now();
-                    if let Err(err) = active_authority.sync_to_latest_checkpoint(&metrics).await {
-                        error!(
-                            "Full node failed to catch up to latest checkpoint: {:?}",
-                            err
-                        );
-                    } else {
-                        info!(
-                            "Full node caught up to latest checkpoint in {:?}",
-                            now.elapsed()
-                        );
-                    }
+                    // TODO: enable checkpoint sync on fullnode
+                    // let metrics = CheckpointMetrics::new(&prometheus_registry);
+                    // active_authority.sync_to_latest_checkpoint(&metrics).await?;
                     (
                         Some(active_authority.spawn_node_sync_process().await),
                         None,


### PR DESCRIPTION
Reverts MystenLabs/sui#4221 - there are problems with `transactions_to_checkpoint` consistency and `extra_transactions` might grow infinitely