### PR TITLE
[fe] Add top-level command alias for easier monorepo management

### DIFF
--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
-        run: pnpm --filter sui-explorer lint
+        run: pnpm explorer lint
       - name: Unit Tests
-        run: pnpm --filter sui-explorer test:unit
+        run: pnpm explorer test:unit
       - name: Build
-        run: pnpm --filter sui-explorer build
+        run: pnpm explorer build
   end_to_end_static:
     name: End-to-end tests (Static)
     needs: diff
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Cypress
-        run: pnpm --filter sui-explorer exec cypress install
+        run: pnpm explorer exec cypress install
       - name: Run e2e tests
         uses: cypress-io/github-action@v4
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Cypress
-        run: pnpm --filter sui-explorer exec cypress install
+        run: pnpm explorer exec cypress install
       - name: Run e2e tests
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test
-        run: pnpm --filter @mysten/sui.js test:unit
+        run: pnpm sdk test:unit
       - name: Build
-        run: pnpm --filter @mysten/sui.js build
+        run: pnpm sdk build
   end_to_end:
     name: End-to-end tests
     needs: diff
@@ -52,4 +52,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run e2e tests
-        run: pnpm dlx concurrently --kill-others --success command-1 'cargo run --bin sui-test-validator' 'pnpm --filter @mysten/sui.js test:e2e'
+        run: pnpm dlx concurrently --kill-others --success command-1 'cargo run --bin sui-test-validator' 'pnpm sdk test:e2e'

--- a/.github/workflows/wallet-adapter.yml
+++ b/.github/workflows/wallet-adapter.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm --filter sui-wallet-adapter build
+        run: pnpm wallet-adapter build

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -16,8 +16,6 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isWalletExt == 'true'
     runs-on: ubuntu-latest
-    env:
-      working-directory: ./apps/wallet
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,17 +30,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
-        working-directory: ${{env.working-directory}}
-        run: pnpm lint
+        run: pnpm wallet lint
       - name: Test
-        working-directory: ${{env.working-directory}}
-        run: pnpm test
+        run: pnpm wallet test
       - name: Build
-        working-directory: ${{env.working-directory}}
-        run: pnpm build:prod
+        run: pnpm wallet build:prod
       - name: Package
-        working-directory: ${{env.working-directory}}
-        run: pnpm pack:zip
+        run: pnpm wallet pack:zip
       - uses: actions/upload-artifact@v3
         with:
           name: wallet-extension

--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "sui-monorepo",
   "private": true,
   "license": "Apache-2.0",
+  "scripts": {
+    "explorer": "pnpm --filter ./apps/explorer",
+    "wallet": "pnpm --filter ./apps/wallet",
+    "wallet-adapter": "pnpm --filter ./sdk/wallet-adapter",
+    "sdk": "pnpm --filter ./sdk/typescript",
+    "bcs": "pnpm --filter ./sdk/bcs"
+  },
   "pnpm": {
     "overrides": {
       "node-notifier": "10.0.0",

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -31,8 +31,8 @@ To get started you need to install [pnpm](https://pnpm.io/), then run the follow
 ```bash
 # Install all dependencies
 $ pnpm install
-# Run the build for the TypeScript SDK and all of its dependencies.
-$ pnpm --filter @mysten/sui.js... build
+# Run the build for the TypeScript SDK
+$ pnpm sdk build
 ```
 
 ## Type Doc

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -707,16 +707,23 @@ export function isEpochId(obj: any, _argumentName?: string): obj is EpochId {
     )
 }
 
+export function isGenericAuthoritySignature(obj: any, _argumentName?: string): obj is GenericAuthoritySignature {
+    return (
+        (isTransactionDigest(obj) as boolean ||
+            Array.isArray(obj) &&
+            obj.every((e: any) =>
+                isTransactionDigest(e) as boolean
+            ))
+    )
+}
+
 export function isAuthorityQuorumSignInfo(obj: any, _argumentName?: string): obj is AuthorityQuorumSignInfo {
     return (
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
         isSuiMoveTypeParameterIndex(obj.epoch) as boolean &&
-        ((Array.isArray(obj.signature) &&
-        obj.signature.every((e: any) =>
-            isTransactionDigest(e) as boolean
-        )) || isTransactionDigest(obj.signature) as boolean)
+        isGenericAuthoritySignature(obj.signature) as boolean
     )
 }
 

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -707,23 +707,16 @@ export function isEpochId(obj: any, _argumentName?: string): obj is EpochId {
     )
 }
 
-export function isGenericAuthoritySignature(obj: any, _argumentName?: string): obj is GenericAuthoritySignature {
-    return (
-        (isTransactionDigest(obj) as boolean ||
-            Array.isArray(obj) &&
-            obj.every((e: any) =>
-                isTransactionDigest(e) as boolean
-            ))
-    )
-}
-
 export function isAuthorityQuorumSignInfo(obj: any, _argumentName?: string): obj is AuthorityQuorumSignInfo {
     return (
         (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
         isSuiMoveTypeParameterIndex(obj.epoch) as boolean &&
-        isGenericAuthoritySignature(obj.signature) as boolean
+        ((Array.isArray(obj.signature) &&
+        obj.signature.every((e: any) =>
+            isTransactionDigest(e) as boolean
+        )) || isTransactionDigest(obj.signature) as boolean)
     )
 }
 


### PR DESCRIPTION
This adds new top-level commands for `pnpm` which make it easier to run scoped commands from the root. Examples:

```bash
# Run the dev process for the explorer
pnpm explorer dev
# Start building the wallet extension
pnpm wallet start
# Build the TypeScript SDK
pnpm sdk build
```

The main benefit of these changes is that we have a lot less dependence on package names and directory locations for DX and CI/CD.