### PR TITLE
[Sui/Tests] Removing tokio yields/sleeps

### DIFF
--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -249,12 +249,10 @@ async fn checkpoint_with_shared_objects() {
     spawn_checkpoint_processes(&aggregator, &handles).await;
 
     // Publish the move package to all authorities and get the new package ref.
-    tokio::task::yield_now().await;
     let gas = gas_objects.pop().unwrap();
     let package_ref = publish_counter_package(gas, configs.validator_set()).await;
 
     // Make a transaction to create a counter.
-    tokio::task::yield_now().await;
     let create_counter_transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -274,7 +272,6 @@ async fn checkpoint_with_shared_objects() {
     let ((counter_id, _, _), _) = effects.effects.created[0];
 
     // We can finally make a valid shared-object transaction (incrementing the counter).
-    tokio::task::yield_now().await;
     let increment_counter_transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -35,7 +35,6 @@ async fn shared_object_transaction() {
 
     // Submit the transaction. Note that this transaction is random and we do not expect
     // it to be successfully executed by the Move execution engine.
-    tokio::task::yield_now().await;
     let _effects = submit_shared_object_transaction(transaction, &configs.validator_set()[0..1])
         .await
         .unwrap();
@@ -53,12 +52,10 @@ async fn many_shared_object_transactions() {
     let _handles = spawn_test_authorities(objects, &configs).await;
 
     // Make a test shared object certificate.
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     let transaction = test_shared_object_transactions().pop().unwrap();
 
     // Submit the transaction. Note that this transaction is random and we do not expect
     // it to be successfully executed by the Move execution engine.
-    tokio::task::yield_now().await;
     let _effects = submit_shared_object_transaction(transaction, configs.validator_set())
         .await
         .unwrap();
@@ -74,14 +71,12 @@ async fn call_shared_object_contract() {
     // the handles (or the authorities will stop).
     let configs = test_authority_configs();
     let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
+
     // Publish the move package to all authorities and get the new package ref.
-    tokio::task::yield_now().await;
-    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     let package_ref =
         publish_counter_package(gas_objects.pop().unwrap(), configs.validator_set()).await;
 
     // Make a transaction to create a counter.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -94,7 +89,6 @@ async fn call_shared_object_contract() {
     let ((counter_id, _, _), _) = effects.created[0];
 
     // Ensure the value of the counter is `0`.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -111,7 +105,6 @@ async fn call_shared_object_contract() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
 
     // Make a transaction to increment the counter.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -125,7 +118,6 @@ async fn call_shared_object_contract() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
 
     // Ensure the value of the counter is `1`.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -155,12 +147,10 @@ async fn shared_object_flood() {
     let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
 
     // Publish the move package to all authorities and get the new package ref.
-    tokio::task::yield_now().await;
     let package_ref =
         publish_counter_package(gas_objects.pop().unwrap(), configs.validator_set()).await;
 
     // Make a transaction to create a counter.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -173,7 +163,6 @@ async fn shared_object_flood() {
     let ((counter_id, _, _), _) = effects.created[0];
 
     // Ensure the value of the counter is `0`.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -190,7 +179,6 @@ async fn shared_object_flood() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
 
     // Make a transaction to increment the counter.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -204,7 +192,6 @@ async fn shared_object_flood() {
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
 
     // Ensure the value of the counter is `1`.
-    tokio::task::yield_now().await;
     let transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -231,12 +218,10 @@ async fn shared_object_sync() {
     let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
 
     // Publish the move package to all authorities and get the new package ref.
-    tokio::task::yield_now().await;
     let package_ref =
         publish_counter_package(gas_objects.pop().unwrap(), configs.validator_set()).await;
 
     // Send a transaction to create a counter, but only to one authority.
-    tokio::task::yield_now().await;
     let create_counter_transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -275,7 +260,6 @@ async fn shared_object_sync() {
     }
 
     // Make a transaction to increment the counter.
-    tokio::task::yield_now().await;
     let increment_counter_transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -305,13 +289,11 @@ async fn shared_object_sync() {
 
     // Now send the missing certificates to the outdated authorities. We also re-send
     // the transaction to the first authority who should simply ignore it.
-    tokio::task::yield_now().await;
     let effects =
         submit_single_owner_transaction(create_counter_transaction, configs.validator_set()).await;
     assert!(matches!(effects.status, ExecutionStatus::Success { .. }));
 
     // Now we can try again with the shared-object transaction who failed before.
-    tokio::task::yield_now().await;
     let effects = submit_shared_object_transaction(
         increment_counter_transaction,
         &configs.validator_set()[1..],
@@ -332,12 +314,10 @@ async fn replay_shared_object_transaction() {
     let _handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
 
     // Publish the move package to all authorities and get the new package ref.
-    tokio::task::yield_now().await;
     let package_ref =
         publish_counter_package(gas_objects.pop().unwrap(), configs.validator_set()).await;
 
     // Send a transaction to create a counter (only to one authority) -- twice.
-    tokio::task::yield_now().await;
     let create_counter_transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",
@@ -377,12 +357,10 @@ async fn shared_object_on_gateway() {
     );
 
     // Publish the move package to all authorities and get the new package ref.
-    tokio::task::yield_now().await;
     let package_ref =
         publish_counter_package(gas_objects.pop().unwrap(), configs.validator_set()).await;
 
     // Send a transaction to create a counter.
-    tokio::task::yield_now().await;
     let create_counter_transaction = move_transaction(
         gas_objects.pop().unwrap(),
         "counter",


### PR DESCRIPTION
Removing calls to `yield` and `sleep` in test code which should not be required for correctness, to avoid copypasta issues in future.  There are some more calls to `sleep` in other tests, which I have kept, because they each came with a reason why the test was sleeping.

## Test Plan

Ran both test binaries that were changed 50 times, to try and flush out any difference in flakiness of the tests with and without `sleep`/`yield`, and observed no difference:

```
$ cargo nextest run --no-run -E 'binary(shared_objects_tests)'
$ for i in (seq 50)
    ./target/deps/shared_objects_tests-XXXXXXXX
  end | tee /tmp/output.log
$ # Same for checkpoints_tests
```