### PR TITLE
wallet-ext:ts-sdk: use named exports from bip39

### DIFF
--- a/apps/wallet/src/shared/utils/bip39.ts
+++ b/apps/wallet/src/shared/utils/bip39.ts
@@ -1,6 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import bip39 from '@scure/bip39';
+import {
+    generateMnemonic as bip39GenerateMnemonic,
+    validateMnemonic as bip39ValidateMnemonic,
+} from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
 /**
@@ -9,7 +12,7 @@ import { wordlist } from '@scure/bip39/wordlists/english';
  * @returns a 12 words string separated by spaces.
  */
 export function generateMnemonic(): string {
-    return bip39.generateMnemonic(wordlist);
+    return bip39GenerateMnemonic(wordlist);
 }
 
 /**
@@ -20,7 +23,7 @@ export function generateMnemonic(): string {
  * @returns true if the mnemonic is valid, false otherwise.
  */
 export function validateMnemonics(mnemonics: string): boolean {
-    return bip39.validateMnemonic(mnemonics, wordlist);
+    return bip39ValidateMnemonic(mnemonics, wordlist);
 }
 
 /**

--- a/sdk/typescript/src/cryptography/mnemonics.ts
+++ b/sdk/typescript/src/cryptography/mnemonics.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import bip39 from '@scure/bip39';
+import { mnemonicToSeedSync as bip39MnemonicToSeedSync } from '@scure/bip39';
 
 /**
  * Parse and validate a path that is compliant to SLIP-0010 in form m/44'/784'/{account_index}'/{change_index}'/{address_index}'.
@@ -33,7 +33,7 @@ export function isValidBIP32Path(path: string): boolean {
  * @param mnemonics 12 words string split by spaces.
  */
 export function mnemonicToSeed(mnemonics: string): Uint8Array {
-  return bip39.mnemonicToSeedSync(mnemonics, '');
+  return bip39MnemonicToSeedSync(mnemonics, '');
 }
 
 /**


### PR DESCRIPTION
* it seems that `@scure/bip39` doesn't have a default export and that break the wallet