### PR TITLE
[FE] Use pnpm diffs instead of file-based diffs

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -7,15 +7,9 @@ outputs:
   isRust:
     description: True when changes happened to the rust code
     value: "${{ steps.diff.outputs.isRust }}"
-  isExplorerClient:
-    description: True when there are changes to files related to explorer client
-    value: "${{ steps.diff.outputs.isExplorerClient }}"
   isTypescriptSDK:
     description: True when there are changes to files related to TypeScript SDK
     value: "${{ steps.diff.outputs.isTypescriptSDK }}"
-  isWalletExt:
-    description: True when there are changes to files related to Wallet Extension
-    value: "${{ steps.diff.outputs.isWalletExt }}"
 runs:
   using: composite
   steps:
@@ -30,9 +24,6 @@ runs:
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
           - '.github/workflows/rust.yml'
-        isExplorerClient:
-          - 'explorer/client/**'
-          - '.github/workflows/explorer-client-prs.yml'
         isTypescriptSDK:
           - 'sdk/typescript/**'
           - 'crates/sui-open-rpc/samples/**'
@@ -41,6 +32,3 @@ runs:
           - 'doc/**'
           - '*.md'
           - '.github/workflows/docs.yml'
-        isWalletExt:
-          - 'wallet/**'
-          - '.github/workflows/wallet-ext-prs.yml'

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -7,9 +7,6 @@ outputs:
   isRust:
     description: True when changes happened to the rust code
     value: "${{ steps.diff.outputs.isRust }}"
-  isTypescriptSDK:
-    description: True when there are changes to files related to TypeScript SDK
-    value: "${{ steps.diff.outputs.isTypescriptSDK }}"
 runs:
   using: composite
   steps:
@@ -24,10 +21,6 @@ runs:
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
           - '.github/workflows/rust.yml'
-        isTypescriptSDK:
-          - 'sdk/typescript/**'
-          - 'crates/sui-open-rpc/samples/**'
-          - '.github/workflows/ts-sdk.yml'
         isDoc:
           - 'doc/**'
           - '*.md'

--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -7,6 +7,9 @@ outputs:
   isTypeScriptSDK:
     description: True when there are changes to files related to TypeScript SDK
     value: "${{ steps.changes.outputs.sdk }}"
+  isWalletExt:
+    description: True when there are changes to files related to Wallet Extension
+    value: "${{ steps.changes.outputs.wallet }}"
   isWalletAdapter:
     description: True when there are changes to files related to wallet adapter
     value: "${{ steps.changes.outputs.walletAdapter }}"
@@ -30,4 +33,5 @@ runs:
       run: |
         echo "::set-output name=explorer::$(jq 'any(.[]; .name == "sui-explorer")' changes.json)"
         echo "::set-output name=sdk::$(jq 'any(.[]; .name == "@mysten/sui.js")' changes.json)"
+        echo "::set-output name=wallet::$(jq 'any(.[]; .name == "sui-wallet")' changes.json)"
         echo "::set-output name=walletAdapter::$(jq 'any(.[]; .name | startswith("@mysten/wallet-adapter"))' changes.json)"

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes
-        uses: "./.github/actions/diffs"
+        uses: "./.github/actions/pnpm-diffs"
         id: diff
   client_checks:
     name: Test & Build

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes
-        uses: "./.github/actions/diffs"
+        uses: "./.github/actions/pnpm-diffs"
         id: diff
   run_checks:
     name: Lint, Test & Build

--- a/crates/sui-open-rpc/package.json
+++ b/crates/sui-open-rpc/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "@mysten/sui-open-rpc",
+	"private": true
+}

--- a/crates/sui-open-rpc/samples/objects.json
+++ b/crates/sui-open-rpc/samples/objects.json
@@ -86,6 +86,7 @@
           "id": {
             "id": "0x1f45933e11d09fa15e65ba6735ce4205c3deec24"
           },
+
           "sword": {
             "type": "0xeaa96afeecd3cf700ca68d6cad4af93f05b59bcd::hero::Sword",
             "fields": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
     devDependencies:
       '@changesets/cli': 2.24.3
 
+  crates/sui-open-rpc:
+    specifiers: {}
+
   explorer/client:
     specifiers:
       '@mysten/sui.js': workspace:*
@@ -119,6 +122,7 @@ importers:
   sdk/typescript:
     specifiers:
       '@mysten/bcs': workspace:*
+      '@mysten/sui-open-rpc': workspace:*
       '@size-limit/preset-small-lib': ^7.0.8
       '@types/bn.js': ^5.1.0
       '@types/lossless-json': ^1.0.1
@@ -154,6 +158,7 @@ importers:
       lossless-json: 1.0.5
       tweetnacl: 1.0.3
     devDependencies:
+      '@mysten/sui-open-rpc': link:../../crates/sui-open-rpc
       '@size-limit/preset-small-lib': 7.0.8_size-limit@7.0.8
       '@types/bn.js': 5.1.0
       '@types/lossless-json': 1.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
-  - 'wallet-adapter/**'
-  - 'sdk/**'
-  - 'explorer/**'
-  - 'wallet/**'
+  - "wallet-adapter/**"
+  - "sdk/**"
+  - "explorer/**"
+  - "wallet/**"
+  - "crates/sui-open-rpc"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -59,6 +59,7 @@
     }
   ],
   "devDependencies": {
+    "@mysten/sui-open-rpc": "workspace:*",
     "@size-limit/preset-small-lib": "^7.0.8",
     "@types/bn.js": "^5.1.0",
     "@types/lossless-json": "^1.0.1",

--- a/sdk/typescript/test/tsconfig.json
+++ b/sdk/typescript/test/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["./"]
+  "include": ["./"],
+  "compilerOptions": {
+    "resolveJsonModule": true
+  }
 }

--- a/sdk/typescript/test/types/framework.test.ts
+++ b/sdk/typescript/test/types/framework.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import mockObjectData from '../../../../crates/sui-open-rpc/samples/objects.json';
+import mockObjectData from '@mysten/sui-open-rpc/samples/objects.json';
 import { Coin, GetObjectDataResponse } from '../../src';
 
 import BN from 'bn.js';

--- a/sdk/typescript/test/types/objects.test.ts
+++ b/sdk/typescript/test/types/objects.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import mockObjectData from '../../../../crates/sui-open-rpc/samples/objects.json';
+import mockObjectData from '@mysten/sui-open-rpc/samples/objects.json';
 
 import { isGetObjectDataResponse } from '../../src/index.guard';
 

--- a/sdk/typescript/test/types/transactions.test.ts
+++ b/sdk/typescript/test/types/transactions.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import mockTransactionData from '../../../../crates/sui-open-rpc/samples/transactions.json';
+import mockTransactionData from '@mysten/sui-open-rpc/samples/transactions.json';
 
 import { isSuiTransactionResponse } from '../../src/index.guard';
 


### PR DESCRIPTION
I introduced pnpm diffs in #4239, but didn't migrate everything to them. This PR migrates all FE projects to use pnpm-based diffs, which will ensure that dependent projects have their tests run when making changes. This should improve our overall reliability, and minimize cross-package breakages.

One of challenges here was the crate-dependency for `sui-open-rpc` within the SDK. Ideally, this data would come from localnet, but until that happens, I fixed this by making `@mysten/sui-open-rpc` which is a private package in the pnpm monorepo. This allows pnpm to detect the cross-workspace dependency correctly (vs the previous out-of-package import, which would need an import graph to detect, which is much more expensive).