### PR TITLE
[Explorer] Swaps three dots for unicode ellipsis

### DIFF
--- a/explorer/client/src/components/transactions-for-id/TxForID.tsx
+++ b/explorer/client/src/components/transactions-for-id/TxForID.tsx
@@ -69,7 +69,7 @@ function TxForIDView({ showData }: { showData: TxnData[] | undefined }) {
                 transactionId: [
                     {
                         url: data.txId,
-                        name: truncate(data.txId, 26, '...'),
+                        name: truncate(data.txId, 26),
                         category: 'transactions',
                         isLink: true,
                         copy: false,

--- a/explorer/client/src/utils/stringUtils.ts
+++ b/explorer/client/src/utils/stringUtils.ts
@@ -40,7 +40,7 @@ export function transformURL(url: string) {
 export function truncate(fullStr: string, strLen: number, separator?: string) {
     if (fullStr.length <= strLen) return fullStr;
 
-    separator = separator || '...';
+    separator = separator || '\u{2026}';
 
     const sepLen = separator.length,
         charsToShow = strLen - sepLen,


### PR DESCRIPTION
Currently, three dots (`...`) are used to indicate a horizontal ellipsis when truncating addresses:

![image](https://user-images.githubusercontent.com/11377188/187411365-81c1c264-94e1-438e-8866-cebe81485829.png)

The problem with this is that each `.` represents an individual character. As we are using a monospaced typeface (`Space Mono`), this means that three character spaces are being taken up.

This PR replaces the three dot characters with a single horizontal ellipsis character using the advanced unicode:

![image](https://user-images.githubusercontent.com/11377188/187411287-baef8ca0-a138-42a7-80c7-e5d5d2e69e9c.png)

As can be seen in the above screenshots, the result is that more characters of the address can be displayed in the same space because the ellipsis now takes up one character space not three.

Thank you @mlogan for your help with identifying the value of using the horizontal ellipsis unicode character.