### PR TITLE
implement pay sui

### DIFF
--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -405,6 +405,7 @@ pub enum OperationType {
     // Readonly
     GasSpent,
     Pay,
+    PaySui,
     TransferObject,
     Publish,
     MoveCall,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -441,6 +441,9 @@ pub enum SuiError {
 
     #[error("Invalid epoch request response: {0}")]
     InvalidEpochResponse(String),
+
+    #[error("Empty input coins for PaySui transaction")]
+    EmptyInputCoins,
 }
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;


### PR DESCRIPTION
the main changes in this PR:
- add paySui transaction type including its transaction construction
- change existing pay(), instead of always making new coins and assigning the new coins to recipients, the updated pay() tries to reuse the existing input coins, updating them to proper amounts and assigning to recipients.
  - the main reason that we want to re-use the input coin, is that gas payment coin needs to live through the transaction, meaning that either coins to be deleted in one transaction or coins created in a transaction cannot be the gas payment coin of this transaction.
- also added some unit tests