### PR TITLE
[Explorer] Removes Become a Validator link

### DIFF
--- a/explorer/client/src/components/validator-map/ValidatorMap.tsx
+++ b/explorer/client/src/components/validator-map/ValidatorMap.tsx
@@ -6,7 +6,6 @@ import { ParentSizeModern } from '@visx/responsive';
 import { TooltipWithBounds, useTooltip } from '@visx/tooltip';
 import React, { useCallback, useMemo } from 'react';
 
-import { ReactComponent as ForwardArrowDark } from '../../assets/SVGIcons/forward-arrow-dark.svg';
 import { WorldMap } from './WorldMap';
 import { type NodeLocation } from './types';
 
@@ -121,14 +120,6 @@ export default function ValidatorMap() {
                         <div className={styles.stat}>{countryCount}</div>
                     </div>
                 </div>
-
-                <a
-                    href="https://bit.ly/sui_validator"
-                    className={styles.button}
-                >
-                    <span>Become a Validator</span>
-                    <ForwardArrowDark />
-                </a>
             </div>
 
             <div className={styles.mapcontainer}>


### PR DESCRIPTION
This PR removes the `Become a Validator` button following feedback from Ben Holcomb (@bholc646 ).

### Before
![image](https://user-images.githubusercontent.com/11377188/187877539-1cee64ae-b76a-43a0-9618-eb5ce3dfb71c.png)

### After
![image](https://user-images.githubusercontent.com/11377188/187877647-ef0fba62-68f6-4a75-a5af-15e0c2f0b02a.png)

### Here's the new look on mobile:
![image](https://user-images.githubusercontent.com/11377188/187877750-058ed748-6036-413d-8654-807454bdda96.png)

