### PR TITLE
Allow backoff to not penalize all workloads in mixed mode

### DIFF
--- a/crates/sui-benchmark/src/drivers/driver.rs
+++ b/crates/sui-benchmark/src/drivers/driver.rs
@@ -1,18 +1,17 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
-use crate::workloads::workload::Payload;
-use crate::workloads::workload::Workload;
 use async_trait::async_trait;
 use prometheus::Registry;
 use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_client::NetworkAuthorityClient;
 
+use crate::workloads::workload::WorkloadInfo;
+
 #[async_trait]
 pub trait Driver<T> {
     async fn run(
         &self,
-        workload: Box<dyn Workload<dyn Payload>>,
+        workload: Vec<WorkloadInfo>,
         aggregator: AuthorityAggregator<NetworkAuthorityClient>,
         registry: &Registry,
     ) -> Result<T, anyhow::Error>;

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -253,3 +253,10 @@ impl CombinationWorkload {
         Box::new(CombinationWorkload { workloads })
     }
 }
+
+pub struct WorkloadInfo {
+    pub target_qps: u64,
+    pub num_workers: u64,
+    pub max_in_flight_ops: u64,
+    pub workload: Box<dyn Workload<dyn Payload>>,
+}


### PR DESCRIPTION
In the current testnet setup, we noticed a couple times when shared counter workload completely stop making progress that it affected the transaction throughout of transfer object workload. This is because the backoff in load gen considers total pending requests across all workloads before deciding to send a request. We aim to fix this behavior by adding a new mode (disjoint_mode) where different workloads run completely independently such that even if one is completely dead, the other keeps making progress as expected.