### PR TITLE
[Dependencies]: Convert to packages for mysten-infra 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,9 +4683,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4294,7 +4294,8 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysten-network"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a#9deac015fbf66e24b6da9699630e06750eaa094a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e706e64bf9aeab7958ccc2de336e358c89869099f4e268d26833d5afd19f23fa"
 dependencies = [
  "bincode",
  "bytes",
@@ -4315,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e#d96230a9272c322a7eefac49708aadfff1eed77e"
+source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a#9deac015fbf66e24b6da9699630e06750eaa094a"
 dependencies = [
  "bincode",
  "bytes",
@@ -4335,8 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "name-variant"
-version = "1.0.0"
-source = "git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e#d96230a9272c322a7eefac49708aadfff1eed77e"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c053f5dc2372fc0489f34614d5064df83b42c9918b6df8f8d9410010d547f6"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -6987,13 +6989,13 @@ dependencies = [
  "sui-sdk",
  "sui-swarm",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "test-utils",
  "tokio",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
- "typed-store-macros",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-store-derive",
  "unescape",
  "workspace-hack 0.1.0",
 ]
@@ -7059,7 +7061,7 @@ dependencies = [
  "sui-quorum-driver",
  "sui-sdk",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "test-utils",
  "tokio",
@@ -7090,7 +7092,7 @@ dependencies = [
  "sui-sdk",
  "sui-swarm",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "test-utils",
  "tokio",
@@ -7155,7 +7157,7 @@ dependencies = [
  "move-package",
  "move-vm-runtime",
  "multiaddr",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "node",
  "once_cell",
  "parking_lot 0.12.1",
@@ -7179,7 +7181,7 @@ dependencies = [
  "sui-storage",
  "sui-types",
  "tap",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "test-fuzz",
  "test-utils",
@@ -7188,8 +7190,8 @@ dependencies = [
  "tokio-retry",
  "tokio-stream",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
- "typed-store-macros",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-store-derive",
  "types",
  "workspace-hack 0.1.0",
 ]
@@ -7247,7 +7249,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-node",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-utils",
  "thiserror",
  "tokio",
@@ -7314,7 +7316,7 @@ dependencies = [
  "clap 3.2.17",
  "futures",
  "move-package",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus",
  "serde 1.0.144",
  "sui-config",
@@ -7326,7 +7328,7 @@ dependencies = [
  "sui-node",
  "sui-sdk",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-utils",
  "tokio",
  "tracing",
@@ -7411,7 +7413,7 @@ name = "sui-network"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sui-types",
  "tonic",
  "tonic-build 0.7.2 (git+https://github.com/hyperium/tonic.git?rev=de2e4ac077c076736dc451f3415ea7da1a61a560)",
@@ -7430,7 +7432,7 @@ dependencies = [
  "jemalloc-ctl",
  "jemallocator",
  "multiaddr",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.12.1",
  "prometheus",
  "sui-config",
@@ -7441,10 +7443,10 @@ dependencies = [
  "sui-storage",
  "sui-telemetry",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "workspace-hack 0.1.0",
 ]
 
@@ -7558,13 +7560,13 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-types",
  "tap",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
  "tokio-stream",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
- "typed-store-macros",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-store-derive",
  "workspace-hack 0.1.0",
 ]
 
@@ -7574,14 +7576,14 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus",
  "rand 0.8.5",
  "sui-config",
  "sui-node",
  "sui-types",
  "tap",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
  "tonic-health",
@@ -7631,7 +7633,7 @@ dependencies = [
  "executor",
  "eyre",
  "futures",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb",
  "serde 1.0.144",
  "serde_with 1.14.0",
@@ -7641,13 +7643,13 @@ dependencies = [
  "sui-core",
  "sui-storage",
  "sui-types",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "textwrap 0.15.0",
  "tokio",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
- "typed-store-macros",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-store-derive",
  "workspace-hack 0.1.0",
 ]
 
@@ -7722,7 +7724,7 @@ dependencies = [
  "thiserror",
  "tonic",
  "tracing",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "workspace-hack 0.1.0",
  "zeroize",
 ]
@@ -7824,7 +7826,8 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a#9deac015fbf66e24b6da9699630e06750eaa094a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5997cf07ccebedf30d53f94effb0c992b655278e4777d71762aada8766b027"
 dependencies = [
  "crossterm 0.25.0",
  "once_cell",
@@ -7843,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "telemetry-subscribers"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e#d96230a9272c322a7eefac49708aadfff1eed77e"
+source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a#9deac015fbf66e24b6da9699630e06750eaa094a"
 dependencies = [
  "crossterm 0.25.0",
  "once_cell",
@@ -8614,7 +8617,8 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 [[package]]
 name = "typed-store"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a#9deac015fbf66e24b6da9699630e06750eaa094a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21224c183bca74b370af8d75fcf32e0b1a98b33c56ae01248c099ec8c793c511"
 dependencies = [
  "bincode",
  "collectable",
@@ -8632,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e#d96230a9272c322a7eefac49708aadfff1eed77e"
+source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a#9deac015fbf66e24b6da9699630e06750eaa094a"
 dependencies = [
  "bincode",
  "collectable",
@@ -8648,9 +8652,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-store-macros"
-version = "0.0.0"
-source = "git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e#d96230a9272c322a7eefac49708aadfff1eed77e"
+name = "typed-store-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758c580e0d0c055fa619f4438aa4ca5e9f80df01c9a8a2de323d789cdc8316fa"
 dependencies = [
  "eyre",
  "fdlimit",
@@ -8661,7 +8666,6 @@ dependencies = [
  "syn 1.0.99",
  "tempfile",
  "tokio",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
 ]
 
 [[package]]
@@ -9633,8 +9637,8 @@ dependencies = [
  "multihash",
  "multihash-derive",
  "multimap",
+ "mysten-network 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mysten-network 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a)",
- "mysten-network 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
  "name-variant",
  "named-lock",
  "nested",
@@ -9862,8 +9866,8 @@ dependencies = [
  "tap",
  "target-lexicon",
  "target-spec",
+ "telemetry-subscribers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "telemetry-subscribers 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a)",
- "telemetry-subscribers 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
  "tempfile",
  "tera",
  "termcolor",
@@ -9923,9 +9927,9 @@ dependencies = [
  "tui",
  "twox-hash",
  "typed-arena",
+ "typed-store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-store 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=9deac015fbf66e24b6da9699630e06750eaa094a)",
- "typed-store 0.1.0 (git+https://github.com/MystenLabs/mysten-infra?rev=d96230a9272c322a7eefac49708aadfff1eed77e)",
- "typed-store-macros",
+ "typed-store-derive",
  "typenum",
  "types",
  "ucd-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8030,18 +8030,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.3"
 leb128 = "0.2.5"
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 
 move-binary-format = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e", features = ["address20"] }

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -22,7 +22,7 @@ rocksdb = "0.19.0"
 serde_with = { version = "1.14.0", features = ["hex"] }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["time", "registry", "env-filter"] }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 clap = { version = "3.1.17", features = ["derive"] }
 prometheus = "0.13.1"
 multiaddr = "0.14.0"

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = { version = "0.1.36", features = ["log"] }
 clap = { version = "3.1.14", features = ["derive"] }
 reqwest = { version = "0.11.11", features = ["blocking", "json"] }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 async-trait = "0.1.57"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.3"

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = "0.8.26"
 rand = "0.8.5"
 dirs = "4.0.0"
 multiaddr = "0.14.0"
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 tracing = "0.1.36"
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c022a2ae23ca7cc2778293fd3b1db42e8cd02d3b" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -46,9 +46,9 @@ move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "e1
 move-core-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e", features = ["address20"] }
 move-vm-runtime = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
-typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
-mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+typed-store = "0.1.0"
+typed-store-derive = "0.1.0"
+mysten-network = "0.1.0"
 
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137", package = "config" }
 narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137", package = "consensus" }
@@ -69,7 +69,7 @@ move-package = { git = "https://github.com/move-language/move", rev = "e1e647b73
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.26"
 pretty_assertions = "1.2.1"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 
 test-fuzz = "3.0.4"
 test-utils = { path = "../test-utils" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -58,7 +58,7 @@ narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c022a2ae23ca7cc2778293fd3b1db42e8cd02d3b"}
 workspace-hack = { path = "../workspace-hack"}
-thiserror = "1.0.32"
+thiserror = "1.0.34"
 eyre = "0.6.8"
 
 [dev-dependencies]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -29,7 +29,7 @@ prometheus = "0.13.1"
 arc-swap = "1.5.1"
 tokio-retry = "0.3"
 scopeguard = "1.1"
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 tap = "1.0"
 
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -13,7 +13,7 @@ use sui_types::batch::{SignedBatch, TxSequenceNumber};
 use typed_store::rocks::DBMap;
 use typed_store::traits::TypedStoreDebug;
 
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 #[derive(DBMapUtils)]
 pub struct AuthorityStoreTables<S> {
     /// This is a map between the object (ID, version) and the latest state of the object, namely the

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -34,7 +34,7 @@ use typed_store::{
     rocks::{DBBatch, DBMap},
     Map,
 };
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 
 use crate::checkpoints::causal_order_effects::CausalOrder;
 use crate::{

--- a/crates/sui-core/src/epoch/epoch_store.rs
+++ b/crates/sui-core/src/epoch/epoch_store.rs
@@ -12,7 +12,7 @@ use typed_store::rocks::DBMap;
 use typed_store::traits::TypedStoreDebug;
 
 use typed_store::Map;
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 
 #[derive(DBMapUtils)]
 pub struct EpochStore {

--- a/crates/sui-cost-tables/Cargo.toml
+++ b/crates/sui-cost-tables/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 move-binary-format = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e", features = ["address20"] }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 workspace-hack = { path = "../workspace-hack"}
 
 anyhow = { version = "1.0.64", features = ["backtrace"] }

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -28,7 +28,7 @@ sui-node = { path = "../sui-node" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }
 sui-config = { path = "../sui-config" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-trait = "0.1.57"
 axum = "0.5.13"
 clap = { version = "3.2.17", features = ["derive"] }
-thiserror = "1.0.32"
+thiserror = "1.0.34"
 tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.36"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/crates/sui-framework-build/Cargo.toml
+++ b/crates/sui-framework-build/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 
 sui-types = { path = "../sui-types" }
 sui-verifier = { path = "../../crates/sui-verifier" }

--- a/crates/sui-framework/Cargo.toml
+++ b/crates/sui-framework/Cargo.toml
@@ -13,7 +13,7 @@ bcs = "0.1.3"
 linked-hash-map = "0.5.6"
 smallvec = "1.9.0"
 num_enum = "0.5.7"
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 sha3 = "0.10.1"
 curve25519-dalek-ng = "4.1.1"
 

--- a/crates/sui-gateway/Cargo.toml
+++ b/crates/sui-gateway/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 futures = "0.3.23"
 prometheus = "0.13.1"
 clap = { version = "3.2.17", features = ["derive"] }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 
 sui-core = { path = "../sui-core" }
 sui-config = { path = "../sui-config" }
@@ -26,7 +26,7 @@ sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-node = { path = "../sui-node" }
 
 
-mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+mysten-network = "0.1.0"
 move-package = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 workspace-hack = { path = "../workspace-hack"}
 

--- a/crates/sui-network/Cargo.toml
+++ b/crates/sui-network/Cargo.toml
@@ -13,7 +13,7 @@ tonic = "0.7"
 sui-types = { path = "../sui-types" }
 
 
-mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+mysten-network = "0.1.0"
 workspace-hack = { path = "../workspace-hack"}
 
 [build-dependencies]

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.36"
 parking_lot = "0.12.1"
 futures = "0.3.23"
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
+typed-store = "0.1.0"
 chrono = "0.4.0"
 
 sui-config = { path = "../sui-config" }
@@ -28,8 +28,8 @@ sui-telemetry = { path = "../sui-telemetry" }
 sui-types = { path = "../sui-types" }
 sui-quorum-driver = { path = "../sui-quorum-driver" }
 
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
-mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
+mysten-network = "0.1.0"
 workspace-hack = { path = "../workspace-hack"}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -27,8 +27,8 @@ tempfile = "3.3.0"
 tap = "1.0.1"
 
 sui-types = { path = "../sui-types" }
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
-typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
+typed-store = "0.1.0"
+typed-store-derive = "0.1.0"
 move-core-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e", features = ["address20"] }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 workspace-hack = { path = "../workspace-hack"}
@@ -39,7 +39,7 @@ anyhow = "1.0.64"
 tempfile = "3.3.0"
 num_cpus = "1.13.1"
 pretty_assertions = "1.2.0"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 
 [[bench]]
 name = "write_ahead_log"

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -6,7 +6,7 @@
 
 use rocksdb::Options;
 use serde::{de::DeserializeOwned, Serialize};
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::batch::TxSequenceNumber;

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -25,7 +25,7 @@ use tracing::{debug, error, info, trace, warn};
 use typed_store::rocks::{DBBatch, DBMap};
 use typed_store::traits::Map;
 use typed_store::traits::TypedStoreDebug;
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 
 use sui_types::base_types::{ObjectRef, TransactionDigest};
 use sui_types::batch::TxSequenceNumber;

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -15,7 +15,7 @@ use typed_store::rocks::DBMap;
 
 use typed_store::traits::Map;
 use typed_store::traits::TypedStoreDebug;
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 
 use tracing::trace;
 

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use sui_types::base_types::TransactionDigest;
 use typed_store::traits::TypedStoreDebug;
-use typed_store_macros::DBMapUtils;
+use typed_store_derive::DBMapUtils;
 
 use sui_types::error::{SuiError, SuiResult};
 

--- a/crates/sui-swarm/Cargo.toml
+++ b/crates/sui-swarm/Cargo.toml
@@ -21,8 +21,8 @@ sui-config = { path = "../sui-config" }
 sui-node = { path = "../sui-node" }
 sui-types = { path = "../sui-types" }
 
-mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+mysten-network = "0.1.0"
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -12,13 +12,13 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.36"
 clap = { version = "3.2.17", features = ["derive"] }
 
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
-mysten-network = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
+mysten-network = "0.1.0"
 textwrap = "0.15"
 futures = "0.3.23"
 rocksdb = "0.19.0"
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
-typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
+typed-store = "0.1.0"
+typed-store-derive = "0.1.0"
 tempfile = "3.3.0"
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137", package = "executor" }
 serde_with = { version = "1.14.0", features = ["hex"] }

--- a/crates/sui-transactional-test-runner/Cargo.toml
+++ b/crates/sui-transactional-test-runner/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 anyhow = "1.0.64"
 bimap = "0.6.2"
 clap = { version = "3.1.8", features = ["derive"] }
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 rand = "0.8.5"
 
 move-binary-format = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -39,8 +39,8 @@ roaring = "0.10.0"
 enum_dispatch = "^0.3"
 eyre = "0.6.8"
 
-name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+name-variant = "0.1.0"
+typed-store = "0.1.0"
 
 move-binary-format = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -18,7 +18,7 @@ curve25519-dalek = { version = "3", default-features = false, features = ["serde
 serde-name = "0.2.1"
 sha2 = "0.9.9"
 sha3 = "0.10.2"
-thiserror = "1.0.31"
+thiserror = "1.0.34"
 tracing = "0.1"
 hex = "0.4.3"
 serde_bytes = "0.11.7"

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.3"
 byteorder = "1.4.3"
 itertools = "0.10.3"
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }
 curve25519-dalek = { version = "3", default-features = false, features = ["serde", "u64_backend"] }

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -19,7 +19,7 @@ serde_with = { version = "1.14.0", features = ["hex"] }
 tracing = "0.1.36"
 bcs = "0.1.3"
 clap = { version = "3.2.17", features = ["derive"] }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e" }
+telemetry-subscribers = "0.1.0"
 
 sui-core = { path = "../sui-core" }
 sui-framework = { path = "../sui-framework" }
@@ -36,8 +36,8 @@ colored = "2.0.0"
 unescape = "0.1.0"
 shell-words = "1.1.0"
 rocksdb = "0.19.0"
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
-typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
+typed-store = "0.1.0"
+typed-store-derive = "0.1.0"
 
 tempfile = "3.3.0"
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137", package = "executor" }
@@ -62,8 +62,8 @@ tempfile = "3.3.0"
 futures = "0.3.23"
 prometheus = "0.13.1"
 
-typed-store = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
-typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e"}
+typed-store = "0.1.0"
+typed-store-derive = "0.1.0"
 jsonrpsee = { version = "0.15.1", features = ["full"] }
 
 test-utils = { path = "../test-utils" }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -28,7 +28,7 @@ sui-node = { path = "../sui-node" }
 sui-swarm = { path = "../sui-swarm" }
 sui-types = { path = "../sui-types" }
 sui-sdk = { path = "../sui-sdk" }
-once_cell = "1.13.1"
+once_cell = "1.14.0"
 
 move-package = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e", features = ["address20"] }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -317,8 +317,8 @@ move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "e1e
 move-vm-types = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
-mysten-network-9500fda680e9dd4e = { package = "mysten-network", git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", default-features = false }
 mysten-network-859fc8e9f8dcae20 = { package = "mysten-network", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", default-features = false }
+mysten-network-c65f7effa3be6d31 = { package = "mysten-network", version = "0.1", default-features = false }
 named-lock = { version = "0.1", default-features = false }
 nested = { version = "0.1", default-features = false }
 network = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137", default-features = false }
@@ -497,8 +497,8 @@ tabular = { version = "0.2", features = ["ansi-cell", "strip-ansi-escapes", "uni
 tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "1", default-features = false, features = ["serde", "summaries"] }
-telemetry-subscribers-9500fda680e9dd4e = { package = "telemetry-subscribers", git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 telemetry-subscribers-859fc8e9f8dcae20 = { package = "telemetry-subscribers", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
+telemetry-subscribers-c65f7effa3be6d31 = { package = "telemetry-subscribers", version = "0.1", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 tempfile = { version = "3", default-features = false }
 tera = { version = "1", features = ["builtins", "chrono", "chrono-tz", "humansize", "percent-encoding", "rand", "slug", "urlencode"] }
 termcolor = { version = "1", default-features = false }
@@ -550,8 +550,8 @@ try-lock = { version = "0.2", default-features = false }
 tui = { version = "0.17", features = ["crossterm"] }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
-typed-store-9500fda680e9dd4e = { package = "typed-store", git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", default-features = false }
 typed-store-859fc8e9f8dcae20 = { package = "typed-store", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", default-features = false }
+typed-store-c65f7effa3be6d31 = { package = "typed-store", version = "0.1", default-features = false }
 typenum = { version = "1", default-features = false }
 types = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137" }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
@@ -940,9 +940,9 @@ multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-mysten-network-9500fda680e9dd4e = { package = "mysten-network", git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", default-features = false }
 mysten-network-859fc8e9f8dcae20 = { package = "mysten-network", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", default-features = false }
-name-variant = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", default-features = false }
+mysten-network-c65f7effa3be6d31 = { package = "mysten-network", version = "0.1", default-features = false }
+name-variant = { version = "0.1", default-features = false }
 named-lock = { version = "0.1", default-features = false }
 nested = { version = "0.1", default-features = false }
 network = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137", default-features = false }
@@ -1169,8 +1169,8 @@ tabular = { version = "0.2", features = ["ansi-cell", "strip-ansi-escapes", "uni
 tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "1", default-features = false, features = ["serde", "summaries"] }
-telemetry-subscribers-9500fda680e9dd4e = { package = "telemetry-subscribers", git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 telemetry-subscribers-859fc8e9f8dcae20 = { package = "telemetry-subscribers", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
+telemetry-subscribers-c65f7effa3be6d31 = { package = "telemetry-subscribers", version = "0.1", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 tempfile = { version = "3", default-features = false }
 tera = { version = "1", features = ["builtins", "chrono", "chrono-tz", "humansize", "percent-encoding", "rand", "slug", "urlencode"] }
 termcolor = { version = "1", default-features = false }
@@ -1230,9 +1230,9 @@ try-lock = { version = "0.2", default-features = false }
 tui = { version = "0.17", features = ["crossterm"] }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
-typed-store-9500fda680e9dd4e = { package = "typed-store", git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", default-features = false }
 typed-store-859fc8e9f8dcae20 = { package = "typed-store", git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", default-features = false }
-typed-store-macros = { git = "https://github.com/MystenLabs/mysten-infra", rev = "d96230a9272c322a7eefac49708aadfff1eed77e", default-features = false }
+typed-store-c65f7effa3be6d31 = { package = "typed-store", version = "0.1", default-features = false }
+typed-store-derive = { version = "0.1", default-features = false }
 typenum = { version = "1", default-features = false }
 types = { git = "https://github.com/MystenLabs/narwhal", rev = "842a611a0a58dd378a904d85f79b4edbbbc7b137" }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
- package dependencies for mysten-infra ~& fastcrypto,~
~- Updates the NW pointer~

This will speed up any release to Sui

Edit: fastcrypto & NW have breaking changes that can't be so easily integrated. Scoping down this PR.