### PR TITLE
[move] Added support for passing vectors of objects to entry functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9526,6 +9526,7 @@ dependencies = [
  "lazy_static 0.2.11",
  "lazy_static 1.4.0",
  "lazycell",
+ "leb128",
  "lexical-core",
  "libc",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "lexical-core"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6967,6 +6973,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "leb128",
  "move-binary-format",
  "move-core-types",
  "move-package",

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 bcs = "0.1.3"
+leb128 = "0.2.5"
 once_cell = "1.13.1"
 
 move-binary-format = { git = "https://github.com/move-language/move", rev = "70b34a66473c34ad30d101290b249f2db3c847a2" }

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -1213,17 +1213,15 @@ fn inner_param_type<'a>(
             mutable_ref_objects.insert(idx as LocalIndex, object_id);
             Ok(&**inner_t)
         }
-        SignatureToken::Vector(inner_t) => {
-            return inner_param_type(
-                object,
-                object_id,
-                idx,
-                inner_t,
-                arg_type,
-                mutable_ref_objects,
-                by_value_objects,
-            );
-        }
+        SignatureToken::Vector(inner_t) => inner_param_type(
+            object,
+            object_id,
+            idx,
+            inner_t,
+            arg_type,
+            mutable_ref_objects,
+            by_value_objects,
+        ),
         t @ SignatureToken::Struct(_)
         | t @ SignatureToken::StructInstantiation(_, _)
         | t @ SignatureToken::TypeParameter(_) => {
@@ -1246,15 +1244,13 @@ fn inner_param_type<'a>(
             by_value_objects.insert(object_id);
             Ok(t)
         }
