### PR TITLE
[wallet-ext] Fix CI wallet download URL

### DIFF
--- a/.github/workflows/wallet-ext-comment.yml
+++ b/.github/workflows/wallet-ext-comment.yml
@@ -42,7 +42,7 @@ jobs:
               return '';
             }
 
-            return matchArtifact.archive_download_url;
+            return `https://github.com/MystenLabs/sui/suites/8476270273/artifacts/${matchArtifact.id}`;
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1


### PR DESCRIPTION
The URL was pointing to an API, but not the actual download URL.