### PR TITLE
[wallet-ext][sdk] Introduce generic dapp transaction signing interface

### DIFF
--- a/.changeset/ten-experts-prove.md
+++ b/.changeset/ten-experts-prove.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Added generic signAndExecuteTransaction method to the SDK, which can be used with any supported type of transaction.

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -21,6 +21,8 @@ function openTxWindow(txRequestID: string) {
     );
 }
 
+Browser.storage.local.remove(TX_STORE_KEY);
+
 class Transactions {
     private _txResponseMessages = new Subject<TransactionRequestResponse>();
 

--- a/apps/wallet/src/background/Transactions.ts
+++ b/apps/wallet/src/background/Transactions.ts
@@ -21,8 +21,6 @@ function openTxWindow(txRequestID: string) {
     );
 }
 
-Browser.storage.local.remove(TX_STORE_KEY);
-
 class Transactions {
     private _txResponseMessages = new Subject<TransactionRequestResponse>();
 

--- a/apps/wallet/src/dapp-interface/DAppInterface.ts
+++ b/apps/wallet/src/dapp-interface/DAppInterface.ts
@@ -8,7 +8,11 @@ import { WindowMessageStream } from '_messaging/WindowMessageStream';
 import { isErrorPayload } from '_payloads';
 import { ALL_PERMISSION_TYPES } from '_payloads/permissions';
 
-import type { SuiAddress, MoveCallTransaction } from '@mysten/sui.js';
+import type {
+    SuiAddress,
+    MoveCallTransaction,
+    SignableTransaction,
+} from '@mysten/sui.js';
 import type { Payload } from '_payloads';
 import type { GetAccount } from '_payloads/account/GetAccount';
 import type { GetAccountResponse } from '_payloads/account/GetAccountResponse';
@@ -83,6 +87,19 @@ export class DAppInterface {
                 type: 'get-account',
             }),
             (response) => response.accounts
+        );
+    }
+
+    public signAndSendTransaction(transaction: SignableTransaction) {
+        return mapToPromise(
+            this.send<ExecuteTransactionRequest, ExecuteTransactionResponse>({
+                type: 'execute-transaction-request',
+                transaction: {
+                    type: 'v2',
+                    data: transaction,
+                },
+            }),
+            (response) => response.result
         );
     }
 

--- a/apps/wallet/src/dapp-interface/DAppInterface.ts
+++ b/apps/wallet/src/dapp-interface/DAppInterface.ts
@@ -90,7 +90,7 @@ export class DAppInterface {
         );
     }
 
