### PR TITLE
[Narwal] Added metric to report total use of channel

### DIFF
--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -89,6 +89,50 @@ pub struct PrimaryChannelMetrics {
     pub tx_committed_certificates: IntGauge,
     /// occupancy of the channel from the `primary::Core` to the `Consensus`
     pub tx_new_certificates: IntGauge,
+
+    // totals
+    /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::PayloadReceiver`
+    pub tx_others_digests_total: IntGauge,
+    /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::Proposer`
+    pub tx_our_digests_total: IntGauge,
+    /// total received on channel from the `primary::Core` to the `primary::Proposer`
+    pub tx_parents_total: IntGauge,
+    /// total received on channel from the `primary::Proposer` to the `primary::Core`
+    pub tx_headers_total: IntGauge,
+    /// total received on channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`
+    pub tx_sync_headers_total: IntGauge,
+    /// total received on channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`
+    pub tx_sync_certificates_total: IntGauge,
+    /// total received on channel from the `primary::HeaderWaiter` to the `primary::Core`
+    pub tx_headers_loopback_total: IntGauge,
+    /// total received on channel from the `primary::CertificateWaiter` to the `primary::Core`
+    pub tx_certificates_loopback_total: IntGauge,
+    /// total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Core`
+    pub tx_primary_messages_total: IntGauge,
+    /// total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Helper`
+    pub tx_helper_requests_total: IntGauge,
+    /// total received on channel from the `primary::ConsensusAPIGrpc` (when external consensus is being
+    /// used) & `executor::Subscriber` (when internal consensus, ex Bullshark, is being used)  to
+    /// the `primary::BlockWaiter`.
+    pub tx_get_block_commands_total: IntGauge,
+    /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockWaiter`
+    pub tx_batches_total: IntGauge,
+    /// total received on channel from the `primary::ConsensusAPIGrpc` to the `primary::BlockRemover`
+    pub tx_block_removal_commands_total: IntGauge,
+    /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockRemover`
+    pub tx_batch_removal_total: IntGauge,
+    /// total received on channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`
+    pub tx_block_synchronizer_commands_total: IntGauge,
+    /// total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`
+    pub tx_availability_responses_total: IntGauge,
+    /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::StateHandler`
+    pub tx_state_handler_total: IntGauge,
+    /// total received on channel from the reconfigure notification to most components.
+    pub tx_reconfigure_total: IntGauge,
+    /// total received on channel from the `Consensus` to the `primary::Core`
+    pub tx_committed_certificates_total: IntGauge,
+    /// total received on channel from the `primary::Core` to the `Consensus`
+    pub tx_new_certificates_total: IntGauge,
 }
 
 impl PrimaryChannelMetrics {
@@ -107,6 +151,22 @@ impl PrimaryChannelMetrics {
     pub const NAME_GET_BLOCK_COMMANDS: &'static str = "tx_get_block_commands";
     pub const DESC_GET_BLOCK_COMMANDS: &'static str =
         "occupancy of the channel from the `primary::ConsensusAPIGrpc` & `executor::Subscriber` to the `primary::BlockWaiter`";
+
+    // The consistent use of this constant in the below, as well as in `node::spawn_primary` is
+    // load-bearing, see `replace_registered_committed_certificates_metric`.
+    pub const NAME_COMMITTED_CERTS_TOTAL: &'static str = "tx_committed_certificates_total";
+    pub const DESC_COMMITTED_CERTS_TOTAL: &'static str =
+        "total received on channel from the `Consensus` to the `primary::Core`";
+    // The consistent use of this constant in the below, as well as in `node::spawn_primary` is
+    // load-bearing, see `replace_registered_new_certificates_metric`.
+    pub const NAME_NEW_CERTS_TOTAL: &'static str = "tx_new_certificates_total";
+    pub const DESC_NEW_CERTS_TOTAL: &'static str =
+        "total received on channel from the `primary::Core` to the `Consensus`";
+    // The consistent use of this constant in the below, as well as in `node::spawn_primary` is
+    // load-bearing, see `replace_registered_tx_get_block_commands_metric`.
+    pub const NAME_GET_BLOCK_COMMANDS_TOTAL: &'static str = "tx_get_block_commands_total";
+    pub const DESC_GET_BLOCK_COMMANDS_TOTAL: &'static str =
+        "total received on channel from the `primary::ConsensusAPIGrpc` & `executor::Subscriber` to the `primary::BlockWaiter`";
 
     pub fn new(registry: &Registry) -> Self {
         Self {
@@ -210,6 +270,112 @@ impl PrimaryChannelMetrics {
                 Self::DESC_NEW_CERTS,
                 registry
             ).unwrap(),
+
+            // totals 
+
+            tx_others_digests_total: register_int_gauge_with_registry!(
+                "tx_others_digests_total",
+                "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::PayloadReceiver`",
+                registry
+            ).unwrap(),
+            tx_our_digests_total: register_int_gauge_with_registry!(
+                "tx_our_digests_total",
+                "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::Proposer`",
+                registry
+            ).unwrap(),
+            tx_parents_total: register_int_gauge_with_registry!(
+                "tx_parents_total",
+                "total received on channel from the `primary::Core` to the `primary::Proposer`",
+                registry
+            ).unwrap(),
+            tx_headers_total: register_int_gauge_with_registry!(
+                "tx_headers_total",
+                "total received on channel from the `primary::Proposer` to the `primary::Core`",
+                registry
+            ).unwrap(),
+            tx_sync_headers_total: register_int_gauge_with_registry!(
+                "tx_sync_headers_total",
+                "total received on channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`",
+                registry
+            ).unwrap(),
+            tx_sync_certificates_total: register_int_gauge_with_registry!(
+                "tx_sync_certificates_total",
+                "total received on channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`",
+                registry
+            ).unwrap(),
+            tx_headers_loopback_total: register_int_gauge_with_registry!(
+                "tx_headers_loopback_total",
+                "total received on channel from the `primary::HeaderWaiter` to the `primary::Core`",
+                registry
+            ).unwrap(),
+            tx_certificates_loopback_total: register_int_gauge_with_registry!(
+                "tx_certificates_loopback_total",
+                "total received on channel from the `primary::CertificateWaiter` to the `primary::Core`",
+                registry
+            ).unwrap(),
+            tx_primary_messages_total: register_int_gauge_with_registry!(
+                "tx_primary_messages_total",
+                "total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Core`",
+                registry
+            ).unwrap(),
+            tx_helper_requests_total: register_int_gauge_with_registry!(
+                "tx_helper_requests_total",
+                "total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Helper`",
+                registry
+            ).unwrap(),
+            tx_get_block_commands_total: register_int_gauge_with_registry!(
+                "tx_get_block_commands_total",
+                "total received on channel from the `primary::ConsensusAPIGrpc` & `executor::Subscriber` to the `primary::BlockWaiter`",
+                registry
+            ).unwrap(),
+            tx_batches_total: register_int_gauge_with_registry!(
+                "tx_batches_total",
+                "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockWaiter`",
+                registry
+            ).unwrap(),
+            tx_block_removal_commands_total: register_int_gauge_with_registry!(
+                "tx_block_removal_commands_total",
+                "total received on channel from the `primary::ConsensusAPIGrpc` to the `primary::BlockRemover`",
+                registry
+            ).unwrap(),
+            tx_batch_removal_total: register_int_gauge_with_registry!(
+                "tx_batch_removal_total",
+                "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockRemover`",
+                registry
+            ).unwrap(),
+            tx_block_synchronizer_commands_total: register_int_gauge_with_registry!(
+                "tx_block_synchronizer_commands_total",
+                "total received on channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`",
+                registry
+            ).unwrap(),
+            tx_availability_responses_total: register_int_gauge_with_registry!(
+                "tx_availability_responses_total",
+                "total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`",
+                registry
+            ).unwrap(),
+            tx_state_handler_total: register_int_gauge_with_registry!(
+                "tx_state_handler_total",
+                "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::StateHandler`",
+                registry
+            ).unwrap(),
+            tx_reconfigure_total: register_int_gauge_with_registry!(
+                "tx_reconfigure_total",
+                "total received on channel from the reconfigure notification to most components.",
+                registry
+            ).unwrap(),
+            tx_committed_certificates_total: register_int_gauge_with_registry!(
+                Self::NAME_COMMITTED_CERTS_TOTAL,
+                Self::DESC_COMMITTED_CERTS_TOTAL,
+                registry
+            ).unwrap(),
+            tx_new_certificates_total: register_int_gauge_with_registry!(
+                Self::NAME_NEW_CERTS_TOTAL,
+                Self::DESC_NEW_CERTS_TOTAL,
+                registry
+            ).unwrap(),
+
+
+
         }
     }
 

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -6,8 +6,9 @@ use network::metrics::NetworkMetrics;
 use prometheus::{
     core::{AtomicI64, GenericGauge},
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, HistogramVec,
-    IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Registry,
 };
 use std::time::Duration;
 use tonic::Code;
