### PR TITLE
[checkpoint] Separate proposal and checkpoint content type

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -813,7 +813,6 @@ where
         return None;
     }
 
-<<<<<<< HEAD
     // We have ran out of authorities?
     if available_authorities.is_empty() {
         // We have created as many fragments as possible, so exit.
@@ -829,11 +828,11 @@ where
         .await
     {
         Ok(response) => {
-            if let AuthorityCheckpointInfo::CheckpointProposal {
+            if let CheckpointResponse::CheckpointProposal {
                 proposal,
                 prev_cert,
                 proposal_contents,
-            } = &response.info
+            } = response
             {
                 // Check if there is a latest checkpoint
                 if let Some(prev) = prev_cert {
@@ -863,7 +862,7 @@ where
 
                 let other_proposal = CheckpointProposal::new_from_signed_proposal_summary(
                     proposal.as_ref().unwrap().clone(),
-                    proposal_contents.unwrap(),
+                    proposal_contents.as_ref().unwrap().clone(),
                 );
 
                 let fragment = my_proposal.fragment_with(&other_proposal);

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -18,9 +18,9 @@ use sui_types::{
     error::{SuiError, SuiResult},
     messages::{CertifiedTransaction, TransactionInfoRequest},
     messages_checkpoint::{
-        AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
-        CheckpointContents, CheckpointDigest, CheckpointFragment, CheckpointProposal,
-        CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber, SignedCheckpointSummary,
+        AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest,
+        CheckpointFragment, CheckpointProposal, CheckpointRequest, CheckpointResponse,
+        CheckpointSequenceNumber, SignedCheckpointSummary,
     },
 };
 use tokio::time::Instant;
@@ -454,10 +454,8 @@ where
             },
             |mut state, name, weight, result| {
                 Box::pin(async move {
-                    if let Ok(CheckpointResponse {
-                        info: AuthorityCheckpointInfo::AuthenticatedCheckpoint(checkpoint),
-                        ..
-                    }) = result
+                    if let Ok(CheckpointResponse::AuthenticatedCheckpoint { checkpoint, .. }) =
+                        result
                     {
                         state.responses.push((name, checkpoint));
                         state.good_weight += weight;
@@ -815,6 +813,7 @@ where
         return None;
     }
 
+<<<<<<< HEAD
     // We have ran out of authorities?
     if available_authorities.is_empty() {
         // We have created as many fragments as possible, so exit.
@@ -833,6 +832,7 @@ where
             if let AuthorityCheckpointInfo::CheckpointProposal {
                 proposal,
                 prev_cert,
+                proposal_contents,
             } = &response.info
             {
                 // Check if there is a latest checkpoint
@@ -849,7 +849,7 @@ where
                 }
 
                 // For some reason the proposal is empty?
-                if proposal.is_none() || response.detail.is_none() {
+                if proposal.is_none() || proposal_contents.is_none() {
                     return None;
                 }
 
@@ -863,7 +863,7 @@ where
 
                 let other_proposal = CheckpointProposal::new_from_signed_proposal_summary(
                     proposal.as_ref().unwrap().clone(),
-                    response.detail.unwrap(),
+                    proposal_contents.unwrap(),
                 );
 
                 let fragment = my_proposal.fragment_with(&other_proposal);

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -16,8 +16,8 @@ use sui_types::{
     error::{SuiError, SuiResult},
     messages::*,
     messages_checkpoint::{
-        AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
-        CheckpointContents, CheckpointRequest, CheckpointResponse,
+        AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents, CheckpointRequest,
+        CheckpointResponse,
     },
 };
 use tracing::{debug, error, info, instrument, trace, Instrument};
@@ -1763,15 +1763,12 @@ where
                 Box::pin(async move {
                     let resp = client.handle_checkpoint(r).await?;
 
-                    if let CheckpointResponse {
-                        info:
-                            AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(
-                                AuthenticatedCheckpoint::Certified(past),
-                            )),
-                        detail,
+                    if let CheckpointResponse::AuthenticatedCheckpoint {
+                        checkpoint: Some(AuthenticatedCheckpoint::Certified(past)),
+                        contents,
                     } = resp
                     {
-                        Ok((past, detail))
+                        Ok((past, contents))
                     } else {
                         Err(SuiError::GenericAuthorityError {
                             error: "expected Certified checkpoint".into(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::{collections::HashSet, path::Path, sync::Arc};
 use sui_storage::default_db_options;
-use sui_types::messages_checkpoint::CheckpointProposal;
+use sui_types::messages_checkpoint::{CheckpointProposal, CheckpointProposalContents};
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests},
     batch::TxSequenceNumber,
@@ -22,9 +22,9 @@ use sui_types::{
     error::{SuiError, SuiResult},
     fp_ensure,
     messages_checkpoint::{
-        AuthenticatedCheckpoint, AuthorityCheckpointInfo, CertifiedCheckpointSummary,
-        CheckpointContents, CheckpointDigest, CheckpointFragment, CheckpointResponse,
-        CheckpointSequenceNumber, CheckpointSummary, SignedCheckpointSummary,
+        AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest,
+        CheckpointFragment, CheckpointResponse, CheckpointSequenceNumber, CheckpointSummary,
+        SignedCheckpointSummary,
     },
 };
 use tracing::{debug, error, info};
@@ -207,7 +207,7 @@ impl CheckpointStore {
                 .iter()
                 .filter(|(_, seq)| seq < locals.proposal_next_transaction.as_ref().unwrap())
                 .map(|(digest, _)| digest);
-            let transactions = CheckpointContents::new(transactions);
+            let transactions = CheckpointProposalContents::new(transactions);
             let proposal = CheckpointProposal::new(
                 epoch,
                 checkpoint_sequence,
@@ -313,12 +313,10 @@ impl CheckpointStore {
             _ => None,
         };
 
-        Ok(CheckpointResponse {
-            info: AuthorityCheckpointInfo::CheckpointProposal {
-                proposal: signed_proposal,
-                prev_cert,
-            },
-            detail: contents,
+        Ok(CheckpointResponse::CheckpointProposal {
+            proposal: signed_proposal,
+            prev_cert,
+            proposal_contents: contents,
         })
     }
 
@@ -338,9 +336,9 @@ impl CheckpointStore {
                 .get(&c.summary().sequence_number)?,
             _ => None,
         };
-        Ok(CheckpointResponse {
-            info: AuthorityCheckpointInfo::AuthenticatedCheckpoint(checkpoint),
-            detail: contents,
+        Ok(CheckpointResponse::AuthenticatedCheckpoint {
+            checkpoint,
+            contents,
         })
     }
 
@@ -357,9 +355,11 @@ impl CheckpointStore {
         let previous_digest = self.get_prev_checkpoint_digest(sequence_number)?;
 
         // Create a causal order of all transactions in the checkpoint.
-        let ordered_contents = CheckpointContents {
-            transactions: effects_store.get_complete_causal_order(transactions, self)?,
-        };
+        let ordered_contents = CheckpointContents::new_with_causally_ordered_transactions(
+            effects_store
+                .get_complete_causal_order(transactions, self)?
+                .into_iter(),
+        );
 
         let summary =
             CheckpointSummary::new(epoch, sequence_number, &ordered_contents, previous_digest);
@@ -827,7 +827,7 @@ impl CheckpointStore {
             0
         };
 
-        let transactions = CheckpointContents::new(self.tables.extra_transactions.keys());
+        let transactions = CheckpointProposalContents::new(self.tables.extra_transactions.keys());
         let size = transactions.transactions.len();
         info!(cp_seq=?checkpoint_sequence, ?size, "A new checkpoint proposal is created");
         debug!(

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -392,7 +392,7 @@ impl CheckpointStore {
         debug!(
             "Number of transactions in checkpoint {:?}: {:?}",
             checkpoint_sequence_number,
-            contents.transactions.len()
+            contents.size()
         );
 
         // Make a DB batch
@@ -724,7 +724,7 @@ impl CheckpointStore {
         committee: &Committee,
         effects_store: impl CausalOrder + PendCertificateForExecution,
     ) -> SuiResult {
-        self.check_checkpoint_transactions(contents.transactions.iter(), &effects_store)?;
+        self.check_checkpoint_transactions(contents.iter(), &effects_store)?;
         self.process_synced_checkpoint_certificate(checkpoint, contents, committee)
     }
 

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -582,7 +582,8 @@ fn update_processed_transactions_already_in_checkpoint() {
     let t2 = ExecutionDigests::random();
     let t3 = ExecutionDigests::random();
 
-    let checkpoint = CheckpointContents::new([t1, t2].into_iter());
+    let checkpoint =
+        CheckpointContents::new_with_causally_ordered_transactions([t1, t2].into_iter());
     cps.update_new_checkpoint_inner(0, &checkpoint, cps.tables.checkpoints.batch())
         .unwrap();
     cps.update_processed_transactions(&[(2, t2), (3, t3)])

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -202,7 +202,9 @@ fn make_checkpoint_db() {
     assert!(cps
         .update_new_checkpoint(
             0,
-            &CheckpointContents::new([t1, t2, t4, t5].into_iter()),
+            &CheckpointContents::new_with_causally_ordered_transactions(
+                [t1, t2, t4, t5].into_iter()
+            ),
             PendCertificateForExecutionNoop
         )
         .is_err());
@@ -213,7 +215,7 @@ fn make_checkpoint_db() {
 
     cps.update_new_checkpoint(
         0,
-        &CheckpointContents::new([t1, t2, t4, t5].into_iter()),
+        &CheckpointContents::new_with_causally_ordered_transactions([t1, t2, t4, t5].into_iter()),
         PendCertificateForExecutionNoop,
     )
     .unwrap();
@@ -275,7 +277,7 @@ fn make_proposals() {
     assert!(cps1
         .update_new_checkpoint(
             0,
-            &CheckpointContents::new(ckp_items.iter().cloned()),
+            &CheckpointContents::new_with_causally_ordered_transactions(ckp_items.iter().cloned()),
             PendCertificateForExecutionNoop
         )
         .is_err());
@@ -294,25 +296,25 @@ fn make_proposals() {
 
     cps1.update_new_checkpoint(
         0,
-        &CheckpointContents::new(ckp_items.iter().cloned()),
+        &CheckpointContents::new_with_causally_ordered_transactions(ckp_items.iter().cloned()),
         PendCertificateForExecutionNoop,
     )
     .unwrap();
     cps2.update_new_checkpoint(
         0,
-        &CheckpointContents::new(ckp_items.iter().cloned()),
+        &CheckpointContents::new_with_causally_ordered_transactions(ckp_items.iter().cloned()),
         PendCertificateForExecutionNoop,
     )
     .unwrap();
     cps3.update_new_checkpoint(
         0,
-        &CheckpointContents::new(ckp_items.iter().cloned()),
+        &CheckpointContents::new_with_causally_ordered_transactions(ckp_items.iter().cloned()),
         PendCertificateForExecutionNoop,
     )
     .unwrap();
     cps4.update_new_checkpoint(
         0,
-        &CheckpointContents::new(ckp_items.iter().cloned()),
+        &CheckpointContents::new_with_causally_ordered_transactions(ckp_items.iter().cloned()),
         PendCertificateForExecutionNoop,
     )
     .unwrap();
@@ -412,12 +414,12 @@ fn latest_proposal() {
     // No checkpoint no proposal
 
     let response = cps1.handle_proposal(false).expect("no errors");
-    assert!(response.detail.is_none());
     assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::CheckpointProposal {
+        response,
+        CheckpointResponse::CheckpointProposal {
             proposal: None,
             prev_cert: None,
+            proposal_contents: None,
         }
     ));
 
@@ -435,48 +437,46 @@ fn latest_proposal() {
 
     // Check the latest checkpoint with no detail
     let response = cps1.handle_proposal(false).expect("no errors");
-    assert!(response.detail.is_none());
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::CheckpointProposal { .. }
-    ));
-    if let AuthorityCheckpointInfo::CheckpointProposal {
+    if let CheckpointResponse::CheckpointProposal {
         proposal,
         prev_cert,
-    } = response.info
+        proposal_contents,
+    } = response
     {
         assert!(proposal.is_some());
         assert!(prev_cert.is_none());
+        assert!(proposal_contents.is_none());
 
         let current_proposal = proposal.unwrap();
         current_proposal
             .verify(&committee, None)
             .expect("no signature error");
         assert_eq!(current_proposal.summary.sequence_number, 0);
+    } else {
+        panic!("Unexpected response");
     }
 
     // --- TEST 2 ---
 
     // Check the latest checkpoint with detail
     let response = cps1.handle_proposal(true).expect("no errors");
-    assert!(response.detail.is_some());
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::CheckpointProposal { .. }
-    ));
-    if let AuthorityCheckpointInfo::CheckpointProposal {
+    if let CheckpointResponse::CheckpointProposal {
         proposal,
         prev_cert,
-    } = response.info
+        proposal_contents,
+    } = response
     {
         assert!(proposal.is_some());
         assert!(prev_cert.is_none());
+        assert!(proposal_contents.is_some());
 
         let current_proposal = proposal.unwrap();
         current_proposal
-            .verify(&committee, response.detail.as_ref())
+            .verify(&committee, proposal_contents.as_ref())
             .expect("no signature error");
         assert_eq!(current_proposal.summary.sequence_number, 0);
+    } else {
+        panic!("Unexpected response");
     }
 
     // ---
@@ -535,13 +535,12 @@ fn latest_proposal() {
         .unwrap();
 
     let response = cps1.handle_proposal(false).expect("no errors");
-    assert!(response.detail.is_none());
-    // The proposal should have been cleared now.
     assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::CheckpointProposal {
+        response,
+        CheckpointResponse::CheckpointProposal {
             proposal: None,
             prev_cert: None,
+            proposal_contents: None,
         }
     ));
 
@@ -555,14 +554,11 @@ fn latest_proposal() {
 
     // Get the full proposal with previous proposal
     let response = cps1.handle_proposal(true).expect("no errors");
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::CheckpointProposal { .. }
-    ));
-    if let AuthorityCheckpointInfo::CheckpointProposal {
+    if let CheckpointResponse::CheckpointProposal {
         proposal,
         prev_cert,
-    } = response.info
+        ..
+    } = response
     {
         assert!(proposal.is_some());
         assert!(matches!(prev_cert, Some(_)));
@@ -572,6 +568,8 @@ fn latest_proposal() {
             .verify(&committee, None)
             .expect("no signature error");
         assert_eq!(current_proposal.summary.sequence_number, 1);
+    } else {
+        panic!("Unexpected response");
     }
 }
 
@@ -636,20 +634,12 @@ fn set_get_checkpoint() {
         .handle_authenticated_checkpoint(&Some(0), true)
         .unwrap();
     assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::AuthenticatedCheckpoint(None)
+        response,
+        CheckpointResponse::AuthenticatedCheckpoint {
+            checkpoint: None,
+            contents: None,
+        }
     ));
-    assert!(response.detail.is_none());
-
-    // There is no previous checkpoint
-    let response = cps1
-        .handle_authenticated_checkpoint(&Some(0), true)
-        .unwrap();
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::AuthenticatedCheckpoint(None)
-    ));
-    assert!(response.detail.is_none());
 
     // ---
 
@@ -688,28 +678,25 @@ fn set_get_checkpoint() {
     let response = cps1
         .handle_authenticated_checkpoint(&Some(0), true)
         .unwrap();
-    assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(AuthenticatedCheckpoint::Signed(..)))
-    ));
-    if let AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(
-        AuthenticatedCheckpoint::Signed(signed),
-    )) = response.info
+
+    if let CheckpointResponse::AuthenticatedCheckpoint {
+        checkpoint: Some(AuthenticatedCheckpoint::Signed(signed)),
+        contents,
+    } = response
     {
-        signed.verify(&committee, response.detail.as_ref()).unwrap();
+        signed.verify(&committee, contents.as_ref()).unwrap();
+    } else {
+        panic!("Unexpected response");
     }
 
     // Make a certificate
     let mut signed_checkpoint: Vec<SignedCheckpointSummary> = Vec::new();
     for x in [&mut cps1, &mut cps2, &mut cps3] {
-        match x
-            .handle_authenticated_checkpoint(&Some(0), true)
-            .unwrap()
-            .info
-        {
-            AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(
-                AuthenticatedCheckpoint::Signed(signed),
-            )) => signed_checkpoint.push(signed),
+        match x.handle_authenticated_checkpoint(&Some(0), true).unwrap() {
+            CheckpointResponse::AuthenticatedCheckpoint {
+                checkpoint: Some(AuthenticatedCheckpoint::Signed(signed)),
+                ..
+            } => signed_checkpoint.push(signed),
             _ => unreachable!(),
         };
     }
@@ -730,16 +717,18 @@ fn set_get_checkpoint() {
         .handle_authenticated_checkpoint(&Some(0), true)
         .unwrap();
     assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(AuthenticatedCheckpoint::Certified(
+        response,
+        CheckpointResponse::AuthenticatedCheckpoint {
+            checkpoint: Some(AuthenticatedCheckpoint::Certified(..)),
             ..
-        )))
+        }
     ));
 
     // --- TEST 3 ---
 
     // Setting with contents succeeds BUT has not processed transactions
-    let contents = CheckpointContents::new(ckp_items.into_iter());
+    let contents =
+        CheckpointContents::new_with_causally_ordered_transactions(ckp_items.into_iter());
     let response_ckp = cps4.process_new_checkpoint_certificate(
         &checkpoint_cert,
         &contents,
@@ -763,10 +752,11 @@ fn set_get_checkpoint() {
         .handle_authenticated_checkpoint(&Some(0), true)
         .unwrap();
     assert!(matches!(
-        response.info,
-        AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(AuthenticatedCheckpoint::Certified(
+        response,
+        CheckpointResponse::AuthenticatedCheckpoint {
+            checkpoint: Some(AuthenticatedCheckpoint::Certified(..)),
             ..
-        )))
+        }
     ));
 }
 
@@ -1429,7 +1419,11 @@ fn test_fragment_full_flow() {
         .handle_authenticated_checkpoint(&Some(0), true)
         .expect("No errors on response");
     // Ensure the reconstruction worked
-    assert_eq!(response.detail.unwrap().transactions.len(), 2);
+    if let CheckpointResponse::AuthenticatedCheckpoint { contents, .. } = response {
+        assert_eq!(contents.unwrap().transactions.len(), 2);
+    } else {
+        panic!("Unexpected response");
+    }
 
     // TEST 3 -- feed the framents to the node 6 which cannot decode the
     // sequence of fragments.
@@ -1720,18 +1714,23 @@ async fn checkpoint_messaging_flow() {
             .expect("No issues");
 
         assert!(matches!(
-            response.info,
-            AuthorityCheckpointInfo::CheckpointProposal { .. }
+            response,
+            CheckpointResponse::CheckpointProposal { .. }
         ));
 
-        if let AuthorityCheckpointInfo::CheckpointProposal { proposal, .. } = &response.info {
+        if let CheckpointResponse::CheckpointProposal {
+            proposal,
+            proposal_contents,
+            ..
+        } = response
+        {
             assert!(proposal.is_some());
 
             proposals.push((
                 *auth,
                 CheckpointProposal::new_from_signed_proposal_summary(
-                    proposal.as_ref().unwrap().clone(),
-                    response.detail.unwrap(),
+                    proposal.unwrap(),
+                    proposal_contents.unwrap(),
                 ),
             ));
         }
@@ -1777,7 +1776,7 @@ async fn checkpoint_messaging_flow() {
 
     // Step 3 - get the signed checkpoint
     let mut signed_checkpoint = Vec::new();
-    let mut contents = None;
+    let mut checkpoint_contents = None;
     let mut failed_authorities = HashSet::new();
     for (auth, client) in &setup.aggregator.authority_clients {
         let response = client
@@ -1785,12 +1784,13 @@ async fn checkpoint_messaging_flow() {
             .await
             .expect("No issues");
 
-        match &response.info {
-            AuthorityCheckpointInfo::AuthenticatedCheckpoint(Some(
-                AuthenticatedCheckpoint::Signed(checkpoint),
-            )) => {
-                signed_checkpoint.push(checkpoint.clone());
-                contents = response.detail.clone();
+        match response {
+            CheckpointResponse::AuthenticatedCheckpoint {
+                checkpoint: Some(AuthenticatedCheckpoint::Signed(checkpoint)),
+                contents,
+            } => {
+                signed_checkpoint.push(checkpoint);
+                checkpoint_contents = contents;
             }
             _ => {
                 failed_authorities.insert(*auth);
@@ -1798,7 +1798,7 @@ async fn checkpoint_messaging_flow() {
         }
     }
 
-    let contents = contents.unwrap();
+    let contents = checkpoint_contents.unwrap();
     assert_eq!(contents.transactions.len(), 1);
 
     // Construct a certificate

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1421,7 +1421,7 @@ fn test_fragment_full_flow() {
         .expect("No errors on response");
     // Ensure the reconstruction worked
     if let CheckpointResponse::AuthenticatedCheckpoint { contents, .. } = response {
-        assert_eq!(contents.unwrap().transactions.len(), 2);
+        assert_eq!(contents.unwrap().size(), 2);
     } else {
         panic!("Unexpected response");
     }
@@ -1800,7 +1800,7 @@ async fn checkpoint_messaging_flow() {
     }
 
     let contents = checkpoint_contents.unwrap();
-    assert_eq!(contents.transactions.len(), 1);
+    assert_eq!(contents.size(), 1);
 
     // Construct a certificate
     // We need at least f+1 signatures

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1141,6 +1141,7 @@ mod bcs_signable {
     impl BcsSignable for crate::batch::AuthorityBatch {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointSummary {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointContents {}
+    impl BcsSignable for crate::messages_checkpoint::CheckpointProposalContents {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointProposalSummary {}
     impl BcsSignable for crate::messages::TransactionEffects {}
     impl BcsSignable for crate::messages::TransactionData {}

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -175,7 +175,7 @@ impl CheckpointSummary {
         previous_digest: Option<CheckpointDigest>,
     ) -> CheckpointSummary {
         let mut waypoint = Box::new(Waypoint::default());
-        transactions.transactions.iter().for_each(|tx| {
+        transactions.iter().for_each(|tx| {
             waypoint.insert(tx);
         });
 
@@ -283,7 +283,7 @@ impl SignedCheckpointSummary {
             let content_digest = contents.digest();
             fp_ensure!(
                 content_digest == self.summary.content_digest,
-                SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, received content digest {:?}, received {} transactions", self.summary, content_digest, contents.transactions.len())}
+                SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, received content digest {:?}, received {} transactions", self.summary, content_digest, contents.size())}
             );
         }
 
@@ -371,7 +371,7 @@ impl CertifiedCheckpointSummary {
             let content_digest = contents.digest();
             fp_ensure!(
                 content_digest == self.summary.content_digest,
-                SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, content digest = {:?}, transactions {}", self.summary, content_digest, contents.transactions.len())}
+                SuiError::GenericAuthorityError{error:format!("Checkpoint contents digest mismatch: summary={:?}, content digest = {:?}, transactions {}", self.summary, content_digest, contents.size())}
             );
         }
 
@@ -412,7 +412,7 @@ impl CheckpointProposalContents {
 /// the same order for each checkpoint content.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointContents {
-    pub transactions: Vec<ExecutionDigests>,
+    transactions: Vec<ExecutionDigests>,
 }
 
 impl CheckpointContents {
@@ -427,6 +427,10 @@ impl CheckpointContents {
 
     pub fn iter(&self) -> Iter<'_, ExecutionDigests> {
         self.transactions.iter()
+    }
+
+    pub fn size(&self) -> usize {
+        self.transactions.len()
     }
 
     pub fn digest(&self) -> CheckpointContentsDigest {

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -379,6 +379,11 @@ impl CertifiedCheckpointSummary {
     }
 }
 
+/// CheckpointProposalContents represents the contents of a proposal.
+/// Contents in a proposal are not yet causally ordered, and hence we don't care about
+/// the order of transactions in the content. It's only important that two proposal
+/// contents with the same transactions should have the same digest. Hence we use BTreeSet
+/// as the container. This also has the benefit of removing any duplicate transactions.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointProposalContents {
     // TODO: Currently we are not really using the effects digests, but in the future we may be
@@ -401,6 +406,10 @@ impl CheckpointProposalContents {
     }
 }
 
+/// CheckpointContents are the transactions included in an upcoming checkpoint.
+/// They must have already been causally ordered. Since the causal order algorithm
+/// is the same among validators, we expect all honest validators to come up with
+/// the same order for each checkpoint content.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointContents {
     pub transactions: Vec<ExecutionDigests>,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -589,17 +589,17 @@ fn test_user_signature_committed_in_checkpoints() {
     let checkpoint_summary_a = CheckpointSummary::new(
         0,
         1,
-        &CheckpointContents {
-            transactions: vec![execution_digest_a],
-        },
+        &CheckpointContents::new_with_causally_ordered_transactions(
+            [execution_digest_a].into_iter(),
+        ),
         None,
     );
     let checkpoint_summary_b = CheckpointSummary::new(
         0,
         1,
-        &CheckpointContents {
-            transactions: vec![execution_digest_b],
-        },
+        &CheckpointContents::new_with_causally_ordered_transactions(
+            [execution_digest_b].into_iter(),
+        ),
         None,
     );
 


### PR DESCRIPTION
A major difference between the checkpoint content and proposal content is that the proposal content is unordered while checkpoint content is causally ordered. Hence we use BTreeSet for proposal content while Vec for checkpoint contet. This PR makes such distinction, and could potentially help reduce errors.