-    public signAndSendTransaction(transaction: SignableTransaction) {
+    public signAndExecuteTransaction(transaction: SignableTransaction) {
         return mapToPromise(
             this.send<ExecuteTransactionRequest, ExecuteTransactionResponse>({
                 type: 'execute-transaction-request',

--- a/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/transactions/ExecuteTransactionRequest.ts
@@ -3,10 +3,11 @@
 
 import { isBasePayload } from '_payloads';
 
-import type { MoveCallTransaction } from '@mysten/sui.js';
+import type { MoveCallTransaction, SignableTransaction } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 export type TransactionDataType =
+    | { type: 'v2'; data: SignableTransaction }
     | { type: 'move-call'; data: MoveCallTransaction }
     | { type: 'serialized-move-call'; data: string };
 

--- a/apps/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
+++ b/apps/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
@@ -189,29 +189,40 @@ export function DappTxApprovalPage() {
         }
     }, [loading, txRequest]);
 
-    const valuesContent = useMemo(
-        () =>
-            txRequest?.tx?.type === 'move-call'
-                ? [
-                      { label: 'Transaction Type', content: 'MoveCall' },
-                      {
-                          label: 'Function',
-                          content: txRequest.tx.data.function,
-                      },
-                      {
-                          label: 'Gas Fees',
-                          content: txRequest.tx.data.gasBudget,
-                      },
-                  ]
-                : [
-                      {
-                          label: 'Transaction Type',
-                          content: 'SerializedMoveCall',
-                      },
-                      { label: 'Contents', content: txRequest?.tx?.data },
-                  ],
-        [txRequest]
-    );
+    const valuesContent = useMemo(() => {
+        switch (txRequest?.tx.type) {
+            case 'v2': {
+                return [
+                    {
+                        label: 'Transaction Type',
+                        content: txRequest.tx.data.kind,
+                    },
+                ];
+            }
+            case 'move-call':
+                return [
+                    { label: 'Transaction Type', content: 'MoveCall' },
+                    {
+                        label: 'Function',
+                        content: txRequest.tx.data.function,
+                    },
+                    {
+                        label: 'Gas Fees',
+                        content: txRequest.tx.data.gasBudget,
+                    },
+                ];
+            case 'serialized-move-call':
+                return [
+                    {
+                        label: 'Transaction Type',
+                        content: 'SerializedMoveCall',
+                    },
+                    { label: 'Contents', content: txRequest?.tx?.data },
+                ];
+            default:
+                return [];
+        }
+    }, [txRequest]);
 
     return (
         <Loading loading={loading}>

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -80,7 +80,11 @@ export const respondToTransactionRequest = createAsyncThunk<
         if (approved) {
             const signer = api.getSignerInstance(keypairVault.getKeyPair());
             try {
-                if (txRequest.tx.type === 'move-call') {
+                if (txRequest.tx.type === 'v2') {
+                    txResult = await signer.signAndExecuteTransaction(
+                        txRequest.tx.data
+                    );
+                } else if (txRequest.tx.type === 'move-call') {
                     txResult = await signer.executeMoveCall(txRequest.tx.data);
                 } else if (txRequest.tx.type === 'serialized-move-call') {
                     const txBytes = new Base64DataBuffer(txRequest.tx.data);

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -68,11 +68,14 @@ export abstract class SignerWithProvider implements Signer {
     transaction: Base64DataBuffer | SignableTransaction
   ): Promise<SuiTransactionResponse> {
     // Handle submitting raw transaction bytes:
-    if (transaction instanceof Base64DataBuffer || 'bytes' in transaction) {
+    if (
+      transaction instanceof Base64DataBuffer ||
+      transaction.kind === 'bytes'
+    ) {
       const txBytes =
         transaction instanceof Base64DataBuffer
           ? transaction
-          : new Base64DataBuffer(transaction.bytes);
+          : new Base64DataBuffer(transaction.data);
 
       const sig = await this.signData(txBytes);
       return await this.provider.executeTransaction(
@@ -83,21 +86,24 @@ export abstract class SignerWithProvider implements Signer {
       );
     }
 
-    if ('moveCall' in transaction) {
-      return this.executeMoveCall(transaction.moveCall);
-    } else if ('transferSui' in transaction) {
-      return this.transferSui(transaction.transferSui);
-    } else if ('transferObject' in transaction) {
-      return this.transferObject(transaction.transferObject);
-    } else if ('mergeCoin' in transaction) {
-      return this.mergeCoin(transaction.mergeCoin);
-    } else if ('splitCoin' in transaction) {
-      return this.splitCoin(transaction.splitCoin);
-    } else if ('pay' in transaction) {
-      return this.pay(transaction.pay);
+    switch (transaction.kind) {
+      case 'moveCall':
+        return this.executeMoveCall(transaction.data);
+      case 'transferSui':
+        return this.transferSui(transaction.data);
+      case 'transferObject':
+        return this.transferObject(transaction.data);
+      case 'mergeCoin':
+        return this.mergeCoin(transaction.data);
+      case 'splitCoin':
+        return this.splitCoin(transaction.data);
+      case 'pay':
+        return this.pay(transaction.data);
+      default:
+        throw new Error(
+          `Unknown transaction kind: "${(transaction as any).kind}"`
+        );
     }
-
-    throw new Error('Unknown transaction provided.');
   }
 
   /**
@@ -108,11 +114,14 @@ export abstract class SignerWithProvider implements Signer {
     requestType: ExecuteTransactionRequestType
   ): Promise<SuiExecuteTransactionResponse> {
     // Handle submitting raw transaction bytes:
-    if (transaction instanceof Base64DataBuffer || 'bytes' in transaction) {
+    if (
+      transaction instanceof Base64DataBuffer ||
+      transaction.kind === 'bytes'
+    ) {
       const txBytes =
         transaction instanceof Base64DataBuffer
           ? transaction
-          : new Base64DataBuffer(transaction.bytes);
+          : new Base64DataBuffer(transaction.data);
 
       const sig = await this.signData(txBytes);
       return await this.provider.executeTransactionWithRequestType(
@@ -124,30 +133,30 @@ export abstract class SignerWithProvider implements Signer {
       );
     }
 
-    if ('moveCall' in transaction) {
-      return this.executeMoveCallWithRequestType(
-        transaction.moveCall,
-        requestType
-      );
-    } else if ('transferSui' in transaction) {
-      return this.transferSuiWithRequestType(
-        transaction.transferSui,
-        requestType
-      );
-    } else if ('transferObject' in transaction) {
-      return this.transferObjectWithRequestType(
-        transaction.transferObject,
-        requestType
-      );
-    } else if ('mergeCoin' in transaction) {
-      return this.mergeCoinWithRequestType(transaction.mergeCoin, requestType);
-    } else if ('splitCoin' in transaction) {
-      return this.splitCoinWithRequestType(transaction.splitCoin, requestType);
-    } else if ('pay' in transaction) {
-      return this.payWithRequestType(transaction.pay, requestType);
+    switch (transaction.kind) {
+      case 'moveCall':
+        return this.executeMoveCallWithRequestType(
+          transaction.data,
+          requestType
+        );
+      case 'transferSui':
+        return this.transferSuiWithRequestType(transaction.data, requestType);
+      case 'transferObject':
+        return this.transferObjectWithRequestType(
+          transaction.data,
+          requestType
+        );
+      case 'mergeCoin':
+        return this.mergeCoinWithRequestType(transaction.data, requestType);
+      case 'splitCoin':
+        return this.splitCoinWithRequestType(transaction.data, requestType);
+      case 'pay':
+        return this.payWithRequestType(transaction.data, requestType);
+      default:
+        throw new Error(
+          `Unknown transaction kind: "${(transaction as any).kind}"`
+        );
     }
-
-    throw new Error('Unknown transaction provided.');
   }
 
   /**

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -62,7 +62,7 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Sign a transaction and submit to the Gateway for execution
+   * Sign a transaction and submit to the Gateway for execution
    */
   async signAndExecuteTransaction(
     transaction: Base64DataBuffer | SignableTransaction

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -55,7 +55,9 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
-      throw new Error(`Error transferring object: ${err} with args ${t}`);
+      throw new Error(
+        `Error transferring object: ${err} with args ${JSON.stringify(t)}`
+      );
     }
   }
 
@@ -72,7 +74,9 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
-      throw new Error(`Error transferring Sui coin: ${err} with args ${t}`);
+      throw new Error(
+        `Error transferring Sui coin: ${err} with args ${JSON.stringify(t)}`
+      );
     }
   }
 
@@ -96,7 +100,9 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
-      throw new Error(`Error executing Pay transaction: ${err} with args ${t}`);
+      throw new Error(
+        `Error executing Pay transaction: ${err} with args ${JSON.stringify(t)}`
+      );
     }
   }
 
@@ -122,7 +128,9 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
       );
       return new Base64DataBuffer(resp.txBytes);
     } catch (err) {
-      throw new Error(`Error executing a move call: ${err} with args ${t}`);
+      throw new Error(
+        `Error executing a move call: ${err} with args ${JSON.stringify(t)}`
+      );
     }
   }
 

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -60,26 +60,36 @@ export interface MoveCallTransaction {
 /** A type that represents the possible transactions that can be signed: */
 export type SignableTransaction =
   | {
-      moveCall: MoveCallTransaction;
+      kind: 'moveCall';
+      data: MoveCallTransaction;
     }
   | {
-      transferSui: TransferSuiTransaction;
+      kind: 'transferSui';
+      data: TransferSuiTransaction;
     }
   | {
-      transferObject: TransferObjectTransaction;
+      kind: 'transferObject';
+      data: TransferObjectTransaction;
     }
   | {
-      mergeCoin: MergeCoinTransaction;
+      kind: 'mergeCoin';
+      data: MergeCoinTransaction;
     }
   | {
-      splitCoin: SplitCoinTransaction;
+      kind: 'splitCoin';
+      data: SplitCoinTransaction;
     }
   | {
-      pay: PayTransaction;
+      kind: 'pay';
+      data: PayTransaction;
     }
   | {
-      bytes: Uint8Array;
+      kind: 'bytes';
+      data: Uint8Array;
     };
+
+export type SignableTransactionKind = SignableTransaction['kind'];
+export type SignableTransactionData = SignableTransaction['data'];
 
 /**
  * Transaction type used for publishing Move modules to the Sui.

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -57,6 +57,30 @@ export interface MoveCallTransaction {
   gasBudget: number;
 }
 
+/** A type that represents the possible transactions that can be signed: */
+export type SignableTransaction =
+  | {
+      moveCall: MoveCallTransaction;
+    }
+  | {
+      transferSui: TransferSuiTransaction;
+    }
+  | {
+      transferObject: TransferObjectTransaction;
+    }
+  | {
+      mergeCoin: MergeCoinTransaction;
+    }
+  | {
+      splitCoin: SplitCoinTransaction;
+    }
+  | {
+      pay: PayTransaction;
+    }
+  | {
+      bytes: Uint8Array;
+    };
+
 /**
  * Transaction type used for publishing Move modules to the Sui.
  *

--- a/sdk/wallet-adapter/packages/adapters/base-adapter/src/base.ts
+++ b/sdk/wallet-adapter/packages/adapters/base-adapter/src/base.ts
@@ -3,6 +3,7 @@
 
 import {
   MoveCallTransaction,
+  SignableTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -15,6 +16,9 @@ export interface WalletCapabilities {
   // Connection Management
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
+  signAndSendTransaction?(
+    transaction: SignableTransaction
+  ): Promise<SuiTransactionResponse>;
   // DappInterfaces
   getAccounts: () => Promise<SuiAddress[]>;
   executeMoveCall: (

--- a/sdk/wallet-adapter/packages/adapters/base-adapter/src/base.ts
+++ b/sdk/wallet-adapter/packages/adapters/base-adapter/src/base.ts
@@ -16,7 +16,7 @@ export interface WalletCapabilities {
   // Connection Management
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
-  signAndSendTransaction?(
+  signAndExecuteTransaction?(
     transaction: SignableTransaction
   ): Promise<SuiTransactionResponse>;
   // DappInterfaces

--- a/sdk/wallet-adapter/packages/adapters/base-adapter/src/base.ts
+++ b/sdk/wallet-adapter/packages/adapters/base-adapter/src/base.ts
@@ -16,14 +16,22 @@ export interface WalletCapabilities {
   // Connection Management
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
+
+  /**
+   * Suggest a transaction for the user to sign. Supports all valid transaction types.
+   */
   signAndExecuteTransaction?(
     transaction: SignableTransaction
   ): Promise<SuiTransactionResponse>;
-  // DappInterfaces
+
   getAccounts: () => Promise<SuiAddress[]>;
+
+  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
   executeMoveCall: (
     transaction: MoveCallTransaction
   ) => Promise<SuiTransactionResponse>;
+
+  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
   executeSerializedMoveCall: (
     transactionBytes: Uint8Array
   ) => Promise<SuiTransactionResponse>;

--- a/sdk/wallet-adapter/packages/adapters/sui-wallet/src/adapter.ts
+++ b/sdk/wallet-adapter/packages/adapters/sui-wallet/src/adapter.ts
@@ -3,6 +3,7 @@
 
 import {
   MoveCallTransaction,
+  SignableTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -22,7 +23,11 @@ interface SuiWallet {
   executeSerializedMoveCall: (
     transactionBytes: Uint8Array
   ) => Promise<SuiTransactionResponse>;
+  signAndExecuteTransaction: (
+    transaction: SignableTransaction
+  ) => Promise<SuiTransactionResponse>;
 }
+
 interface SuiWalletWindow {
   suiWallet: SuiWallet;
 }
@@ -46,6 +51,11 @@ export class SuiWalletAdapter implements WalletCapabilities {
     transactionBytes: Uint8Array
   ): Promise<SuiTransactionResponse> {
     return window.suiWallet.executeSerializedMoveCall(transactionBytes);
+  }
+  signAndExecuteTransaction(
+    transaction: SignableTransaction
+  ): Promise<SuiTransactionResponse> {
+    return window.suiWallet.signAndExecuteTransaction(transaction);
   }
 
   name = "Sui Wallet";

--- a/sdk/wallet-adapter/packages/react-providers/src/WalletProvider.tsx
+++ b/sdk/wallet-adapter/packages/react-providers/src/WalletProvider.tsx
@@ -2,125 +2,153 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FC, ReactNode, useCallback, useEffect, useState } from "react";
-import type { SuiAddress, MoveCallTransaction, SuiTransactionResponse } from '@mysten/sui.js';
+import type {
+  SuiAddress,
+  MoveCallTransaction,
+  SuiTransactionResponse,
+  SignableTransaction,
+} from "@mysten/sui.js";
 import { WalletCapabilities } from "@mysten/wallet-adapter-base";
-import { Wallet, WalletContext } from './useWallet';
+import { Wallet, WalletContext } from "./useWallet";
 
 export interface WalletAdapter {
-    adapter: WalletCapabilities;
+  adapter: WalletCapabilities;
 }
 
 export interface WalletProviderProps {
-    children: ReactNode;
-    // Pass this through props to add list of supported wallets
-    supportedWallets: Wallet[]
+  children: ReactNode;
+  // Pass this through props to add list of supported wallets
+  supportedWallets: Wallet[];
 }
 
 export const WalletProvider: FC<WalletProviderProps> = ({
-    children,
-    supportedWallets
+  children,
+  supportedWallets,
 }) => {
-    // Wallet that user chose
-    const [wallet, setWallet] = useState<WalletAdapter | null>(null);
-    const [connected, setConnected] = useState(false)
-    const [connecting, setConnecting] = useState(false)
+  // Wallet that user chose
+  const [wallet, setWallet] = useState<WalletAdapter | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [connecting, setConnecting] = useState(false);
 
-
-    const connect = useCallback(
-        async () => {
-            if (wallet == null) {
-                return;
-            }
-            try {
-                setConnecting(true);
-                await wallet.adapter.connect()
-                setConnected(true)
-            } catch (e) {
-                setConnected(false)
-            }
-            setConnecting(false);
-    }, [wallet]);
-
-    const disconnect = async () => {
-        setConnected(false);
-        setWalletAndUpdateStorage(null);
+  const connect = useCallback(async () => {
+    if (wallet == null) {
+      return;
     }
-
-    // Use this to update wallet so that the chosen wallet persists after reload.
-    const setWalletAndUpdateStorage = useCallback((selectedWallet: Wallet | null) => {
-        setWallet(selectedWallet);
-        if (selectedWallet != null) {
-            localStorage.setItem('suiWallet', selectedWallet.adapter.name);
-        } else {
-            localStorage.removeItem('suiWallet');
-        }
-    }, []);
-
-    // Changes the selected wallet
-    const choose = useCallback((name: string) => {
-        let newWallet = supportedWallets.find(wallet => wallet.adapter.name === name);
-        if (newWallet) {
-            setWalletAndUpdateStorage(newWallet);
-        }
-        connect();
-    }, [supportedWallets, connect, setWalletAndUpdateStorage]);
-
-    // If the wallet is null, check if there isn't anything in local storage
-    // Note: Optimize this.
-    useEffect(() => {
-        if (!wallet && !connected && !connecting) {
-            let walletItem = localStorage.getItem('suiWallet');
-            if (typeof walletItem === 'string') {
-                const items = walletItem;
-                choose(items);
-            }
-        }
-    }, [choose, connected, connecting, wallet]);
-
-    // Returns all accounts (i.e. public keys) managed by the selected wallet
-    const getAccounts = async (): Promise<SuiAddress[]> => {
-        if (wallet == null) throw Error('Wallet Not Connected');
-        return await wallet.adapter.getAccounts();
+    try {
+      setConnecting(true);
+      await wallet.adapter.connect();
+      setConnected(true);
+    } catch (e) {
+      setConnected(false);
     }
+    setConnecting(false);
+  }, [wallet]);
 
-    // Requests wallet for signature and executes if signed
-    const executeMoveCall = async (transaction: MoveCallTransaction): Promise<SuiTransactionResponse> => {
-        if (wallet == null) throw Error('Wallet Not Connected');
-        return await wallet.adapter.executeMoveCall(transaction);
+  const disconnect = async () => {
+    setConnected(false);
+    setWalletAndUpdateStorage(null);
+  };
+
+  // Use this to update wallet so that the chosen wallet persists after reload.
+  const setWalletAndUpdateStorage = useCallback(
+    (selectedWallet: Wallet | null) => {
+      setWallet(selectedWallet);
+      if (selectedWallet != null) {
+        localStorage.setItem("suiWallet", selectedWallet.adapter.name);
+      } else {
+        localStorage.removeItem("suiWallet");
+      }
+    },
+    []
+  );
+
+  // Changes the selected wallet
+  const choose = useCallback(
+    (name: string) => {
+      let newWallet = supportedWallets.find(
+        (wallet) => wallet.adapter.name === name
+      );
+      if (newWallet) {
+        setWalletAndUpdateStorage(newWallet);
+      }
+      connect();
+    },
+    [supportedWallets, connect, setWalletAndUpdateStorage]
+  );
+
+  // If the wallet is null, check if there isn't anything in local storage
+  // Note: Optimize this.
+  useEffect(() => {
+    if (!wallet && !connected && !connecting) {
+      let walletItem = localStorage.getItem("suiWallet");
+      if (typeof walletItem === "string") {
+        const items = walletItem;
+        choose(items);
+      }
     }
+  }, [choose, connected, connecting, wallet]);
 
-    // Requests wallet for signature on serialized transaction and executes if signed
-    const executeSerializedMoveCall = async (transactionBytes: Uint8Array): Promise<SuiTransactionResponse> => {
-        if (wallet == null) throw Error('Wallet Not Connected');
-        return await wallet.adapter.executeSerializedMoveCall(transactionBytes);
+  // Returns all accounts (i.e. public keys) managed by the selected wallet
+  const getAccounts = async (): Promise<SuiAddress[]> => {
+    if (wallet == null) throw Error("Wallet Not Connected");
+    return await wallet.adapter.getAccounts();
+  };
+
+  // Requests wallet for signature and executes if signed
+  const executeMoveCall = async (
+    transaction: MoveCallTransaction
+  ): Promise<SuiTransactionResponse> => {
+    if (wallet == null) throw Error("Wallet Not Connected");
+    return await wallet.adapter.executeMoveCall(transaction);
+  };
+
+  // Requests wallet for signature on serialized transaction and executes if signed
+  const executeSerializedMoveCall = async (
+    transactionBytes: Uint8Array
+  ): Promise<SuiTransactionResponse> => {
+    if (wallet == null) throw Error("Wallet Not Connected");
+    return await wallet.adapter.executeSerializedMoveCall(transactionBytes);
+  };
+
+  const signAndExecuteTransaction = async (
+    transaction: SignableTransaction
+  ): Promise<SuiTransactionResponse> => {
+    if (wallet == null) {
+      throw new Error("Wallet Not Connected");
     }
+    if (!wallet.adapter.signAndExecuteTransaction) {
+      throw new Error(
+        'Wallet does not support "signAndExecuteTransaction" method'
+      );
+    }
+    return await wallet.adapter.signAndExecuteTransaction(transaction);
+  };
 
-    // Attempt to connect whenever user selects a new wallet
-    useEffect(() => {
-        if (
-            wallet != null &&
-            connecting !== true &&
-            connected !== true
-        ) {
-            connect();
-        }
-    }, [connect, wallet, connecting, connected])
+  // Attempt to connect whenever user selects a new wallet
+  useEffect(() => {
+    if (wallet != null && connecting !== true && connected !== true) {
+      connect();
+    }
+  }, [connect, wallet, connecting, connected]);
 
-    // Whenever the user selectes a new wallet
-    return (
-        <WalletContext.Provider value={{
-                supportedWallets,
-                wallet,
-                connecting: connecting,
-                connected: connected,
-                select: choose,
-                connect,
-                disconnect,
-                getAccounts,
-                executeMoveCall,
-                executeSerializedMoveCall
-        }}>
-            {children}
-        </WalletContext.Provider>
-    );
+  // Whenever the user selectes a new wallet
+  return (
+    <WalletContext.Provider
+      value={{
+        supportedWallets,
+        wallet,
+        connecting: connecting,
+        connected: connected,
+        select: choose,
+        connect,
+        disconnect,
+        getAccounts,
+        signAndExecuteTransaction,
+        executeMoveCall,
+        executeSerializedMoveCall,
+      }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
 };

--- a/sdk/wallet-adapter/packages/react-providers/src/useWallet.ts
+++ b/sdk/wallet-adapter/packages/react-providers/src/useWallet.ts
@@ -3,6 +3,7 @@
 
 import {
   MoveCallTransaction,
+  SignableTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -28,9 +29,16 @@ export interface WalletContextState {
   disconnect(): Promise<void>;
 
   getAccounts: () => Promise<SuiAddress[]>;
+
+  signAndExecuteTransaction(
+    transaction: SignableTransaction
+  ): Promise<SuiTransactionResponse>;
+
+  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
   executeMoveCall: (
     transaction: MoveCallTransaction
   ) => Promise<SuiTransactionResponse>;
+  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
   executeSerializedMoveCall: (
     transactionBytes: Uint8Array
   ) => Promise<SuiTransactionResponse>;
@@ -59,6 +67,15 @@ const DEFAULT_CONTEXT = {
   getAccounts() {
     return Promise.reject(
       console.error(constructMissingProviderErrorMessage("get", "getAccounts"))
+    );
+  },
+  signAndExecuteTransaction(
+    transaction: SignableTransaction
+  ): Promise<SuiTransactionResponse> {
+    return Promise.reject(
+      console.error(
+        constructMissingProviderErrorMessage("get", "signAndExecuteTransaction")
+      )
     );
   },
   executeMoveCall(

--- a/sdk/wallet-adapter/src/App.tsx
+++ b/sdk/wallet-adapter/src/App.tsx
@@ -1,28 +1,25 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
-import './App.css';
-import { root } from '.';
-import { Wallet, WalletProvider } from '@mysten/wallet-adapter-react';
-import { SuiWalletAdapter, MockWalletAdapter} from '@mysten/wallet-adapter-all-wallets';
-import { WalletWrapper } from '@mysten/wallet-adapter-react-ui';
-import { Button } from '@mui/material';
-import { TestButton } from './TestButton';
+import "./App.css";
+import { Wallet, WalletProvider } from "@mysten/wallet-adapter-react";
+import { SuiWalletAdapter } from "@mysten/wallet-adapter-all-wallets";
+import { WalletWrapper } from "@mysten/wallet-adapter-react-ui";
+import { TestButton } from "./TestButton";
 
 function App() {
   const supportedWallets: Wallet[] = [
     {
-      adapter: new SuiWalletAdapter()
+      adapter: new SuiWalletAdapter(),
     },
   ];
 
   return (
     <div className="App">
       <header className="App-header">
-         <WalletProvider supportedWallets={supportedWallets}>
-          <TestButton/>
-          <WalletWrapper/>
+        <WalletProvider supportedWallets={supportedWallets}>
+          <TestButton />
+          <WalletWrapper />
         </WalletProvider>
       </header>
     </div>

--- a/sdk/wallet-adapter/src/TestButton.tsx
+++ b/sdk/wallet-adapter/src/TestButton.tsx
@@ -6,23 +6,27 @@ import React from "react";
 import { useWallet } from "@mysten/wallet-adapter-react";
 
 export function TestButton() {
-  let { connected, getAccounts, executeMoveCall } = useWallet();
+  let { connected, getAccounts, signAndExecuteTransaction } = useWallet();
 
   const handleClick = async () => {
     getAccounts().then((accounts) => {
       console.log("Getting Accounts", accounts);
     });
-    await executeMoveCall({
-      packageObjectId: "0x2",
-      module: "devnet_nft",
-      function: "mint",
-      typeArguments: [],
-      arguments: [
-        "name",
-        "capy",
-        "https://cdn.britannica.com/94/194294-138-B2CF7780/overview-capybara.jpg?w=800&h=450&c=crop",
-      ],
-      gasBudget: 10000,
+
+    await signAndExecuteTransaction({
+      kind: "moveCall",
+      data: {
+        packageObjectId: "0x2",
+        module: "devnet_nft",
+        function: "mint",
+        typeArguments: [],
+        arguments: [
+          "name",
+          "capy",
+          "https://cdn.britannica.com/94/194294-138-B2CF7780/overview-capybara.jpg?w=800&h=450&c=crop",
+        ],
+        gasBudget: 10000,
+      },
     });
   };
 

--- a/sdk/wallet-adapter/tsconfig.json
+++ b/sdk/wallet-adapter/tsconfig.json
@@ -1,21 +1,29 @@
 {
-	"extends": "./tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
       "@mysten/wallet-adapter-react": ["./packages/react-providers/src"],
       "@mysten/wallet-adapter-react-ui": ["./packages/ui/src"],
       "@mysten/wallet-adapter-all-wallets": [
-        "./packages/adapters/integrations/all-wallets/src"
+        "./packages/adapters/all-wallets/src"
       ],
       "@mysten/wallet-adapter-base": ["./packages/adapters/base-adapter/src"],
       "@mysten/wallet-adapter-sui-wallet": [
-        "./packages/adapters/integrations/sui-wallet/src"
+        "./packages/adapters/sui-wallet/src"
       ],
       "@mysten/wallet-adapter-mock-wallet": [
-        "./packages/adapters/integrations/mock-wallet/src"
+        "./packages/adapters/mock-wallet/src"
       ]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "./packages/react-providers" },
+    { "path": "./packages/ui" },
+    { "path": "./packages/adapters/all-wallets" },
+    { "path": "./packages/adapters/base-adapter" },
+    { "path": "./packages/adapters/sui-wallet" },
+    { "path": "./packages/adapters/mock-wallet" }
+  ]
 }

--- a/sdk/wallet-adapter/vite.config.ts
+++ b/sdk/wallet-adapter/vite.config.ts
@@ -3,9 +3,16 @@
 
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import tsconfigPaths from "vite-tsconfig-paths";
+import tsconfig from './tsconfig.json';
+
+// TODO: Make an internal helper for this:
+const alias = {};
+Object.entries(tsconfig.compilerOptions.paths).forEach(([key, [value]]) => {
+  alias[key] = new URL(value, import.meta.url).pathname + '/';
+});
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  plugins: [react()],
+  resolve: { alias },
 });


### PR DESCRIPTION
Our current dapp interface and wallet adapters have a specialized methods for each support transaction type (with only move-call currently supported). This is challenging to keep up-to-date and requires changes to the actual adapter side of things for every new type of transaction. To address this, I'm introducing a new set of transaction methods, which can operate on a `SignableTransaction`. This is just a union of all of the possible types of transaction creations, with a tag to denote which kind of transaction it is. I added support down to the SDK level since this is useful for all application and wallet developers.

This updated dapp interface is essential for our upcoming standardized wallet adapters.

Another thing that I think would help this longer-term would be introducing new APIs solely for transaction building, and separate it completely out of the signing interface. I think for now though, having these APIs is an easier transition for developers.