### PR TITLE
Count pending spawned tasks in authority_server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7139,6 +7139,7 @@ dependencies = [
  "node",
  "once_cell",
  "parking_lot 0.12.1",
+ "pin-project",
  "pretty_assertions",
  "prometheus",
  "rand 0.8.5",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -31,6 +31,7 @@ tokio-retry = "0.3"
 scopeguard = "1.1"
 once_cell = "1.13.1"
 tap = "1.0"
+pin-project = "1.0.12"
 
 sui-adapter = { path = "../sui-adapter" }
 sui-framework = { path = "../sui-framework" }

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -21,5 +21,6 @@ pub mod transaction_streamer;
 #[cfg(test)]
 pub mod test_utils;
 
+mod metrics;
 mod node_sync;
 mod query_helpers;

--- a/crates/sui-core/src/metrics.rs
+++ b/crates/sui-core/src/metrics.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use pin_project::{pin_project, pinned_drop};
+use prometheus::IntGauge;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+// TODO - this eventually needs to be moved to infra crate if proven useful
+#[pin_project(PinnedDrop)]
+pub struct Watchdog<W> {
+    #[pin]
+    inner: W,
+    gauge: IntGauge,
+}
+
+impl<W> Watchdog<W> {
+    pub fn new(gauge: IntGauge, inner: W) -> Self {
+        gauge.inc();
+        Self { inner, gauge }
+    }
+}
+
+impl<W: Future> Future for Watchdog<W> {
+    type Output = W::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.inner.poll(cx)
+    }
+}
+
+#[pinned_drop]
+impl<W> PinnedDrop for Watchdog<W> {
+    fn drop(self: Pin<&mut Self>) {
+        self.gauge.dec();
+    }
+}
+
+pub trait WatchdogFutureExt: Future + Sized {
+    fn watch_pending(self, gauge: IntGauge) -> Watchdog<Self> {
+        Watchdog::new(gauge, self)
+    }
+}
+
+impl<T: Future> WatchdogFutureExt for T {}


### PR DESCRIPTION
authority_server spawns tasks on each incoming request for transaction or certificate, this PR allows to monitor number of such pending tasks.