### PR TITLE
[TypeScript SDK] Add e2e tests

### DIFF
--- a/.changeset/fifty-tips-boil.md
+++ b/.changeset/fifty-tips-boil.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add util function to get coin balances

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -170,7 +170,7 @@ export const getDataOnTxDigests = (
                         return {
                             seq,
                             txId: digest,
-                            status: getExecutionStatusType(txEff),
+                            status: getExecutionStatusType(txEff)!,
                             txGas: getTotalGasUsed(txEff),
                             suiAmount: getTransferSuiAmount(txn),
                             kind: txKind,

--- a/apps/explorer/src/pages/transaction-result/TransactionResult.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionResult.tsx
@@ -110,7 +110,7 @@ const transformTransactionResponse = (
 ): TxnState => {
     return {
         ...txObj.certificate,
-        status: getExecutionStatusType(txObj),
+        status: getExecutionStatusType(txObj)!,
         gasFee: getTotalGasUsed(txObj),
         txError: getExecutionStatusError(txObj) ?? '',
         txId: id,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,7 @@ importers:
       '@size-limit/preset-small-lib': ^7.0.8
       '@types/bn.js': ^5.1.0
       '@types/lossless-json': ^1.0.1
+      axios: ^0.27.2
       bn.js: ^5.2.0
       buffer: ^6.0.3
       cross-fetch: ^3.1.5
@@ -346,6 +347,7 @@ importers:
       '@size-limit/preset-small-lib': 7.0.8_size-limit@7.0.8
       '@types/bn.js': 5.1.0
       '@types/lossless-json': 1.0.1
+      axios: 0.27.2
       eslint: 8.23.0
       eslint-config-prettier: 8.5.0_eslint@8.23.0
       eslint-config-react-app: 7.0.1_itqs5654cmlnjraw6gjzqacppi
@@ -8487,10 +8489,6 @@ packages:
       readable-stream: 3.6.0
       safe-buffer: 5.2.1
     dev: true
-
-  /browserify-unibabel/3.0.0:
-    resolution: {integrity: sha512-j3MX0k2dC1/DEo9jSUyj7zpv5wLd1+klpFwYlM0E5mr7MX6LblQOWb+jkBEKV2iRszmhJuLHAtNuqranlGnpNQ==}
-    dev: false
 
   /browserify-zlib/0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
@@ -19799,7 +19797,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.2
-      webpack: 5.74.0_webpack-cli@4.10.0
+      webpack: 5.74.0
     dev: true
 
   /terser/4.8.1:

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -65,6 +65,7 @@
     "@size-limit/preset-small-lib": "^7.0.8",
     "@types/bn.js": "^5.1.0",
     "@types/lossless-json": "^1.0.1",
+    "axios": "^0.27.2",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -201,6 +201,22 @@ export class JsonRpcProvider extends Provider {
     return objects.filter((obj: SuiObjectInfo) => Coin.isSUI(obj));
   }
 
+  async getCoinBalancesOwnedByAddress(
+    address: string,
+    typeArg?: string
+  ): Promise<GetObjectDataResponse[]> {
+    const objects = await this.getObjectsOwnedByAddress(address);
+    const coinIds = objects
+      .filter(
+        (obj: SuiObjectInfo) =>
+          Coin.isCoin(obj) &&
+          (typeArg === undefined || typeArg === Coin.getCoinTypeArg(obj))
+      )
+      .map((c) => c.objectId);
+
+    return await this.getObjectBatch(coinIds);
+  }
+
   async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {
     try {
       return await this.client.requestWithType(

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -45,6 +45,15 @@ export abstract class Provider {
   ): Promise<SuiObjectInfo[]>;
 
   /**
+   * Convenience method for getting all coins objects owned by an address
+   * @param typeArg optional argument for filter by coin type
+   */
+  abstract getCoinBalancesOwnedByAddress(
+    address: string,
+    typeArg?: string
+  ): Promise<GetObjectDataResponse[]>;
+
+  /**
    * Get details about an object
    */
   abstract getObject(objectId: string): Promise<GetObjectDataResponse>;

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -40,6 +40,13 @@ export class VoidProvider extends Provider {
     throw this.newError('getGasObjectsOwnedByAddress');
   }
 
+  async getCoinBalancesOwnedByAddress(
+    _address: string,
+    _typeArg?: string
+  ): Promise<GetObjectDataResponse[]> {
+    throw this.newError('getCoinBalancesOwnedByAddress');
+  }
+
   async getObject(_objectId: string): Promise<GetObjectDataResponse> {
     throw this.newError('getObject');
   }

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -254,8 +254,6 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
       sender: signerAddress,
     };
 
-    console.log('transactiondata', txData);
-
     return this.serializeTransactionData(txData);
   }
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -307,21 +307,26 @@ export function getTransactionKindName(
 /* ----------------------------- ExecutionStatus ---------------------------- */
 
 export function getExecutionStatusType(
-  data: SuiTransactionResponse
-): ExecutionStatusType {
-  return getExecutionStatus(data).status;
+  data: SuiTransactionResponse | SuiExecuteTransactionResponse
+): ExecutionStatusType | undefined {
+  return getExecutionStatus(data)?.status;
 }
 
 export function getExecutionStatus(
-  data: SuiTransactionResponse
-): ExecutionStatus {
-  return data.effects.status;
+  data: SuiTransactionResponse | SuiExecuteTransactionResponse
+): ExecutionStatus | undefined {
+  if ('effects' in data) {
+    return data.effects.status;
+  } else if ('EffectsCert' in data) {
+    return data.EffectsCert.effects.effects.status;
+  }
+  return undefined;
 }
 
 export function getExecutionStatusError(
   data: SuiTransactionResponse
 ): string | undefined {
-  return getExecutionStatus(data).error;
+  return getExecutionStatus(data)?.error;
 }
 
 export function getExecutionStatusGasSummary(

--- a/sdk/typescript/test/e2e/example.test.ts
+++ b/sdk/typescript/test/e2e/example.test.ts
@@ -1,6 +1,0 @@
-// Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-import { describe } from 'vitest';
-
-describe.todo('Write some tests that run against localnet.');

--- a/sdk/typescript/test/e2e/local-txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/local-txn-builder.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  getExecutionStatusType,
+  LocalTxnDataSerializer,
+  RawSigner,
+} from '../../src';
+import {
+  DEFAULT_RECIPIENT,
+  DEFAULT_GAS_BUDGET,
+  setup,
+  TestToolbox,
+} from './utils/setup';
+
+describe('Local Transaction Builder', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+
+  beforeAll(async () => {
+    toolbox = await setup('fullnode');
+    signer = new RawSigner(
+      toolbox.keypair,
+      toolbox.provider,
+      new LocalTxnDataSerializer(toolbox.provider)
+    );
+  });
+
+  it('Split coin', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.splitCoinWithRequestType({
+      coinObjectId: coins[0].objectId,
+      splitAmounts: [DEFAULT_GAS_BUDGET * 2],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[1].objectId,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Merge coin', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.mergeCoinWithRequestType({
+      primaryCoin: coins[0].objectId,
+      coinToMerge: coins[1].objectId,
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[2].objectId,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Move Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.executeMoveCallWithRequestType({
+      packageObjectId: '0x2',
+      module: 'devnet_nft',
+      function: 'mint',
+      typeArguments: [],
+      arguments: [
+        'Example NFT',
+        'An NFT created by the wallet Command Line Tool',
+        'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+      ],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[0].objectId,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Transfer Sui', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.transferSuiWithRequestType({
+      suiObjectId: coins[0].objectId,
+      gasBudget: DEFAULT_GAS_BUDGET,
+      recipient: DEFAULT_RECIPIENT,
+      amount: 100,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Transfer Object', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.transferObjectWithRequestType({
+      objectId: coins[0].objectId,
+      gasBudget: DEFAULT_GAS_BUDGET,
+      recipient: DEFAULT_RECIPIENT,
+      gasPayment: coins[1].objectId,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+});

--- a/sdk/typescript/test/e2e/objects.test.ts
+++ b/sdk/typescript/test/e2e/objects.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { getMoveObjectType } from '../../src';
+import { setup, TestToolbox } from './utils/setup';
+
+describe('Object Reading API', () => {
+  let toolbox: TestToolbox;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+  });
+
+  it('Get Owned Objects', async () => {
+    const gasObjects = await toolbox.provider.getObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    expect(gasObjects.length).to.greaterThan(0);
+  });
+
+  it('Get Object', async () => {
+    const gasObjects = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    expect(gasObjects.length).to.greaterThan(0);
+    const objectInfos = await Promise.all(
+      gasObjects.map((gasObject) =>
+        toolbox.provider.getObject(gasObject['objectId'])
+      )
+    );
+    objectInfos.forEach((objectInfo) =>
+      expect(getMoveObjectType(objectInfo)).to.equal(
+        '0x2::coin::Coin<0x2::sui::SUI>'
+      )
+    );
+  });
+});

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { setup, TestToolbox } from './utils/setup';
+
+describe('Transaction Reading API', () => {
+  let toolbox: TestToolbox;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+  });
+
+  it('Get Total Transactions', async () => {
+    const numTransactions = await toolbox.provider.getTotalTransactionNumber();
+    expect(numTransactions).to.greaterThan(0);
+  });
+
+  it('Get Transaction', async () => {
+    const resp = await toolbox.provider.getRecentTransactions(1);
+    const digest = resp[0][1];
+    const txn = await toolbox.provider.getTransactionWithEffects(digest);
+    expect(txn.certificate.transactionDigest).toEqual(digest);
+  });
+});

--- a/sdk/typescript/test/e2e/rpc-txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/rpc-txn-builder.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  Coin,
+  getExecutionStatusType,
+  getObjectId,
+  RawSigner,
+  SuiObjectInfo,
+} from '../../src';
+import {
+  DEFAULT_GAS_BUDGET,
+  DEFAULT_RECIPIENT,
+  setup,
+  TestToolbox,
+} from './utils/setup';
+
+describe('RPC Transaction Builder', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+
+  beforeAll(async () => {
+    toolbox = await setup('gateway');
+    signer = new RawSigner(toolbox.keypair, toolbox.provider);
+  });
+
+  it('Split coin', async () => {
+    const coins = await toolbox.provider.getCoinBalancesOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.splitCoin({
+      coinObjectId: getObjectId(coins[0]),
+      splitAmounts: [DEFAULT_GAS_BUDGET],
+      gasBudget: DEFAULT_GAS_BUDGET,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Merge coin', async () => {
+    const coins = await toolbox.provider.getCoinBalancesOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.mergeCoin({
+      primaryCoin: getObjectId(coins[0]),
+      coinToMerge: getObjectId(coins[1]),
+      gasBudget: DEFAULT_GAS_BUDGET,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Move Call', async () => {
+    const txn = await signer.executeMoveCall({
+      packageObjectId: '0x2',
+      module: 'devnet_nft',
+      function: 'mint',
+      typeArguments: [],
+      arguments: [
+        'Example NFT',
+        'An NFT created by the wallet Command Line Tool',
+        'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+      ],
+      gasBudget: DEFAULT_GAS_BUDGET,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Transfer Object', async () => {
+    const coins = await toolbox.provider.getCoinBalancesOwnedByAddress(
+      toolbox.address()
+    );
+    const txn = await signer.transferObject({
+      objectId: getObjectId(coins[0]),
+      gasBudget: DEFAULT_GAS_BUDGET,
+      recipient: DEFAULT_RECIPIENT,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+
+  it('Transfer Sui', async () => {
+    const coins = (
+      await toolbox.provider.getCoinBalancesOwnedByAddress(toolbox.address())
+    ).filter((c) => Coin.getBalance(c)!.gtn(DEFAULT_GAS_BUDGET));
+    const txn = await signer.transferSui({
+      suiObjectId: getObjectId(coins[0]),
+      gasBudget: DEFAULT_GAS_BUDGET,
+      recipient: DEFAULT_RECIPIENT,
+      amount: null,
+    });
+    expect(getExecutionStatusType(txn)).toEqual('success');
+  });
+});

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import axios from 'axios';
+import {
+  Ed25519Keypair,
+  JsonRpcProvider,
+  JsonRpcProviderWithCache,
+} from '../../../src';
+
+const DEFAULT_FAUCET_URL = 'http://127.0.0.1:9123/faucet';
+const DEFAULT_FULLNODE_URL = 'http://127.0.0.1:9000';
+const DEFAULT_GATEWAY_URL = 'http://127.0.0.1:5001';
+
+export const DEFAULT_RECIPIENT = '0x36096be6a0314052931babed39f53c0666a6b0df';
+export const DEFAULT_GAS_BUDGET = 1000;
+
+export class TestToolbox {
+  constructor(
+    public keypair: Ed25519Keypair,
+    public provider: JsonRpcProvider
+  ) {}
+
+  address() {
+    return this.keypair.getPublicKey().toSuiAddress();
+  }
+}
+
+export async function requestToken(recipient: string): Promise<void> {
+  const res = await axios.post<{ ok: boolean }>(DEFAULT_FAUCET_URL, {
+    recipient,
+  });
+  if (!res.data.ok) {
+    throw new Error('Unable to invoke local faucet.');
+  }
+}
+
+type RPCType = 'gateway' | 'fullnode';
+type ProviderType = 'rpc' | 'rpc-with-cache';
+
+export function getProvider(
+  rpcType: RPCType,
+  providerType: ProviderType
+): JsonRpcProvider {
+  const url =
+    rpcType === 'fullnode' ? DEFAULT_FULLNODE_URL : DEFAULT_GATEWAY_URL;
+  return providerType === 'rpc'
+    ? new JsonRpcProvider(url)
+    : new JsonRpcProviderWithCache(url);
+}
+
+export async function setup(
+  rpcType: RPCType = 'fullnode',
+  providerType: ProviderType = 'rpc'
+) {
+  const keypair = Ed25519Keypair.generate();
+  const address = keypair.getPublicKey().toSuiAddress();
+  await requestToken(address);
+
+  return new TestToolbox(keypair, getProvider(rpcType, providerType));
+}


### PR DESCRIPTION
Adding a few e2e tests (against local validators) for:
- get objects
- get transactions
- executeTransaction using RPC endpoints
- executeTransactions using local transaction serializer