### PR TITLE
[events] Remove checkpoint number from events

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -784,10 +784,8 @@ impl AuthorityState {
 
         // Emit events
         if let Some(event_handler) = &self.event_handler {
-            let checkpoint_num = self.latest_checkpoint_num.load(Ordering::Relaxed);
-
             event_handler
-                .process_events(&effects.effects, timestamp_ms, seq, checkpoint_num)
+                .process_events(&effects.effects, timestamp_ms, seq)
                 .await?;
 
             self.metrics

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -47,7 +47,6 @@ impl EventHandler {
         effects: &TransactionEffects,
         timestamp_ms: u64,
         seq_num: u64,
-        checkpoint_num: u64,
     ) -> SuiResult {
         let res: Result<Vec<_>, _> = effects
             .events
@@ -57,13 +56,11 @@ impl EventHandler {
         let envelopes = res?;
 
         // Ingest all envelopes together at once (for efficiency) into Event Store
-        self.event_store
-            .add_events(&envelopes, checkpoint_num)
-            .await?;
+        self.event_store.add_events(&envelopes).await?;
         trace!(
             num_events = envelopes.len(),
             tx_digest =? effects.transaction_digest,
-            checkpoint_num, "Finished writing events to event store"
+            "Finished writing events to event store"
         );
 
         // serially dispatch event processing to honor events' orders.

--- a/crates/sui-storage/src/event_store/mod.rs
+++ b/crates/sui-storage/src/event_store/mod.rs
@@ -7,7 +7,7 @@
 //! - Filtering of events per Move package, type, or other fields
 //! - Persistent/reliable streaming, which needs to recover filtered events from a marker
 //!   or point in time
-//!   
+//!
 //! Events are also archived into checkpoints so this API should support that as well.
 //!
 
@@ -49,7 +49,6 @@ pub const AMOUNT_KEY: &str = "amount";
 pub struct StoredEvent {
     /// UTC timestamp in milliseconds
     timestamp: u64,
-    checkpoint_num: u64,
     /// Not present for non-transaction System events (eg EpochChange)
     tx_digest: Option<TransactionDigest>,
     /// The variant name from SuiEvent, eg MoveEvent, Publish, etc.
@@ -326,11 +325,7 @@ pub trait EventStore {
     /// which have sequence numbers below the current one will be skipped.  This feature
     /// is intended for deduplication.
     /// Returns Ok(rows_affected).
-    async fn add_events(
-        &self,
-        events: &[EventEnvelope],
-        checkpoint_num: u64,
-    ) -> Result<u64, SuiError>;
+    async fn add_events(&self, events: &[EventEnvelope]) -> Result<u64, SuiError>;
 
     /// Returns at most `limit` events emitted by a given
     /// transaction, sorted in order emitted.
@@ -401,14 +396,6 @@ pub trait EventStore {
         object: &ObjectID,
         limit: usize,
     ) -> Result<Vec<StoredEvent>, SuiError>;
-
-    /// Generic event iterator to return events emitted in checkpoints
-    /// [start_checkpoint, end_checkpoint), order not guaranteed.
-    fn events_by_checkpoint(
-        &self,
-        start_checkpoint: u64,
-        end_checkpoint: u64,
-    ) -> Result<StreamedResult, SuiError>;
 
     /// Generic event iterator that returns events emitted between
     /// [start_time, end_time), sorted in descending time.

--- a/crates/sui-storage/tests/event_store_integration_test.rs
+++ b/crates/sui-storage/tests/event_store_integration_test.rs
@@ -15,7 +15,7 @@ async fn test_stored_event_to_sui_event() -> Result<(), anyhow::Error> {
     db.initialize().await.map_err(anyhow::Error::from)?;
 
     let new_obj = test_utils::new_test_newobj_event(1_666_000, 1, None, None, None);
-    insert_and_fetch_by_tx_digest_then_compare(new_obj, 1, &db).await?;
+    insert_and_fetch_by_tx_digest_then_compare(new_obj, &db).await?;
 
     let move_ = test_utils::new_test_move_event(
         1_666_001,
@@ -24,10 +24,10 @@ async fn test_stored_event_to_sui_event() -> Result<(), anyhow::Error> {
         "a_module",
         "whatever",
     );
-    insert_and_fetch_by_tx_digest_then_compare(move_, 1, &db).await?;
+    insert_and_fetch_by_tx_digest_then_compare(move_, &db).await?;
 
     let delete_obj = test_utils::new_test_deleteobj_event(1_666_002, 3, None, None);
-    insert_and_fetch_by_tx_digest_then_compare(delete_obj, 1, &db).await?;
+    insert_and_fetch_by_tx_digest_then_compare(delete_obj, &db).await?;
 
     let transfer_obj = test_utils::new_test_transfer_event(
         1_666_003,
@@ -38,10 +38,10 @@ async fn test_stored_event_to_sui_event() -> Result<(), anyhow::Error> {
         None,
         None,
     );
-    insert_and_fetch_by_tx_digest_then_compare(transfer_obj, 1, &db).await?;
+    insert_and_fetch_by_tx_digest_then_compare(transfer_obj, &db).await?;
 
     let publish = test_utils::new_test_publish_event(1_001_000, 5, None);
-    assert_eq!(db.add_events(&vec![publish.clone()], 1).await?, 1);
+    assert_eq!(db.add_events(&vec![publish.clone()]).await?, 1);
     let mut queried_events = db
         .events_by_type(1_001_000, 1_002_000, EventType::Publish, 1)
         .await?;
@@ -56,15 +56,10 @@ async fn test_stored_event_to_sui_event() -> Result<(), anyhow::Error> {
 
 async fn insert_and_fetch_by_tx_digest_then_compare(
     event_envelope: EventEnvelope,
-    checkpoint: u64,
     db: &SqlEventStore,
 ) -> Result<(), anyhow::Error> {
     let tx_digest = event_envelope.tx_digest.unwrap();
-    assert_eq!(
-        db.add_events(&vec![event_envelope.clone()], checkpoint)
-            .await?,
-        1
-    );
+    assert_eq!(db.add_events(&vec![event_envelope.clone()]).await?, 1);
 
     let mut events = db.events_by_transaction(tx_digest, 10).await?;
     assert_eq!(events.len(), 1);


### PR DESCRIPTION
Events are processed and generated on fullnodes. There is no guarantee that the fullnode knows which checkpoint the processed event will be included. Hence we should not include checkpoint number in events. If we want this link, we can have this link latter but the other direction, from checkpoint -> effects -> events
Resolves https://github.com/MystenLabs/sui/issues/4345