### PR TITLE
[frontend] Rust changes should trigger TS tests

### DIFF
--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -4,11 +4,14 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isClient: ${{ contains(fromJson(steps.diff.outputs.packages), 'sui-explorer') }}
+      isClient: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-explorer') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
-      - name: Detect Changes
+      - name: Detect Changes (pnpm)
         uses: "./.github/actions/pnpm-diffs"
+        id: pnpm
+      - name: Detect Changes (diff)
+        uses: "./.github/actions/diffs"
         id: diff
   client_checks:
     name: Lint, Test & Build

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -4,12 +4,16 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isTypescriptSDK: ${{ contains(fromJson(steps.diff.outputs.packages), '@mysten/sui.js') }}
+      isTypescriptSDK: ${{ contains(fromJson(steps.pnpm.outputs.packages), '@mysten/sui.js') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
-      - name: Detect Changes
+      - name: Detect Changes (pnpm)
         uses: "./.github/actions/pnpm-diffs"
+        id: pnpm
+      - name: Detect Changes (diff)
+        uses: "./.github/actions/diffs"
         id: diff
+
   client_checks:
     name: Test & Build
     needs: diff

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -4,11 +4,14 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     outputs:
-      isWalletExt: ${{ contains(fromJson(steps.diff.outputs.packages), 'sui-wallet') }}
+      isWalletExt: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
-      - name: Detect Changes
+      - name: Detect Changes (pnpm)
         uses: "./.github/actions/pnpm-diffs"
+        id: pnpm
+      - name: Detect Changes (diff)
+        uses: "./.github/actions/diffs"
         id: diff
 
   run_checks:


### PR DESCRIPTION
Rust changes can have an impact on everything, so when considering tests that should run, we should have rust changes also trigger the frontend / sdk projects. Right now I opted for the SDK, Explorer, and Wallet which seemed like the most likely surfaces to have issues. Wallet Adapters should be relatively immune to these changes since they just interact with the wallet / SDK.

The only open question I have right now is the wallet comment PR. It might be confusing why it's showing up if you're only making rust changes. We can either disable it or leave it be.