### PR TITLE
docs(sui-security): Fix typo

### DIFF
--- a/doc/src/learn/sui-security.md
+++ b/doc/src/learn/sui-security.md
@@ -77,7 +77,7 @@ on which address and how the shared assets may be used.
 
 ### Transaction finality
 
-A valid transaction submitted to all validators to be certified and its certificate also has to be submitted to all validators
+A valid transaction submitted to all validators has to be certified and its certificate also has to be submitted to all validators
 to be finalized. Even if a subset of validators do not follow the protocol, the transaction can be finalized through the
 remaining validators that correctly follow the Sui protocol. This is achieved through the use of cryptographic
 Byzantine fault tolerant agreement protocols for broadcast and consensus defined by the Sui protocol. These protocols


### PR DESCRIPTION
I'm not sure if the original version is correct, so I submitted what I think it should be.  Feel free to just ignore the suggestion if it does not apply.