### PR TITLE
[narwhal] Try harder worker dissemination (RFC)

### DIFF
--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -290,7 +290,11 @@ impl BatchMaker {
             let _ = store.notify_read(digest).await;
 
             // Also wait for sending to be done here
-            // (TODO: sending to others is an optimization, no need to wait.)
+            //
+            // TODO: Here if we get back Err it means that potentially this was not send
+            //       to a quorum. However, if that happens we can still proceed on the basis
+            //       that an other authority will request the batch from us, and we will deliver
+            //       it since it is now stored. So ignore the error for the moment.
             let _ = done_sending.await;
 
             // Finally send to primary

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -29,6 +29,9 @@ use types::{
     WorkerOurBatchMessage,
 };
 
+// The number of batches to store / transmit in parallel.
+pub const MAX_PARALLEL_BATCH: usize = 25;
+
 #[cfg(test)]
 #[path = "tests/batch_maker_tests.rs"]
 pub mod batch_maker_tests;
@@ -103,8 +106,6 @@ impl BatchMaker {
         let mut current_batch_size = 0;
 
         let mut batch_pipeline = FuturesOrdered::new();
-        // The number of batches to store / transmit in parallel.
-        const MAX_PARALLEL_BATCH: usize = 25;
 
         loop {
             tokio::select! {

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -1,12 +1,14 @@
+use std::time::Duration;
+
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::{Committee, SharedWorkerCache, Stake, WorkerId};
 use crypto::PublicKey;
-use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
+use futures::stream::{futures_unordered::FuturesUnordered, FuturesOrdered, StreamExt as _};
 use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use store::Store;
-use tokio::{sync::watch, task::JoinHandle};
+use tokio::{sync::watch, task::JoinHandle, time::timeout};
 use types::{
     metered_channel::Receiver, Batch, BatchDigest, ReconfigureNotification, WorkerBatchMessage,
 };
@@ -72,11 +74,16 @@ impl QuorumWaiter {
 
     /// Main loop.
     async fn run(&mut self) {
+        // 
+        let mut pipeline = FuturesOrdered::new();
+        let mut best_effort_with_timeout = FuturesUnordered::new();
+
         loop {
             tokio::select! {
 
-                Some((batch, opt_channel)) = self.rx_message.recv() => {
-
+                // When a new batch is available, and the pipeline is not full, add a new
+                // task to the pipeline to send this batch to workers. 
+                Some((batch, opt_channel)) = self.rx_message.recv(), if pipeline.len() < 20 => {
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
                         .worker_cache
@@ -86,7 +93,7 @@ impl QuorumWaiter {
                         .map(|(name, info)| (name, info.name))
                         .collect();
                     let (primary_names, worker_names): (Vec<_>, _) = workers.into_iter().unzip();
-                    let message = WorkerBatchMessage{batch: batch.clone()};
+                    let message  = WorkerBatchMessage{batch: batch.clone()};
                     let handlers = self.network.broadcast(worker_names, &message).await;
 
                     // Collect all the handlers to receive acknowledgements.
@@ -104,35 +111,50 @@ impl QuorumWaiter {
                     // the dag). This should reduce the amount of synching.
                     let threshold = self.committee.quorum_threshold();
                     let mut total_stake = self.committee.stake(&self.name);
-                    loop {
-                        tokio::select! {
-                            Some(stake) = wait_for_quorum.next() => {
+
+                    pipeline.push_back(async move {
+                        // A future that sends to 2/3 stake then returns. Also prints an error
+                        // if we terminate before we have managed to get to the full 2/3 stake.
+                        let _ = &wait_for_quorum;
+                        loop{
+                            if let Some(stake) = wait_for_quorum.next().await {
                                 total_stake += stake;
                                 if total_stake >= threshold {
+
                                     // Notify anyone waiting for this.
                                     if let Some(channel) = opt_channel {
                                         let _ = channel.send(());
                                     }
-                                    break;
+                                    break
                                 }
-                            }
-
-                            result = self.rx_reconfigure.changed() => {
-                                result.expect("Committee channel dropped");
-                                let message = self.rx_reconfigure.borrow().clone();
-                                match message {
-                                    ReconfigureNotification::NewEpoch(new_committee)
-                                        | ReconfigureNotification::UpdateCommittee(new_committee) => {
-                                            self.committee = new_committee;
-                                            tracing::debug!("Dropping batch: committee updated to {}", self.committee);
-                                            break; // Don't wait for acknowledgements.
-                                    },
-                                    ReconfigureNotification::Shutdown => return
-                                }
+                            } else {
+                                tracing::error!("Batch dissemination ended without a quorum.");
+                                break;
                             }
                         }
-                    }
+                        (batch, wait_for_quorum)
+                    });
                 },
+
+                // Process futures in the pipeline. They complete when we have sent to >2/3
+                // of other worker by stake, but after that we still try to send to the remaining
+                // on a best effort basis.
+                Some((_batch, mut remaining)) = pipeline.next() => {
+
+                    // Attempt to send messages to the remaining workers
+                    best_effort_with_timeout.push(async move {
+                        // Bound the attempt to a few seconds to tolerate nodes that are 
+                        // offline and will never succeed.
+                        timeout(Duration::from_secs(5), async move{
+                            while remaining.next().await.is_some() { }
+                        }).await
+                    });
+
+                },
+
+                // Drive the best effort send efforts which may update remaining workers
+                // or timeout.
+                Some(_) = best_effort_with_timeout.next() => {}
 
                 // Trigger reconfigure.
                 result = self.rx_reconfigure.changed() => {
@@ -144,6 +166,13 @@ impl QuorumWaiter {
                         },
                         ReconfigureNotification::UpdateCommittee(new_committee) => {
                             self.committee = new_committee;
+
+                            // Upon reconfiguration we drop all current batches.
+                            //
+                            // TODO: ensure that if the batch has not been distributed to the right
+                            //       commitee we do not propose it?
+                            pipeline = FuturesOrdered::new();
+                            best_effort_with_timeout = FuturesUnordered::new()
 
                         },
                         ReconfigureNotification::Shutdown => return

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -148,15 +148,18 @@ impl QuorumWaiter {
                 Some((_batch, mut remaining)) = pipeline.next() => {
 
                     // Attempt to send messages to the remaining workers
-                    best_effort_with_timeout.push(async move {
-                        // Bound the attempt to a few seconds to tolerate nodes that are
-                        // offline and will never succeed.
-                        //
-                        // TODO: make the constant a config parameter.
-                        timeout(Duration::from_secs(5), async move{
-                            while remaining.next().await.is_some() { }
-                        }).await
-                    });
+                    if remaining.len() > 0 {
+                        trace!("Best effort dissemination for batch {} for remaining {}", batch.digest(), remaining.len());
+                        best_effort_with_timeout.push(async move {
+                           // Bound the attempt to a few seconds to tolerate nodes that are
+                           // offline and will never succeed.
+                           //
+                           // TODO: make the constant a config parameter.
+                           timeout(Duration::from_secs(5), async move{
+                               while remaining.next().await.is_some() { }
+                           }).await
+                       });
+                    }
 
                 },
 

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -74,7 +74,7 @@ impl QuorumWaiter {
 
     /// Main loop.
     async fn run(&mut self) {
-        // 
+        //
         let mut pipeline = FuturesOrdered::new();
         let mut best_effort_with_timeout = FuturesUnordered::new();
 
@@ -143,7 +143,7 @@ impl QuorumWaiter {
 
                     // Attempt to send messages to the remaining workers
                     best_effort_with_timeout.push(async move {
-                        // Bound the attempt to a few seconds to tolerate nodes that are 
+                        // Bound the attempt to a few seconds to tolerate nodes that are
                         // offline and will never succeed.
                         timeout(Duration::from_secs(5), async move{
                             while remaining.next().await.is_some() { }

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -83,6 +83,8 @@ impl QuorumWaiter {
 
                 // When a new batch is available, and the pipeline is not full, add a new
                 // task to the pipeline to send this batch to workers. 
+                //
+                // TODO: make the constant a config parameter.
                 Some((batch, opt_channel)) = self.rx_message.recv(), if pipeline.len() < 20 => {
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
@@ -145,6 +147,8 @@ impl QuorumWaiter {
                     best_effort_with_timeout.push(async move {
                         // Bound the attempt to a few seconds to tolerate nodes that are
                         // offline and will never succeed.
+                        //
+                        // TODO: make the constant a config parameter.
                         timeout(Duration::from_secs(5), async move{
                             while remaining.next().await.is_some() { }
                         }).await

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -12,6 +12,7 @@ use tokio::{sync::watch, task::JoinHandle, time::timeout};
 use types::{
     metered_channel::Receiver, Batch, BatchDigest, ReconfigureNotification, WorkerBatchMessage,
 };
+use crate::batch_maker::MAX_PARALLEL_BATCH;
 
 #[cfg(test)]
 #[path = "tests/quorum_waiter_tests.rs"]
@@ -82,10 +83,10 @@ impl QuorumWaiter {
             tokio::select! {
 
                 // When a new batch is available, and the pipeline is not full, add a new
-                // task to the pipeline to send this batch to workers. 
+                // task to the pipeline to send this batch to workers.
                 //
                 // TODO: make the constant a config parameter.
-                Some((batch, opt_channel)) = self.rx_message.recv(), if pipeline.len() < 20 => {
+                Some((batch, opt_channel)) = self.rx_message.recv(), if pipeline.len() < MAX_PARALLEL_BATCH => {
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
                         .worker_cache

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -50,7 +50,7 @@ async fn make_batch() {
     // Ensure the batch is as expected.
     let expected_batch = Batch::new(vec![tx.clone(), tx.clone()]);
     let batch = rx_message.recv().await.unwrap();
-    assert_eq!(batch.0, expected_batch);
+    assert_eq!(batch.0.transactions, expected_batch.transactions);
 
     // Eventually deliver message
     if let Some(resp) = batch.1 {

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -63,3 +63,70 @@ async fn wait_for_quorum() {
         assert_eq!(handle.recv().await.unwrap(), message);
     }
 }
+
+#[tokio::test]
+async fn pipeline_for_quorum() {
+    let store = test_utils::open_batch_store();
+    let (tx_message, rx_message) = test_utils::test_channel!(1);
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let committee = fixture.committee();
+    let worker_cache = fixture.shared_worker_cache();
+    let my_primary = fixture.authorities().next().unwrap().public_key();
+    let myself = fixture.authorities().next().unwrap().worker(0);
+
+    let (_tx_reconfiguration, rx_reconfiguration) =
+        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
+
+    // setup network
+    let network = test_network(myself.keypair(), &myself.info().worker_address);
+    // Spawn a `QuorumWaiter` instance.
+    let _quorum_waiter_handler = QuorumWaiter::spawn(
+        my_primary.clone(),
+        /* worker_id */ 0,
+        store.clone(),
+        committee.clone(),
+        worker_cache.clone(),
+        rx_reconfiguration,
+        rx_message,
+        P2pNetwork::new(network.clone()),
+    );
+
+    // Make a batch.
+    let batch = batch();
+    let message = WorkerBatchMessage {
+        batch: batch.clone(),
+    };
+
+    // Spawn enough listeners to acknowledge our batches.
+    let mut listener_handles = Vec::new();
+    for worker in fixture.authorities().skip(1).map(|a| a.worker(0)) {
+        let handle =
+            WorkerToWorkerMockServer::spawn(worker.keypair(), worker.info().worker_address.clone());
+        listener_handles.push(handle);
+
+        // ensure that the networks are connected
+        network
+            .connect(network::multiaddr_to_address(&worker.info().worker_address).unwrap())
+            .await
+            .unwrap();
+    }
+
+    // Forward the batch along with the handlers to the `QuorumWaiter`.
+    let (s0, r0) = tokio::sync::oneshot::channel();
+    tx_message.send((batch.clone(), Some(s0))).await.unwrap();
+
+    // Forward the batch along with the handlers to the `QuorumWaiter`.
+    let (s1, r1) = tokio::sync::oneshot::channel();
+    tx_message.send((batch.clone(), Some(s1))).await.unwrap();
+
+    // Wait for the `QuorumWaiter` to gather enough acknowledgements and output the batch.
+    r0.await.unwrap();
+
+    // Ensure the other listeners correctly received the batch.
+    for (mut handle, _network) in listener_handles {
+        assert_eq!(handle.recv().await.unwrap(), message);
+        assert_eq!(handle.recv().await.unwrap(), message);
+    }
+
+    r1.await.unwrap();
+}


### PR DESCRIPTION
Added logic to the quorum waiter on the Narwhal worker to:
* Try to disseminate a pipeline of batch per worker, rather than a single batch as a time. This means that multiple batches can be in-flight as long as the network does not do anything unexpected.
* After a batch is disseminated to >2/3 nodes wait a bit (but do not block next batch processing) to try to disseminate it also to the other workers not in this initial set. This should help, hopefully, with all live workers getting batches rather than just the initial ones.