### PR TITLE
[reconfig] Allow sync last checkpoint tx when validator is halted

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -513,13 +513,15 @@ impl AuthorityState {
         }
     }
 
-    /// Execute a certificate that's know to have already finalized (i.e. executed by a quorum of
-    /// validators). For such certificate, we don't have to wait for consensus to set shared object
+    /// Execute a certificate that's known to have correct effects.
+    /// For such certificate, we don't have to wait for consensus to set shared object
     /// locks because we already know the shared object versions based on the effects.
     /// This function can be called either by a fullnode after seeing a quorum of signed effects,
     /// or by a validator after seeing the certificate included by a certified checkpoint.
+    /// TODO: down the road, we may want to execute a shared object tx on a validator when f+1
+    /// validators have executed it.
     #[instrument(level = "trace", skip_all)]
-    pub async fn handle_finalized_certificate(
+    pub async fn handle_certificate_with_effects(
         &self,
         certificate: CertifiedTransaction,
         // Signed effects is signed by only one validator, it is not a
@@ -531,7 +533,7 @@ impl AuthorityState {
     ) -> SuiResult {
         let _metrics_guard = start_timer(self.metrics.handle_node_sync_certificate_latency.clone());
         let digest = *certificate.digest();
-        debug!(?digest, "handle_finalized_certificate");
+        debug!(?digest, "handle_certificate_with_effects");
         fp_ensure!(
             signed_effects.effects.transaction_digest == digest,
             SuiError::ErrorWhileProcessingConfirmationTransaction {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -506,8 +506,10 @@ impl CheckpointStore {
 
         // Send to consensus for sequencing.
         if let Some(sender) = &self.sender {
-            debug!("Send fragment: {} -- {}", self.name, other_name);
+            let seq = fragment.proposer.summary.sequence_number;
+            debug!(cp_seq=?seq, "Sending fragment: {} -- {}", self.name, other_name);
             sender.send_to_consensus(fragment.clone())?;
+            debug!(cp_seq=?seq, "Fragment successfully sent: {} -- {}", self.name, other_name);
         } else {
             return Err(SuiError::from("No consensus sender configured"));
         }

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -102,6 +102,13 @@ impl DigestsMessage {
         }
     }
 
+    fn new_for_pending_ckpt(digest: &TransactionDigest, tx: oneshot::Sender<SyncResult>) -> Self {
+        Self {
+            sync_arg: SyncArg::PendingCheckpoint(*digest),
+            tx: Some(tx),
+        }
+    }
+
     fn new_for_exec_driver(digest: &TransactionDigest, tx: oneshot::Sender<SyncResult>) -> Self {
         Self {
             sync_arg: SyncArg::ExecDriver(*digest),
@@ -140,6 +147,13 @@ pub enum SyncArg {
     /// In checkpoint mode, all txes are known to be final.
     Checkpoint(ExecutionDigests),
 
+    /// Transactions in the current checkpoint to be signed/stored.
+    /// We don't have the effect digest since we may not have it when constructing the checkpoint.
+    /// The primary difference between PendingCheckpoint and ExecDriver is that PendingCheckpoint
+    /// sync can by-pass validator halting. This is to ensure that the last checkpoint of the epoch
+    /// can always be formed when there are missing transactions.
+    PendingCheckpoint(TransactionDigest),
+
     /// Used by the execution driver to execute pending certs. No effects digest is provided,
     /// because this mode is used on validators only, who must compute the effects digest
     /// themselves - they cannot trust some other validator's version of the effects because that
@@ -165,7 +179,9 @@ impl SyncArg {
                     effects,
                 },
             ) => (transaction, Some(effects)),
-            SyncArg::Parent(digest) | SyncArg::ExecDriver(digest) => (digest, None),
+            SyncArg::Parent(digest)
+            | SyncArg::ExecDriver(digest)
+            | SyncArg::PendingCheckpoint(digest) => (digest, None),
         }
     }
 }
@@ -417,7 +433,7 @@ where
 
         match self
             .state
-            .handle_node_sync_certificate(cert.clone(), effects.clone())
+            .handle_finalized_certificate(cert.clone(), effects.clone())
             .await
         {
             Ok(_) => Ok(SyncStatus::CertExecuted),
@@ -429,11 +445,19 @@ where
         &self,
         permit: OwnedSemaphorePermit,
         digest: &TransactionDigest,
+        bypass_validator_halt: bool,
     ) -> SyncResult {
         trace!(?digest, "validator pending execution requested");
         let cert = self.get_cert(digest).await?;
 
-        match self.state.handle_certificate(cert.clone()).await {
+        let result = if bypass_validator_halt {
+            self.state
+                .handle_certificate_bypass_validator_halt(cert.clone())
+                .await
+        } else {
+            self.state.handle_certificate(cert.clone()).await
+        };
+        match result {
             Ok(_) => Ok(SyncStatus::CertExecuted),
             Err(SuiError::ObjectNotFound { .. })
             | Err(SuiError::ObjectErrors { .. })
@@ -451,7 +475,13 @@ where
 
                 // Parents have been executed, so this should now succeed.
                 debug!(?digest, "parents executed, re-attempting cert");
-                self.state.handle_certificate(cert.clone()).await?;
+                if bypass_validator_halt {
+                    self.state
+                        .handle_certificate_bypass_validator_halt(cert.clone())
+                        .await
+                } else {
+                    self.state.handle_certificate(cert.clone()).await
+                }?;
                 Ok(SyncStatus::CertExecuted)
             }
             Err(e) => Err(e),
@@ -490,7 +520,12 @@ where
         // down.
         let (digests, authorities_with_cert) = match arg {
             SyncArg::ExecDriver(digest) => {
-                return self.process_exec_driver_digest(permit, &digest).await;
+                return self
+                    .process_exec_driver_digest(permit, &digest, false)
+                    .await;
+            }
+            SyncArg::PendingCheckpoint(digest) => {
+                return self.process_exec_driver_digest(permit, &digest, true).await;
             }
             SyncArg::Parent(digest) => {
                 // digest is known to be final because it appeared in the dependencies list of a
@@ -566,7 +601,7 @@ where
             .await?;
 
         self.state
-            .handle_node_sync_certificate(cert, effects.clone())
+            .handle_finalized_certificate(cert, effects.clone())
             .await?;
 
         Ok(SyncStatus::CertExecuted)
@@ -869,7 +904,7 @@ impl NodeSyncHandle {
         let mut futures = FuturesOrdered::new();
         for digests in transactions {
             let (tx, rx) = oneshot::channel();
-            let msg = DigestsMessage::new_for_exec_driver(&digests.transaction, tx);
+            let msg = DigestsMessage::new_for_pending_ckpt(&digests.transaction, tx);
             Self::send_msg_with_tx(self.sender.clone(), msg).await?;
             futures.push_back(Self::map_rx(rx));
         }

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -433,7 +433,7 @@ where
 
         match self
             .state
-            .handle_finalized_certificate(cert.clone(), effects.clone())
+            .handle_certificate_with_effects(cert.clone(), effects.clone())
             .await
         {
             Ok(_) => Ok(SyncStatus::CertExecuted),
@@ -601,7 +601,7 @@ where
             .await?;
 
         self.state
-            .handle_finalized_certificate(cert, effects.clone())
+            .handle_certificate_with_effects(cert, effects.clone())
             .await?;
 
         Ok(SyncStatus::CertExecuted)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2425,7 +2425,7 @@ async fn test_consensus_message_processed() {
             handle_cert(&authority2, &certificate).await
         } else {
             authority2
-                .handle_finalized_certificate(certificate.clone(), effects1.clone())
+                .handle_certificate_with_effects(certificate.clone(), effects1.clone())
                 .await
                 .unwrap();
             authority2

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2425,7 +2425,7 @@ async fn test_consensus_message_processed() {
             handle_cert(&authority2, &certificate).await
         } else {
             authority2
-                .handle_node_sync_certificate(certificate.clone(), effects1.clone())
+                .handle_finalized_certificate(certificate.clone(), effects1.clone())
                 .await
                 .unwrap();
             authority2

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{NetworkConfig, NodeConfig, ValidatorInfo};
-use sui_core::authority_client::NetworkAuthorityClientMetrics;
+use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClientMetrics};
 use sui_core::epoch::epoch_store::EpochStore;
 use sui_core::{
     authority_active::{
@@ -21,6 +21,8 @@ use sui_core::{
 use sui_types::{committee::Committee, object::Object};
 
 pub use sui_node::SuiNode;
+use sui_types::base_types::ObjectID;
+use sui_types::messages::{ObjectInfoRequest, ObjectInfoRequestKind};
 
 /// The default network buffer size of a test authority.
 pub const NETWORK_BUFFER_SIZE: usize = 65_000;
@@ -139,4 +141,17 @@ pub fn get_client(config: &ValidatorInfo) -> NetworkAuthorityClient {
         Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
     )
     .unwrap()
+}
+
+pub async fn get_object(config: &ValidatorInfo, object_id: ObjectID) -> Object {
+    get_client(config)
+        .handle_object_info_request(ObjectInfoRequest {
+            object_id,
+            request_kind: ObjectInfoRequestKind::LatestObjectInfo(None),
+        })
+        .await
+        .unwrap()
+        .object()
+        .unwrap()
+        .clone()
 }


### PR DESCRIPTION
During reconfiguration, when the validators are halted, if we find out that we are missing some transactions from the last checkpoint, we need to be able to execute them. This PR adds a path that allows us to execute transactions even when the validator is halted, if we know for sure that the transaction has been finalized.
The code is becoming a bit messy and hard to reason about. I have some ideas to clean this up but would love to get feedback first. One way to make this easier to reason about is to define a ProofOfFinality struct, and then pass it into process certificate. This will at least allow us easily find out where the proof came from.