### PR TITLE
[Explorer] Adds Name field to Owned NFTs

### DIFF
--- a/explorer/client/src/components/ownedobjects/OwnedObjectConstants.tsx
+++ b/explorer/client/src/components/ownedobjects/OwnedObjectConstants.tsx
@@ -10,6 +10,7 @@ export type DataType = {
     Version?: string;
     display?: string;
     balance?: BN;
+    name?: string;
 }[];
 
 export const ITEMS_PER_PAGE: number = 6;

--- a/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
+++ b/explorer/client/src/components/ownedobjects/styles/OwnedObjects.module.css
@@ -42,3 +42,7 @@
 .fail {
     @apply text-red-600 font-sans font-semibold mt-2;
 }
+
+.name {
+    @apply text-sui-grey-90 font-medium text-[13px] leading-[130%];
+}

--- a/explorer/client/src/components/ownedobjects/views/OwnedNFTView.tsx
+++ b/explorer/client/src/components/ownedobjects/views/OwnedNFTView.tsx
@@ -19,6 +19,9 @@ export default function OwnedNFTView({ results }: { results: DataType }) {
                         </div>
                     )}
                     <div className={styles.textitem}>
+                        {entryObj.name && (
+                            <div className={styles.name}>{entryObj.name}</div>
+                        )}
                         <div>
                             <Longtext
                                 text={entryObj.id}


### PR DESCRIPTION
Following discussion with @mystie711 on Slack and the updated Figma Design, this PR adds the human-readable name as a field for each Owned NFT.

As can be seen when looking at http://localhost:3000/addresses/0x7c824faed726e261ab672f7132844a1766013d7f, this can handle both the case where there is a name (left) and there is not a name (right):

![image](https://user-images.githubusercontent.com/11377188/189925628-37d73577-b114-495c-8a23-245f4fbd04d1.png)