### PR TITLE
Rename cmd from transfer-coin to transfer

### DIFF
--- a/crates/sui-cost/src/empirical_transaction_cost.rs
+++ b/crates/sui-cost/src/empirical_transaction_cost.rs
@@ -172,7 +172,7 @@ async fn run_common_single_writer_tx_costs(
     let resp = SuiClientCommands::Transfer {
         gas: None,
         to: recipient,
-        coin_object_id: obj_id,
+        object_id: obj_id,
         gas_budget: 10000,
     }
     .execute(&mut context)
@@ -193,7 +193,7 @@ async fn run_common_single_writer_tx_costs(
     let resp = SuiClientCommands::Transfer {
         gas: Some(gas),
         to: recipient,
-        coin_object_id: obj_id,
+        object_id: obj_id,
         gas_budget: 10000,
     }
     .execute(&mut context)

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -251,7 +251,7 @@ async fn create_transfer_response(
 ) -> Result<SuiTransactionResponse, anyhow::Error> {
     let response = SuiClientCommands::Transfer {
         to: address,
-        coin_object_id: coins.first().unwrap().object_id,
+        object_id: coins.first().unwrap().object_id,
         gas: None,
         gas_budget: 1000,
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -136,16 +136,16 @@ pub enum SuiClientCommands {
         gas_budget: u64,
     },
 
-    /// Transfer coin object
-    #[clap(name = "transfer-coin")]
+    /// Transfer object
+    #[clap(name = "transfer")]
     Transfer {
         /// Recipient address
         #[clap(long)]
         to: SuiAddress,
 
-        /// Coin to transfer, in 20 bytes Hex string
+        /// Object to transfer, in 20 bytes Hex string
         #[clap(long)]
-        coin_object_id: ObjectID,
+        object_id: ObjectID,
 
         /// ID of the gas object for gas payment, in 20 bytes Hex string
         /// If not provided, a gas object with at least gas_budget value will be selected
@@ -324,7 +324,7 @@ impl SuiClientCommands {
 
             SuiClientCommands::Transfer {
                 to,
-                coin_object_id: object_id,
+                object_id,
                 gas,
                 gas_budget,
             } => {

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -302,7 +302,7 @@ async fn test_gas_command() -> Result<(), anyhow::Error> {
     // Send an object
     SuiClientCommands::Transfer {
         to: recipient,
-        coin_object_id: object_to_send,
+        object_id: object_to_send,
         gas: Some(object_id),
         gas_budget: 50000,
     }
@@ -575,7 +575,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     let resp = SuiClientCommands::Transfer {
         gas: Some(gas_obj_id),
         to: recipient,
-        coin_object_id: obj_id,
+        object_id: obj_id,
         gas_budget: 50000,
     }
     .execute(&mut context)
@@ -665,7 +665,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     let resp = SuiClientCommands::Transfer {
         gas: None,
         to: recipient,
-        coin_object_id: obj_id,
+        object_id: obj_id,
         gas_budget: 50000,
     }
     .execute(&mut context)

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -64,7 +64,7 @@ async fn transfer_coin(
     );
     let res = SuiClientCommands::Transfer {
         to: receiver,
-        coin_object_id: object_to_send,
+        object_id: object_to_send,
         gas: None,
         gas_budget: 50000,
     }

--- a/doc/src/contribute/cli-client.md
+++ b/doc/src/contribute/cli-client.md
@@ -216,7 +216,7 @@ The following commands are supported by the Sui client:
     split-coin            Split a coin object into multiple coins
     switch                Switch active address and network (e.g., Devnet, local RPC server)
     sync                  Synchronize client state with authorities
-    transfer-coin         Transfer coin object
+    transfer              Transfer object
     transfer-sui          Transfer SUI, and pay gas with the same SUI coin object. If amount is
                               specified, only the amount is transferred; otherwise the entire object
                               is transferred
@@ -540,7 +540,7 @@ Here is example `json` output:
 
 ## Transferring coins
 
-Coins *are* objects yet have a specific use case that allow for native commands like transfer-coin/merge-coin/split-coin to be used. This is different from non-coin objects that can only be mutated via [Move calls](#calling-move-code).
+Coins *are* objects yet have a specific use case that allow for native commands like transfer/merge-coin/split-coin to be used. This is different from non-coin objects that can only be mutated via [Move calls](#calling-move-code).
 
 If you inspect a newly created account, you would expect the account does not own any object. Let us inspect the fresh account we create in the [Generating a new account](#generating-a-new-account) section (`C72CF3ADCC4D11C03079CEF2C8992AEA5268677A`):
 
@@ -555,14 +555,14 @@ To add objects to the account, you can [invoke a Move function](#calling-move-co
 or you can transfer one of the existing coins from the genesis account to the new account using a dedicated Sui client command.
 We will explore how to transfer coins using the Sui CLI client in this section.
 
-`transfer-coin` command usage:
+`transfer` command usage:
 
 ```shell
-sui-client-transfer-coin
-Transfer coin object
+sui-client-transfer
+Transfer object
 
 USAGE:
-    sui client transfer-coin [OPTIONS] --to <TO> --coin-object-id <COIN_OBJECT_ID> --gas-budget <GAS_BUDGET>
+    sui client transfer [OPTIONS] --to <TO> --coin-object-id <COIN_OBJECT_ID> --gas-budget <GAS_BUDGET>
 
 OPTIONS:
         --coin-object-id <COIN_OBJECT_ID>
@@ -595,7 +595,7 @@ mechanisms. For now, just set something large enough.
 Here is an example transfer of an object to account `0xf456ebef195e4a231488df56b762ac90695be2dd`:
 
 ```shell
-$ sui client transfer-coin --to 0xf456ebef195e4a231488df56b762ac90695be2dd --coin-object-id 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 --gas-budget 100
+$ sui client transfer --to 0xf456ebef195e4a231488df56b762ac90695be2dd --coin-object-id 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 --gas-budget 100
 ```
 
 With output like:

--- a/doc/src/contribute/cli-client.md
+++ b/doc/src/contribute/cli-client.md
@@ -540,7 +540,7 @@ Here is example `json` output:
 
 ## Transferring coins
 
-Coins *are* objects yet have a specific use case that allow for native commands like transfer/merge-coin/split-coin to be used. This is different from non-coin objects that can only be mutated via [Move calls](#calling-move-code).
+Coins *are* objects, but they have a specific use case that allows you to use native commands such as `transfer`, `merge-coin`, and `split-coin`. This is different from non-coin objects that you can mutate only using [Move calls](#calling-move-code).
 
 If you inspect a newly created account, you would expect the account does not own any object. Let us inspect the fresh account we create in the [Generating a new account](#generating-a-new-account) section (`C72CF3ADCC4D11C03079CEF2C8992AEA5268677A`):
 


### PR DESCRIPTION
`transfer-coin` actually works for all objects. Renaming as approp