### PR TITLE
[authority_store] Atomically store effects and executed_sequence

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -713,11 +713,18 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // We can't write this until after sequencing succeeds (which happens in
         // batch_update_objects), as effects_exists is used as a check in many places
         // for "did the tx finish".
-        self.tables.effects.insert(transaction_digest, effects)?;
+        let batch = self.tables.effects.batch();
+        let batch = batch.insert_batch(
+            &self.tables.effects,
+            [(transaction_digest, effects)].into_iter(),
+        )?;
 
         // Writing to executed_sequence must be done *after* writing to effects, so that we never
         // broadcast a sequenced transaction (via the batch system) for which no effects can be
         // retrieved.
+        //
+        // Currently we write both effects and executed_sequence in the same batch to avoid
+        // consistency issues between the two (see #4395 for more details).
         //
         // Note that this write may be done repeatedly when retrying a tx. The
         // sequence_transaction call in batch_update_objects assigns a sequence number to
@@ -729,10 +736,16 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             ?effects_digest,
             "storing sequence number to executed_sequence"
         );
-        self.tables.executed_sequence.insert(
-            &assigned_seq,
-            &ExecutionDigests::new(*transaction_digest, *effects_digest),
+        let batch = batch.insert_batch(
+            &self.tables.executed_sequence,
+            [(
+                assigned_seq,
+                ExecutionDigests::new(*transaction_digest, *effects_digest),
+            )]
+            .into_iter(),
         )?;
+
+        batch.write()?;
 
         Ok(())
     }


### PR DESCRIPTION
Currently, storage can become in inconsistent state if node crashes between writing effects and executed_sequence.

After effects are written transaction is not going to be re-executed during retry, therefore `executed_sequence` table won't be updated, which means batch service won't be able to pick up transaction to share it with other nodes and include to checkpoint.