### PR TITLE
[Explorer] Clicking on the Object Type should go to the Address/Module associated with the Type string not the last transaction

### DIFF
--- a/explorer/client/src/pages/object-result/ObjectResult.tsx
+++ b/explorer/client/src/pages/object-result/ObjectResult.tsx
@@ -1,12 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    getObjectId,
-    getTransactions,
-    getTransactionSender,
-    getMoveCallTransaction,
-} from '@mysten/sui.js';
+import { getTransactionSender } from '@mysten/sui.js';
 import * as Sentry from '@sentry/react';
 import React, { useEffect, useState, useContext } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
@@ -47,53 +42,30 @@ const Fail = ({ objID }: { objID: string | undefined }): JSX.Element => {
     );
 };
 
-// Get the data for the object ID and either:
-// address that publishes a Package or
-// module and package associated with token
+// Get the data for the object ID and address that publishes a Package:
 function getObjectDataWithPackageAddress(objID: string, network: string) {
     return rpc(network)
         .getObject(objID as string)
         .then((objState) => {
             const resp: DataType = translate(objState) as DataType;
-            if (resp.data.tx_digest) {
+            if (resp.objType === 'Move Package' && resp.data.tx_digest) {
                 return rpc(network)
                     .getTransactionWithEffects(resp.data.tx_digest)
-                    .then((txEff) => {
-                        if (resp.objType === 'Move Package') {
-                            // If Package, then extract publisher address
-                            return {
-                                ...resp,
-                                publisherAddress: getTransactionSender(
-                                    txEff.certificate
-                                ),
-                            };
-                        } else {
-                            // If Token, then extract the module and package
-                            const movecall = getMoveCallTransaction(
-                                getTransactions(txEff.certificate)[0]
-                            );
-                            if (!movecall) return resp;
-                            return {
-                                ...resp,
-                                module: movecall.module,
-                                package: getObjectId(movecall.package),
-                            };
-                        }
-                    })
+                    .then((txEff) => ({
+                        ...resp,
+                        publisherAddress: getTransactionSender(
+                            txEff.certificate
+                        ),
+                    }))
                     .catch((err) => {
                         console.log(err);
                         // TODO: Not sure if I should show Genesis as Package Publisher or ignore it
-
-                        if (resp.objType === 'Move Package') {
-                            return {
-                                ...(resp.owner === 'Immutable'
-                                    ? { publisherAddress: 'Genesis' }
-                                    : {}),
-                                ...resp,
-                            };
-                        } else {
-                            return resp;
-                        }
+                        return {
+                            ...(resp.owner === 'Immutable'
+                                ? { publisherAddress: 'Genesis' }
+                                : {}),
+                            ...resp,
+                        };
                     });
             }
             return resp;

--- a/explorer/client/src/pages/object-result/ObjectResult.tsx
+++ b/explorer/client/src/pages/object-result/ObjectResult.tsx
@@ -48,6 +48,20 @@ function getObjectDataWithPackageAddress(objID: string, network: string) {
         .getObject(objID as string)
         .then((objState) => {
             const resp: DataType = translate(objState) as DataType;
+
+            const GENESIS_TX_DIGEST =
+                'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+
+            if (
+                resp.data.tx_digest &&
+                resp.data.tx_digest === GENESIS_TX_DIGEST
+            ) {
+                return {
+                    ...resp,
+                    publisherAddress: 'Genesis',
+                };
+            }
+
             if (resp.objType === 'Move Package' && resp.data.tx_digest) {
                 return rpc(network)
                     .getTransactionWithEffects(resp.data.tx_digest)
@@ -59,13 +73,7 @@ function getObjectDataWithPackageAddress(objID: string, network: string) {
                     }))
                     .catch((err) => {
                         console.log(err);
-                        // TODO: Not sure if I should show Genesis as Package Publisher or ignore it
-                        return {
-                            ...(resp.owner === 'Immutable'
-                                ? { publisherAddress: 'Genesis' }
-                                : {}),
-                            ...resp,
-                        };
+                        return resp;
                     });
             }
             return resp;

--- a/explorer/client/src/pages/object-result/ObjectResultType.tsx
+++ b/explorer/client/src/pages/object-result/ObjectResultType.tsx
@@ -25,8 +25,6 @@ export type DataType = {
     ethAddress?: string;
     ethTokenId?: string;
     publisherAddress?: string;
-    module?: string;
-    package?: string;
     contract_id?: { bytes: string };
     data: {
         contents: {

--- a/explorer/client/src/pages/object-result/views/TokenView.tsx
+++ b/explorer/client/src/pages/object-result/views/TokenView.tsx
@@ -16,14 +16,18 @@ import {
     checkIsPropertyType,
     extractName,
 } from '../../../utils/objectUtils';
-import { trimStdLibPrefix, genFileTypeMsg } from '../../../utils/stringUtils';
+import {
+    trimStdLibPrefix,
+    genFileTypeMsg,
+    normalizeSuiAddress,
+} from '../../../utils/stringUtils';
 import { type DataType } from '../ObjectResultType';
 
 import styles from './ObjectView.module.css';
 function TokenView({ data }: { data: DataType }) {
     const viewedData = {
         ...data,
-        objType: trimStdLibPrefix(data.objType),
+        objType: data.objType,
         tx_digest: data.data.tx_digest,
         owner: getOwnerStr(data.owner),
         url: parseImageURL(data.data.contents),
@@ -65,7 +69,11 @@ function TokenView({ data }: { data: DataType }) {
         setImageFullScreen(true);
     }, []);
 
-    const href = `/objects/${viewedData.package}?module=${viewedData.module}`;
+    const genhref = (objType: string) => {
+        const metadataarr = objType.split('::');
+        const address = normalizeSuiAddress(metadataarr[0]);
+        return `/objects/${address}?module=${metadataarr[1]}`;
+    };
 
     return (
         <div>
@@ -76,22 +84,14 @@ function TokenView({ data }: { data: DataType }) {
                         <tbody>
                             <tr>
                                 <td>Type</td>
-                                {viewedData.package && viewedData.module ? (
-                                    <td>
-                                        <Link
-                                            to={href}
-                                            className={styles.objecttypelink}
-                                        >
-                                            {trimStdLibPrefix(
-                                                viewedData.objType
-                                            )}
-                                        </Link>
-                                    </td>
-                                ) : (
-                                    <td>
+                                <td>
+                                    <Link
+                                        to={genhref(viewedData.objType)}
+                                        className={styles.objecttypelink}
+                                    >
                                         {trimStdLibPrefix(viewedData.objType)}
-                                    </td>
-                                )}
+                                    </Link>
+                                </td>
                             </tr>
                             <tr>
                                 <td>Object ID</td>


### PR DESCRIPTION
### The Problem

Go to https://explorer.devnet.sui.io/objects/0x125590262eff8187d90b220a2e64b053ad3f3fa8. When the user clicks on the Type field, they go to 0xa276e9b404ccd264eb592df850a8064538ba8e89 and not 0x2.

### Proposed Solution

The package and address should be extracted from the type string and not the details on the last transaction

### Demo

https://user-images.githubusercontent.com/11377188/189092085-136640a6-43d0-42b7-b0b9-9737d179a474.mp4



