### PR TITLE
[lockservice] Improve object lock errors

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1900,7 +1900,9 @@ impl AuthorityState {
         &self,
         object_ref: &ObjectRef,
     ) -> Result<Option<SignedTransaction>, SuiError> {
-        self.database.get_transaction_lock(object_ref).await
+        self.database
+            .get_object_locking_transaction(object_ref)
+            .await
     }
 
     // Helper functions to manage certificates

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -56,7 +56,7 @@ use sui_json_rpc_types::{
     SuiParsedSplitCoinResponse, SuiParsedTransactionResponse, SuiTransactionEffects,
     SuiTransactionResponse, SuiTypeTag, TransferObjectParams,
 };
-use sui_types::error::SuiError::ConflictingTransaction;
+use sui_types::error::SuiError::ObjectLockConflict;
 
 use crate::epoch::epoch_store::EpochStore;
 use tap::TapFallible;
@@ -733,8 +733,9 @@ where
             // we should first try to finish executing the previous transaction. If that failed,
             // we should just reset the locks.
             match err {
-                ConflictingTransaction {
+                ObjectLockConflict {
                     pending_transaction,
+                    ..
                 } => {
                     debug!(tx_digest=?pending_transaction, "Objects locked by a previous transaction, re-executing the previous transaction");
                     if let Err(err) = self.retry_pending_tx(pending_transaction).await {

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -249,7 +249,7 @@ async fn test_coin_split_insufficient_gas() {
     assert_eq!(
         gateway
             .store()
-            .get_transaction_lock(&gas_object.compute_object_reference())
+            .get_object_locking_transaction(&gas_object.compute_object_reference())
             .await
             .unwrap(),
         None
@@ -438,7 +438,7 @@ async fn test_public_transfer_object_with_retry() {
     assert_eq!(
         gateway
             .store()
-            .get_transaction_lock(&coin_object.compute_object_reference())
+            .get_object_locking_transaction(&coin_object.compute_object_reference())
             .await
             .unwrap(),
         None,
@@ -459,7 +459,7 @@ async fn test_public_transfer_object_with_retry() {
     assert_eq!(gateway.store().pending_transactions().iter().count(), 0);
     assert!(gateway
         .store()
-        .get_transaction_lock(&coin_object.compute_object_reference())
+        .get_object_locking_transaction(&coin_object.compute_object_reference())
         .await
         .is_err());
     assert!(gateway.store().effects_exists(&tx_digest).unwrap());

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -102,10 +102,6 @@ pub enum SuiError {
     },
     #[error("Invalid Authority Bitmap: {}", error)]
     InvalidAuthorityBitmap { error: String },
-    #[error("Conflicting transaction already received: {pending_transaction:?}")]
-    ConflictingTransaction {
-        pending_transaction: TransactionDigest,
-    },
     #[error("Transaction processing failed: {err}")]
     ErrorWhileProcessingTransactionTransaction { err: String },
     #[error("Confirmation transaction processing failed: {err}")]
@@ -267,11 +263,22 @@ pub enum SuiError {
     #[error("Attempt to update state of TxContext from a different instance than original.")]
     InvalidTxUpdate,
     #[error("Attempt to re-initialize a transaction lock for objects {:?}.", refs)]
-    TransactionLockExists { refs: Vec<ObjectRef> },
-    #[error("Attempt to set an non-existing transaction lock.")]
-    TransactionLockDoesNotExist,
-    #[error("Attempt to reset a set transaction lock to a different value.")]
-    TransactionLockReset,
+    ObjectLockAlreadyInitialized { refs: Vec<ObjectRef> },
+    #[error("Object {obj_ref:?} lock has not been initialized.")]
+    ObjectLockUninitialized { obj_ref: ObjectRef },
+    #[error(
+        "Object {obj_ref:?} already locked by a different transaction: {pending_transaction:?}"
+    )]
+    ObjectLockConflict {
+        obj_ref: ObjectRef,
+        pending_transaction: TransactionDigest,
+    },
+    #[error("Objects {obj_refs:?} are already locked by a transaction from a future epoch {locked_epoch:?}), attempt to override with a transaction from epoch {new_epoch:?}")]
+    ObjectLockedAtFutureEpoch {
+        obj_refs: Vec<ObjectRef>,
+        locked_epoch: EpochId,
+        new_epoch: EpochId,
+    },
     #[error("Could not find the referenced transaction [{:?}].", digest)]
     TransactionNotFound { digest: TransactionDigest },
     #[error("Could not find the referenced object {:?}.", object_id)]


### PR DESCRIPTION
This is a follow up from https://github.com/MystenLabs/sui/pull/4858:
1. Make sure we never override the lock by a tx from past epoch
2. Rename function name
3. Rename all TransactionLock error to ObjectLock error.