### PR TITLE
Explicitly classify sui errors in consensus handler

### DIFF
--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1410,12 +1410,7 @@ fn test_fragment_full_flow() {
     while let Ok(fragment) = rx.try_recv() {
         all_fragments.push(fragment.clone());
         assert!(cps0
-            .handle_internal_fragment(
-                seq.clone(),
-                fragment,
-                &committee,
-                PendCertificateForExecutionNoop
-            )
+            .handle_internal_fragment(seq.clone(), fragment, PendCertificateForExecutionNoop)
             .is_ok());
         seq.next(
             /* total_batches */ 100, /* total_transactions */ 100,
@@ -1445,7 +1440,6 @@ fn test_fragment_full_flow() {
         let _ = cps6.handle_internal_fragment(
             seq.clone(),
             fragment.clone(),
-            &committee,
             PendCertificateForExecutionNoop,
         );
         seq.next(
@@ -1466,7 +1460,6 @@ fn test_fragment_full_flow() {
         let _ = cps6.handle_internal_fragment(
             seq.clone(),
             fragment.clone(),
-            &committee,
             PendCertificateForExecutionNoop,
         );
         seq.next(
@@ -1621,7 +1614,6 @@ pub async fn checkpoint_tests_setup(
         .iter()
         .map(|a| (a.authority.clone(), a.checkpoint.clone()))
         .collect();
-    let c = committee.clone();
     let _join = tokio::task::spawn(async move {
         let mut seq = ExecutionIndices::default();
         while let Some(msg) = _rx.recv().await {
@@ -1630,7 +1622,6 @@ pub async fn checkpoint_tests_setup(
                     if let Err(err) = cps.lock().handle_internal_fragment(
                         seq.clone(),
                         msg.clone(),
-                        &c,
                         PendCertificateForExecutionNoop,
                     ) {
                         println!("Error: {:?}", err);
@@ -1638,7 +1629,6 @@ pub async fn checkpoint_tests_setup(
                 } else if let Err(err) = cps.lock().handle_internal_fragment(
                     seq.clone(),
                     msg.clone(),
-                    &c,
                     authority.database.clone(),
                 ) {
                     println!("Error: {:?}", err);

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -5,7 +5,7 @@
 use crate::{base_types::*, committee::EpochId, messages::ExecutionFailureStatus};
 use move_binary_format::errors::{Location, PartialVMError, VMError};
 use move_core_types::vm_status::{StatusCode, StatusType};
-use narwhal_executor::{ExecutionStateError, SubscriberError};
+use narwhal_executor::SubscriberError;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;
@@ -464,18 +464,6 @@ impl std::convert::From<&str> for SuiError {
         SuiError::GenericAuthorityError {
             error: error.to_string(),
         }
-    }
-}
-
-impl ExecutionStateError for SuiError {
-    fn node_error(&self) -> bool {
-        matches!(
-            self,
-            Self::ObjectFetchFailed { .. }
-                | Self::ByzantineAuthoritySuspicion { .. }
-                | Self::StorageError(..)
-                | Self::GenericAuthorityError { .. }
-        )
     }
 }
 


### PR DESCRIPTION
Narwhal consensus handler requires to distinguish between incorrect transaction data and internal node errors - incorrect transactions should be skipped while node errors should prevent advancing to next narwhal transaction since they may indicate node state was not fully updated.

We currently have a pretty arbitrary way to classify sui errors according to this schema based on underlying SUI error type. This is dangerous because it means that malicious validator can send incorrect data to consensus that will be interpreted as node failed and will essentially kill the network(as all honest validators won't be able to proceed with consensus). The opposite misinterpretation is equally bad as it can allow incomplete state in case of node errors.

This diff makes differentiation more explicit and separates input verification stage from the processing stage.