### PR TITLE
crypto: simplify keystore

### DIFF
--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -19,7 +19,6 @@ use sui_sdk::{
     rpc_types::SuiData,
     types::{
         base_types::{ObjectID, SuiAddress},
-        crypto::Signature,
         id::UID,
         messages::Transaction,
     },
@@ -96,11 +95,10 @@ impl TicTacToe {
             )
             .await?;
 
-        // Get signer from keystore
-        let signer = self.keystore.signer(player_x);
-
-        // Sign the transaction
-        let signature = Signature::new(&create_game_call, &signer);
+        // Sign transaction.
+        let signature = self
+            .keystore
+            .sign(&player_x, &create_game_call.to_bytes())?;
 
         // Execute the transaction.
         let response = self
@@ -187,11 +185,10 @@ impl TicTacToe {
                 )
                 .await?;
 
-            // Get signer from keystore
-            let signer = self.keystore.signer(my_identity);
-
-            // Sign the transaction
-            let signature = Signature::new(&place_mark_call, &signer);
+            // Sign transaction.
+            let signature = self
+                .keystore
+                .sign(&my_identity, &place_mark_call.to_bytes())?;
 
             // Execute the transaction.
             let response = self

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -6,7 +6,6 @@ use sui_sdk::{
     crypto::KeystoreType,
     types::{
         base_types::{ObjectID, SuiAddress},
-        crypto::Signature,
         messages::Transaction,
     },
     SuiClient,
@@ -33,10 +32,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Get signer from keystore
     let keystore = KeystoreType::File(keystore_path).init()?;
-    let signer = keystore.signer(my_address);
-
-    // Sign the transaction
-    let signature = Signature::new(&transfer_tx, &signer);
+    let signature = keystore.sign(&my_address, &transfer_tx.to_bytes())?;
 
     // Execute the transaction
     let transaction_response = sui

--- a/crates/sui-sdk/src/crypto.rs
+++ b/crates/sui-sdk/src/crypto.rs
@@ -176,10 +176,6 @@ impl SuiKeystore {
         self.keys().iter().map(|k| k.into()).collect()
     }
 
-    pub fn signer(&self, signer: SuiAddress) -> impl Signer<Signature> + '_ {
-        KeystoreSigner::new(&*self.0, signer)
-    }
-
     pub fn import_from_mnemonic(
         &mut self,
         phrase: &str,
@@ -200,26 +196,6 @@ impl SuiKeystore {
 
     pub fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error> {
         self.0.sign(address, msg)
-    }
-}
-
-struct KeystoreSigner<'a> {
-    keystore: &'a dyn AccountKeystore,
-    address: SuiAddress,
-}
-
-impl<'a> KeystoreSigner<'a> {
-    pub fn new(keystore: &'a dyn AccountKeystore, account: SuiAddress) -> Self {
-        Self {
-            keystore,
-            address: account,
-        }
-    }
-}
-
-impl Signer<Signature> for KeystoreSigner<'_> {
-    fn try_sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {
-        self.keystore.sign(&self.address, msg)
     }
 }
 

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -88,13 +88,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .transfer_sui(my_address, gas_object_id, 1000, recipient, Some(1000))
         .await?;
 
-    // Get signer from keystore
+    // Sign transaction
     let keystore = KeystoreType::File(keystore_path).init()?;
-    let signer = keystore.signer(my_address);
-
-    // Sign the transaction
-    let signature = Signature::new(&transfer_tx, &signer);
-
+    let signature = keystore.sign(&my_address, &transfer_tx)?;
+    
     // Execute the transaction
     let transaction_response = sui
         .quorum_driver()


### PR DESCRIPTION
1/n improvement to pave for modular crypto service, remove the signer method and use sign method in keystore directly. this helps extract keystore its own service