### PR TITLE
[lockservice] Add epoch to object transaction lock

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1051,7 +1051,7 @@ impl AuthorityState {
                 match self.get_object(&request.object_id).await {
                     Ok(Some(object)) => {
                         let lock = if !object.is_owned_or_quasi_shared() {
-                            // Unowned obejcts have no locks.
+                            // Unowned objects have no locks.
                             None
                         } else {
                             self.get_transaction_lock(&object.compute_object_reference())
@@ -1840,7 +1840,7 @@ impl AuthorityState {
         signed_transaction: SignedTransaction,
     ) -> Result<(), SuiError> {
         self.database
-            .lock_and_write_transaction(mutable_input_objects, signed_transaction)
+            .lock_and_write_transaction(self.epoch(), mutable_input_objects, signed_transaction)
             .await
     }
 
@@ -1900,7 +1900,7 @@ impl AuthorityState {
         &self,
         object_ref: &ObjectRef,
     ) -> Result<Option<SignedTransaction>, SuiError> {
-        self.database.get_transaction_envelope(object_ref).await
+        self.database.get_transaction_lock(object_ref).await
     }
 
     // Helper functions to manage certificates

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -589,7 +589,11 @@ where
             "Setting transaction lock"
         );
         self.store
-            .lock_and_write_transaction(mutable_input_objects, transaction)
+            .lock_and_write_transaction(
+                self.authorities.committee.epoch,
+                mutable_input_objects,
+                transaction,
+            )
             .await
     }
 

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -249,7 +249,7 @@ async fn test_coin_split_insufficient_gas() {
     assert_eq!(
         gateway
             .store()
-            .get_transaction_envelope(&gas_object.compute_object_reference())
+            .get_transaction_lock(&gas_object.compute_object_reference())
             .await
             .unwrap(),
         None
@@ -438,7 +438,7 @@ async fn test_public_transfer_object_with_retry() {
     assert_eq!(
         gateway
             .store()
-            .get_transaction_envelope(&coin_object.compute_object_reference())
+            .get_transaction_lock(&coin_object.compute_object_reference())
             .await
             .unwrap(),
         None,
@@ -459,7 +459,7 @@ async fn test_public_transfer_object_with_retry() {
     assert_eq!(gateway.store().pending_transactions().iter().count(), 0);
     assert!(gateway
         .store()
-        .get_transaction_envelope(&coin_object.compute_object_reference())
+        .get_transaction_lock(&coin_object.compute_object_reference())
         .await
         .is_err());
     assert!(gateway.store().effects_exists(&tx_digest).unwrap());


### PR DESCRIPTION
This PR adds the epoch id to the object lock along with the transaction digest.
This will enable us to "unlock" locked objects at epoch boundaries, and hence free objects from potential equivocated state.