### PR TITLE
More info in telemetry event

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -122,10 +122,11 @@ async fn main() -> Result<()> {
         });
     }
 
-    task::spawn(async {
+    let is_validator = config.consensus_config().is_some();
+    task::spawn(async move {
         loop {
             sleep(Duration::from_secs(3600)).await;
-            send_telemetry_event().await;
+            send_telemetry_event(is_validator).await;
         }
     });
 


### PR DESCRIPTION
This PR adds more info to the node telemetry events.
Test with local nodes:
- timestamp (secs from epoch) to compute active nodes over past X days
![Screen Shot 2022-09-08 at 4 17 41 PM](https://user-images.githubusercontent.com/106119108/189218238-731a003d-699c-408d-8725-31ff27ecb749.png)
- git revision 
![Screen Shot 2022-09-08 at 4 17 23 PM](https://user-images.githubusercontent.com/106119108/189218146-25bf192a-1acc-4079-a29b-45581940e834.png)
- fullnode or validator tag
![Screen Shot 2022-09-08 at 4 17 31 PM](https://user-images.githubusercontent.com/106119108/189218930-a06106db-9c98-45ba-bc88-754779f5a87b.png)

