### PR TITLE
wallet-ext: fix connection request pending

### DIFF
--- a/wallet/src/background/Permissions.ts
+++ b/wallet/src/background/Permissions.ts
@@ -1,35 +1,142 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { filter, lastValueFrom, map, race, Subject, take, tap } from 'rxjs';
+import {
+    catchError,
+    concatMap,
+    filter,
+    from,
+    mergeWith,
+    share,
+    Subject,
+} from 'rxjs';
 import { v4 as uuidV4 } from 'uuid';
 import Browser from 'webextension-polyfill';
 
+import Tabs from './Tabs';
 import { Window } from './Window';
+import {
+    ALL_PERMISSION_TYPES,
+    isValidPermissionTypes,
+} from '_payloads/permissions';
 
 import type { ContentScriptConnection } from './connections/ContentScriptConnection';
 import type {
     Permission,
     PermissionResponse,
     PermissionType,
-} from '_messages/payloads/permissions';
-
-function openPermissionWindow(permissionID: string) {
-    return new Window(
-        Browser.runtime.getURL('ui.html') +
-            `#/dapp/connect/${encodeURIComponent(permissionID)}`
-    );
-}
+} from '_payloads/permissions';
+import type { Observable } from 'rxjs';
 
 const PERMISSIONS_STORAGE_KEY = 'permissions';
