### PR TITLE
Sadhan/fix bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -72,8 +72,8 @@ jobs:
     - name: retrieve benchmark results
       id: get-comment-body
       run: |
-        owned="Owned $(cat artifacts/owned.txt | grep -e '|' -e '-' -e 'Bench' -e '+')"
-        shared="Shared $(cat artifacts/shared.txt | grep -e '|' -e '-' -e 'Bench' -e '+')"
+        owned="Benchmark Results(owned tx):\n$(cat artifacts/owned.txt | grep -e '+-----' -e 'tps' -e '+=====' -e '|')"
+        shared="Benchmark Results(shared tx):\n$(cat artifacts/shared.txt | grep -e '+-----' -e 'tps' -e '+=====' -e '|')"
         echo ::set-output name=owned::$owned
         echo ::set-output name=shared::$shared
     - name: Create commit comment

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1883,7 +1883,10 @@ impl AuthorityState {
             .await
             .tap_ok(|_| {
                 debug!(?digest, ?effects_digest, ?self.name, "commit_certificate finished");
-            })
+            })?;
+        // We only notify i.e. update low watermark once database changes are committed
+        notifier_ticket.notify();
+        Ok(())
 
         // implicitly we drop the ticket here and that notifies the batch manager
     }

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -211,12 +211,7 @@ impl TransactionNotifierTicket {
     pub fn seq(&self) -> u64 {
         self.seq
     }
-}
-
-/// A custom drop to notify authority state's transaction_notifier
-/// that a new certified transaction's has just been executed and committed.
-impl Drop for TransactionNotifierTicket {
-    fn drop(&mut self) {
+    pub fn notify(self) {
         let mut inner = self.transaction_notifier.inner.lock();
         inner.live_tickets.remove(&self.seq);
 

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -80,7 +80,7 @@ async fn test_start_epoch_change() {
     assert_eq!(checkpoints.lock().next_transaction_sequence_expected(), 0);
 
     // Drain ticket.
-    drop(ticket);
+    ticket.notify();
     tokio::time::sleep(Duration::from_secs(3)).await;
     // After we drained ticket, epoch change should have started, as it will actively update
     // the newly processed transactions regardless whether batch service has picked up.

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -333,7 +333,7 @@ async fn test_subscription_safe_client() {
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
             .expect("Failed to write.");
-        drop(ticket);
+        ticket.notify();
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     println!("Sent tickets.");


### PR DESCRIPTION
The result parsing isn't great as we pick up a lot of useless data. This PR aims to fix it such that we only filter out the benchmark results from the output