### PR TITLE
keytool: Remove default key scheme as ed25519

### DIFF
--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -11,8 +11,9 @@ This directory contains examples of interacting with a Move language smart contr
    1. [Connect to Sui Devnet](https://github.com/MystenLabs/sui/blob/main/doc/src/build/devnet.md).
    1. [Make sure you have two addresses with gas](https://github.com/MystenLabs/sui/blob/main/doc/src/build/cli-client.md#adding-accounts-to-the-client) by using the `new-address` command to create new addresses:
       ```shell
-      sui client new-address
+      sui client new-address ed25519
       ```
+      New address can be created with key scheme flag `{secp256k1 | ed25519}`. 
       You can skip this step if you are going to play with a friend. :)
    1. [Request Sui tokens](https://github.com/MystenLabs/sui/blob/main/doc/src/build/install.md#sui-tokens) for all addresses that will be used to join the game.
 

--- a/crates/sui-sdk/src/crypto.rs
+++ b/crates/sui-sdk/src/crypto.rs
@@ -23,7 +23,7 @@ use rand::rngs::adapter::ReadRng;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
     get_key_pair_from_rng, random_key_pair_by_type_from_rng, EncodeDecodeBase64, PublicKey,
-    Signature, SuiKeyPair,
+    Signature, SignatureScheme, SuiKeyPair,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -156,16 +156,16 @@ impl SuiKeystore {
 
     pub fn generate_new_key(
         &mut self,
-        key_scheme: String,
-    ) -> Result<(SuiAddress, String, u8), anyhow::Error> {
+        key_scheme: SignatureScheme,
+    ) -> Result<(SuiAddress, String, SignatureScheme), anyhow::Error> {
         let mnemonic = Mnemonic::generate(12)?;
         let seed = mnemonic.to_seed("");
         let mut rng = RngWrapper(ReadRng::new(&seed));
-        match random_key_pair_by_type_from_rng(key_scheme.as_str(), &mut rng) {
+        match random_key_pair_by_type_from_rng(key_scheme, &mut rng) {
             Ok((address, kp)) => {
-                let flag = kp.public().flag();
+                let k = kp.public();
                 self.0.add_key(kp)?;
-                Ok((address, mnemonic.to_string(), flag))
+                Ok((address, mnemonic.to_string(), k.scheme()))
             }
             Err(e) => Err(anyhow!("error generating key {:?}", e)),
         }
@@ -186,11 +186,11 @@ impl SuiKeystore {
     pub fn import_from_mnemonic(
         &mut self,
         phrase: &str,
-        key_scheme: String,
+        key_scheme: SignatureScheme,
     ) -> Result<SuiAddress, anyhow::Error> {
         let seed = &Mnemonic::from_str(phrase).unwrap().to_seed("");
         let mut rng = RngWrapper(ReadRng::new(seed));
-        match random_key_pair_by_type_from_rng(key_scheme.as_str(), &mut rng) {
+        match random_key_pair_by_type_from_rng(key_scheme, &mut rng) {
             Ok((address, kp)) => {
                 self.0.add_key(kp)?;
                 Ok(address)

--- a/crates/sui-sdk/src/crypto.rs
+++ b/crates/sui-sdk/src/crypto.rs
@@ -156,12 +156,12 @@ impl SuiKeystore {
 
     pub fn generate_new_key(
         &mut self,
-        key_scheme: Option<String>,
+        key_scheme: String,
     ) -> Result<(SuiAddress, String, u8), anyhow::Error> {
         let mnemonic = Mnemonic::generate(12)?;
         let seed = mnemonic.to_seed("");
         let mut rng = RngWrapper(ReadRng::new(&seed));
-        match random_key_pair_by_type_from_rng(key_scheme, &mut rng) {
+        match random_key_pair_by_type_from_rng(key_scheme.as_str(), &mut rng) {
             Ok((address, kp)) => {
                 let flag = kp.public().flag();
                 self.0.add_key(kp)?;
@@ -186,11 +186,11 @@ impl SuiKeystore {
     pub fn import_from_mnemonic(
         &mut self,
         phrase: &str,
-        key_scheme: Option<String>,
+        key_scheme: String,
     ) -> Result<SuiAddress, anyhow::Error> {
         let seed = &Mnemonic::from_str(phrase).unwrap().to_seed("");
         let mut rng = RngWrapper(ReadRng::new(seed));
-        match random_key_pair_by_type_from_rng(key_scheme, &mut rng) {
+        match random_key_pair_by_type_from_rng(key_scheme.as_str(), &mut rng) {
             Ok((address, kp)) => {
                 self.0.add_key(kp)?;
                 Ok(address)

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -17,11 +17,13 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
 
-    let (address, phrase, flag) = keystore.generate_new_key(None).unwrap();
+    let (address, phrase, flag) = keystore.generate_new_key("ed25519".to_string()).unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");
     let mut keystore2 = KeystoreType::File(keystore_path_2).init().unwrap();
-    let imported_address = keystore2.import_from_mnemonic(&phrase, None).unwrap();
+    let imported_address = keystore2
+        .import_from_mnemonic(&phrase, "ed25519".to_string())
+        .unwrap();
     assert_eq!(flag, Ed25519SuiSignature::SCHEME.flag());
     assert_eq!(address, imported_address);
 }
@@ -37,7 +39,9 @@ fn sui_wallet_address_mnemonic_test() -> Result<(), anyhow::Error> {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
 
-    keystore.import_from_mnemonic(phrase, None).unwrap();
+    keystore
+        .import_from_mnemonic(phrase, "ed25519".to_string())
+        .unwrap();
 
     let pubkey = keystore.keys()[0].clone();
     assert_eq!(pubkey.flag(), Ed25519SuiSignature::SCHEME.flag());

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -6,7 +6,7 @@ use sha3::{Digest, Sha3_256};
 use tempfile::TempDir;
 
 use sui_sdk::crypto::KeystoreType;
-use sui_types::crypto::SuiSignatureInner;
+use sui_types::crypto::{SignatureScheme, SuiSignatureInner};
 use sui_types::{
     base_types::{SuiAddress, SUI_ADDRESS_LENGTH},
     crypto::Ed25519SuiSignature,
@@ -17,14 +17,14 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
 
-    let (address, phrase, flag) = keystore.generate_new_key("ed25519".to_string()).unwrap();
+    let (address, phrase, scheme) = keystore.generate_new_key(SignatureScheme::ED25519).unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");
     let mut keystore2 = KeystoreType::File(keystore_path_2).init().unwrap();
     let imported_address = keystore2
-        .import_from_mnemonic(&phrase, "ed25519".to_string())
+        .import_from_mnemonic(&phrase, SignatureScheme::ED25519)
         .unwrap();
-    assert_eq!(flag, Ed25519SuiSignature::SCHEME.flag());
+    assert_eq!(scheme.flag(), Ed25519SuiSignature::SCHEME.flag());
     assert_eq!(address, imported_address);
 }
 
@@ -40,7 +40,7 @@ fn sui_wallet_address_mnemonic_test() -> Result<(), anyhow::Error> {
     let mut keystore = KeystoreType::File(keystore_path).init().unwrap();
 
     keystore
-        .import_from_mnemonic(phrase, "ed25519".to_string())
+        .import_from_mnemonic(phrase, SignatureScheme::ED25519)
         .unwrap();
 
     let pubkey = keystore.keys()[0].clone();

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -273,6 +273,12 @@ impl PublicKey {
             PublicKey::Secp256k1KeyPair(_) => Secp256k1SuiSignature::SCHEME.flag(),
         }
     }
+    pub fn scheme(&self) -> SignatureScheme {
+        match self {
+            PublicKey::Ed25519KeyPair(_) => Ed25519SuiSignature::SCHEME,
+            PublicKey::Secp256k1KeyPair(_) => Secp256k1SuiSignature::SCHEME,
+        }
+    }
 }
 
 //
@@ -439,9 +445,9 @@ where
 
 /// Wrapper function to return SuiKeypair based on key scheme string
 pub fn random_key_pair_by_type(
-    key_scheme: &str,
+    key_scheme: SignatureScheme,
 ) -> Result<(SuiAddress, SuiKeyPair), anyhow::Error> {
-    match key_scheme {
+    match key_scheme.to_string().as_ref() {
         "secp256k1" => {
             let (addr, key_pair): (_, Secp256k1KeyPair) = get_key_pair();
             Ok((addr, SuiKeyPair::Secp256k1SuiKeyPair(key_pair)))
@@ -474,22 +480,21 @@ where
 
 /// Wrapper function to return SuiKeypair based on key scheme string with seedable rng.
 pub fn random_key_pair_by_type_from_rng<R>(
-    key_scheme: &str,
+    key_scheme: SignatureScheme,
     csprng: &mut R,
 ) -> Result<(SuiAddress, SuiKeyPair), anyhow::Error>
 where
     R: rand::CryptoRng + rand::RngCore,
 {
     match key_scheme {
-        "secp256k1" => {
+        SignatureScheme::Secp256k1 => {
             let (addr, key_pair): (_, Secp256k1KeyPair) = get_key_pair_from_rng(csprng);
             Ok((addr, SuiKeyPair::Secp256k1SuiKeyPair(key_pair)))
         }
-        "ed25519" => {
+        SignatureScheme::ED25519 => {
             let (addr, key_pair): (_, Ed25519KeyPair) = get_key_pair_from_rng(csprng);
             Ok((addr, SuiKeyPair::Ed25519SuiKeyPair(key_pair)))
         }
-        _ => Err(anyhow!("Unrecognized key scheme")),
     }
 }
 
@@ -1330,6 +1335,41 @@ impl SignatureScheme {
         match self {
             SignatureScheme::ED25519 => 0x00,
             SignatureScheme::Secp256k1 => 0x01,
+        }
+    }
+
+    pub fn from_flag(flag: &str) -> Result<SignatureScheme, SuiError> {
+        let byte_int = flag
+            .parse::<u8>()
+            .map_err(|_| SuiError::KeyConversionError("Invalid key scheme".to_string()))?;
+        match byte_int {
+            0x00 => Ok(SignatureScheme::ED25519),
+            0x01 => Ok(SignatureScheme::Secp256k1),
+            _ => Err(SuiError::KeyConversionError(
+                "Invalid key scheme".to_string(),
+            )),
+        }
+    }
+}
+
+impl FromStr for SignatureScheme {
+    type Err = SuiError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ed25519" => Ok(SignatureScheme::ED25519),
+            "secp256k1" => Ok(SignatureScheme::Secp256k1),
+            _ => Err(SuiError::KeyConversionError(
+                "Invalid key scheme".to_string(),
+            )),
+        }
+    }
+}
+
+impl ToString for SignatureScheme {
+    fn to_string(&self) -> String {
+        match self {
+            SignatureScheme::ED25519 => "ed25519".to_string(),
+            SignatureScheme::Secp256k1 => "secp256k1".to_string(),
         }
     }
 }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -439,18 +439,18 @@ where
 
 /// Wrapper function to return SuiKeypair based on key scheme string
 pub fn random_key_pair_by_type(
-    key_scheme: Option<String>,
+    key_scheme: &str,
 ) -> Result<(SuiAddress, SuiKeyPair), anyhow::Error> {
-    match key_scheme.as_deref() {
-        Some("secp256k1") => {
+    match key_scheme {
+        "secp256k1" => {
             let (addr, key_pair): (_, Secp256k1KeyPair) = get_key_pair();
             Ok((addr, SuiKeyPair::Secp256k1SuiKeyPair(key_pair)))
         }
-        Some("ed25519") | None => {
+        "ed25519" => {
             let (addr, key_pair): (_, Ed25519KeyPair) = get_key_pair();
             Ok((addr, SuiKeyPair::Ed25519SuiKeyPair(key_pair)))
         }
-        Some(_) => Err(anyhow!("Unrecognized key scheme")),
+        _ => Err(anyhow!("Unrecognized key scheme")),
     }
 }
 
@@ -474,22 +474,22 @@ where
 
 /// Wrapper function to return SuiKeypair based on key scheme string with seedable rng.
 pub fn random_key_pair_by_type_from_rng<R>(
-    key_scheme: Option<String>,
+    key_scheme: &str,
     csprng: &mut R,
 ) -> Result<(SuiAddress, SuiKeyPair), anyhow::Error>
 where
     R: rand::CryptoRng + rand::RngCore,
 {
-    match key_scheme.as_deref() {
-        Some("secp256k1") => {
+    match key_scheme {
+        "secp256k1" => {
             let (addr, key_pair): (_, Secp256k1KeyPair) = get_key_pair_from_rng(csprng);
             Ok((addr, SuiKeyPair::Secp256k1SuiKeyPair(key_pair)))
         }
-        Some("ed25519") | None => {
+        "ed25519" => {
             let (addr, key_pair): (_, Ed25519KeyPair) = get_key_pair_from_rng(csprng);
             Ok((addr, SuiKeyPair::Ed25519SuiKeyPair(key_pair)))
         }
-        Some(_) => Err(anyhow!("Unrecognized key scheme")),
+        _ => Err(anyhow!("Unrecognized key scheme")),
     }
 }
 

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -26,7 +26,6 @@ use sui_json_rpc_types::{
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_sdk::crypto::SuiKeystore;
 use sui_sdk::{ClientType, SuiClient};
-use sui_types::sui_serde::{Base64, Encoding};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
@@ -34,6 +33,10 @@ use sui_types::{
     messages::Transaction,
     object::Owner,
     parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS,
+};
+use sui_types::{
+    crypto::SignatureScheme,
+    sui_serde::{Base64, Encoding},
 };
 use tracing::info;
 
@@ -190,7 +193,7 @@ pub enum SuiClientCommands {
 
     /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1}.
     #[clap(name = "new-address")]
-    NewAddress { key_scheme: String },
+    NewAddress { key_scheme: SignatureScheme },
 
     /// Obtain all objects owned by the address.
     #[clap(name = "objects")]
@@ -407,8 +410,8 @@ impl SuiClientCommands {
                 SuiClientCommandResult::SyncClientState
             }
             SuiClientCommands::NewAddress { key_scheme } => {
-                let (address, phrase, flag) = context.keystore.generate_new_key(key_scheme)?;
-                SuiClientCommandResult::NewAddress((address, phrase, flag))
+                let (address, phrase, scheme) = context.keystore.generate_new_key(key_scheme)?;
+                SuiClientCommandResult::NewAddress((address, phrase, scheme))
             }
             SuiClientCommands::Gas { address } => {
                 let address = address.unwrap_or(context.active_address()?);
@@ -771,10 +774,11 @@ impl Display for SuiClientCommandResult {
             SuiClientCommandResult::SyncClientState => {
                 writeln!(writer, "Client state sync complete.")?;
             }
-            SuiClientCommandResult::NewAddress((address, recovery_phrase, flag)) => {
+            SuiClientCommandResult::NewAddress((address, recovery_phrase, scheme)) => {
                 writeln!(
                     writer,
-                    "Created new keypair for address with flag {flag}: [{address}]"
+                    "Created new keypair for address with scheme {:?}: [{address}]",
+                    scheme
                 )?;
                 writeln!(writer, "Secret Recovery Phrase : [{recovery_phrase}]")?;
             }
@@ -943,7 +947,7 @@ pub enum SuiClientCommandResult {
     Addresses(Vec<SuiAddress>),
     Objects(Vec<SuiObjectInfo>),
     SyncClientState,
-    NewAddress((SuiAddress, String, u8)),
+    NewAddress((SuiAddress, String, SignatureScheme)),
     Gas(Vec<GasCoin>),
     SplitCoin(SuiTransactionResponse),
     MergeCoin(SuiTransactionResponse),

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -188,9 +188,9 @@ pub enum SuiClientCommands {
     #[clap(name = "addresses")]
     Addresses,
 
-    /// Generate new address and keypair, with optional keypair scheme {ed25519 | secp256k1}, default to ed25519.
+    /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1}.
     #[clap(name = "new-address")]
-    NewAddress { key_scheme: Option<String> },
+    NewAddress { key_scheme: String },
 
     /// Obtain all objects owned by the address.
     #[clap(name = "objects")]

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -26,7 +26,7 @@ mod keytool_tests;
 pub enum KeyToolCommand {
     /// Generate a new keypair with optional keypair scheme flag, default using ed25519. Output file to current dir (to generate keypair to sui.keystore, use `sui client new-address`)
     Generate {
-        key_scheme: Option<String>,
+        key_scheme: String,
     },
     Show {
         file: PathBuf,
@@ -47,7 +47,7 @@ pub enum KeyToolCommand {
     /// Import mnemonic phrase and generate keypair based on key scheme, default using ed25519.
     Import {
         mnemonic_phrase: String,
-        key_scheme: Option<String>,
+        key_scheme: String,
     },
     /// This is a temporary helper function to ensure that testnet genesis does not break while
     /// we transition towards BLS signatures.
@@ -60,15 +60,12 @@ impl KeyToolCommand {
     pub fn execute(self, keystore: &mut SuiKeystore) -> Result<(), anyhow::Error> {
         match self {
             KeyToolCommand::Generate { key_scheme } => {
-                let k = key_scheme.clone();
-                match random_key_pair_by_type(key_scheme) {
+                let k = key_scheme.as_str();
+                match random_key_pair_by_type(k) {
                     Ok((address, keypair)) => {
                         let file_name = format!("{address}.key");
                         write_keypair_to_file(&keypair, &file_name)?;
-                        println!(
-                            "{:?} key generated and saved to '{file_name}'",
-                            k.unwrap_or_else(|| "ed25519".to_string())
-                        )
+                        println!("{k} key generated and saved to '{file_name}'")
                     }
                     Err(e) => {
                         println!("Failed to generate keypair: {:?}", e)

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -12,7 +12,7 @@ use sui_sdk::crypto::SuiKeystore;
 use sui_types::base_types::SuiAddress;
 use sui_types::base_types::{decode_bytes_hex, encode_bytes_hex};
 use sui_types::crypto::{
-    random_key_pair_by_type, AuthorityKeyPair, EncodeDecodeBase64, SuiKeyPair,
+    random_key_pair_by_type, AuthorityKeyPair, EncodeDecodeBase64, SignatureScheme, SuiKeyPair,
 };
 use sui_types::sui_serde::{Base64, Encoding};
 
@@ -26,7 +26,7 @@ mod keytool_tests;
 pub enum KeyToolCommand {
     /// Generate a new keypair with keypair scheme flag {ed25519 | secp256k1}. Output file to current dir (to generate keypair to sui.keystore, use `sui client new-address`)
     Generate {
-        key_scheme: String,
+        key_scheme: SignatureScheme,
     },
     Show {
         file: PathBuf,
@@ -35,7 +35,7 @@ pub enum KeyToolCommand {
     Unpack {
         keypair: SuiKeyPair,
     },
-    /// List all keys in the keystore
+    /// List all keys by its address, public key, key scheme in the keystore
     List,
     /// Create signature using the sui keystore and provided data.
     Sign {
@@ -47,7 +47,7 @@ pub enum KeyToolCommand {
     /// Import mnemonic phrase and generate keypair based on key scheme flag {ed25519 | secp256k1}.
     Import {
         mnemonic_phrase: String,
-        key_scheme: String,
+        key_scheme: SignatureScheme,
     },
     /// This is a temporary helper function to ensure that testnet genesis does not break while
     /// we transition towards BLS signatures.
@@ -60,12 +60,12 @@ impl KeyToolCommand {
     pub fn execute(self, keystore: &mut SuiKeystore) -> Result<(), anyhow::Error> {
         match self {
             KeyToolCommand::Generate { key_scheme } => {
-                let k = key_scheme.as_str();
-                match random_key_pair_by_type(k) {
+                let k = key_scheme.to_string();
+                match random_key_pair_by_type(key_scheme) {
                     Ok((address, keypair)) => {
                         let file_name = format!("{address}.key");
                         write_keypair_to_file(&keypair, &file_name)?;
-                        println!("{k} key generated and saved to '{file_name}'")
+                        println!("{:?} key generated and saved to '{file_name}'", k);
                     }
                     Err(e) => {
                         println!("Failed to generate keypair: {:?}", e)

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -24,7 +24,7 @@ mod keytool_tests;
 #[derive(Subcommand)]
 #[clap(rename_all = "kebab-case")]
 pub enum KeyToolCommand {
-    /// Generate a new keypair with optional keypair scheme flag, default using ed25519. Output file to current dir (to generate keypair to sui.keystore, use `sui client new-address`)
+    /// Generate a new keypair with keypair scheme flag {ed25519 | secp256k1}. Output file to current dir (to generate keypair to sui.keystore, use `sui client new-address`)
     Generate {
         key_scheme: String,
     },
@@ -44,7 +44,7 @@ pub enum KeyToolCommand {
         #[clap(long)]
         data: String,
     },
-    /// Import mnemonic phrase and generate keypair based on key scheme, default using ed25519.
+    /// Import mnemonic phrase and generate keypair based on key scheme flag {ed25519 | secp256k1}.
     Import {
         mnemonic_phrase: String,
         key_scheme: String,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -24,7 +24,7 @@ use sui_config::{
 use sui_sdk::crypto::KeystoreType;
 use sui_sdk::ClientType;
 use sui_swarm::memory::Swarm;
-use sui_types::crypto::{KeypairTraits, SuiKeyPair};
+use sui_types::crypto::{KeypairTraits, SignatureScheme, SuiKeyPair};
 use tracing::info;
 
 #[allow(clippy::large_enum_variant)]
@@ -400,15 +400,16 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
                 .unwrap_or(&sui_config_dir()?)
                 .join(SUI_KEYSTORE_FILENAME);
             let keystore = KeystoreType::File(keystore_path);
-            println!("Generating keypair ...\n");
-
-            println!("Do you want to generate a secp256k1 keypair instead? [y/N] No will select Ed25519 by default. ");
-            let key_scheme = match read_line()?.trim() {
-                "y" => String::from("secp256k1"),
-                _ => String::from("ed25519"),
+            println!("Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1):");
+            let key_scheme = match SignatureScheme::from_flag(read_line()?.trim()) {
+                Ok(s) => s,
+                Err(e) => return Err(anyhow!("{e}")),
             };
-            let (new_address, phrase, flag) = keystore.init()?.generate_new_key(key_scheme)?;
-            println!("Generated new keypair for address with flag {flag} [{new_address}]");
+            let (new_address, phrase, scheme) = keystore.init()?.generate_new_key(key_scheme)?;
+            println!(
+                "Generated new keypair for address with scheme {:?} [{new_address}]",
+                scheme.to_string()
+            );
             println!("Secret Recovery Phrase : [{phrase}]");
             SuiClientConfig {
                 keystore,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -404,8 +404,8 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
 
             println!("Do you want to generate a secp256k1 keypair instead? [y/N] No will select Ed25519 by default. ");
             let key_scheme = match read_line()?.trim() {
-                "y" => Some(String::from("secp256k1")),
-                _ => None,
+                "y" => String::from("secp256k1"),
+                _ => String::from("ed25519"),
             };
             let (new_address, phrase, flag) = keystore.init()?.generate_new_key(key_scheme)?;
             println!("Generated new keypair for address with flag {flag} [{new_address}]");

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -765,9 +765,11 @@ async fn test_switch_command() -> Result<(), anyhow::Error> {
     context.config.active_address = None;
 
     // Create a new address
-    let os = SuiClientCommands::NewAddress { key_scheme: None }
-        .execute(&mut context)
-        .await?;
+    let os = SuiClientCommands::NewAddress {
+        key_scheme: "ed25519".to_string(),
+    }
+    .execute(&mut context)
+    .await?;
     let new_addr = if let SuiClientCommandResult::NewAddress((a, _, _)) = os {
         a
     } else {
@@ -817,7 +819,7 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
     );
 
     SuiClientCommands::NewAddress {
-        key_scheme: Some("secp256k1".to_string()),
+        key_scheme: "secp256k1".to_string(),
     }
     .execute(&mut context)
     .await?;
@@ -835,26 +837,11 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
 
     // random key scheme errors out
     assert!(SuiClientCommands::NewAddress {
-        key_scheme: Some("random".to_string()),
+        key_scheme: "random".to_string(),
     }
     .execute(&mut context)
     .await
     .is_err());
-
-    SuiClientCommands::NewAddress { key_scheme: None }
-        .execute(&mut context)
-        .await?;
-
-    // None key scheme defaults to Ed25519
-    assert_eq!(
-        context
-            .keystore
-            .keys()
-            .iter()
-            .filter(|k| k.flag() == Ed25519SuiSignature::SCHEME.flag())
-            .count(),
-        6
-    );
     Ok(())
 }
 

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -410,13 +410,14 @@ not enough, there are two ways to add accounts to the Sui CLI client if needed.
 To create a new account, execute the `new-address` command:
 
 ```shell
-$ sui client new-address
+$ sui client new-address ed25519
 ```
+New address creation requires key scheme flag `{secp256k1 | ed25519}`. 
 
 The output shows a confirmation after the account has been created:
 
 ```
-Created new keypair for address : 0xc72cf3adcc4d11c03079cef2c8992aea5268677a
+Created new keypair for address with flag 0: [0xc72cf3adcc4d11c03079cef2c8992aea5268677a]
 ```
 
 ### Add existing accounts to `client.yaml` manually

--- a/doc/src/build/devnet.md
+++ b/doc/src/build/devnet.md
@@ -183,12 +183,13 @@ In the previous section, we learned how to publish a Move package; and in this s
 
 Let’s assume that the placeholder for the address of the player to receive a sword is <PLAYER_ADDRESS>. If you don’t know any address other than your own, you can create one using the following `client` command and use it whenever you see the <PLAYER_ADDRESS> placeholder:
 ```shell
-$ sui client new-address
+$ sui client new-address ed25519
 ```
+New address creation requires key scheme flag `{secp256k1 | ed25519}`. 
 
 Which yields output resembling:
 ```shell
-Created new keypair for address : 2D32ED71381BEF7F3D8C57B48DF82123593672AA
+Created new keypair for address with flag 0: [0x19de019c19fc800a6aeba4eb4133f6db91ca7c2c]
 ```
 
 In order to create a sword and transfer it to another player, we use the following command to call the `sword_create` [function](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/move_tutorial/sources/m1.move#L44) in the `M1` [module](https://github.com/MystenLabs/sui/blob/main/sui_programmability/examples/move_tutorial/sources/m1.move#L4) of the package we previously published.


### PR DESCRIPTION
now `sui keytool generate` and `sui client new-address` must specify key scheme type as argument {secp256k1 || ed25519}