### PR TITLE
Fix error message for handle_consensus_transaction

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -379,8 +379,8 @@ pub enum SuiError {
     ConsensusConnectionBroken(String),
     #[error("Failed to hear back from consensus: {0}")]
     FailedToHearBackFromConsensus(String),
-    #[error("Failed to lock shared objects: {0}")]
-    SharedObjectLockingFailure(String),
+    #[error("Failed to execute handle_consensus_transaction on Sui: {0}")]
+    HandleConsensusTransactionFailure(String),
     #[error("Consensus listener is out of capacity")]
     ListenerCapacityExceeded,
     #[error("Failed to serialize/deserialize Narwhal message: {0}")]
@@ -460,7 +460,7 @@ impl std::convert::From<VMError> for SuiError {
 
 impl std::convert::From<SubscriberError> for SuiError {
     fn from(error: SubscriberError) -> Self {
-        SuiError::SharedObjectLockingFailure(error.to_string())
+        SuiError::HandleConsensusTransactionFailure(error.to_string())
     }
 }
 


### PR DESCRIPTION
This error happens when failed to call handle_consensus_transaction, which is not just for shared object locks, but could also be for checkpoint fragments (or any consensus message in the future). Make the error more generic.