### PR TITLE
[explorer] Introduce more base UI components

### DIFF
--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import ButtonOrLink from './utils/ButtonOrLink';
+
+const buttonStyles = cva(
+    [
+        'inline-flex items-center justify-center',
+        // TODO: Remove when CSS reset is applied.
+        'cursor-pointer font-sans no-underline',
+    ],
+    {
+        variants: {
+            variant: {
+                primary:
+                    'bg-sui-dark text-sui-light hover:text-white border-none',
+                secondary:
+                    'bg-sui-grey-90 text-sui-grey-50 hover:text-white border-none',
+                outline:
+                    'bg-white border border-solid border-sui-grey-55 text-sui-grey-70 hover:text-sui-grey-90 hover:border-sui-grey-65 active:text-sui-grey-100 active:border-sui-grey-75',
+            },
+            size: {
+                md: 'px-3 py-2 rounded-md text-bodySmall font-semibold',
+                lg: 'px-4 py-3 rounded-lg text-body font-semibold',
+            },
+        },
+        defaultVariants: {
+            variant: 'primary',
+            size: 'md',
+        },
+    }
+);
+
+export interface ButtonProps extends VariantProps<typeof buttonStyles> {}
+
+export function Button({ variant, size, ...props }: ButtonProps) {
+    return (
+        <ButtonOrLink className={buttonStyles({ variant, size })} {...props} />
+    );
+}

--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -3,7 +3,7 @@
 
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import ButtonOrLink from './utils/ButtonOrLink';
+import ButtonOrLink, { type ButtonOrLinkProps } from './utils/ButtonOrLink';
 
 const buttonStyles = cva(
     [
@@ -33,7 +33,9 @@ const buttonStyles = cva(
     }
 );
 
-export interface ButtonProps extends VariantProps<typeof buttonStyles> {}
+export interface ButtonProps
+    extends VariantProps<typeof buttonStyles>,
+        ButtonOrLinkProps {}
 
 export function Button({ variant, size, ...props }: ButtonProps) {
     return (

--- a/apps/explorer/src/ui/Card.tsx
+++ b/apps/explorer/src/ui/Card.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { type ReactNode } from 'react';
+
+const cardStyles = cva('bg-sui-grey-40', {
+    variants: {
+        spacing: {
+            sm: 'px-5 py-4 rounded-lg',
+            md: 'p-5 rounded-xl',
+            lg: 'p-8 rounded-xl',
+        },
+    },
+    defaultVariants: {
+        spacing: 'md',
+    },
+});
+
+export interface CardProps extends VariantProps<typeof cardStyles> {
+    children: ReactNode;
+}
+
+export function Card({ spacing, children }: CardProps) {
+    return <div className={cardStyles({ spacing })}>{children}</div>;
+}

--- a/apps/explorer/src/ui/VerticalList.tsx
+++ b/apps/explorer/src/ui/VerticalList.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import clsx from 'clsx';
+import { type ReactNode } from 'react';
+
+export interface ListItemProps {
+    active?: boolean;
+    children: ReactNode;
+    onClick?(): void;
+}
+
+export function ListItem({ active, children, onClick }: ListItemProps) {
+    return (
+        <li className="list-none">
+            <button
+                type="button"
+                className={clsx(
+                    'cursor-pointer px-3 py-2 rounded-md text-body block w-full font-sans border-1 border-solid text-left',
+                    active
+                        ? 'bg-sui-grey-45 text-sui-grey-90 font-semibold border-sui-grey-50 shadow-sm'
+                        : 'bg-white text-sui-grey-80 font-medium border-transparent'
+                )}
+                onClick={onClick}
+            >
+                {children}
+            </button>
+        </li>
+    );
+}
+
+export interface VerticalListProps {
+    children: ReactNode;
+}
+
+export function VerticalList({ children }: VerticalListProps) {
+    return <ul className="flex flex-col p-0 m-0 gap-1">{children}</ul>;
+}

--- a/apps/explorer/src/ui/stories/Button.stories.tsx
+++ b/apps/explorer/src/ui/stories/Button.stories.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ComponentStory, type ComponentMeta } from '@storybook/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { Button } from '../Button';
+
+export default {
+    title: 'UI/Button',
+    component: Button,
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        ),
+    ],
+} as ComponentMeta<typeof Button>;
+
+const Template: ComponentStory<typeof Button> = (args) => (
+    <div className="flex flex-col items-start gap-2">
+        <Button to="/relative" {...args}>
+            Router Link
+        </Button>
+        <Button to="/relative" size="lg" {...args}>
+            Large Router Link
+        </Button>
+        <Button href="https://google.com" {...args}>
+            External Link
+        </Button>
+        <Button href="https://google.com" size="lg" {...args}>
+            Large External Link
+        </Button>
+        <Button onClick={() => alert('on click')} {...args}>
+            Button
+        </Button>
+        <Button onClick={() => alert('on click')} size="lg" {...args}>
+            Large Button
+        </Button>
+    </div>
+);
+
+export const Primary = Template.bind({});
+Primary.args = { variant: 'primary' };
+
+export const Secondary = Template.bind({});
+Secondary.args = { variant: 'secondary' };
+
+export const Outline = Template.bind({});
+Outline.args = { variant: 'outline' };

