### PR TITLE
[checkpoint] Add next epoch committee to checkpoint summary

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -349,6 +349,7 @@ impl CheckpointStore {
         sequence_number: CheckpointSequenceNumber,
         transactions: impl Iterator<Item = &'a ExecutionDigests> + Clone,
         effects_store: impl CausalOrder + PendCertificateForExecution,
+        next_epoch_committee: Option<Committee>,
     ) -> SuiResult {
         // Make sure that all transactions in the checkpoint have been executed locally.
         self.check_checkpoint_transactions(transactions.clone(), &effects_store)?;
@@ -362,8 +363,13 @@ impl CheckpointStore {
                 .into_iter(),
         );
 
-        let summary =
-            CheckpointSummary::new(epoch, sequence_number, &ordered_contents, previous_digest);
+        let summary = CheckpointSummary::new(
+            epoch,
+            sequence_number,
+            &ordered_contents,
+            previous_digest,
+            next_epoch_committee,
+        );
 
         let checkpoint = AuthenticatedCheckpoint::Signed(
             SignedCheckpointSummary::new_from_summary(summary, self.name, &*self.secret),

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -490,7 +490,13 @@ fn latest_proposal() {
 
     // Fail to set if transactions not processed.
     assert!(cps1
-        .sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop,)
+        .sign_new_checkpoint(
+            epoch,
+            0,
+            ckp_items.iter(),
+            TestCausalOrderPendCertNoop,
+            None
+        )
         .is_err());
 
     // Set the transactions as executed.
@@ -505,14 +511,38 @@ fn latest_proposal() {
     cps4.handle_internal_batch(0, &batch).unwrap();
 
     // Try to get checkpoint
-    cps1.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
-    cps2.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
-    cps3.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
-    cps4.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
+    cps1.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
+    cps2.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
+    cps3.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
+    cps4.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
 
     // --- TEST3 ---
 
@@ -653,7 +683,13 @@ fn set_get_checkpoint() {
 
     // Need to load the transactions as processed, before getting a checkpoint.
     assert!(cps1
-        .sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop,)
+        .sign_new_checkpoint(
+            epoch,
+            0,
+            ckp_items.iter(),
+            TestCausalOrderPendCertNoop,
+            None
+        )
         .is_err());
     let batch: Vec<_> = ckp_items
         .iter()
@@ -664,12 +700,30 @@ fn set_get_checkpoint() {
     cps2.handle_internal_batch(0, &batch).unwrap();
     cps3.handle_internal_batch(0, &batch).unwrap();
 
-    cps1.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
-    cps2.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
-    cps3.sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderPendCertNoop)
-        .unwrap();
+    cps1.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
+    cps2.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
+    cps3.sign_new_checkpoint(
+        epoch,
+        0,
+        ckp_items.iter(),
+        TestCausalOrderPendCertNoop,
+        None,
+    )
+    .unwrap();
     // cps4.handle_internal_set_checkpoint(summary, &transactions)
     //     .unwrap();
 
@@ -821,6 +875,7 @@ fn checkpoint_integration() {
                     old_checkpoint,
                     transactions.iter(),
                     TestCausalOrderPendCertNoop,
+                    None,
                 )
                 .is_ok());
 
@@ -866,7 +921,8 @@ fn checkpoint_integration() {
                 committee.epoch,
                 next_checkpoint,
                 transactions.iter(),
-                TestCausalOrderPendCertNoop
+                TestCausalOrderPendCertNoop,
+                None
             )
             .is_err());
 
@@ -1402,7 +1458,7 @@ fn test_fragment_full_flow() {
         seq.next_transaction_index += 1;
     }
     let transactions = cps0.attempt_to_construct_checkpoint(&committee).unwrap();
-    cps0.sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop)
+    cps0.sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop, None)
         .unwrap();
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
@@ -1756,7 +1812,7 @@ async fn checkpoint_messaging_flow() {
             .unwrap();
         auth.checkpoint
             .lock()
-            .sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop)
+            .sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop, None)
             .unwrap();
     }
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -89,18 +89,7 @@ where
 
         let sui_system_state = self.state.get_sui_system_state_object().await?;
         let next_epoch = epoch + 1;
