### PR TITLE
[reconfig] Do not respawn node sync process

### DIFF
--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -200,9 +200,6 @@ where
         self.state.unhalt_validator();
         info!(?epoch, "Validator unhalted.");
 
-        // Restart the node sync process so it gets the new epoch info.
-        self.respawn_node_sync_process().await;
-
         info!(
             "===== Epoch change finished. We are now at epoch {:?} =====",
             next_epoch


### PR DESCRIPTION
Node sync process only runs on fullnode, while reconfiguration only happens on a validator.