### PR TITLE
Transaction Orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8393,6 +8393,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "serde_json",
+ "signature",
  "sui",
  "sui-adapter",
  "sui-config",

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -31,8 +31,7 @@ use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
 use sui_types::crypto::EmptySignInfo;
 use sui_types::messages::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    TransactionEnvelope,
+    QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, TransactionEnvelope,
 };
 use tokio::sync::Barrier;
 use tokio::time;
@@ -330,13 +329,13 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                 let committee_cloned = committee.clone();
                                 let start = Instant::now();
                                 let res = qd
-                                    .execute_transaction(ExecuteTransactionRequest {
+                                    .execute_transaction(QuorumDriverRequest {
                                         transaction: b.0.clone(),
-                                        request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+                                        request_type: QuorumDriverRequestType::WaitForEffectsCert,
                                     })
                                     .map(move |res| {
                                         match res {
-                                            Ok(ExecuteTransactionResponse::EffectsCert(result)) => {
+                                            Ok(QuorumDriverResponse::EffectsCert(result)) => {
                                                 let (cert, effects) = *result;
                                                 let new_version = effects.effects.mutated.iter().find(|(object_ref, _)| {
                                                     object_ref.0 == b.1.get_object_id()
@@ -383,13 +382,13 @@ impl Driver<BenchmarkStats> for BenchDriver {
                                 let metrics_cloned = metrics_cloned.clone();
                                 let committee_cloned = committee.clone();
                                 let res = qd
-                                    .execute_transaction(ExecuteTransactionRequest {
+                                    .execute_transaction(QuorumDriverRequest {
                                         transaction: tx.clone(),
-                                    request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+                                    request_type: QuorumDriverRequestType::WaitForEffectsCert,
                                 })
                                 .map(move |res| {
                                     match res {
-                                        Ok(ExecuteTransactionResponse::EffectsCert(result)) => {
+                                        Ok(QuorumDriverResponse::EffectsCert(result)) => {
                                             let (cert, effects) = *result;
                                             let new_version = effects.effects.mutated.iter().find(|(object_ref, _)| {
                                                 object_ref.0 == payload.get_object_id()

--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -182,7 +182,7 @@ impl BenchDriver {
     pub async fn make_workers(
         &self,
         workload_info: &WorkloadInfo,
-        aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
+        aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
     ) -> Vec<BenchWorker> {
         let mut num_requests = workload_info.max_in_flight_ops / workload_info.num_workers;
         let mut target_qps = workload_info.target_qps / workload_info.num_workers;
@@ -198,7 +198,7 @@ impl BenchDriver {
                     target_qps,
                     payload: workload_info
                         .workload
-                        .make_test_payloads(num_requests, aggregator)
+                        .make_test_payloads(num_requests, aggregator.clone())
                         .await,
                 });
             }
@@ -223,7 +223,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
     async fn run(
         &self,
         workloads: Vec<WorkloadInfo>,
-        aggregator: AuthorityAggregator<NetworkAuthorityClient>,
+        aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
         registry: &Registry,
         show_progress: bool,
         run_duration: Interval,
@@ -233,7 +233,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
         let (tx, mut rx) = tokio::sync::mpsc::channel(100);
         let mut bench_workers = vec![];
         for workload in workloads.iter() {
-            bench_workers.extend(self.make_workers(workload, &aggregator).await);
+            bench_workers.extend(self.make_workers(workload, aggregator.clone()).await);
         }
         let num_workers = bench_workers.len() as u64;
         if num_workers == 0 {

--- a/crates/sui-benchmark/src/drivers/driver.rs
+++ b/crates/sui-benchmark/src/drivers/driver.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use crate::drivers::Interval;
 use async_trait::async_trait;
 use prometheus::Registry;
@@ -14,7 +16,7 @@ pub trait Driver<T> {
     async fn run(
         &self,
         workload: Vec<WorkloadInfo>,
-        aggregator: AuthorityAggregator<NetworkAuthorityClient>,
+        aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
         registry: &Registry,
         show_progress: bool,
         run_duration: Interval,

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -111,16 +111,16 @@ impl TransferObjectWorkload {
 
 #[async_trait]
 impl Workload<dyn Payload> for TransferObjectWorkload {
-    async fn init(&mut self, _aggregator: &AuthorityAggregator<NetworkAuthorityClient>) {
+    async fn init(&mut self, _aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>) {
         return;
     }
     async fn make_test_payloads(
         &self,
         count: u64,
-        aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
+        aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
     ) -> Vec<Box<dyn Payload>> {
         // Read latest test gas object
-        let primary_gas = get_latest(self.test_gas, aggregator).await.unwrap();
+        let primary_gas = get_latest(self.test_gas, aggregator.clone()).await.unwrap();
         let mut primary_gas_ref = primary_gas.compute_object_reference();
         let owner = *self
             .transfer_keypairs
@@ -138,7 +138,7 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
                     &self.test_gas_keypair,
                     MAX_GAS_FOR_TESTING,
                     *owner,
-                    aggregator,
+                    aggregator.clone(),
                 )
                 .await
                 {
@@ -157,7 +157,7 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
                 &self.test_gas_keypair,
                 1,
                 owner,
-                aggregator,
+                aggregator.clone(),
             )
             .await
             {

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -18,10 +18,7 @@ use futures::FutureExt;
 use sui_types::{
     base_types::SuiAddress,
     crypto::AccountKeyPair,
-    messages::{
-        ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-        Transaction,
-    },
+    messages::{QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, Transaction},
 };
 use test_utils::messages::make_transfer_sui_transaction;
 use tracing::error;
@@ -54,12 +51,12 @@ pub async fn transfer_sui_for_testing(
     let quorum_driver_handler =
         QuorumDriverHandler::new(client.clone(), QuorumDriverMetrics::new_for_tests());
     let qd = quorum_driver_handler.clone_quorum_driver();
-    qd.execute_transaction(ExecuteTransactionRequest {
+    qd.execute_transaction(QuorumDriverRequest {
         transaction: tx.clone(),
-        request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+        request_type: QuorumDriverRequestType::WaitForEffectsCert,
     })
     .map(move |res| match res {
-        Ok(ExecuteTransactionResponse::EffectsCert(result)) => {
+        Ok(QuorumDriverResponse::EffectsCert(result)) => {
             let (_, effects) = *result;
             let minted = effects.effects.created.get(0).unwrap().0;
             let updated = effects
@@ -99,11 +96,11 @@ pub async fn submit_transaction(
     aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
 ) -> Option<TransactionEffects> {
     let qd = QuorumDriverHandler::new(aggregator.clone(), QuorumDriverMetrics::new_for_tests());
-    if let ExecuteTransactionResponse::EffectsCert(result) = qd
+    if let QuorumDriverResponse::EffectsCert(result) = qd
         .clone_quorum_driver()
-        .execute_transaction(ExecuteTransactionRequest {
+        .execute_transaction(QuorumDriverRequest {
             transaction,
-            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
         })
         .await
         .unwrap()

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use std::sync::Arc;
 use std::{collections::HashMap, fmt};
 use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
 use sui_core::{
@@ -39,7 +40,7 @@ pub async fn transfer_sui_for_testing(
     keypair: &AccountKeyPair,
     value: u64,
     address: SuiAddress,
-    client: &AuthorityAggregator<NetworkAuthorityClient>,
+    aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
 ) -> Option<UpdatedAndNewlyMinted> {
     let tx = make_transfer_sui_transaction(
         gas.0,
@@ -49,7 +50,7 @@ pub async fn transfer_sui_for_testing(
         keypair,
     );
     let quorum_driver_handler =
-        QuorumDriverHandler::new(client.clone(), QuorumDriverMetrics::new_for_tests());
+        QuorumDriverHandler::new(aggregator.clone(), QuorumDriverMetrics::new_for_tests());
     let qd = quorum_driver_handler.clone_quorum_driver();
     qd.execute_transaction(QuorumDriverRequest {
         transaction: tx.clone(),
@@ -82,7 +83,7 @@ pub async fn transfer_sui_for_testing(
 
 pub async fn get_latest(
     object_id: ObjectID,
-    aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
+    aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
 ) -> Option<Object> {
     // Return the latest object version
     match aggregator.get_object_info_execute(object_id).await.unwrap() {
@@ -93,7 +94,7 @@ pub async fn get_latest(
 
 pub async fn submit_transaction(
     transaction: Transaction,
-    aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
+    aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
 ) -> Option<TransactionEffects> {
     let qd = QuorumDriverHandler::new(aggregator.clone(), QuorumDriverMetrics::new_for_tests());
     if let QuorumDriverResponse::EffectsCert(result) = qd
@@ -187,11 +188,11 @@ impl fmt::Display for WorkloadType {
 
 #[async_trait]
 pub trait Workload<T: Payload + ?Sized>: Send + Sync {
-    async fn init(&mut self, aggregator: &AuthorityAggregator<NetworkAuthorityClient>);
+    async fn init(&mut self, aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>);
     async fn make_test_payloads(
         &self,
         count: u64,
-        client: &AuthorityAggregator<NetworkAuthorityClient>,
+        client: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
     ) -> Vec<Box<T>>;
 }
 
@@ -202,20 +203,20 @@ pub struct CombinationWorkload {
 
 #[async_trait]
 impl Workload<dyn Payload> for CombinationWorkload {
-    async fn init(&mut self, aggregator: &AuthorityAggregator<NetworkAuthorityClient>) {
+    async fn init(&mut self, aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>) {
         for (_, (_, workload)) in self.workloads.iter_mut() {
-            workload.init(aggregator).await;
+            workload.init(aggregator.clone()).await;
         }
     }
     async fn make_test_payloads(
         &self,
         count: u64,
-        aggregator: &AuthorityAggregator<NetworkAuthorityClient>,
+        aggregator: Arc<AuthorityAggregator<NetworkAuthorityClient>>,
     ) -> Vec<Box<dyn Payload>> {
         let mut workloads: HashMap<WorkloadType, (u32, Vec<Box<dyn Payload>>)> = HashMap::new();
         for (workload_type, (weight, workload)) in self.workloads.iter() {
             let payloads: Vec<Box<dyn Payload>> =
-                workload.make_test_payloads(count, aggregator).await;
+                workload.make_test_payloads(count, aggregator.clone()).await;
             assert_eq!(payloads.len() as u64, count);
             workloads
                 .entry(*workload_type)

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -72,10 +72,10 @@ mod test {
             1,  // transfer_object_weight
         )];
 
-        let aggregator = test_authority_aggregator(swarm.config());
+        let aggregator = Arc::new(test_authority_aggregator(swarm.config()));
 
         for w in workloads.iter_mut() {
-            w.workload.init(&aggregator).await;
+            w.workload.init(aggregator.clone()).await;
         }
 
         let driver = BenchDriver::new(5);

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -4,10 +4,26 @@
 use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use sui_json_rpc_types::{SuiExecuteTransactionResponse, SuiExecutionStatus};
-use sui_types::messages::ExecuteTransactionRequestType;
+use sui_sdk::SuiClient;
+use sui_types::{messages::ExecuteTransactionRequestType, base_types::TransactionDigest};
 use tracing::info;
 
 pub struct FullNodeExecuteTransactionTest;
+
+impl FullNodeExecuteTransactionTest {
+    async fn verify_transaction(fullnode: &SuiClient, tx_digest: TransactionDigest) {
+        fullnode
+        .read_api()
+        .get_transaction(tx_digest)
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed get transaction {:?} from fullnode: {:?}",
+                tx_digest, e
+            )
+        });
+    }
+}
 
 #[async_trait]
 impl TestCaseImpl for FullNodeExecuteTransactionTest {
@@ -21,10 +37,10 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         ctx.get_sui_from_faucet(Some(3)).await;
-        let mut txns = ctx.make_transactions(3).await;
+        let mut txns = ctx.make_transactions(4).await;
         assert!(
-            txns.len() >= 3,
-            "Expect at least 3 txns, but only got {}. Do we get enough gas objects from faucet?",
+            txns.len() >= 4,
+            "Expect at least 4 txns, but only got {}. Do we get enough gas objects from faucet?",
             txns.len(),
         );
 
@@ -47,17 +63,8 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
             // Verify fullnode observes the txn
             ctx.let_fullnode_sync(vec![tx_digest], 5).await;
+            Self::verify_transaction(fullnode, tx_digest).await;
 
-            fullnode
-                .read_api()
-                .get_transaction(tx_digest)
-                .await
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Failed get transaction {:?} from fullnode: {:?}",
-                        txn_digest, e
-                    )
-                });
         } else {
             panic!("Expect ImmediateReturn but got {:?}", response);
         }
@@ -78,19 +85,11 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             // Verify fullnode observes the txn
             ctx.let_fullnode_sync(vec![txn_digest], 5).await;
 
-            fullnode
-                .read_api()
-                .get_transaction(txn_digest)
-                .await
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Failed get transaction {:?} from fullnode: {:?}",
-                        txn_digest, e
-                    )
-                });
+            Self::verify_transaction(fullnode, txn_digest).await;
         } else {
             panic!("Expect TxCert but got {:?}", response);
         }
+
 
         info!("Test execution with WaitForEffectsCert");
         let txn = txns.swap_remove(0);
@@ -98,13 +97,18 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
         let response = fullnode
             .quorum_driver()
-            .execute_transaction_by_fullnode(txn, ExecuteTransactionRequestType::WaitForEffectsCert)
+            .execute_transaction_by_fullnode(
+                txn,
+                ExecuteTransactionRequestType::WaitForEffectsCert,
+            )
             .await?;
         if let SuiExecuteTransactionResponse::EffectsCert {
             certificate,
             effects,
+            confirmed_local_execution,
         } = response
         {
+            assert!(!confirmed_local_execution);
             assert_eq!(txn_digest, certificate.transaction_digest);
             if !matches!(effects.effects.status, SuiExecutionStatus::Success { .. }) {
                 panic!(
@@ -114,17 +118,39 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             }
             // Verify fullnode observes the txn
             ctx.let_fullnode_sync(vec![txn_digest], 5).await;
+            Self::verify_transaction(fullnode, txn_digest).await;
 
-            fullnode
-                .read_api()
-                .get_transaction(txn_digest)
-                .await
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Failed get transaction {:?} from fullnode: {:?}",
-                        txn_digest, e
-                    )
-                });
+        } else {
+            panic!("Expect EffectsCert but got {:?}", response);
+        }
+
+        info!("Test execution with WaitForLocalExecution");
+        let txn = txns.swap_remove(0);
+        let txn_digest = *txn.digest();
+
+        let response = fullnode
+            .quorum_driver()
+            .execute_transaction_by_fullnode(
+                txn,
+                ExecuteTransactionRequestType::WaitForLocalExecution,
+            )
+            .await?;
+        if let SuiExecuteTransactionResponse::EffectsCert {
+            certificate,
+            effects,
+            confirmed_local_execution,
+        } = response
+        {
+            assert!(confirmed_local_execution);
+            assert_eq!(txn_digest, certificate.transaction_digest);
+            if !matches!(effects.effects.status, SuiExecutionStatus::Success { .. }) {
+                panic!(
+                    "Failed to execute transfer tranasction {:?}: {:?}",
+                    txn_digest, effects.effects.status
+                )
+            }
+            // Unlike in other execution modes, there's no need to wait for the node to sync
+            Self::verify_transaction(fullnode, txn_digest).await;
         } else {
             panic!("Expect EffectsCert but got {:?}", response);
         }

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -37,10 +37,13 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         ctx.get_sui_from_faucet(Some(3)).await;
-        let mut txns = ctx.make_transactions(4).await;
+
+        let txn_count = 4;
+        let mut txns = ctx.make_transactions(txn_count).await;
         assert!(
-            txns.len() >= 4,
-            "Expect at least 4 txns, but only got {}. Do we get enough gas objects from faucet?",
+            txns.len() >= txn_count,
+            "Expect at least {} txns, but only got {}. Do we generate enough gas objects during genesis?",
+            txn_count,
             txns.len(),
         );
 

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -36,9 +36,9 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
     }
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
-        ctx.get_sui_from_faucet(Some(3)).await;
-
         let txn_count = 4;
+        ctx.get_sui_from_faucet(Some(txn_count)).await;
+
         let mut txns = ctx.make_transactions(txn_count).await;
         assert!(
             txns.len() >= txn_count,

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -5,7 +5,7 @@ use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use sui_json_rpc_types::{SuiExecuteTransactionResponse, SuiExecutionStatus};
 use sui_sdk::SuiClient;
-use sui_types::{messages::ExecuteTransactionRequestType, base_types::TransactionDigest};
+use sui_types::{base_types::TransactionDigest, messages::ExecuteTransactionRequestType};
 use tracing::info;
 
 pub struct FullNodeExecuteTransactionTest;
@@ -13,15 +13,15 @@ pub struct FullNodeExecuteTransactionTest;
 impl FullNodeExecuteTransactionTest {
     async fn verify_transaction(fullnode: &SuiClient, tx_digest: TransactionDigest) {
         fullnode
-        .read_api()
-        .get_transaction(tx_digest)
-        .await
-        .unwrap_or_else(|e| {
-            panic!(
-                "Failed get transaction {:?} from fullnode: {:?}",
-                tx_digest, e
-            )
-        });
+            .read_api()
+            .get_transaction(tx_digest)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed get transaction {:?} from fullnode: {:?}",
+                    tx_digest, e
+                )
+            });
     }
 }
 
@@ -64,7 +64,6 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             // Verify fullnode observes the txn
             ctx.let_fullnode_sync(vec![tx_digest], 5).await;
             Self::verify_transaction(fullnode, tx_digest).await;
-
         } else {
             panic!("Expect ImmediateReturn but got {:?}", response);
         }
@@ -90,17 +89,13 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             panic!("Expect TxCert but got {:?}", response);
         }
 
-
         info!("Test execution with WaitForEffectsCert");
         let txn = txns.swap_remove(0);
         let txn_digest = *txn.digest();
 
         let response = fullnode
             .quorum_driver()
-            .execute_transaction_by_fullnode(
-                txn,
-                ExecuteTransactionRequestType::WaitForEffectsCert,
-            )
+            .execute_transaction_by_fullnode(txn, ExecuteTransactionRequestType::WaitForEffectsCert)
             .await?;
         if let SuiExecuteTransactionResponse::EffectsCert {
             certificate,
@@ -119,7 +114,6 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             // Verify fullnode observes the txn
             ctx.let_fullnode_sync(vec![txn_digest], 5).await;
             Self::verify_transaction(fullnode, txn_digest).await;
-
         } else {
             panic!("Expect EffectsCert but got {:?}", response);
         }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -523,32 +523,30 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub async fn handle_certificate_with_effects(
         &self,
-        certificate: &CertifiedTransaction,
-        // NOTE: the caller of this (node_sync) must promise to wait until it
-        // knows for sure this tx is finalized, namely, it has seen a
-        // CertifiedTransactionEffects or at least f+1 identifical effects
-        // digests matching this TransactionEffectsEnvelope, before calling
-        // this function, in order to prevent a byzantine validator from
-        // giving us incorrect effects.
-        // TODO: allow CertifiedTransactionEffects only
-        effects: &TransactionEffectsEnvelope<S>,
+        certificate: CertifiedTransaction,
+        // Signed effects is signed by only one validator, it is not a
+        // CertifiedTransactionEffects. The caller of this (node_sync) must promise to
+        // wait until it has seen at least f+1 identifical effects digests matching this
+        // SignedTransactionEffects before calling this function, in order to prevent a
+        // byzantine validator from giving us incorrect effects.
+        signed_effects: SignedTransactionEffects,
     ) -> SuiResult {
         let _metrics_guard = start_timer(self.metrics.handle_node_sync_certificate_latency.clone());
         let digest = *certificate.digest();
         debug!(?digest, "handle_certificate_with_effects");
         fp_ensure!(
-            effects.effects.transaction_digest == tx_digest,
+            signed_effects.effects.transaction_digest == digest,
             SuiError::ErrorWhileProcessingConfirmationTransaction {
                 err: "effects/tx digest mismatch".to_string()
             }
         );
 
-        let tx_guard = self.database.acquire_tx_guard(certificate).await?;
+        let tx_guard = self.database.acquire_tx_guard(&certificate).await?;
 
         if certificate.contains_shared_object() {
             self.database.acquire_shared_locks_from_effects(
-                certificate,
-                &effects.effects,
+                &certificate,
+                &signed_effects.effects,
                 &tx_guard,
             )?;
         }
@@ -556,15 +554,15 @@ impl AuthorityState {
         let resp = self
             .process_certificate(tx_guard, &certificate, true)
             .await
-            .tap_err(|e| debug!(?tx_digest, "process_certificate failed: {}", e))?;
+            .tap_err(|e| debug!(?digest, "process_certificate failed: {}", e))?;
 
-        let expected_effects_digest = effects.digest();
+        let expected_effects_digest = signed_effects.digest();
         let observed_effects_digest = resp.signed_effects.as_ref().map(|e| e.digest());
         if observed_effects_digest != Some(expected_effects_digest) {
             error!(
                 ?expected_effects_digest,
                 ?observed_effects_digest,
-                ?effects.effects,
+                ?signed_effects,
                 ?resp.signed_effects,
                 input_objects = ?certificate.signed_data.data.input_objects(),
                 "Locally executed effects do not match canonical effects!");

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -523,30 +523,32 @@ impl AuthorityState {
     #[instrument(level = "trace", skip_all)]
     pub async fn handle_certificate_with_effects(
         &self,
-        certificate: CertifiedTransaction,
-        // Signed effects is signed by only one validator, it is not a
-        // CertifiedTransactionEffects. The caller of this (node_sync) must promise to
-        // wait until it has seen at least f+1 identifical effects digests matching this
-        // SignedTransactionEffects before calling this function, in order to prevent a
-        // byzantine validator from giving us incorrect effects.
-        signed_effects: SignedTransactionEffects,
+        certificate: &CertifiedTransaction,
+        // NOTE: the caller of this (node_sync) must promise to wait until it
+        // knows for sure this tx is finalized, namely, it has seen a
+        // CertifiedTransactionEffects or at least f+1 identifical effects
+        // digests matching this TransactionEffectsEnvelope, before calling
+        // this function, in order to prevent a byzantine validator from
+        // giving us incorrect effects.
+        // TODO: allow CertifiedTransactionEffects only
+        effects: &TransactionEffectsEnvelope<S>,
     ) -> SuiResult {
         let _metrics_guard = start_timer(self.metrics.handle_node_sync_certificate_latency.clone());
         let digest = *certificate.digest();
         debug!(?digest, "handle_certificate_with_effects");
         fp_ensure!(
-            signed_effects.effects.transaction_digest == digest,
+            effects.effects.transaction_digest == tx_digest,
             SuiError::ErrorWhileProcessingConfirmationTransaction {
                 err: "effects/tx digest mismatch".to_string()
             }
         );
 
-        let tx_guard = self.database.acquire_tx_guard(&certificate).await?;
+        let tx_guard = self.database.acquire_tx_guard(certificate).await?;
 
         if certificate.contains_shared_object() {
             self.database.acquire_shared_locks_from_effects(
-                &certificate,
-                &signed_effects.effects,
+                certificate,
+                &effects.effects,
                 &tx_guard,
             )?;
         }
@@ -554,15 +556,15 @@ impl AuthorityState {
         let resp = self
             .process_certificate(tx_guard, &certificate, true)
             .await
-            .tap_err(|e| debug!(?digest, "process_certificate failed: {}", e))?;
+            .tap_err(|e| debug!(?tx_digest, "process_certificate failed: {}", e))?;
 
-        let expected_effects_digest = signed_effects.digest();
+        let expected_effects_digest = effects.digest();
         let observed_effects_digest = resp.signed_effects.as_ref().map(|e| e.digest());
         if observed_effects_digest != Some(expected_effects_digest) {
             error!(
                 ?expected_effects_digest,
                 ?observed_effects_digest,
-                ?signed_effects,
+                ?effects.effects,
                 ?resp.signed_effects,
                 input_objects = ?certificate.signed_data.data.input_objects(),
                 "Locally executed effects do not match canonical effects!");

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -252,10 +252,6 @@ impl<A> ActiveAuthority<A> {
         let entry = lock.entry(name).or_default();
         entry.can_initiate_contact_now()
     }
-
-    pub fn clone_node_sync_state(&self) -> Arc<NodeSyncState<A>> {
-        self.node_sync_state.clone()
-    }
 }
 
 impl<A> Clone for ActiveAuthority<A> {
@@ -380,10 +376,11 @@ where
     }
 
     async fn respawn_node_sync_process_impl(
-        &self,
+        self: Arc<Self>,
         mut lock_guard: MutexGuard<'_, Option<NodeSyncProcessHandle>>,
     ) {
-        info!(epoch = ?self.state.committee.load().epoch, "respawn_node_sync_process");
+        let epoch = self.state.committee.load().epoch;
+        info!(?epoch, "respawn_node_sync_process");
         Self::cancel_node_sync_process_impl(&mut lock_guard).await;
 
         let (cancel_sender, cancel_receiver) = oneshot::channel();

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -170,7 +170,7 @@ impl<A> ActiveAuthority<A> {
         })
     }
 
-    fn net(&self) -> Arc<AuthorityAggregator<A>> {
+    pub fn net(&self) -> Arc<AuthorityAggregator<A>> {
         self.net.load().clone()
     }
 
@@ -404,17 +404,16 @@ where
         *lock_guard = Some(NodeSyncProcessHandle(join_handle, cancel_sender));
     }
 
-    #[cfg(test)]
-    pub async fn cancel_node_sync_process(&self) {
-        let mut lock_guard = self.node_sync_process.lock().await;
-        Self::cancel_node_sync_process_impl(&mut lock_guard).await;
-    }
-
     /// Spawn pending certificate execution process
     pub async fn spawn_execute_process(self: Arc<Self>) -> JoinHandle<()> {
         tokio::task::spawn(async move {
             execution_process(self).await;
         })
+    }
+
+    pub async fn cancel_node_sync_process_for_tests(&self) {
+        let mut lock_guard = self.node_sync_process.lock().await;
+        Self::cancel_node_sync_process_impl(&mut lock_guard).await;
     }
 }
 

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -170,7 +170,7 @@ impl<A> ActiveAuthority<A> {
         })
     }
 
-    pub fn net(&self) -> Arc<AuthorityAggregator<A>> {
+    pub fn agg_aggregator(&self) -> Arc<AuthorityAggregator<A>> {
         self.net.load().clone()
     }
 
@@ -308,7 +308,7 @@ where
         // TODO: potentially move get_latest_proposal_and_checkpoint_from_all and
         // sync_to_checkpoint out of checkpoint_driver
         let checkpoint_summary = get_latest_checkpoint_from_all(
-            self.net(),
+            self.agg_aggregator(),
             checkpoint_process_control.extra_time_after_quorum,
             checkpoint_process_control.timeout_until_quorum,
         )
@@ -387,7 +387,7 @@ where
         Self::cancel_node_sync_process_impl(&mut lock_guard).await;
 
         let (cancel_sender, cancel_receiver) = oneshot::channel();
-        let aggregator = self.net();
+        let aggregator = self.agg_aggregator();
 
         let node_sync_handle = self.clone().node_sync_handle();
         let node_sync_store = self.node_sync_store.clone();

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -401,7 +401,7 @@ impl ValidatorService {
         // 2) Check idempotency
         let tx_digest = certificate.digest();
         if let Some(response) = state
-            .check_tx_already_executed(tx_digest)
+            .get_tx_info_already_executed(tx_digest)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?
         {

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod quorum_driver;
 pub mod safe_client;
 pub mod streamer;
 pub mod transaction_input_checker;
+pub mod transaction_orchestrator;
 pub mod transaction_streamer;
 
 pub mod test_utils;

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -182,7 +182,7 @@ pub enum SyncArg {
     /// In follow mode, wait for 2f+1 votes for a tx before executing
     Follow(AuthorityName, ExecutionDigests),
 
-    /// Sync a cert that is finalized. It may appear as a parent in the verified effects of some 
+    /// Sync a cert that is finalized. It may appear as a parent in the verified effects of some
     /// other cert, or come from the Transaction Orchestrator.
     Parent(TransactionDigest),
 
@@ -553,7 +553,7 @@ where
             .await?;
 
         match self
-            .state
+            .state()
             .handle_certificate_with_effects(&cert, &effects)
             .await
         {

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -182,8 +182,8 @@ pub enum SyncArg {
     /// In follow mode, wait for 2f+1 votes for a tx before executing
     Follow(AuthorityName, ExecutionDigests),
 
-    /// Sync a cert which is appears as a parent in the verified effects of some other cert,
-    /// and is thus known to be final.
+    /// Sync a cert that is finalized. It may appear as a parent in the verified effects of some 
+    /// other cert, or come from the Transaction Orchestrator.
     Parent(TransactionDigest),
 
     /// In checkpoint mode, all txes are known to be final.
@@ -553,8 +553,8 @@ where
             .await?;
 
         match self
-            .state()
-            .handle_certificate_with_effects(cert.clone(), effects.clone())
+            .state
+            .handle_certificate_with_effects(&cert, &effects)
             .await
         {
             Ok(_) => Ok(SyncStatus::CertExecuted),
@@ -657,8 +657,9 @@ where
                     .await;
             }
             SyncArg::Parent(digest) => {
-                // digest is known to be final because it appeared in the dependencies list of a
-                // verified TransactionEffects
+                // digest is known to be final because it either appeared in
+                // the dependencies list of a verified TransactionEffects, or
+                // is passed from TransactionOrchestrator
                 return self.process_parent_request(permit, epoch_id, &digest).await;
             }
             SyncArg::Follow(_peer, digests) => {
@@ -714,7 +715,7 @@ where
             .await?;
 
         self.state()
-            .handle_certificate_with_effects(cert, effects.clone())
+            .handle_certificate_with_effects(&cert, &effects)
             .await?;
 
         Ok(SyncStatus::CertExecuted)

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -76,7 +76,7 @@ where
         request: ExecuteTransactionRequest,
     ) -> SuiResult<ExecuteTransactionResponse> {
         let tx_digest = request.transaction.digest();
-        debug!("Receive tranasction execution request {tx_digest:?}");
+        debug!(?tx_digest, "Receive tranasction execution request");
         self.metrics.current_requests_in_flight.inc();
         let _metrics_guard = scopeguard::guard(self.metrics.clone(), |metrics| {
             metrics.current_requests_in_flight.dec();
@@ -246,6 +246,8 @@ where
         quorum_driver: Arc<QuorumDriver<A>>,
         mut task_receiver: Receiver<QuorumTask<A>>,
     ) {
+        // TODO https://github.com/MystenLabs/sui/issues/4565
+        // spawn a tokio task for each job for higher concurrency
         loop {
             if let Some(task) = task_receiver.recv().await {
                 match task {

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -254,7 +254,10 @@ where
                 debug!(?tx_digest, "Orchestrator failed to executue transaction optimistically due to missing parents");
 
                 match node_sync_handle
-                    .handle_parents_request(std::iter::once(*tx_digest))
+                    .handle_parents_request(
+                        state.committee.load().epoch,
+                        std::iter::once(*tx_digest),
+                    )
                     .await?
                     .next()
                     .await

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-Transaction Orchestrator is a Quorum Driver wrapper that proactively
-execute finalzied transactions locally by leveraging the NodeSyncState.
+Transaction Orchestrator is a Node component that utilizes Quorum Driver to
+move transactions forward in validators and proactively executes finalized
+transactions locally by leveraging the NodeSyncState.
 */
 
 use std::sync::Arc;
@@ -140,14 +141,14 @@ where
         effects_cert: &CertifiedTransactionEffects,
     ) -> SuiResult {
         // TODO: attempt a finalized tx at most once per request.
-        // Every WaitForEffectsCert request will be attempted to execute twice,
-        // one from the subscriber queue, one from the proactively execution
-        // before returning results to clients. This is not insanely bad because
+        // Every WaitForLocalExecution request will be attempted to execute twice,
+        // one from the subscriber queue, one from the proactive execution before
+        // returning results to clients. This is not insanely bad because:
         // 1. it's possible that one attempt finishes before the other, so there's
-        //      zero extra work
+        //      zero extra work except DB checks
         // 2. an up-to-date fullnode should have minimal overhead to sync parents
         //      (for one extra time)
-        // 3. the tx will be executed at most once per lock guard.
+        // 3. at the end of day, the tx will be executed at most once per lock guard.
         let tx_digest = tx_cert.digest();
         if node_sync_state.is_tx_finalized_and_executed_locally(tx_digest)? {
             return Ok(());

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -44,7 +44,7 @@ where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
     pub fn new(
-        validators: AuthorityAggregator<A>,
+        validators: Arc<AuthorityAggregator<A>>,
         node_sync_state: Arc<NodeSyncState<A>>,
         prometheus_registry: &Registry,
     ) -> Self {

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -168,4 +168,8 @@ where
             }
         }
     }
+
+    pub fn quorum_driver(&self) -> &Arc<QuorumDriver<A>> {
+        &self.quorum_driver
+    }
 }

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+    FIXME
+*/
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::authority_aggregator::AuthorityAggregator;
+use crate::authority_client::AuthorityAPI;
+use crate::node_sync::NodeSyncState;
+use crate::quorum_driver::{QuorumDriver, QuorumDriverHandler, QuorumDriverMetrics};
+use prometheus::Registry;
+use sui_types::error::{SuiError, SuiResult};
+use sui_types::messages::{
+    CertifiedTransaction, CertifiedTransactionEffects, ExecuteTransactionRequest,
+    ExecuteTransactionResponse,
+};
+use tap::TapFallible;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::Receiver;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tracing::{debug, error, warn};
+
+/// When requested to execute a transaction with WaitForEffectsCert,
+/// TransactionOrchestrator attemps to execute this transaction locally
+/// after it is finalized.
+/// Some(true) => executed locally
+/// Some(false) => not executed locally, due to timeout or other errors
+/// None => did not attempt to execute locally (not with WaitForEffectsCert request type)
+pub type IsTransactionExecutedLocally = Option<bool>;
+
+// How long to wait for local execution (including parents) before a timeout
+// is returned to client.
+const LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct TransactiondOrchestrator<A> {
+    _quorum_driver_handler: QuorumDriverHandler<A>,
+    quorum_driver: Arc<QuorumDriver<A>>,
+    node_sync_state: Arc<NodeSyncState<A>>,
+    _local_executor_handle: JoinHandle<()>,
+}
+
+impl<A> TransactiondOrchestrator<A>
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    pub fn new(
+        validators: AuthorityAggregator<A>,
+        node_sync_state: Arc<NodeSyncState<A>>,
+        prometheus_registry: &Registry,
+    ) -> Self {
+        let quorum_driver_handler =
+            QuorumDriverHandler::new(validators, QuorumDriverMetrics::new(prometheus_registry));
+        let quorum_driver = quorum_driver_handler.clone_quorum_driver();
+        let effects_receiver = quorum_driver_handler.subscribe();
+        let state_clone = node_sync_state.clone();
+        let _local_executor_handle = {
+            tokio::task::spawn(async move {
+                Self::loop_execute_finalized_tx_locally(state_clone, effects_receiver).await;
+            })
+        };
+        Self {
+            _quorum_driver_handler: quorum_driver_handler,
+            quorum_driver,
+            node_sync_state,
+            _local_executor_handle,
+        }
+    }
+
+    pub async fn execute_transaction(
+        &self,
+        request: ExecuteTransactionRequest,
+    ) -> SuiResult<(ExecuteTransactionResponse, IsTransactionExecutedLocally)> {
+        // TODO check if tx is already executed on this node.
+        // Note: since EffectsCert is not stored today, we need to gather that from validators
+        // (and maybe store it for caching purposes)
+
+        let execution_result = self
+            .quorum_driver
+            .execute_transaction(request)
+            .await
+            .tap_err(|err| debug!("Failed to execute transction via Quorum Driver: {:?}", err))?;
+
+        match &execution_result {
+            ExecuteTransactionResponse::EffectsCert(result) => {
+                let (tx_cert, effects_cert) = result.as_ref();
+                match Self::execute_finalized_tx_locally(
+                    &self.node_sync_state,
+                    tx_cert,
+                    effects_cert,
+                )
+                .await
+                {
+                    Ok(_) => Ok((execution_result, Some(true))),
+                    Err(_) => Ok((execution_result, Some(false))),
+                }
+            }
+            _ => Ok((execution_result, None)),
+        }
+    }
+
+    async fn execute_finalized_tx_locally(
+        node_sync_state: &Arc<NodeSyncState<A>>,
+        tx_cert: &CertifiedTransaction,
+        effects_cert: &CertifiedTransactionEffects,
+    ) -> SuiResult {
+        // TODO: attempt a finalized tx at most once per request.
+        // Every WaitForEffectsCert request will be attempted to execute twice,
+        // one from the subscriber queue, one from the proactively execution
+        // before returning results to clients. This is not insanely bad because
+        // 1. it's possible that one attempt finishes before the other, so there's
+        //      zero extra work
+        // 2. an up-to-date fullnode should have minimal overhead to sync parents
+        //      (for one extra time)
+        // 3. the tx will be executed at most once per lock guard.
+        let tx_digest = tx_cert.digest();
+        if node_sync_state.is_tx_finalized_and_executed_locally(tx_digest)? {
+            return Ok(());
+        }
+        match timeout(
+            LOCAL_EXECUTION_TIMEOUT,
+            node_sync_state.execute_finalized_transaction_for_orchestrator(tx_cert, effects_cert),
+        )
+        .await
+        {
+            Err(_elapsed) => {
+                debug!(
+                    ?tx_digest,
+                    "Executing tx locally by orchestrator timed out within {:?}.",
+                    LOCAL_EXECUTION_TIMEOUT
+                );
+                Err(SuiError::TimeoutError)
+            }
+            Ok(Err(err)) => {
+                debug!(
+                    ?tx_digest,
+                    "Executing tx locally by orchestrator failed with error: {:?}", err
+                );
+                Err(SuiError::TransactionOrchestratorLocalExecutionError {
+                    error: err.to_string(),
+                })
+            }
+            Ok(Ok(_)) => Ok(()),
+        }
+    }
+
+    async fn loop_execute_finalized_tx_locally(
+        node_sync_state: Arc<NodeSyncState<A>>,
+        mut effects_receiver: Receiver<(CertifiedTransaction, CertifiedTransactionEffects)>,
+    ) {
+        loop {
+            match effects_receiver.recv().await {
+                Ok((tx_cert, effects_cert)) => {
+                    Self::execute_finalized_tx_locally(&node_sync_state, &tx_cert, &effects_cert)
+                        .await;
+                }
+                Err(RecvError::Closed) => {
+                    error!("Sender of effects subscriber queue has been dropped!");
+                    return;
+                }
+                Err(RecvError::Lagged(skipped_count)) => {
+                    warn!("Skipped {skipped_count} transasctions in effects subscriber queue.");
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2421,7 +2421,8 @@ async fn test_consensus_message_processed() {
         let effects2 = if send_first && rng.gen_bool(0.5) {
             handle_cert(&authority2, &certificate).await
         } else {
-            authority2.handle_certificate_with_effects(certificate.clone(), effects1.clone())
+            authority2
+                .handle_certificate_with_effects(&certificate, &effects1)
                 .await
                 .unwrap();
             authority2

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2421,8 +2421,7 @@ async fn test_consensus_message_processed() {
         let effects2 = if send_first && rng.gen_bool(0.5) {
             handle_cert(&authority2, &certificate).await
         } else {
-            authority2
-                .handle_certificate_with_effects(certificate.clone(), effects1.clone())
+            authority2.handle_certificate_with_effects(certificate.clone(), effects1.clone())
                 .await
                 .unwrap();
             authority2

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -366,6 +366,9 @@ pub enum SuiExecuteTransactionResponse {
     EffectsCert {
         certificate: SuiCertifiedTransaction,
         effects: SuiCertifiedTransactionEffects,
+        // If the transaction is confirmed to be executed locally
+        // before this reponse.
+        confirmed_local_execution: bool,
     },
 }
 
@@ -385,13 +388,14 @@ impl SuiExecuteTransactionResponse {
                 }
             }
             ExecuteTransactionResponse::EffectsCert(cert) => {
-                let (certificate, effects) = *cert;
+                let (certificate, effects, is_executed_locally) = *cert;
                 let certificate: SuiCertifiedTransaction = certificate.try_into()?;
                 let effects: SuiCertifiedTransactionEffects =
                     SuiCertifiedTransactionEffects::try_from(effects, resolver)?;
                 SuiExecuteTransactionResponse::EffectsCert {
                     certificate,
                     effects,
+                    confirmed_local_execution: is_executed_locally,
                 }
             }
         })

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -515,8 +515,20 @@ pub trait EventReadApi {
 
 #[open_rpc(namespace = "sui", tag = "APIs to execute transactions.")]
 #[rpc(server, client, namespace = "sui")]
-pub trait QuorumDriverApi {
-    /// Execute the transaction and wait for results if desired
+pub trait TransactionExecutionApi {
+    /// Execute the transaction and wait for results if desired.
+    /// Request types:
+    /// 1. ImmediateReturn: immediate return to client without waiting for any results
+    ///     Note the transaction may fail without being noticed by client in this mode.
+    ///     After getting the response, client use poll the node to check transaction's result
+    /// 2. WaitForTxCert: wait for TransactionCertificate and then return to client.
+    /// 3. WaitForEffectsCert: wait for TransactionEffectsCert and then return to client.
+    ///     This mode is a proxy for transaction finality.
+    /// 4. WaitForLocalExecution: wait for TransactionEffectsCert and make sure the node has
+    ///     executed the transaction locally before returning the client. The local execution
+    ///     makes sure this node is aware of this transaction when client fires subsequent queries.
+    ///     However if the node fails to execute the transaction locally in a timely manner,
+    ///     a bool type in the response is set to false to indicated the case.
     #[method(name = "executeTransaction")]
     async fn execute_transaction(
         &self,

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -518,13 +518,14 @@ pub trait EventReadApi {
 pub trait TransactionExecutionApi {
     /// Execute the transaction and wait for results if desired.
     /// Request types:
-    /// 1. ImmediateReturn: immediate return to client without waiting for any results
-    ///     Note the transaction may fail without being noticed by client in this mode.
-    ///     After getting the response, client use poll the node to check transaction's result
-    /// 2. WaitForTxCert: wait for TransactionCertificate and then return to client.
-    /// 3. WaitForEffectsCert: wait for TransactionEffectsCert and then return to client.
+    /// 1. ImmediateReturn: immediately returns a response to client without waiting
+    ///     for any execution results.  Note the transaction may fail without being
+    ///     noticed by client in this mode. After getting the response, the client
+    ///     may poll the node to check the result of the transaction.
+    /// 2. WaitForTxCert: waits for TransactionCertificate and then return to client.
+    /// 3. WaitForEffectsCert: waits for TransactionEffectsCert and then return to client.
     ///     This mode is a proxy for transaction finality.
-    /// 4. WaitForLocalExecution: wait for TransactionEffectsCert and make sure the node has
+    /// 4. WaitForLocalExecution: waits for TransactionEffectsCert and make sure the node
     ///     executed the transaction locally before returning the client. The local execution
     ///     makes sure this node is aware of this transaction when client fires subsequent queries.
     ///     However if the node fails to execute the transaction locally in a timely manner,

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -513,7 +513,7 @@ pub trait EventReadApi {
     ) -> RpcResult<Vec<SuiEventEnvelope>>;
 }
 
-#[open_rpc(namespace = "sui", tag = "Quorum Driver APIs to execute transactions.")]
+#[open_rpc(namespace = "sui", tag = "APIs to execute transactions.")]
 #[rpc(server, client, namespace = "sui")]
 pub trait QuorumDriverApi {
     /// Execute the transaction and wait for results if desired

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -27,9 +27,9 @@ pub mod bcs_api;
 pub mod estimator_api;
 pub mod event_api;
 pub mod gateway_api;
-pub mod quorum_driver_api;
 pub mod read_api;
 pub mod streaming_api;
+pub mod transaction_execution_api;
 
 pub enum ServerBuilder<M = ()> {
     HttpBuilder(HttpServerBuilder<M>),

--- a/crates/sui-json-rpc/src/quorum_driver_api.rs
+++ b/crates/sui-json-rpc/src/quorum_driver_api.rs
@@ -12,7 +12,7 @@ use signature::Signature;
 use std::sync::Arc;
 use sui_core::authority::{AuthorityStore, ResolverWrapper};
 use sui_core::authority_client::NetworkAuthorityClient;
-use sui_core::quorum_driver::QuorumDriver;
+use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_json_rpc_types::SuiExecuteTransactionResponse;
 use sui_open_rpc::Module;
 use sui_types::crypto::SignatureScheme;
@@ -25,13 +25,16 @@ use sui_types::{
 };
 
 pub struct FullNodeQuorumDriverApi {
-    pub quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
+    // pub quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
+    pub quorum_driver: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
     pub module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
 }
 
 impl FullNodeQuorumDriverApi {
     pub fn new(
-        quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
+        // quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
+        // FIXME
+        quorum_driver: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
         module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
     ) -> Self {
         Self {
@@ -59,6 +62,7 @@ impl QuorumDriverApiServer for FullNodeQuorumDriverApi {
         .map_err(|e| anyhow!(e))?;
         let txn = Transaction::new(data, signature);
         let txn_digest = *txn.digest();
+
         let response = self
             .quorum_driver
             .execute_transaction(ExecuteTransactionRequest {

--- a/crates/sui-json-rpc/src/quorum_driver_api.rs
+++ b/crates/sui-json-rpc/src/quorum_driver_api.rs
@@ -25,20 +25,17 @@ use sui_types::{
 };
 
 pub struct FullNodeQuorumDriverApi {
-    // pub quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
-    pub quorum_driver: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
+    pub transaction_orchestrator: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
     pub module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
 }
 
 impl FullNodeQuorumDriverApi {
     pub fn new(
-        // quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
-        // FIXME
-        quorum_driver: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
+        transaction_orchestrator: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
         module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
     ) -> Self {
         Self {
-            quorum_driver,
+            transaction_orchestrator,
             module_cache,
         }
     }
@@ -64,7 +61,7 @@ impl QuorumDriverApiServer for FullNodeQuorumDriverApi {
         let txn_digest = *txn.digest();
 
         let response = self
-            .quorum_driver
+            .transaction_orchestrator
             .execute_transaction(ExecuteTransactionRequest {
                 transaction: txn,
                 request_type,

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::api::QuorumDriverApiServer;
+use crate::api::TransactionExecutionApiServer;
 use crate::SuiRpcModule;
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -24,12 +24,12 @@ use sui_types::{
     messages::{Transaction, TransactionData},
 };
 
-pub struct FullNodeQuorumDriverApi {
+pub struct FullNodeTransactionExecutionApi {
     pub transaction_orchestrator: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
     pub module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
 }
 
-impl FullNodeQuorumDriverApi {
+impl FullNodeTransactionExecutionApi {
     pub fn new(
         transaction_orchestrator: Arc<TransactiondOrchestrator<NetworkAuthorityClient>>,
         module_cache: Arc<SyncModuleCache<ResolverWrapper<AuthorityStore>>>,
@@ -42,7 +42,7 @@ impl FullNodeQuorumDriverApi {
 }
 
 #[async_trait]
-impl QuorumDriverApiServer for FullNodeQuorumDriverApi {
+impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
     async fn execute_transaction(
         &self,
         tx_bytes: Base64,
@@ -77,12 +77,12 @@ impl QuorumDriverApiServer for FullNodeQuorumDriverApi {
     }
 }
 
-impl SuiRpcModule for FullNodeQuorumDriverApi {
+impl SuiRpcModule for FullNodeTransactionExecutionApi {
     fn rpc(self) -> RpcModule<Self> {
         self.into_rpc()
     }
 
     fn rpc_doc_module() -> Module {
-        crate::api::QuorumDriverApiOpenRpc::module_doc()
+        crate::api::TransactionExecutionApiOpenRpc::module_doc()
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -180,14 +180,14 @@ impl SuiNode {
             None
         };
 
-        let pending_store = Arc::new(NodeSyncStore::open_tables_read_write(
+        let node_sync_store = Arc::new(NodeSyncStore::open_tables_read_write(
             config.db_path().join("node_sync_db"),
             None,
             None,
         ));
         let active_authority = Arc::new(ActiveAuthority::new(
             state.clone(),
-            pending_store,
+            node_sync_store,
             net,
             GossipMetrics::new(&prometheus_registry),
             network_metrics.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -189,7 +189,9 @@ impl SuiNode {
         let transaction_orchestrator = if is_full_node {
             Some(Arc::new(TransactiondOrchestrator::new(
                 arc_net,
-                active_authority.node_sync_state.clone(),
+                state.clone(),
+                active_authority.node_sync_handle(),
+                // active_authority.node_sync_state.clone(),
                 &prometheus_registry,
             )))
         } else {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -185,10 +185,11 @@ impl SuiNode {
             network_metrics.clone(),
         )?);
 
+        let arc_net = active_authority.agg_aggregator();
+
         let transaction_orchestrator = if is_full_node {
             Some(Arc::new(TransactiondOrchestrator::new(
-                // FIXME
-                net.clone(),
+                arc_net,
                 active_authority.node_sync_state.clone(),
                 &prometheus_registry,
             )))
@@ -324,12 +325,6 @@ impl SuiNode {
     pub fn active(&self) -> &Arc<ActiveAuthority<NetworkAuthorityClient>> {
         &self.active
     }
-
-    // pub fn quorum_driver(&self) -> Option<Arc<QuorumDriver<NetworkAuthorityClient>>> {
-    //     self.transaction_orchestrator
-    //         .as_ref()
-    //         .map(|to| to.quorum_driver().clone())
-    // }
 
     pub fn transaction_orchestrator(
         &self,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -190,8 +190,7 @@ impl SuiNode {
             Some(Arc::new(TransactiondOrchestrator::new(
                 arc_net,
                 state.clone(),
-                active_authority.node_sync_handle(),
-                // active_authority.node_sync_state.clone(),
+                active_authority.clone().node_sync_handle(),
                 &prometheus_registry,
             )))
         } else {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -45,9 +45,9 @@ use sui_core::epoch::epoch_store::EpochStore;
 use sui_json_rpc::event_api::EventReadApiImpl;
 use sui_json_rpc::event_api::EventStreamingApiImpl;
 use sui_json_rpc::http_server::HttpServerHandle;
-use sui_json_rpc::quorum_driver_api::FullNodeQuorumDriverApi;
 use sui_json_rpc::read_api::FullNodeApi;
 use sui_json_rpc::read_api::ReadApi;
+use sui_json_rpc::transaction_execution_api::FullNodeTransactionExecutionApi;
 use sui_json_rpc::ws_server::WsServerHandle;
 use sui_json_rpc::JsonRpcServerBuilder;
 use sui_types::crypto::KeypairTraits;
@@ -66,7 +66,6 @@ pub struct SuiNode {
     _checkpoint_process_handle: Option<tokio::task::JoinHandle<()>>,
     state: Arc<AuthorityState>,
     active: Arc<ActiveAuthority<NetworkAuthorityClient>>,
-    // quorum_driver_handler: Option<QuorumDriverHandler<NetworkAuthorityClient>>,
     transaction_orchestrator: Option<Arc<TransactiondOrchestrator<NetworkAuthorityClient>>>,
     _prometheus_registry: Registry,
 }
@@ -375,7 +374,7 @@ pub async fn build_http_servers(
     server.register_module(BcsApiImpl::new(state.clone()))?;
 
     if let Some(transaction_orchestrator) = transaction_orchestrator {
-        server.register_module(FullNodeQuorumDriverApi::new(
+        server.register_module(FullNodeTransactionExecutionApi::new(
             transaction_orchestrator.clone(),
             state.module_cache.clone(),
         ))?;

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -21,11 +21,11 @@ use sui_config::gateway::GatewayConfig;
 use sui_core::gateway_state::{GatewayClient, GatewayState};
 pub use sui_json as json;
 use sui_json_rpc::api::EventStreamingApiClient;
-use sui_json_rpc::api::QuorumDriverApiClient;
 use sui_json_rpc::api::RpcBcsApiClient;
 use sui_json_rpc::api::RpcFullNodeReadApiClient;
 use sui_json_rpc::api::RpcGatewayApiClient;
 use sui_json_rpc::api::RpcReadApiClient;
+use sui_json_rpc::api::TransactionExecutionApiClient;
 use sui_json_rpc::api::WalletSyncApiClient;
 pub use sui_json_rpc_types as rpc_types;
 use sui_json_rpc_types::{
@@ -429,7 +429,7 @@ impl QuorumDriver {
         Ok(match &*self.api {
             SuiClientApi::Rpc(c) => {
                 let (tx_bytes, flag, signature, pub_key) = tx.to_network_data_for_execution();
-                QuorumDriverApiClient::execute_transaction(
+                TransactionExecutionApiClient::execute_transaction(
                     &c.http,
                     tx_bytes,
                     flag,

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
+// use std::sync::Arc;
 
 use anyhow::{anyhow, Error};
 use base64ct::Encoding;
@@ -1501,3 +1502,12 @@ impl ToString for SignatureScheme {
         }
     }
 }
+
+// impl Signer<Ed25519Signature> for Arc<Ed25519KeyPair> {
+//     fn try_sign(&self, msg: &[u8]) -> Result<Ed25519Signature, signature::Error> {
+//         Ok(Ed25519Signature {
+//             sig: self.secret.0.sign(msg),
+//             bytes: once_cell::sync::OnceCell::new(),
+//         })
+//     }
+// }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -3,7 +3,6 @@
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
-// use std::sync::Arc;
 
 use anyhow::{anyhow, Error};
 use base64ct::Encoding;
@@ -1502,12 +1501,3 @@ impl ToString for SignatureScheme {
         }
     }
 }
-
-// impl Signer<Ed25519Signature> for Arc<Ed25519KeyPair> {
-//     fn try_sign(&self, msg: &[u8]) -> Result<Ed25519Signature, signature::Error> {
-//         Ok(Ed25519Signature {
-//             sig: self.secret.0.sign(msg),
-//             bytes: once_cell::sync::OnceCell::new(),
-//         })
-//     }
-// }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -343,6 +343,9 @@ pub enum SuiError {
     #[error("Failed to deserialize fields into JSON: {error:?}")]
     ExtraFieldFailedToDeserialize { error: String },
 
+    #[error("Failed to execute transaction locally by Orchestrator: {error:?}")]
+    TransactionOrchestratorLocalExecutionError { error: String },
+
     #[error(
     "Failed to achieve quorum between authorities, cause by : {:#?}",
     errors.iter().map(| e | ToString::to_string(&e)).collect::<Vec<String>>()

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1684,6 +1684,16 @@ impl CertifiedTransactionEffects {
             auth_signature: EmptySignInfo {},
         }
     }
+
+    // pub fn to_signed_effects(self) -> SignedTransactionEffects {
+    //     let sigs = self.auth_signature.signature.0.get(0).unwrap();
+    //     self.auth_signature
+    //     SignedTransactionEffects {
+    //         transaction_effects_digest: self.transaction_effects_digest,
+    //         effects: self.effects,
+    //         auth_signature: AuthoritySignInfo {},
+    //     }
+    // }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2033,6 +2033,7 @@ pub enum ExecuteTransactionRequestType {
     ImmediateReturn,
     WaitForTxCert,
     WaitForEffectsCert,
+    WaitForLocalExecution,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -2041,8 +2042,41 @@ pub struct ExecuteTransactionRequest {
     pub request_type: ExecuteTransactionRequestType,
 }
 
+/// When requested to execute a transaction with WaitForLocalExecution,
+/// TransactionOrchestrator attemps to execute this transaction locally
+/// after it is finalized. This value represents whether the transaction
+/// is confirmed to be executed on this node before the response returns.
+pub type IsTransactionExecutedLocally = bool;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ExecuteTransactionResponse {
+    ImmediateReturn,
+    TxCert(Box<CertifiedTransaction>),
+    // TODO: Change to CertifiedTransactionEffects eventually.
+    EffectsCert(
+        Box<(
+            CertifiedTransaction,
+            CertifiedTransactionEffects,
+            IsTransactionExecutedLocally,
+        )>,
+    ),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, schemars::JsonSchema)]
+pub enum QuorumDriverRequestType {
+    ImmediateReturn,
+    WaitForTxCert,
+    WaitForEffectsCert,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct QuorumDriverRequest {
+    pub transaction: Transaction,
+    pub request_type: QuorumDriverRequestType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum QuorumDriverResponse {
     ImmediateReturn,
     TxCert(Box<CertifiedTransaction>),
     // TODO: Change to CertifiedTransactionEffects eventually.

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1684,16 +1684,6 @@ impl CertifiedTransactionEffects {
             auth_signature: EmptySignInfo {},
         }
     }
-
-    // pub fn to_signed_effects(self) -> SignedTransactionEffects {
-    //     let sigs = self.auth_signature.signature.0.get(0).unwrap();
-    //     self.auth_signature
-    //     SignedTransactionEffects {
-    //         transaction_effects_digest: self.transaction_effects_digest,
-    //         effects: self.effects,
-    //         auth_signature: AuthoritySignInfo {},
-    //     }
-    // }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -2043,7 +2033,7 @@ pub struct ExecuteTransactionRequest {
 }
 
 /// When requested to execute a transaction with WaitForLocalExecution,
-/// TransactionOrchestrator attemps to execute this transaction locally
+/// TransactionOrchestrator attempts to execute this transaction locally
 /// after it is finalized. This value represents whether the transaction
 /// is confirmed to be executed on this node before the response returns.
 pub type IsTransactionExecutedLocally = bool;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -25,16 +25,15 @@ use sui_json_rpc_types::{
     GetObjectDataResponse, SuiExecuteTransactionResponse, SuiObjectInfo, SuiParsedObject,
     SuiTransactionResponse,
 };
-use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData, SuiObjectRead, SuiRawData};
+use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData};
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_sdk::crypto::SuiKeystore;
 use sui_sdk::{ClientType, SuiClient};
+use sui_types::crypto::SignatureScheme;
 use sui_types::sui_serde::{Base64, Encoding};
-use sui_types::{base_types::ObjectRef, crypto::SignatureScheme};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
-    messages::ExecuteTransactionRequestType,
     messages::Transaction,
     object::Owner,
     parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS,
@@ -775,13 +774,15 @@ impl WalletContext {
                 .quorum_driver()
                 .execute_transaction_by_fullnode(
                     tx,
-                    ExecuteTransactionRequestType::WaitForEffectsCert,
+                    sui_types::messages::ExecuteTransactionRequestType::WaitForLocalExecution,
                 )
                 .await;
             match result {
+                // TODO: if confirmed_local_execution is false, poll fullnode until it's confirmed
                 Ok(SuiExecuteTransactionResponse::EffectsCert {
                     certificate,
                     effects,
+                    confirmed_local_execution: _,
                 }) => Ok(SuiTransactionResponse {
                     certificate,
                     effects: effects.effects,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -21,16 +21,16 @@ use tracing::info;
 
 use sui_framework::build_move_package_to_bytes;
 use sui_json::SuiJsonValue;
-use sui_json_rpc_types::SuiData;
 use sui_json_rpc_types::{
     GetObjectDataResponse, SuiExecuteTransactionResponse, SuiObjectInfo, SuiParsedObject,
     SuiTransactionResponse,
 };
+use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData, SuiObjectRead, SuiRawData};
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_sdk::crypto::SuiKeystore;
 use sui_sdk::{ClientType, SuiClient};
-use sui_types::crypto::SignatureScheme;
 use sui_types::sui_serde::{Base64, Encoding};
+use sui_types::{base_types::ObjectRef, crypto::SignatureScheme};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
@@ -679,6 +679,14 @@ impl WalletContext {
         );
 
         Ok(self.config.active_address.unwrap())
+    }
+
+    /// Get the latest object reference given a object id
+    pub async fn get_object_ref(
+        &self,
+        object_id: ObjectID,
+    ) -> Result<GetRawObjectDataResponse, anyhow::Error> {
+        self.client.read_api().get_object(object_id).await
     }
 
     /// Get all the gas objects (and conveniently, gas amounts) for the address

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -882,12 +882,14 @@ async fn test_full_node_transaction_orchestrator_rpc_ok() -> Result<(), anyhow::
     let (swarm, mut context, _address) = setup_network_and_wallet().await?;
     let (_node, jsonrpc_client, _) = set_up_jsonrpc(&swarm, None).await?;
 
-    let mut txns = make_transactions_with_wallet_context(&mut context, 3).await;
+    let txn_count = 4;
+    let mut txns = make_transactions_with_wallet_context(&mut context, txn_count).await;
     assert!(
-        txns.len() >= 3,
-        "Expect at least 3 txns but only got {}. Do we generate enough gas objects during genesis?",
-        txns.len(),
+        txns.len() >= txn_count,
+        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
+        txn_count,
     );
+
     let txn = txns.swap_remove(0);
     let tx_digest = txn.digest();
 
@@ -1063,7 +1065,7 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
         recipient,
     );
     context.execute_transaction(nft_transfer_tx).await.unwrap();
-    sleep(Duration::from_millis(500)).await;
+    sleep(Duration::from_millis(1000)).await;
     let (object_ref_v2, object_v2, _) = get_obj_read_from_node(&node, object_id, None).await?;
     assert_ne!(object_ref_v2, object_ref_v1);
 

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -8,8 +8,7 @@ use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
 use sui_node::SuiNode;
 use sui_types::base_types::SuiAddress;
 use sui_types::messages::{
-    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    Transaction,
+    QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, Transaction,
 };
 use test_utils::authority::{
     spawn_test_authorities, test_authority_aggregator, test_authority_configs,
@@ -53,13 +52,13 @@ async fn test_execute_transaction_immediate() {
     });
     assert!(matches!(
         quorum_driver
-            .execute_transaction(ExecuteTransactionRequest {
+            .execute_transaction(QuorumDriverRequest {
                 transaction: tx,
-                request_type: ExecuteTransactionRequestType::ImmediateReturn,
+                request_type: QuorumDriverRequestType::ImmediateReturn,
             })
             .await
             .unwrap(),
-        ExecuteTransactionResponse::ImmediateReturn
+        QuorumDriverResponse::ImmediateReturn
     ));
 
     handle.await.unwrap();
@@ -78,10 +77,10 @@ async fn test_execute_transaction_wait_for_cert() {
         assert_eq!(*cert.digest(), digest);
         assert_eq!(effects.effects.transaction_digest, digest);
     });
-    if let ExecuteTransactionResponse::TxCert(cert) = quorum_driver
-        .execute_transaction(ExecuteTransactionRequest {
+    if let QuorumDriverResponse::TxCert(cert) = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
             transaction: tx,
-            request_type: ExecuteTransactionRequestType::WaitForTxCert,
+            request_type: QuorumDriverRequestType::WaitForTxCert,
         })
         .await
         .unwrap()
@@ -107,10 +106,10 @@ async fn test_execute_transaction_wait_for_effects() {
         assert_eq!(*cert.digest(), digest);
         assert_eq!(effects.effects.transaction_digest, digest);
     });
-    if let ExecuteTransactionResponse::EffectsCert(result) = quorum_driver
-        .execute_transaction(ExecuteTransactionRequest {
+    if let QuorumDriverResponse::EffectsCert(result) = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
             transaction: tx,
-            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
         })
         .await
         .unwrap()
@@ -136,9 +135,9 @@ async fn test_update_validators() {
         tokio::time::sleep(Duration::from_secs(3)).await;
 
         let result = quorum_driver
-            .execute_transaction(ExecuteTransactionRequest {
+            .execute_transaction(QuorumDriverRequest {
                 transaction: tx,
-                request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+                request_type: QuorumDriverRequestType::WaitForEffectsCert,
             })
             .await;
         // This now will fail due to epoch mismatch.

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -1,0 +1,231 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::Registry;
+use sui_core::authority_client::NetworkAuthorityClient;
+use sui_core::quorum_driver::QuorumDriver;
+use sui_core::transaction_orchestrator::TransactiondOrchestrator;
+use sui_json_rpc_types::SuiObjectRead;
+use sui_node::SuiNode;
+use sui_types::messages::{
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
+    Transaction,
+};
+use test_utils::messages::{
+    // make_counter_create_transaction_with_wallet_context,
+    make_counter_increment_transaction_with_wallet_context,
+    make_transactions_with_wallet_context,
+};
+use test_utils::network::setup_network_and_wallet;
+use test_utils::transaction::{
+    increment_counter, publish_basics_package_and_make_counter, transfer_sui, wait_for_all_txes,
+    wait_for_tx,
+};
+
+#[tokio::test]
+async fn test_local_execution_basic() -> Result<(), anyhow::Error> {
+    let (swarm, mut context, _) = setup_network_and_wallet().await?;
+
+    let config = swarm.config().generate_fullnode_config();
+    let node = SuiNode::start(&config, Registry::new()).await?;
+    let active = node.active();
+
+    // Disable node sync process
+    active.cancel_node_sync_process_for_tests().await;
+
+    // FIXME the clone?
+    let net = (*active.net()).clone();
+    let node_sync_state = active.node_sync_state.clone();
+    let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
+
+    let mut txns = make_transactions_with_wallet_context(&mut context, 4).await;
+    assert!(
+        txns.len() >= 4,
+        "Expect at least 4 txns. Do we generate enough gas objects during genesis?"
+    );
+
+    // Quorum driver does not execute txn locally
+    let txn = txns.swap_remove(0);
+    let digest = *txn.digest();
+    let res = orchestrator
+        .quorum_driver()
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: txn,
+            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
+    // Since node sync is turned off, this node does not know about this txn
+    assert!(node.state().get_transaction(digest).await.is_err());
+
+    // Transaction Orchestrator proactivcely executes txn locally
+    let txn = txns.swap_remove(0);
+    let digest = *txn.digest();
+    let (res, executed_locally) = orchestrator
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: txn,
+            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
+    assert!(executed_locally.unwrap());
+    matches!(res, ExecuteTransactionResponse::EffectsCert(..));
+    // This node knows about this txn even though node sync is toggled off.
+    assert!(node.state().get_transaction(digest).await.is_ok());
+
+    // Test ImmediateReturn and WaitForTxCert eventually are executed too
+    let txn = txns.swap_remove(0);
+    let digest1 = *txn.digest();
+    orchestrator
+        .quorum_driver()
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: txn,
+            request_type: ExecuteTransactionRequestType::ImmediateReturn,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
+
+    let txn = txns.swap_remove(0);
+    let digest2 = *txn.digest();
+    orchestrator
+        .quorum_driver()
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: txn,
+            request_type: ExecuteTransactionRequestType::WaitForTxCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
+
+    wait_for_all_txes(vec![digest1, digest2], node.state().clone()).await;
+    assert!(node.state().get_transaction(digest1).await.is_ok());
+    assert!(node.state().get_transaction(digest2).await.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error> {
+    let (swarm, mut context, _) = setup_network_and_wallet().await?;
+
+    let config = swarm.config().generate_fullnode_config();
+    let node = SuiNode::start(&config, Registry::new()).await?;
+    let active = node.active();
+
+    // Disable node sync process
+    active.cancel_node_sync_process_for_tests().await;
+
+    // FIXME the clone?
+    let net = (*active.net()).clone();
+    let node_sync_state = active.node_sync_state.clone();
+    let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
+
+    // Signer is the 2nd address in keystore (index: 1)
+    let signer = context.keystore.addresses().get(0).cloned().unwrap();
+    let (pkg_ref, counter_id) = publish_basics_package_and_make_counter(&context, signer).await;
+
+    // Construct a dependency graph:
+    // tx1 -> tx2 -> tx3 -------> tx5
+    //                            /\
+    //                            ||
+    //               tx4  ---------
+
+    let digest1 = increment_counter(&context, signer, None, pkg_ref, counter_id)
+        .await
+        .certificate
+        .transaction_digest;
+    let digest2 = increment_counter(&context, signer, None, pkg_ref, counter_id)
+        .await
+        .certificate
+        .transaction_digest;
+
+    let tx_3 =
+        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
+            .await;
+    let digest3 = *tx_3.digest();
+    orchestrator
+        .quorum_driver()
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: tx_3,
+            request_type: ExecuteTransactionRequestType::WaitForTxCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest3, e));
+
+    // The node does not know about these txns
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    assert!(node.state().get_transaction(digest1).await.is_err());
+    assert!(node.state().get_transaction(digest2).await.is_err());
+    assert!(node.state().get_transaction(digest3).await.is_err());
+    // assert!(node.state().get_transaction(digest4).await.is_err());
+    // assert!(node.state().get_transaction(digest5).await.is_err());
+
+    // let new_gas_ref = match context.get_object_ref(sent_obj_id).await.unwrap() {
+    //     SuiObjectRead::Exists(obj) => obj.reference,
+    //     other => panic!("Failed to get a new gas for following use: {:?}", other)
+    // }.to_object_ref();
+
+    let tx_4 = make_counter_increment_transaction_with_wallet_context(
+        // &context, signer, counter_id, Some(new_gas_ref)
+        &context, signer, counter_id, None,
+    )
+    .await;
+    let digest4 = *tx_4.digest();
+    let (res, executed_locally) = orchestrator
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: tx_4,
+            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest4, e));
+    assert!(executed_locally.unwrap());
+    matches!(res, ExecuteTransactionResponse::EffectsCert(..));
+
+    assert!(node.state().get_transaction(digest1).await.is_ok());
+    assert!(node.state().get_transaction(digest2).await.is_ok());
+    assert!(node.state().get_transaction(digest3).await.is_ok());
+    // assert!(node.state().get_transaction(digest4).await.is_ok());
+    // assert!(node.state().get_transaction(digest5).await.is_ok());
+    assert!(node.state().get_transaction(digest4).await.is_ok());
+
+    let digest5 = increment_counter(&context, signer, None, pkg_ref, counter_id)
+        .await
+        .certificate
+        .transaction_digest;
+    let digest6 = increment_counter(&context, signer, None, pkg_ref, counter_id)
+        .await
+        .certificate
+        .transaction_digest;
+
+    let tx_7 =
+        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
+            .await;
+    let digest7 = *tx_7.digest();
+    orchestrator
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: tx_7,
+            request_type: ExecuteTransactionRequestType::ImmediateReturn,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest7, e));
+
+    wait_for_all_txes(vec![digest5, digest6, digest7], node.state().clone()).await;
+    assert!(node.state().get_transaction(digest5).await.is_ok());
+    assert!(node.state().get_transaction(digest6).await.is_ok());
+    assert!(node.state().get_transaction(digest7).await.is_ok());
+
+    Ok(())
+}
+
+// async fn execute_for_tx_cert(
+//     quorum_driver: &std::sync::Arc<QuorumDriver<NetworkAuthorityClient>>,
+//     txn: Transaction,
+// ) {
+//     let txn_digest = *txn.digest();
+//     quorum_driver
+//         .execute_transaction(ExecuteTransactionRequest {
+//             transaction: txn,
+//             request_type: ExecuteTransactionRequestType::WaitForTxCert,
+//         })
+//         .await
+//         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", txn_digest, e));
+// }

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -2,28 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::Registry;
+use sui::client_commands::WalletContext;
 use sui_core::authority_client::NetworkAuthorityClient;
-use sui_core::quorum_driver::QuorumDriver;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
-use sui_json_rpc_types::SuiObjectRead;
 use sui_node::SuiNode;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
-    Transaction,
+    QuorumDriverRequest, QuorumDriverRequestType, Transaction,
 };
 use test_utils::messages::{
-    // make_counter_create_transaction_with_wallet_context,
-    make_counter_increment_transaction_with_wallet_context,
-    make_transactions_with_wallet_context,
+    make_counter_increment_transaction_with_wallet_context, make_transactions_with_wallet_context,
 };
 use test_utils::network::setup_network_and_wallet;
 use test_utils::transaction::{
-    increment_counter, publish_basics_package_and_make_counter, transfer_sui, wait_for_all_txes,
-    wait_for_tx,
+    increment_counter, publish_basics_package_and_make_counter, wait_for_all_txes, wait_for_tx,
 };
 
 #[tokio::test]
-async fn test_local_execution_basic() -> Result<(), anyhow::Error> {
+async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     let (swarm, mut context, _) = setup_network_and_wallet().await?;
 
     let config = swarm.config().generate_fullnode_config();
@@ -47,11 +44,11 @@ async fn test_local_execution_basic() -> Result<(), anyhow::Error> {
     // Quorum driver does not execute txn locally
     let txn = txns.swap_remove(0);
     let digest = *txn.digest();
-    let res = orchestrator
+    orchestrator
         .quorum_driver()
-        .execute_transaction(ExecuteTransactionRequest {
+        .execute_transaction(QuorumDriverRequest {
             transaction: txn,
-            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
         })
         .await
         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
@@ -61,50 +58,22 @@ async fn test_local_execution_basic() -> Result<(), anyhow::Error> {
     // Transaction Orchestrator proactivcely executes txn locally
     let txn = txns.swap_remove(0);
     let digest = *txn.digest();
-    let (res, executed_locally) = orchestrator
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
-            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
-    assert!(executed_locally.unwrap());
-    matches!(res, ExecuteTransactionResponse::EffectsCert(..));
+
+    let res = execute_with_orchestrator(&orchestrator, txn,  ExecuteTransactionRequestType::WaitForLocalExecution).await;
+
+    if let ExecuteTransactionResponse::EffectsCert(result) = res {
+        let (_, _, executed_locally) = *result;
+        assert!(executed_locally);
+    };
+
     // This node knows about this txn even though node sync is toggled off.
     assert!(node.state().get_transaction(digest).await.is_ok());
-
-    // Test ImmediateReturn and WaitForTxCert eventually are executed too
-    let txn = txns.swap_remove(0);
-    let digest1 = *txn.digest();
-    orchestrator
-        .quorum_driver()
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
-            request_type: ExecuteTransactionRequestType::ImmediateReturn,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
-
-    let txn = txns.swap_remove(0);
-    let digest2 = *txn.digest();
-    orchestrator
-        .quorum_driver()
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: txn,
-            request_type: ExecuteTransactionRequestType::WaitForTxCert,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
-
-    wait_for_all_txes(vec![digest1, digest2], node.state().clone()).await;
-    assert!(node.state().get_transaction(digest1).await.is_ok());
-    assert!(node.state().get_transaction(digest2).await.is_ok());
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error> {
+async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
     let (swarm, mut context, _) = setup_network_and_wallet().await?;
 
     let config = swarm.config().generate_fullnode_config();
@@ -119,113 +88,145 @@ async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error
     let node_sync_state = active.node_sync_state.clone();
     let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
 
-    // Signer is the 2nd address in keystore (index: 1)
-    let signer = context.keystore.addresses().get(0).cloned().unwrap();
-    let (pkg_ref, counter_id) = publish_basics_package_and_make_counter(&context, signer).await;
+    let mut txns = make_transactions_with_wallet_context(&mut context, 4).await;
+    assert!(
+        txns.len() >= 4,
+        "Expect at least 4 txns. Do we generate enough gas objects during genesis?"
+    );
 
-    // Construct a dependency graph:
-    // tx1 -> tx2 -> tx3 -------> tx5
-    //                            /\
-    //                            ||
-    //               tx4  ---------
+    // Test ImmediateReturn and WaitForTxCert eventually are executed too
+    let txn = txns.swap_remove(0);
+    let digest1 = *txn.digest();
+ 
+    execute_with_orchestrator(&orchestrator, txn,  ExecuteTransactionRequestType::ImmediateReturn).await;
 
-    let digest1 = increment_counter(&context, signer, None, pkg_ref, counter_id)
-        .await
-        .certificate
-        .transaction_digest;
-    let digest2 = increment_counter(&context, signer, None, pkg_ref, counter_id)
-        .await
-        .certificate
-        .transaction_digest;
+    let txn = txns.swap_remove(0);
+    let digest2 = *txn.digest();
+    execute_with_orchestrator(&orchestrator, txn,  ExecuteTransactionRequestType::WaitForTxCert).await;
 
-    let tx_3 =
-        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
-            .await;
-    let digest3 = *tx_3.digest();
-    orchestrator
-        .quorum_driver()
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: tx_3,
-            request_type: ExecuteTransactionRequestType::WaitForTxCert,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest3, e));
+    let txn = txns.swap_remove(0);
+    let digest3 = *txn.digest();
+    execute_with_orchestrator(&orchestrator, txn,  ExecuteTransactionRequestType::WaitForEffectsCert).await;
 
-    // The node does not know about these txns
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-    assert!(node.state().get_transaction(digest1).await.is_err());
-    assert!(node.state().get_transaction(digest2).await.is_err());
-    assert!(node.state().get_transaction(digest3).await.is_err());
-    // assert!(node.state().get_transaction(digest4).await.is_err());
-    // assert!(node.state().get_transaction(digest5).await.is_err());
-
-    // let new_gas_ref = match context.get_object_ref(sent_obj_id).await.unwrap() {
-    //     SuiObjectRead::Exists(obj) => obj.reference,
-    //     other => panic!("Failed to get a new gas for following use: {:?}", other)
-    // }.to_object_ref();
-
-    let tx_4 = make_counter_increment_transaction_with_wallet_context(
-        // &context, signer, counter_id, Some(new_gas_ref)
-        &context, signer, counter_id, None,
-    )
-    .await;
-    let digest4 = *tx_4.digest();
-    let (res, executed_locally) = orchestrator
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: tx_4,
-            request_type: ExecuteTransactionRequestType::WaitForEffectsCert,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest4, e));
-    assert!(executed_locally.unwrap());
-    matches!(res, ExecuteTransactionResponse::EffectsCert(..));
-
-    assert!(node.state().get_transaction(digest1).await.is_ok());
-    assert!(node.state().get_transaction(digest2).await.is_ok());
-    assert!(node.state().get_transaction(digest3).await.is_ok());
-    // assert!(node.state().get_transaction(digest4).await.is_ok());
-    // assert!(node.state().get_transaction(digest5).await.is_ok());
-    assert!(node.state().get_transaction(digest4).await.is_ok());
-
-    let digest5 = increment_counter(&context, signer, None, pkg_ref, counter_id)
-        .await
-        .certificate
-        .transaction_digest;
-    let digest6 = increment_counter(&context, signer, None, pkg_ref, counter_id)
-        .await
-        .certificate
-        .transaction_digest;
-
-    let tx_7 =
-        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
-            .await;
-    let digest7 = *tx_7.digest();
-    orchestrator
-        .execute_transaction(ExecuteTransactionRequest {
-            transaction: tx_7,
-            request_type: ExecuteTransactionRequestType::ImmediateReturn,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest7, e));
-
-    wait_for_all_txes(vec![digest5, digest6, digest7], node.state().clone()).await;
-    assert!(node.state().get_transaction(digest5).await.is_ok());
-    assert!(node.state().get_transaction(digest6).await.is_ok());
-    assert!(node.state().get_transaction(digest7).await.is_ok());
+    let digests = vec![digest1, digest2, digest3];
+    wait_for_all_txes(digests.clone(), node.state().clone()).await;
+    node_knows_txes(&node, &digests).await;
 
     Ok(())
 }
 
-// async fn execute_for_tx_cert(
-//     quorum_driver: &std::sync::Arc<QuorumDriver<NetworkAuthorityClient>>,
-//     txn: Transaction,
-// ) {
-//     let txn_digest = *txn.digest();
-//     quorum_driver
-//         .execute_transaction(ExecuteTransactionRequest {
-//             transaction: txn,
-//             request_type: ExecuteTransactionRequestType::WaitForTxCert,
-//         })
-//         .await
-//         .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", txn_digest, e));
-// }
+#[tokio::test]
+async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error> {
+    let (swarm, context, _) = setup_network_and_wallet().await?;
+
+    let config = swarm.config().generate_fullnode_config();
+    let node = SuiNode::start(&config, Registry::new()).await?;
+    let active = node.active();
+
+    // Disable node sync process
+    active.cancel_node_sync_process_for_tests().await;
+
+    // FIXME the clone?
+    let net = (*active.net()).clone();
+    let node_sync_state = active.node_sync_state.clone();
+    let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
+
+    let signer = context.keystore.addresses().get(0).cloned().unwrap();
+    let (pkg_ref, counter_id) = publish_basics_package_and_make_counter(&context, signer).await;
+
+    // Construct a dependency graph:
+    // tx0.1 -> ... -> tx0.19 -------> tx1 -> tx2 ----> tx3.0 -> ... tx3.19 -> tx3
+
+    let digests0 = increment(&context, &signer, counter_id, 20, pkg_ref).await;
+
+    let tx1 =
+        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
+            .await;
+    let digest1 = *tx1.digest();
+    orchestrator
+        .quorum_driver()
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx1,
+            request_type: QuorumDriverRequestType::WaitForTxCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest1, e));
+
+    // The node does not know about these txns
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    node_does_not_know_txes(&node, &digests0).await;
+
+    // WaitForLocalExecution synchronuously executes all previous txns
+    let tx2 =
+        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
+            .await;
+    let digest2 = *tx2.digest();
+    let res = execute_with_orchestrator(&orchestrator, tx2,  ExecuteTransactionRequestType::WaitForLocalExecution).await;
+
+    if let ExecuteTransactionResponse::EffectsCert(result) = res {
+        let (_, _, executed_locally) = *result;
+        assert!(executed_locally);
+    };
+    // Now the node knows about all past txns
+    node_knows_txes(&node, &digests0).await;
+    node_knows_txes(&node, &vec![digest2]).await;
+
+    // Do another round of counter incrementing
+    let digests3 = increment(&context, &signer, counter_id, 20, pkg_ref).await;
+
+    node_does_not_know_txes(&node, &digests3).await;
+
+    let tx4 =
+        make_counter_increment_transaction_with_wallet_context(&context, signer, counter_id, None)
+            .await;
+    let digest4 = *tx4.digest();
+    // ImmediateReturn asynchronuously executes all previous txns
+    execute_with_orchestrator(&orchestrator, tx4,  ExecuteTransactionRequestType::ImmediateReturn).await;
+
+    // Wait for the async execution to finish
+    wait_for_tx(digest4, node.state().clone()).await;
+    node_knows_txes(&node, &digests3).await;
+
+    Ok(())
+}
+
+async fn increment(
+    context: &WalletContext,
+    signer: &SuiAddress,
+    counter_id: ObjectID,
+    delta: usize,
+    pkg_ref: ObjectRef,
+) -> Vec<TransactionDigest> {
+    let mut digests = Vec::with_capacity(delta);
+    for _ in 0..delta {
+        let digest = increment_counter(context, *signer, None, pkg_ref, counter_id)
+            .await
+            .certificate
+            .transaction_digest;
+        digests.push(digest);
+    }
+    digests
+}
+
+async fn node_knows_txes(node: &SuiNode, digests: &Vec<TransactionDigest>) {
+    for digest in digests {
+        assert!(node.state().get_transaction(*digest).await.is_ok());
+    }
+}
+
+async fn node_does_not_know_txes(node: &SuiNode, digests: &Vec<TransactionDigest>) {
+    for digest in digests {
+        assert!(node.state().get_transaction(*digest).await.is_err());
+    }
+}
+
+async fn execute_with_orchestrator(orchestrator: &TransactiondOrchestrator<NetworkAuthorityClient>, txn: Transaction, request_type: ExecuteTransactionRequestType) -> ExecuteTransactionResponse {
+    let digest = *txn.digest();
+    orchestrator
+        .execute_transaction(ExecuteTransactionRequest {
+            transaction: txn,
+            request_type: request_type,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e))
+}

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -31,7 +31,7 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     active.cancel_node_sync_process_for_tests().await;
 
     let net = active.agg_aggregator();
-    let node_sync_handle = active.node_sync_handle();
+    let node_sync_handle = active.clone().node_sync_handle();
     let orchestrator =
         TransactiondOrchestrator::new(net, node.state(), node_sync_handle, &Registry::new());
 
@@ -91,7 +91,7 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
     active.cancel_node_sync_process_for_tests().await;
 
     let net = active.agg_aggregator();
-    let node_sync_handle = active.node_sync_handle();
+    let node_sync_handle = active.clone().node_sync_handle();
     let orchestrator =
         TransactiondOrchestrator::new(net, node.state(), node_sync_handle, &Registry::new());
 
@@ -151,7 +151,7 @@ async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error
     active.cancel_node_sync_process_for_tests().await;
 
     let net = active.agg_aggregator();
-    let node_sync_handle = active.node_sync_handle();
+    let node_sync_handle = active.clone().node_sync_handle();
     let orchestrator =
         TransactiondOrchestrator::new(net, node.state(), node_sync_handle, &Registry::new());
 

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -30,15 +30,16 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     // Disable node sync process
     active.cancel_node_sync_process_for_tests().await;
 
-    // FIXME the clone?
-    let net = (*active.net()).clone();
+    let net = active.agg_aggregator();
     let node_sync_state = active.node_sync_state.clone();
     let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
 
-    let mut txns = make_transactions_with_wallet_context(&mut context, 4).await;
+    let txn_count = 4;
+    let mut txns = make_transactions_with_wallet_context(&mut context, txn_count).await;
     assert!(
-        txns.len() >= 4,
-        "Expect at least 4 txns. Do we generate enough gas objects during genesis?"
+        txns.len() >= txn_count,
+        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
+        txn_count,
     );
 
     // Quorum driver does not execute txn locally
@@ -88,15 +89,16 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
     // Disable node sync process
     active.cancel_node_sync_process_for_tests().await;
 
-    // FIXME the clone?
-    let net = (*active.net()).clone();
+    let net = active.agg_aggregator();
     let node_sync_state = active.node_sync_state.clone();
     let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
 
-    let mut txns = make_transactions_with_wallet_context(&mut context, 4).await;
+    let txn_count = 4;
+    let mut txns = make_transactions_with_wallet_context(&mut context, txn_count).await;
     assert!(
-        txns.len() >= 4,
-        "Expect at least 4 txns. Do we generate enough gas objects during genesis?"
+        txns.len() >= txn_count,
+        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
+        txn_count,
     );
 
     // Test ImmediateReturn and WaitForTxCert eventually are executed too
@@ -146,8 +148,7 @@ async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error
     // Disable node sync process
     active.cancel_node_sync_process_for_tests().await;
 
-    // FIXME the clone?
-    let net = (*active.net()).clone();
+    let net = active.agg_aggregator();
     let node_sync_state = active.node_sync_state.clone();
     let orchestrator = TransactiondOrchestrator::new(net, node_sync_state, &Registry::new());
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 futures = "0.3.23"
 tempfile = "3.3.0"
 tracing = "0.1.36"
+signature = "1.6.0"
 bcs = "0.1.3"
 jsonrpsee-http-client = "0.15.1"
 prometheus = "0.13.2"

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -7,7 +7,6 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use move_core_types::language_storage::TypeTag;
 use move_package::BuildConfig;
-use signature::Signer;
 use std::path::PathBuf;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -7,6 +7,7 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use move_core_types::language_storage::TypeTag;
 use move_package::BuildConfig;
+use signature::Signer;
 use std::path::PathBuf;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
@@ -149,6 +150,55 @@ pub async fn make_transactions_with_wallet_context(
     res
 }
 
+pub async fn make_counter_increment_transaction_with_wallet_context(
+    context: &WalletContext,
+    sender: SuiAddress,
+    counter_id: ObjectID,
+    gas_object_ref: Option<ObjectRef>,
+) -> Transaction {
+    let package_object_ref = genesis::get_framework_object_ref();
+    let gas_objeect_ref = match gas_object_ref {
+        Some(obj_ref) => obj_ref,
+        None => get_gas_object_with_wallet_context(context, &sender)
+            .await
+            .unwrap(),
+    };
+    let data = TransactionData::new_move_call(
+        sender,
+        package_object_ref,
+        "counter".parse().unwrap(),
+        "increment".parse().unwrap(),
+        Vec::new(),
+        gas_objeect_ref,
+        vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
+        MAX_GAS,
+    );
+    let signature = context.keystore.sign(&sender, &data.to_bytes()).unwrap();
+    Transaction::new(data, signature)
+}
+
+// pub async fn make_counter_create_transaction_with_wallet_context(
+//     context: &mut WalletContext,
+// ) -> Transaction {
+//     let sender = context.active_address().unwrap();
+//     let package_object_ref = genesis::get_framework_object_ref();
+//     let gas_object_ref = get_gas_object_with_wallet_context(context, &sender)
+//         .await
+//         .unwrap();
+//     let data = TransactionData::new_move_call(
+//         sender,
+//         package_object_ref,
+//         "counter".parse().unwrap(),
+//         "create".parse().unwrap(),
+//         Vec::new(),
+//         gas_object_ref,
+//         vec![],
+//         MAX_GAS,
+//     );
+//     let signature = context.keystore.sign(&sender, &data.to_bytes()).unwrap();
+//     Transaction::new(data, signature)
+// }
+
 /// Make a few different single-writer test transactions owned by specific addresses.
 pub fn make_transactions_with_pre_genesis_objects(
     keys: SuiKeystore,
@@ -196,11 +246,11 @@ pub fn test_shared_object_transactions() -> Vec<Transaction> {
     // Make one transaction per gas object (all containing the same shared object).
     let mut transactions = Vec::new();
     let shared_object_id = test_shared_object().id();
-    for gas_object in test_gas_objects() {
-        let module = "object_basics";
-        let function = "create";
-        let package_object_ref = genesis::get_framework_object_ref();
+    let module = "object_basics";
+    let function = "create";
+    let package_object_ref = genesis::get_framework_object_ref();
 
+    for gas_object in test_gas_objects() {
         let data = TransactionData::new_move_call(
             sender,
             package_object_ref,
@@ -326,6 +376,7 @@ pub fn make_counter_increment_transaction(
     counter_id: ObjectID,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
+    // keypair: &dyn Signer<Signature>,
 ) -> Transaction {
     let data = TransactionData::new_move_call(
         sender,

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -176,28 +176,6 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
     Transaction::new(data, signature)
 }
 
-// pub async fn make_counter_create_transaction_with_wallet_context(
-//     context: &mut WalletContext,
-// ) -> Transaction {
-//     let sender = context.active_address().unwrap();
-//     let package_object_ref = genesis::get_framework_object_ref();
-//     let gas_object_ref = get_gas_object_with_wallet_context(context, &sender)
-//         .await
-//         .unwrap();
-//     let data = TransactionData::new_move_call(
-//         sender,
-//         package_object_ref,
-//         "counter".parse().unwrap(),
-//         "create".parse().unwrap(),
-//         Vec::new(),
-//         gas_object_ref,
-//         vec![],
-//         MAX_GAS,
-//     );
-//     let signature = context.keystore.sign(&sender, &data.to_bytes()).unwrap();
-//     Transaction::new(data, signature)
-// }
-
 /// Make a few different single-writer test transactions owned by specific addresses.
 pub fn make_transactions_with_pre_genesis_objects(
     keys: SuiKeystore,
@@ -375,7 +353,6 @@ pub fn make_counter_increment_transaction(
     counter_id: ObjectID,
     sender: SuiAddress,
     keypair: &AccountKeyPair,
-    // keypair: &dyn Signer<Signature>,
 ) -> Transaction {
     let data = TransactionData::new_move_call(
         sender,
@@ -399,8 +376,6 @@ pub fn move_transaction(
     package_ref: ObjectRef,
     arguments: Vec<CallArg>,
 ) -> Transaction {
-    // The key pair of the sender of the transaction.
-
     move_transaction_with_type_tags(gas_object, module, function, package_ref, &[], arguments)
 }
 


### PR DESCRIPTION
## Problem Statement
1. Even a successful `WaitForEffectsCert` execution request does not guarantee the exact fullnode has executed the transaction before returning the response to client. This makes it unreliable for the client to make subsequent queries based on this transaction. This PR introduces a `WaitForLocalExecution` mode to solve this problem.
2. Transactions finalized in write path (quorum driver) can be proactively executed, rather than waiting for the node sync process. This enables future partial/sparse node implementation.
Also see detailed motivation [here](https://docs.google.com/document/d/1YiQ7-X4lB31V_eckbk6aLzLoPsVqM8VjVfbMDlcQIVQ/).

## Implementation
Introduce `TransactionOrchestrator`, a components that wraps a `QuorumDriver` to submit transactions to validators and proactively executes finalized transactions locally. This component leverages some node sync facilities for local execution and dependency processing. 
All finalized transactions submitted from the execution RPC endpoint will be attempted to be executed on the same node, in a queue (a tokio channel) in submission order. Finalized transactions with `WaitForLocalExecution` request type are handled in a fast track by bypassing the queue. If the execution succeeds, a `true` value is returned to client to signal it. Otherwise (some transient failure, or timeout due to missing dependencies), a `false` is returned. When the client gets a `false`, and it needs to make some dependent queries, it then needs to poll the node (e.g. `sui_getTransaction`) until the node is aware of the transaction.

Q1: Why add `TransactionOrchestrator` rather than add the missing features to `QuorumDriver`? 
A1: we want to keep `QuorumDriver` a completely stateless component that can be ported to anywhere a directly connection to validator is desired (e.g. embedded quorum driver in sdk). 

Q2: Why use node sync state?
A2: Node sync state has the major features that needed for execution, particularly the dependencies retrieval and execution. it's also worth noting that, this write path does NOT rely on the node sync process. E.g. a fullnode can work without an active node sync process but only `TransactionOrchestrator` to execute transactions that it cares about. This is one way to tell the partial/sparse node story. 

Q3: Will this change impact how node sync process work?
A3: No, it is almost transparent to node sync process and should not impact its performance. The only noticeable thing is when there are a considerable number of write path transactions (from `TransactionOrchestrator`) missing parents then the normal node sync process may be slower. However this can only occur when the node is out-of-date.

## Changes
1. implement `TransactionOrchestrator` and tests
2. modify some functions in node sync state to make it support this new use case
3. replace `QuorumDriver` with `TransactionOrchestrator` in `SuiNode`
4. let `QuorumDriver` takes an `Arc<AuthorityAggregator>` rather than `AuthorityAggregator`. This enables `AuthorityActive` and `TransactionOrchestrator` shares the same `AuthorityAggregator`, and removes the necessity of updating `TransactionOrchestrator`/`QuorumDriver` the new committee in epoch boundaries
5. rpc changes - rename `QuorumDriverApi` to `TransactionExecutionApi`, add detailed comments about different types of request mode
6. other trivial but required changes

## Caveats
In the current implementation of `TransactionOrchestrator`, a `WaitForLocalExecution` request will be attempted twice, once before returning the response to client and the other one in the general execution queue. This should not be a big problem because 1. the potential redundant steps are cheap and 2. the expensive part, i.e. the actual execution is guaranteed to happen (at most) once. 


## Next 
Once this PR is merged, I will add metrics in a follow-up PR and start deprecation process of gateway.

