### PR TITLE
fix: should import `Self` from `sui::tx_context` in docs

### DIFF
--- a/doc/src/build/move/write-package.md
+++ b/doc/src/build/move/write-package.md
@@ -51,7 +51,7 @@ module my_first_package::my_module {
     // Part 1: imports
     use sui::object::{Self, UID};
     use sui::transfer;
-    use sui::tx_context::TxContext;
+    use sui::tx_context::{Self, TxContext};
 
     // Part 2: struct definitions
     struct Sword has key, store {


### PR DESCRIPTION
in the docs, we use `tx_context::sender` but that shows up as:

```
Unbound module alias 'tx_context'
```

in Move Analyzer, importing Self fixes this.