### PR TITLE
[transaction] Check batch transaction validity

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -731,7 +731,7 @@ impl AuthorityState {
             effects.effects.all_mutated(),
             cert.signed_data
                 .data
-                .move_calls()?
+                .move_calls()
                 .iter()
                 .map(|mc| (mc.package.0, mc.module.clone(), mc.function.clone())),
             seq,

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -26,6 +26,8 @@ pub async fn check_transaction_input<S, T>(
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
 {
+    transaction.signed_data.data.kind.validity_check()?;
+
     let mut gas_status = check_gas(
         store,
         transaction.gas_payment_object_ref().0,

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -400,7 +400,7 @@ pub fn deduct_gas(gas_object: &mut Object, deduct_amount: u64, rebate_amount: u6
     // The object must be a gas coin as we have checked in transaction handle phase.
     let gas_coin = GasCoin::try_from(&*gas_object).unwrap();
     let balance = gas_coin.value();
-    debug_assert!(balance >= deduct_amount);
+    assert!(balance >= deduct_amount);
     let new_gas_coin = GasCoin::new(*gas_coin.id(), balance + rebate_amount - deduct_amount);
     let move_object = gas_object.data.try_as_move_mut().unwrap();
     move_object.update_contents_and_increment_version(bcs::to_bytes(&new_gas_coin).unwrap());

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -297,6 +297,35 @@ impl TransactionKind {
             TransactionKind::Single(SingleTransactionKind::ChangeEpoch(_))
         )
     }
+
+    pub fn validity_check(&self) -> SuiResult {
+        match self {
+            Self::Batch(b) => {
+                fp_ensure!(
+                    !b.is_empty(),
+                    SuiError::InvalidBatchTransaction {
+                        error: "Batch Transaction cannot be empty".to_string(),
+                    }
+                );
+                // Check that all transaction kinds can be in a batch.
+                let valid = self.single_transactions().all(|s| match s {
+                    SingleTransactionKind::Call(_) => true,
+                    SingleTransactionKind::TransferObject(_) => true,
+                    SingleTransactionKind::TransferSui(_) => false,
+                    SingleTransactionKind::ChangeEpoch(_) => false,
+                    SingleTransactionKind::Publish(_) => false,
+                });
+                fp_ensure!(
+                    valid,
+                    SuiError::InvalidBatchTransaction {
+                        error: "Batch transaction contains non-batchable transactions. Only Call and TransferObject are allowed".to_string()
+                    }
+                );
+            }
+            Self::Single(_) => (),
+        }
+        Ok(())
+    }
 }
 
 impl Display for TransactionKind {
@@ -447,46 +476,22 @@ impl TransactionData {
         &self.gas_payment
     }
 
-    pub fn move_calls(&self) -> SuiResult<Vec<&MoveCall>> {
-        let move_calls = match &self.kind {
-            TransactionKind::Single(s) => s.move_call().into_iter().collect(),
-            TransactionKind::Batch(b) => {
-                let mut result = vec![];
-                for kind in b {
-                    fp_ensure!(
-                        !matches!(kind, &SingleTransactionKind::Publish(..)),
-                        SuiError::InvalidBatchTransaction {
-                            error: "Publish transaction is not allowed in Batch Transaction"
-                                .to_owned(),
-                        }
-                    );
-                    result.extend(kind.move_call().into_iter());
-                }
-                result
-            }
-        };
-        Ok(move_calls)
+    pub fn move_calls(&self) -> Vec<&MoveCall> {
+        self.kind
+            .single_transactions()
+            .flat_map(|s| s.move_call())
+            .collect()
     }
 
     pub fn input_objects(&self) -> SuiResult<Vec<InputObjectKind>> {
-        let mut inputs = match &self.kind {
-            TransactionKind::Single(s) => s.input_objects()?,
-            TransactionKind::Batch(b) => {
-                let mut result = vec![];
-                for kind in b {
-                    fp_ensure!(
-                        !matches!(kind, &SingleTransactionKind::Publish(..)),
-                        SuiError::InvalidBatchTransaction {
-                            error: "Publish transaction is not allowed in Batch Transaction"
-                                .to_owned(),
-                        }
-                    );
-                    let sub = kind.input_objects()?;
-                    result.extend(sub);
-                }
-                result
-            }
-        };
+        let mut inputs: Vec<_> = self
+            .kind
+            .single_transactions()
+            .map(|s| s.input_objects())
+            .collect::<SuiResult<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect();
         if !self.kind.is_system_tx() {
             inputs.push(InputObjectKind::ImmOrOwnedMoveObject(
                 *self.gas_payment_object_ref(),


### PR DESCRIPTION
Adds batch transaction validity check during transaction input check: a batch cannot be empty and can only contain Call and TranserObject.
Also simplified a few other functions to consolidate the check.
Added test
Changed debug_assert to assert for gas check.