### PR TITLE
[cluster test] deterministically wait for fullnode to sync txns

### DIFF
--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -1,23 +1,12 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use super::{
-    cluster::{new_wallet_context_from_cluster, Cluster},
-    helper::ObjectChecker,
-    wallet_client::WalletClient,
-};
-use anyhow::bail;
+use super::cluster::{new_wallet_context_from_cluster, Cluster};
 use async_trait::async_trait;
-use clap::*;
 use std::collections::HashMap;
 use std::sync::Arc;
-use sui_faucet::{CoinInfo, Faucet, FaucetResponse, SimpleFaucet};
+use sui_faucet::{Faucet, FaucetResponse, SimpleFaucet};
+use sui_types::base_types::{encode_bytes_hex, SuiAddress};
 use sui_types::crypto::KeypairTraits;
-use sui_types::{
-    base_types::{encode_bytes_hex, SuiAddress},
-    gas_coin::GasCoin,
-    object::Owner,
-};
-use tokio::time::{sleep, Duration};
 use tracing::{debug, info, info_span, Instrument};
 use uuid::Uuid;
 
@@ -52,12 +41,7 @@ impl FaucetClientFactory {
 /// Faucet Client abstraction
 #[async_trait]
 pub trait FaucetClient {
-    async fn request_sui_coins(
-        &self,
-        client: &WalletClient,
-        minimum_coins: Option<usize>,
-        request_address: Option<SuiAddress>,
-    ) -> Result<Vec<GasCoin>, anyhow::Error>;
+    async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse;
 }
 
 /// Client for a remote faucet that is accessible by POST requests
@@ -76,16 +60,10 @@ impl RemoteFaucetClient {
 impl FaucetClient for RemoteFaucetClient {
     /// Request test SUI coins from faucet.
     /// It also verifies the effects are observed by gateway/fullnode.
-    async fn request_sui_coins(
-        &self,
-        client: &WalletClient,
-        minimum_coins: Option<usize>,
-        request_address: Option<SuiAddress>,
-    ) -> Result<Vec<GasCoin>, anyhow::Error> {
+    async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
         let gas_url = format!("{}/gas", self.remote_url);
         debug!("Getting coin from remote faucet {}", gas_url);
-        let address = request_address.unwrap_or_else(|| client.get_wallet_address());
-        let data = HashMap::from([("recipient", encode_bytes_hex(&address))]);
+        let data = HashMap::from([("recipient", encode_bytes_hex(&request_address))]);
         let map = HashMap::from([("FixedAmountRequest", data)]);
 
         let response = reqwest::Client::new()
@@ -101,27 +79,9 @@ impl FaucetClient for RemoteFaucetClient {
 
         if let Some(error) = faucet_response.error {
             panic!("Failed to get gas tokens with error: {}", error)
-        }
+        };
 
-        sleep(Duration::from_secs(2)).await;
-
-        let gas_coins = into_gas_coin_with_owner_check(
-            faucet_response.transferred_gas_objects,
-            address,
-            client,
-        )
-        .await;
-
-        let minimum_coins = minimum_coins.unwrap_or(5);
-
-        if gas_coins.len() < minimum_coins {
-            bail!(
-                "Expect to get at least {minimum_coins} Sui Coins for address {address}, but only got {}",
-                gas_coins.len()
-            )
-        }
-
-        Ok(gas_coins)
+        faucet_response
     }
 }
 
@@ -138,52 +98,13 @@ impl LocalFaucetClient {
 }
 #[async_trait]
 impl FaucetClient for LocalFaucetClient {
-    async fn request_sui_coins(
-        &self,
-        client: &WalletClient,
-        minimum_coins: Option<usize>,
-        request_address: Option<SuiAddress>,
-    ) -> Result<Vec<GasCoin>, anyhow::Error> {
-        let address = request_address.unwrap_or_else(|| client.get_wallet_address());
+    async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
         let receipt = self
             .simple_faucet
-            .send(Uuid::new_v4(), address, &[50000; 5])
+            .send(Uuid::new_v4(), request_address, &[50000; 5])
             .await
             .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {}", err));
 
-        sleep(Duration::from_secs(2)).await;
-
-        let gas_coins = into_gas_coin_with_owner_check(receipt.sent, address, client).await;
-
-        let minimum_coins = minimum_coins.unwrap_or(5);
-
-        if gas_coins.len() < minimum_coins {
-            bail!(
-                "Expect to get at least {minimum_coins} Sui Coins for address {address}, but only got {}. Try minting more coins on genesis.",
-                gas_coins.len()
-            )
-        }
-
-        Ok(gas_coins)
+        receipt.into()
     }
-}
-
-async fn into_gas_coin_with_owner_check(
-    coin_info: Vec<CoinInfo>,
-    owner: SuiAddress,
-    client: &WalletClient,
-) -> Vec<GasCoin> {
-    futures::future::join_all(
-        coin_info
-            .iter()
-            .map(|coin_info| {
-                ObjectChecker::new(coin_info.id)
-                    .owner(Owner::AddressOwner(owner))
-                    .check_into_gas_coin(client.get_fullnode())
-            })
-            .collect::<Vec<_>>(),
-    )
-    .await
-    .into_iter()
-    .collect::<Vec<_>>()
 }

--- a/crates/sui-cluster-test/src/test_case/call_contract_test.rs
+++ b/crates/sui-cluster-test/src/test_case/call_contract_test.rs
@@ -106,15 +106,16 @@ impl TestCaseImpl for CallContractTest {
         )).unwrap_or_else(|| panic!("Expect such a MoveEvent in events {:?}", events));
 
         // Verify fullnode observes the txn
-        ctx.let_fullnode_sync().await;
+        ctx.let_fullnode_sync(vec![effects.transaction_digest], 5)
+            .await;
 
-        let sui_object = ObjectChecker::new(nft_id)
+        let object = ObjectChecker::new(nft_id)
             .owner(Owner::AddressOwner(signer))
-            .check_into_sui_object(ctx.get_fullnode())
+            .check_into_object(ctx.get_fullnode())
             .await;
 
         assert_eq!(
-            sui_object.reference.version,
+            object.reference.version,
             SequenceNumber::from_u64(1),
             "Expect sequence number to be 1"
         );

--- a/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_execute_transaction_test.rs
@@ -46,7 +46,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             assert_eq!(txn_digest, tx_digest);
 
             // Verify fullnode observes the txn
-            ctx.let_fullnode_sync().await;
+            ctx.let_fullnode_sync(vec![tx_digest], 5).await;
 
             fullnode
                 .read_api()
@@ -76,7 +76,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
             assert_eq!(txn_digest, certificate.transaction_digest);
 
             // Verify fullnode observes the txn
-            ctx.let_fullnode_sync().await;
+            ctx.let_fullnode_sync(vec![txn_digest], 5).await;
 
             fullnode
                 .read_api()
@@ -113,7 +113,7 @@ impl TestCaseImpl for FullNodeExecuteTransactionTest {
                 )
             }
             // Verify fullnode observes the txn
