### PR TITLE
[ts-sdk] Fix publishing due to sui-open-rpc issue

### DIFF
--- a/crates/sui-open-rpc/package.json
+++ b/crates/sui-open-rpc/package.json
@@ -1,4 +1,0 @@
-{
-	"name": "@mysten/sui-open-rpc",
-	"private": true
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,6 @@ importers:
     devDependencies:
       '@changesets/cli': 2.24.3
 
-  crates/sui-open-rpc:
-    specifiers: {}
-
   explorer/client:
     specifiers:
       '@mysten/sui.js': workspace:*
@@ -122,7 +119,7 @@ importers:
   sdk/typescript:
     specifiers:
       '@mysten/bcs': workspace:*
-      '@mysten/sui-open-rpc': workspace:*
+      '@mysten/sui-open-rpc': file:../../crates/sui-open-rpc
       '@size-limit/preset-small-lib': ^7.0.8
       '@types/bn.js': ^5.1.0
       '@types/lossless-json': ^1.0.1
@@ -158,7 +155,7 @@ importers:
       lossless-json: 1.0.5
       tweetnacl: 1.0.3
     devDependencies:
-      '@mysten/sui-open-rpc': link:../../crates/sui-open-rpc
+      '@mysten/sui-open-rpc': file:crates/sui-open-rpc
       '@size-limit/preset-small-lib': 7.0.8_size-limit@7.0.8
       '@types/bn.js': 5.1.0
       '@types/lossless-json': 1.0.1
@@ -13870,4 +13867,10 @@ packages:
 
   /zstd-codec/0.1.4:
     resolution: {integrity: sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==}
+    dev: true
+
+  file:crates/sui-open-rpc:
+    resolution: {directory: crates/sui-open-rpc, type: directory}
+    name: sui-open-rpc
+    version: 0.0.0
     dev: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,3 @@ packages:
   - "sdk/**"
   - "explorer/**"
   - "wallet/**"
-  - "crates/sui-open-rpc"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -59,7 +59,7 @@
     }
   ],
   "devDependencies": {
-    "@mysten/sui-open-rpc": "workspace:*",
+    "@mysten/sui-open-rpc": "file:../../crates/sui-open-rpc",
     "@size-limit/preset-small-lib": "^7.0.8",
     "@types/bn.js": "^5.1.0",
     "@types/lossless-json": "^1.0.1",

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@mysten/bcs': new URL('./bcs/src', import.meta.url).toString(),
+      '@mysten/sui-open-rpc': new URL(
+        '../../crates/sui-open-rpc',
+        import.meta.url
+      ).toString(),
     },
   },
 });


### PR DESCRIPTION
It turns out that the workspace dependency into a private package can cause publishing issues. This uses a file dependency, which isn't the most ideal, but at least resolves this issue.