### PR TITLE
[framework] Fix `0x2::coin::join_vec`

### DIFF
--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -125,8 +125,7 @@ module sui::coin {
         let i = 0;
         let len = vector::length(&coins);
         while (i < len) {
-            // remove first from front
-            let coin = vector::remove(&mut coins, 0);
+            let coin = vector::pop_back(&mut coins);
             join(self, coin);
             i = i + 1
         };

--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -125,7 +125,8 @@ module sui::coin {
         let i = 0;
         let len = vector::length(&coins);
         while (i < len) {
-            let coin = vector::remove(&mut coins, i);
+            // remove first from front
+            let coin = vector::remove(&mut coins, 0);
             join(self, coin);
             i = i + 1
         };


### PR DESCRIPTION
The length of the `vector` is getting smaller, but `i` is getting bigger.
This will cause an `EINDEX_OUT_OF_BOUNDS` error.

Fix: remove first from front every time.

companion: #4837 