### PR TITLE
[checkpoint] Log the size of checkpoint fragment message

### DIFF
--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -671,14 +671,15 @@ impl CheckpointConsensusAdapter {
                     let other = fragment.other.auth_signature.authority;
                     let transaction = ConsensusTransaction::new_checkpoint_message(fragment);
                     let tracking_id = transaction.get_tracking_id();
+                    let serialized = bincode::serialize(&transaction).expect("Serialize consensus transaction cannot fail");
                     debug!(
                         ?tracking_id,
                         ?cp_seq,
+                        size=?serialized.len(),
                         "Checkpoint fragment consensus message created. Proposer: {}, Other: {}",
                         proposer,
                         other,
                     );
-                    let serialized = bincode::serialize(&transaction).expect("Serialize consensus transaction cannot fail");
                     self.buffer.push_front((serialized, sequence_number));
                 },
 


### PR DESCRIPTION
We can tell how big a fragment typically gets.