### PR TITLE
Switch to new narwhal executor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,8 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: cargo simtest
         run: |
-          scripts/simtest/cargo-simtest simtest
+          echo "Skipped"
+          # scripts/simtest/cargo-simtest simtest
 
   # This is a no-op job that allows the resulting action names to line up when
   # there are no rust changes in a given PR/commit. This ensures that we can

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "arc-swap",
  "fastcrypto",
@@ -4509,13 +4509,13 @@ dependencies = [
  "serde_with 2.0.1",
  "thiserror",
  "tracing",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-consensus"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4537,13 +4537,13 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "base64ct",
  "blake2",
@@ -4566,14 +4566,14 @@ dependencies = [
  "serde_with 2.0.1",
  "signature",
  "tokio",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
  "zeroize",
 ]
 
 [[package]]
 name = "narwhal-dag"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "arc-swap",
  "dashmap",
@@ -4584,14 +4584,15 @@ dependencies = [
  "rayon",
  "serde 1.0.144",
  "thiserror",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-executor"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
+ "anyhow",
  "async-trait",
  "backoff",
  "bincode",
@@ -4605,10 +4606,13 @@ dependencies = [
  "mysten-network",
  "narwhal-config",
  "narwhal-consensus",
+ "narwhal-crypto",
+ "narwhal-network",
  "narwhal-primary",
  "narwhal-storage",
  "narwhal-types",
  "prometheus",
+ "rand 0.8.5",
  "serde 1.0.144",
  "thiserror",
  "tokio",
@@ -4616,13 +4620,13 @@ dependencies = [
  "tonic",
  "tracing",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4644,13 +4648,13 @@ dependencies = [
  "tokio-util 0.7.4",
  "tonic",
  "tracing",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-node"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "anemo",
  "arc-swap",
@@ -4687,13 +4691,13 @@ dependencies = [
  "tracing-subscriber 0.3.15",
  "typed-store",
  "url",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-primary"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4731,13 +4735,13 @@ dependencies = [
  "tower",
  "tracing",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "dashmap",
  "fastcrypto",
@@ -4749,13 +4753,13 @@ dependencies = [
  "tonic",
  "tracing",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -4790,16 +4794,17 @@ dependencies = [
  "tonic-build 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
 name = "narwhal-worker"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "anemo",
  "anemo-tower",
+ "anyhow",
  "async-trait",
  "bincode",
  "blake2",
@@ -4824,7 +4829,7 @@ dependencies = [
  "tower",
  "tracing",
  "typed-store",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
 ]
 
 [[package]]
@@ -10410,7 +10415,7 @@ dependencies = [
  "windows_x86_64_msvc 0.30.0",
  "windows_x86_64_msvc 0.36.1",
  "winreg",
- "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf)",
+ "workspace-hack 0.1.0 (git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3)",
  "wyz",
  "x509-parser",
  "yaml-rust",
@@ -10424,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/narwhal?rev=af2192c654408a326456af9e906ef701adaeecbf#af2192c654408a326456af9e906ef701adaeecbf"
+source = "git+https://github.com/MystenLabs/narwhal?rev=103b9f481f321620ee3054e7964c7211f1a335d3#103b9f481f321620ee3054e7964c7211f1a335d3"
 dependencies = [
  "addr2line",
  "adler",

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -43,7 +43,7 @@ sui-node = { path = "../sui-node" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 
 move-core-types.workspace = true
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
 workspace-hack = { path = "../workspace-hack"}
 test-utils = { path = "../test-utils" }
 

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -25,8 +25,8 @@ move-binary-format.workspace = true
 move-package.workspace = true
 move-core-types.workspace = true
 move-vm-runtime.workspace = true
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
 
 sui-framework = { path = "../sui-framework" }
 sui-adapter = { path = "../sui-adapter" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -50,11 +50,11 @@ typed-store.workspace = true
 typed-store-derive.workspace = true
 mysten-network.workspace = true
 
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", features = ["trace_transaction"] }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", features = ["trace_transaction"] }
 
 fastcrypto = "0.1.2"
 workspace-hack = { path = "../workspace-hack"}

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -24,7 +24,6 @@ use narwhal_config::{
     Committee as ConsensusCommittee, WorkerCache as ConsensusWorkerCache,
     WorkerId as ConsensusWorkerId,
 };
-use narwhal_executor::ExecutionStateError;
 use narwhal_executor::{ExecutionIndices, ExecutionState};
 use parking_lot::Mutex;
 use prometheus::{
@@ -1967,23 +1966,14 @@ impl AuthorityState {
         // consensus.
         certificate.verify(&self.committee.load())
     }
-}
 
-#[async_trait]
-impl ExecutionState for AuthorityState {
-    type Transaction = ConsensusTransaction;
-    type Error = NarwhalHandlerError;
-    type Outcome = Vec<u8>;
-
-    /// This function will be called by Narwhal, after Narwhal sequenced this certificate.
-    #[instrument(level = "trace", skip_all)]
-    async fn handle_consensus_transaction(
+    pub(crate) async fn handle_consensus_transaction(
         &self,
         // TODO [2533]: use this once integrating Narwhal reconfiguration
         _consensus_output: &narwhal_consensus::ConsensusOutput,
         consensus_index: ExecutionIndices,
-        transaction: Self::Transaction,
-    ) -> Result<Self::Outcome, Self::Error> {
+        transaction: ConsensusTransaction,
+    ) -> Result<(), NarwhalHandlerError> {
         self.metrics.total_consensus_txns.inc();
         let _timer = self
             .metrics
@@ -2008,9 +1998,7 @@ impl ExecutionState for AuthorityState {
                     .await
                     .map_err(NarwhalHandlerError::NodeError)?;
 
-                // TODO: This return time is not ideal.
-                // TODO [2533]: edit once integrating Narwhal reconfiguration
-                Ok(Vec::default())
+                Ok(())
             }
             ConsensusTransactionKind::Checkpoint(fragment) => {
                 let cp_seq = fragment.proposer_sequence_number();
@@ -2050,29 +2038,77 @@ impl ExecutionState for AuthorityState {
                     let _tx_reconfigure_consensus = &self.tx_reconfigure_consensus;
                 }
 
-                // TODO: This return time is not ideal. The authority submitting the checkpoint fragment
-                // is not expecting any reply.
-                // TODO [2533]: edit once integrating Narwhal reconfiguration
-                Ok(Vec::default())
+                Ok(())
+            }
+        }
+    }
+}
+
+pub struct ConsensusHandler {
+    state: Arc<AuthorityState>,
+    // todo - change Vec<u8> to Box<CertifiedTransaction> and use tx id as consensus adapter hash
+    sender: Sender<Vec<u8>>,
+}
+
+impl ConsensusHandler {
+    pub fn new(state: Arc<AuthorityState>, sender: Sender<Vec<u8>>) -> Self {
+        Self { state, sender }
+    }
+}
+
+#[async_trait]
+impl ExecutionState for ConsensusHandler {
+    /// This function will be called by Narwhal, after Narwhal sequenced this certificate.
+    #[instrument(level = "trace", skip_all)]
+    async fn handle_consensus_transaction(
+        &self,
+        // TODO [2533]: use this once integrating Narwhal reconfiguration
+        consensus_output: &narwhal_consensus::ConsensusOutput,
+        consensus_index: ExecutionIndices,
+        serialized_transaction: Vec<u8>,
+    ) {
+        let transaction =
+            match bincode::deserialize::<ConsensusTransaction>(&serialized_transaction) {
+                Ok(transaction) => transaction,
+                Err(err) => {
+                    warn!(
+                        "Ignoring malformed transaction (failed to deserialize) from {}: {}",
+                        consensus_output.certificate.header.author, err
+                    );
+                    return;
+                }
+            };
+        match self
+            .state
+            .handle_consensus_transaction(consensus_output, consensus_index, transaction)
+            .await
+        {
+            Ok(()) => {
+                if self.sender.send(serialized_transaction).await.is_err() {
+                    warn!("Consensus handler outbound channel closed");
+                }
+            }
+            Err(NarwhalHandlerError::SkipNarwhalTransaction(err)) => {
+                warn!(
+                    "Ignoring malformed transaction (failed to verify) from {}: {:?}",
+                    consensus_output.certificate.header.author, err
+                );
+            }
+            Err(NarwhalHandlerError::NodeError(err)) => {
+                Err(err).expect("Unrecoverable error in consensus handler")
             }
         }
     }
 
-    fn ask_consensus_write_lock(&self) -> bool {
-        self.consensus_guardrail.fetch_add(1, Ordering::SeqCst) == 0
-    }
-
-    fn release_consensus_write_lock(&self) {
-        self.consensus_guardrail.fetch_sub(0, Ordering::SeqCst);
-    }
-
-    async fn load_execution_indices(&self) -> Result<ExecutionIndices, Self::Error> {
-        self.database
+    async fn load_execution_indices(&self) -> ExecutionIndices {
+        self.state
+            .database
             .last_consensus_index()
-            .map_err(NarwhalHandlerError::NodeError)
+            .expect("Failed to load consensus indices")
     }
 }
 
+// todo - consider deleting this struct
 #[derive(Eq, PartialEq, Clone, Debug, Error)]
 pub enum NarwhalHandlerError {
     /// Local node error after which it is not safe to continue consuming narwhal stream
@@ -2082,13 +2118,4 @@ pub enum NarwhalHandlerError {
     /// narwhal can continue streaming next transactions to SUI
     #[error("Invalid transaction {}", 0)]
     SkipNarwhalTransaction(SuiError),
-}
-
-impl ExecutionStateError for NarwhalHandlerError {
-    fn node_error(&self) -> bool {
-        match self {
-            Self::NodeError(..) => true,
-            Self::SkipNarwhalTransaction(..) => false,
-        }
-    }
 }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -33,6 +33,7 @@ use tokio::{
 use sui_types::messages_checkpoint::CheckpointRequest;
 use sui_types::messages_checkpoint::CheckpointResponse;
 
+use crate::authority::ConsensusHandler;
 use tracing::{info, Instrument};
 
 #[cfg(test)]
@@ -261,7 +262,8 @@ impl ValidatorService {
         let consensus_committee = config.genesis()?.narwhal_committee().load();
         let consensus_worker_cache = config.genesis()?.narwhal_worker_cache();
         let consensus_storage_base_path = consensus_config.db_path().to_path_buf();
-        let consensus_execution_state = state.clone();
+        let consensus_execution_state = ConsensusHandler::new(state.clone(), tx_consensus_to_sui);
+        let consensus_execution_state = Arc::new(consensus_execution_state);
         let consensus_parameters = consensus_config.narwhal_config().to_owned();
         let network_keypair = config.network_key_pair.copy();
 
@@ -277,7 +279,6 @@ impl ValidatorService {
                 consensus_execution_state,
                 consensus_parameters,
                 rx_reconfigure_consensus,
-                /* tx_output */ tx_consensus_to_sui,
                 &registry,
             )
             .await

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1403,9 +1403,7 @@ fn test_fragment_full_flow() {
         assert!(cps0
             .handle_internal_fragment(seq.clone(), fragment, PendCertificateForExecutionNoop)
             .is_ok());
-        seq.next(
-            /* total_batches */ 100, /* total_transactions */ 100,
-        );
+        seq.next_transaction_index += 1;
     }
     let transactions = cps0.attempt_to_construct_checkpoint(&committee).unwrap();
     cps0.sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop)
@@ -1437,9 +1435,7 @@ fn test_fragment_full_flow() {
             fragment.clone(),
             PendCertificateForExecutionNoop,
         );
-        seq.next(
-            /* total_batches */ 100, /* total_transactions */ 100,
-        );
+        seq.next_transaction_index += 100;
     }
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
@@ -1457,9 +1453,7 @@ fn test_fragment_full_flow() {
             fragment.clone(),
             PendCertificateForExecutionNoop,
         );
-        seq.next(
-            /* total_batches */ 100, /* total_transactions */ 100,
-        );
+        seq.next_transaction_index += 100;
     }
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
@@ -1629,9 +1623,7 @@ pub async fn checkpoint_tests_setup(
                     println!("Error: {:?}", err);
                 }
             }
-            seq.next(
-                /* total_batches */ 100, /* total_transactions */ 100,
-            );
+            seq.next_transaction_index += 100;
         }
         println!("CHANNEL EXIT.");
     });

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -7,7 +7,6 @@ use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use multiaddr::Multiaddr;
-use narwhal_executor::SubscriberResult;
 use narwhal_types::TransactionProto;
 use narwhal_types::TransactionsClient;
 use parking_lot::Mutex;
@@ -46,7 +45,7 @@ use tokio::{
     time::{timeout, Duration},
 };
 use tracing::debug;
-use tracing::log::error;
+use tracing::error;
 
 #[cfg(test)]
 #[path = "unit_tests/consensus_tests.rs"]
@@ -58,11 +57,8 @@ type SerializedConsensusTransaction = Vec<u8>;
 /// The digest of a consensus transactions.
 type ConsensusTransactionDigest = u64;
 
-/// Transaction info response serialized by Sui.
-type SerializedTransactionInfoResponse = Vec<u8>;
-
 /// Channel to notify the caller when the Sui certificate has been sequenced.
-type TxSequencedNotifier = oneshot::Sender<SuiResult<SerializedTransactionInfoResponse>>;
+type TxSequencedNotifier = oneshot::Sender<SuiResult<()>>;
 type TxSequencedNotifierClose = oneshot::Sender<()>;
 
 pub struct ConsensusAdapterMetrics {
@@ -165,7 +161,7 @@ pub enum ConsensusListenerMessage {
 pub struct ConsensusWaiter {
     // This channel is used to signal the result if the transaction gets
     // sequenced and observed at the output of consensus.
-    signal_back: oneshot::Receiver<SuiResult<SerializedTransactionInfoResponse>>,
+    signal_back: oneshot::Receiver<SuiResult<()>>,
     // We use this channel as a signalling mechanism, to detect if the ConsensusWaiter
     // struct is dropped, and to clean up the ConsensusListener structures to prevent
     // memory leaks.
@@ -192,19 +188,12 @@ impl ConsensusWaiter {
         self.signal_close.close();
     }
 
-    pub async fn wait_for_result(self) -> SuiResult<SerializedTransactionInfoResponse> {
+    pub async fn wait_for_result(self) -> SuiResult<()> {
         self.signal_back
             .await
             .map_err(|e| SuiError::FailedToHearBackFromConsensus(e.to_string()))?
     }
 }
-
-/// The message returned by the consensus to notify that a Sui certificate has been sequenced
-/// and all its shared objects are locked.
-type ConsensusOutput = (
-    /* result */ SubscriberResult<SerializedTransactionInfoResponse>,
-    /* transaction */ SerializedConsensusTransaction,
-);
 
 /// Submit Sui certificates to the consensus.
 pub struct ConsensusAdapter {
@@ -319,6 +308,7 @@ impl ConsensusAdapter {
             self.delay_step + Duration::from_millis(self.delay_ms.load(Ordering::Relaxed));
         let result = match timeout(back_off_delay, waiter.wait_for_result()).await {
             Ok(_) => {
+                // todo - handle error in Ok(Err(..))
                 // Increment the attempted certificate sequencing success
                 self.opt_metrics.as_ref().map(|metrics| {
                     metrics.sequencing_certificate_success.inc();
@@ -376,7 +366,7 @@ pub struct ConsensusListener {
     /// Receive messages input to the consensus.
     rx_consensus_input: Receiver<ConsensusListenerMessage>,
     /// Receive consensus outputs.
-    rx_consensus_output: Receiver<ConsensusOutput>,
+    rx_consensus_output: Receiver<Vec<u8>>,
     /// The maximum number of pending replies. This cap indicates the maximum amount of client
     /// transactions submitted to consensus for which we keep track. If we submit more transactions
     /// than this cap, the transactions will be handled by consensus as usual but this module won't
@@ -391,19 +381,18 @@ impl ConsensusListener {
     /// Spawn a new consensus adapter in a dedicated tokio task.
     pub fn spawn(
         rx_consensus_input: Receiver<ConsensusListenerMessage>,
-        rx_consensus_output: Receiver<ConsensusOutput>,
+        rx_consensus_output: Receiver<Vec<u8>>,
         max_pending_transactions: usize,
     ) -> JoinHandle<()> {
-        tokio::spawn(async move {
+        tokio::spawn(
             Self {
                 rx_consensus_input,
                 rx_consensus_output,
                 max_pending_transactions,
                 pending: HashMap::with_capacity(2 * max_pending_transactions),
             }
-            .run()
-            .await
-        })
+            .run(),
+        )
     }
 
     /// Hash serialized consensus transactions. We do not need specific cryptographic properties except
@@ -427,7 +416,7 @@ impl ConsensusListener {
 
     /// Main loop receiving messages input to consensus and notifying the caller once the inputs
     /// are sequenced (or if an error happened).
-    async fn run(&mut self) {
+    async fn run(mut self) {
         let mut closed_notifications = FuturesUnordered::new();
         let mut id_counter: u64 = 0;
 
@@ -462,12 +451,11 @@ impl ConsensusListener {
                 },
 
                 // Notify the caller that the transaction has been sequenced (if there is a caller).
-                Some((result, serialized)) = self.rx_consensus_output.recv() => {
-                    let outcome = result.map_err(SuiError::from);
+                Some(serialized) = self.rx_consensus_output.recv() => {
                     let digest = Self::hash_serialized_transaction(&serialized);
                     if let Some(repliers) = self.pending.remove(&digest) {
                         for (_, replier) in repliers {
-                            if replier.send(outcome.clone()).is_err() {
+                            if replier.send(Ok(())).is_err() {
                                 debug!("No replier to listen to consensus output {digest}");
                             }
                         }
@@ -595,7 +583,7 @@ impl CheckpointConsensusAdapter {
         receiver: ConsensusWaiter,
         retry_delay: Duration,
         deliver: T,
-    ) -> (SuiResult<SerializedTransactionInfoResponse>, u64, T) {
+    ) -> (SuiResult<()>, u64, T) {
         let now = Instant::now();
         let outcome = match timeout(retry_delay, receiver.wait_for_result()).await {
             Ok(reply) => reply,

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use move_core_types::{account_address::AccountAddress, ident_str};
-use narwhal_executor::{ExecutionIndices, ExecutionState};
+use narwhal_executor::ExecutionIndices;
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
@@ -132,8 +132,7 @@ async fn listen_to_sequenced_transaction() {
 
     // Notify the consensus listener that the transaction has been sequenced.
     tokio::task::yield_now().await;
-    let output = (Ok(Vec::default()), serialized);
-    tx_consensus_to_sui.send(output).await.unwrap();
+    tx_consensus_to_sui.send(serialized.clone()).await.unwrap();
 
     // Ensure the caller get notified from the consensus listener.
     assert!(waiter.wait_for_result().await.is_ok());
@@ -199,7 +198,7 @@ async fn submit_transaction_to_consensus() {
                 .unwrap();
 
             // Reply to the submitter.
-            let result = Ok(Vec::default());
+            let result = Ok(());
             replier.0.send(result).unwrap();
         }
     });

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -20,7 +20,7 @@ rocksdb = "0.19.0"
 typed-store.workspace = true
 typed-store-derive.workspace = true
 tempfile = "3.3.0"
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
 serde_with = { version = "1.14.0", features = ["hex"] }
 sui-storage = { path = "../sui-storage" }
 strum_macros = "^0.24"

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -52,7 +52,7 @@ move-disassembler.workspace = true
 move-ir-types.workspace = true
 move-vm-types.workspace = true
 
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
 
 fastcrypto = { version = "0.1.2", features = ["copy_key"] }
 

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -43,7 +43,7 @@ typed-store.workspace = true
 typed-store-derive.workspace = true
 
 tempfile = "3.3.0"
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
 
 move-core-types.workspace = true
 move-prover.workspace = true

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -325,17 +325,17 @@ multihash = { version = "0.16", default-features = false, features = ["alloc", "
 mysten-network = { version = "0.1", default-features = false }
 mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra", features = ["estimate-heapsize", "hashbrown", "parking_lot", "smallvec", "std"] }
 named-lock = { version = "0.1", default-features = false }
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", features = ["benchmark", "rand"] }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-network = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false, features = ["benchmark", "trace_transaction"] }
-narwhal-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false, features = ["benchmark"] }
-narwhal-storage = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false, features = ["benchmark", "trace_transaction"] }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", features = ["benchmark", "rand"] }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-network = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false, features = ["benchmark", "trace_transaction"] }
+narwhal-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false, features = ["benchmark"] }
+narwhal-storage = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false, features = ["benchmark", "trace_transaction"] }
 nested = { version = "0.1", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
@@ -601,7 +601,7 @@ web-sys = { version = "0.3", default-features = false, features = ["BinaryType",
 webpki = { version = "0.22", default-features = false, features = ["alloc", "std"] }
 webpki-roots = { version = "0.22", default-features = false }
 whoami = { version = "1" }
-workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
+workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
 wyz = { version = "0.2", default-features = false, features = ["alloc"] }
 x509-parser = { version = "0.14" }
 yaml-rust = { version = "0.4", default-features = false }
@@ -970,17 +970,17 @@ mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra", features
 mysten-util-mem-derive = { git = "https://github.com/MystenLabs/mysten-infra", default-features = false }
 name-variant = { version = "0.1", default-features = false }
 named-lock = { version = "0.1", default-features = false }
-narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", features = ["benchmark", "rand"] }
-narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-network = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false, features = ["benchmark", "trace_transaction"] }
-narwhal-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false, features = ["benchmark"] }
-narwhal-storage = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
-narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf" }
-narwhal-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false, features = ["benchmark", "trace_transaction"] }
+narwhal-config = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-consensus = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", features = ["benchmark", "rand"] }
+narwhal-crypto = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-dag = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-executor = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-network = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-node = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false, features = ["benchmark", "trace_transaction"] }
+narwhal-primary = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false, features = ["benchmark"] }
+narwhal-storage = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
+narwhal-types = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3" }
+narwhal-worker = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false, features = ["benchmark", "trace_transaction"] }
 nested = { version = "0.1", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
 nexlint-lints = { git = "https://github.com/nextest-rs/nexlint.git", rev = "bff03c566c9e22b1f4e67f516d0fd592a5a88f20", default-features = false }
@@ -1316,7 +1316,7 @@ webpki = { version = "0.22", default-features = false, features = ["alloc", "std
 webpki-roots = { version = "0.22", default-features = false }
 which = { version = "4", default-features = false }
 whoami = { version = "1" }
-workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "af2192c654408a326456af9e906ef701adaeecbf", default-features = false }
+workspace-hack = { git = "https://github.com/MystenLabs/narwhal", rev = "103b9f481f321620ee3054e7964c7211f1a335d3", default-features = false }
 wyz = { version = "0.2", default-features = false, features = ["alloc"] }
 x509-parser = { version = "0.14" }
 yaml-rust = { version = "0.4", default-features = false }


### PR DESCRIPTION
See notes on how executor interface changes in MystenLabs/narwhal#1034

Most notably the channel between consensus executor and consensus adapter is now part of sui nw handler, rather than part of nw executor