### PR TITLE
[Explorer] Prevents collision when owned object has more text

### DIFF
--- a/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
@@ -23,6 +23,10 @@
     @apply my-[5vh] sm:my-[1vh] break-all lg:w-[50%] h-[72px] flex items-center;
 }
 
+.objectbox a {
+    @apply font-mono;
+}
+
 .ownedobjectheader {
     @apply pb-1;
 }

--- a/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
@@ -20,7 +20,7 @@
 }
 
 .objectbox {
-    @apply my-[5vh] sm:my-[1vh] break-all lg:w-[50%] max-h-[72px] flex items-center;
+    @apply my-[5vh] sm:my-[1vh] break-all lg:w-[50%] h-fit flex items-center;
 }
 
 .ownedobjectheader {

--- a/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
@@ -20,7 +20,7 @@
 }
 
 .objectbox {
-    @apply my-[5vh] sm:my-[1vh] break-all lg:w-[50%] h-fit flex items-center;
+    @apply my-[5vh] sm:my-[1vh] break-all lg:w-[50%] h-[72px] flex items-center;
 }
 
 .ownedobjectheader {
@@ -32,7 +32,13 @@
 }
 
 .typevalue {
-    @apply text-sui-grey-80;
+    @apply text-sui-grey-80 overflow-hidden;
+
+    display: block;
+    display: -webkit-box; /* stylelint-disable-line value-no-vendor-prefix */
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
 }
 
 .gray {

--- a/explorer/client/src/components/ownedobjects/views/OwnedNFTView.tsx
+++ b/explorer/client/src/components/ownedobjects/views/OwnedNFTView.tsx
@@ -27,10 +27,8 @@ export default function OwnedNFTView({ results }: { results: DataType }) {
                                 alttext={alttextgen(entryObj.id)}
                             />
                         </div>
-                        <div>
-                            <span className={styles.typevalue}>
-                                {trimStdLibPrefix(entryObj.Type)}
-                            </span>
+                        <div className={styles.typevalue}>
+                            {trimStdLibPrefix(entryObj.Type)}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
#### The Problem

The problem is that when the owned objects have long pieces of summary text, this text collides. This can be seen here: https://explorer.devnet.sui.io/addresses/0x9b598c9c5f28c94a660d3cbc047f67a510a60e7a 

![image](https://user-images.githubusercontent.com/11377188/189203041-9b2599b1-6438-4542-8138-ecee7c946c45.png)

#### The Solution in Action

##### With longer text

![image](https://user-images.githubusercontent.com/11377188/189203235-d1db9809-e30d-4e8d-be06-b199c8f89681.png)
![image](https://user-images.githubusercontent.com/11377188/189203333-758e8b6e-6904-4cca-8994-bddd78997e49.png)

#### With shorter text
![image](https://user-images.githubusercontent.com/11377188/189203498-18867ddd-8458-46a9-86c4-d22c7ea551a2.png)
![image](https://user-images.githubusercontent.com/11377188/189203689-38d5ccb4-e082-44e8-b7e7-09b7141d94a4.png)

