### PR TITLE
[Explorer] Adds ellipsis to handle text running over multiple lines in owned coins

### DIFF
--- a/explorer/client/src/components/ownedobjects/styles/OwnedCoin.module.css
+++ b/explorer/client/src/components/ownedobjects/styles/OwnedCoin.module.css
@@ -1,3 +1,12 @@
+.oneline,
+.oneline div {
+    @apply truncate min-w-0;
+}
+
+.cointype {
+    @apply pr-[15px];
+}
+
 .groupview {
     @apply text-left;
 }

--- a/explorer/client/src/components/ownedobjects/views/OwnedCoinView.tsx
+++ b/explorer/client/src/components/ownedobjects/views/OwnedCoinView.tsx
@@ -41,7 +41,9 @@ function SingleCoinView({
                 <div className={isOpen ? styles.openicon : styles.closedicon}>
                     <ContentIcon />
                 </div>
-                <div>{handleCoinType(coinLabel)}</div>
+                <div className={`${styles.oneline} ${styles.cointype}`}>
+                    {handleCoinType(coinLabel)}
+                </div>
                 <div>{subObjList.length}</div>
                 <div>
                     {subObjList[0]._isCoin &&
@@ -61,7 +63,7 @@ function SingleCoinView({
                             <div className={styles.objectid}>
                                 <div />
                                 <div>Object ID</div>
-                                <div>
+                                <div className={styles.oneline}>
                                     <Longtext
                                         text={subObj.id}
                                         category="objects"


### PR DESCRIPTION
For each coin owned by an address or object, this PR caps the text for the type of the coin and the text for the address to one line. If text exceeds one line, the line is terminated in an ellipsis (&mldr;).

On Desktop:
![image](https://user-images.githubusercontent.com/11377188/192007154-ca42d48e-cefc-48d3-8702-70704f80d0dd.png)

On Mobile:
![image](https://user-images.githubusercontent.com/11377188/192007265-58d33f69-56bf-4eb8-aac2-fddb88dd5acc.png)




For comparison the current handling can be seen with the URL https://explorer.devnet.sui.io/addresses/0x901943abc072415eb36f9aabc1abf3ddddce6ce8.