-        let next_epoch_validators = &sui_system_state.validators.next_epoch_validators;
-        let votes = next_epoch_validators
-            .iter()
-            .map(|metadata| {
-                (
-                    AuthorityPublicKeyBytes::from_bytes(metadata.pubkey_bytes.as_ref())
-                        .expect("Validity of public key bytes should be verified on-chain"),
-                    metadata.next_epoch_stake + metadata.next_epoch_delegation,
-                )
-            })
-            .collect();
-        let new_committee = Committee::new(next_epoch, votes)?;
+        let new_committee = sui_system_state.get_next_epoch_committee();
         debug!(
             ?epoch,
             "New committee for the next epoch: {}", new_committee

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -6,7 +6,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::slice::Iter;
 
 use crate::base_types::ExecutionDigests;
-use crate::committee::EpochId;
+use crate::committee::{EpochId, StakeUnit};
 use crate::crypto::{AuthoritySignInfo, AuthoritySignInfoTrait, AuthorityWeakQuorumSignInfo};
 use crate::error::SuiResult;
 use crate::messages::CertifiedTransaction;
@@ -166,6 +166,12 @@ pub struct CheckpointSummary {
     pub sequence_number: CheckpointSequenceNumber,
     pub content_digest: CheckpointContentsDigest,
     pub previous_digest: Option<CheckpointDigest>,
+    /// If this checkpoint is the last checkpoint of the epoch, we also include the committee
+    /// of the next epoch. This allows anyone receiving this checkpoint know that the epoch
+    /// will change after this checkpoint, as well as what the new committee is.
+    /// The committee is stored as a vector of validator pub key and stake pairs. The vector
+    /// should be sorted based on the Committee data structure.
+    pub next_epoch_committee: Option<Vec<(AuthorityName, StakeUnit)>>,
 }
 
 impl CheckpointSummary {
@@ -174,6 +180,7 @@ impl CheckpointSummary {
         sequence_number: CheckpointSequenceNumber,
         transactions: &CheckpointContents,
         previous_digest: Option<CheckpointDigest>,
+        next_epoch_committee: Option<Committee>,
     ) -> CheckpointSummary {
         let mut waypoint = Box::new(Waypoint::default());
         transactions.iter().for_each(|tx| {
@@ -187,6 +194,7 @@ impl CheckpointSummary {
             sequence_number,
             content_digest,
             previous_digest,
+            next_epoch_committee: next_epoch_committee.map(|c| c.voting_rights),
         }
     }
 
@@ -236,9 +244,15 @@ impl SignedCheckpointSummary {
         signer: &dyn signature::Signer<AuthoritySignature>,
         transactions: &CheckpointContents,
         previous_digest: Option<CheckpointDigest>,
+        next_epoch_committee: Option<Committee>,
     ) -> SignedCheckpointSummary {
-        let checkpoint =
-            CheckpointSummary::new(epoch, sequence_number, transactions, previous_digest);
+        let checkpoint = CheckpointSummary::new(
+            epoch,
+            sequence_number,
+            transactions,
+            previous_digest,
+            next_epoch_committee,
+        );
         SignedCheckpointSummary::new_from_summary(checkpoint, authority, signer)
     }
 
@@ -698,7 +712,7 @@ mod tests {
             .map(|k| {
                 let name = k.public().into();
 
-                SignedCheckpointSummary::new(committee.epoch, 1, name, k, &set, None)
+                SignedCheckpointSummary::new(committee.epoch, 1, name, k, &set, None, None)
             })
             .collect();
 
@@ -726,7 +740,7 @@ mod tests {
             .map(|k| {
                 let name = k.public().into();
 
-                SignedCheckpointSummary::new(committee.epoch, 1, name, k, &set, None)
+                SignedCheckpointSummary::new(committee.epoch, 1, name, k, &set, None, None)
             })
             .collect();
 
@@ -745,7 +759,7 @@ mod tests {
                     [ExecutionDigests::random()].into_iter(),
                 );
 
-                SignedCheckpointSummary::new(committee.epoch, 1, name, k, &set, None)
+                SignedCheckpointSummary::new(committee.epoch, 1, name, k, &set, None, None)
             })
             .collect();
 

--- a/crates/sui-types/src/sui_system_state.rs
+++ b/crates/sui-types/src/sui_system_state.rs
@@ -1,11 +1,15 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::traits::ToFromBytes;
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::IdentStr, language_storage::StructTag,
 };
 use serde::{Deserialize, Serialize};
 
+use crate::base_types::AuthorityName;
+use crate::committee::{Committee, StakeUnit};
+use crate::crypto::AuthorityPublicKeyBytes;
 use crate::{
     balance::{Balance, Supply},
     id::UID,
@@ -42,6 +46,17 @@ pub struct ValidatorMetadata {
     pub next_epoch_stake: u64,
     pub next_epoch_delegation: u64,
     pub next_epoch_gas_price: u64,
+}
+
+impl ValidatorMetadata {
+    pub fn to_validator_and_stake_pair(&self) -> (AuthorityName, StakeUnit) {
+        (
+            // TODO: Make sure we are actually verifying this on-chain.
+            AuthorityPublicKeyBytes::from_bytes(self.pubkey_bytes.as_ref())
+                .expect("Validity of public key bytes should be verified on-chain"),
+            self.next_epoch_stake + self.next_epoch_delegation,
+        )
+    }
 }
 
 /// Rust version of the Move sui::validator::Validator type
@@ -107,5 +122,19 @@ impl SuiSystemState {
             module: SUI_SYSTEM_MODULE_NAME.to_owned(),
             type_params: vec![],
         }
+    }
+
+    pub fn get_next_epoch_committee(&self) -> Committee {
+        Committee::new(
+            self.epoch + 1,
+            self.validators
+                .next_epoch_validators
+                .iter()
+                .map(ValidatorMetadata::to_validator_and_stake_pair)
+                .collect(),
+        )
+        // unwrap is safe because we should have verified the committee on-chain.
+        // TODO: Make sure we actually verify it.
+        .unwrap()
     }
 }

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -593,6 +593,7 @@ fn test_user_signature_committed_in_checkpoints() {
             [execution_digest_a].into_iter(),
         ),
         None,
+        None,
     );
     let checkpoint_summary_b = CheckpointSummary::new(
         0,
@@ -600,6 +601,7 @@ fn test_user_signature_committed_in_checkpoints() {
         &CheckpointContents::new_with_causally_ordered_transactions(
             [execution_digest_b].into_iter(),
         ),
+        None,
         None,
     );
 


### PR DESCRIPTION
If client is following all checkpoints (which is the closest we have as blocks), they should be able to figure out when epoch is changing in what way. Today we don't have such information in checkpoints, and one has to know the protocol to figure out which checkpoint is the last one of an epoch.
To enable above, this PR adds an optional field to CheckpointSummary to include the committee information of the next epoch, if it is the last checkpoint of the epoch. This allows any client upon seeing this checkpoint immediately know that the epoch is changing, without relying on other data structures. This will significantly reduce the complexity of sync: we no longer need to worry about epoch sync, but can rely on checkpoints only.