+const PERMISSION_UI_URL = `${Browser.runtime.getURL('ui.html')}#/dapp/connect/`;
+const PERMISSION_UI_URL_REGEX = new RegExp(
+    `${PERMISSION_UI_URL}([0-9a-f-]+$)`,
+    'i'
+);
 
 class Permissions {
-    private _permissionResponses: Subject<PermissionResponse> = new Subject();
+    public static getUiUrl(permissionID: string) {
+        return `${PERMISSION_UI_URL}${encodeURIComponent(permissionID)}`;
+    }
 
-    public async acquirePermissions(
+    public static isPermissionUiUrl(url: string) {
+        return PERMISSION_UI_URL_REGEX.test(url);
+    }
+
+    public static getPermissionIDFromUrl(url: string) {
+        const match = PERMISSION_UI_URL_REGEX.exec(url);
+        if (match) {
+            return match[1];
+        }
+        return null;
+    }
+
+    private _permissionResponses: Subject<PermissionResponse> = new Subject();
+    //NOTE: we need at least one subscription in order for this to handle permission requests
+    public readonly permissionReply: Observable<Permission | null>;
+
+    constructor() {
+        this.permissionReply = this._permissionResponses.pipe(
+            mergeWith(
+                Tabs.onRemoved.pipe(
+                    filter((aTab) =>
+                        Permissions.isPermissionUiUrl(aTab.url || '')
+                    )
+                )
+            ),
+            concatMap((data) =>
+                from(
+                    (async () => {
+                        let permissionID: string | null;
+                        const response: Partial<Permission> = {
+                            allowed: false,
+                            accounts: [],
+                            responseDate: new Date().toISOString(),
+                        };
+                        if ('url' in data) {
+                            permissionID = Permissions.getPermissionIDFromUrl(
+                                data.url || ''
+                            );
+                        } else {
+                            permissionID = data.id;
+                            response.allowed = data.allowed;
+                            response.accounts = data.accounts;
+                            response.responseDate = data.responseDate;
+                        }
+                        let aPermissionRequest: Permission | null = null;
+                        if (permissionID) {
+                            aPermissionRequest = await this.getPermissionByID(
+                                permissionID
+                            );
+                        }
+                        if (
+                            aPermissionRequest &&
+                            this.isPendingPermissionRequest(aPermissionRequest)
+                        ) {
+                            const finalPermission: Permission = {
+                                ...aPermissionRequest,
+                                ...response,
+                            };
+                            return finalPermission;
+                        }
+                        // ignore the event
+                        return null;
+                    })()
+                ).pipe(
+                    filter((data) => data !== null),
+                    concatMap((permission) =>
+                        from(
+                            (async () => {
+                                if (permission) {
+                                    await this.storePermission(permission);
+                                    return permission;
+                                }
+                                return null;
+                            })()
+                        )
+                    )
+                )
+            ),
+            // we ignore any errors and continue to handle other requests
+            // TODO: expose those errors to dapp?
+            catchError((_error, originalSource) => originalSource),
+            share()
+        );
+    }
+
+    public async startRequestPermissions(
         permissionTypes: readonly PermissionType[],
-        connection: ContentScriptConnection
-    ): Promise<Permission> {
+        connection: ContentScriptConnection,
+        requestMsgID: string
+    ): Promise<Permission | null> {
+        if (!isValidPermissionTypes(permissionTypes)) {
+            throw new Error(
+                `Invalid permission types. Allowed type are ${ALL_PERMISSION_TYPES.join(
+                    ', '
+                )}`
+            );
+        }
         const { origin } = connection;
         const existingPermission = await this.getPermission(origin);
         const hasPendingRequest = await this.hasPendingPermissionRequest(
@@ -37,6 +144,13 @@ class Permissions {
             existingPermission
         );
         if (hasPendingRequest) {
+            if (existingPermission) {
+                const uiUrl = Permissions.getUiUrl(existingPermission.id);
+                const found = await Tabs.highlight({ url: uiUrl });
+                if (!found) {
+                    await new Window(uiUrl).show();
+                }
+            }
             throw new Error('Another permission request is pending.');
         }
         const alreadyAllowed = await this.hasPermissions(
@@ -51,44 +165,11 @@ class Permissions {
             connection.origin,
             permissionTypes,
             connection.originFavIcon,
+            requestMsgID,
             existingPermission
         );
-        const permissionWindow = openPermissionWindow(pRequest.id);
-        const onWindowCloseStream = await permissionWindow.show();
-        const responseStream = this._permissionResponses.pipe(
-            filter((resp) => resp.id === pRequest.id),
-            map((resp) => {
-                pRequest.allowed = resp.allowed;
-                pRequest.accounts = resp.accounts;
-                pRequest.responseDate = resp.responseDate;
-                return pRequest;
-            }),
-            tap(() => permissionWindow.close())
-        );
-        return lastValueFrom(
-            race(
-                onWindowCloseStream.pipe(
-                    map(() => {
-                        pRequest.allowed = false;
-                        pRequest.accounts = [];
-                        pRequest.responseDate = new Date().toISOString();
-                        return pRequest;
-                    })
-                ),
-                responseStream
-            ).pipe(
-                take(1),
-                tap(async (permission) => {
-                    await this.storePermission(permission);
-                }),
-                map((permission) => {
-                    if (!permission.allowed) {
-                        throw new Error('Permission rejected');
-                    }
-                    return permission;
-                })
-            )
-        );
+        await new Window(Permissions.getUiUrl(pRequest.id)).show();
+        return null;
     }
 
     public handlePermissionResponse(response: PermissionResponse) {
@@ -122,7 +203,10 @@ class Permissions {
         permission?: Permission | null
     ): Promise<boolean> {
         const existingPermission = await this.getPermission(origin, permission);
-        return !!existingPermission && existingPermission.responseDate === null;
+        return (
+            !!existingPermission &&
+            this.isPendingPermissionRequest(existingPermission)
+        );
     }
 
     public async hasPermissions(
@@ -144,17 +228,24 @@ class Permissions {
         origin: string,
         permissionTypes: readonly PermissionType[],
         favIcon: string | undefined,
+        requestMsgID: string,
         existingPermission?: Permission | null
     ): Promise<Permission> {
         let permissionToStore: Permission;
         if (existingPermission) {
-            existingPermission.allowed = null;
             existingPermission.responseDate = null;
-            permissionTypes.forEach((aPermission) => {
-                if (!existingPermission.permissions.includes(aPermission)) {
-                    existingPermission.permissions.push(aPermission);
-                }
-            });
+            existingPermission.requestMsgID = requestMsgID;
+            if (existingPermission.allowed) {
+                permissionTypes.forEach((aPermission) => {
+                    if (!existingPermission.permissions.includes(aPermission)) {
+                        existingPermission.permissions.push(aPermission);
+                    }
+                });
+            } else {
+                existingPermission.permissions =
+                    permissionTypes as PermissionType[];
+            }
+            existingPermission.allowed = null;
             permissionToStore = existingPermission;
         } else {
             permissionToStore = {
@@ -166,6 +257,7 @@ class Permissions {
                 favIcon,
                 permissions: permissionTypes as PermissionType[],
                 responseDate: null,
+                requestMsgID,
             };
         }
         await this.storePermission(permissionToStore);
@@ -178,6 +270,20 @@ class Permissions {
         await Browser.storage.local.set({
             [PERMISSIONS_STORAGE_KEY]: permissions,
         });
+    }
+
+    private async getPermissionByID(id: string) {
+        const permissions = await this.getPermissions();
+        for (const aPermission of Object.values(permissions)) {
+            if (aPermission.id === id) {
+                return aPermission;
+            }
+        }
+        return null;
+    }
+
+    private isPendingPermissionRequest(permissionRequest: Permission) {
+        return permissionRequest.responseDate === null;
     }
 }
 

--- a/wallet/src/background/Tabs.ts
+++ b/wallet/src/background/Tabs.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fromEventPattern, map, mergeWith, share, Subject } from 'rxjs';
+import Browser from 'webextension-polyfill';
+
+import type { Tabs as BrowserTabs } from 'webextension-polyfill';
+
+const onRemovedStream = fromEventPattern<
+    [number, BrowserTabs.OnRemovedRemoveInfoType]
+>(
+    (handler) => Browser.tabs.onRemoved.addListener(handler),
+    (handler) => Browser.tabs.onRemoved.removeListener(handler)
+).pipe(share());
+
+const onCreatedStream = fromEventPattern<BrowserTabs.Tab>(
+    (handler) => Browser.tabs.onCreated.addListener(handler),
+    (handler) => Browser.tabs.onCreated.removeListener(handler)
+).pipe(share());
+
+const onUpdatedStream = fromEventPattern<
+    [number, BrowserTabs.OnUpdatedChangeInfoType, BrowserTabs.Tab]
+>(
+    (handler) => Browser.tabs.onUpdated.addListener(handler),
+    (handler) => Browser.tabs.onUpdated.removeListener(handler)
+).pipe(share());
+
+type TabInfo = {
+    id: number;
+    url: string | null;
+    closed?: boolean;
+};
+
+class Tabs {
+    private tabs: Map<number, TabInfo> = new Map();
+    private _onRemoved: Subject<TabInfo> = new Subject();
+
+    constructor() {
+        Browser.tabs.query({}).then((tabs) => {
+            for (const { id, url } of tabs) {
+                if (id && url) {
+                    this.tabs.set(id, { id, url });
+                }
+            }
+        });
+        onCreatedStream
+            .pipe(
+                mergeWith(onUpdatedStream.pipe(map(([_1, _2, aTab]) => aTab)))
+            )
+            .subscribe((aTab) => {
+                const { id, url } = aTab;
+                if (id && url) {
+                    const currentTab = this.tabs.get(id);
+                    if (
+                        currentTab &&
+                        currentTab.url &&
+                        currentTab.url !== url
+                    ) {
+                        // notify as removed tab when we change the url
+                        this._onRemoved.next({
+                            id,
+                            url: currentTab.url,
+                            closed: false,
+                        });
+                    }
+                    this.tabs.set(id, { id, url });
+                }
+            });
+        onRemovedStream.subscribe(([tabID]) => {
+            const tabInfo: TabInfo = this.tabs.get(tabID) || {
+                id: tabID,
+                url: null,
+            };
+            tabInfo.closed = true;
+            this.tabs.delete(tabID);
+            this._onRemoved.next(tabInfo);
+        });
+    }
+
+    /**
+     * An observable that emits when a tab wea closed or when the url has changed
+     */
+    public get onRemoved() {
+        return this._onRemoved.asObservable();
+    }
+
+    public async highlight(option: { url: string } | { tabID: number }) {
+        let tabToHighlight: BrowserTabs.Tab | null = null;
+        if ('tabID' in option) {
+            try {
+                tabToHighlight = await Browser.tabs.get(option.tabID);
+            } catch (e) {
+                //Do nothing
+            }
+        }
+        if ('url' in option) {
+            const url = option.url.split('#')[0];
+            const tabs = (
+                await Browser.tabs.query({
+                    url,
+                })
+            ).filter((aTab) => aTab.url === option.url);
+            if (tabs.length) {
+                tabToHighlight = tabs[0];
+            }
+        }
+        if (!tabToHighlight) {
+            return false;
+        }
+        if (tabToHighlight.windowId) {
+            await Browser.windows.update(tabToHighlight.windowId, {
+                drawAttention: true,
+                focused: true,
+            });
+        }
+        await Browser.tabs.highlight({
+            tabs: tabToHighlight.index,
+            windowId: tabToHighlight.windowId,
+        });
+        return true;
+    }
+}
+
+export default new Tabs();

--- a/wallet/src/background/connections/index.ts
+++ b/wallet/src/background/connections/index.ts
@@ -7,6 +7,7 @@ import { ContentScriptConnection } from './ContentScriptConnection';
 import { UiConnection } from './UiConnection';
 
 import type { Connection } from './Connection';
+import type { Permission } from '_payloads/permissions';
 
 export class Connections {
     private _connections: Connection[] = [];
@@ -39,5 +40,16 @@ export class Connections {
                 port.disconnect();
             }
         });
+    }
+
+    notifyForPermissionReply(permission: Permission) {
+        for (const aConnection of this._connections) {
+            if (
+                aConnection instanceof ContentScriptConnection &&
+                aConnection.origin === permission.origin
+            ) {
+                aConnection.permissionReply(permission);
+            }
+        }
     }
 }

--- a/wallet/src/background/index.ts
+++ b/wallet/src/background/index.ts
@@ -3,6 +3,7 @@
 
 import Browser from 'webextension-polyfill';
 
+import Permissions from './Permissions';
 import { Connections } from './connections';
 import { openInNewTab } from '_shared/utils';
 
@@ -12,4 +13,10 @@ Browser.runtime.onInstalled.addListener((details) => {
     }
 });
 
-new Connections();
+const connections = new Connections();
+
+Permissions.permissionReply.subscribe((permission) => {
+    if (permission) {
+        connections.notifyForPermissionReply(permission);
+    }
+});

--- a/wallet/src/manifest/manifest.json
+++ b/wallet/src/manifest/manifest.json
@@ -6,7 +6,7 @@
     "background": {
         "service_worker": "background.js"
     },
-    "permissions": ["storage"],
+    "permissions": ["storage", "tabs"],
     "action": {
         "default_popup": "ui.html?type=popup"
     },

--- a/wallet/src/shared/messaging/WindowMessageStream.ts
+++ b/wallet/src/shared/messaging/WindowMessageStream.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { filter, fromEvent, map } from 'rxjs';
+import { filter, fromEvent, map, share } from 'rxjs';
 
 import type { Message } from '_messages';
 import type { Observable } from 'rxjs';
@@ -35,7 +35,8 @@ export class WindowMessageStream {
                     message.source === window &&
                     message.data.target === this._name
             ),
-            map((message) => message.data.payload)
+            map((message) => message.data.payload),
+            share()
         );
     }
 

