### PR TITLE
ci: detect changes for rust under crates directory

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -17,7 +17,7 @@ runs:
     with:
       filters: |
         isRust:
-          - '!(explorer|doc|.github|sdk|wallet)/**'
+          - 'crates/**'
           - '.github/workflows/bench.yml'
           - '.github/workflows/codecov.yml'
           - '.github/workflows/rust.yml'


### PR DESCRIPTION
it seems that rust checks/workflows are running for changes that are not related to rust eg. explorer/wallet-ext. This PR changes the diff action to detect rust changes only under the crates directory.