### PR TITLE
Make checkpoint store non optional

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -32,10 +32,7 @@
 use arc_swap::ArcSwap;
 use std::{collections::HashMap, ops::Deref, sync::Arc, time::Duration};
 use sui_storage::node_sync_store::NodeSyncStore;
-use sui_types::{
-    base_types::AuthorityName,
-    error::{SuiError, SuiResult},
-};
+use sui_types::{base_types::AuthorityName, error::SuiResult};
 use tokio::{
     sync::{oneshot, Mutex, MutexGuard},
     task::JoinHandle,
@@ -292,13 +289,7 @@ where
         self: Arc<Self>,
         checkpoint_process_control: CheckpointProcessControl,
     ) -> SuiResult {
-        let checkpoint_store =
-            self.state
-                .checkpoints
-                .clone()
-                .ok_or(SuiError::UnsupportedFeatureError {
-                    error: "Checkpoint not supported".to_owned(),
-                })?;
+        let checkpoint_store = self.state.checkpoints.clone();
 
         // TODO: fullnode should not get proposals
         // TODO: potentially move get_latest_proposal_and_checkpoint_from_all and

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -73,13 +73,7 @@ async fn checkpoint_active_flow_happy_path() {
 
     let mut value_set = BTreeSet::new();
     for a in authorities {
-        let next_checkpoint_sequence = a
-            .authority
-            .checkpoints
-            .as_ref()
-            .unwrap()
-            .lock()
-            .next_checkpoint();
+        let next_checkpoint_sequence = a.authority.checkpoints.lock().next_checkpoint();
         // TODO: This check is not very meaningful after we allowed empty checkpoints.
         // What we want to check is probably the number of non-empty checkpoints.
         assert!(
@@ -170,13 +164,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
 
     let mut value_set = BTreeSet::new();
     for a in authorities {
-        let next_checkpoint_sequence = a
-            .authority
-            .checkpoints
-            .as_ref()
-            .unwrap()
-            .lock()
-            .next_checkpoint();
+        let next_checkpoint_sequence = a.authority.checkpoints.lock().next_checkpoint();
         // TODO: This check is not very meaningful after we allowed empty checkpoints.
         // What we want to check is probably the number of non-empty checkpoints.
         assert!(
@@ -267,13 +255,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
 
     let mut value_set = BTreeSet::new();
     for a in authorities {
-        let next_checkpoint_sequence = a
-            .authority
-            .checkpoints
-            .as_ref()
-            .unwrap()
-            .lock()
-            .next_checkpoint();
+        let next_checkpoint_sequence = a.authority.checkpoints.lock().next_checkpoint();
         // TODO: This check is not very meaningful after we allowed empty checkpoints.
         // What we want to check is probably the number of non-empty checkpoints.
         assert!(
@@ -328,13 +310,7 @@ async fn test_empty_checkpoint() {
     tokio::time::sleep(Duration::from_secs(10 * 60)).await;
 
     for a in authorities {
-        let next_checkpoint_sequence = a
-            .authority
-            .checkpoints
-            .as_ref()
-            .unwrap()
-            .lock()
-            .next_checkpoint();
+        let next_checkpoint_sequence = a.authority.checkpoints.lock().next_checkpoint();
         assert!(next_checkpoint_sequence > 0)
     }
 }

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -214,13 +214,12 @@ impl crate::authority::AuthorityState {
 
                 // If a checkpointing service is present, register the batch with it
                 // to insert the transactions into future checkpoint candidates
-                if let Some(checkpoint) = &self.checkpoints {
-                    if let Err(err) = checkpoint.lock().handle_internal_batch(
-                        new_batch.data().next_sequence_number,
-                        &current_batch,
-                    ) {
-                        error!("Checkpointing service error: {}", err);
-                    }
+                if let Err(err) = self
+                    .checkpoints
+                    .lock()
+                    .handle_internal_batch(new_batch.data().next_sequence_number, &current_batch)
+                {
+                    error!("Checkpointing service error: {}", err);
                 }
 
                 // Send the update

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -961,8 +961,6 @@ async fn test_batch_to_checkpointing() {
     assert_eq!(
         authority_state
             .checkpoints
-            .as_ref()
-            .unwrap()
             .lock()
             .next_transaction_sequence_expected(),
         4
@@ -1080,8 +1078,6 @@ async fn test_batch_to_checkpointing_init_crash() {
         assert_eq!(
             authority_state
                 .checkpoints
-                .as_ref()
-                .unwrap()
                 .lock()
                 .next_transaction_sequence_expected(),
             4
@@ -1596,7 +1592,7 @@ pub async fn checkpoint_tests_setup(
                 async move { inner_state.run_batch_service(1000, batch_interval).await },
             );
 
-        let checkpoint = authority.checkpoints.as_ref().unwrap().clone();
+        let checkpoint = authority.checkpoints.clone();
         authorities.push(TestAuthority {
             store: authority.database.clone(),
             authority,

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -45,7 +45,7 @@ where
     /// all transactions from the second to the least checkpoint of the epoch. It's called by a
     /// validator that belongs to the committee of the current epoch.
     pub async fn start_epoch_change(&self) -> SuiResult {
-        let checkpoints = self.state.checkpoints.as_ref().unwrap();
+        let checkpoints = &self.state.checkpoints;
         assert!(
             checkpoints.lock().is_ready_to_start_epoch_change(),
             "start_epoch_change called at the wrong checkpoint",
@@ -65,7 +65,7 @@ where
     pub async fn finish_epoch_change(&self) -> SuiResult {
         let epoch = self.state.committee.load().epoch;
         info!(?epoch, "Finishing epoch change");
-        let checkpoints = self.state.checkpoints.as_ref().unwrap();
+        let checkpoints = &self.state.checkpoints;
         {
             let mut checkpoints = checkpoints.lock();
             assert!(
@@ -394,7 +394,7 @@ where
                 }
             }
         };
-        let mut checkpoint_store = self.state.checkpoints.as_ref().unwrap().lock();
+        let mut checkpoint_store = self.state.checkpoints.lock();
         let mut unbatched = self.state.database.transactions_in_seq_range(
             checkpoint_store.next_transaction_sequence_expected(),
             last_ticket,

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -48,7 +48,7 @@ async fn test_start_epoch_change() {
 
     // Set the checkpoint number to be near the end of epoch.
 
-    let checkpoints = state.checkpoints.as_ref().unwrap();
+    let checkpoints = &state.checkpoints;
     checkpoints
         .lock()
         .set_locals_for_testing(CheckpointLocals {
@@ -193,8 +193,6 @@ async fn test_finish_epoch_change() {
                 };
                 state
                     .checkpoints
-                    .as_ref()
-                    .unwrap()
                     .lock()
                     .set_locals_for_testing(locals.clone())
                     .unwrap();
@@ -204,8 +202,6 @@ async fn test_finish_epoch_change() {
                 locals.next_checkpoint += 1;
                 state
                     .checkpoints
-                    .as_ref()
-                    .unwrap()
                     .lock()
                     .set_locals_for_testing(locals.clone())
                     .unwrap();

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -133,7 +133,7 @@ impl SuiNode {
                 index_store.clone(),
                 event_store,
                 transaction_streamer,
-                Some(checkpoint_store),
+                checkpoint_store,
                 genesis,
                 &prometheus_registry,
                 tx_reconfigure_consensus,

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -26,7 +26,7 @@ use typed_store::traits::Map;
 /// Helper function determining whether the checkpoint store of an authority contains the input
 /// transactions' digests.
 fn transactions_in_checkpoint(authority: &AuthorityState) -> HashSet<TransactionDigest> {
-    let checkpoints_store = authority.checkpoints().unwrap();
+    let checkpoints_store = authority.checkpoints();
 
     // Get all transactions in the first 10 checkpoints.
     (0..10)
@@ -92,7 +92,6 @@ async fn wait_for_advance_to_next_checkpoint(
             authority
                 .state()
                 .checkpoints()
-                .unwrap()
                 .lock()
                 .get_locals()
                 .next_checkpoint
@@ -118,7 +117,7 @@ async fn sequence_fragments() {
     let mut proposals: Vec<_> = handles
         .iter_mut()
         .map(|handle| {
-            let checkpoints_store = handle.state().checkpoints().unwrap();
+            let checkpoints_store = handle.state().checkpoints();
             checkpoints_store
                 .lock()
                 .handle_internal_batch(next_sequence_number, &transactions)
@@ -136,7 +135,6 @@ async fn sequence_fragments() {
         let status = handle
             .state()
             .checkpoints()
-            .unwrap()
             .lock()
             .tables
             .fragments
@@ -155,7 +153,6 @@ async fn sequence_fragments() {
         let _response = handle
             .state()
             .checkpoints()
-            .unwrap()
             .lock()
             .submit_local_fragment_to_consensus(&fragment, committee);
     }
@@ -166,7 +163,6 @@ async fn sequence_fragments() {
             handle
                 .state()
                 .checkpoints()
-                .unwrap()
                 .lock()
                 .tables
                 .fragments

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -163,14 +163,7 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
 
     // Create a proposal on validator 0, which ensures that the transaction above will be included
     // in the checkpoint.
-    nodes[0]
-        .state()
-        .checkpoints
-        .as_ref()
-        .unwrap()
-        .lock()
-        .set_proposal(0)
-        .unwrap();
+    nodes[0].state().checkpoints.lock().set_proposal(0).unwrap();
     let mut checkpoint_processes = vec![];
     // Only validator 1 and 2 will participate the checkpoint progress, which will use fragments
     // involving validator 0, 1, 2. Since validator 1 and 2 don't have the above transaction
@@ -182,8 +175,6 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
             while !active
                 .state
                 .checkpoints
-                .as_ref()
-                .unwrap()
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {
@@ -204,8 +195,6 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
     while !nodes[3]
         .state()
         .checkpoints
-        .as_ref()
-        .unwrap()
         .lock()
         .is_ready_to_finish_epoch_change()
     {
@@ -280,8 +269,6 @@ async fn fast_forward_to_ready_for_reconfig_start(nodes: &[SuiNode]) {
             while !active
                 .state
                 .checkpoints
-                .as_ref()
-                .unwrap()
                 .lock()
                 .is_ready_to_start_epoch_change()
             {
@@ -304,8 +291,6 @@ async fn fast_forward_to_ready_for_reconfig_finish(nodes: &[SuiNode]) {
             while !active
                 .state
                 .checkpoints
-                .as_ref()
-                .unwrap()
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {


### PR DESCRIPTION
We made the checkpoint store optional in the past because fullnode didn't have it first.
Now all nodes should have a checkpoint store. Make it non-optional can simplify some code and usage.