### PR TITLE
[Explorer] Fixes text overhang in failure message in Transaction Results Page

### DIFF
--- a/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
+++ b/explorer/client/src/pages/transaction-result/TxResultHeader.module.css
@@ -23,7 +23,7 @@
 }
 
 .failed {
-    @apply bg-[#EB5A291A] capitalize text-sm font-sans text-[#B94118] font-normal p-0.5 pr-3 pl-3 rounded-[10px] inline-block m-0 mt-1;
+    @apply bg-[#EB5A291A] capitalize text-sm font-sans text-[#B94118] font-normal p-0.5 pr-3 pl-3 rounded-[10px] inline-block m-0 mt-1 break-all;
 
     box-sizing: border-box;
 }


### PR DESCRIPTION
Current
![image](https://user-images.githubusercontent.com/11377188/188426523-fb8ee706-dc92-43e9-b122-70cec8f622e8.png)

Before
![image](https://user-images.githubusercontent.com/11377188/188426918-6994aa4f-70b8-404b-8e92-d2498f1f5892.png)