-            ctx.let_fullnode_sync().await;
+            ctx.let_fullnode_sync(vec![txn_digest], 5).await;
 
             fullnode
                 .read_api()

--- a/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
+++ b/crates/sui-cluster-test/src/test_case/native_transfer_test.rs
@@ -77,7 +77,8 @@ impl TestCaseImpl for NativeTransferTest {
             .check(&event);
 
         // Verify fullnode observes the txn
-        ctx.let_fullnode_sync().await;
+        ctx.let_fullnode_sync(vec![response.certificate.transaction_digest], 5)
+            .await;
 
         let _ = ObjectChecker::new(*obj_to_transfer.id())
             .owner(Owner::AddressOwner(recipient_addr))

--- a/crates/sui-faucet/src/faucet/mod.rs
+++ b/crates/sui-faucet/src/faucet/mod.rs
@@ -3,11 +3,7 @@
 use crate::FaucetError;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use sui_json_rpc_types::SuiParsedObject;
-use sui_types::{
-    base_types::{ObjectID, SuiAddress},
-    gas_coin::GasCoin,
-};
+use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use uuid::Uuid;
 
 mod simple_faucet;
@@ -22,6 +18,7 @@ pub struct FaucetReceipt {
 pub struct CoinInfo {
     pub amount: u64,
     pub id: ObjectID,
+    pub transfer_tx_digest: TransactionDigest,
 }
 
 #[async_trait]
@@ -33,22 +30,4 @@ pub trait Faucet {
         recipient: SuiAddress,
         amounts: &[u64],
     ) -> Result<FaucetReceipt, FaucetError>;
-}
-
-impl<'a> FromIterator<&'a SuiParsedObject> for FaucetReceipt {
-    fn from_iter<T: IntoIterator<Item = &'a SuiParsedObject>>(iter: T) -> Self {
-        FaucetReceipt {
-            sent: iter.into_iter().map(|o| o.into()).collect(),
-        }
-    }
-}
-
-impl From<&SuiParsedObject> for CoinInfo {
-    fn from(v: &SuiParsedObject) -> Self {
-        let gas_coin = GasCoin::try_from(v).unwrap();
-        Self {
-            amount: gas_coin.value(),
-            id: *gas_coin.id(),
-        }
-    }
 }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -334,7 +334,8 @@ impl Faucet for SimpleFaucet {
         Ok(FaucetReceipt {
             sent: results
                 .iter()
-                .map(|(_digest, obj_id, amount, _gas_id)| CoinInfo {
+                .map(|(digest, obj_id, amount, _gas_id)| CoinInfo {
+                    transfer_tx_digest: *digest,
                     amount: *amount,
                     id: *obj_id,
                 })

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Write;
+use std::fmt::{Debug, Write};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
@@ -58,6 +58,19 @@ pub struct SuiClient {
 enum SuiClientApi {
     Rpc(RpcClient),
     Embedded(GatewayClient),
+}
+
+impl Debug for SuiClientApi {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SuiClientApi::Rpc(rpc_client) => write!(
+                f,
+                "RPC client. Http: {:?}, Websocket: {:?}",
+                rpc_client.http, rpc_client.ws
+            ),
+            SuiClientApi::Embedded(_) => write!(f, "Embedded Gateway client."),
+        }
+    }
 }
 
 struct RpcClient {
@@ -200,6 +213,7 @@ impl SuiClient {
     }
 }
 
+#[derive(Debug)]
 pub struct ReadApi {
     api: Arc<SuiClientApi>,
 }

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -138,6 +138,8 @@ pub async fn submit_move_transaction(
 
     let signature = context.keystore.sign(&sender, &data.to_bytes()).unwrap();
     let tx = Transaction::new(data, signature);
+    let tx_digest = tx.digest();
+    debug!(?tx_digest, "submitting move transaction");
 
     context
         .client


### PR DESCRIPTION
The cluster test cases can be flaky - sometimes fullnode takes a bit longer to catch up with the new transactions. This PR makes the behavior to wait for a transaction more deterministic. 

Changes:
1. `let_fullnode_sync` is changed to polling from fullnode periodically with a timeout from sleeping for a fixed duration.
2. include transaction digests in `FaucetResponse`
3. simplify the interfaces for `FaucetClient` and move the shared logic in two implementations to the `TestContext`
4. make `SuiClientApi` `Debug`gable