### PR TITLE
Increase base consensus timeout and make it a config

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -180,6 +180,7 @@ impl<R: ::rand::RngCore + ::rand::CryptoRng> ConfigBuilder<R> {
                 let consensus_config = ConsensusConfig {
                     consensus_address,
                     consensus_db_path,
+                    delay_step: Some(15_000),
                     narwhal_config: Default::default(),
                 };
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -152,6 +152,7 @@ impl NodeConfig {
 pub struct ConsensusConfig {
     pub consensus_address: Multiaddr,
     pub consensus_db_path: PathBuf,
+    pub delay_step: Option<u64>,
 
     pub narwhal_config: ConsensusParameters,
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -15,6 +15,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms
@@ -55,6 +56,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms
@@ -95,6 +97,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms
@@ -135,6 +138,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms
@@ -175,6 +179,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms
@@ -215,6 +220,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms
@@ -255,6 +261,7 @@ validator_configs:
     consensus-config:
       consensus-address: ""
       consensus-db-path: /tmp/foo/
+      delay-step: 15000
       narwhal-config:
         header_size: 1000
         max_header_delay: 100ms

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -213,12 +213,13 @@ impl ValidatorService {
 
         let metrics = ConsensusAdapterMetrics::new(&prometheus_registry);
 
+        let delay_step = consensus_config.delay_step.unwrap_or(15_000);
         // The consensus adapter allows the authority to send user certificates through consensus.
         let consensus_adapter = ConsensusAdapter::new(
             consensus_config.address().to_owned(),
             state.clone_committee(),
             tx_sui_to_consensus.clone(),
-            /* max_delay */ Duration::from_millis(5_000),
+            Duration::from_millis(delay_step),
             metrics.clone(),
         );
 


### PR DESCRIPTION
Sui has a timeout on sending transaction to the nw consensus and automatically adjusts the timeout based on recent latency from nw it has seen in case of success, or linearly increases in case of timeout.

In the stress test network we see quite a few of nw timeouts from the sui transaction submission side, and we indeed [see](http://grafana.shared.internal.sui.io:3000/goto/wqnUWbGVz?orgId=1) that control delay is adjusted accordingly to the timeouts and nw is not stuck.

However, it seems that current timeout adjustment logic drops timeout pretty quickly which causes timeouts again.

While this is not end of the world, it is noise and probably suboptimal.

It also can be noticed that current base timeout value is very close to the actual consensus delay, so the timeout has to be frequently adjusted. Therefore, a short-medium term fix (this PR) is just to bump the delay step for timeout calculations so that it is further away from median nw latency.

In the future we can improve timeout calculation by using weighted avg over a longer window instead of weighting current and next timing only.