### PR TITLE
[wallet-ext] Workflow run wallet extension

### DIFF
--- a/.github/workflows/wallet-ext-comment.yml
+++ b/.github/workflows/wallet-ext-comment.yml
@@ -15,24 +15,33 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+      - name: "Download artifact"
+        uses: actions/github-script@v6
+        id: get-artifact
         with:
+          result-encoding: string
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
+               run_id: context.payload.workflow_run.id,
             });
 
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "wallet-extension"
             })[0];
 
+            if (!matchArtifact) {
+              return '';
+            }
+
+            return matchArtifact.archive_download_url;
+
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1
+        if: steps.get-artifact.outputs.result != ''
         with:
           comment_includes: "💳 Wallet Extension"
           message: |
-            💳 Wallet Extension has been built, you can download the packaged extension here: https://github.com/MystenLabs/sui/actions/runs/${{ github.run_id }}#artifacts
+            💳 Wallet Extension has been built, you can download the packaged extension here: ${{steps.get-artifact.outputs.result}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wallet-ext-comment.yml
+++ b/.github/workflows/wallet-ext-comment.yml
@@ -1,0 +1,38 @@
+name: Wallet Extension PR Comment
+
+# NOTE: This workflow run indirection is used to securely comment on PRs when
+# wallet builds are completed.
+on:
+  workflow_run:
+    workflows: ["Wallet Extension PR Checks"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "wallet-extension"
+            })[0];
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          comment_includes: "💳 Wallet Extension"
+          message: |
+            💳 Wallet Extension has been built, you can download the packaged extension here: https://github.com/MystenLabs/sui/actions/runs/${{ github.run_id }}#artifacts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -1,8 +1,8 @@
-name: Wallet Extension PR checks
+name: Wallet Extension PR Checks
 on: pull_request
 jobs:
   diff:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     outputs:
       isWalletExt: ${{ steps.diff.outputs.isWalletExt }}
     steps:
@@ -10,11 +10,12 @@ jobs:
       - name: Detect Changes
         uses: "./.github/actions/pnpm-diffs"
         id: diff
+
   run_checks:
     name: Lint, Test & Build
     needs: diff
     if: needs.diff.outputs.isWalletExt == 'true'
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     env:
       working-directory: ./wallet
     steps:
@@ -49,10 +50,3 @@ jobs:
           path: wallet/web-ext-artifacts/*
           if-no-files-found: error
           retention-days: 7
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v1
-        with:
-          comment_includes: "💳 Wallet Extension"
-          message: |
-            💳 Wallet Extension has been built, you can download the packaged extension here: https://github.com/MystenLabs/sui/actions/runs/${{ github.run_id }}#artifacts
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -44,7 +44,6 @@ jobs:
         working-directory: ${{env.working-directory}}
         run: pnpm pack:zip
       - uses: actions/upload-artifact@v2
-        if: always()
         with:
           name: wallet-extension
           path: wallet/web-ext-artifacts/*

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -1,7 +1,6 @@
 # Sui Wallet
 
-
-A Chrome (v88+) extension wallet for [Sui](https://sui.io).
+A Chrome (v88+) extension wallet for [Sui](https://sui.io). test change
 
 # Set Up
 

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -1,6 +1,6 @@
 # Sui Wallet
 
-A Chrome (v88+) extension wallet for [Sui](https://sui.io). test change
+A Chrome (v88+) extension wallet for [Sui](https://sui.io).
 
 # Set Up
 

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -1,5 +1,6 @@
 # Sui Wallet
 
+
 A Chrome (v88+) extension wallet for [Sui](https://sui.io).
 
 # Set Up


### PR DESCRIPTION
It was noticed that pull-requests from forks don't correctly comment on PRs. This is due to the security of github tokens on forked repos, where they do not have write access to the repo. The solution here is to use some indirection through `workflow_call`, which can comment on the PR but importantly does not build the extension (which is potentially a security issue).

This is based on guidance from Github: https://securitylab.github.com/research/github-actions-preventing-pwn-requests

Note that this won't work (and therefore we can't test this) until this merges, as `workflow_call` only runs from the `main` branch. I tested the best I could locally using `act` though.