### PR TITLE
[ts-sdk] Update docs to recommend experimental-tagged packages

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -16,30 +16,24 @@ You can also use your preferred npm client, such as yarn or pnpm.
 
 ## Working with local network
 
-Note that the [published SDK](https://www.npmjs.com/package/@mysten/sui.js) might go out of sync with the RPC server on the `main` branch until the next bi-weekly release, therefore it's recommended to build the SDK locally if you want to test against the local network.
-
-To get started you need to install [pnpm](https://pnpm.io/), then run the following command in the `sui/sdk/typescript` directory to build the SDK and [create a symlink](https://docs.npmjs.com/cli/v8/commands/npm-link) in the global folder.
+Note that the `latest` tag for the [published SDK](https://www.npmjs.com/package/@mysten/sui.js) might go out of sync with the RPC server on the `main` branch until the next release. If you're developing against a local network, we recommend using the `experimental`-tagged packages, which contain the latest changes from `main`.
 
 ```bash
-$ cd <path to sui repo>/sdk/typescript
-$ pnpm install && pnpm build
-$ npm link
-```
-
-Next, go to your project directory and create a symbolic link from globally-installed `@mysten/sui.js` to the `node_modules/` of your project directory.
-
-```bash
-cd <your project directory>
-npm link @mysten/sui.js
-```
-
-If you wish to rebuild all dependencies of the TypeScript SDK, or if you're encountering issues with the `@mysten/bcs` module not being found, you can re-build the SDK module and all of it's local dependencies using the following command:
-
-```bash
-pnpm --filter @mysten/sui.js... build
+npm install @mysten/sui.js@experimental
 ```
 
 Refer to the [JSON RPC doc](https://github.com/MystenLabs/sui/blob/main/doc/src/build/json-rpc.md) for instructions about how to start a local network and local RPC server
+
+## Building Locally
+
+To get started you need to install [pnpm](https://pnpm.io/), then run the following command.
+
+```bash
+# Install all dependencies
+$ pnpm install
+# Run the build for the TypeScript SDK and all of its dependencies.
+$ pnpm --filter @mysten/sui.js... build
+```
 
 ## Type Doc
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -22,7 +22,7 @@ Note that the `latest` tag for the [published SDK](https://www.npmjs.com/package
 npm install @mysten/sui.js@experimental
 ```
 
-Refer to the [JSON RPC doc](https://github.com/MystenLabs/sui/blob/main/doc/src/build/json-rpc.md) for instructions about how to start a local network and local RPC server
+Refer to the [JSON RPC](https://github.com/MystenLabs/sui/blob/main/doc/src/build/json-rpc.md) topic for instructions about how to start a local network and local RPC server.
 
 ## Building Locally
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -26,7 +26,7 @@ Refer to the [JSON RPC](https://github.com/MystenLabs/sui/blob/main/doc/src/buil
 
 ## Building Locally
 
-To get started you need to install [pnpm](https://pnpm.io/), then run the following command.
+To get started you need to install [pnpm](https://pnpm.io/), then run the following command:
 
 ```bash
 # Install all dependencies


### PR DESCRIPTION
Rather than encouraging developers to use an `npm link`, we should encourage usage of the new `experimental` package tags that are automatically generated.