### PR TITLE
[sui framework] add decimals to TreasuryCap for Coin<T>

### DIFF
--- a/sui_programmability/examples/fungible_tokens/sources/managed.move
+++ b/sui_programmability/examples/fungible_tokens/sources/managed.move
@@ -18,7 +18,7 @@ module fungible_tokens::managed {
     /// registered once.
     fun init(witness: MANAGED, ctx: &mut TxContext) {
         // Get a treasury cap for the coin and give it to the transaction sender
-        let treasury_cap = coin::create_currency<MANAGED>(witness, ctx);
+        let treasury_cap = coin::create_currency<MANAGED>(witness, 2, ctx);
         transfer::transfer(treasury_cap, tx_context::sender(ctx))
     }
 


### PR DESCRIPTION
This is important info for wallets etc. to know about a fungible token. I'm not sure if `TreasuryCap` is the best home for this information (e.g., we may want a big registry for this + token name info etc in the future), but it is the only place we have for now.

This change is inspired by user questions about the minimum denomination of SUI.