### PR TITLE
Elaborate `ExecutionFailureStatus::MovePrimitiveRuntimeError` by adding sub_status, module_id and message

### DIFF
--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -198,7 +198,15 @@ ExecutionFailureStatus:
     23:
       SuiMoveVerificationError: UNIT
     24:
-      MovePrimitiveRuntimeError: UNIT
+      MovePrimitiveRuntimeError:
+        STRUCT:
+          - sub_status:
+              OPTION: U64
+          - module_id:
+              OPTION:
+                TYPENAME: ModuleId
+          - message:
+              OPTION: STR
     25:
       MoveAbort:
         TUPLE:

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -565,7 +565,14 @@ impl From<VMError> for ExecutionError {
             }
             (StatusCode::OUT_OF_GAS, _, _) => ExecutionFailureStatus::InsufficientGas,
             _ => match error.major_status().status_type() {
-                StatusType::Execution => ExecutionFailureStatus::MovePrimitiveRuntimeError,
+                StatusType::Execution => ExecutionFailureStatus::MovePrimitiveRuntimeError {
+                    sub_status: error.sub_status(),
+                    module_id: match error.location() {
+                        Location::Module(module_id) => Some(module_id.clone()),
+                        _ => None,
+                    },
+                    message: error.message().cloned(),
+                },
                 StatusType::Validation
                 | StatusType::Verification
                 | StatusType::Deserialization

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1060,8 +1060,12 @@ pub enum ExecutionFailureStatus {
     //
     // Errors from the Move VM
     //
-    // TODO module id + func def + offset?
-    MovePrimitiveRuntimeError,
+    // TODO func def + offset?
+    MovePrimitiveRuntimeError {
+        sub_status: Option<u64>,
+        module_id: Option<ModuleId>,
+        message: Option<String>,
+    },
     /// Indicates and `abort` from inside Move code. Contains the location of the abort and the
     /// abort code
     MoveAbort(ModuleId, u64), // TODO func def + offset?
@@ -1229,10 +1233,14 @@ impl std::fmt::Display for ExecutionFailureStatus {
                 "Sui Move Bytecode Verification Error. \
                 Please run the Sui Move Verifier for more information."
             ),
-            ExecutionFailureStatus::MovePrimitiveRuntimeError => write!(
+            ExecutionFailureStatus::MovePrimitiveRuntimeError {
+                module_id,
+                sub_status,
+                message,
+            } => write!(
                 f,
-                "Move Primitive Runtime Error. \
-                Arithmetic error, stack overflow, max value depth, etc."
+                "Move Primitive Runtime Error. sub_status: {:?}, module_id: {:?}, message: {:?}.",
+                sub_status, module_id, message,
             ),
             ExecutionFailureStatus::MoveAbort(m, c) => {
                 write!(f, "Move Runtime Abort. Module: {}, Status Code: {}", m, c)


### PR DESCRIPTION
as title. 

I encountered this error when calling a move function in devnet. The returned error is too vague to be meaningful. I needed to start a cluster locally and modify code to print the error (which turned out to be a vector out-of-index error). Overall it would be fairly challenging for a move dev to tell what happened with this error type. 

This PR adds sub_status, module_id and message to the error type to convey more useful information.