### PR TITLE
fix(consensus_adapter): reduce shared object transaction amplification by ~3

### DIFF
--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -34,6 +34,7 @@ once_cell = "1.16"
 tap = "1.0"
 either = "1.8.0"
 hex = "0.4.3"
+rand = "0.8.5"
 
 sui-adapter = { path = "../sui-adapter" }
 sui-framework = { path = "../sui-framework" }
@@ -71,7 +72,6 @@ sui-macros = { path = "../sui-macros" }
 
 [dev-dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
-rand = "0.8.5"
 
 serde-reflection = "0.3.6"
 serde_yaml = "0.8.26"

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -101,6 +101,7 @@ impl AuthorityServer {
     ) -> Self {
         let consensus_adapter = ConsensusAdapter::new(
             consensus_address,
+            state.clone_committee(),
             tx_consensus_listener,
             Duration::from_secs(20),
             ConsensusAdapterMetrics::new_test(),
@@ -308,6 +309,7 @@ impl ValidatorService {
         // The consensus adapter allows the authority to send user certificates through consensus.
         let consensus_adapter = ConsensusAdapter::new(
             consensus_config.address().to_owned(),
+            state.clone_committee(),
             tx_consensus_listener.clone(),
             timeout,
             ca_metrics.clone(),

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -165,6 +165,7 @@ async fn submit_transaction_to_consensus_adapter() {
     // Make a new consensus adapter instance.
     let adapter = ConsensusAdapter::new_test(
         Box::new(SubmitDirectly(state.clone())),
+        committee.clone(),
         tx_consensus_listener,
         /* timeout */ Duration::from_secs(5),
         metrics,

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -258,7 +258,7 @@ async fn run_actual_and_estimate_costs(
 
     for (tx_type, tx) in tx_map {
         let gas_used = if tx_type.is_shared_object_tx() {
-            submit_shared_object_transaction(tx.clone(), &configs.validator_set()[0..1])
+            submit_shared_object_transaction(tx.clone(), configs.validator_set())
                 .await
                 .unwrap()
                 .gas_cost_summary()

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -198,7 +198,6 @@ impl BatchMaker {
     ) -> Option<impl Future<Output = ()>> {
         #[cfg(feature = "benchmark")]
         {
-            use fastcrypto::hash::Hash;
             let digest = batch.digest();
 
             // Look for sample txs (they all start with 0) and gather their txs id (the next 8 bytes).


### PR DESCRIPTION
This submits shared object transactions to only (f+1) validators.

Context: Each validator submits all shared object transactions it knows of, creating a shared object throughput amplification of 3f+1 over the optimum,

The Issue: This throughput amplification creates a burden on all subsequent steps in the pipeline.

The Mitigation: submit deterministically to (f+1) validators by stake, ensuring at least one honest submission.