### PR TITLE
remove batch_info_request_start_seq and add follower_start_seq_num

### DIFF
--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -256,6 +256,10 @@ impl crate::authority::AuthorityState {
             metrics.follower_connections_concurrent.dec();
         });
 
+        metrics
+            .follower_start_seq_num
+            .observe(request.start.unwrap_or(0) as f64);
+
         // Register a subscriber to not miss any updates
         let subscriber = self.subscribe_batch();
 

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -242,10 +242,6 @@ impl AuthorityAPI for NetworkAuthorityClient {
         &self,
         request: BatchInfoRequest,
     ) -> Result<BatchInfoResponseItemStream, SuiError> {
-        self.metrics
-            .batch_info_request_start_seq
-            .observe(request.start.unwrap_or(0) as f64);
-
         let stream = self
             .client()
             .batch_info(request)
@@ -490,8 +486,6 @@ pub struct NetworkAuthorityClientMetrics {
     pub handle_object_info_request_latency: Histogram,
     pub handle_transaction_info_request_latency: Histogram,
     pub handle_checkpoint_request_latency: Histogram,
-
-    pub batch_info_request_start_seq: Histogram,
 }
 
 impl NetworkAuthorityClientMetrics {
@@ -530,12 +524,6 @@ impl NetworkAuthorityClientMetrics {
             handle_checkpoint_request_latency: register_histogram_with_registry!(
                 "handle_checkpoint_request_latency",
                 "Latency of handle checkpoint request",
-                registry
-            )
-            .unwrap(),
-            batch_info_request_start_seq: register_histogram_with_registry!(
-                "batch_info_request_start_seq",
-                "The start sequences of the batch info requests",
                 registry
             )
             .unwrap(),


### PR DESCRIPTION
1. remove `batch_info_request_start_seq` on the client side as it's not configured correctly. Instead we should use [`safe_client_follower_streaming_from_seq_number_by_address`](https://github.com/MystenLabs/sui/blob/main/crates/sui-core/src/safe_client.rs#L55) which is already there.
2. add `follower_start_seq_num` on the server side as a histogram with the proper bucket configs.