### PR TITLE
[explorer] Support filtering the fullnode map by time window

### DIFF
--- a/apps/explorer/src/components/validator-map/NodesLocation.tsx
+++ b/apps/explorer/src/components/validator-map/NodesLocation.tsx
@@ -14,7 +14,13 @@ const MIN_NODE_SIZE = 2;
 const MAX_NODE_SIZE = 7;
 
 export function NodesLocation({ node, projection }: Props) {
-    const position = projection(node.location);
+    const position = projection(
+        node.location
+            .split(',')
+            .reverse()
+            .map((geo) => parseFloat(geo)) as [number, number]
+    );
+
     const r = Math.max(
         Math.min(Math.floor(node.count / NODE_MULTIPLIER), MAX_NODE_SIZE),
         MIN_NODE_SIZE

--- a/apps/explorer/src/components/validator-map/ValidatorMap.module.css
+++ b/apps/explorer/src/components/validator-map/ValidatorMap.module.css
@@ -1,5 +1,5 @@
 .card {
-    @apply rounded-lg bg-sui-grey-40 flex flex-col justify-end min-h-[220px] antialiased relative;
+    @apply rounded-lg bg-sui-grey-40 flex flex-col justify-end min-h-[320px] antialiased relative;
 }
 
 .container {
@@ -27,7 +27,7 @@
 }
 
 .map {
-    @apply absolute inset-0 md:left-32 pointer-events-none md:pointer-events-auto;
+    @apply absolute inset-0 md:left-0 pointer-events-none md:pointer-events-auto;
 }
 
 .map svg {

--- a/apps/explorer/src/components/validator-map/ValidatorMap.module.css
+++ b/apps/explorer/src/components/validator-map/ValidatorMap.module.css
@@ -27,7 +27,7 @@
 }
 
 .map {
-    @apply absolute inset-0 md:left-0 pointer-events-none md:pointer-events-auto;
+    @apply absolute inset-0 pointer-events-none md:pointer-events-auto;
 }
 
 .map svg {

--- a/apps/explorer/src/components/validator-map/ValidatorMap.tsx
+++ b/apps/explorer/src/components/validator-map/ValidatorMap.tsx
@@ -28,7 +28,7 @@ const DATE_FILTER_TO_WINDOW = {
 };
 
 export default function ValidatorMap() {
-    const [dateFilter, setDateFilter] = useDateFilterState('ALL');
+    const [dateFilter, setDateFilter] = useDateFilterState('D');
 
     const { data } = useQuery(['validator-map', dateFilter], async () => {
         const res = await fetch(

--- a/apps/explorer/src/components/validator-map/ValidatorMap.tsx
+++ b/apps/explorer/src/components/validator-map/ValidatorMap.tsx
@@ -11,23 +11,17 @@ import { type NodeLocation } from './types';
 
 import styles from './ValidatorMap.module.css';
 
-const HOST = 'https://imgmod.sui.io';
+// const HOST = 'https://imgmod.sui.io';
+const HOST = 'http://localhost:9200';
 
-type NodeList = {
-    ip_address: string;
-    city: string;
-    region: string;
-    country: string;
-    location: string;
-}[];
+type CountryNodes = Record<string, { count: number; country: string }>;
 
-type CountryNodes = Record<string, { count: number; countryCode: string }>;
-
-const regionNamesInEnglish = new Intl.DisplayNames(['en'], { type: 'region' });
+const regionNamesInEnglish = new Intl.DisplayNames('en', { type: 'region' });
+const numberFormatter = new Intl.NumberFormat('en');
 
 export default function ValidatorMap() {
     const { data } = useQuery(['validator-map'], async () => {
-        const res = await fetch(`${HOST}/location`, {
+        const res = await fetch(`${HOST}/location?version=v2`, {
             method: 'GET',
         });
 
@@ -35,44 +29,32 @@ export default function ValidatorMap() {
             return [];
         }
 
-        return res.json() as Promise<NodeList>;
+        return res.json() as Promise<NodeLocation[]>;
     });
 
-    const { nodes, countryCount, countryNodes } = useMemo<{
-        nodes: NodeLocation[];
-        countryCount?: number;
+    const { totalCount, countryCount, countryNodes } = useMemo<{
+        totalCount: number | null;
+        countryCount: number | null;
         countryNodes: CountryNodes;
     }>(() => {
         if (!data) {
-            return { nodes: [], countryNodes: {} };
+            return { totalCount: null, countryCount: null, countryNodes: {} };
         }
 
-        const nodeLocations: Record<string, NodeLocation> = {};
+        let totalCount = 0;
         const countryNodes: CountryNodes = {};
 
-        data.forEach(({ city, region, country, location }) => {
-            const key = `${city}-${region}-${country}`;
-
+        data.forEach(({ count, country }) => {
+            totalCount += count;
             countryNodes[country] ??= {
                 count: 0,
-                countryCode: country,
+                country,
             };
             countryNodes[country].count += 1;
-
-            nodeLocations[key] ??= {
-                count: 0,
-                city,
-                countryCode: country,
-                location: location
-                    .split(',')
-                    .reverse()
-                    .map((geo) => parseFloat(geo)) as [number, number],
-            };
-            nodeLocations[key].count += 1;
         });
 
         return {
-            nodes: Object.values(nodeLocations),
+            totalCount,
             countryCount: Object.keys(countryNodes).length,
             countryNodes,
         };
@@ -113,11 +95,17 @@ export default function ValidatorMap() {
                 <div className={styles.contents}>
                     <div>
                         <div className={styles.title}>Total Nodes</div>
-                        <div className={styles.stat}>{data?.length}</div>
+                        <div className={styles.stat}>
+                            {totalCount &&
+                                numberFormatter.format(totalCount)}
+                        </div>
                     </div>
                     <div>
                         <div className={styles.title}>Total Countries</div>
-                        <div className={styles.stat}>{countryCount}</div>
+                        <div className={styles.stat}>
+                            {countryCount &&
+                                numberFormatter.format(countryCount)}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -127,7 +115,7 @@ export default function ValidatorMap() {
                     <ParentSizeModern>
                         {(parent) => (
                             <WorldMap
-                                nodes={nodes}
+                                nodes={data}
                                 width={parent.width}
                                 height={parent.height}
                                 onMouseOver={handleMouseOver}
@@ -153,8 +141,8 @@ export default function ValidatorMap() {
                     <div className={styles.tipdivider} />
                     <div>
                         {regionNamesInEnglish.of(
-                            countryNodes[tooltipData].countryCode
-                        ) || countryNodes[tooltipData].countryCode}
+                            countryNodes[tooltipData].country
+                        ) || countryNodes[tooltipData].country}
                     </div>
                 </TooltipWithBounds>
             )}

--- a/apps/explorer/src/components/validator-map/ValidatorMap.tsx
+++ b/apps/explorer/src/components/validator-map/ValidatorMap.tsx
@@ -11,19 +11,35 @@ import { type NodeLocation } from './types';
 
 import styles from './ValidatorMap.module.css';
 
-// const HOST = 'https://imgmod.sui.io';
-const HOST = 'http://localhost:9200';
+import { DateFilter, useDateFilterState } from '~/ui/DateFilter';
+
+const HOST = 'https://imgmod.sui.io';
 
 type CountryNodes = Record<string, { count: number; country: string }>;
 
 const regionNamesInEnglish = new Intl.DisplayNames('en', { type: 'region' });
 const numberFormatter = new Intl.NumberFormat('en');
 
+const DATE_FILTER_TO_WINDOW = {
+    D: '1d',
+    W: '1w',
+    M: '1m',
+    ALL: 'all',
+};
+
 export default function ValidatorMap() {
-    const { data } = useQuery(['validator-map'], async () => {
-        const res = await fetch(`${HOST}/location?version=v2`, {
-            method: 'GET',
-        });
+    const [dateFilter, setDateFilter] = useDateFilterState('ALL');
+
+    const { data } = useQuery(['validator-map', dateFilter], async () => {
+        const res = await fetch(
+            `${HOST}/location?${new URLSearchParams({
+                version: 'v2',
+                window: DATE_FILTER_TO_WINDOW[dateFilter],
+            })}`,
+            {
+                method: 'GET',
+            }
+        );
 
         if (!res.ok) {
             return [];
@@ -94,20 +110,23 @@ export default function ValidatorMap() {
             <div className={styles.container}>
                 <div className={styles.contents}>
                     <div>
-                        <div className={styles.title}>Total Nodes</div>
+                        <div className={styles.title}>Nodes</div>
                         <div className={styles.stat}>
-                            {totalCount &&
-                                numberFormatter.format(totalCount)}
+                            {totalCount && numberFormatter.format(totalCount)}
                         </div>
                     </div>
                     <div>
-                        <div className={styles.title}>Total Countries</div>
+                        <div className={styles.title}>Countries</div>
                         <div className={styles.stat}>
                             {countryCount &&
                                 numberFormatter.format(countryCount)}
                         </div>
                     </div>
                 </div>
+            </div>
+
+            <div className="absolute top-8 right-8 z-10">
+                <DateFilter value={dateFilter} onChange={setDateFilter} />
             </div>
 
             <div className={styles.mapcontainer}>

--- a/apps/explorer/src/components/validator-map/WorldMap.tsx
+++ b/apps/explorer/src/components/validator-map/WorldMap.tsx
@@ -44,7 +44,7 @@ function BaseWorldMap({
         <svg width={width} height={height}>
             <Mercator
                 data={filteredLand}
-                scale={100}
+                scale={105}
                 translate={[centerX, centerY + 20]}
             >
                 {({ features, projection }) => (

--- a/apps/explorer/src/components/validator-map/types.ts
+++ b/apps/explorer/src/components/validator-map/types.ts
@@ -11,6 +11,7 @@ export interface Feature {
 export interface NodeLocation {
     count: number;
     city: string;
-    countryCode: string;
-    location: [lat: number, long: number];
+    region: string;
+    country: string;
+    location: string;
 }

--- a/apps/explorer/src/ui/DateFilter.tsx
+++ b/apps/explorer/src/ui/DateFilter.tsx
@@ -8,7 +8,7 @@ import { Tab, TabGroup, TabList } from './Tabs';
 export type DateFilterOption = 'D' | 'W' | 'M' | 'ALL';
 
 export function useDateFilterState(defaultFilter: DateFilterOption = 'ALL') {
-	return useState(defaultFilter);
+    return useState(defaultFilter);
 }
 
 export interface DateFilterProps {

--- a/apps/explorer/src/ui/DateFilter.tsx
+++ b/apps/explorer/src/ui/DateFilter.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+
+import { Tab, TabGroup, TabList } from './Tabs';
+
+export type DateFilterOption = 'D' | 'W' | 'M' | 'ALL';
+
+export function useDateFilterState(defaultFilter: DateFilterOption = 'ALL') {
+	return useState(defaultFilter);
+}
+
+export interface DateFilterProps {
+    options?: DateFilterOption[];
+    value: DateFilterOption;
+    onChange(value: DateFilterOption): void;
+}
+
+export function DateFilter({
+    options = ['D', 'W', 'M', 'ALL'],
+    value,
+    onChange,
+}: DateFilterProps) {
+    const selectedIndex = options.indexOf(value);
+
+    return (
+        <TabGroup
+            selectedIndex={selectedIndex}
+            onChange={(index) => {
+                onChange(options[index]);
+            }}
+        >
+            <TabList disableBottomBorder>
+                {options.map((option) => (
+                    <Tab key={option}>{option}</Tab>
+                ))}
+            </TabList>
+        </TabGroup>
+    );
+}

--- a/apps/explorer/src/ui/DateFilter.tsx
+++ b/apps/explorer/src/ui/DateFilter.tsx
@@ -7,7 +7,7 @@ import { Tab, TabGroup, TabList } from './Tabs';
 
 export type DateFilterOption = 'D' | 'W' | 'M' | 'ALL';
 
-export function useDateFilterState(defaultFilter: DateFilterOption = 'ALL') {
+export function useDateFilterState(defaultFilter: DateFilterOption) {
     return useState(defaultFilter);
 }
 

--- a/apps/explorer/src/ui/Tabs.tsx
+++ b/apps/explorer/src/ui/Tabs.tsx
@@ -20,7 +20,7 @@ export function TabPanel(props: TabPanelProps) {
     return <HeadlessTab.Panel className="my-4" {...props} />;
 }
 
-export type TabGroupProps = ExtractProps<typeof HeadlessTab.List> & {
+export type TabGroupProps = ExtractProps<typeof HeadlessTab.Group> & {
     size?: TabSize;
 };
 
@@ -34,7 +34,7 @@ export function TabGroup({ size, ...props }: TabGroupProps) {
 
 const tabStyles = cva(
     [
-        'border-b border-sui-grey-45 ui-selected:border-sui-grey-65 font-semibold text-sui-grey-70 pb-2 -mb-px',
+        'border-b border-transparent ui-selected:border-sui-grey-65 font-semibold text-sui-grey-70 pb-2 -mb-px',
         // TODO: remove once we have a CSS reset:
         'bg-transparent border-0 border-solid outline-none px-0 cursor-pointer',
     ],
@@ -61,14 +61,16 @@ export function Tab({ ...props }: TabProps) {
 
 export type TabListProps = ExtractProps<typeof HeadlessTab.List> & {
     fullWidth?: boolean;
+    disableBottomBorder?: boolean;
 };
 
-export function TabList({ fullWidth, ...props }: TabListProps) {
+export function TabList({ fullWidth, disableBottomBorder, ...props }: TabListProps) {
     return (
         <HeadlessTab.List
             className={clsx(
-                'flex gap-6 border-b border-sui-grey-45 border-solid border-0',
-                fullWidth && 'flex-1'
+                'flex gap-6 border-sui-grey-45 border-solid border-0',
+                fullWidth && 'flex-1',
+                !disableBottomBorder && 'border-b',
             )}
             {...props}
         />

--- a/apps/explorer/src/ui/Tabs.tsx
+++ b/apps/explorer/src/ui/Tabs.tsx
@@ -64,13 +64,17 @@ export type TabListProps = ExtractProps<typeof HeadlessTab.List> & {
     disableBottomBorder?: boolean;
 };
 
-export function TabList({ fullWidth, disableBottomBorder, ...props }: TabListProps) {
+export function TabList({
+    fullWidth,
+    disableBottomBorder,
+    ...props
+}: TabListProps) {
     return (
         <HeadlessTab.List
             className={clsx(
                 'flex gap-6 border-sui-grey-45 border-solid border-0',
                 fullWidth && 'flex-1',
-                !disableBottomBorder && 'border-b',
+                !disableBottomBorder && 'border-b'
             )}
             {...props}
         />

--- a/apps/explorer/src/ui/stories/DateFilter.stories.tsx
+++ b/apps/explorer/src/ui/stories/DateFilter.stories.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DateFilter, useDateFilterState, type DateFilterProps } from '../DateFilter';
+
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+    title: 'UI/DateFilter',
+    component: DateFilter,
+} as ComponentMeta<typeof DateFilter>;
+
+function DateFilterWithState(props: Omit<DateFilterProps, 'value' | 'onChange'>) {
+    const [value, onChange] = useDateFilterState();
+    return <DateFilter {...props} value={value} onChange={onChange} />;
+}
+
+const Template: ComponentStory<typeof DateFilter> = (args) => <DateFilterWithState {...args} />;
+
+export const Default = Template.bind({});
+
+export const CustomOptions = Template.bind({});
+CustomOptions.args = {
+	options: ['D', 'ALL']
+};

--- a/apps/explorer/src/ui/stories/DateFilter.stories.tsx
+++ b/apps/explorer/src/ui/stories/DateFilter.stories.tsx
@@ -1,7 +1,11 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { DateFilter, useDateFilterState, type DateFilterProps } from '../DateFilter';
+import {
+    DateFilter,
+    useDateFilterState,
+    type DateFilterProps,
+} from '../DateFilter';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -10,16 +14,20 @@ export default {
     component: DateFilter,
 } as ComponentMeta<typeof DateFilter>;
 
-function DateFilterWithState(props: Omit<DateFilterProps, 'value' | 'onChange'>) {
+function DateFilterWithState(
+    props: Omit<DateFilterProps, 'value' | 'onChange'>
+) {
     const [value, onChange] = useDateFilterState();
     return <DateFilter {...props} value={value} onChange={onChange} />;
 }
 
-const Template: ComponentStory<typeof DateFilter> = (args) => <DateFilterWithState {...args} />;
+const Template: ComponentStory<typeof DateFilter> = (args) => (
+    <DateFilterWithState {...args} />
+);
 
 export const Default = Template.bind({});
 
 export const CustomOptions = Template.bind({});
 CustomOptions.args = {
-	options: ['D', 'ALL']
+    options: ['D', 'ALL'],
 };

--- a/apps/explorer/src/ui/stories/DateFilter.stories.tsx
+++ b/apps/explorer/src/ui/stories/DateFilter.stories.tsx
@@ -17,7 +17,7 @@ export default {
 function DateFilterWithState(
     props: Omit<DateFilterProps, 'value' | 'onChange'>
 ) {
-    const [value, onChange] = useDateFilterState();
+    const [value, onChange] = useDateFilterState('D');
     return <DateFilter {...props} value={value} onChange={onChange} />;
 }
 


### PR DESCRIPTION
This adds the capability for fullnode filtering in the map, plus updating the design to match the latest Figma

<img width="730" alt="Screen Shot 2022-09-30 at 12 34 12 PM" src="https://user-images.githubusercontent.com/109986297/193343752-d64d35c5-e042-4474-aa81-648dd63630e0.png">
<img width="721" alt="Screen Shot 2022-09-30 at 12 34 21 PM" src="https://user-images.githubusercontent.com/109986297/193343756-7db017c1-4b8c-43db-9686-b231e62007ac.png">
