### PR TITLE
Move mysten-infra dependencies to common Cargo file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,13 @@ opt-level = 1
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 
+# github.com/MystenLabs/mysten-infra dependencies
+typed-store = "0.1.0"
+typed-store-derive = "0.1.0"
+telemetry-subscribers = "0.1.0"
+mysten-network = "0.1.0"
+name-variant = "0.1.0"
+
 # Move dependencies
 move-binary-format = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }
 move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "e1e647b73dbd3652aabb2020728a4a517c26e28e" }

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -22,7 +22,7 @@ rocksdb = "0.19.0"
 serde_with = { version = "1.14.0", features = ["hex"] }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["time", "registry", "env-filter"] }
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 clap = { version = "3.1.17", features = ["derive"] }
 prometheus = "0.13.2"
 multiaddr = "0.14.0"

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = { version = "0.1.36", features = ["log"] }
 clap = { version = "3.1.14", features = ["derive"] }
 reqwest = { version = "0.11.11", features = ["blocking", "json"] }
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 async-trait = "0.1.57"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.3"

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -46,9 +46,9 @@ move-bytecode-utils.workspace = true
 move-core-types.workspace = true
 move-vm-runtime.workspace = true
 
-typed-store = "0.1.0"
-typed-store-derive = "0.1.0"
-mysten-network = "0.1.0"
+typed-store.workspace = true
+typed-store-derive.workspace = true
+mysten-network.workspace = true
 
 narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "5f4b7d3f4edb1fd2e1a2789a2b7167fffe2ff28d" }
 narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "5f4b7d3f4edb1fd2e1a2789a2b7167fffe2ff28d" }
@@ -69,7 +69,7 @@ move-package.workspace = true
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.26"
 pretty_assertions = "1.2.1"
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 
 test-fuzz = "3.0.4"
 test-utils = { path = "../test-utils" }

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -28,7 +28,7 @@ sui-node = { path = "../sui-node" }
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }
 sui-config = { path = "../sui-config" }
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 workspace-hack = { path = "../workspace-hack"}
 
 [dev-dependencies]

--- a/crates/sui-gateway/Cargo.toml
+++ b/crates/sui-gateway/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 futures = "0.3.23"
 prometheus = "0.13.2"
 clap = { version = "3.2.17", features = ["derive"] }
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 
 sui-core = { path = "../sui-core" }
 sui-config = { path = "../sui-config" }
@@ -26,7 +26,7 @@ sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-node = { path = "../sui-node" }
 
 
-mysten-network = "0.1.0"
+mysten-network.workspace = true
 move-package.workspace = true
 workspace-hack = { path = "../workspace-hack"}
 

--- a/crates/sui-network/Cargo.toml
+++ b/crates/sui-network/Cargo.toml
@@ -12,8 +12,7 @@ tonic = "0.7"
 
 sui-types = { path = "../sui-types" }
 
-
-mysten-network = "0.1.0"
+mysten-network.workspace = true
 workspace-hack = { path = "../workspace-hack"}
 
 [build-dependencies]

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.36"
 parking_lot = "0.12.1"
 futures = "0.3.23"
-typed-store = "0.1.0"
+typed-store.workspace = true
 chrono = "0.4.0"
 
 sui-config = { path = "../sui-config" }
@@ -27,8 +27,8 @@ sui-json-rpc = { path = "../sui-json-rpc" }
 sui-telemetry = { path = "../sui-telemetry" }
 sui-types = { path = "../sui-types" }
 
-telemetry-subscribers = "0.1.0"
-mysten-network = "0.1.0"
+telemetry-subscribers.workspace = true
+mysten-network.workspace = true
 workspace-hack = { path = "../workspace-hack"}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 workspace-hack = { path = "../workspace-hack"}
 sui-framework = { path = "../sui-framework" }
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 tracing = "0.1"
 
 [target.'cfg(msim)'.dependencies]

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -27,8 +27,8 @@ tempfile = "3.3.0"
 tap = "1.0.1"
 
 sui-types = { path = "../sui-types" }
-typed-store = "0.1.0"
-typed-store-derive = "0.1.0"
+typed-store.workspace = true
+typed-store-derive.workspace = true
 move-core-types.workspace = true
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 workspace-hack = { path = "../workspace-hack"}
@@ -39,7 +39,7 @@ anyhow = "1.0.64"
 tempfile = "3.3.0"
 num_cpus = "1.13.1"
 pretty_assertions = "1.2.0"
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 
 [[bench]]
 name = "write_ahead_log"

--- a/crates/sui-swarm/Cargo.toml
+++ b/crates/sui-swarm/Cargo.toml
@@ -21,11 +21,11 @@ sui-config = { path = "../sui-config" }
 sui-node = { path = "../sui-node" }
 sui-types = { path = "../sui-types" }
 
-mysten-network = "0.1.0"
+mysten-network.workspace = true
 workspace-hack = { path = "../workspace-hack"}
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator = { path = "../sui-simulator" }
 
 [dev-dependencies]
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -12,13 +12,13 @@ tokio = { version = "1.20.1", features = ["full"] }
 tracing = "0.1.36"
 clap = { version = "3.2.17", features = ["derive"] }
 
-telemetry-subscribers = "0.1.0"
-mysten-network = "0.1.0"
+telemetry-subscribers.workspace = true
+mysten-network.workspace = true
 textwrap = "0.15"
 futures = "0.3.23"
 rocksdb = "0.19.0"
-typed-store = "0.1.0"
-typed-store-derive = "0.1.0"
+typed-store.workspace = true
+typed-store-derive.workspace = true
 tempfile = "3.3.0"
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "5f4b7d3f4edb1fd2e1a2789a2b7167fffe2ff28d" }
 serde_with = { version = "1.14.0", features = ["hex"] }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -41,8 +41,8 @@ eyre = "0.6.8"
 bip32 = "0.4.0"
 slip10_ed25519 = "0.1.3"
 
-name-variant = "0.1.0"
-typed-store = "0.1.0"
+name-variant.workspace = true
+typed-store.workspace = true
 
 move-binary-format.workspace = true
 move-bytecode-utils.workspace = true

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -19,7 +19,7 @@ serde_with = { version = "1.14.0", features = ["hex"] }
 tracing = "0.1.36"
 bcs = "0.1.3"
 clap = { version = "3.2.17", features = ["derive"] }
-telemetry-subscribers = "0.1.0"
+telemetry-subscribers.workspace = true
 bip32 = "0.4.0"
 
 sui-core = { path = "../sui-core" }
@@ -39,8 +39,8 @@ colored = "2.0.0"
 unescape = "0.1.0"
 shell-words = "1.1.0"
 rocksdb = "0.19.0"
-typed-store = "0.1.0"
-typed-store-derive = "0.1.0"
+typed-store.workspace = true
+typed-store-derive.workspace = true
 
 tempfile = "3.3.0"
 narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "5f4b7d3f4edb1fd2e1a2789a2b7167fffe2ff28d" }
@@ -65,8 +65,8 @@ tempfile = "3.3.0"
 futures = "0.3.23"
 prometheus = "0.13.2"
 
-typed-store = "0.1.0"
-typed-store-derive = "0.1.0"
+typed-store.workspace = true
+typed-store-derive.workspace = true
 jsonrpsee = { version = "0.15.1", features = ["full"] }
 
 test-utils = { path = "../test-utils" }


### PR DESCRIPTION
Taking advantage of Rust 1.64 to centralize Mysten-infra dependencies to the common root Cargo file.  This will make upgrading Mysten-infra dependencies much easier.