### PR TITLE
Support for patching blst with a mocked version that bypasses crypto ops

### DIFF
--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -43,6 +43,8 @@ else
   echo "Using MSIM_TEST_SEED=$MSIM_TEST_SEED from the environment"
 fi
 
+RUST_FLAGS=('"--cfg"' '"msim"')
+
 cargo_patch_args=(
   --config 'patch.crates-io.hyper.git = "https://github.com/mystenmark/hyper-madsim-fork.git"'
   --config 'patch.crates-io.hyper.rev = "2b2eca1e983376294c84c93385ebe848ccf9a99f"'
@@ -60,6 +62,23 @@ else
   )
 fi
 
+# Mock out the blst crate to massively speed up the simulation.
+# You should not assume that test runs will be repeatable with and without blst mocking,
+# as blst samples from the PRNG when not mocked.
+if [ -n "$USE_MOCK_CRYPTO" ]; then
+  echo "Using mocked crypto crates - no cryptographic verification will occur"
+  RUST_FLAGS+=(
+    '"--cfg"'
+    '"use_mock_crypto"'
+  )
+  cargo_patch_args+=(
+    --config 'patch.crates-io.blst.git = "https://github.com/MystenLabs/mock-blst.git"'
+    --config 'patch.crates-io.blst.rev = "630ca4d55de8e199e62c5b6a695c702d95fe6498"'
+  )
+fi
+
+RUST_FLAGS=$(IFS=, ; echo "${RUST_FLAGS[*]}")
+
 CARGO_COMMAND=(nextest run --cargo-profile simulator)
 if [ "$1" = "build" ]; then
   shift
@@ -67,7 +86,7 @@ if [ "$1" = "build" ]; then
 fi
 
 cargo ${CARGO_COMMAND[@]} \
-  --config 'build.rustflags = ["--cfg", "msim"]' \
+  --config "build.rustflags = [$RUST_FLAGS]" \
   "${cargo_patch_args[@]}" \
   --config 'patch.crates-io.hyper.git = "https://github.com/mystenmark/hyper-madsim-fork.git"' \
   --config 'patch.crates-io.hyper.rev = "2b2eca1e983376294c84c93385ebe848ccf9a99f"' \


### PR DESCRIPTION
Massively speeds up the simulator in cases where all the verifications would succeed anyway.

Here is the patch to blst: https://github.com/MystenLabs/mock-blst/commit/630ca4d55de8e199e62c5b6a695c702d95fe6498#diff-7f53e1ecce5b519e9002e448e51f119bda7092059ce9b57e9ff3fa1e33767995 - there are copious warnings / `compile_error!` to prevent this from accidentally being included in shipping code.