### PR TITLE
Remove start_paused from tests

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -14,7 +14,7 @@ use sui_types::messages::ExecutionStatus;
 
 use crate::checkpoints::checkpoint_tests::checkpoint_tests_setup;
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn checkpoint_active_flow_happy_path() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();
@@ -91,7 +91,7 @@ async fn checkpoint_active_flow_happy_path() {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn checkpoint_active_flow_crash_client_with_gossip() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();
@@ -188,7 +188,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn checkpoint_active_flow_crash_client_no_gossip() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();
@@ -285,7 +285,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_empty_checkpoint() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -20,7 +20,7 @@ use crate::test_utils::wait_for_tx;
 
 use tracing::info;
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn pending_exec_storage_notify() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();
@@ -103,7 +103,7 @@ async fn pending_exec_storage_notify() {
     assert_eq!(num_certs, certs_back.len());
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn pending_exec_full() {
     // use telemetry_subscribers::init_for_testing;
     // init_for_testing();

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -10,7 +10,7 @@ use crate::authority_aggregator::AuthorityAggregator;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 pub async fn test_gossip_plain() {
     let action_sequence = vec![
         BatchAction::EmitUpdateItem(),
@@ -40,7 +40,7 @@ pub async fn test_gossip_plain() {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 pub async fn test_gossip_error() {
     let action_sequence = vec![BatchAction::EmitError(), BatchAction::EmitUpdateItem()];
 
@@ -66,7 +66,7 @@ pub async fn test_gossip_error() {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 pub async fn test_gossip_after_revert() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -974,7 +974,7 @@ async fn test_batch_to_checkpointing() {
     _join.await.expect("No errors in task").expect("ok");
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_batch_to_checkpointing_init_crash() {
     // Create a random directory to store the DB
     let dir = env::temp_dir();
@@ -1661,7 +1661,7 @@ pub async fn checkpoint_tests_setup(
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn checkpoint_messaging_flow_bug() {
     let mut setup = checkpoint_tests_setup(5, Duration::from_millis(500), true).await;
 
@@ -1674,7 +1674,7 @@ async fn checkpoint_messaging_flow_bug() {
         .expect("All ok.");
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn checkpoint_messaging_flow() {
     let mut setup = checkpoint_tests_setup(5, Duration::from_millis(500), true).await;
 
@@ -1830,7 +1830,7 @@ async fn checkpoint_messaging_flow() {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_no_more_fragments() {
     let mut setup = checkpoint_tests_setup(5, Duration::from_millis(500), true).await;
 

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -412,7 +412,7 @@ mod test {
         Arc::new(NodeSyncStore::open_tables_read_write(db_path, None, None))
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_follower() {
         telemetry_subscribers::init_for_testing();
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1044,7 +1044,7 @@ impl<F: Future> Future for LimitedPoll<F> {
     }
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_handle_certificate_interrupted_retry() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -277,7 +277,7 @@ async fn test_batch_manager_out_of_order() {
     _join.await.expect("No errors in task").expect("ok");
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_batch_manager_drop_out_of_order() {
     // Create a random directory to store the DB
     let dir = env::temp_dir();

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -90,7 +90,7 @@ async fn test_simple_request() {
     client.handle_object_info_request(req).await.unwrap();
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_subscription() {
     let sender = dbg_addr(1);
     let object_id = dbg_object_id(1);
@@ -286,7 +286,7 @@ async fn test_subscription() {
     state.batch_notifier.close();
 }
 
-#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[tokio::test(flavor = "current_thread")]
 async fn test_subscription_safe_client() {
     let sender = dbg_addr(1);
     let object_id = dbg_object_id(1);


### PR DESCRIPTION
It turns out that narwhal does not work well with `start_paused=true`, this PR attempts to remove it from the tests.

Not all of those tests necessarily use narwhal, but I think if those tests pass it is ok to just remove it from all of them since it is redundant.