@@ -92,47 +93,47 @@ pub struct PrimaryChannelMetrics {
 
     // totals
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::PayloadReceiver`
-    pub tx_others_digests_total: IntGauge,
+    pub tx_others_digests_total: IntCounter,
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::Proposer`
-    pub tx_our_digests_total: IntGauge,
+    pub tx_our_digests_total: IntCounter,
     /// total received on channel from the `primary::Core` to the `primary::Proposer`
-    pub tx_parents_total: IntGauge,
+    pub tx_parents_total: IntCounter,
     /// total received on channel from the `primary::Proposer` to the `primary::Core`
-    pub tx_headers_total: IntGauge,
+    pub tx_headers_total: IntCounter,
     /// total received on channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`
-    pub tx_sync_headers_total: IntGauge,
+    pub tx_sync_headers_total: IntCounter,
     /// total received on channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`
-    pub tx_sync_certificates_total: IntGauge,
+    pub tx_sync_certificates_total: IntCounter,
     /// total received on channel from the `primary::HeaderWaiter` to the `primary::Core`
-    pub tx_headers_loopback_total: IntGauge,
+    pub tx_headers_loopback_total: IntCounter,
     /// total received on channel from the `primary::CertificateWaiter` to the `primary::Core`
-    pub tx_certificates_loopback_total: IntGauge,
+    pub tx_certificates_loopback_total: IntCounter,
     /// total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Core`
-    pub tx_primary_messages_total: IntGauge,
+    pub tx_primary_messages_total: IntCounter,
     /// total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Helper`
-    pub tx_helper_requests_total: IntGauge,
+    pub tx_helper_requests_total: IntCounter,
     /// total received on channel from the `primary::ConsensusAPIGrpc` (when external consensus is being
     /// used) & `executor::Subscriber` (when internal consensus, ex Bullshark, is being used)  to
     /// the `primary::BlockWaiter`.
-    pub tx_get_block_commands_total: IntGauge,
+    pub tx_get_block_commands_total: IntCounter,
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockWaiter`
-    pub tx_batches_total: IntGauge,
+    pub tx_batches_total: IntCounter,
     /// total received on channel from the `primary::ConsensusAPIGrpc` to the `primary::BlockRemover`
-    pub tx_block_removal_commands_total: IntGauge,
+    pub tx_block_removal_commands_total: IntCounter,
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockRemover`
-    pub tx_batch_removal_total: IntGauge,
+    pub tx_batch_removal_total: IntCounter,
     /// total received on channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`
-    pub tx_block_synchronizer_commands_total: IntGauge,
+    pub tx_block_synchronizer_commands_total: IntCounter,
     /// total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`
-    pub tx_availability_responses_total: IntGauge,
+    pub tx_availability_responses_total: IntCounter,
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::StateHandler`
-    pub tx_state_handler_total: IntGauge,
+    pub tx_state_handler_total: IntCounter,
     /// total received on channel from the reconfigure notification to most components.
-    pub tx_reconfigure_total: IntGauge,
+    pub tx_reconfigure_total: IntCounter,
     /// total received on channel from the `Consensus` to the `primary::Core`
-    pub tx_committed_certificates_total: IntGauge,
+    pub tx_committed_certificates_total: IntCounter,
     /// total received on channel from the `primary::Core` to the `Consensus`
-    pub tx_new_certificates_total: IntGauge,
+    pub tx_new_certificates_total: IntCounter,
 }
 
 impl PrimaryChannelMetrics {
@@ -273,102 +274,102 @@ impl PrimaryChannelMetrics {
 
             // totals 
 
-            tx_others_digests_total: register_int_gauge_with_registry!(
+            tx_others_digests_total: register_int_counter_with_registry!(
                 "tx_others_digests_total",
                 "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::PayloadReceiver`",
                 registry
             ).unwrap(),
