### PR TITLE
[Move] Fixed a problem with checking Sui framework mismatch

### DIFF
--- a/crates/sui-framework/src/lib.rs
+++ b/crates/sui-framework/src/lib.rs
@@ -178,7 +178,9 @@ fn verify_framework_version(pkg: &CompiledPackage) -> SuiResult<()> {
     let framework_modules = Modules::new(get_sui_framework().iter()).iter_modules_owned();
     let framework: Vec<&CompiledModule> = framework_modules.iter().collect();
 
-    if dep_framework != framework {
+    // compare framework modules pulled as dependencies (if any - a developer may choose to use only
+    // stdlib) with framework modules bundled with the distribution
+    if !dep_framework.is_empty() && dep_framework != framework {
         // note: this advice is overfitted to the most common failure modes we see:
         // user is trying to publish to testnet, but has a `sui` binary and Sui Framework
         // sources that are not in sync. the first part of the advice ensures that the
@@ -191,7 +193,7 @@ fn verify_framework_version(pkg: &CompiledPackage) -> SuiResult<()> {
                     [dependencies]
                     Sui = { git = \"https://github.com/MystenLabs/sui.git\", subdir = \"crates/sui-framework\", rev = \"devnet\" }
 `                   \
-                    If that does not fix the issue, your `sui` binary is likely out of date--try\
+                    If that does not fix the issue, your `sui` binary is likely out of date--try \
                     cargo install --locked --git https://github.com/MystenLabs/sui.git --branch devnet sui"
                 .to_string(),
         });
@@ -206,7 +208,9 @@ fn verify_framework_version(pkg: &CompiledPackage) -> SuiResult<()> {
     let stdlib_modules = Modules::new(get_move_stdlib().iter()).iter_modules_owned();
     let stdlib: Vec<&CompiledModule> = stdlib_modules.iter().collect();
 
-    if dep_stdlib != stdlib {
+    // compare stdlib modules pulled as dependencies (if any) with stdlib modules bundled with the
+    // distribution
+    if !dep_stdlib.is_empty() && dep_stdlib != stdlib {
         return Err(SuiError::ModuleVerificationFailure {
             error: "Move stdlib version mismatch detected.\
                     Make sure that the sui command line tool and the Move standard library code\


### PR DESCRIPTION
This PR resolves https://github.com/MystenLabs/sui/issues/4589. We did not anticipate that someone would use `sui move` command to build code that would not have any Sui framework dependencies (only core Move stdlib dependencies).