### PR TITLE
[sdk]: Replace underlying storage of PublicKey with Uint8Array

### DIFF
--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -84,8 +84,6 @@ export class PublicKey implements PublicKeyData {
         this._buffer = buffer;
       } else if (value instanceof Uint8Array) {
         this._buffer = value;
-      } else if (Array.isArray(value)) {
-        this._buffer = Uint8Array.from(value);
       } else {
         this._buffer = Uint8Array.from(value);
       }

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -9,18 +9,20 @@ import { sha3_256 } from 'js-sha3';
  */
 export type PublicKeyInitData =
   | string
-  | Buffer
   | Uint8Array
-  | Array<number>
+  | Iterable<number>
   | PublicKeyData;
 
-const zeroPadBuffer = (buffer: Uint8Array, length: number): Uint8Array => {
+const zeroPadBuffer = (
+  buffer: Uint8Array,
+  minimumLength: number
+): Uint8Array => {
   // Short circuit if the buffer is already the correct length.
-  if (buffer.length === length) {
+  if (buffer.byteLength >= minimumLength) {
     return buffer;
   }
-  const next = new Uint8Array(length);
-  Buffer.from(buffer).copy(next, length - buffer.length);
+  const next = new Uint8Array(minimumLength);
+  next.set(buffer, minimumLength - buffer.byteLength);
   return next;
 };
 

--- a/sdk/typescript/src/cryptography/publickey.ts
+++ b/sdk/typescript/src/cryptography/publickey.ts
@@ -78,9 +78,9 @@ export class PublicKey implements PublicKeyData {
     } else {
       if (typeof value === 'string') {
         const buffer = Buffer.from(value, 'base64');
-        if (buffer.length !== 32) {
+        if (buffer.length !== PUBLIC_KEY_SIZE) {
           throw new Error(
-            `Invalid public key input. Expected 32 bytes, got ${buffer.length}`
+            `Invalid public key input. Expected ${PUBLIC_KEY_SIZE} bytes, got ${buffer.length}`
           );
         }
         this._buffer = buffer;


### PR DESCRIPTION
Replaces the underlying storage of PublicKey with Uint8Array instead of BN.js.

This improves serialization speed and removes the dependency on BN.js.

