### PR TITLE
[Explorer] Changes website title from SuiExplorer to Sui Explorer

### DIFF
--- a/explorer/client/index.html
+++ b/explorer/client/index.html
@@ -14,7 +14,7 @@
         />
         <link rel="apple-touch-icon" href="/logo192.png" />
         <link rel="manifest" href="/manifest.json" />
-        <title>SuiExplorer</title>
+        <title>Sui Explorer</title>
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This quick-fix PR switches the title of the website from 'SuiExplorer' (see first tab below) to 'Sui Explorer' (see second tab below).

![image](https://user-images.githubusercontent.com/11377188/187404546-d145c8eb-3a5d-47c5-a9d8-7388e7798abd.png)
