### PR TITLE
[adapter] Pass write kind information to temporary store

### DIFF
--- a/crates/sui-adapter/src/in_memory_storage.rs
+++ b/crates/sui-adapter/src/in_memory_storage.rs
@@ -7,7 +7,7 @@ use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::{SuiError, SuiResult},
     object::Object,
-    storage::{BackingPackageStore, DeleteKind, ParentSync},
+    storage::{BackingPackageStore, DeleteKind, ParentSync, WriteKind},
 };
 
 // TODO: We should use AuthorityTemporaryStore instead.
@@ -97,11 +97,11 @@ impl InMemoryStorage {
 
     pub fn finish(
         &mut self,
-        written: BTreeMap<ObjectID, (ObjectRef, Object)>,
+        written: BTreeMap<ObjectID, (ObjectRef, Object, WriteKind)>,
         deleted: BTreeMap<ObjectID, (SequenceNumber, DeleteKind)>,
     ) {
         debug_assert!(written.keys().all(|id| !deleted.contains_key(id)));
-        for (_id, (_, new_object)) in written {
+        for (_id, (_, new_object, _)) in written {
             debug_assert!(new_object.id() == _id);
             self.insert_object(new_object);
         }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -866,7 +866,10 @@ impl AuthorityState {
                 .input_objects()?
                 .iter()
                 .map(|o| o.object_id()),
-            effects.effects.all_mutated(),
+            effects
+                .effects
+                .all_mutated()
+                .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.signed_data
                 .data
                 .move_calls()

--- a/crates/sui-storage/src/indexes.rs
+++ b/crates/sui-storage/src/indexes.rs
@@ -74,11 +74,11 @@ fn timestamps_table_default_config() -> Options {
 }
 
 impl IndexStore {
-    pub fn index_tx<'a>(
+    pub fn index_tx(
         &self,
         sender: SuiAddress,
         active_inputs: impl Iterator<Item = ObjectID>,
-        mutated_objects: impl Iterator<Item = &'a (ObjectRef, Owner)> + Clone,
+        mutated_objects: impl Iterator<Item = (ObjectRef, Owner)> + Clone,
         move_functions: impl Iterator<Item = (ObjectID, Identifier, Identifier)> + Clone,
         sequence: TxSequenceNumber,
         digest: &TransactionDigest,

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -8,7 +8,17 @@ use crate::{
     object::Object,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+pub enum WriteKind {
+    /// The object was in storage already but has been modified
+    Mutate,
+    /// The object was created in this transaction
+    Create,
+    /// The object was previously wrapped in another object, but has been restored to storage
+    Unwrap,
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum DeleteKind {
@@ -22,7 +32,7 @@ pub enum DeleteKind {
 }
 
 pub enum ObjectChange {
-    Write(Object),
+    Write(Object, WriteKind),
     Delete(SequenceNumber, DeleteKind),
 }
 
@@ -31,10 +41,6 @@ pub trait Storage {
     fn reset(&mut self);
 
     fn read_object(&self, id: &ObjectID) -> Option<&Object>;
-
-    // Specify the list of object IDs created during the transaction.
-    // This is needed to determine unwrapped objects at the end.
-    fn set_create_object_ids(&mut self, ids: BTreeSet<ObjectID>);
 
     /// Record an event that happened during execution
     fn log_event(&mut self, event: Event);


### PR DESCRIPTION
- The temporary storage and Storage trait has to recreate a lot of information already known to the adapter
- This removes some messiness about having to determine what objects were created or wrapped, which is already done inside the adapter