### PR TITLE
[doc] Object type 'Info' should be 'UID' now, due to:

### DIFF
--- a/doc/src/build/move/index.md
+++ b/doc/src/build/move/index.md
@@ -145,7 +145,7 @@ represent different types of user-defined coins as Sui objects:
 
 ``` rust
 struct Coin<phantom T> has key, store {
-    info: Info,
+    id: UID,
     value: u64
 }
 ```
@@ -161,7 +161,7 @@ and [structs](https://github.com/move-language/move/blob/main/language/documenta
 in the Move book.
 
 In order for a Move struct type to define a Sui object type such as
-`Coin`, its first field must be `info: Info`, which is a
+`Coin`, its first field must be `id: UID`, which is a
 struct type defined in the
 [object module](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/object.move). The
 Move struct type must


### PR DESCRIPTION
due to:
https://github.com/MystenLabs/sui/commit/7af627ea406f0d838b4a26ec9c7ce123ed59fc08
