### PR TITLE
[Sui CLI] - Support full node

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -286,9 +286,8 @@ pub async fn new_wallet_context_from_cluster(
         .unwrap();
     SuiClientConfig {
         keystore,
-        gateway: ClientType::RPC(rpc_url.into(), None),
+        client_type: ClientType::RPC(rpc_url.into(), None),
         active_address: Some(address),
-        fullnode: None,
     }
     .persisted(&wallet_config_path)
     .save()

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -52,7 +52,7 @@ impl WalletClient {
     }
 
     pub fn get_gateway(&self) -> &SuiClient {
-        &self.wallet_context.gateway
+        &self.wallet_context.client
     }
 
     pub fn get_fullnode(&self) -> &SuiClient {

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -232,7 +232,7 @@ impl SimpleFaucet {
         amount: u64,
     ) -> Result<TransactionData, anyhow::Error> {
         self.wallet
-            .gateway
+            .client
             .transaction_builder()
             .transfer_sui(signer, coin_id, budget, recipient, Some(amount))
             .await
@@ -264,7 +264,7 @@ impl SimpleFaucet {
         let tx = Transaction::new(data, signature);
         info!(tx_digest = ?tx.digest(), ?recipient, ?coin_id, ?uuid, "Broadcasting transfer obj txn");
         let response = context
-            .gateway
+            .client
             .quorum_driver()
             .execute_transaction(tx)
             .await?;

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -139,19 +139,19 @@ async fn create_response_sample() -> Result<
     let address = context.keystore.addresses().first().cloned().unwrap();
 
     context
-        .gateway
+        .client
         .wallet_sync_api()
         .sync_account_state(address)
         .await?;
 
     // Create coin response
     let coins = context
-        .gateway
+        .client
         .read_api()
         .get_objects_owned_by_address(address)
         .await?;
     let coin = context
-        .gateway
+        .client
         .read_api()
         .get_parsed_object(coins.first().unwrap().object_id)
         .await?;
@@ -226,7 +226,7 @@ async fn create_package_object_response(
     .await?;
     if let SuiClientCommandResult::Publish(response) = result {
         let object = context
-            .gateway
+            .client
             .read_api()
             .get_parsed_object(
                 response
@@ -337,7 +337,7 @@ async fn create_hero_response(
         if let SuiClientCommandResult::Call(_, effect) = result {
             let hero = effect.created.first().unwrap();
             let object = context
-                .gateway
+                .client
                 .read_api()
                 .get_parsed_object(hero.reference.object_id)
                 .await?;
@@ -448,7 +448,7 @@ async fn get_nft_response(
 
     if let SuiClientCommandResult::Call(certificate, effects) = result {
         let object = context
-            .gateway
+            .client
             .read_api()
             .get_parsed_object(effects.created.first().unwrap().reference.object_id)
             .await?;

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -1,21 +1,22 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
-use async_recursion::async_recursion;
-use clap::Parser;
-use clap::Subcommand;
-use serde::Deserialize;
 use std::io::{stdin, stdout, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::thread;
 use std::time::Duration;
-use sui_json_rpc_types::SuiData;
-use sui_sdk::crypto::KeystoreType;
+
+use anyhow::anyhow;
+use async_recursion::async_recursion;
+use clap::Parser;
+use clap::Subcommand;
+use serde::Deserialize;
+
 use sui_sdk::{
-    crypto::SuiKeystore,
+    crypto::{KeystoreType, SuiKeystore},
     json::SuiJsonValue,
+    rpc_types::SuiData,
     types::{
         base_types::{ObjectID, SuiAddress},
         crypto::Signature,
@@ -69,10 +70,12 @@ impl TicTacToe {
         let player_o = player_o.unwrap_or_else(|| self.keystore.addresses()[1]);
 
         // Force a sync of signer's state in gateway.
-        self.client
-            .wallet_sync_api()
-            .sync_account_state(player_x)
-            .await?;
+        if self.client.is_gateway() {
+            self.client
+                .wallet_sync_api()
+                .sync_account_state(player_x)
+                .await?;
+        }
 
         // Create a move call transaction using the TransactionBuilder API.
         let create_game_call = self

--- a/crates/sui/src/config/mod.rs
+++ b/crates/sui/src/config/mod.rs
@@ -18,10 +18,8 @@ use sui_sdk::ClientType;
 #[derive(Serialize, Deserialize)]
 pub struct SuiClientConfig {
     pub keystore: KeystoreType,
-    pub gateway: ClientType,
+    pub client_type: ClientType,
     pub active_address: Option<SuiAddress>,
-    // Temporarily make this optional, until we fully deprecate gateway
-    pub fullnode: Option<ClientType>,
 }
 
 impl Config for SuiClientConfig {}
@@ -41,12 +39,7 @@ impl Display for SuiClientConfig {
             None => writeln!(writer, "None")?,
         };
         writeln!(writer, "{}", self.keystore)?;
-        write!(writer, "{}", self.gateway)?;
-
-        if let Some(fullnode_type) = &self.fullnode {
-            write!(writer, "{}", fullnode_type)?;
-        }
-
+        write!(writer, "{}", self.client_type)?;
         write!(f, "{}", writer)
     }
 }

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -51,7 +51,7 @@ async fn transfer_coin(
     let receiver = context.keystore.addresses().get(1).cloned().unwrap();
 
     let object_refs = context
-        .gateway
+        .client
         .read_api()
         .get_objects_owned_by_address(sender)
         .await?;

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -79,7 +79,7 @@ pub async fn publish_basics_package(context: &WalletContext, sender: SuiAddress)
             .collect();
 
         let data = context
-            .gateway
+            .client
             .transaction_builder()
             .publish(sender, all_module_bytes, None, 50000)
             .await
@@ -90,7 +90,7 @@ pub async fn publish_basics_package(context: &WalletContext, sender: SuiAddress)
     };
 
     let resp = context
-        .gateway
+        .client
         .quorum_driver()
         .execute_transaction(transaction)
         .await
@@ -116,7 +116,7 @@ pub async fn submit_move_transaction(
     debug!(?package_ref, ?arguments, "move_transaction");
 
     let data = context
-        .gateway
+        .client
         .transaction_builder()
         .move_call(
             sender,
@@ -135,7 +135,7 @@ pub async fn submit_move_transaction(
     let tx = Transaction::new(data, signature);
 
     context
-        .gateway
+        .client
         .quorum_driver()
         .execute_transaction(tx)
         .await

--- a/doc/src/build/devnet.md
+++ b/doc/src/build/devnet.md
@@ -68,7 +68,7 @@ Or enter a custom URL to connect to a server hosted elsewhere.
 If you have used the Sui client before with a local network, you will have an existing `client.yaml` configuration
 file needing update. Change the configured RPC server URL to Devnet by using:
 ```shell
-$ sui client switch --gateway https://gateway.devnet.sui.io:443
+$ sui client switch --rpc https://gateway.devnet.sui.io:443
 ```
 
 > **Tip:** If you run into issues, reset the Sui configuration by removing its directory, by default located at `~/.sui/sui_config`. Then reinstall [Sui binaries](../build/install.md#binaries).


### PR DESCRIPTION
* removed fullnode from client config (client.yaml)
* renamed gateway config to `rpc`, this can be used to point to either gateway or fullnode 
* retrieve RPC server supported methods using `rpc.discover` method and determine if the client is connecting to gateway or fullnode
* print rpc server's available methods on sui console startup
* fixed issue #4164

todos: 
* Support event subscription in Sui CLI
* Support calling all rpc methods
* Use fullnode rpc in test instead of gateway