### PR TITLE
Adaptive cleanup of mutex table

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -191,7 +191,7 @@ impl ValidatorService {
         tokio::spawn(async move {
             narwhal_node::restarter::NodeRestarter::watch(
                 consensus_keypair,
-                &*consensus_committee,
+                &consensus_committee,
                 consensus_worker_cache,
                 consensus_storage_base_path,
                 consensus_execution_state,


### PR DESCRIPTION
The current mutex table cleanup is not very good with handling load spikes since it runs at a fixed time period. We would want to also do cleanup if size of the table goes over a threshold. This diff adds a size() function (which will also be useful to track #entries in the table) as well as cleanup based on size threshold