### PR TITLE
Fix shared object retries

### DIFF
--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -328,6 +328,13 @@ impl TransactionKind {
         )
     }
 
+    pub fn is_change_epoch_tx(&self) -> bool {
+        matches!(
+            self,
+            TransactionKind::Single(SingleTransactionKind::ChangeEpoch(_))
+        )
+    }
+
     pub fn validity_check(&self) -> SuiResult {
         match self {
             Self::Batch(b) => {


### PR DESCRIPTION
Fixes #4387 

The basic idea here is that transaction_input_check should always load the object versions that will be consumed by the TX, rather than the latest versions in the DB. This behavior comes for free with owned objects, since those are already specified by ObjRef. By using the shared lock table, we provide the same behavior for shared objects.