### PR TITLE
fix typo in the doc.

### DIFF
--- a/doc/src/build/move/build-test.md
+++ b/doc/src/build/move/build-test.md
@@ -65,7 +65,7 @@ file:
 
         // create a sword
         let sword = Sword {
-            info: object::new(&mut ctx),
+            id: object::new(&mut ctx),
             magic: 42,
             strength: 7,
         };


### PR DESCRIPTION
There is no `info` field according to the previous guide. So it should be field `id` here