-        t => {
-            return Err(ExecutionError::new_with_source(
-                ExecutionErrorKind::entry_argument_error(idx, EntryArgumentErrorKind::TypeMismatch),
-                format!(
-                    "Found object argument {}, but function expects {:?}",
-                    arg_type, t
-                ),
-            ));
-        }
+        t => Err(ExecutionError::new_with_source(
+            ExecutionErrorKind::entry_argument_error(idx, EntryArgumentErrorKind::TypeMismatch),
+            format!(
+                "Found object argument {}, but function expects {:?}",
+                arg_type, t
+            ),
+        )),
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -50,14 +50,7 @@ impl TestCallArg {
     pub async fn to_call_arg(self, state: &AuthorityState) -> CallArg {
         match self {
             Self::Object(object_id) => {
-                let object = state.get_object(&object_id).await.unwrap().unwrap();
-                if object.is_shared() {
-                    CallArg::Object(ObjectArg::SharedObject(object_id))
-                } else {
-                    CallArg::Object(ObjectArg::ImmOrOwnedObject(
-                        object.compute_object_reference(),
-                    ))
-                }
+                CallArg::Object(Self::call_arg_from_id(object_id, state).await)
             }
             Self::U64(value) => CallArg::Pure(bcs::to_bytes(&value).unwrap()),
             Self::Address(addr) => {
@@ -67,14 +60,19 @@ impl TestCallArg {
             Self::ObjVec(vec) => {
                 let mut refs = vec![];
                 for object_id in vec {
-                    let object = state.get_object(&object_id).await.unwrap().unwrap();
-                    debug_assert!(!object.is_shared());
-                    refs.push(ObjectArg::ImmOrOwnedObject(
-                        object.compute_object_reference(),
-                    ));
+                    refs.push(Self::call_arg_from_id(object_id, state).await)
                 }
                 CallArg::ObjVec(refs)
             }
+        }
+    }
+
+    async fn call_arg_from_id(object_id: ObjectID, state: &AuthorityState) -> ObjectArg {
+        let object = state.get_object(&object_id).await.unwrap().unwrap();
+        if object.is_shared() {
+            ObjectArg::SharedObject(object_id)
+        } else {
+            ObjectArg::ImmOrOwnedObject(object.compute_object_reference())
         }
     }
 }
@@ -522,6 +520,19 @@ pub async fn send_and_confirm_transaction(
     authority: &AuthorityState,
     transaction: Transaction,
 ) -> Result<TransactionInfoResponse, SuiError> {
+    send_and_confirm_transaction_with_shared(
+        authority,
+        transaction,
+        false, /* no shared objects */
+    )
+    .await
+}
+
+pub async fn send_and_confirm_transaction_with_shared(
+    authority: &AuthorityState,
+    transaction: Transaction,
+    with_shared: bool, // transaction includes shared objects
+) -> Result<TransactionInfoResponse, SuiError> {
     // Make the initial request
     let response = authority.handle_transaction(transaction.clone()).await?;
     let vote = response.signed_transaction.unwrap();
@@ -533,6 +544,56 @@ pub async fn send_and_confirm_transaction(
         .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
         .unwrap()
         .unwrap();
+
+    if with_shared {
+        authority
+            .handle_consensus_transaction(
+                // TODO [2533]: use this once integrating Narwhal reconfiguration
+                &narwhal_consensus::ConsensusOutput {
+                    certificate: narwhal_types::Certificate::default(),
+                    consensus_index: narwhal_types::SequenceNumber::default(),
+                },
+                /* last_consensus_index */ ExecutionIndices::default(),
+                ConsensusTransaction::UserTransaction(Box::new(certificate.clone())),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
+    // we unfortunately don't get a very descriptive error message, but we can at least see that something went wrong inside the VM
+    authority.handle_certificate(certificate).await
+}
+
+pub async fn send_and_confirm_shared_transaction(
+    authority: &AuthorityState,
+    transaction: Transaction,
+) -> Result<TransactionInfoResponse, SuiError> {
+    // Make the initial request
+    let response = authority.handle_transaction(transaction.clone()).await?;
+    let vote = response.signed_transaction.unwrap();
+
+    // Collect signatures from a quorum of authorities
+    let committee = authority.committee.load();
+    let mut builder = SignatureAggregator::try_new(transaction, &committee).unwrap();
+    let certificate = builder
+        .append(vote.auth_sign_info.authority, vote.auth_sign_info.signature)
+        .unwrap()
+        .unwrap();
+
+    authority
+        .handle_consensus_transaction(
+            // TODO [2533]: use this once integrating Narwhal reconfiguration
+            &narwhal_consensus::ConsensusOutput {
+                certificate: narwhal_types::Certificate::default(),
+                consensus_index: narwhal_types::SequenceNumber::default(),
+            },
+            /* last_consensus_index */ ExecutionIndices::default(),
+            ConsensusTransaction::UserTransaction(Box::new(certificate.clone())),
+        )
+        .await
+        .unwrap();
+
     // Submit the confirmation. *Now* execution actually happens, and it should fail when we try to look up our dummy module.
     // we unfortunately don't get a very descriptive error message, but we can at least see that something went wrong inside the VM
     authority.handle_certificate(certificate).await
@@ -2057,6 +2118,33 @@ pub async fn call_move(
     type_args: Vec<TypeTag>,
     test_args: Vec<TestCallArg>,
 ) -> SuiResult<TransactionEffects> {
+    call_move_with_shared(
+        authority,
+        gas_object_id,
+        sender,
+        sender_key,
+        package,
+        module,
+        function,
+        type_args,
+        test_args,
+        false, // no shared objects
+    )
+    .await
+}
+
+pub async fn call_move_with_shared(
+    authority: &AuthorityState,
+    gas_object_id: &ObjectID,
+    sender: &SuiAddress,
+    sender_key: &AccountKeyPair,
+    package: &ObjectRef,
+    module: &'_ str,
+    function: &'_ str,
+    type_args: Vec<TypeTag>,
+    test_args: Vec<TestCallArg>,
+    with_shared: bool, // Move call includes shared objects
+) -> SuiResult<TransactionEffects> {
     let gas_object = authority.get_object(gas_object_id).await.unwrap();
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
     let mut args = vec![];
@@ -2077,7 +2165,8 @@ pub async fn call_move(
     let signature = Signature::new(&data, sender_key);
     let transaction = Transaction::new(data, signature);
 
-    let response = send_and_confirm_transaction(authority, transaction).await?;
+    let response =
+        send_and_confirm_transaction_with_shared(authority, transaction, with_shared).await?;
     Ok(response.signed_effects.unwrap().effects)
 }
 

--- a/crates/sui-core/src/unit_tests/data/entry_point_vector/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/entry_point_vector/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "entry_point_vector"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../sui-framework" }
+
+[addresses]
+entry_point_vector =  "0x0"

--- a/crates/sui-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
+++ b/crates/sui-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
@@ -1,0 +1,45 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module entry_point_vector::entry_point_vector {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use std::vector;
+
+    struct Obj has key {
+        id: UID,
+        value: u64
+    }
+
+    public entry fun mint(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            Obj {
+                id: object::new(ctx), 
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun prim_vec_len(v: vector<u64>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+    }
+
+    public entry fun obj_vec_empty(v: vector<Obj>, _: &mut TxContext) {
+        vector::destroy_empty(v);
+    }
+
+    public entry fun obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 7, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+
+}

--- a/crates/sui-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
+++ b/crates/sui-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
@@ -12,9 +12,24 @@ module entry_point_vector::entry_point_vector {
         value: u64
     }
 
+    struct AnotherObj has key {
+        id: UID,
+        value: u64
+    }
+
     public entry fun mint(v: u64, ctx: &mut TxContext) {
         transfer::transfer(
             Obj {
+                id: object::new(ctx), 
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_another(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            AnotherObj {
                 id: object::new(ctx), 
                 value: v,
             },
@@ -54,6 +69,17 @@ module entry_point_vector::entry_point_vector {
         assert!(vector::length(&v) == 1, 0);
         let Obj {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun two_obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 7, 0);
         object::delete(id);
         vector::destroy_empty(v);
     }

--- a/crates/sui-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
+++ b/crates/sui-core/src/unit_tests/data/entry_point_vector/sources/objects_vector.move
@@ -22,6 +22,26 @@ module entry_point_vector::entry_point_vector {
         )
     }
 
+    public entry fun mint_child(v: u64, parent: &mut Obj, ctx: &mut TxContext) {
+        transfer::transfer_to_object(
+            Obj {
+                id: object::new(ctx),
+                value: v,
+            },
+            parent,
+        )
+    }
+
+    public entry fun mint_shared(v: u64, ctx: &mut TxContext) {
+        transfer::share_object(
+            Obj {
+                id: object::new(ctx),
+                value: v,
+            }
+        )
+    }
+
+
     public entry fun prim_vec_len(v: vector<u64>, _: &mut TxContext) {
         assert!(vector::length(&v) == 2, 0);
     }
@@ -31,15 +51,41 @@ module entry_point_vector::entry_point_vector {
     }
 
     public entry fun obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
-        assert!(vector::length(&v) == 2, 0);
+        assert!(vector::length(&v) == 1, 0);
         let Obj {id, value} = vector::pop_back(&mut v);
         assert!(value == 42, 0);
-        object::delete(id);
-        let Obj {id, value} = vector::pop_back(&mut v);
-        assert!(value == 7, 0);
         object::delete(id);
         vector::destroy_empty(v);
     }
 
+    public entry fun same_objects(o: Obj, v: vector<Obj>, _: &mut TxContext) {
+        let Obj {id, value} = o;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
 
+    public entry fun same_objects_ref(o: &Obj, v: vector<Obj>, _: &mut TxContext) {
+        assert!(o.value == 42, 0);
+        let Obj {id, value: _} = vector::pop_back(&mut v);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun child_access(child: Obj, v: vector<Obj>, _: &mut TxContext) {
+        let Obj {id, value} = child;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun type_param_vec_empty<T: key>(v: vector<T>, _: &mut TxContext) {
+        vector::destroy_empty(v);
+    }
 }

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -45,6 +45,11 @@ CallArg:
       Object:
         NEWTYPE:
           TYPENAME: ObjectArg
+    2:
+      ObjVec:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: ObjectArg
 ChangeEpoch:
   STRUCT:
     - epoch: U64

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1410,6 +1410,22 @@ impl TryFrom<SingleTransactionKind> for SuiTransactionKind {
                         CallArg::Object(ObjectArg::SharedObject(id)) => {
                             SuiJsonValue::new(Value::String(id.to_hex_literal()))
                         }
+                        CallArg::ObjVec(vec) => {
+                            SuiJsonValue::new(Value::Array(
+                                vec.iter()
+                                    .filter_map(|obj_arg| match obj_arg {
+                                        ObjectArg::ImmOrOwnedObject((id, _, _)) => {
+                                            Some(Value::String(id.to_hex_literal()))
+                                        }
+                                        ObjectArg::SharedObject(_) => {
+                                            // ObjVec is guaranteed to never contain shared objects
+                                            debug_assert!(false);
+                                            None
+                                        }
+                                    })
+                                    .collect(),
+                            ))
+                        }
                     })
                     .collect::<Result<Vec<_>, _>>()?,
             }),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -189,12 +189,12 @@ impl SingleTransactionKind {
                     }
                     CallArg::ObjVec(vec) => Some(
                         vec.iter()
-                            .filter_map(|obj_arg| match obj_arg {
+                            .map(|obj_arg| match obj_arg {
                                 ObjectArg::ImmOrOwnedObject(object_ref) => {
-                                    Some(InputObjectKind::ImmOrOwnedMoveObject(*object_ref))
+                                    InputObjectKind::ImmOrOwnedMoveObject(*object_ref)
                                 }
                                 ObjectArg::SharedObject(id) => {
-                                    Some(InputObjectKind::SharedMoveObject(*id))
+                                    InputObjectKind::SharedMoveObject(*id)
                                 }
                             })
                             .collect(),

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_mut_ref_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_mut_ref_vector.exp
@@ -1,0 +1,5 @@
+processed 1 task
+
+task 0 'publish'. lines 6-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &mut vector<T0>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_mut_ref_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_mut_ref_vector.mvir
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, a mutable reference to vector of objects
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+
+    public entry no<T:key>(s: &mut vector<T>, ctx: &mut tx_context.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_ref_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_ref_vector.exp
@@ -1,0 +1,5 @@
+processed 1 task
+
+task 0 'publish'. lines 6-15:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &vector<T0>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_ref_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_obj_ref_vector.mvir
@@ -1,0 +1,15 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, a mutable reference to vector of objects
+
+//# publish
+module 0x0.m {
+    import 0x2.tx_context;
+
+    public entry no<T:key>(s: &vector<T>, ctx: &mut tx_context.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/nested_key_generic_vector_param.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/nested_key_generic_vector_param.exp
@@ -1,5 +1,5 @@
 processed 1 task
 
 task 0 'publish'. lines 4-13:
-created: object(103)
-written: object(102)
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: vector<vector<T0>>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector.exp
@@ -1,0 +1,5 @@
+processed 1 task
+
+task 0 'publish'. lines 6-18:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &mut vector<_::m::S>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector.mvir
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, a mutable reference to vector of objects
+
+//# publish
+module 0x0.m {
+    import 0x2.object;
+    import 0x2.tx_context;
+
+    struct S has key { id: object.UID }
+
+    public entry no(s: &mut vector<Self.S>, ctx: &mut tx_context.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector.exp
@@ -1,0 +1,5 @@
+processed 1 task
+
+task 0 'publish'. lines 6-18:
+Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Invalid entry point parameter type. Expected primitive or object type. Got: &vector<_::m::S>") } }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector.mvir
@@ -1,0 +1,18 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// invalid, a reference to vector of objects
+
+//# publish
+module 0x0.m {
+    import 0x2.object;
+    import 0x2.tx_context;
+
+    struct S has key { id: object.UID }
+
+    public entry no(s: &vector<Self.S>, ctx: &mut tx_context.TxContext) {
+        label l0:
+        abort 0;
+    }
+
+}

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -182,14 +182,10 @@ fn verify_param_type(
     function_type_args: &[AbilitySet],
     param: &SignatureToken,
 ) -> Result<(), String> {
-    if is_primitive(view, function_type_args, param) {
-        return Ok(());
-    }
-
-    if is_object(view, function_type_args, param)? {
-        return Ok(());
-    }
-    if is_object_vector(view, function_type_args, param)? {
+    if is_primitive(view, function_type_args, param)
+        || is_object(view, function_type_args, param)?
+        || is_object_vector(view, function_type_args, param)?
+    {
         Ok(())
     } else {
         Err(format!(

--- a/crates/sui-verifier/src/entry_points_verifier.rs
+++ b/crates/sui-verifier/src/entry_points_verifier.rs
@@ -187,6 +187,9 @@ fn verify_param_type(
     }
 
     if is_object(view, function_type_args, param)? {
+        return Ok(());
+    }
+    if is_object_vector(view, function_type_args, param)? {
         Ok(())
     } else {
         Err(format!(
@@ -259,9 +262,21 @@ pub fn is_object(
 ) -> Result<bool, String> {
     use SignatureToken as S;
     match t {
-        S::Reference(inner) | S::MutableReference(inner) | S::Vector(inner) => {
+        S::Reference(inner) | S::MutableReference(inner) => {
             is_object(view, function_type_args, inner)
         }
+        _ => is_object_struct(view, function_type_args, t),
+    }
+}
+
+pub fn is_object_vector(
+    view: &BinaryIndexedView,
+    function_type_args: &[AbilitySet],
+    t: &SignatureToken,
+) -> Result<bool, String> {
+    use SignatureToken as S;
+    match t {
+        S::Vector(inner) => is_object_struct(view, function_type_args, inner),
         _ => is_object_struct(view, function_type_args, t),
     }
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -254,6 +254,7 @@ keccak = { version = "0.1", default-features = false }
 kstring = { version = "1", features = ["max_inline", "serde"] }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
+leb128 = { version = "0.2", default-features = false }
 lexical-core = { version = "0.7", features = ["arrayvec", "correct", "ryu", "static_assertions", "std", "table"] }
 libc = { version = "0.2", features = ["std"] }
 libm = { version = "0.2" }
@@ -869,6 +870,7 @@ kstring = { version = "1", features = ["max_inline", "serde"] }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
 lazycell = { version = "1", default-features = false }
+leb128 = { version = "0.2", default-features = false }
 lexical-core = { version = "0.7", features = ["arrayvec", "correct", "ryu", "static_assertions", "std", "table"] }
 libc = { version = "0.2", features = ["std"] }
 libloading = { version = "0.7", default-features = false }


### PR DESCRIPTION
This PR implements passing vectors of objects to owned functions and resolves https://github.com/MystenLabs/sui/issues/492. One somewhat tricky part to handle was the fact that the adapter was taking advantage of the fact that one object was corresponding to one parameter - checking of various properties of both objects (based on object ID) and parameters (based on their index IDX) was happening in the same spots. This PR is attempting to refactor and re-use this code but it may result in some (minor) computational redundancy. Another somewhat tricky part was how to combine existing objects in to bcs-encoded vector that can be used as an argument - I am not sure if there is a better way than what this PR does, that is hand-encoding vector length and appending all objects to the result.