### PR TITLE
[sui-tool] Support getting old objects and print fields

### DIFF
--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -348,6 +348,12 @@ ObjectInfoRequestKind:
       PastObjectInfo:
         NEWTYPE:
           TYPENAME: SequenceNumber
+    2:
+      PastObjectInfoDebug:
+        TUPLE:
+          - TYPENAME: SequenceNumber
+          - OPTION:
+              TYPENAME: ObjectFormatOptions
 Owner:
   ENUM:
     0:

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -833,6 +833,11 @@ pub enum ObjectInfoRequestKind {
     LatestObjectInfo(Option<ObjectFormatOptions>),
     /// Request the object state at a specific version
     PastObjectInfo(SequenceNumber),
+    /// Similar to PastObjectInfo, except that it will also return the object content.
+    /// This is used only for debugging purpose and will not work in the long run when
+    /// we stop storing all historic versions of every object.
+    /// No production code should depend on this kind.
+    PastObjectInfoDebug(SequenceNumber, Option<ObjectFormatOptions>),
 }
 
 /// A request for information about an object and optionally its


### PR DESCRIPTION
This PR adds an object info request type that allows us to also return the content of an object for historic versions. This will work for now but will not work when we start to prune objects. Hence I made the kind an explicit debug kind just for us to debug things and no prod code should depend on it.
Also make the sui-tool to query for the layout of object so that we can print it out in a human-readable way.