### PR TITLE
[checkpoint] Increase checkpoint timeout to 60s for e2e tests

### DIFF
--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -82,7 +82,7 @@ async fn wait_for_advance_to_next_checkpoint(
             false => sleep(Duration::from_secs(1)).await,
         }
         cnt += 1;
-        assert!(cnt <= 20);
+        assert!(cnt <= 60);
     }
 
     // Ensure all authorities moved to the next checkpoint sequence number.


### PR DESCRIPTION
20s is perhaps too short for the timeout to advance a checkpoint. This fails sometimes. Increase to 60s which we certainly should not cross over. If it does, it's worth looking into where it's stuck at.