### PR TITLE
Add handle_committeee_info to validators

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1208,6 +1208,23 @@ impl AuthorityState {
         }
     }
 
+    pub fn handle_committee_info_request(
+        &self,
+        request: &CommitteeInfoRequest,
+    ) -> SuiResult<CommitteeInfoResponse> {
+        let (epoch, committee) = match request.epoch {
+            Some(epoch) => (epoch, self.committee_store.get_committee(&epoch)?),
+            None => {
+                let committee = self.committee_store.get_latest_committee();
+                (committee.epoch, Some(committee))
+            }
+        };
+        Ok(CommitteeInfoResponse {
+            epoch,
+            committee_info: committee.map(|c| c.voting_rights),
+        })
+    }
+
     // TODO: This function takes both committee and genesis as parameter.
     // Technically genesis already contains committee information. Could consider merging them.
     pub async fn new(

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -21,8 +21,8 @@ use sui_types::crypto::{get_key_pair, AuthorityKeyPair};
 use sui_types::error::SuiError;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    CertifiedTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
-    TransactionInfoRequest, TransactionInfoResponse,
+    CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse, ObjectInfoRequest,
+    ObjectInfoResponse, Transaction, TransactionInfoRequest, TransactionInfoResponse,
 };
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::Object;
@@ -192,6 +192,13 @@ impl AuthorityAPI for ConfigurableBatchActionClient {
     ) -> Result<CheckpointResponse, SuiError> {
         let state = self.state.clone();
         state.handle_checkpoint_request(&request)
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        self.state.handle_committee_info_request(&request)
     }
 }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -549,4 +549,18 @@ impl Validator for ValidatorService {
 
         return Ok(tonic::Response::new(response));
     }
+
+    async fn committee_info(
+        &self,
+        request: tonic::Request<CommitteeInfoRequest>,
+    ) -> Result<tonic::Response<CommitteeInfoResponse>, tonic::Status> {
+        let request = request.into_inner();
+
+        let response = self
+            .state
+            .handle_committee_info_request(&request)
+            .map_err(|e| tonic::Status::internal(e.to_string()))?;
+
+        return Ok(tonic::Response::new(response));
+    }
 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1046,6 +1046,13 @@ async fn test_quorum_once_with_timeout() {
         ) -> Result<CheckpointResponse, SuiError> {
             unreachable!();
         }
+
+        async fn handle_committee_info_request(
+            &self,
+            _request: CommitteeInfoRequest,
+        ) -> Result<CommitteeInfoResponse, SuiError> {
+            unimplemented!();
+        }
     }
 
     let count = Arc::new(Mutex::new(0));

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -30,8 +30,8 @@ use std::fs;
 use std::sync::Arc;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
-    CertifiedTransaction, ObjectInfoRequest, ObjectInfoResponse, Transaction,
-    TransactionInfoRequest, TransactionInfoResponse,
+    CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse, ObjectInfoRequest,
+    ObjectInfoResponse, Transaction, TransactionInfoRequest, TransactionInfoResponse,
 };
 
 pub(crate) fn init_state_parameters_from_rng<R>(
@@ -621,6 +621,13 @@ impl AuthorityAPI for TrustworthyAuthorityClient {
         });
         Ok(Box::pin(stream))
     }
+
+    async fn handle_committee_info_request(
+        &self,
+        _request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        unimplemented!();
+    }
 }
 
 impl TrustworthyAuthorityClient {
@@ -742,6 +749,13 @@ impl AuthorityAPI for ByzantineAuthorityClient {
             items.pop().map(|item| (Ok(item), items))
         });
         Ok(Box::pin(stream))
+    }
+
+    async fn handle_committee_info_request(
+        &self,
+        _request: CommitteeInfoRequest,
+    ) -> Result<CommitteeInfoResponse, SuiError> {
+        unimplemented!();
     }
 }
 

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -83,6 +83,15 @@ fn main() -> Result<()> {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            Method::builder()
+                .name("committee_info")
+                .route_name("CommitteeInfo")
+                .input_type("sui_types::messages::CommitteeInfoRequest")
+                .output_type("sui_types::messages::CommitteeInfoResponse")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     Builder::new()

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -2081,3 +2081,16 @@ pub enum QuorumDriverResponse {
     // TODO: Change to CertifiedTransactionEffects eventually.
     EffectsCert(Box<(CertifiedTransaction, CertifiedTransactionEffects)>),
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CommitteeInfoRequest {
+    pub epoch: Option<EpochId>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CommitteeInfoResponse {
+    pub epoch: EpochId,
+    pub committee_info: Option<Vec<(AuthorityName, StakeUnit)>>,
+    // TODO: We could also return the certified checkpoint that contains this committee.
+    // This would allows a client to verify the authenticity of the committee.
+}


### PR DESCRIPTION
This PR adds an API to validators that allow a client to query the committee of each epoch.
Note that the returned data is not verifiable yet.
The verifiability will be added in a separate PR (we will need to return the certified checkpoint that committed to the committee).