### PR TITLE
Fix changeset publishing + add changeset CI

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["sui-explorer", "sui-dapp-sdk", "demo-nft-dapp"]
+  "ignore": ["sui-explorer", "demo-nft-dapp"]
 }

--- a/.github/workflows/changesets-ci.yml
+++ b/.github/workflows/changesets-ci.yml
@@ -1,0 +1,22 @@
+name: Changesets CI
+on: pull_request
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7
+      - name: Install Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Attempt to create snapshots.
+        run: pnpm changeset version --snapshot test-do-not-publish


### PR DESCRIPTION
This package was removed but is still being ignored, which is breaking changeset snapshot publishing. I also added a CI task that validates that the changeset versioning process completes, which should give us confidence that we don't break this moving forward.