### PR TITLE
[ts-sdk] Remove errors from ts-auto-guard

### DIFF
--- a/.changeset/rude-cameras-unite.md
+++ b/.changeset/rude-cameras-unite.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Updated publish transactions to accept ArrayLike instead of Iterable.

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -21,4 +21,4 @@ export * from './signers/raw-signer';
 export * from './signers/signer-with-provider';
 
 export * from './types';
-export * from './index.guard';
+export * from './types/index.guard';

--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SignatureScheme } from '../cryptography/publickey';
-import { isSuiObjectRef } from '../index.guard';
+import { isSuiObjectRef } from '../types/index.guard';
 import {
   GetObjectDataResponse,
   SuiObjectInfo,

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -13,7 +13,7 @@ import {
   isSuiMoveNormalizedModule,
   isSuiMoveNormalizedFunction,
   isSuiMoveNormalizedStruct,
-} from '../index.guard';
+} from '../types/index.guard';
 import {
   GatewayTxSeqNumber,
   GetTxnDigestsResponse,

--- a/sdk/typescript/src/rpc/client.guard.ts
+++ b/sdk/typescript/src/rpc/client.guard.ts
@@ -1,12 +1,13 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable */
+
 /*
  * Generated type guards for "client.ts".
  * WARNING: Do not manually change this file.
  */
 import { HttpHeaders, RpcParams, ValidResponse, ErrorResponse } from "./client";
-import { isTransactionDigest } from "../index.guard";
 
 export function isHttpHeaders(obj: any, _argumentName?: string): obj is HttpHeaders {
     return (
@@ -21,7 +22,7 @@ export function isRpcParams(obj: any, _argumentName?: string): obj is RpcParams 
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
-        isTransactionDigest(obj.method) as boolean &&
+        typeof obj.method === "string" &&
         Array.isArray(obj.args)
     )
 }
@@ -32,7 +33,7 @@ export function isValidResponse(obj: any, _argumentName?: string): obj is ValidR
             typeof obj === "object" ||
             typeof obj === "function") &&
         obj.jsonrpc === "2.0" &&
-        isTransactionDigest(obj.id) as boolean
+        typeof obj.id === "string"
     )
 }
 
@@ -42,10 +43,10 @@ export function isErrorResponse(obj: any, _argumentName?: string): obj is ErrorR
             typeof obj === "object" ||
             typeof obj === "function") &&
         obj.jsonrpc === "2.0" &&
-        isTransactionDigest(obj.id) as boolean &&
+        typeof obj.id === "string" &&
         (obj.error !== null &&
             typeof obj.error === "object" ||
             typeof obj.error === "function") &&