--- a/wallet/src/shared/messaging/messages/payloads/permissions/Permission.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/Permission.ts
@@ -13,4 +13,5 @@ export interface Permission {
     permissions: PermissionType[];
     createdDate: string;
     responseDate: string | null;
+    requestMsgID: string;
 }

--- a/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
+++ b/wallet/src/shared/messaging/messages/payloads/permissions/PermissionType.ts
@@ -7,3 +7,12 @@ export const ALL_PERMISSION_TYPES = [
 ] as const;
 type AllPermissionsType = typeof ALL_PERMISSION_TYPES;
 export type PermissionType = AllPermissionsType[number];
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export function isValidPermissionTypes(types: any): types is PermissionType[] {
+    return (
+        Array.isArray(types) &&
+        !!types.length &&
+        types.every((aType) => ALL_PERMISSION_TYPES.includes(aType))
+    );
+}


### PR DESCRIPTION
* notify all the tabs with same origin with the permission for the permission response
* when there is another pending request for the same origin throw an error to the dapp as before but focus or open the permission popup
* add validation for the permission types
* content script lazy connect to bg service

### Permission Request while another one is pending

Before
  
  https://user-images.githubusercontent.com/10210143/189223156-36c4a1b2-0bfe-4712-b288-db25d5483c7b.mov

After
  
  https://user-images.githubusercontent.com/10210143/189223281-97233d90-451b-42e8-81da-e61bb0672d4c.mov

### Fix permission request response handling while background service is inactive

Before

https://user-images.githubusercontent.com/10210143/189226349-7e6636ed-038c-4b26-841f-f17f96cf97ea.mov

After


https://user-images.githubusercontent.com/10210143/189226503-ebeb7766-fc84-4e6d-bec9-09fd34b98200.mov




fixes: #3881