### PR TITLE
[mutex_table] Fix acquire_locks deduplication

### DIFF
--- a/crates/sui-storage/src/mutex_table.rs
+++ b/crates/sui-storage/src/mutex_table.rs
@@ -118,9 +118,10 @@ impl<K: Hash + std::cmp::Eq + Send + Sync + 'static> MutexTable<K> {
     pub async fn acquire_locks<I>(&self, object_iter: I) -> Vec<LockGuard>
     where
         I: Iterator<Item = K>,
+        K: Ord,
     {
         let mut objects: Vec<K> = object_iter.into_iter().collect();
-        objects.sort_by_key(|a| self.get_lock_idx(a));
+        objects.sort_unstable();
         objects.dedup();
 
         let mut guards = Vec::with_capacity(objects.len());


### PR DESCRIPTION
It is critical for `acquire_locks` to deduplicate when acquiring multiple locks.

Current implementation does not deduplicate properly - it sorts by bucket key, which can retain order of different objects preventing their deduplication.

For example, consider we want to lock `A` and `B` which falls into same lock bucket, and we pass ``[A, B, A]` to acquire_locks.

 If they fall into same bucket, sorting won't reorder them and we will get same `[A, B, A]` after sorting. Example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=f2b9dde8d43040baab279645ee4f5035

 If they are not reordered, they will not be de-duplicated(since Vec::dedup only deduplicate consequent elements). This will lead to a deadlock when trying to acquire lock on the same object we already locked.

 I think originally it made sense to use sorting by the lock bucket key, but since #4362 this is not needed and simple unstable_sort will do.