### PR TITLE
Fix reconfig_end_to_end_tests

### DIFF
--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -26,7 +26,7 @@ use test_utils::objects::{generate_gas_object_with_balance, test_gas_objects};
 use test_utils::test_account_keys;
 use test_utils::transaction::submit_shared_object_transaction;
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn reconfig_end_to_end_tests() {
     telemetry_subscribers::init_for_testing();
 


### PR DESCRIPTION
When this test is running narwhal gets stuck and does not produce new commits.
Turn out this can be fixed if we start tokio clock for the test :)

Close #4337