### PR TITLE
[explorer] Set full width for table

### DIFF
--- a/explorer/client/src/components/table/TableCard.module.css
+++ b/explorer/client/src/components/table/TableCard.module.css
@@ -3,7 +3,7 @@
 }
 
 .table {
-    @apply text-sm text-left min-w-max border-collapse;
+    @apply text-sm text-left min-w-max border-collapse w-full;
 
     border-bottom: 1px solid #f0f1f2;
 }


### PR DESCRIPTION
This re-adds the w-full CSS that was removed in #4217. This makes tables fill the available space of the parent, as designed.

Before:
<img width="1502" alt="Screen Shot 2022-08-26 at 2 22 14 PM" src="https://user-images.githubusercontent.com/109986297/186992553-9c7f0494-ed15-4098-b2df-ce3b55ee8ea7.png">

After:
<img width="1436" alt="Screen Shot 2022-08-26 at 2 22 05 PM" src="https://user-images.githubusercontent.com/109986297/186992662-a93a995d-8c25-4fdf-b297-b0aba075d225.png">