-        isTransactionDigest(obj.error.message) as boolean
+        typeof obj.error.message === "string"
     )
 }

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -209,7 +209,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     try {
       const tx = {
         Publish: {
-          modules: t.compiledModules as Iterable<Iterable<number>>,
+          modules: t.compiledModules as ArrayLike<ArrayLike<number>>,
         },
       };
       return await this.constructTransactionData(

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isTransactionBytes } from '../../index.guard';
+import { isTransactionBytes } from '../../types/index.guard';
 import { JsonRpcClient } from '../../rpc/client';
 import { Base64DataBuffer } from '../../serialization/base64';
 import { SuiAddress } from '../../types';

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -83,7 +83,7 @@ export interface PublishTransaction {
    *
    * Each module should be represented as a sequence of bytes.
    */
-  compiledModules: Iterable<string> | Iterable<Iterable<number>>;
+  compiledModules: ArrayLike<string> | ArrayLike<ArrayLike<number>>;
   gasPayment?: ObjectId;
   gasBudget: number;
 }

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -1,204 +1,13 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable */
+
 /*
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { Ed25519KeypairData, Keypair, PublicKeyInitData, PublicKeyData, SignatureScheme, TransferObjectTransaction, TransferSuiTransaction, MergeCoinTransaction, SplitCoinTransaction, MoveCallTransaction, PublishTransaction, TxnDataSerializer, SignaturePubkeyPair, Signer, TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
-import { BN } from "bn.js";
-import { Buffer } from "buffer";
-import { Base64DataBuffer } from "./serialization/base64";
-import { PublicKey } from "./cryptography/publickey";
-
-export function isEd25519KeypairData(obj: any, _argumentName?: string): obj is Ed25519KeypairData {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        obj.publicKey instanceof Uint8Array &&
-        obj.secretKey instanceof Uint8Array
-    )
-}
-
-export function isKeypair(obj: any, _argumentName?: string): obj is Keypair {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        typeof obj.getPublicKey === "function" &&
-        typeof obj.signData === "function"
-    )
-}
-
-export function isPublicKeyInitData(obj: any, _argumentName?: string): obj is PublicKeyInitData {
-    return (
-        (isTransactionDigest(obj) as boolean ||
-            isSuiMoveTypeParameterIndex(obj) as boolean ||
-            obj instanceof Buffer ||
-            obj instanceof Uint8Array ||
-            Array.isArray(obj) &&
-            obj.every((e: any) =>
-                isSuiMoveTypeParameterIndex(e) as boolean
-            ) ||
-            isPublicKeyData(obj) as boolean)
-    )
-}
-
-export function isPublicKeyData(obj: any, _argumentName?: string): obj is PublicKeyData {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        obj._bn instanceof BN
-    )
-}
-
-export function isSignatureScheme(obj: any, _argumentName?: string): obj is SignatureScheme {
-    return (
-        (obj === "ED25519" ||
-            obj === "Secp256k1")
-    )
-}
-
-export function isTransferObjectTransaction(obj: any, _argumentName?: string): obj is TransferObjectTransaction {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isTransactionDigest(obj.objectId) as boolean &&
-        (typeof obj.gasPayment === "undefined" ||
-            isTransactionDigest(obj.gasPayment) as boolean) &&
-        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean &&
-        isTransactionDigest(obj.recipient) as boolean
-    )
-}
-
-export function isTransferSuiTransaction(obj: any, _argumentName?: string): obj is TransferSuiTransaction {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isTransactionDigest(obj.suiObjectId) as boolean &&
-        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean &&
-        isTransactionDigest(obj.recipient) as boolean &&
-        (obj.amount === null ||
-            isSuiMoveTypeParameterIndex(obj.amount) as boolean)
-    )
-}
-
-export function isMergeCoinTransaction(obj: any, _argumentName?: string): obj is MergeCoinTransaction {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isTransactionDigest(obj.primaryCoin) as boolean &&
-        isTransactionDigest(obj.coinToMerge) as boolean &&
-        (typeof obj.gasPayment === "undefined" ||
-            isTransactionDigest(obj.gasPayment) as boolean) &&
-        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean
-    )
-}
-
-export function isSplitCoinTransaction(obj: any, _argumentName?: string): obj is SplitCoinTransaction {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isTransactionDigest(obj.coinObjectId) as boolean &&
-        Array.isArray(obj.splitAmounts) &&
-        obj.splitAmounts.every((e: any) =>
-            isSuiMoveTypeParameterIndex(e) as boolean
-        ) &&
-        (typeof obj.gasPayment === "undefined" ||
-            isTransactionDigest(obj.gasPayment) as boolean) &&
-        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean
-    )
-}
-
-export function isMoveCallTransaction(obj: any, _argumentName?: string): obj is MoveCallTransaction {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isTransactionDigest(obj.packageObjectId) as boolean &&
-        isTransactionDigest(obj.module) as boolean &&
-        isTransactionDigest(obj.function) as boolean &&
-        (Array.isArray(obj.typeArguments) &&
-            obj.typeArguments.every((e: any) =>
-                isTransactionDigest(e) as boolean
-            ) ||
-            Array.isArray(obj.typeArguments) &&
-            obj.typeArguments.every((e: any) =>
-                isTypeTag(e) as boolean
-            )) &&
-        (Array.isArray(obj.arguments) &&
-            obj.arguments.every((e: any) =>
-                isSuiJsonValue(e) as boolean
-            ) ||
-            Array.isArray(obj.arguments) &&
-            obj.arguments.every((e: any) =>
-                isCallArg(e) as boolean
-            )) &&
-        (typeof obj.gasPayment === "undefined" ||
-            isTransactionDigest(obj.gasPayment) as boolean) &&
-        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean
-    )
-}
-
-export function isPublishTransaction(obj: any, _argumentName?: string): obj is PublishTransaction {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        ((obj.compiledModules !== null &&
-            typeof obj.compiledModules === "object" ||
-            typeof obj.compiledModules === "function") &&
-            typeof obj.compiledModules["__@iterator"] === "function" ||
-            (obj.compiledModules !== null &&
-                typeof obj.compiledModules === "object" ||
-                typeof obj.compiledModules === "function") &&
-            typeof obj.compiledModules["__@iterator"] === "function") &&
-        (typeof obj.gasPayment === "undefined" ||
-            isTransactionDigest(obj.gasPayment) as boolean) &&
-        isSuiMoveTypeParameterIndex(obj.gasBudget) as boolean
-    )
-}
-
-export function isTxnDataSerializer(obj: any, _argumentName?: string): obj is TxnDataSerializer {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        typeof obj.newTransferObject === "function" &&
-        typeof obj.newTransferSui === "function" &&
-        typeof obj.newMoveCall === "function" &&
-        typeof obj.newMergeCoin === "function" &&
-        typeof obj.newSplitCoin === "function" &&
-        typeof obj.newPublish === "function"
-    )
-}
-
-export function isSignaturePubkeyPair(obj: any, _argumentName?: string): obj is SignaturePubkeyPair {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isSignatureScheme(obj.signatureScheme) as boolean &&
-        obj.signature instanceof Base64DataBuffer &&
-        obj.pubKey instanceof PublicKey
-    )
-}
-
-export function isSigner(obj: any, _argumentName?: string): obj is Signer {
-    return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        typeof obj.getAddress === "function" &&
-        typeof obj.signData === "function"
-    )
-}
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -1160,7 +969,7 @@ export function isPublishTx(obj: any, _argumentName?: string): obj is PublishTx 
         (obj.Publish.modules !== null &&
             typeof obj.Publish.modules === "object" ||
             typeof obj.Publish.modules === "function") &&
-        typeof obj.Publish.modules["__@iterator"] === "function"
+        isSuiMoveTypeParameterIndex(obj.Publish.modules.length) as boolean
     )
 }
 
@@ -1185,7 +994,7 @@ export function isCallArg(obj: any, _argumentName?: string): obj is CallArg {
             (obj.Pure !== null &&
                 typeof obj.Pure === "object" ||
                 typeof obj.Pure === "function") &&
-            typeof obj.Pure["__@iterator"] === "function" ||
+            isSuiMoveTypeParameterIndex(obj.Pure.length) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -56,7 +56,7 @@ export type SuiMoveNormalizedModule = {
   friends: SuiMoveModuleId[];
   structs: Record<string, SuiMoveNormalizedStruct>;
   exposed_functions: Record<string, SuiMoveNormalizedFunction>;
-}
+};
 
 export type SuiMoveModuleId = {
   address: string;
@@ -67,17 +67,17 @@ export type SuiMoveNormalizedStruct = {
   abilities: SuiMoveAbilitySet;
   type_parameters: SuiMoveStructTypeParameter[];
   fields: SuiMoveNormalizedField[];
-}
+};
 
 export type SuiMoveStructTypeParameter = {
   constraints: SuiMoveAbilitySet;
   is_phantom: boolean;
-}
+};
 
 export type SuiMoveNormalizedField = {
   name: string;
   type_: SuiMoveNormalizedType;
-}
+};
 
 export type SuiMoveNormalizedFunction = {
   visibility: SuiMoveVisibility;
@@ -87,30 +87,28 @@ export type SuiMoveNormalizedFunction = {
   return_: SuiMoveNormalizedType[];
 };
 
-export type SuiMoveVisibility = 
-  | "Private"
-  | "Public"
-  | "Friend";
+export type SuiMoveVisibility = 'Private' | 'Public' | 'Friend';
 
 export type SuiMoveTypeParameterIndex = number;
 
 export type SuiMoveAbilitySet = {
-  abilities: string[],
+  abilities: string[];
 };
 
-export type SuiMoveNormalizedType = (
+export type SuiMoveNormalizedType =
   | string
-  | {TypeParameter: SuiMoveTypeParameterIndex}
-  | {Reference: SuiMoveNormalizedType}
-  | {MutableReference: SuiMoveNormalizedType}
-  | {Vector: SuiMoveNormalizedType}
-  | {Struct: {
-    address: string,
-    module: string,
-    name: string,
-    type_arguments: SuiMoveNormalizedType[],
-  }}
-);
+  | { TypeParameter: SuiMoveTypeParameterIndex }
+  | { Reference: SuiMoveNormalizedType }
+  | { MutableReference: SuiMoveNormalizedType }
+  | { Vector: SuiMoveNormalizedType }
+  | {
+      Struct: {
+        address: string;
+        module: string;
+        name: string;
+        type_arguments: SuiMoveNormalizedType[];
+      };
+    };
 
 export type SuiObject = {
   /** The meat of the object */

--- a/sdk/typescript/src/types/option.ts
+++ b/sdk/typescript/src/types/option.ts
@@ -1,16 +1,23 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export type Option<T> = T | {
-    fields: {
+export type Option<T> =
+  | T
+  | {
+      fields: {
         vec: '';
+      };
+      type: string;
     };
-    type: string;
-}
 
 export function getOption<T>(option: Option<T>): T | undefined {
-    if (typeof option === 'object' && option !== null && 'type' in option && option.type.startsWith('0x1::option::Option<')) {
-        return undefined;
-    }
-    return option as T;
+  if (
+    typeof option === 'object' &&
+    option !== null &&
+    'type' in option &&
+    option.type.startsWith('0x1::option::Option<')
+  ) {
+    return undefined;
+  }
+  return option as T;
 }

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -18,8 +18,8 @@ bcs
       let bytes = Array.from(Buffer.from(str));
       return writer.writeVec(bytes, (writer, el) => writer.write8(el));
     },
-    reader => {
-      let bytes = reader.readVec(reader => reader.read8());
+    (reader) => {
+      let bytes = reader.readVec((reader) => reader.read8());
       return Buffer.from(bytes).toString('utf-8');
     }
   )
@@ -29,8 +29,8 @@ bcs
       let bytes = Array.from(decodeStr(str, 'base64'));
       return writer.writeVec(bytes, (writer, el) => writer.write8(el));
     },
