### PR TITLE
wallet-ext: hide dapp connection status when not connected

### DIFF
--- a/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -74,6 +74,9 @@ function DappStatus() {
             setDisconnecting(false);
         }
     }, [disconnecting, isConnected, activeOriginUrl, dispatch]);
+    if (!isConnected) {
+        return null;
+    }
     return (
         <div className={st.wrapper} ref={wrapperRef}>
             <Component


### PR DESCRIPTION
* showing `not connected` without a further explanations in a tooltip seems to be confusing
* also when the active tab is the extension itself (in expanded mode) it doesn't seem correct


https://user-images.githubusercontent.com/10210143/191111279-e773aa66-3166-41d3-b955-b14a705b0a2a.mov

part #4696 