### PR TITLE
Use burst mode because we sometime miss the tick causing client side …

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -281,7 +281,7 @@ impl Driver<BenchmarkStats> for BenchDriver {
                     hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
                 let mut request_interval =
                     time::interval(Duration::from_micros(request_delay_micros));
-                request_interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+                request_interval.set_missed_tick_behavior(time::MissedTickBehavior::Burst);
                 let mut stat_interval = time::interval(Duration::from_micros(stat_delay_micros));
                 let mut futures: FuturesUnordered<BoxFuture<NextOp>> = FuturesUnordered::new();
 


### PR DESCRIPTION
…throughtput to drop