### PR TITLE
Support reconfiguration in NodeSyncState

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -357,7 +357,8 @@ where
         &self,
         mut lock_guard: MutexGuard<'_, Option<NodeSyncProcessHandle>>,
     ) {
-        info!(epoch = ?self.state.committee.load().epoch, "respawn_node_sync_process");
+        let epoch = self.state.committee.load().epoch;
+        info!(?epoch, "respawn_node_sync_process");
 
         if let Some(NodeSyncProcessHandle(join_handle, cancel_sender)) = lock_guard.take() {
             info!("sending cancel request to node sync task");
@@ -389,6 +390,7 @@ where
         let join_handle = tokio::task::spawn(node_sync_process(
             node_sync_handle,
             node_sync_state,
+            epoch,
             aggregator,
             cancel_receiver,
         ));

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -118,7 +118,7 @@ struct NodeSyncProcessHandle(tokio::task::JoinHandle<()>, oneshot::Sender<()>);
 pub struct ActiveAuthority<A> {
     // The local authority state
     pub state: Arc<AuthorityState>,
-    pub node_sync_state: Arc<NodeSyncState<A>>,
+    pub node_sync_store: Arc<NodeSyncStore>,
 
     // Handle that holds a channel connected to NodeSyncState, used to send sync requests
     // into NodeSyncState.
@@ -153,13 +153,6 @@ impl<A> ActiveAuthority<A> {
 
         let net = Arc::new(net);
 
-        let node_sync_state = Arc::new(NodeSyncState::new(
-            authority.clone(),
-            net.clone(),
-            node_sync_store,
-            gossip_metrics.clone(),
-        ));
-
         Ok(ActiveAuthority {
             health: Arc::new(Mutex::new(
                 committee
@@ -168,7 +161,7 @@ impl<A> ActiveAuthority<A> {
                     .collect(),
             )),
             state: authority,
-            node_sync_state,
+            node_sync_store,
             node_sync_handle: OnceCell::new(),
             node_sync_process: Default::default(),
             net: ArcSwap::from(net),
@@ -265,7 +258,7 @@ impl<A> Clone for ActiveAuthority<A> {
     fn clone(&self) -> Self {
         ActiveAuthority {
             state: self.state.clone(),
-            node_sync_state: self.node_sync_state.clone(),
+            node_sync_store: self.node_sync_store.clone(),
             node_sync_handle: self.node_sync_handle.clone(),
             node_sync_process: self.node_sync_process.clone(),
             net: ArcSwap::from(self.net.load().clone()),
@@ -280,20 +273,23 @@ impl<A> ActiveAuthority<A>
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    pub fn node_sync_handle(&self) -> NodeSyncHandle {
-        let node_sync_state = self.node_sync_state.clone();
+    pub fn node_sync_handle(self: Arc<Self>) -> NodeSyncHandle {
         self.node_sync_handle
-            .get_or_init(|| NodeSyncHandle::new(node_sync_state, self.gossip_metrics.clone()))
+            .get_or_init(|| {
+                let node_sync_state = Arc::new(NodeSyncState::new(self.clone()));
+
+                NodeSyncHandle::new(node_sync_state, self.gossip_metrics.clone())
+            })
             .clone()
     }
 
-    pub async fn sync_to_latest_checkpoint(&self) -> SuiResult {
+    pub async fn sync_to_latest_checkpoint(self: Arc<Self>) -> SuiResult {
         self.sync_to_latest_checkpoint_with_config(Default::default())
             .await
     }
 
     pub async fn sync_to_latest_checkpoint_with_config(
-        &self,
+        self: Arc<Self>,
         checkpoint_process_control: CheckpointProcessControl,
     ) -> SuiResult {
         let checkpoint_store =
@@ -338,8 +334,9 @@ where
     }
 
     /// Restart the node sync process only if one currently exists.
-    pub async fn respawn_node_sync_process(&self) {
-        let lock_guard = self.node_sync_process.lock().await;
+    pub async fn respawn_node_sync_process(self: Arc<Self>) {
+        let self_lock = self.clone();
+        let lock_guard = self_lock.node_sync_process.lock().await;
         if lock_guard.is_some() {
             self.respawn_node_sync_process_impl(lock_guard).await
         } else {
@@ -348,13 +345,14 @@ where
     }
 
     /// Start the node sync process.
-    pub async fn spawn_node_sync_process(&self) {
-        let lock_guard = self.node_sync_process.lock().await;
+    pub async fn spawn_node_sync_process(self: Arc<Self>) {
+        let self_lock = self.clone();
+        let lock_guard = self_lock.node_sync_process.lock().await;
         self.respawn_node_sync_process_impl(lock_guard).await
     }
 
     async fn respawn_node_sync_process_impl(
-        &self,
+        self: Arc<Self>,
         mut lock_guard: MutexGuard<'_, Option<NodeSyncProcessHandle>>,
     ) {
         let epoch = self.state.committee.load().epoch;
@@ -383,13 +381,13 @@ where
         let (cancel_sender, cancel_receiver) = oneshot::channel();
         let aggregator = self.net();
 
-        let node_sync_handle = self.node_sync_handle();
-        let node_sync_state = self.node_sync_state.clone();
+        let node_sync_handle = self.clone().node_sync_handle();
+        let node_sync_store = self.node_sync_store.clone();
 
         info!("spawning node sync task");
         let join_handle = tokio::task::spawn(node_sync_process(
             node_sync_handle,
-            node_sync_state,
+            node_sync_store,
             epoch,
             aggregator,
             cancel_receiver,
@@ -401,7 +399,7 @@ where
     /// Spawn pending certificate execution process
     pub async fn spawn_execute_process(self: Arc<Self>) -> JoinHandle<()> {
         tokio::task::spawn(async move {
-            execution_process(&self).await;
+            execution_process(self).await;
         })
     }
 }
@@ -431,7 +429,7 @@ where
     ) -> JoinHandle<()> {
         // Spawn task to take care of checkpointing
         tokio::task::spawn(async move {
-            checkpoint_process(&self, &checkpoint_process_control, metrics, enable_reconfig).await;
+            checkpoint_process(self, &checkpoint_process_control, metrics, enable_reconfig).await;
         })
     }
 }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -153,7 +153,7 @@ pub enum CheckpointStepError {
 }
 
 pub async fn checkpoint_process<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     timing: &CheckpointProcessControl,
     metrics: CheckpointMetrics,
     enable_reconfig: bool,
@@ -172,7 +172,7 @@ pub async fn checkpoint_process<A>(
     let mut last_cert_time = Instant::now();
 
     loop {
-        let result = checkpoint_process_step(active_authority, timing).await;
+        let result = checkpoint_process_step(active_authority.clone(), timing).await;
         let state_checkpoints = active_authority.state.checkpoints.as_ref().unwrap();
         let next_cp_seq = state_checkpoints.lock().next_checkpoint();
         match result {
@@ -273,7 +273,7 @@ pub async fn checkpoint_process<A>(
 }
 
 pub async fn checkpoint_process_step<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     timing: &CheckpointProcessControl,
 ) -> Result<CheckpointStepResult, CheckpointStepError>
 where
@@ -319,7 +319,7 @@ where
             );
             // TODO: The sync process only works within an epoch.
             sync_to_checkpoint(
-                active_authority,
+                active_authority.clone(),
                 state_checkpoints.clone(),
                 checkpoint.clone(),
             )
@@ -327,7 +327,7 @@ where
             .map_err(|err| CheckpointStepError::SyncCheckpointFromQuorumFailed(Box::new(err)))?;
         }
 
-        if update_latest_checkpoint(active_authority, state_checkpoints, &checkpoint)
+        if update_latest_checkpoint(active_authority.clone(), state_checkpoints, &checkpoint)
             .await
             .map_err(|err| CheckpointStepError::UpdateLatestCheckpointFailed(Box::new(err)))?
         {
@@ -354,7 +354,7 @@ where
 
     // (4) Now we try to create fragments and get list of transactions for the checkpoint.
     let transactions = match create_fragments(
-        active_authority,
+        active_authority.clone(),
         state_checkpoints.clone(),
         &my_proposal,
         committee,
@@ -381,7 +381,7 @@ where
 }
 
 pub async fn sync_and_sign_new_checkpoint<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     epoch: EpochId,
     seq: CheckpointSequenceNumber,
     transactions: BTreeSet<ExecutionDigests>,
@@ -390,6 +390,7 @@ where
     A: AuthorityAPI + Send + Sync + 'static + Clone + Reconfigurable,
 {
     let errors = active_authority
+        .clone()
         .node_sync_handle()
         .sync_pending_checkpoint_transactions(epoch, transactions.iter())
         .await?
@@ -576,7 +577,7 @@ where
 /// Such content can either be obtained locally if there was already a signed checkpoint, or
 /// downloaded from other validators if not available.
 async fn update_latest_checkpoint<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     state_checkpoints: &Arc<Mutex<CheckpointStore>>,
     checkpoint: &CertifiedCheckpointSummary,
 ) -> SuiResult<bool>
@@ -659,7 +660,7 @@ where
 
 /// Download all checkpoints that are not known to us
 pub async fn sync_to_checkpoint<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     checkpoint_db: Arc<Mutex<CheckpointStore>>,
     latest_known_checkpoint: CertifiedCheckpointSummary,
 ) -> SuiResult
@@ -701,7 +702,7 @@ where
             get_one_checkpoint_with_contents(net.clone(), seq, &available_authorities).await?;
 
         process_new_checkpoint_certificate(
-            active_authority,
+            active_authority.clone(),
             &checkpoint_db,
             &net.committee,
             &past,
@@ -714,7 +715,7 @@ where
 }
 
 async fn process_new_checkpoint_certificate<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     checkpoint_db: &Arc<Mutex<CheckpointStore>>,
     committee: &Committee,
     checkpoint_cert: &CertifiedCheckpointSummary,
@@ -791,7 +792,7 @@ where
 /// If it didn't't succeed, pick an authority at random that we haven't seen fragments
 /// with yet, make a new fragment and send to consensus.
 pub async fn create_fragments<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     checkpoint_db: Arc<Mutex<CheckpointStore>>,
     my_proposal: &CheckpointProposal,
     committee: &Committee,
@@ -893,7 +894,9 @@ where
                 let fragment = my_proposal.fragment_with(&other_proposal);
 
                 // We need to augment the fragment with the missing transactions
-                match augment_fragment_with_diff_transactions(active_authority, fragment).await {
+                match augment_fragment_with_diff_transactions(active_authority.clone(), fragment)
+                    .await
+                {
                     Ok(fragment) => {
                         // On success send the fragment to consensus
                         if let Err(err) = checkpoint_db.lock().submit_local_fragment_to_consensus(
@@ -924,7 +927,7 @@ where
 /// come from the local database, but others will come from downloading them from the other
 /// authority.
 pub async fn augment_fragment_with_diff_transactions<A>(
-    active_authority: &ActiveAuthority<A>,
+    active_authority: Arc<ActiveAuthority<A>>,
     mut fragment: CheckpointFragment,
 ) -> Result<CheckpointFragment, SuiError>
 where

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -391,7 +391,7 @@ where
 {
     let errors = active_authority
         .node_sync_handle()
-        .sync_pending_checkpoint_transactions(transactions.iter())
+        .sync_pending_checkpoint_transactions(epoch, transactions.iter())
         .await?
         .zip(futures::stream::iter(transactions.iter()))
         .filter_map(|(r, digests)| async move {
@@ -723,9 +723,10 @@ async fn process_new_checkpoint_certificate<A>(
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
+    let epoch = checkpoint_cert.summary.epoch;
     let errors = active_authority
         .node_sync_handle()
-        .sync_checkpoint_cert_transactions(contents)
+        .sync_checkpoint_cert_transactions(epoch, contents)
         .await?
         .zip(futures::stream::iter(contents.iter()))
         .filter_map(|(r, digests)| async move {

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -119,10 +119,14 @@ where
         .remove_pending_certificates(indexes_to_delete)?;
 
     // Send them for execution
+    let epoch = active_authority.state.committee.load().epoch;
     let sync_handle = active_authority.node_sync_handle();
     let executed: Vec<_> = sync_handle
         // map to extract digest
-        .handle_execution_request(pending_transactions.iter().map(|(_, digest)| *digest))
+        .handle_execution_request(
+            epoch,
+            pending_transactions.iter().map(|(_, digest)| *digest),
+        )
         .await?
         // zip results back together with seq
         .zip(stream::iter(pending_transactions.iter()))

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio::time::{sleep, timeout, Duration, Instant};
 
-use super::{NodeSyncHandle, NodeSyncState, SyncResult};
+use super::{NodeSyncHandle, SyncResult};
 
 use tap::TapFallible;
 use tracing::{debug, info, trace, warn};
@@ -33,7 +33,7 @@ const DRAIN_RESULTS_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub async fn node_sync_process<A>(
     node_sync_handle: NodeSyncHandle,
-    node_sync_state: Arc<NodeSyncState<A>>,
+    node_sync_store: Arc<NodeSyncStore>,
     epoch_id: EpochId,
     aggregator: Arc<AuthorityAggregator<A>>,
     cancel_receiver: oneshot::Receiver<()>,
@@ -42,7 +42,7 @@ pub async fn node_sync_process<A>(
 {
     follower_process(
         node_sync_handle.clone(),
-        node_sync_state.node_sync_store.clone(),
+        node_sync_store,
         epoch_id,
         aggregator,
         NUM_ITEMS_PER_REQUEST,

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use sui_storage::node_sync_store::NodeSyncStore;
 use sui_types::{
-    base_types::{AuthorityName, ExecutionDigests},
+    base_types::{AuthorityName, EpochId, ExecutionDigests},
     batch::{TxSequenceNumber, UpdateItem},
     error::{SuiError, SuiResult},
     messages::{BatchInfoRequest, BatchInfoResponseItem},
@@ -34,6 +34,7 @@ const DRAIN_RESULTS_TIMEOUT: Duration = Duration::from_secs(1);
 pub async fn node_sync_process<A>(
     node_sync_handle: NodeSyncHandle,
     node_sync_state: Arc<NodeSyncState<A>>,
+    epoch_id: EpochId,
     aggregator: Arc<AuthorityAggregator<A>>,
     cancel_receiver: oneshot::Receiver<()>,
 ) where
@@ -42,6 +43,7 @@ pub async fn node_sync_process<A>(
     follower_process(
         node_sync_handle.clone(),
         node_sync_state.node_sync_store.clone(),
+        epoch_id,
         aggregator,
         NUM_ITEMS_PER_REQUEST,
         &node_sync_handle.metrics,
@@ -53,6 +55,7 @@ pub async fn node_sync_process<A>(
 async fn follower_process<A, Handler>(
     node_sync_handle: Handler,
     node_sync_store: Arc<NodeSyncStore>,
+    epoch_id: EpochId,
     aggregator: Arc<AuthorityAggregator<A>>,
     max_stream_items: u64,
     metrics: &GossipMetrics,
@@ -73,10 +76,17 @@ async fn follower_process<A, Handler>(
             let start_time = Instant::now();
             let client = aggregator.clone_client(name);
             async move {
-                let result =
-                    follow_one_peer(handle, store, *name, client, max_stream_items, metrics)
-                        .await
-                        .tap_err(|e| warn!("follower task exited with error {}", e));
+                let result = follow_one_peer(
+                    handle,
+                    store,
+                    epoch_id,
+                    *name,
+                    client,
+                    max_stream_items,
+                    metrics,
+                )
+                .await
+                .tap_err(|e| warn!("follower task exited with error {}", e));
                 (result, start_time, name)
             }
         };
@@ -142,6 +152,7 @@ async fn follower_process<A, Handler>(
 trait SyncHandler {
     async fn handle_digest(
         &self,
+        epoch_id: EpochId,
         peer: AuthorityName,
         seq: TxSequenceNumber,
         digests: ExecutionDigests,
@@ -152,11 +163,12 @@ trait SyncHandler {
 impl SyncHandler for NodeSyncHandle {
     async fn handle_digest(
         &self,
+        epoch_id: EpochId,
         peer: AuthorityName,
         _seq: TxSequenceNumber,
         digests: ExecutionDigests,
     ) -> SuiResult<BoxFuture<'static, SyncResult>> {
-        self.handle_sync_digest(peer, digests).await
+        self.handle_sync_digest(epoch_id, peer, digests).await
     }
 }
 
@@ -169,6 +181,7 @@ struct FollowResult {
 async fn follow_one_peer<A, Handler>(
     sync_handle: Handler,
     node_sync_store: Arc<NodeSyncStore>,
+    epoch_id: EpochId,
     peer: AuthorityName,
     client: SafeClient<A>,
     max_stream_items: u64,
@@ -195,21 +208,23 @@ where
         ($seq: expr, $digests: expr) => {{
             let seq = $seq;
             let digests = $digests;
-            let fut = sync_handle.handle_digest(peer, seq, digests).await?;
+            let fut = sync_handle
+                .handle_digest(epoch_id, peer, seq, digests)
+                .await?;
             results.push(result_block(fut, seq, digests));
         }};
     }
 
     let remove_from_seq_store = |seq| {
         trace!(?peer, ?seq, "removing completed batch stream item");
-        node_sync_store.remove_batch_stream_item(peer, seq)
+        node_sync_store.remove_batch_stream_item(epoch_id, peer, seq)
     };
 
     let mut follow_result = FollowResult::default();
 
     // Process everything currently in the db.
     let mut first = true;
-    for (seq, digests) in node_sync_store.batch_stream_iter(&peer)? {
+    for (seq, digests) in node_sync_store.batch_stream_iter(epoch_id, &peer)? {
         if first {
             first = false;
             debug!(
@@ -224,7 +239,7 @@ where
 
     // Find the sequence to start streaming at.
     let start_seq = node_sync_store
-        .latest_seq_for_peer(&peer)?
+        .latest_seq_for_peer(epoch_id, &peer)?
         .map(|seq| seq + 1)
         .unwrap_or(0);
 
@@ -264,7 +279,7 @@ where
                     Some(Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digests))))) => {
                         trace!(?peer, ?digests, ?seq, "received tx from peer");
                         metrics.total_tx_received.inc();
-                        node_sync_store.enqueue_execution_digests(peer, seq, &digests)?;
+                        node_sync_store.enqueue_execution_digests(epoch_id, peer, seq, &digests)?;
                         process_digest!(seq, digests);
 
                         follow_result.items_from_stream += 1;
@@ -367,11 +382,12 @@ mod test {
     impl SyncHandler for TestNodeSyncHandler {
         async fn handle_digest(
             &self,
+            epoch_id: EpochId,
             peer: AuthorityName,
             seq: TxSequenceNumber,
             digests: ExecutionDigests,
         ) -> SuiResult<BoxFuture<'static, SyncResult>> {
-            debug!(?peer, ?digests, "handle_digest");
+            debug!(?peer, ?digests, ?epoch_id, "handle_digest");
             if let Some(after) = *self.break_after.lock().unwrap() {
                 if seq > after {
                     // reset so that the handler can make progress after follower is restarted.
@@ -451,6 +467,7 @@ mod test {
             follow_one_peer(
                 test_handler.clone().break_after(1),
                 sync_store.clone(),
+                0,
                 peer,
                 net.clone_client(&peer),
                 3,
@@ -464,6 +481,7 @@ mod test {
             let result = follow_one_peer(
                 test_handler.clone(),
                 sync_store.clone(),
+                0,
                 peer,
                 net.clone_client(&peer),
                 3,
@@ -499,6 +517,7 @@ mod test {
                     follower_process(
                         test_handler_clone.break_after(2),
                         sync_store,
+                        0,
                         net_clone,
                         5,
                         &metrics,

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -11,7 +11,9 @@ use tokio_stream::{Stream, StreamExt};
 use std::collections::{hash_map, BTreeSet, HashMap};
 use sui_storage::node_sync_store::NodeSyncStore;
 use sui_types::{
-    base_types::{AuthorityName, ExecutionDigests, TransactionDigest, TransactionEffectsDigest},
+    base_types::{
+        AuthorityName, EpochId, ExecutionDigests, TransactionDigest, TransactionEffectsDigest,
+    },
     committee::Committee,
     error::{SuiError, SuiResult},
     messages::{
@@ -91,44 +93,67 @@ where
 
 struct DigestsMessage {
     sync_arg: SyncArg,
+    epoch_id: EpochId,
     tx: Option<oneshot::Sender<SyncResult>>,
 }
 
 impl DigestsMessage {
-    fn new_for_ckpt(digests: &ExecutionDigests, tx: oneshot::Sender<SyncResult>) -> Self {
+    fn new_for_ckpt(
+        epoch_id: EpochId,
+        digests: &ExecutionDigests,
+        tx: oneshot::Sender<SyncResult>,
+    ) -> Self {
         Self {
+            epoch_id,
             sync_arg: SyncArg::Checkpoint(*digests),
             tx: Some(tx),
         }
     }
 
-    fn new_for_pending_ckpt(digest: &TransactionDigest, tx: oneshot::Sender<SyncResult>) -> Self {
+    fn new_for_pending_ckpt(
+        epoch_id: EpochId,
+        digest: &TransactionDigest,
+        tx: oneshot::Sender<SyncResult>,
+    ) -> Self {
         Self {
+            epoch_id,
             sync_arg: SyncArg::PendingCheckpoint(*digest),
             tx: Some(tx),
         }
     }
 
-    fn new_for_exec_driver(digest: &TransactionDigest, tx: oneshot::Sender<SyncResult>) -> Self {
+    fn new_for_exec_driver(
+        epoch_id: EpochId,
+        digest: &TransactionDigest,
+        tx: oneshot::Sender<SyncResult>,
+    ) -> Self {
         Self {
+            epoch_id,
             sync_arg: SyncArg::ExecDriver(*digest),
             tx: Some(tx),
         }
     }
 
-    fn new_for_parents(digest: &TransactionDigest, tx: oneshot::Sender<SyncResult>) -> Self {
+    fn new_for_parents(
+        epoch_id: EpochId,
+        digest: &TransactionDigest,
+        tx: oneshot::Sender<SyncResult>,
+    ) -> Self {
         Self {
+            epoch_id,
             sync_arg: SyncArg::Parent(*digest),
             tx: Some(tx),
         }
     }
 
     fn new(
+        epoch_id: EpochId,
         digests: &ExecutionDigests,
         peer: AuthorityName,
         tx: oneshot::Sender<SyncResult>,
     ) -> Self {
         Self {
+            epoch_id,
             sync_arg: SyncArg::Follow(peer, *digests),
             tx: Some(tx),
         }
@@ -319,7 +344,12 @@ where
         // https://github.com/tokio-rs/tokio/discussions/2648
         let limit = Arc::new(Semaphore::new(MAX_NODE_SYNC_CONCURRENCY));
 
-        while let Some(DigestsMessage { sync_arg, tx }) = receiver.recv().await {
+        while let Some(DigestsMessage {
+            epoch_id,
+            sync_arg,
+            tx,
+        }) = receiver.recv().await
+        {
             let state = self.clone();
             let limit = limit.clone();
 
@@ -330,7 +360,7 @@ where
             tokio::spawn(async move {
                 let res = timeout(
                     MAX_NODE_TASK_LIFETIME,
-                    state.process_digest(sync_arg, permit),
+                    state.process_digest(epoch_id, sync_arg, permit),
                 )
                 .await
                 .map_err(|_| SuiError::TimeoutError);
@@ -346,14 +376,14 @@ where
                     Ok(Ok(res)) => {
                         // Garbage collect data for this tx.
                         if let SyncStatus::CertExecuted = res {
-                            state.cleanup_cert(digest);
+                            state.cleanup_cert(epoch_id, digest);
                         }
                         Ok(res)
                     }
                 };
 
                 // Notify waiters even if tx failed, to avoid leaking resources.
-                trace!(?digest, "notifying parents and waiters");
+                trace!(?epoch_id, ?digest, "notifying parents and waiters");
                 Self::notify(&state.pending_parents, digest, res.clone()).await;
                 Self::notify(&state.pending_txes, digest, res.clone()).await;
 
@@ -366,6 +396,7 @@ where
                         // will be retried.
                         debug!(
                             ?sync_arg,
+                            ?epoch_id,
                             "could not send process_digest response to caller",
                         );
                     }
@@ -376,29 +407,48 @@ where
 
     async fn get_true_effects(
         &self,
+        epoch_id: EpochId,
         cert: &CertifiedTransaction,
     ) -> SuiResult<SignedTransactionEffects> {
         let digest = cert.digest();
-        match self.node_sync_store.get_effects(digest)? {
+
+        if epoch_id != cert.epoch() {
+            warn!(?digest, "certificate is from wrong epoch");
+            return Err(SuiError::WrongEpoch {
+                expected_epoch: epoch_id,
+            });
+        }
+
+        match self.node_sync_store.get_effects(epoch_id, digest)? {
             Some(effects) => Ok(effects),
             None => {
                 let effects = self.aggregator.execute_cert_to_true_effects(cert).await?;
-                self.node_sync_store.store_effects(digest, &effects)?;
+                self.node_sync_store
+                    .store_effects(epoch_id, digest, &effects)?;
                 Ok(effects)
             }
         }
     }
 
-    async fn get_cert(&self, digest: &TransactionDigest) -> SuiResult<CertifiedTransaction> {
-        match self.state.database.read_certificate(digest)? {
-            Some(cert) => Ok(cert),
-            None => {
-                let (cert, _) = self
-                    .download_cert_and_effects(None, &DownloadRequest::Validator(*digest))
-                    .await?;
-                Ok(cert)
+    async fn get_cert(
+        &self,
+        epoch_id: EpochId,
+        digest: &TransactionDigest,
+    ) -> SuiResult<CertifiedTransaction> {
+        if let Some(cert) = self.state.database.read_certificate(digest)? {
+            if cert.epoch() == epoch_id {
+                return Ok(cert);
             }
+            warn!(
+                ?digest, ?epoch_id, cert_epoch = ?cert.epoch(),
+                "Found certificate from prior epoch in authority db"
+            );
         }
+
+        let (cert, _) = self
+            .download_cert_and_effects(epoch_id, None, &DownloadRequest::Validator(*digest))
+            .await?;
+        Ok(cert)
     }
 
     fn get_missing_parents(
@@ -417,18 +467,23 @@ where
     async fn process_parent_request(
         &self,
         permit: OwnedSemaphorePermit,
+        epoch_id: EpochId,
         digest: &TransactionDigest,
     ) -> SyncResult {
         trace!(?digest, "parent certificate execution requested");
 
-        let cert = self.get_cert(digest).await?;
-        let effects = self.get_true_effects(&cert).await?;
+        // Note that parents can be from previous epochs. However, when we attempt are trying to
+        // sync parents of certs in epoch N, if the parent is from epoch P < N, the parent must
+        // already be final, so we shouldn't get this far. Since the parent therefore must be from
+        // the same epoch, we can assume the same epoch_id will hold.
+        let cert = self.get_cert(epoch_id, digest).await?;
+        let effects = self.get_true_effects(epoch_id, &cert).await?;
 
         // Must release permit before enqueuing new work to prevent deadlock.
         std::mem::drop(permit);
 
         let missing_parents = self.get_missing_parents(&effects.effects)?;
-        self.enqueue_parent_execution_requests(digest, &missing_parents, false)
+        self.enqueue_parent_execution_requests(epoch_id, digest, &missing_parents, false)
             .await?;
 
         match self
@@ -443,12 +498,13 @@ where
 
     async fn process_exec_driver_digest(
         &self,
+        epoch_id: EpochId,
         permit: OwnedSemaphorePermit,
         digest: &TransactionDigest,
         bypass_validator_halt: bool,
     ) -> SyncResult {
         trace!(?digest, "validator pending execution requested");
-        let cert = self.get_cert(digest).await?;
+        let cert = self.get_cert(epoch_id, digest).await?;
 
         let result = if bypass_validator_halt {
             self.state
@@ -464,13 +520,13 @@ where
             | Err(SuiError::SharedObjectLockNotSetError) => {
                 debug!(?digest, "cert execution failed due to missing parents");
 
-                let effects = self.get_true_effects(&cert).await?;
+                let effects = self.get_true_effects(epoch_id, &cert).await?;
 
                 // Must release permit before enqueuing new work to prevent deadlock.
                 std::mem::drop(permit);
 
                 let missing_parents = self.get_missing_parents(&effects.effects)?;
-                self.enqueue_parent_execution_requests(digest, &missing_parents, true)
+                self.enqueue_parent_execution_requests(epoch_id, digest, &missing_parents, true)
                     .await?;
 
                 // Parents have been executed, so this should now succeed.
@@ -488,15 +544,20 @@ where
         }
     }
 
-    pub fn cleanup_cert(&self, digest: &TransactionDigest) {
+    pub fn cleanup_cert(&self, epoch_id: EpochId, digest: &TransactionDigest) {
         debug!(?digest, "cleaning up temporary sync data");
         let _ = self
             .node_sync_store
-            .cleanup_cert(digest)
+            .cleanup_cert(epoch_id, digest)
             .tap_err(|e| warn!("cleanup_cert failed: {}", e));
     }
 
-    async fn process_digest(&self, arg: SyncArg, permit: OwnedSemaphorePermit) -> SyncResult {
+    async fn process_digest(
+        &self,
+        epoch_id: EpochId,
+        arg: SyncArg,
+        permit: OwnedSemaphorePermit,
+    ) -> SyncResult {
         trace!(?arg, "process_digest");
 
         let digest = arg.transaction_digest();
@@ -521,16 +582,18 @@ where
         let (digests, authorities_with_cert) = match arg {
             SyncArg::ExecDriver(digest) => {
                 return self
-                    .process_exec_driver_digest(permit, &digest, false)
+                    .process_exec_driver_digest(epoch_id, permit, &digest, false)
                     .await;
             }
             SyncArg::PendingCheckpoint(digest) => {
-                return self.process_exec_driver_digest(permit, &digest, true).await;
+                return self
+                    .process_exec_driver_digest(epoch_id, permit, &digest, true)
+                    .await;
             }
             SyncArg::Parent(digest) => {
                 // digest is known to be final because it appeared in the dependencies list of a
                 // verified TransactionEffects
-                return self.process_parent_request(permit, &digest).await;
+                return self.process_parent_request(permit, epoch_id, &digest).await;
             }
             SyncArg::Follow(peer, digests) => {
                 // Check if the tx is final.
@@ -538,14 +601,17 @@ where
                 let quorum_threshold = self.committee.quorum_threshold();
 
                 self.node_sync_store.record_effects_vote(
+                    epoch_id,
                     peer,
                     digests.transaction,
                     digests.effects,
                     stake,
                 )?;
-                let votes = self
-                    .node_sync_store
-                    .count_effects_votes(digests.transaction, digests.effects)?;
+                let votes = self.node_sync_store.count_effects_votes(
+                    epoch_id,
+                    digests.transaction,
+                    digests.effects,
+                )?;
 
                 let is_final = votes >= quorum_threshold;
 
@@ -557,10 +623,11 @@ where
 
                 (
                     digests,
-                    Some(
-                        self.node_sync_store
-                            .get_voters(digests.transaction, digests.effects)?,
-                    ),
+                    Some(self.node_sync_store.get_voters(
+                        epoch_id,
+                        digests.transaction,
+                        digests.effects,
+                    )?),
                 )
             }
             SyncArg::Checkpoint(digests) => {
@@ -586,7 +653,11 @@ where
         // Download the cert and effects - either finality has been establish (above), or
         // we are a validator.
         let (cert, effects) = self
-            .download_cert_and_effects(authorities_with_cert, &DownloadRequest::Node(digests))
+            .download_cert_and_effects(
+                epoch_id,
+                authorities_with_cert,
+                &DownloadRequest::Node(digests),
+            )
             .await?;
 
         let effects = effects
@@ -597,7 +668,7 @@ where
             })
             .tap_err(|e| error!(?digest, "error: {}", e))?;
 
-        self.process_parents(permit, &digests.transaction, &effects)
+        self.process_parents(permit, epoch_id, &digests.transaction, &effects)
             .await?;
 
         self.state
@@ -610,6 +681,7 @@ where
     async fn process_parents(
         &self,
         permit: OwnedSemaphorePermit,
+        epoch_id: EpochId,
         digest: &TransactionDigest,
         effects: &SignedTransactionEffects,
     ) -> SuiResult {
@@ -641,6 +713,7 @@ where
 
         if let Err(err) = self
             .enqueue_parent_execution_requests(
+                epoch_id,
                 digest,
                 &missing_parents,
                 false, /* not validator */
@@ -658,6 +731,7 @@ where
 
     async fn enqueue_parent_execution_requests(
         &self,
+        epoch_id: EpochId,
         digest: &TransactionDigest,
         parents: &[TransactionDigest],
         is_validator: bool,
@@ -667,14 +741,14 @@ where
         let handle = NodeSyncHandle::new_from_sender(self.sender.clone(), self.metrics.clone());
         let errors: Vec<_> = if is_validator {
             handle
-                .handle_execution_request(parents.iter().cloned())
+                .handle_execution_request(epoch_id, parents.iter().cloned())
                 .await?
                 .filter_map(|r| r.err())
                 .collect()
                 .await
         } else {
             handle
-                .handle_parents_request(parents.iter().cloned())
+                .handle_parents_request(epoch_id, parents.iter().cloned())
                 .await?
                 .filter_map(|r| r.err())
                 .collect()
@@ -733,12 +807,17 @@ where
     // Transactions are not currently persisted anywhere, however (validators delete them eagerly).
     async fn download_cert_and_effects(
         &self,
+        epoch_id: EpochId,
         authorities_with_cert: Option<BTreeSet<AuthorityName>>,
         req: &DownloadRequest,
     ) -> SuiResult<(CertifiedTransaction, Option<SignedTransactionEffects>)> {
         let tx_digest = *req.transaction_digest();
 
-        match (req, self.node_sync_store.get_cert_and_effects(&tx_digest)?) {
+        match (
+            req,
+            self.node_sync_store
+                .get_cert_and_effects(epoch_id, &tx_digest)?,
+        ) {
             (DownloadRequest::Node(_), (Some(cert), Some(effects))) => {
                 return Ok((cert, Some(effects)))
             }
@@ -759,6 +838,7 @@ where
                     .notify(
                         &tx_digest,
                         Self::download_impl(
+                            epoch_id,
                             authorities_with_cert,
                             aggregator,
                             &req,
@@ -777,21 +857,23 @@ where
                 error: format!("{:?}", e),
             })??;
 
-        let cert = self.node_sync_store.get_cert(&tx_digest)?.ok_or_else(|| {
-            SuiError::GenericAuthorityError {
+        let cert = self
+            .node_sync_store
+            .get_cert(epoch_id, &tx_digest)?
+            .ok_or_else(|| SuiError::GenericAuthorityError {
                 error: format!(
                     "cert/effects for {:?} should have been in the node_sync_store",
                     tx_digest
                 ),
-            }
-        })?;
+            })?;
 
-        let effects = self.node_sync_store.get_effects(&tx_digest)?;
+        let effects = self.node_sync_store.get_effects(epoch_id, &tx_digest)?;
 
         Ok((cert, effects))
     }
 
     async fn download_impl(
+        epoch_id: EpochId,
         authorities: Option<BTreeSet<AuthorityName>>,
         aggregator: Arc<AuthorityAggregator<A>>,
         req: &DownloadRequest,
@@ -809,8 +891,8 @@ where
                     )
                     .await?;
                 metrics.total_successful_attempts_cert_downloads.inc();
-                node_sync_store.store_cert(&resp.0)?;
-                node_sync_store.store_effects(req.transaction_digest(), &resp.1)?;
+                node_sync_store.store_cert(epoch_id, &resp.0)?;
+                node_sync_store.store_effects(epoch_id, req.transaction_digest(), &resp.1)?;
             }
             DownloadRequest::Validator(digest) => {
                 let resp = aggregator.handle_cert_info_request(digest, None).await?;
@@ -820,7 +902,7 @@ where
                         ..
                     } => {
                         // can only store cert here, effects are not verified yet.
-                        node_sync_store.store_cert(&cert)?;
+                        node_sync_store.store_cert(epoch_id, &cert)?;
                     }
                     _ => return Err(SuiError::TransactionNotFound { digest: *digest }),
                 }
@@ -880,12 +962,13 @@ impl NodeSyncHandle {
     /// we can fully trust the effect digests in the checkpoint content.
     pub async fn sync_checkpoint_cert_transactions(
         &self,
+        epoch_id: EpochId,
         checkpoint_contents: &CheckpointContents,
     ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digests in checkpoint_contents.iter() {
             let (tx, rx) = oneshot::channel();
-            let msg = DigestsMessage::new_for_ckpt(digests, tx);
+            let msg = DigestsMessage::new_for_ckpt(epoch_id, digests, tx);
             Self::send_msg_with_tx(self.sender.clone(), msg).await?;
             futures.push_back(Self::map_rx(rx));
         }
@@ -899,12 +982,13 @@ impl NodeSyncHandle {
     /// TODO: This shall eventually be able to bypass the validator halt.
     pub async fn sync_pending_checkpoint_transactions(
         &self,
+        epoch_id: EpochId,
         transactions: impl Iterator<Item = &ExecutionDigests>,
     ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digests in transactions {
             let (tx, rx) = oneshot::channel();
-            let msg = DigestsMessage::new_for_pending_ckpt(&digests.transaction, tx);
+            let msg = DigestsMessage::new_for_pending_ckpt(epoch_id, &digests.transaction, tx);
             Self::send_msg_with_tx(self.sender.clone(), msg).await?;
             futures.push_back(Self::map_rx(rx));
         }
@@ -914,12 +998,13 @@ impl NodeSyncHandle {
 
     pub async fn handle_execution_request(
         &self,
+        epoch_id: EpochId,
         digests: impl Iterator<Item = TransactionDigest>,
     ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digest in digests {
             let (tx, rx) = oneshot::channel();
-            let msg = DigestsMessage::new_for_exec_driver(&digest, tx);
+            let msg = DigestsMessage::new_for_exec_driver(epoch_id, &digest, tx);
             Self::send_msg_with_tx(self.sender.clone(), msg).await?;
             futures.push_back(Self::map_rx(rx));
         }
@@ -929,12 +1014,13 @@ impl NodeSyncHandle {
 
     pub async fn handle_parents_request(
         &self,
+        epoch_id: EpochId,
         digests: impl Iterator<Item = TransactionDigest>,
     ) -> SuiResult<impl Stream<Item = SyncResult>> {
         let mut futures = FuturesOrdered::new();
         for digest in digests {
             let (tx, rx) = oneshot::channel();
-            let msg = DigestsMessage::new_for_parents(&digest, tx);
+            let msg = DigestsMessage::new_for_parents(epoch_id, &digest, tx);
             Self::send_msg_with_tx(self.sender.clone(), msg).await?;
             futures.push_back(Self::map_rx(rx));
         }
@@ -944,12 +1030,13 @@ impl NodeSyncHandle {
 
     pub async fn handle_sync_digest(
         &self,
+        epoch_id: EpochId,
         peer: AuthorityName,
         digests: ExecutionDigests,
     ) -> SuiResult<BoxFuture<'static, SyncResult>> {
         let (tx, rx) = oneshot::channel();
         let sender = self.sender.clone();
-        Self::send_msg_with_tx(sender, DigestsMessage::new(&digests, peer, tx)).await?;
+        Self::send_msg_with_tx(sender, DigestsMessage::new(epoch_id, &digests, peer, tx)).await?;
         Ok(Self::map_rx(rx))
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -196,7 +196,7 @@ impl SuiNode {
         let gossip_handle = if is_full_node {
             info!("Starting full node sync to latest checkpoint (this may take a while)");
             let now = Instant::now();
-            if let Err(err) = active_authority.sync_to_latest_checkpoint().await {
+            if let Err(err) = active_authority.clone().sync_to_latest_checkpoint().await {
                 error!(
                     "Full node failed to catch up to latest checkpoint: {:?}",
                     err

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -25,7 +25,7 @@ use serde_with::Bytes;
 use sha2::Sha512;
 use sha3::Sha3_256;
 
-use crate::committee::EpochId;
+pub use crate::committee::EpochId;
 use crate::crypto::{
     AuthorityPublicKey, AuthorityPublicKeyBytes, KeypairTraits, PublicKey, SuiPublicKey,
 };

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1927,6 +1927,10 @@ impl CertifiedTransaction {
 
         obligation.verify_all().map(|_| ())
     }
+
+    pub fn epoch(&self) -> EpochId {
+        self.auth_sign_info.epoch
+    }
 }
 
 impl Display for CertifiedTransaction {

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -65,8 +65,9 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
 
     // verify that the intermediate sync data is cleared.
     let sync_store = node.active().node_sync_store.clone();
-    assert!(sync_store.get_cert(&digest).unwrap().is_none());
-    assert!(sync_store.get_effects(&digest).unwrap().is_none());
+    let epoch_id = 0;
+    assert!(sync_store.get_cert(epoch_id, &digest).unwrap().is_none());
+    assert!(sync_store.get_effects(epoch_id, &digest).unwrap().is_none());
 
     // verify that the node has seen the transfer
     let object_read = node.state().get_object_read(&transferred_object).await?;

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -64,7 +64,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     wait_for_tx(digest, node.state().clone()).await;
 
     // verify that the intermediate sync data is cleared.
-    let sync_store = node.active().node_sync_state.store();
+    let sync_store = node.active().node_sync_store.clone();
     assert!(sync_store.get_cert(&digest).unwrap().is_none());
     assert!(sync_store.get_effects(&digest).unwrap().is_none());
 

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -188,7 +188,8 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
                 .is_ready_to_finish_epoch_change()
             {
                 let _ =
-                    checkpoint_process_step(&active, &CheckpointProcessControl::default()).await;
+                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
+                        .await;
             }
         });
         checkpoint_processes.push(handle);
@@ -208,8 +209,11 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
         .lock()
         .is_ready_to_finish_epoch_change()
     {
-        let _ =
-            checkpoint_process_step(nodes[3].active(), &CheckpointProcessControl::default()).await;
+        let _ = checkpoint_process_step(
+            nodes[3].active().clone(),
+            &CheckpointProcessControl::default(),
+        )
+        .await;
     }
 }
 
@@ -282,7 +286,8 @@ async fn fast_forward_to_ready_for_reconfig_start(nodes: &[SuiNode]) {
                 .is_ready_to_start_epoch_change()
             {
                 let _ =
-                    checkpoint_process_step(&active, &CheckpointProcessControl::default()).await;
+                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
+                        .await;
             }
         });
         checkpoint_processes.push(handle);
@@ -305,7 +310,8 @@ async fn fast_forward_to_ready_for_reconfig_finish(nodes: &[SuiNode]) {
                 .is_ready_to_finish_epoch_change()
             {
                 let _ =
-                    checkpoint_process_step(&active, &CheckpointProcessControl::default()).await;
+                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
+                        .await;
             }
         });
         checkpoint_processes.push(handle);


### PR DESCRIPTION
This change does two things:
- Every sync request now includes the epoch during which the request was initiated. NodeSyncStore uses this to avoid collisions between pieces of data from different epochs. For instance, a cert may be formed in two consecutive epochs with the same digest. Although the one from the earlier epoch must never have become final, we need to make sure it is impossible for NodeSyncStore to return the stale cert when we are attempting to fetch the newer one.
- The AuthorityAggregator and Committee are now read from an `Arc<ActiveAuthority>`, so that we are always using the latest one.