-    reader => {
-      let bytes = reader.readVec(reader => reader.read8());
+    (reader) => {
+      let bytes = reader.readVec((reader) => reader.read8());
       return encodeStr(new Uint8Array(bytes), 'base64');
     }
   );
@@ -98,7 +98,7 @@ bcs.registerStructType('TransferSuiTx', {
  */
 export type PublishTx = {
   Publish: {
-    modules: Iterable<Iterable<number>>;
+    modules: ArrayLike<ArrayLike<number>>;
   };
 };
 
@@ -132,7 +132,7 @@ export type ObjectArg = { ImmOrOwned: SuiObjectRef } | { Shared: string };
  * For `Pure` arguments BCS is required. You must encode the values with BCS according
  * to the type required by the called function. Pure accepts only serialized values
  */
-export type CallArg = { Pure: Iterable<number> } | { Object: ObjectArg };
+export type CallArg = { Pure: ArrayLike<number> } | { Object: ObjectArg };
 
 bcs
   .registerEnumType('ObjectArg', {

--- a/sdk/typescript/test/rpc/client.test.ts
+++ b/sdk/typescript/test/rpc/client.test.ts
@@ -9,7 +9,7 @@ import {
   MOCK_ENDPOINT,
   MOCK_PORT,
 } from '../mocks/rpc-http';
-import { isGetOwnedObjectsResponse } from '../../src/index.guard';
+import { isGetOwnedObjectsResponse } from '../../src/types/index.guard';
 import { SuiObjectInfo } from '../../src';
 
 const EXAMPLE_OBJECT: SuiObjectInfo = {

--- a/sdk/typescript/test/types/objects.test.ts
+++ b/sdk/typescript/test/types/objects.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import mockObjectData from '@mysten/sui-open-rpc/samples/objects.json';
 
-import { isGetObjectDataResponse } from '../../src/index.guard';
+import { isGetObjectDataResponse } from '../../src/types/index.guard';
 
 describe('Test Objects Definition', () => {
   it('Test against different object definitions', () => {

--- a/sdk/typescript/test/types/transactions.test.ts
+++ b/sdk/typescript/test/types/transactions.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from 'vitest';
 import mockTransactionData from '@mysten/sui-open-rpc/samples/transactions.json';
 
-import { isSuiTransactionResponse } from '../../src/index.guard';
+import { isSuiTransactionResponse } from '../../src/types/index.guard';
 
 describe('Test Transaction Definition', () => {
   it('Test against different transaction definitions', () => {

--- a/sdk/typescript/type_guards.mjs
+++ b/sdk/typescript/type_guards.mjs
@@ -4,9 +4,9 @@
 import { readFile, writeFile } from 'fs/promises';
 import { generate } from 'ts-auto-guard';
 
-const GUARD_FILES = ['src/rpc/client.guard.ts', 'src/index.guard.ts'];
+const GUARD_FILES = ['src/rpc/client.guard.ts', 'src/types/index.guard.ts'];
 const LICENSE =
-  '// Copyright (c) 2022, Mysten Labs, Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n';
+  '// Copyright (c) 2022, Mysten Labs, Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n/* eslint-disable */\n\n';
 
 async function main() {
   const tsconfig = new URL('./tsconfig.json', import.meta.url);
@@ -17,7 +17,7 @@ async function main() {
 
   await generate({
     project: tsconfig.pathname,
-    paths: ['src/rpc/client.ts', 'src/**.ts'],
+    paths: ['src/rpc/client.ts', 'src/types/index.ts'],
     processOptions: {
       exportAll: true,
     },


### PR DESCRIPTION
The `ts-auto-guard` generation was causing a lot of warning messages during build, due to it .

The only really interesting thing here is swapping the `Iterable` definition for `ArrayLike`. From what I can tell this should cover all of the expected usage of the module, and it silences a warning from `ts-auto-guard` about how iterables generate function definitions.