### PR TITLE
Fix how we handle control-c in stress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7395,6 +7395,7 @@ dependencies = [
  "tempfile",
  "test-utils",
  "tokio",
+ "tokio-util 0.7.4",
  "tracing",
  "tracing-subscriber 0.3.15",
  "workspace-hack 0.1.0",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -35,6 +35,7 @@ duration-str = "0.4.0"
 hdrhistogram = "7.5.1"
 comfy-table = "6.1.0"
 bcs = "0.1.3"
+tokio-util = "0.7.4"
 sui-core = { path = "../sui-core" }
 sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }


### PR DESCRIPTION
The current approach of handling contorl-c signal is incorrect as it does it inside one worker. This basically means to terminate the program with control-c, we need to press it any many times as there are workers to make it work. Instead we need a way to cancel all tasks on the first signal. This PR fixes the erroneous behavior