### PR TITLE
Adding GITHUB_TOKEN back

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -40,5 +40,5 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request
         uses: changesets/action@v1
-        with:
-          ssh-key: ${{ secrets.SSH_CHANGESETS_PUSH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The job ran successfully: https://github.com/MystenLabs/sui/actions/runs/3153735657/jobs/5130544875

But since there were no
![Screen Shot 2022-09-29 at 11 42 58 AM](https://user-images.githubusercontent.com/15659060/193116141-deae8887-09a2-4888-9199-712beac592a3.png)
 changes nothing got triggered
