### PR TITLE
wallet-ext: replace popper with floating-ui

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -79,9 +79,9 @@
         "webpack-merge": "^5.8.0"
     },
     "dependencies": {
+        "@floating-ui/react-dom-interactions": "^0.10.1",
         "@metamask/browser-passworder": "^3.0.0",
         "@mysten/sui.js": "workspace:*",
-        "@popperjs/core": "^2.11.6",
         "@reduxjs/toolkit": "^1.8.3",
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",
@@ -94,7 +94,6 @@
         "react-dom": "^18.2.0",
         "react-intl": "^6.0.5",
         "react-number-format": "^4.9.3",
-        "react-popper": "^2.3.0",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
         "react-textarea-autosize": "^8.3.4",

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -90,6 +90,7 @@
         "classnames": "^2.3.1",
         "eslint-plugin-react": "^7.31.8",
         "formik": "^2.2.9",
+        "framer-motion": "^7.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intl": "^6.0.5",

--- a/apps/wallet/src/ui/app/shared/dapp-status/DappStatus.module.scss
+++ b/apps/wallet/src/ui/app/shared/dapp-status/DappStatus.module.scss
@@ -1,10 +1,6 @@
 @use '_values/colors';
 @use '_utils';
 
-.wrapper {
-    display: contents;
-}
-
 .container {
     display: flex;
     flex-flow: row;
@@ -68,6 +64,8 @@
     padding: 10px 12px;
     z-index: 999;
     max-width: 55%;
+    top: 0;
+    left: 0;
 }
 
 .popup-content {
@@ -79,7 +77,7 @@
 .popup-arrow {
     position: absolute;
     z-index: -1;
-    top: -5px;
+    top: -6px;
 
     &::before {
         content: '';

--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -10,6 +10,7 @@ import {
     arrow,
 } from '@floating-ui/react-dom-interactions';
 import cn from 'classnames';
+import { motion, AnimatePresence } from 'framer-motion';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import { appDisconnect } from './actions';
@@ -105,48 +106,61 @@ function DappStatus() {
                     <Icon icon={SuiIcons.ChevronDown} className={st.chevron} />
                 ) : null}
             </Component>
-            {visible ? (
-                <div
-                    className={st.popup}
-                    style={{ top: y || 0, left: x || 0 }}
-                    {...getFloatingProps()}
-                    ref={floating}
-                >
-                    <div className={st.popupContent}>
-                        <div className={st.originContainer}>
-                            {activeOriginFavIcon ? (
-                                <img
-                                    src={activeOriginFavIcon}
-                                    className={st.favicon}
-                                    alt="App Icon"
-                                />
-                            ) : null}
-                            <span className={st.originText}>
-                                <div>Connected to</div>
-                                <div className={st.originUrl}>
-                                    {activeOrigin}
-                                </div>
-                            </span>
+            <AnimatePresence>
+                {visible ? (
+                    <motion.div
+                        initial={{
+                            opacity: 0,
+                            scale: 0,
+                            y: 'calc(-50% - 15px)',
+                        }}
+                        animate={{ opacity: 1, scale: 1, y: 0 }}
+                        exit={{ opacity: 0, scale: 0, y: 'calc(-50% - 15px)' }}
+                        transition={{
+                            duration: 0.3,
+                            ease: 'anticipate',
+                        }}
+                        className={st.popup}
+                        style={{ top: y || 0, left: x || 0 }}
+                        {...getFloatingProps()}
+                        ref={floating}
+                    >
+                        <div className={st.popupContent}>
+                            <div className={st.originContainer}>
+                                {activeOriginFavIcon ? (
+                                    <img
+                                        src={activeOriginFavIcon}
+                                        className={st.favicon}
+                                        alt="App Icon"
+                                    />
+                                ) : null}
+                                <span className={st.originText}>
+                                    <div>Connected to</div>
+                                    <div className={st.originUrl}>
+                                        {activeOrigin}
+                                    </div>
+                                </span>
+                            </div>
+                            <div className={st.divider} />
+                            <Loading loading={disconnecting}>
+                                <button
+                                    type="button"
+                                    className={st.disconnect}
+                                    onClick={onHandleDisconnect}
+                                    disabled={disconnecting}
+                                >
+                                    Disconnect App
+                                </button>
+                            </Loading>
                         </div>
-                        <div className={st.divider} />
-                        <Loading loading={disconnecting}>
-                            <button
-                                type="button"
-                                className={st.disconnect}
-                                onClick={onHandleDisconnect}
-                                disabled={disconnecting}
-                            >
-                                Disconnect App
-                            </button>
-                        </Loading>
-                    </div>
-                    <div
-                        className={st.popupArrow}
-                        ref={arrowRef}
-                        style={{ left: arrowData?.x || 0 }}
-                    />
-                </div>
-            ) : null}
+                        <div
+                            className={st.popupArrow}
+                            ref={arrowRef}
+                            style={{ left: arrowData?.x || 0 }}
+                        />
+                    </motion.div>
+                ) : null}
+            </AnimatePresence>
         </>
     );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,7 @@ importers:
       eslint-plugin-react: ^7.31.8
       eslint-webpack-plugin: ^3.2.0
       formik: ^2.2.9
+      framer-motion: ^7.5.1
       html-webpack-plugin: ^5.5.0
       mini-css-extract-plugin: ^2.6.1
       onchange: ^7.1.0
@@ -214,6 +215,7 @@ importers:
       classnames: 2.3.1
       eslint-plugin-react: 7.31.8_eslint@8.23.0
       formik: 2.2.9_react@18.2.0
+      framer-motion: 7.5.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-intl: 6.0.8_n4upredruleo7vrbwztywbpoxq
@@ -3382,11 +3384,24 @@ packages:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
     dev: false
 
+  /@emotion/is-prop-valid/0.8.8:
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    requiresBuild: true
+    dependencies:
+      '@emotion/memoize': 0.7.4
+    dev: false
+    optional: true
+
   /@emotion/is-prop-valid/1.2.0:
     resolution: {integrity: sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==}
     dependencies:
       '@emotion/memoize': 0.8.0
     dev: false
+
+  /@emotion/memoize/0.7.4:
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    dev: false
+    optional: true
 
   /@emotion/memoize/0.8.0:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
@@ -3963,6 +3978,53 @@ packages:
   /@metamask/browser-passworder/3.0.0:
     resolution: {integrity: sha512-hD10mgvhcDkZX8wnauw8udp1K2MzcbZfrN7Yon9sQ+OqVK9kiQ4VhZAyZNZTy9KJLtfoVD9Y2F6L4gEese7hDA==}
     engines: {node: '>=12.0.0'}
+    dev: false
+
+  /@motionone/animation/10.14.0:
+    resolution: {integrity: sha512-h+1sdyBP8vbxEBW5gPFDnj+m2DCqdlAuf2g6Iafb1lcMnqjsRXWlPw1AXgvUMXmreyhqmPbJqoNfIKdytampRQ==}
+    dependencies:
+      '@motionone/easing': 10.14.0
+      '@motionone/types': 10.14.0
+      '@motionone/utils': 10.14.0
+      tslib: 2.4.0
+    dev: false
+
+  /@motionone/dom/10.13.1:
+    resolution: {integrity: sha512-zjfX+AGMIt/fIqd/SL1Lj93S6AiJsEA3oc5M9VkUr+Gz+juRmYN1vfvZd6MvEkSqEjwPQgcjN7rGZHrDB9APfQ==}
+    dependencies:
+      '@motionone/animation': 10.14.0
+      '@motionone/generators': 10.14.0
+      '@motionone/types': 10.14.0
+      '@motionone/utils': 10.14.0
+      hey-listen: 1.0.8
+      tslib: 2.4.0
+    dev: false
+
+  /@motionone/easing/10.14.0:
+    resolution: {integrity: sha512-2vUBdH9uWTlRbuErhcsMmt1jvMTTqvGmn9fHq8FleFDXBlHFs5jZzHJT9iw+4kR1h6a4SZQuCf72b9ji92qNYA==}
+    dependencies:
+      '@motionone/utils': 10.14.0
+      tslib: 2.4.0
+    dev: false
+
+  /@motionone/generators/10.14.0:
+    resolution: {integrity: sha512-6kRHezoFfIjFN7pPpaxmkdZXD36tQNcyJe3nwVqwJ+ZfC0e3rFmszR8kp9DEVFs9QL/akWjuGPSLBI1tvz+Vjg==}
+    dependencies:
+      '@motionone/types': 10.14.0
+      '@motionone/utils': 10.14.0
+      tslib: 2.4.0
+    dev: false
+
+  /@motionone/types/10.14.0:
+    resolution: {integrity: sha512-3bNWyYBHtVd27KncnJLhksMFQ5o2MSdk1cA/IZqsHtA9DnRM1SYgN01CTcJ8Iw8pCXF5Ocp34tyAjY7WRpOJJQ==}
+    dev: false
+
+  /@motionone/utils/10.14.0:
+    resolution: {integrity: sha512-sLWBLPzRqkxmOTRzSaD3LFQXCPHvDzyHJ1a3VP9PRzBxyVd2pv51/gMOsdAcxQ9n+MIeGJnxzXBYplUHKj4jkw==}
+    dependencies:
+      '@motionone/types': 10.14.0
+      hey-listen: 1.0.8
+      tslib: 2.4.0
     dev: false
 
   /@mrmlnc/readdir-enhanced/2.2.1:
@@ -12411,6 +12473,30 @@ packages:
       map-cache: 0.2.2
     dev: true
 
+  /framer-motion/7.5.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-shqLAFgYT7QMVomusesPurlq9pQGLO64PTbWdQPkMg2cHmxI0ISG9BajGY3krg56yhBMI7QP/3u54bs/To0mOA==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@motionone/dom': 10.13.1
+      framesync: 6.1.2
+      hey-listen: 1.0.8
+      popmotion: 11.0.5
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      style-value-types: 5.1.2
+      tslib: 2.4.0
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
+
+  /framesync/6.1.2:
+    resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
   /fresh/0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -13114,6 +13200,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
+
+  /hey-listen/1.0.8:
+    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+    dev: false
 
   /history/5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
@@ -16487,6 +16577,15 @@ packages:
       '@babel/runtime': 7.18.9
     dev: true
 
+  /popmotion/11.0.5:
+    resolution: {integrity: sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA==}
+    dependencies:
+      framesync: 6.1.2
+      hey-listen: 1.0.8
+      style-value-types: 5.1.2
+      tslib: 2.4.0
+    dev: false
+
   /portfinder/1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
     engines: {node: '>= 0.12.0'}
@@ -19246,6 +19345,13 @@ packages:
     dependencies:
       inline-style-parser: 0.1.1
     dev: true
+
+  /style-value-types/5.1.2:
+    resolution: {integrity: sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q==}
+    dependencies:
+      hey-listen: 1.0.8
+      tslib: 2.4.0
+    dev: false
 
   /styled-jsx/5.0.2_react@18.2.0:
     resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,9 +136,9 @@ importers:
 
   apps/wallet:
     specifiers:
+      '@floating-ui/react-dom-interactions': ^0.10.1
       '@metamask/browser-passworder': ^3.0.0
       '@mysten/sui.js': workspace:*
-      '@popperjs/core': ^2.11.6
       '@reduxjs/toolkit': ^1.8.3
       '@scure/bip32': ^1.1.0
       '@scure/bip39': ^1.1.0
@@ -177,7 +177,6 @@ importers:
       react-dom: ^18.2.0
       react-intl: ^6.0.5
       react-number-format: ^4.9.3
-      react-popper: ^2.3.0
       react-redux: ^8.0.2
       react-router-dom: ^6.3.0
       react-textarea-autosize: ^8.3.4
@@ -204,9 +203,9 @@ importers:
       webpack-merge: ^5.8.0
       yup: ^0.32.11
     dependencies:
+      '@floating-ui/react-dom-interactions': 0.10.1_7ey2zzynotv32rpkwno45fsx4e
       '@metamask/browser-passworder': 3.0.0
       '@mysten/sui.js': link:../../sdk/typescript
-      '@popperjs/core': 2.11.6
       '@reduxjs/toolkit': 1.8.5_kkwg4cbsojnjnupd3btipussee
       '@scure/bip32': 1.1.0
       '@scure/bip39': 1.1.0
@@ -219,7 +218,6 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       react-intl: 6.0.8_n4upredruleo7vrbwztywbpoxq
       react-number-format: 4.9.3_biqbaboplfbrettd7655fr4n2y
-      react-popper: 2.3.0_r6q5zrenym2zg7je7hgi674bti
       react-redux: 8.0.2_6hrpdt74nuubt2lijsfizev3cu
       react-router-dom: 6.3.0_biqbaboplfbrettd7655fr4n2y
       react-textarea-autosize: 8.3.4_w5j4k42lgipnm43s3brx6h3c34
@@ -3499,6 +3497,41 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@floating-ui/core/1.0.1:
+    resolution: {integrity: sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==}
+    dev: false
+
+  /@floating-ui/dom/1.0.2:
+    resolution: {integrity: sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==}
+    dependencies:
+      '@floating-ui/core': 1.0.1
+    dev: false
+
+  /@floating-ui/react-dom-interactions/0.10.1_7ey2zzynotv32rpkwno45fsx4e:
+    resolution: {integrity: sha512-mb9Sn/cnPjVlEucSZTSt4Iu7NAvqnXTvmzeE5EtfdRhVQO6L94dqqT+DPTmJmbiw4XqzoyGP+Q6J+I5iK2p6bw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 1.0.0_biqbaboplfbrettd7655fr4n2y
+      aria-hidden: 1.2.1_w5j4k42lgipnm43s3brx6h3c34
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /@floating-ui/react-dom/1.0.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.0.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /@formatjs/ecma402-abstract/1.11.10:
     resolution: {integrity: sha512-v8nuQpx6pc0xzg4VMCXPWesFx8PxBysdF7q1CGEoet0X9nhbGPGNq0SC+D9g+Kh0pWWITidlEYsepLF7lb8Tqw==}
@@ -7780,6 +7813,21 @@ packages:
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  /aria-hidden/1.2.1_w5j4k42lgipnm43s3brx6h3c34:
+    resolution: {integrity: sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.0.20
+      react: 18.2.0
+      tslib: 2.4.0
+    dev: false
 
   /aria-query/4.2.2:
     resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==}
@@ -17500,10 +17548,6 @@ packages:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
     dev: false
 
-  /react-fast-compare/3.2.0:
-    resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
-    dev: false
-
   /react-ga4/1.4.1:
     resolution: {integrity: sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==}
     dev: false
@@ -17560,20 +17604,6 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    dev: false
-
-  /react-popper/2.3.0_r6q5zrenym2zg7je7hgi674bti:
-    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
-    peerDependencies:
-      '@popperjs/core': ^2.0.0
-      react: ^16.8.0 || ^17 || ^18
-      react-dom: ^16.8.0 || ^17 || ^18
-    dependencies:
-      '@popperjs/core': 2.11.6
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-fast-compare: 3.2.0
-      warning: 4.0.3
     dev: false
 
   /react-redux/8.0.2_6hrpdt74nuubt2lijsfizev3cu:
@@ -21086,12 +21116,6 @@ packages:
     dependencies:
       makeerror: 1.0.12
     dev: true
-
-  /warning/4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
   /watchpack-chokidar2/2.0.1:
     resolution: {integrity: sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==}


### PR DESCRIPTION
https://user-images.githubusercontent.com/10210143/193358033-c728dcf6-a94a-43b0-8e7d-1b5812205e1c.mov

Note: The only difference with before is that clicking on other elements will not cancel the event (when the popover is open) and might result to something more than closing the popover, eg. navigate to  another view. (Added #4907 for this)

closes: #4716 