### PR TITLE
wallet-ext: disable plausible auto outbound tracking

### DIFF
--- a/apps/wallet/src/shared/plausible.ts
+++ b/apps/wallet/src/shared/plausible.ts
@@ -6,16 +6,17 @@ import Browser from 'webextension-polyfill';
 
 const WALLET_URL = Browser.runtime.getURL('').slice(0, -1);
 
-const PLAUSIBLE_ENABLED = true || process.env.NODE_ENV === 'production';
+const PLAUSIBLE_ENABLED = process.env.NODE_ENV === 'production';
 
 const plausible = Plausible({
     domain: WALLET_URL,
 });
 
+// NOTE: Disabled this because it breaks opening new tabs when clicking on anchor elements
 // Plausible's outbound link tracking works by inspecting the document, which doesn't exist in every context.
-if (PLAUSIBLE_ENABLED && typeof document !== 'undefined') {
-    plausible.enableAutoOutboundTracking();
-}
+// if (PLAUSIBLE_ENABLED && typeof document !== 'undefined') {
+//     plausible.enableAutoOutboundTracking();
+// }
 
 export const trackEvent: typeof plausible.trackEvent = (...args) => {
     if (PLAUSIBLE_ENABLED) {


### PR DESCRIPTION
* fixes opening links in new tabs

before:


https://user-images.githubusercontent.com/10210143/193884923-e58eaca7-57a8-4e6f-b0dc-02ce90439df3.mov


after: 


https://user-images.githubusercontent.com/10210143/193884992-001a55c3-8ad1-430d-8a6a-b067042373ea.mov

