### PR TITLE
wallet-ext: show loading indicator only for initial load

### DIFF
--- a/apps/wallet/src/ui/app/hooks/useObjectsState.ts
+++ b/apps/wallet/src/ui/app/hooks/useObjectsState.ts
@@ -14,7 +14,7 @@ export function useObjectsState() {
     const showError =
         !!error && (!lastSync || Date.now() - lastSync > 30 * 1000);
     const syncedOnce = !!lastSync;
-    const loading = objectsLoading && !syncedOnce;
+    const loading = objectsLoading && !syncedOnce && !error;
     return useMemo(
         () => ({
             loading,


### PR DESCRIPTION
* there is a case that the first request to load objects owned by the wallet account fails, and after that for every request the loading indicator is visible together with the out of sync error. This shows the indicator only for the initial load

Before:


https://user-images.githubusercontent.com/10210143/192514310-d7711b5a-2761-437c-ab75-d62163486a0b.mov

After:


https://user-images.githubusercontent.com/10210143/192514337-04485387-fe37-49c9-beef-7554ebea983d.mov

