### PR TITLE
Trigger parent cert execution for SharedObjectLockNotSetObject

### DIFF
--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -435,7 +435,9 @@ where
 
         match self.state.handle_certificate(cert.clone()).await {
             Ok(_) => Ok(SyncStatus::CertExecuted),
-            Err(SuiError::ObjectNotFound { .. }) | Err(SuiError::ObjectErrors { .. }) => {
+            Err(SuiError::ObjectNotFound { .. })
+            | Err(SuiError::ObjectErrors { .. })
+            | Err(SuiError::SharedObjectLockNotSetObject) => {
                 debug!(?digest, "cert execution failed due to missing parents");
 
                 let effects = self.get_true_effects(&cert).await?;


### PR DESCRIPTION
In the case where a cert is final, but the local validator has not yet processed all preceding certs that touch a shared object, we will get the `SharedObjectLockNotSetObject` error. This change will cause node sync to try and fetch the parents.

If the cert isn't yet final, its not guaranteed that the parents can be found, because no validators may yet have created effects for the cert.