### PR TITLE
Transaction Streamer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7680,6 +7680,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "sui-cost-tables",
+ "test-utils",
  "thiserror",
  "tonic",
  "tracing",

--- a/crates/sui-benchmark/src/benchmark/validator_preparer.rs
+++ b/crates/sui-benchmark/src/benchmark/validator_preparer.rs
@@ -294,6 +294,7 @@ fn make_authority_state(
                 None,
                 None,
                 None,
+                None,
                 &sui_config::genesis::Genesis::get_default_genesis(),
                 &prometheus::Registry::new(),
                 tx_reconfigure_consensus,

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -57,9 +57,17 @@ impl NetworkConfig {
         Self::generate_with_rng(config_dir, quorum_size, OsRng)
     }
 
+    pub fn generate_fullnode_config(&self) -> NodeConfig {
+        self.generate_fullnode_config_with_custom_db_path(None, true)
+    }
+
     /// Generate a fullnode config based on this `NetworkConfig`. This is useful if you want to run
     /// a fullnode and have it connect to a network defined by this `NetworkConfig`.
-    pub fn generate_fullnode_config(&self) -> NodeConfig {
+    pub fn generate_fullnode_config_with_custom_db_path(
+        &self,
+        fullnode_db_dir: Option<&str>,
+        enable_websocket: bool,
+    ) -> NodeConfig {
         let protocol_key_pair: Arc<AuthorityKeyPair> =
             Arc::new(get_key_pair_from_rng(&mut OsRng).1);
         let account_key_pair: Arc<SuiKeyPair> = Arc::new(
@@ -81,12 +89,16 @@ impl NetworkConfig {
             protocol_key_pair,
             account_key_pair,
             network_key_pair,
-            db_path: db_path.join(FULL_NODE_DB_PATH),
+            db_path: db_path.join(fullnode_db_dir.unwrap_or(FULL_NODE_DB_PATH)),
             network_address: utils::new_network_address(),
             metrics_address: utils::available_local_socket_address(),
             admin_interface_port: utils::get_available_port(),
             json_rpc_address: utils::available_local_socket_address(),
-            websocket_address: Some(utils::available_local_socket_address()),
+            websocket_address: if enable_websocket {
+                Some(utils::available_local_socket_address())
+            } else {
+                None
+            },
             consensus_config: None,
             enable_event_processing: true,
             enable_gossip: true,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -777,6 +777,11 @@ impl AuthorityState {
             }
         }
 
+        // Stream transaction
+        if let Some(transaction_streamer) = &self.transaction_streamer {
+            transaction_streamer.enqueue((cert, effects.clone())).await;
+        }
+
         // Emit events
         if let Some(event_handler) = &self.event_handler {
             let checkpoint_num = self.latest_checkpoint_num.load(Ordering::Relaxed);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -10,6 +10,7 @@ use crate::{
     execution_engine,
     query_helpers::QueryHelpers,
     transaction_input_checker,
+    transaction_streamer::TransactionStreamer,
 };
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
@@ -306,6 +307,7 @@ pub struct AuthorityState {
     pub module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>, // TODO: use strategies (e.g. LRU?) to constraint memory usage
 
     pub event_handler: Option<Arc<EventHandler>>,
+    pub transaction_streamer: Option<Arc<TransactionStreamer>>,
 
     /// The checkpoint store
     pub checkpoints: Option<Arc<Mutex<CheckpointStore>>>,
@@ -1062,6 +1064,7 @@ impl AuthorityState {
         epoch_store: Arc<EpochStore>,
         indexes: Option<Arc<IndexStore>>,
         event_store: Option<Arc<EventStoreType>>,
+        transaction_streamer: Option<Arc<TransactionStreamer>>,
         checkpoints: Option<Arc<Mutex<CheckpointStore>>>,
         genesis: &Genesis,
         prometheus_registry: &prometheus::Registry,
@@ -1106,6 +1109,7 @@ impl AuthorityState {
             // this is because they largely deal with different types of MoveStructs
             module_cache: Arc::new(SyncModuleCache::new(ResolverWrapper(store.clone()))),
             event_handler,
+            transaction_streamer,
             checkpoints,
             epoch_store,
             batch_channels: tx,
@@ -1218,6 +1222,7 @@ impl AuthorityState {
             secret.clone(),
             store,
             epochs,
+            None,
             None,
             None,
             Some(Arc::new(Mutex::new(checkpoints))),

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -18,7 +18,7 @@ use sui_types::{
 
 use crate::authority::{AuthorityStore, ResolverWrapper};
 use crate::streamer::Streamer;
-use sui_types::event_filter::EventFilter;
+use sui_types::filter::EventFilter;
 
 #[cfg(test)]
 #[path = "unit_tests/event_handler_tests.rs"]

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod gateway_state;
 pub mod safe_client;
 pub mod streamer;
 pub mod transaction_input_checker;
+pub mod transaction_streamer;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/crates/sui-core/src/streamer.rs
+++ b/crates/sui-core/src/streamer.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiError;
-use sui_types::event_filter::Filter;
+use sui_types::filter::Filter;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, RwLock};

--- a/crates/sui-core/src/transaction_streamer.rs
+++ b/crates/sui-core/src/transaction_streamer.rs
@@ -37,7 +37,13 @@ impl TransactionStreamer {
             error!(?tx_digest, error =? e, "Failed to send tx to dispatch");
             return false;
         }
-        return true;
+        true
+    }
+}
+
+impl Default for TransactionStreamer {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/sui-core/src/transaction_streamer.rs
+++ b/crates/sui-core/src/transaction_streamer.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::Stream;
+
+use sui_types::messages::TxCertAndSignedEffects;
+
+use sui_types::filter::TransactionFilter;
+
+use tracing::error;
+
+use super::streamer::Streamer;
+
+const CHANNEL_SIZE: usize = 1000;
+
+pub struct TransactionStreamer {
+    streamer: Streamer<TxCertAndSignedEffects, TransactionFilter>,
+}
+
+impl TransactionStreamer {
+    pub fn new() -> Self {
+        TransactionStreamer {
+            streamer: Streamer::spawn(CHANNEL_SIZE),
+        }
+    }
+
+    pub fn subscribe(
+        &self,
+        filter: TransactionFilter,
+    ) -> impl Stream<Item = TxCertAndSignedEffects> {
+        self.streamer.subscribe(filter)
+    }
+
+    pub async fn enqueue(&self, tx: TxCertAndSignedEffects) -> bool {
+        let tx_digest = *tx.0.digest();
+        if let Err(e) = self.streamer.send(tx).await {
+            error!(?tx_digest, error =? e, "Failed to send tx to dispatch");
+            return false;
+        }
+        return true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use test_utils::messages::{make_tx_certs_and_signed_effects, test_shared_object_transactions};
+    use tokio::time::{timeout, Duration};
+
+    #[tokio::test]
+    async fn test_basic() -> Result<(), anyhow::Error> {
+        let streamer = TransactionStreamer::new();
+        let mut stream = streamer.subscribe(TransactionFilter::Any);
+        let tx = test_shared_object_transactions().swap_remove(0);
+        let (mut tx_certs, mut signed_effects) = make_tx_certs_and_signed_effects(vec![tx]);
+        let tx_cert = tx_certs.swap_remove(0);
+        let tx_digest = *tx_cert.digest();
+        let signed_effects = signed_effects.swap_remove(0);
+        let result = streamer.enqueue((tx_cert, signed_effects.clone())).await;
+
+        assert!(result);
+        if let Some((cert, effects)) = stream.next().await {
+            assert_eq!(cert.digest(), &tx_digest);
+            assert_eq!(effects, signed_effects);
+        } else {
+            panic!("Expect Some value but got None");
+        }
+
+        // No more
+        assert!(timeout(Duration::from_millis(500), stream.next())
+            .await
+            .is_err());
+        Ok(())
+    }
+}

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -68,6 +68,7 @@ pub(crate) async fn init_state(
         None,
         None,
         None,
+        None,
         &sui_config::genesis::Genesis::get_default_genesis(),
         &prometheus::Registry::new(),
         tx_reconfigure_consensus,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -39,7 +39,7 @@ use sui_types::crypto::{AuthorityStrongQuorumSignInfo, SignableBytes, Signature}
 use sui_types::error::SuiError;
 use sui_types::event::{Event, TransferType};
 use sui_types::event::{EventEnvelope, EventType};
-use sui_types::event_filter::EventFilter;
+use sui_types::filter::{EventFilter, TransactionFilter};
 use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
@@ -2124,6 +2124,23 @@ pub struct MoveCallParams {
     #[serde(default)]
     pub type_arguments: Vec<SuiTypeTag>,
     pub arguments: Vec<SuiJsonValue>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename = "SuiTransactionFilter")]
+pub enum SuiTransactionFilter {
+    Any,
+}
+
+impl TryInto<TransactionFilter> for SuiTransactionFilter {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<TransactionFilter, anyhow::Error> {
+        use SuiTransactionFilter::*;
+        Ok(match self {
+            Any => TransactionFilter::Any,
+        })
+    }
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -2132,14 +2132,12 @@ pub enum SuiTransactionFilter {
     Any,
 }
 
-impl TryInto<TransactionFilter> for SuiTransactionFilter {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<TransactionFilter, anyhow::Error> {
+impl From<SuiTransactionFilter> for TransactionFilter {
+    fn from(filter: SuiTransactionFilter) -> Self {
         use SuiTransactionFilter::*;
-        Ok(match self {
+        match filter {
             Any => TransactionFilter::Any,
-        })
+        }
     }
 }
 

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -10,11 +10,7 @@ use sui_json_rpc_types::{
     GatewayTxSeqNumber, GetObjectDataResponse, GetRawObjectDataResponse, MoveFunctionArgType,
     RPCTransactionRequestParams, SuiEventEnvelope, SuiEventFilter, SuiExecuteTransactionResponse,
     SuiGasCostSummary, SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
-    SuiObjectInfo, SuiTransactionResponse, SuiTypeTag, TransactionBytes,
-    RPCTransactionRequestParams, SuiCertifiedTransaction, SuiEventEnvelope, SuiEventFilter,
-    SuiExecuteTransactionResponse, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
-    SuiMoveNormalizedStruct, SuiObjectInfo, SuiTransactionEffects, SuiTransactionFilter,
-    SuiTransactionResponse, SuiTypeTag, TransactionBytes,
+    SuiObjectInfo, SuiTransactionFilter, SuiTransactionResponse, SuiTypeTag, TransactionBytes,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
@@ -359,7 +355,7 @@ pub trait RpcBcsApi {
 #[rpc(server, client, namespace = "sui")]
 pub trait TransactionStreamingApi {
     /// Subscribe to a stream of Sui event
-    #[subscription(name = "subscribeTransaction", item = (SuiCertifiedTransaction, SuiTransactionEffects))]
+    #[subscription(name = "subscribeTransaction", item = SuiTransactionResponse)]
     fn subscribe_transaction(
         &self,
         /// the filter criteria of the transaction stream.

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -11,6 +11,10 @@ use sui_json_rpc_types::{
     RPCTransactionRequestParams, SuiEventEnvelope, SuiEventFilter, SuiExecuteTransactionResponse,
     SuiGasCostSummary, SuiMoveNormalizedFunction, SuiMoveNormalizedModule, SuiMoveNormalizedStruct,
     SuiObjectInfo, SuiTransactionResponse, SuiTypeTag, TransactionBytes,
+    RPCTransactionRequestParams, SuiCertifiedTransaction, SuiEventEnvelope, SuiEventFilter,
+    SuiExecuteTransactionResponse, SuiMoveNormalizedFunction, SuiMoveNormalizedModule,
+    SuiMoveNormalizedStruct, SuiObjectInfo, SuiTransactionEffects, SuiTransactionFilter,
+    SuiTransactionResponse, SuiTypeTag, TransactionBytes,
 };
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
@@ -349,6 +353,18 @@ pub trait RpcBcsApi {
         /// the id of the object
         object_id: ObjectID,
     ) -> RpcResult<GetRawObjectDataResponse>;
+}
+
+#[open_rpc(namespace = "sui", tag = "Transaction Subscription")]
+#[rpc(server, client, namespace = "sui")]
+pub trait TransactionStreamingApi {
+    /// Subscribe to a stream of Sui event
+    #[subscription(name = "subscribeTransaction", item = (SuiCertifiedTransaction, SuiTransactionEffects))]
+    fn subscribe_transaction(
+        &self,
+        /// the filter criteria of the transaction stream.
+        filter: SuiTransactionFilter,
+    );
 }
 
 #[open_rpc(namespace = "sui", tag = "Event Subscription")]

--- a/crates/sui-json-rpc/src/event_api.rs
+++ b/crates/sui-json-rpc/src/event_api.rs
@@ -2,19 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::api::EventReadApiServer;
 use crate::api::EventStreamingApiServer;
+use crate::streaming_api::spawn_subscription;
 use crate::SuiRpcModule;
 use async_trait::async_trait;
 use futures::{StreamExt, TryStream};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::SubscriptionResult;
-use jsonrpsee_core::error::SubscriptionClosed;
 use jsonrpsee_core::server::rpc_module::RpcModule;
 use jsonrpsee_core::server::rpc_module::SubscriptionSink;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::ModuleId;
-use serde::Serialize;
-use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 use sui_core::authority::AuthorityState;
@@ -65,30 +63,10 @@ impl EventStreamingApiServer for EventStreamingApiImpl {
                 event,
             })
         });
-        spawn_subscript(sink, stream);
+        spawn_subscription(sink, stream);
 
         Ok(())
     }
-}
-
-fn spawn_subscript<S, T, E>(mut sink: SubscriptionSink, rx: S)
-where
-    S: TryStream<Ok = T, Error = E> + Unpin + Send + 'static,
-    T: Serialize,
-    E: Display,
-{
-    tokio::spawn(async move {
-        match sink.pipe_from_try_stream(rx).await {
-            SubscriptionClosed::Success => {
-                sink.close(SubscriptionClosed::Success);
-            }
-            SubscriptionClosed::RemotePeerAborted => (),
-            SubscriptionClosed::Failed(err) => {
-                warn!(error = ?err, "Event subscription closed.");
-                sink.close(err);
-            }
-        };
-    });
 }
 
 impl SuiRpcModule for EventStreamingApiImpl {

--- a/crates/sui-json-rpc/src/event_api.rs
+++ b/crates/sui-json-rpc/src/event_api.rs
@@ -5,7 +5,7 @@ use crate::api::EventStreamingApiServer;
 use crate::streaming_api::spawn_subscription;
 use crate::SuiRpcModule;
 use async_trait::async_trait;
-use futures::{StreamExt, TryStream};
+use futures::StreamExt;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::SubscriptionResult;
 use jsonrpsee_core::server::rpc_module::RpcModule;

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -29,6 +29,7 @@ pub mod event_api;
 pub mod gateway_api;
 pub mod quorum_driver_api;
 pub mod read_api;
+pub mod streaming_api;
 
 pub enum ServerBuilder<M = ()> {
     HttpBuilder(HttpServerBuilder<M>),

--- a/crates/sui-json-rpc/src/streaming_api.rs
+++ b/crates/sui-json-rpc/src/streaming_api.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::api::EventReadApiServer;
+use crate::api::EventStreamingApiServer;
+use crate::api::TransactionStreamingApiServer;
+use crate::SuiRpcModule;
+use async_trait::async_trait;
+use futures::{StreamExt, TryStream};
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::types::SubscriptionResult;
+use jsonrpsee_core::error::SubscriptionClosed;
+use jsonrpsee_core::server::rpc_module::RpcModule;
+use jsonrpsee_core::server::rpc_module::SubscriptionSink;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::ModuleId;
+use serde::Serialize;
+use std::fmt::Display;
+use std::str::FromStr;
+use std::sync::Arc;
+use sui_core::authority::AuthorityState;
+use sui_core::event_handler::EventHandler;
+use sui_core::transaction_streamer::TransactionStreamer;
+use sui_json_rpc_types::SuiCertifiedTransaction;
+use sui_json_rpc_types::SuiTransactionEffects;
+use sui_json_rpc_types::SuiTransactionFilter;
+use sui_json_rpc_types::{SuiEvent, SuiEventEnvelope, SuiEventFilter};
+use sui_open_rpc::Module;
+use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
+use sui_types::object::Owner;
+use tracing::warn;
+
+pub struct TransactionStreamingApiImpl {
+    state: Arc<AuthorityState>,
+    transaction_streamer: Arc<TransactionStreamer>,
+}
+
+impl TransactionStreamingApiImpl {
+    pub fn new(state: Arc<AuthorityState>, transaction_streamer: Arc<TransactionStreamer>) -> Self {
+        Self {
+            state,
+            transaction_streamer,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionStreamingApiServer for TransactionStreamingApiImpl {
+    fn subscribe_transaction(
+        &self,
+        mut sink: SubscriptionSink,
+        filter: SuiTransactionFilter,
+    ) -> SubscriptionResult {
+        let filter = match filter.try_into() {
+            Ok(filter) => filter,
+            Err(e) => {
+                let e = jsonrpsee_core::Error::from(e);
+                warn!(error = ?e, "Rejecting subscription request.");
+                return Ok(sink.reject(e)?);
+            }
+        };
+
+        let state = self.state.clone();
+        let stream = self.transaction_streamer.subscribe(filter);
+        let stream = stream.map(move |(tx_cert, signed_effects)| {
+            SuiCertifiedTransaction::try_from(tx_cert).and_then(|tx_cert| {
+                SuiTransactionEffects::try_from(signed_effects.effects, state.module_cache.as_ref())
+                    .and_then(|effects| Ok((tx_cert, effects)))
+            })
+            // let sui_tx_cert  = SuiCertifiedTransaction::try_from(tx_cert);
+            // sui_tx_cert.map(|tx_cert| {
+            //     let sui_signed_effects = SuiTransactionEffects::try_from(signed_effects.effects, state.module_cache.as_ref())?;
+            //     (tx_cert, sui_signed_effects)
+            // })
+        });
+        spawn_subscription(sink, stream);
+
+        Ok(())
+    }
+}
+
+impl SuiRpcModule for TransactionStreamingApiImpl {
+    fn rpc(self) -> RpcModule<Self> {
+        self.into_rpc()
+    }
+
+    fn rpc_doc_module() -> Module {
+        crate::api::TransactionStreamingApiOpenRpc::module_doc()
+    }
+}
+
+pub fn spawn_subscription<S, T, E>(mut sink: SubscriptionSink, rx: S)
+where
+    S: TryStream<Ok = T, Error = E> + Unpin + Send + 'static,
+    T: Serialize,
+    E: Display,
+{
+    tokio::spawn(async move {
+        match sink.pipe_from_try_stream(rx).await {
+            SubscriptionClosed::Success => {
+                sink.close(SubscriptionClosed::Success);
+            }
+            SubscriptionClosed::RemotePeerAborted => (),
+            SubscriptionClosed::Failed(err) => {
+                warn!(error = ?err, "Event subscription closed.");
+                sink.close(err);
+            }
+        };
+    });
+}

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use anyhow::bail;
 use anyhow::Result;
 use futures::TryFutureExt;
 use parking_lot::Mutex;
@@ -13,7 +14,9 @@ use sui_config::NodeConfig;
 use sui_core::authority_active::checkpoint_driver::CheckpointMetrics;
 use sui_core::authority_aggregator::{AuthAggMetrics, AuthorityAggregator};
 use sui_core::authority_server::ValidatorService;
+use sui_core::event_handler;
 use sui_core::safe_client::SafeClientMetrics;
+use sui_core::transaction_streamer::TransactionStreamer;
 use sui_core::{
     authority::{AuthorityState, AuthorityStore},
     authority_active::{gossip::GossipMetrics, ActiveAuthority},
@@ -24,6 +27,7 @@ use sui_core::{
     checkpoints::CheckpointStore,
 };
 use sui_json_rpc::bcs_api::BcsApiImpl;
+use sui_json_rpc::streaming_api::TransactionStreamingApiImpl;
 use sui_network::api::ValidatorServer;
 use sui_quorum_driver::QuorumDriverMetrics;
 use sui_quorum_driver::{QuorumDriver, QuorumDriverHandler};
@@ -125,6 +129,11 @@ impl SuiNode {
         };
 
         let (tx_reconfigure_consensus, rx_reconfigure_consensus) = channel(100);
+        let transaction_streamer = match config.websocket_address {
+            Some(_) => Some(Arc::new(TransactionStreamer::new())),
+            None => None,
+        };
+
         let state = Arc::new(
             AuthorityState::new(
                 config.protocol_public_key(),
@@ -133,6 +142,7 @@ impl SuiNode {
                 epoch_store.clone(),
                 index_store.clone(),
                 event_store,
+                transaction_streamer,
                 Some(checkpoint_store),
                 genesis,
                 &prometheus_registry,
@@ -378,11 +388,20 @@ pub async fn build_node_server(
         .into_http_server_handle()
         .expect("Expect a http server handle");
 
-    // TODO: we will change the conditions soon when we introduce txn subs
-    let ws_server_handle = match (config.websocket_address, state.event_handler.clone()) {
-        (Some(ws_addr), Some(event_handler)) => {
+    let ws_server_handle = match config.websocket_address {
+        Some(ws_addr) => {
             let mut server = JsonRpcServerBuilder::new(true, prometheus_registry)?;
-            server.register_module(EventStreamingApiImpl::new(state.clone(), event_handler))?;
+            if let Some(tx_streamer) = state.transaction_streamer.clone() {
+                server.register_module(TransactionStreamingApiImpl::new(
+                    state.clone(),
+                    tx_streamer,
+                ))?;
+            } else {
+                bail!("Expect State to have Some TransactionStreamer when websocket_address is present in node config");
+            }
+            if let Some(event_handler) = state.event_handler.clone() {
+                server.register_module(EventStreamingApiImpl::new(state.clone(), event_handler))?;
+            }
             Some(
                 server
                     .start(ws_addr)
@@ -391,7 +410,22 @@ pub async fn build_node_server(
                     .expect("Expect a websocket server handle"),
             )
         }
-        _ => None,
+        None => None,
     };
+    // // TODO: we will change the conditions soon when we introduce txn subs
+    // let ws_server_handle = match (config.websocket_address, state.event_handler.clone()) {
+    //     (Some(ws_addr), Some(event_handler)) => {
+    //         let mut server = JsonRpcServerBuilder::new(true, prometheus_registry)?;
+    //         server.register_module(EventStreamingApiImpl::new(state.clone(), event_handler))?;
+    //         Some(
+    //             server
+    //                 .start(ws_addr)
+    //                 .await?
+    //                 .into_ws_server_handle()
+    //                 .expect("Expect a websocket server handle"),
+    //         )
+    //     }
+    //     _ => None,
+    // };
     Ok((Some(rpc_server_handle), ws_server_handle))
 }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -58,3 +58,4 @@ workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
 bincode = "1.3.3"
+test-utils = { path = "../test-utils" }

--- a/crates/sui-types/src/filter.rs
+++ b/crates/sui-types/src/filter.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use crate::base_types::SuiAddress;
 use crate::event::EventType;
 use crate::event::{Event, EventEnvelope};
+use crate::messages::TxCertAndSignedEffects;
 use crate::object::Owner;
 use crate::ObjectID;
 
@@ -71,6 +72,20 @@ impl EventFilter {
 impl Filter<EventEnvelope> for EventFilter {
     fn matches(&self, item: &EventEnvelope) -> bool {
         self.try_matches(item).unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TransactionFilter {
+    // subscribe to all transactions
+    Any,
+}
+
+impl Filter<TxCertAndSignedEffects> for TransactionFilter {
+    fn matches(&self, _item: &TxCertAndSignedEffects) -> bool {
+        match self {
+            TransactionFilter::Any => true,
+        }
     }
 }
 

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -37,7 +37,7 @@ pub mod sui_serde;
 pub mod sui_system_state;
 pub mod waypoint;
 
-pub mod event_filter;
+pub mod filter;
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -802,6 +802,7 @@ impl PartialEq for SignedTransaction {
 }
 
 pub type CertifiedTransaction = TransactionEnvelope<AuthorityStrongQuorumSignInfo>;
+pub type TxCertAndSignedEffects = (CertifiedTransaction, SignedTransactionEffects);
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct AccountInfoRequest {

--- a/crates/sui-types/src/unit_tests/event_filter_tests.rs
+++ b/crates/sui-types/src/unit_tests/event_filter_tests.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use crate::base_types::{SuiAddress, TransactionDigest};
 use crate::event::{Event, EventEnvelope};
 use crate::event::{EventType, TransferType};
-use crate::event_filter::{EventFilter, Filter};
+use crate::filter::{EventFilter, Filter};
 use crate::gas_coin::GasCoin;
 use crate::object::Owner;
 use crate::{ObjectID, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -16,16 +16,15 @@ use crate::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPub
 use crate::messages_checkpoint::CheckpointContents;
 use crate::messages_checkpoint::CheckpointSummary;
 use crate::object::Owner;
-use test_utils::message::random_object_ref;
 
 use super::*;
-// fn random_object_ref() -> ObjectRef {
-//     (
-//         ObjectID::random(),
-//         SequenceNumber::new(),
-//         ObjectDigest::new([0; 32]),
-//     )
-// }
+fn random_object_ref() -> ObjectRef {
+    (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::new([0; 32]),
+    )
+}
 
 #[test]
 fn test_signed_values() {

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -16,15 +16,16 @@ use crate::crypto::{get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPub
 use crate::messages_checkpoint::CheckpointContents;
 use crate::messages_checkpoint::CheckpointSummary;
 use crate::object::Owner;
+use test_utils::message::random_object_ref;
 
 use super::*;
-fn random_object_ref() -> ObjectRef {
-    (
-        ObjectID::random(),
-        SequenceNumber::new(),
-        ObjectDigest::new([0; 32]),
-    )
-}
+// fn random_object_ref() -> ObjectRef {
+//     (
+//         ObjectID::random(),
+//         SequenceNumber::new(),
+//         ObjectDigest::new([0; 32]),
+//     )
+// }
 
 #[test]
 fn test_signed_values() {

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::authority::get_client;
-use crate::messages::{create_publish_move_package_transaction, make_certificates};
+use crate::messages::{create_publish_move_package_transaction, make_tx_certs_and_signed_effects};
 use crate::test_account_keys;
 use futures::StreamExt;
 use move_package::BuildConfig;
@@ -194,7 +194,10 @@ pub async fn submit_single_owner_transaction(
     transaction: Transaction,
     configs: &[ValidatorInfo],
 ) -> TransactionEffects {
-    let certificate = make_certificates(vec![transaction]).pop().unwrap();
+    let certificate = make_tx_certs_and_signed_effects(vec![transaction])
+        .0
+        .pop()
+        .unwrap();
 
     let mut responses = Vec::new();
     for config in configs {
@@ -215,7 +218,10 @@ pub async fn submit_shared_object_transaction(
     transaction: Transaction,
     configs: &[ValidatorInfo],
 ) -> SuiResult<TransactionEffects> {
-    let certificate = make_certificates(vec![transaction]).pop().unwrap();
+    let certificate = make_tx_certs_and_signed_effects(vec![transaction])
+        .0
+        .pop()
+        .unwrap();
 
     let replies = loop {
         let futures: Vec<_> = configs


### PR DESCRIPTION
Create a transaction streamer and transaction subscription apis. Luckily we can rely a lot on previous work on event sub. 

1. FN enables transaction subscription when the node config has a valid "websocket_address"
2. Today a pubsub connectino subscribes to all finalized txns. In the future more filters will be added according to [this proposal](https://www.notion.so/mystenlabs/Sui-Transaction-Subscription-018f56549b894115af57f196c6515633) and the discussions inside

Why do we need this:
1. see [this proposal](https://www.notion.so/mystenlabs/Sui-Transaction-Subscription-018f56549b894115af57f196c6515633)
2. we may use this in the incentivized testnet program. 

Test plan:
started a local network with a fullnode, `websocat  ws://127.0.0.1:9001` then `{"jsonrpc":"2.0", "id": 1, "method": "sui_subscribeTransaction", "params": ["Any"]}`. Made txns and saw they came through websocat. 

In the next PR, I will move EventStreamingAPI into `streaming_api.rs`