### PR TITLE
git: exclude annotated tags when using git-describe

### DIFF
--- a/crates/sui-rosetta/docker/build.sh
+++ b/crates/sui-rosetta/docker/build.sh
@@ -8,7 +8,7 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DOCKERFILE="$DIR/Dockerfile"
-GIT_REVISION="$(git describe --always --dirty)"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 
 echo

--- a/crates/sui/build.rs
+++ b/crates/sui/build.rs
@@ -7,7 +7,7 @@ use std::{env, process::Command};
 fn main() {
     if env::var("GIT_REVISION").is_err() {
         let output = Command::new("git")
-            .args(["describe", "--always", "--dirty"])
+            .args(["describe", "--always", "--dirty", "--exclude", "*"])
             .output()
             .unwrap();
         if !output.status.success() {

--- a/docker/sui-node/build.sh
+++ b/docker/sui-node/build.sh
@@ -8,7 +8,7 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DOCKERFILE="$DIR/Dockerfile"
-GIT_REVISION="$(git describe --always --dirty)"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 
 # option to build using debug symbols

--- a/docker/sui-tools/build.sh
+++ b/docker/sui-tools/build.sh
@@ -8,7 +8,7 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DOCKERFILE="$DIR/Dockerfile"
-GIT_REVISION="$(git describe --always --dirty)"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 
 echo


### PR DESCRIPTION
This forces the output of git-describe to be "commithash[-dirty]".