### PR TITLE
[crypto] Bulletproofs/PedCom: nothing up my sleeve number for group generation

### DIFF
--- a/crates/sui-framework/src/natives/crypto.rs
+++ b/crates/sui-framework/src/natives/crypto.rs
@@ -27,9 +27,10 @@ pub const INVALID_RISTRETTO_SCALAR: u64 = 4;
 pub const BULLETPROOFS_VERIFICATION_FAILED: u64 = 5;
 pub const INVALID_PUBKEY: u64 = 6;
 
-pub const BP_DOMAIN: &[u8] = b"mizu";
+/// Using the word "sui" for nothing-up-my-sleeve number guarantees.
+pub const BP_DOMAIN: &[u8] = b"sui";
 
-/// Native implemention of ecrecover in public Move API, see crypto.move for specifications.
+/// Native implementation of ecrecover in public Move API, see crypto.move for specifications.
 pub fn ecrecover(
     _context: &mut NativeContext,
     ty_args: Vec<Type>,
@@ -146,7 +147,7 @@ pub fn secp256k1_verify(
     }
 }
 
-/// Native implemention of bls12381_verify in public Move API, see crypto.move for specifications.
+/// Native implementation of bls12381_verify in public Move API, see crypto.move for specifications.
 /// Note that this function only works for signatures in G1 and public keys in G2.
 pub fn bls12381_verify_g1_sig(
     _context: &mut NativeContext,
@@ -179,7 +180,8 @@ pub fn bls12381_verify_g1_sig(
     }
 }
 
-/// Native implemention of Bulletproofs range proof in public Move API, see crypto.move for specifications.
+/// Native implementation of Bulletproofs range proof in public Move API, see crypto.move for
+/// specifications.
 pub fn verify_range_proof(
     _context: &mut NativeContext,
     ty_args: Vec<Type>,

--- a/crates/sui-framework/src/natives/test_scenario_wip.rs
+++ b/crates/sui-framework/src/natives/test_scenario_wip.rs
@@ -408,7 +408,7 @@ fn is_expected_ty(specified_ty: &TypeTag, expected_ty: &StructTag) -> bool {
 }
 
 fn get_specified_ty(context: &mut NativeContext, ty_args: Vec<Type>) -> StructTag {
-    assert!(ty_args.len() == 1);
+    assert_eq!(ty_args.len(), 1);
     match context.type_to_type_tag(&ty_args[0]).unwrap() {
         TypeTag::Struct(s) => s,
         _ => panic!("impossible, must be a struct since it has key"),


### PR DESCRIPTION
Hint: using "sui" instead of "mizu" is considered _more_ acceptable to guarantee nothing up my sleeve numbers -> see https://en.wikipedia.org/wiki/Nothing-up-my-sleeve_number
Issue: https://github.com/MystenLabs/sui/issues/4563