### PR TITLE
[move] framework unit tests should verify the move modules

### DIFF
--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -217,10 +217,10 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn cmework_move_unit_tests() {
+    fn run_framework_move_unit_tests() {
         get_sui_framework();
         get_move_stdlib();
-        build_move_package(
+        build_and_verify_package(
             &PathBuf::from(DEFAULT_FRAMEWORK_PATH),
             BuildConfig::default(),
         )


### PR DESCRIPTION
Right now the Move unit tests that get run when we do `cargo test` in the sui-framework folder do not verify the modules. This PR fixes that and issue #4268.