--- a/apps/explorer/src/ui/stories/Card.stories.tsx
+++ b/apps/explorer/src/ui/stories/Card.stories.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ComponentStory, type ComponentMeta } from '@storybook/react';
+
+import { Card } from '../Card';
+
+export default {
+    title: 'UI/Card',
+    component: Card,
+} as ComponentMeta<typeof Card>;
+
+const Template: ComponentStory<typeof Card> = (args) => (
+    <Card {...args}>This is card content.</Card>
+);
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Small = Template.bind({});
+Small.args = { spacing: 'sm' };
+
+export const Large = Template.bind({});
+Large.args = { spacing: 'lg' };

--- a/apps/explorer/src/ui/stories/VerticalList.stories.tsx
+++ b/apps/explorer/src/ui/stories/VerticalList.stories.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ComponentStory, type ComponentMeta } from '@storybook/react';
+
+import { ListItem, VerticalList } from '../VerticalList';
+
+export default {
+    title: 'UI/VerticalList',
+    component: VerticalList,
+} as ComponentMeta<typeof VerticalList>;
+
+const Template: ComponentStory<typeof VerticalList> = (args) => (
+    <VerticalList {...args}>
+        <ListItem>One</ListItem>
+        <ListItem active>Two</ListItem>
+        <ListItem>Three</ListItem>
+        <ListItem>Four</ListItem>
+    </VerticalList>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/apps/explorer/src/ui/utils/ButtonOrLink.tsx
+++ b/apps/explorer/src/ui/utils/ButtonOrLink.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ComponentProps, forwardRef } from 'react';
+import { Link, type LinkProps } from 'react-router-dom';
+
+export interface ButtonOrLinkProps
+    extends Omit<
+        Partial<LinkProps> & ComponentProps<'a'> & ComponentProps<'button'>,
+        'ref'
+    > {}
+
+export default forwardRef<
+    HTMLAnchorElement | HTMLButtonElement,
+    ButtonOrLinkProps
+>(({ href, to, ...props }, ref: any) => {
+    // External link:
+    if (href) {
+        return (
+            // eslint-disable-next-line jsx-a11y/anchor-has-content
+            <a
+                ref={ref}
+                target="_blank"
+                rel="noreferrer noopener"
+                href={href}
+                {...props}
+            />
+        );
+    }
+
+    // Internal router link:
+    if (to) {
+        return <Link to={to} ref={ref} {...props} />;
+    }
+
+    // NOTE: We set the default type to be "button" to avoid accidentally submitting forms.
+    return <button {...props} type={props.type || 'button'} ref={ref} />;
+});


### PR DESCRIPTION
This introduces the `Button`, `Card`, and `VerticalList` components, based on the figma designs, which will be needed in the upcoming package interaction work.

Some screenshots. For more comprehensive examples, run `pnpm explorer storybook` locally:
<img width="413" alt="Screen Shot 2022-10-03 at 7 27 41 PM" src="https://user-images.githubusercontent.com/109986297/193721451-ad41f04c-0bdd-4935-aa20-de2f130432a7.png">
<img width="406" alt="Screen Shot 2022-10-03 at 7 27 31 PM" src="https://user-images.githubusercontent.com/109986297/193721455-8b895ead-ed41-40cb-ae94-4db1adcf8129.png">
<img width="400" alt="Screen Shot 2022-10-03 at 7 27 45 PM" src="https://user-images.githubusercontent.com/109986297/193721447-995baa41-1b36-4269-a851-510459878ed4.png">