-            tx_our_digests_total: register_int_gauge_with_registry!(
+            tx_our_digests_total: register_int_counter_with_registry!(
                 "tx_our_digests_total",
                 "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::Proposer`",
                 registry
             ).unwrap(),
-            tx_parents_total: register_int_gauge_with_registry!(
+            tx_parents_total: register_int_counter_with_registry!(
                 "tx_parents_total",
                 "total received on channel from the `primary::Core` to the `primary::Proposer`",
                 registry
             ).unwrap(),
-            tx_headers_total: register_int_gauge_with_registry!(
+            tx_headers_total: register_int_counter_with_registry!(
                 "tx_headers_total",
                 "total received on channel from the `primary::Proposer` to the `primary::Core`",
                 registry
             ).unwrap(),
-            tx_sync_headers_total: register_int_gauge_with_registry!(
+            tx_sync_headers_total: register_int_counter_with_registry!(
                 "tx_sync_headers_total",
                 "total received on channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`",
                 registry
             ).unwrap(),
-            tx_sync_certificates_total: register_int_gauge_with_registry!(
+            tx_sync_certificates_total: register_int_counter_with_registry!(
                 "tx_sync_certificates_total",
                 "total received on channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`",
                 registry
             ).unwrap(),
-            tx_headers_loopback_total: register_int_gauge_with_registry!(
+            tx_headers_loopback_total: register_int_counter_with_registry!(
                 "tx_headers_loopback_total",
                 "total received on channel from the `primary::HeaderWaiter` to the `primary::Core`",
                 registry
             ).unwrap(),
-            tx_certificates_loopback_total: register_int_gauge_with_registry!(
+            tx_certificates_loopback_total: register_int_counter_with_registry!(
                 "tx_certificates_loopback_total",
                 "total received on channel from the `primary::CertificateWaiter` to the `primary::Core`",
                 registry
             ).unwrap(),
-            tx_primary_messages_total: register_int_gauge_with_registry!(
+            tx_primary_messages_total: register_int_counter_with_registry!(
                 "tx_primary_messages_total",
                 "total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Core`",
                 registry
             ).unwrap(),
-            tx_helper_requests_total: register_int_gauge_with_registry!(
+            tx_helper_requests_total: register_int_counter_with_registry!(
                 "tx_helper_requests_total",
                 "total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::Helper`",
                 registry
             ).unwrap(),
-            tx_get_block_commands_total: register_int_gauge_with_registry!(
+            tx_get_block_commands_total: register_int_counter_with_registry!(
                 "tx_get_block_commands_total",
                 "total received on channel from the `primary::ConsensusAPIGrpc` & `executor::Subscriber` to the `primary::BlockWaiter`",
                 registry
             ).unwrap(),
-            tx_batches_total: register_int_gauge_with_registry!(
+            tx_batches_total: register_int_counter_with_registry!(
                 "tx_batches_total",
                 "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockWaiter`",
                 registry
             ).unwrap(),
-            tx_block_removal_commands_total: register_int_gauge_with_registry!(
+            tx_block_removal_commands_total: register_int_counter_with_registry!(
                 "tx_block_removal_commands_total",
                 "total received on channel from the `primary::ConsensusAPIGrpc` to the `primary::BlockRemover`",
                 registry
             ).unwrap(),
-            tx_batch_removal_total: register_int_gauge_with_registry!(
+            tx_batch_removal_total: register_int_counter_with_registry!(
                 "tx_batch_removal_total",
                 "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::BlockRemover`",
                 registry
             ).unwrap(),
-            tx_block_synchronizer_commands_total: register_int_gauge_with_registry!(
+            tx_block_synchronizer_commands_total: register_int_counter_with_registry!(
                 "tx_block_synchronizer_commands_total",
                 "total received on channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`",
                 registry
             ).unwrap(),
-            tx_availability_responses_total: register_int_gauge_with_registry!(
+            tx_availability_responses_total: register_int_counter_with_registry!(
                 "tx_availability_responses_total",
                 "total received on channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`",
                 registry
             ).unwrap(),
-            tx_state_handler_total: register_int_gauge_with_registry!(
+            tx_state_handler_total: register_int_counter_with_registry!(
                 "tx_state_handler_total",
                 "total received on channel from the `primary::WorkerReceiverHandler` to the `primary::StateHandler`",
                 registry
             ).unwrap(),
-            tx_reconfigure_total: register_int_gauge_with_registry!(
+            tx_reconfigure_total: register_int_counter_with_registry!(
                 "tx_reconfigure_total",
                 "total received on channel from the reconfigure notification to most components.",
                 registry
             ).unwrap(),
-            tx_committed_certificates_total: register_int_gauge_with_registry!(
+            tx_committed_certificates_total: register_int_counter_with_registry!(
                 Self::NAME_COMMITTED_CERTS_TOTAL,
                 Self::DESC_COMMITTED_CERTS_TOTAL,
                 registry
             ).unwrap(),
-            tx_new_certificates_total: register_int_gauge_with_registry!(
+            tx_new_certificates_total: register_int_counter_with_registry!(
                 Self::NAME_NEW_CERTS_TOTAL,
                 Self::DESC_NEW_CERTS_TOTAL,
                 registry

--- a/narwhal/types/src/metered_channel.rs
+++ b/narwhal/types/src/metered_channel.rs
@@ -9,6 +9,10 @@ use tokio::sync::mpsc::{
     error::{SendError, TryRecvError, TrySendError},
 };
 
+#[cfg(test)]
+#[path = "tests/metered_channel_tests.rs"]
+mod metered_channel_tests;
+
 /// An [`mpsc::Sender`](tokio::sync::mpsc::Sender) with an [`IntGauge`]
 /// counting the number of currently queued items.
 #[derive(Debug)]
@@ -32,6 +36,7 @@ impl<T> Clone for Sender<T> {
 pub struct Receiver<T> {
     inner: mpsc::Receiver<T>,
     gauge: IntGauge,
+    total: Option<IntGauge>,
 }
 
 impl<T> Receiver<T> {
@@ -43,6 +48,9 @@ impl<T> Receiver<T> {
             .inspect(|opt| {
                 if opt.is_some() {
                     self.gauge.dec();
+                    if let Some(total_gauge) = &self.total {
+                        total_gauge.inc();
+                    }
                 }
             })
             .await
@@ -53,6 +61,9 @@ impl<T> Receiver<T> {
     pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
         self.inner.try_recv().map(|val| {
             self.gauge.dec();
+            if let Some(total_gauge) = &self.total {
+                total_gauge.inc();
+            }
             val
         })
     }
@@ -70,6 +81,9 @@ impl<T> Receiver<T> {
         match self.inner.poll_recv(cx) {
             res @ Poll::Ready(Some(_)) => {
                 self.gauge.dec();
+                if let Some(total_gauge) = &self.total {
+                    total_gauge.inc();
+                }
                 res
             }
             s => s,
@@ -267,6 +281,29 @@ pub fn channel<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
         Receiver {
             inner: receiver,
             gauge: gauge.clone(),
+            total: None,
+        },
+    )
+}
+
+#[track_caller]
+pub fn channel_with_total<T>(
+    size: usize,
+    gauge: &IntGauge,
+    total_gauge: &IntGauge,
+) -> (Sender<T>, Receiver<T>) {
+    gauge.set(0);
+    total_gauge.set(0);
+    let (sender, receiver) = mpsc::channel(size);
+    (
+        Sender {
+            inner: sender,
+            gauge: gauge.clone(),
+        },
+        Receiver {
+            inner: receiver,
+            gauge: gauge.clone(),
+            total: Some(total_gauge.clone()),
         },
     )
 }

--- a/narwhal/types/src/metered_channel.rs
+++ b/narwhal/types/src/metered_channel.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(dead_code)] // TODO: complete tests - This kinda sorta facades the whole tokio::mpsc::{Sender, Receiver}: without tests, this will be fragile to maintain.
 use futures::{FutureExt, Stream, TryFutureExt};
-use prometheus::IntGauge;
+use prometheus::{IntCounter, IntGauge};
 use std::task::{Context, Poll};
 use tokio::sync::mpsc::{
     self,
@@ -36,7 +36,7 @@ impl<T> Clone for Sender<T> {
 pub struct Receiver<T> {
     inner: mpsc::Receiver<T>,
     gauge: IntGauge,
-    total: Option<IntGauge>,
+    total: Option<IntCounter>,
 }
 
 impl<T> Receiver<T> {
@@ -290,10 +290,9 @@ pub fn channel<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
 pub fn channel_with_total<T>(
     size: usize,
     gauge: &IntGauge,
-    total_gauge: &IntGauge,
+    total_gauge: &IntCounter,
 ) -> (Sender<T>, Receiver<T>) {
     gauge.set(0);
-    total_gauge.set(0);
     let (sender, receiver) = mpsc::channel(size);
     (
         Sender {

--- a/narwhal/types/src/tests/metered_channel_tests.rs
+++ b/narwhal/types/src/tests/metered_channel_tests.rs
@@ -7,7 +7,7 @@ use futures::{
     task::{noop_waker, Context, Poll},
     FutureExt,
 };
-use prometheus::IntGauge;
+use prometheus::{IntCounter, IntGauge};
 use tokio::sync::mpsc::error::TrySendError;
 
 #[test]
@@ -27,7 +27,7 @@ fn test_send() {
 #[test]
 fn test_total() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let counter_total = IntGauge::new("TEST_TOTAL", "test_total").unwrap();
+    let counter_total = IntCounter::new("TEST_TOTAL", "test_total").unwrap();
     let (tx, mut rx) = channel_with_total(8, &counter, &counter_total);
 
     assert_eq!(counter.get(), 0);

--- a/narwhal/types/src/tests/metered_channel_tests.rs
+++ b/narwhal/types/src/tests/metered_channel_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use super::{channel, channel_with_total};
 use futures::{
     executor::block_on,
     task::{noop_waker, Context, Poll},
@@ -8,12 +9,11 @@ use futures::{
 };
 use prometheus::IntGauge;
 use tokio::sync::mpsc::error::TrySendError;
-use types::metered_channel;
 
 #[test]
 fn test_send() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(8, &counter);
+    let (tx, mut rx) = channel(8, &counter);
 
     assert_eq!(counter.get(), 0);
     let item = 42;
@@ -25,9 +25,25 @@ fn test_send() {
 }
 
 #[test]
+fn test_total() {
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let counter_total = IntGauge::new("TEST_TOTAL", "test_total").unwrap();
+    let (tx, mut rx) = channel_with_total(8, &counter, &counter_total);
+
+    assert_eq!(counter.get(), 0);
+    let item = 42;
+    block_on(tx.send(item)).unwrap();
+    assert_eq!(counter.get(), 1);
+    let received_item = block_on(rx.recv()).unwrap();
+    assert_eq!(received_item, item);
+    assert_eq!(counter.get(), 0);
+    assert_eq!(counter_total.get(), 1);
+}
+
+#[test]
 fn test_empty_closed_channel() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(8, &counter);
+    let (tx, mut rx) = channel(8, &counter);
 
     assert_eq!(counter.get(), 0);
     let item = 42;
@@ -53,7 +69,7 @@ fn test_empty_closed_channel() {
 #[test]
 fn test_reserve() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(8, &counter);
+    let (tx, mut rx) = channel(8, &counter);
 
     assert_eq!(counter.get(), 0);
     let item = 42;
@@ -70,7 +86,7 @@ fn test_reserve() {
 #[test]
 fn test_reserve_and_drop() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, _rx) = metered_channel::channel::<i32>(8, &counter);
+    let (tx, _rx) = channel::<i32>(8, &counter);
 
     assert_eq!(counter.get(), 0);
 
@@ -88,7 +104,7 @@ fn test_send_backpressure() {
     let mut cx = Context::from_waker(&waker);
 
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(1, &counter);
+    let (tx, mut rx) = channel(1, &counter);
 
     assert_eq!(counter.get(), 0);
     block_on(tx.send(1)).unwrap();
@@ -109,7 +125,7 @@ fn test_reserve_backpressure() {
     let mut cx = Context::from_waker(&waker);
 
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(1, &counter);
+    let (tx, mut rx) = channel(1, &counter);
 
     assert_eq!(counter.get(), 0);
     let permit = block_on(tx.reserve()).unwrap();
@@ -131,7 +147,7 @@ fn test_send_backpressure_multi_senders() {
     let waker = noop_waker();
     let mut cx = Context::from_waker(&waker);
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx1, mut rx) = metered_channel::channel(1, &counter);
+    let (tx1, mut rx) = channel(1, &counter);
 
     assert_eq!(counter.get(), 0);
     block_on(tx1.send(1)).unwrap();
@@ -150,7 +166,7 @@ fn test_send_backpressure_multi_senders() {
 #[test]
 fn test_try_send() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(1, &counter);
+    let (tx, mut rx) = channel(1, &counter);
 
     assert_eq!(counter.get(), 0);
     let item = 42;
@@ -164,7 +180,7 @@ fn test_try_send() {
 #[test]
 fn test_try_send_full() {
     let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
-    let (tx, mut rx) = metered_channel::channel(2, &counter);
+    let (tx, mut rx) = channel(2, &counter);
 
     assert_eq!(counter.get(), 0);
     let item = 42;

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -96,6 +96,24 @@ pub struct WorkerChannelMetrics {
     pub tx_client_processor: IntGauge,
     /// occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)
     pub tx_worker_helper: IntGauge,
+
+    // Record the total events received to infer progress rates
+    /// total received from the channel from various handlers to the `worker::PrimaryConnector`
+    pub tx_primary_total: IntGauge,
+    /// total received from the channel from the `handlers::PrimaryReceiverHandler` to the `worker::Synchronizer`
+    pub tx_synchronizer_total: IntGauge,
+    /// total received from the channel from the `handlers::PrimaryReceiverHandler` to the `handlers::ChildRpcSender`
+    pub tx_request_batches_rpc_total: IntGauge,
+    /// total received from the channel from the `worker::TxReceiverhandler` to the `worker::BatchMaker`
+    pub tx_batch_maker_total: IntGauge,
+    /// total received from the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`
+    pub tx_quorum_waiter_total: IntGauge,
+    /// total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`
+    pub tx_worker_processor_total: IntGauge,
+    /// total received from the channel from the `worker::QuorumWaiter` to the `worker::Processor`
+    pub tx_client_processor_total: IntGauge,
+    /// total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)
+    pub tx_worker_helper_total: IntGauge,
 }
 
 impl WorkerChannelMetrics {
@@ -141,6 +159,50 @@ impl WorkerChannelMetrics {
                 "occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)",
                 registry
             ).unwrap(),
+
+            // Totals:
+
+            tx_primary_total: register_int_gauge_with_registry!(
+                "tx_primary_total",
+                "total received from the channel from various handlers to the `worker::PrimaryConnector`",
+                registry
+            ).unwrap(),
+            tx_synchronizer_total: register_int_gauge_with_registry!(
+                "tx_synchronizer_total",
+                "total received from the channel from the `worker::PrimaryReceiverHandler` to the `worker::Synchronizer`",
+                registry
+            ).unwrap(),
+            tx_request_batches_rpc_total: register_int_gauge_with_registry!(
+                "tx_request_batches_rpc_total",
+                "total received from the channel from the `handlers::PrimaryReceiverHandler` to the `handlers::ChildRpcSender`",
+                registry
+            ).unwrap(),
+            tx_batch_maker_total: register_int_gauge_with_registry!(
+                "tx_batch_maker_total",
+                "total received from the channel from the `worker::TxReceiverhandler` to the `worker::BatchMaker`",
+                registry
+            ).unwrap(),
+            tx_quorum_waiter_total: register_int_gauge_with_registry!(
+                "tx_quorum_waiter_total",
+                "total received from the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`",
+                registry
+            ).unwrap(),
+            tx_worker_processor_total: register_int_gauge_with_registry!(
+                "tx_worker_processor_total",
+                "total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`",
+                registry
+            ).unwrap(),
+            tx_client_processor_total: register_int_gauge_with_registry!(
+                "tx_client_processor_total",
+                "total received from the channel from the `worker::QuorumWaiter` to the `worker::Processor`",
+                registry
+            ).unwrap(),
+            tx_worker_helper_total: register_int_gauge_with_registry!(
+                "tx_worker_helper_total",
+                "total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)",
+                registry
+            ).unwrap(),
+
         }
     }
 }

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -5,7 +5,7 @@ use network::metrics::NetworkMetrics;
 use prometheus::{
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry, HistogramVec,
-    IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    IntCounterVec, IntGauge, IntGaugeVec, Registry, IntCounter, register_int_counter_with_registry,
 };
 use std::time::Duration;
 use tonic::Code;
@@ -99,21 +99,21 @@ pub struct WorkerChannelMetrics {
 
     // Record the total events received to infer progress rates
     /// total received from the channel from various handlers to the `worker::PrimaryConnector`
-    pub tx_primary_total: IntGauge,
+    pub tx_primary_total: IntCounter,
     /// total received from the channel from the `handlers::PrimaryReceiverHandler` to the `worker::Synchronizer`
-    pub tx_synchronizer_total: IntGauge,
+    pub tx_synchronizer_total: IntCounter,
     /// total received from the channel from the `handlers::PrimaryReceiverHandler` to the `handlers::ChildRpcSender`
-    pub tx_request_batches_rpc_total: IntGauge,
+    pub tx_request_batches_rpc_total: IntCounter,
     /// total received from the channel from the `worker::TxReceiverhandler` to the `worker::BatchMaker`
-    pub tx_batch_maker_total: IntGauge,
+    pub tx_batch_maker_total: IntCounter,
     /// total received from the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`
-    pub tx_quorum_waiter_total: IntGauge,
+    pub tx_quorum_waiter_total: IntCounter,
     /// total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`
-    pub tx_worker_processor_total: IntGauge,
+    pub tx_worker_processor_total: IntCounter,
     /// total received from the channel from the `worker::QuorumWaiter` to the `worker::Processor`
-    pub tx_client_processor_total: IntGauge,
+    pub tx_client_processor_total: IntCounter,
     /// total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)
-    pub tx_worker_helper_total: IntGauge,
+    pub tx_worker_helper_total: IntCounter,
 }
 
 impl WorkerChannelMetrics {
@@ -162,42 +162,42 @@ impl WorkerChannelMetrics {
 
             // Totals:
 
-            tx_primary_total: register_int_gauge_with_registry!(
+            tx_primary_total: register_int_counter_with_registry!(
                 "tx_primary_total",
                 "total received from the channel from various handlers to the `worker::PrimaryConnector`",
                 registry
             ).unwrap(),
-            tx_synchronizer_total: register_int_gauge_with_registry!(
+            tx_synchronizer_total: register_int_counter_with_registry!(
                 "tx_synchronizer_total",
                 "total received from the channel from the `worker::PrimaryReceiverHandler` to the `worker::Synchronizer`",
                 registry
             ).unwrap(),
-            tx_request_batches_rpc_total: register_int_gauge_with_registry!(
+            tx_request_batches_rpc_total: register_int_counter_with_registry!(
                 "tx_request_batches_rpc_total",
                 "total received from the channel from the `handlers::PrimaryReceiverHandler` to the `handlers::ChildRpcSender`",
                 registry
             ).unwrap(),
-            tx_batch_maker_total: register_int_gauge_with_registry!(
+            tx_batch_maker_total: register_int_counter_with_registry!(
                 "tx_batch_maker_total",
                 "total received from the channel from the `worker::TxReceiverhandler` to the `worker::BatchMaker`",
                 registry
             ).unwrap(),
-            tx_quorum_waiter_total: register_int_gauge_with_registry!(
+            tx_quorum_waiter_total: register_int_counter_with_registry!(
                 "tx_quorum_waiter_total",
                 "total received from the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`",
                 registry
             ).unwrap(),
-            tx_worker_processor_total: register_int_gauge_with_registry!(
+            tx_worker_processor_total: register_int_counter_with_registry!(
                 "tx_worker_processor_total",
                 "total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`",
                 registry
             ).unwrap(),
-            tx_client_processor_total: register_int_gauge_with_registry!(
+            tx_client_processor_total: register_int_counter_with_registry!(
                 "tx_client_processor_total",
                 "total received from the channel from the `worker::QuorumWaiter` to the `worker::Processor`",
                 registry
             ).unwrap(),
-            tx_worker_helper_total: register_int_gauge_with_registry!(
+            tx_worker_helper_total: register_int_counter_with_registry!(
                 "tx_worker_helper_total",
                 "total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)",
                 registry

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -4,8 +4,9 @@ use mysten_network::metrics::MetricsCallbackProvider;
 use network::metrics::NetworkMetrics;
 use prometheus::{
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, HistogramVec,
-    IntCounterVec, IntGauge, IntGaugeVec, Registry, IntCounter, register_int_counter_with_registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Registry,
 };
 use std::time::Duration;
 use tonic::Code;


### PR DESCRIPTION
This PR: 
* Allows a metered channel to optionally track the total number of items received. This allows tracking progress rather than just remaining capacity allowing us to observe whether there is (slow progress) or whether a channel makes no progress.
* Instruments all Narwhal worker channels to use this facility.