### PR TITLE
[Benchmark] Fix qps calculation when only the last worker has traffic

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -189,8 +189,9 @@ impl BenchDriver {
         let mut workers = vec![];
         for i in 0..workload_info.num_workers {
             if i == workload_info.num_workers - 1 {
-                num_requests += workload_info.max_in_flight_ops % workload_info.num_workers;
-                target_qps += workload_info.target_qps % workload_info.num_workers;
+                num_requests =
+                    workload_info.max_in_flight_ops - workers.len() as u64 * num_requests;
+                target_qps = workload_info.target_qps - workers.len() as u64 * target_qps;
             }
             if num_requests > 0 && target_qps > 0 {
                 workers.push(BenchWorker {


### PR DESCRIPTION
When we have `workload_info.max_in_flight_ops = 60`, `workload_info.target_qps = 4` and `workload_info.num_workers = 10`, only 1 worker will be created with 4 target qps and 6 max inflight qps.

The 6 max inflight qps is too small. If each txn takes ~5s to go through, the workload qps will be ~ 1.2 = 6/5. Fix the calculation of max inflight qps here, so the last worker would use max 60 inflight tps instead.

Setting `in_flight_ratio` in `WorkloadInfo` instead of `max_in_flight_ops` would be another approach.