### PR TITLE
Add consensus time metrics on SUI side

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -94,6 +94,7 @@ pub mod authority_store_tables;
 
 mod authority_store;
 use crate::epoch::epoch_store::EpochStore;
+use crate::metrics::TaskUtilizationExt;
 pub use authority_store::{
     AuthorityStore, GatewayStore, ResolverWrapper, SuiDataStore, UpdateType,
 };
@@ -141,6 +142,8 @@ pub struct AuthorityMetrics {
     handle_node_sync_certificate_latency: Histogram,
 
     total_consensus_txns: IntCounter,
+    handle_consensus_duration_mcs: IntCounter,
+    verify_narwhal_transaction_duration_mcs: IntCounter,
 
     pub follower_items_streamed: IntCounter,
     pub follower_items_loaded: IntCounter,
@@ -277,6 +280,18 @@ impl AuthorityMetrics {
             total_consensus_txns: register_int_counter_with_registry!(
                 "total_consensus_txns",
                 "Total number of consensus transactions received from narwhal",
+                registry,
+            )
+            .unwrap(),
+            handle_consensus_duration_mcs: register_int_counter_with_registry!(
+                "handle_consensus_duration_mcs",
+                "Total duration of handle_consensus_transaction",
+                registry,
+            )
+            .unwrap(),
+            verify_narwhal_transaction_duration_mcs: register_int_counter_with_registry!(
+                "verify_narwhal_transaction_duration_mcs",
+                "Total duration of verify_narwhal_transaction",
                 registry,
             )
             .unwrap(),
@@ -1876,6 +1891,10 @@ impl AuthorityState {
     }
 
     fn verify_narwhal_transaction(&self, certificate: &CertifiedTransaction) -> SuiResult {
+        let _timer = self
+            .metrics
+            .verify_narwhal_transaction_duration_mcs
+            .utilization_timer();
         // Ensure the input is a shared object certificate. Remember that Byzantine authorities
         // may input anything into consensus.
         fp_ensure!(
@@ -1905,6 +1924,10 @@ impl ExecutionState for AuthorityState {
         transaction: Self::Transaction,
     ) -> Result<Self::Outcome, Self::Error> {
         self.metrics.total_consensus_txns.inc();
+        let _timer = self
+            .metrics
+            .handle_consensus_duration_mcs
+            .utilization_timer();
         let tracking_id = transaction.get_tracking_id();
         match transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {

--- a/crates/sui-core/src/metrics.rs
+++ b/crates/sui-core/src/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::Histogram;
+use prometheus::{Histogram, IntCounter};
 use tokio::time::Instant;
 
 pub fn start_timer(metrics: Histogram) -> impl Drop {
@@ -9,4 +9,32 @@ pub fn start_timer(metrics: Histogram) -> impl Drop {
     scopeguard::guard((metrics, start_ts), |(metrics, start_ts)| {
         metrics.observe(start_ts.elapsed().as_secs_f64());
     })
+}
+
+pub struct TaskUtilizationGuard<'a> {
+    metric: &'a IntCounter,
+    start: Instant,
+}
+
+pub trait TaskUtilizationExt {
+    /// Measures amount of time spent until guard is dropped and increments the counter by duration in mcs
+    /// Primary usage for this counter is to measure 'utilization' of the single task
+    /// E.g. having rate(metric) / 1_000_000 can tell what portion of time this task is busy
+    /// For the tasks that are run in single thread this indicates how close is this task to a complete saturation
+    fn utilization_timer(&self) -> TaskUtilizationGuard;
+}
+
+impl TaskUtilizationExt for IntCounter {
+    fn utilization_timer(&self) -> TaskUtilizationGuard {
+        TaskUtilizationGuard {
+            start: Instant::now(),
+            metric: self,
+        }
+    }
+}
+
+impl<'a> Drop for TaskUtilizationGuard<'a> {
+    fn drop(&mut self) {
+        self.metric.inc_by(self.start.elapsed().as_micros() as u64);
+    }
 }


### PR DESCRIPTION
This diff adds few metrics
(a) `sequencing_certificate_latency`: histogram for consensus adapter that measures latency of transaction sequencing. This should be a key metric that shows how much consensus contributes to overall transaction latency. Normally in the stress test tool we should see `shared_object_latency = owned_object_latency + sequencing_certificate_latency`. Metric that existed before, `sequencing_certificate_control_delay` is a proxy metric(it indicates consensus timeout derived from the current latency) and is hard to use directly.

(b) `handle_consensus_duration_mcs` is a metric that can be used to derive the utilization of the `handle_consensus_transaction` task. The metrics is simply a sum of execution times. Based on this metric we can build a graph `rate(handle_consensus_duration_mcs) / 1_000_000`, this graph will show 'utilization' of the consensus task on sui side. If value here gets close to 1.0 it means that consensus is sequencing transactions faster than sui can process them(e.g. assign shared object locks or process checkpoints).

(c) `verify_narwhal_transaction_duration_mcs` similarly will show what percentage of consensus transaction execution is spent on signature verification

We will need to add something similar to (b) on the narwhal side to include batch waiter etc time.