### PR TITLE
wallet-ext: set up experimentation framework

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -80,6 +80,7 @@
     },
     "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.10.1",
+        "@growthbook/growthbook": "^0.18.1",
         "@metamask/browser-passworder": "^3.0.0",
         "@mysten/sui.js": "workspace:*",
         "@reduxjs/toolkit": "^1.8.3",

--- a/apps/wallet/src/ui/app/experimentation/experiments.ts
+++ b/apps/wallet/src/ui/app/experimentation/experiments.ts
@@ -1,6 +1,0 @@
-// Copyright (c) 2022, Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-export enum EXPERIMENTS {
-    DEPRECATE_GATEWAY = 'deprecate-gateway',
-}

--- a/apps/wallet/src/ui/app/experimentation/experiments.ts
+++ b/apps/wallet/src/ui/app/experimentation/experiments.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export enum EXPERIMENTS {
+    DEPRECATE_GATEWAY = 'deprecate-gateway',
+}

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -3,21 +3,20 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
+const DEFAULT_DEV_API_KEY = 'key_dev_dc2872e15e0c5f95';
+
 export default class FeatureGating {
-    private _growthBook: GrowthBook;
+    #growthBook: GrowthBook;
+
     constructor() {
         // Create a GrowthBook context
-        this._growthBook = new GrowthBook();
+        this.#growthBook = new GrowthBook();
     }
 
     public async init() {
-        if (process.env.NODE_ENV !== 'production') {
-            return;
-        }
+        const apiKey = process.env.GROWTH_BOOK_API_KEY ?? DEFAULT_DEV_API_KEY;
         // Load feature definitions
-        await fetch(
-            `https://cdn.growthbook.io/api/features/${process.env.GROWTH_BOOK_API_KEY}`
-        )
+        await fetch(`https://cdn.growthbook.io/api/features/${apiKey}`)
             .then((res) => {
                 if (res.ok) {
                     return res.json();
@@ -25,9 +24,10 @@ export default class FeatureGating {
                 throw new Error(res.statusText);
             })
             .then((parsed) => {
-                this._growthBook.setFeatures(parsed.features);
+                this.#growthBook.setFeatures(parsed.features);
             })
             .catch(() => {
+                // eslint-disable-next-line no-console
                 console.warn(
                     `Failed to fetch feature definitions from GrowthBook with API_KEY ${process.env.GROWTH_BOOK_API_KEY}`
                 );
@@ -35,6 +35,6 @@ export default class FeatureGating {
     }
 
     public isOn(featureName: string): boolean {
-        return this._growthBook.isOn(featureName);
+        return this.#growthBook.isOn(featureName);
     }
 }

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -3,7 +3,8 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
-const DEFAULT_DEV_API_KEY = 'key_dev_dc2872e15e0c5f95';
+const GROWTHBOOK_API_KEY =
+    process.env.GROWTH_BOOK_API_KEY ?? 'key_dev_dc2872e15e0c5f95';
 
 export default class FeatureGating {
     #growthBook: GrowthBook;
@@ -14,9 +15,10 @@ export default class FeatureGating {
     }
 
     public async init() {
-        const apiKey = process.env.GROWTH_BOOK_API_KEY ?? DEFAULT_DEV_API_KEY;
         // Load feature definitions
-        await fetch(`https://cdn.growthbook.io/api/features/${apiKey}`)
+        await fetch(
+            `https://cdn.growthbook.io/api/features/${GROWTHBOOK_API_KEY}`
+        )
             .then((res) => {
                 if (res.ok) {
                     return res.json();

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GrowthBook } from '@growthbook/growthbook';
+
+export default class FeatureGating {
+    private _growthBook: GrowthBook;
+    constructor() {
+        // Create a GrowthBook context
+        this._growthBook = new GrowthBook();
+    }
+
+    public async init() {
+        if (process.env.NODE_ENV !== 'production') {
+            return;
+        }
+        // Load feature definitions
+        await fetch(
+            `https://cdn.growthbook.io/api/features/${process.env.GROWTH_BOOK_API_KEY}`
+        )
+            .then((res) => {
+                if (res.ok) {
+                    return res.json();
+                }
+                throw new Error(res.statusText);
+            })
+            .then((parsed) => {
+                this._growthBook.setFeatures(parsed.features);
+            })
+            .catch(() => {
+                console.warn(
+                    `Failed to fetch feature definitions from GrowthBook with API_KEY ${process.env.GROWTH_BOOK_API_KEY}`
+                );
+            });
+    }
+
+    public isOn(featureName: string): boolean {
+        return this._growthBook.isOn(featureName);
+    }
+}

--- a/apps/wallet/src/ui/app/redux/store/thunk-extras.ts
+++ b/apps/wallet/src/ui/app/redux/store/thunk-extras.ts
@@ -4,14 +4,18 @@
 import ApiProvider from '_app/ApiProvider';
 import KeypairVault from '_app/KeypairVault';
 import { BackgroundClient } from '_app/background-client';
+import FeatureGating from '_app/experimentation/feature-gating';
 
 import type { RootState } from '_redux/RootReducer';
 import type { AppDispatch } from '_store';
 
+const featureGating = new FeatureGating();
+
 export const thunkExtras = {
     keypairVault: new KeypairVault(),
-    api: new ApiProvider(),
+    api: new ApiProvider(featureGating),
     background: new BackgroundClient(),
+    featureGating: featureGating,
 };
 
 type ThunkExtras = typeof thunkExtras;

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -20,6 +20,7 @@ async function init() {
     if (process.env.NODE_ENV === 'development') {
         Object.defineProperty(window, 'store', { value: store });
     }
+    await thunkExtras.featureGating.init();
     store.dispatch(initAppType(getFromLocationSearch(window.location.search)));
     await store.dispatch(initNetworkFromStorage()).unwrap();
     await thunkExtras.background.init(store.dispatch);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,7 @@ importers:
   apps/wallet:
     specifiers:
       '@floating-ui/react-dom-interactions': ^0.10.1
+      '@growthbook/growthbook': ^0.18.1
       '@metamask/browser-passworder': ^3.0.0
       '@mysten/sui.js': workspace:*
       '@reduxjs/toolkit': ^1.8.3
@@ -206,6 +207,7 @@ importers:
       yup: ^0.32.11
     dependencies:
       '@floating-ui/react-dom-interactions': 0.10.1_7ey2zzynotv32rpkwno45fsx4e
+      '@growthbook/growthbook': 0.18.1
       '@metamask/browser-passworder': 3.0.0
       '@mysten/sui.js': link:../../sdk/typescript
       '@reduxjs/toolkit': 1.8.5_kkwg4cbsojnjnupd3btipussee
@@ -3643,6 +3645,11 @@ packages:
       graphql: 15.8.0
       tslib: 2.2.0
     dev: true
+
+  /@growthbook/growthbook/0.18.1:
+    resolution: {integrity: sha512-hNNh515lleAUzTch+ezYYVHBteYTIAF1Xxh6+dLJk+BjbhPXUo6X9qNcryIN1b/IMLVnO1ZfE5zbAzVGEQai2w==}
+    engines: {node: '>=10'}
+    dev: false
 
   /@hapi/hoek/9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -19891,7 +19898,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.2
-      webpack: 5.74.0_webpack-cli@4.10.0
+      webpack: 5.74.0
     dev: true
 
   /terser/4.8.1:


### PR DESCRIPTION
This PR sets up [GrowthBook](https://docs.growthbook.io/) to control feature rollout so that risky feature can be rolled out gradually and turned on/off without uploading a new package to the Chrome web store

# Testing
Verify the following three scenarios:
1. when API key is not set and environment == 'production', there will be a warning in the console and all feature values are default to false.
2. When environment != 'production', all feature values are default to false.
3. When API key is set and environment == 'production', correct value is returned based on the experiment settings

