### PR TITLE
Remove `ChildRpcSender`; send child batch request RPCs directly in handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=b145cbcf4a1917197e2b9ee6a1523afdb623dbf2#b145cbcf4a1917197e2b9ee6a1523afdb623dbf2"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=302ff6f98fffa30a3a18e919766cd63f5b4c5aa8#302ff6f98fffa30a3a18e919766cd63f5b4c5aa8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -84,7 +84,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=b145cbcf4a1917197e2b9ee6a1523afdb623dbf2#b145cbcf4a1917197e2b9ee6a1523afdb623dbf2"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=302ff6f98fffa30a3a18e919766cd63f5b4c5aa8#302ff6f98fffa30a3a18e919766cd63f5b4c5aa8"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.43",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=b145cbcf4a1917197e2b9ee6a1523afdb623dbf2#b145cbcf4a1917197e2b9ee6a1523afdb623dbf2"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=302ff6f98fffa30a3a18e919766cd63f5b4c5aa8#302ff6f98fffa30a3a18e919766cd63f5b4c5aa8"
 dependencies = [
  "anemo",
  "bytes",

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -19,8 +19,8 @@ addr2line = { version = "0.17", default-features = false }
 adler = { version = "1", default-features = false }
 ahash = { version = "0.7", features = ["std"] }
 aho-corasick = { version = "0.7", features = ["std"] }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -615,9 +615,9 @@ addr2line = { version = "0.17", default-features = false }
 adler = { version = "1", default-features = false }
 ahash = { version = "0.7", features = ["std"] }
 aho-corasick = { version = "0.7", features = ["std"] }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2", default-features = false }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8", default-features = false }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }

--- a/narwhal/network/Cargo.toml
+++ b/narwhal/network/Cargo.toml
@@ -27,8 +27,8 @@ serde = "1.0.144"
 workspace-hack.workspace = true
 eyre = "0.6.8"
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 anyhow = "1.0.65"
 
 [dev-dependencies]

--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -44,7 +44,7 @@ worker = { path = "../worker", package = "narwhal-worker" }
 workspace-hack.workspace = true
 eyre = "0.6.8"
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -45,8 +45,8 @@ mysten-network.workspace = true
 store.workspace = true
 workspace-hack.workspace = true
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 
 [dev-dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }

--- a/narwhal/test-utils/Cargo.toml
+++ b/narwhal/test-utils/Cargo.toml
@@ -43,5 +43,5 @@ store = { version = "0.1.0", package = "typed-store"}
 workspace-hack.workspace = true
 telemetry-subscribers.workspace = true
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 tower = { version = "0.4.13", features = ["full"] }

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -942,6 +942,14 @@ impl WorkerFixture {
         &self.info
     }
 
+    pub fn new_network(&self, router: anemo::Router) -> anemo::Network {
+        anemo::Network::bind(network::multiaddr_to_address(&self.info().worker_address).unwrap())
+            .server_name("narwhal")
+            .private_key(self.keypair().private().0.to_bytes())
+            .start(router)
+            .unwrap()
+    }
+
     fn generate<R, P>(mut rng: R, id: WorkerId, mut get_port: P) -> Self
     where
         R: rand::RngCore + rand::CryptoRng,

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -36,7 +36,7 @@ config = { path = "../config", package = "narwhal-config" }
 fastcrypto = "0.1.2"
 crypto = { path = "../crypto", package = "narwhal-crypto" }
 dag = { path = "../dag", package = "narwhal-dag" }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 workspace-hack.workspace = true
 
 [dev-dependencies]
@@ -49,7 +49,7 @@ test-utils = { path = "../test-utils", package = "narwhal-test-utils" }
 prost-build = "0.10.4"
 rustversion = "1.0.9"
 tonic-build = { version = "0.7.2", features = [ "prost", "transport" ] }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 
 [features]
 default = []

--- a/narwhal/worker/Cargo.toml
+++ b/narwhal/worker/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = "1.4.3"
 bytes = "1.2.1"
 futures = "0.3.24"
 multiaddr = "0.14.0"
+rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.144", features = ["derive"] }
 tap = "1.0.1"
 tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
@@ -31,8 +32,8 @@ types = { path = "../types", package = "narwhal-types" }
 mysten-network.workspace = true
 prometheus = "0.13.2"
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "302ff6f98fffa30a3a18e919766cd63f5b4c5aa8" }
 anyhow = "1.0.65"
 
 store.workspace = true

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -243,7 +243,6 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
             .collect();
         while let Some(result) = handles.next().await {
             match result {
-                // TODO: is there a not-icky way to dedupe this code w/ above without async closures?
                 Ok(Ok(response)) => {
                     for batch in response.into_body().batches {
                         let digest = &batch.digest();

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -4,159 +4,26 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use config::{SharedWorkerCache, WorkerId};
-use crypto::{NetworkPublicKey, PublicKey};
+use crypto::PublicKey;
 use fastcrypto::Hash;
 use futures::{stream::FuturesUnordered, StreamExt};
-use network::{LuckyNetwork, P2pNetwork, UnreliableNetwork};
+
+use rand::seq::SliceRandom;
 use std::{collections::HashSet, time::Duration};
 use store::Store;
 use tap::TapFallible;
-use tokio::{
-    sync::{oneshot, watch},
-    task::JoinHandle,
-    time::{self, Timeout},
-};
+use tokio::time::{self};
 use tracing::{debug, error, info, trace};
 use types::{
-    error::DagError,
-    metered_channel::{Receiver, Sender},
-    Batch, BatchDigest, PrimaryToWorker, PrimaryWorkerMessage, ReconfigureNotification,
-    RequestBatchRequest, RequestBatchResponse, WorkerBatchRequest, WorkerBatchResponse,
-    WorkerMessage, WorkerPrimaryMessage, WorkerSynchronizeMessage, WorkerToWorker,
+    error::DagError, metered_channel::Sender, Batch, BatchDigest, PrimaryToWorker,
+    PrimaryWorkerMessage, RequestBatchRequest, RequestBatchResponse, WorkerBatchRequest,
+    WorkerBatchResponse, WorkerMessage, WorkerPrimaryMessage, WorkerSynchronizeMessage,
+    WorkerToWorker, WorkerToWorkerClient,
 };
 
 #[cfg(test)]
 #[path = "tests/handlers_tests.rs"]
 pub mod handlers_tests;
-
-// Makes it possible via channels for anemo RPC handler functions to send child RPCs.
-// TODO: replace this once anemo adds support for access to the network within handlers.
-pub struct ChildRpcSender {
-    // The public key of this authority.
-    name: PublicKey,
-    // The id of this worker.
-    id: WorkerId,
-    // The worker information cache.
-    worker_cache: SharedWorkerCache,
-    // Timeout on RequestBatches RPC.
-    request_batches_timeout: Duration,
-    // Incoming RequestBatches requests to be sent out. Uses `unreliable_send` if a target is
-    // provided, or `lucky_broadcast` if a target node count is provided.
-    rx_request_batches_rpc: Receiver<(
-        Option<NetworkPublicKey>,
-        Option<usize>,
-        WorkerBatchRequest,
-        oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
-    )>,
-    /// Receive reconfiguration updates.
-    rx_reconfigure: watch::Receiver<ReconfigureNotification>,
-    // Network to use for sending requests.
-    network: P2pNetwork,
-}
-
-impl ChildRpcSender {
-    #[must_use]
-    pub fn spawn(
-        name: PublicKey,
-        id: WorkerId,
-        worker_cache: SharedWorkerCache,
-        request_batches_timeout: Duration,
-        rx_request_batches_rpc: Receiver<(
-            Option<NetworkPublicKey>,
-            Option<usize>,
-            WorkerBatchRequest,
-            oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
-        )>,
-        rx_reconfigure: watch::Receiver<ReconfigureNotification>,
-        network: P2pNetwork,
-    ) -> JoinHandle<()> {
-        tokio::spawn(async move {
-            Self {
-                name,
-                id,
-                worker_cache,
-                request_batches_timeout,
-                rx_request_batches_rpc,
-                rx_reconfigure,
-                network,
-            }
-            .run()
-            .await;
-        })
-    }
-
-    async fn handle_worker_batch_responses(
-        responses: Vec<Timeout<JoinHandle<Result<anemo::Response<WorkerBatchResponse>>>>>,
-        response_channel: oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
-    ) {
-        let mut results: FuturesUnordered<_> = responses.into_iter().collect();
-        let mut last_result: Result<anemo::Response<WorkerBatchResponse>> = Err(anyhow::anyhow!(
-            "no WorkerBatchResponse received (or request(s) timed out)"
-        ));
-        while let Some(result) = results.next().await {
-            match result {
-                Ok(Ok(Ok(result))) => {
-                    let _ = response_channel.send(Ok(result));
-                    return;
-                }
-                Ok(Ok(Err(e))) => last_result = Err(e),
-                _ => (),
-            }
-        }
-        let _ = response_channel.send(last_result);
-    }
-
-    async fn run(&mut self) {
-        let mut inflight_requests = FuturesUnordered::new();
-        loop {
-            tokio::select! {
-                Some((target, num_nodes, request, response_channel)) = self.rx_request_batches_rpc.recv() => {
-                    if target.is_some() && num_nodes.is_some() {
-                        panic!("cannot set both target and num_nodes");
-                    }
-                    if let Some(target) = target {
-                        match self.network.unreliable_send(target, &request) {
-                            Ok(handle) => {
-                                inflight_requests.push(Self::handle_worker_batch_responses(
-                                    vec![time::timeout(self.request_batches_timeout, handle)], response_channel))
-                            },
-                            Err(e) => {
-                                let _ = response_channel.send(Err(e));
-                            },
-                        }
-                    } else if let Some(num_nodes) = num_nodes {
-                        let names = self.worker_cache.load()
-                            .others_workers(&self.name, &self.id)
-                            .into_iter()
-                            .map(|(_, info)| info.name)
-                            .collect();
-                        let handles: Vec<_> = self.network.lucky_broadcast(names, &request, num_nodes)
-                            .into_iter()
-                            .flatten()
-                            .map(|handle| time::timeout(self.request_batches_timeout, handle))
-                            .collect();
-                        if handles.is_empty() {
-                            let _ = response_channel.send(
-                                Err(anyhow::anyhow!("could not lucky_broadcast WorkerBatchRequest to any node")));
-                        } else {
-                            inflight_requests.push(Self::handle_worker_batch_responses(handles, response_channel));
-                        };
-                    } else {
-                        panic!("one of target or num_nodes must be set");
-                    }
-                },
-                result = self.rx_reconfigure.changed() => {
-                    result.expect("Committee channel dropped");
-                    if let ReconfigureNotification::Shutdown = self.rx_reconfigure.borrow().clone() {
-                        return
-                    }
-                },
-                Some(_) = inflight_requests.next() => {},
-                else => { break }
-            }
-        }
-    }
-}
 
 /// Defines how the network receiver handles incoming workers messages.
 #[derive(Clone)]
@@ -204,20 +71,18 @@ impl WorkerToWorker for WorkerReceiverHandler {
 /// Defines how the network receiver handles incoming primary messages.
 #[derive(Clone)]
 pub struct PrimaryReceiverHandler {
+    // The public key of this authority.
+    pub name: PublicKey,
+    // The id of this worker.
     pub id: WorkerId,
     // The worker information cache.
     pub worker_cache: SharedWorkerCache,
     pub store: Store<BatchDigest, Batch>,
+    // Timeout on RequestBatches RPC.
+    pub request_batches_timeout: Duration,
     // Number of random nodes to query when retrying batch requests.
     pub request_batches_retry_nodes: usize,
     pub tx_synchronizer: Sender<PrimaryWorkerMessage>,
-    // Output channel to send child worker batch requests.
-    pub tx_request_batches_rpc: Sender<(
-        Option<NetworkPublicKey>,
-        Option<usize>,
-        WorkerBatchRequest,
-        oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
-    )>,
     // Output channel to send messages to primary.
     pub tx_primary: Sender<WorkerPrimaryMessage>,
     // Output channel to process received batches.
@@ -244,7 +109,7 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
         &self,
         request: anemo::Request<WorkerSynchronizeMessage>,
     ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
-        let message = request.into_body();
+        let message = request.body();
 
         let mut missing = HashSet::new();
         let mut available = HashSet::new();
@@ -296,40 +161,52 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
                 )));
             }
         };
-
-        debug!(
-            "Sending WorkerBatchRequest message to {} for missing batches {:?}",
-            worker_name,
-            missing.clone()
-        );
-
-        // TODO: restore a metric tracking number of batches with inflight requests?
-        let (tx_batch_response, rx_batch_response) = oneshot::channel();
         let message = WorkerBatchRequest {
             digests: missing.iter().cloned().collect(),
         };
-        self.tx_request_batches_rpc
-            .send((Some(worker_name.clone()), None, message, tx_batch_response))
+        debug!(
+            "Sending WorkerBatchRequest message to {worker_name} for missing batches {:?}",
+            message.digests
+        );
+
+        let network = request
+            .extensions()
+            .get::<anemo::NetworkRef>()
+            .unwrap()
+            .upgrade()
+            .ok_or_else(|| {
+                anemo::rpc::Status::internal("Unable to access network to send child RPCs")
+            })?;
+        let peer_id = anemo::PeerId(worker_name.0.to_bytes());
+        if let Some(peer) = network.peer(peer_id) {
+            match time::timeout(
+                self.request_batches_timeout,
+                WorkerToWorkerClient::new(peer).request_batches(message),
+            )
             .await
-            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
-        let response = rx_batch_response
-            .await
-            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
-        if let Ok(response) = response {
-            for batch in response.into_body().batches {
-                let digest = &batch.digest();
-                if missing.remove(digest) {
-                    // Only send batch to processor if we haven't received it already
-                    // from another source.
-                    if self.tx_batch_processor.send(batch).await.is_err() {
-                        // Assume error sending to processor means we're shutting down.
-                        return Err(anemo::rpc::Status::internal("shutting down"));
+            {
+                Ok(Ok(response)) => {
+                    for batch in response.into_body().batches {
+                        let digest = &batch.digest();
+                        if missing.remove(digest) {
+                            // Only send batch to processor if we haven't received it already
+                            // from another source.
+                            if self.tx_batch_processor.send(batch).await.is_err() {
+                                // Assume error sending to processor means we're shutting down.
+                                return Err(anemo::rpc::Status::internal("shutting down"));
+                            }
+                        }
                     }
+                }
+                Ok(Err(e)) => {
+                    info!("WorkerBatchRequest to first target {worker_name} failed: {e:?}");
+                }
+                Err(_) => {
+                    debug!("WorkerBatchRequest to first target {worker_name} timed out");
                 }
             }
         } else {
-            let e = response.err().unwrap();
-            info!("WorkerBatchRequest to first target {worker_name} failed: {e}");
+            info!("Unable to reach primary peer {worker_name} on the network");
         }
 
         if missing.is_empty() {
@@ -340,39 +217,59 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
         // If first request timed out or was missing batches, try broadcasting to some others.
         // TODO: refactor this to retry forever unless RPC is canceled. This will require more
         // invasive changes to primary code and cancellation propagation support in anemo.
-        let (tx_batch_response, rx_batch_response) = oneshot::channel();
         let message = WorkerBatchRequest {
             digests: missing.iter().cloned().collect(),
         };
-        self.tx_request_batches_rpc
-            .send((
-                None,
-                Some(self.request_batches_retry_nodes),
-                message,
-                tx_batch_response,
-            ))
-            .await
-            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
-        let response = rx_batch_response
-            .await
-            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
-        if let Ok(response) = response {
-            for batch in response.into_body().batches {
-                if missing.remove(&batch.digest()) {
-                    // Only send batch to processor if we haven't received it already
-                    // from another source.
-                    if self.tx_batch_processor.send(batch).await.is_err() {
-                        // Assume error sending to processor means we're shutting down.
-                        return Err(anemo::rpc::Status::internal("shutting down"));
+        let names: Vec<_> = self
+            .worker_cache
+            .load()
+            .others_workers(&self.name, &self.id)
+            .into_iter()
+            .map(|(_, info)| info.name)
+            .collect();
+        let mut clients: Vec<_> = names
+            .choose_multiple(&mut rand::thread_rng(), self.request_batches_retry_nodes)
+            .filter_map(|name| network.peer(anemo::PeerId(name.0.to_bytes())))
+            .map(WorkerToWorkerClient::new)
+            .collect();
+        let mut handles: FuturesUnordered<_> = clients
+            .iter_mut()
+            .map(|client| {
+                time::timeout(
+                    self.request_batches_timeout,
+                    client.request_batches(message.clone()),
+                )
+            })
+            .collect();
+        while let Some(result) = handles.next().await {
+            match result {
+                // TODO: is there a not-icky way to dedupe this code w/ above without async closures?
+                Ok(Ok(response)) => {
+                    for batch in response.into_body().batches {
+                        let digest = &batch.digest();
+                        if missing.remove(digest) {
+                            // Only send batch to processor if we haven't received it already
+                            // from another source.
+                            if self.tx_batch_processor.send(batch).await.is_err() {
+                                // Assume error sending to processor means we're shutting down.
+                                return Err(anemo::rpc::Status::internal("shutting down"));
+                            }
+                        }
                     }
                 }
+                Ok(Err(e)) => {
+                    info!("WorkerBatchRequest to first target {worker_name} failed: {e:?}");
+                }
+                Err(_) => {
+                    debug!("WorkerBatchRequest to first target {worker_name} timed out");
+                }
+            }
+            if missing.is_empty() {
+                // If nothing remains to fetch, we're done.
+                return Ok(anemo::Response::new(()));
             }
         }
 
-        if missing.is_empty() {
-            // If nothing remains to fetch, we're done.
-            return Ok(anemo::Response::new(()));
-        }
         Err(anemo::rpc::Status::unknown(format!(
             "Unable to retrieve batches after retry: {missing:?}"
         )))

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use fastcrypto::Hash;
 use test_utils::CommitteeFixture;
+use types::WorkerToWorkerServer;
 
 #[tokio::test]
 async fn synchronize() {
@@ -11,31 +12,30 @@ async fn synchronize() {
 
     let (tx_synchronizer, _rx_synchronizer) = test_utils::test_channel!(1);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(1);
-    let (tx_request_batches_rpc, mut rx_request_batches_rpc) = test_utils::test_channel!(1);
     let (tx_batch_processor, mut rx_batch_processor) = test_utils::test_channel!(1);
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let worker_cache = fixture.shared_worker_cache();
+    let name = fixture.authorities().next().unwrap().public_key();
     let id = 0;
 
     // Create a new test store.
     let store = test_utils::open_batch_store();
 
     let handler = PrimaryReceiverHandler {
+        name,
         id,
         worker_cache,
         store,
+        request_batches_timeout: Duration::from_secs(999),
         request_batches_retry_nodes: 3, // Not used in this test.
         tx_synchronizer,
-        tx_request_batches_rpc,
         tx_primary,
         tx_batch_processor,
     };
 
     // Set up mock behavior for child RequestBatches RPC.
     let target_primary = fixture.authorities().nth(1).unwrap();
-    let target_worker = target_primary.worker(id);
-    let target_worker_network_key = target_worker.info().name.clone();
     let target = target_primary.public_key();
     let batch = test_utils::batch();
     let missing = vec![batch.digest()];
@@ -43,33 +43,55 @@ async fn synchronize() {
         digests: missing.clone(),
         target,
     };
-    let responder_handle = tokio::spawn(async move {
-        let (target, num_nodes, request, response_channel) =
-            rx_request_batches_rpc.recv().await.unwrap();
-        assert_eq!(target.unwrap(), target_worker_network_key);
-        assert!(num_nodes.is_none());
-        assert_eq!(request, WorkerBatchRequest { digests: missing });
 
-        // Reply with batch.
-        assert!(response_channel
-            .send(Ok(anemo::Response::new(WorkerBatchResponse {
-                batches: vec![batch.clone()]
-            })))
-            .is_ok());
+    struct MockWorkerToWorker {
+        expected_request: WorkerBatchRequest,
+        response: WorkerBatchResponse,
+    }
+    #[async_trait]
+    impl WorkerToWorker for MockWorkerToWorker {
+        async fn send_message(
+            &self,
+            _request: anemo::Request<WorkerMessage>,
+        ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
+            unimplemented!();
+        }
+        async fn request_batches(
+            &self,
+            request: anemo::Request<WorkerBatchRequest>,
+        ) -> Result<anemo::Response<WorkerBatchResponse>, anemo::rpc::Status> {
+            assert_eq!(*request.body(), self.expected_request);
+            Ok(anemo::Response::new(self.response.clone()))
+        }
+    }
 
-        // Ensure the handler sends the returned batch to the processor.
-        let recv_batch = rx_batch_processor.recv().await.unwrap();
-        let recv_digest = &recv_batch.digest();
-        debug!("Received batch {recv_digest:?} from handler for processing");
-        assert_eq!(recv_batch, batch);
-    });
+    let routes =
+        anemo::Router::new().add_rpc_service(WorkerToWorkerServer::new(MockWorkerToWorker {
+            expected_request: WorkerBatchRequest { digests: missing },
+            response: WorkerBatchResponse {
+                batches: vec![batch.clone()],
+            },
+        }));
+    let target_worker = target_primary.worker(id);
+    let _recv_network = target_worker.new_network(routes);
 
     // Send a sync request.
-    handler
-        .synchronize(anemo::Request::new(message))
+    let mut request = anemo::Request::new(message);
+    let send_network = test_utils::random_network();
+    send_network
+        .connect_with_peer_id(
+            network::multiaddr_to_address(&target_worker.info().worker_address).unwrap(),
+            anemo::PeerId(target_worker.info().name.0.to_bytes()),
+        )
         .await
         .unwrap();
-    responder_handle.await.unwrap();
+    assert!(request
+        .extensions_mut()
+        .insert(send_network.downgrade())
+        .is_none());
+    handler.synchronize(request).await.unwrap();
+    let recv_batch = rx_batch_processor.recv().await.unwrap();
+    assert_eq!(recv_batch, batch);
 }
 
 #[tokio::test]
@@ -78,23 +100,24 @@ async fn synchronize_when_batch_exists() {
 
     let (tx_synchronizer, _rx_synchronizer) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
-    let (tx_request_batches_rpc, _rx_request_batches_rpc) = test_utils::test_channel!(1);
     let (tx_batch_processor, _rx_batch_processor) = test_utils::test_channel!(1);
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let worker_cache = fixture.shared_worker_cache();
+    let name = fixture.authorities().next().unwrap().public_key();
     let id = 0;
 
     // Create a new test store.
     let store = test_utils::open_batch_store();
 
     let handler = PrimaryReceiverHandler {
+        name,
         id,
         worker_cache,
         store: store.clone(),
+        request_batches_timeout: Duration::from_secs(999),
         request_batches_retry_nodes: 3, // Not used in this test.
         tx_synchronizer,
-        tx_request_batches_rpc,
         tx_primary,
         tx_batch_processor,
     };
@@ -124,6 +147,7 @@ async fn synchronize_when_batch_exists() {
     });
 
     // Send a sync request.
+    // Don't bother to inject a fake network because handler shouldn't need it.
     handler
         .synchronize(anemo::Request::new(message))
         .await


### PR DESCRIPTION
Upgrades anemo to new rev with this feature.