### PR TITLE
[checkpoint] Incremental checkpoint construction

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1366,7 +1366,7 @@ impl AuthorityState {
         let mut checkpoints = CheckpointStore::open(
             &path.join("checkpoints"),
             None,
-            genesis_committee.epoch,
+            &genesis_committee,
             secret.public().into(),
             secret.clone(),
         )
@@ -2011,7 +2011,12 @@ impl AuthorityState {
 
                 let mut checkpoint = self.checkpoints.lock();
                 checkpoint
-                    .handle_internal_fragment(consensus_index, *fragment, self.database.clone())
+                    .handle_internal_fragment(
+                        consensus_index,
+                        *fragment,
+                        self.database.clone(),
+                        &self.committee.load(),
+                    )
                     .map_err(NarwhalHandlerError::NodeError)?;
 
                 // NOTE: The method `handle_internal_fragment` is idempotent, so we don't need

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -836,9 +836,7 @@ where
         "Going through remaining validators to generate fragments",
     );
 
-    let result = checkpoint_db
-        .lock()
-        .attempt_to_construct_checkpoint(committee);
+    let result = checkpoint_db.lock().attempt_to_construct_checkpoint();
 
     match result {
         Err(err) => {

--- a/crates/sui-core/src/checkpoints/causal_order_effects.rs
+++ b/crates/sui-core/src/checkpoints/causal_order_effects.rs
@@ -298,7 +298,7 @@ mod tests {
         let mut cps = CheckpointStore::open(
             &path,
             None,
-            committee.epoch,
+            &committee,
             k.public().into(),
             Arc::pin(k.copy()),
         )

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -7,155 +7,59 @@ use tracing::debug;
 
 use sui_types::base_types::ExecutionDigests;
 use sui_types::committee::StakeUnit;
-use sui_types::messages_checkpoint::CheckpointProposalSummary;
+use sui_types::messages_checkpoint::{CheckpointProposalSummary, CheckpointSequenceNumber};
 use sui_types::{
     base_types::AuthorityName,
     committee::Committee,
-    error::SuiError,
     messages::CertifiedTransaction,
     messages_checkpoint::CheckpointFragment,
     waypoint::{GlobalCheckpoint, WaypointError},
 };
 
+// TODO: This probably deserve a better name.
 pub struct FragmentReconstruction {
-    pub committee: Committee,
     pub global: GlobalCheckpoint<AuthorityName, ExecutionDigests>,
     pub extra_transactions: BTreeMap<ExecutionDigests, CertifiedTransaction>,
 }
 
-impl FragmentReconstruction {
-    /// Take an ordered list of fragments and attempts to construct a connected
-    /// component checkpoint with weight over 2/3 of stake. Note that the minimum
-    /// prefix of links is used in this process.
-    ///
-    /// It is important to always use the minimum prefix since additional fragments
-    /// may be added by the consensus, but only the prefix that constructs the
-    /// checkpoint is safe to use. After that prefix different authorities will have
-    /// different information to finalize the process:
-    ///  - f+1 to 2f+1 honest authorities will be included in the prefix and can
-    ///    immediately compute and sign the checkpoint.
-    ///  - the remaining honest authorities will instead have to use other strategies
-    ///    such as downloading the checkpoint, or using other links (off the consensus)
-    ///    to compute it.
-    pub fn construct(
-        seq: u64,
-        committee: Committee,
-        fragments: &[CheckpointFragment],
-    ) -> Result<FragmentReconstruction, SuiError> {
-        let mut span = SpanGraph::new(&committee);
-        let mut fragments_used = Vec::new();
-        let mut proposals: HashMap<AuthorityName, CheckpointProposalSummary> = HashMap::new();
-        let mut extra_transactions = BTreeMap::new();
-
-        let total_fragments_count = fragments.len();
-        let mut max_weight_seen = 0;
-        for frag in fragments {
-            // Double check we have only been given waypoints for the correct sequence number
-            debug_assert!(frag.proposer.summary.sequence_number == seq);
-
-            // Check the checkpoint summary of the proposal is the same as the previous one.
-            // Otherwise ignore the link.
-            let n1 = frag.proposer.authority();
-            if *proposals
-                .entry(*n1)
-                .or_insert_with(|| frag.proposer.summary.clone())
-                != frag.proposer.summary
-            {
-                continue;
-            }
-
-            let n2 = frag.other.authority();
-            if *proposals
-                .entry(*n2)
-                .or_insert_with(|| frag.other.summary.clone())
-                != frag.other.summary
-            {
-                continue;
-            }
-
-            // Add to the links we will consider.
-            fragments_used.push(frag);
-
-            // Merge the link.
-            let (top, weight) = span.merge(n1, n2);
-            max_weight_seen = max(max_weight_seen, weight);
-
-            // We have found a connected component larger than the 2/3 threshold
-            if weight >= committee.quorum_threshold() {
-                // Get all links that are part of this component
-                let mut active_links: VecDeque<_> = fragments_used
-                    .into_iter()
-                    .filter(|frag| span.top_node(frag.proposer.authority()).0 == top)
-                    .collect();
-
-                let mut global = GlobalCheckpoint::new();
-                while let Some(link) = active_links.pop_front() {
-                    match global.insert(link.diff.clone()) {
-                        Ok(_) | Err(WaypointError::NothingToDo) => {
-                            extra_transactions.extend(link.certs.clone());
-                        }
-                        Err(WaypointError::CannotConnect) => {
-                            // Reinsert the fragment at the end
-                            active_links.push_back(link);
-                        }
-                        other => {
-                            // This is bad news, we did not intend to fail here.
-                            // We should have checked all conditions to avoid being
-                            // in this situation. TODO: audit this.
-                            panic!("Unexpected result: {:?}", other);
-                            // Or: unreachable!();
-                        }
-                    }
-                }
-
-                return Ok(FragmentReconstruction {
-                    global,
-                    committee,
-                    extra_transactions,
-                });
-            }
-        }
-        debug!(
-            ?max_weight_seen,
-            ?total_fragments_count,
-            num_fragments_used = fragments_used.len(),
-            "Unable to construct a checkpoint after using all fragments",
-        );
-
-        // If we run out of candidates with no checkpoint, there is no
-        // checkpoint yet.
-        Err(SuiError::from(
-            "Failed to construct checkpoint after using all fragments",
-        ))
-    }
-}
-
 // A structure that stores a set of spanning trees, and that supports addition
 // of links to merge them, and construct ever growing components.
-struct SpanGraph {
-    nodes: HashMap<AuthorityName, (AuthorityName, StakeUnit)>,
+#[derive(Clone, Debug)]
+pub enum SpanGraph {
+    // A newly created span graph is always in Uninitialized state, and will be turned into
+    // InProgress upon receiving the first fragment.
+    Uninitialized,
+    InProgress(InProgressSpanGraph),
+    Completed(CompletedSpanGraph),
 }
 
-impl SpanGraph {
-    /// Initialize the graph with each authority just pointing to itself.
-    pub fn new(committee: &Committee) -> SpanGraph {
-        let nodes: HashMap<AuthorityName, (AuthorityName, StakeUnit)> =
-            committee.members().map(|(n, w)| (*n, (*n, *w))).collect();
-
-        SpanGraph { nodes }
+impl Default for SpanGraph {
+    fn default() -> Self {
+        Self::Uninitialized
     }
+}
 
-    /// Follow pointer until you get to a node that only point to itself
-    /// and return the node name, and the weight of the tree that points
-    /// indirectly to it.
-    pub fn top_node(&self, name: &AuthorityName) -> (AuthorityName, StakeUnit) {
-        let mut next_name = name;
-        while self.nodes[next_name].0 != *next_name {
-            next_name = &self.nodes[next_name].0
-        }
-        self.nodes[next_name]
-    }
+#[derive(Clone, Debug)]
+pub struct InProgressSpanGraph {
+    /// Each validator is a node in the span graph. This maps from each validator
+    /// to the root of the tree it belongs to and the total stake of the tree.
+    nodes: HashMap<AuthorityName, (AuthorityName, StakeUnit)>,
 
+    /// The sequence number of the checkpoint being constructed.
+    next_checkpoint: CheckpointSequenceNumber,
+
+    /// Fragments that have been used so far.
+    fragments_used: Vec<CheckpointFragment>,
+
+    /// Proposals from each validator seen so far. This is needed to detect potential conflicting
+    /// fragments.
+    proposals_used: HashMap<AuthorityName, CheckpointProposalSummary>,
+
+    /// The max stake we have seen so far in a span tree.
+    max_weight_seen: StakeUnit,
+}
+
+impl InProgressSpanGraph {
     /// Add a link effectively merging two authorities into the same
     /// connected components. This is done by take the top node of the
     /// first and making it point to the top node of the second, and
@@ -178,5 +82,178 @@ impl SpanGraph {
         self.nodes.get_mut(&top2).unwrap().1 = new_weight;
         debug_assert!(self.top_node(name1) == self.top_node(name2));
         (top2, new_weight)
+    }
+
+    /// Follow pointer until you get to a node that only point to itself
+    /// and return the node name, and the weight of the tree that points
+    /// indirectly to it.
+    pub fn top_node(&self, name: &AuthorityName) -> (AuthorityName, StakeUnit) {
+        let mut next_name = name;
+        while self.nodes[next_name].0 != *next_name {
+            next_name = &self.nodes[next_name].0
+        }
+        self.nodes[next_name]
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompletedSpanGraph {
+    active_links: VecDeque<CheckpointFragment>,
+}
+
+impl SpanGraph {
+    pub fn mew(
+        committee: &Committee,
+        next_checkpoint: CheckpointSequenceNumber,
+        fragments: &[CheckpointFragment],
+    ) -> Self {
+        let mut span = Self::default();
+        for frag in fragments {
+            span.add_fragment_to_span(committee, next_checkpoint, frag);
+            if span.is_completed() {
+                break;
+            }
+        }
+        span
+    }
+
+    /// Reset the span graph back to Uninitialized.
+    pub fn reset(&mut self) {
+        *self = Self::Uninitialized;
+    }
+
+    /// Add a new fragment to the span graph and checks whether it can construct a connected
+    /// component checkpoint with weight over 2/3 of stake. Note that the minimum
+    /// prefix of links is used in this process.
+    ///
+    /// It is important to always use the minimum prefix since additional fragments
+    /// may be added by the consensus, but only the prefix that constructs the
+    /// checkpoint is safe to use. After that prefix different authorities will have
+    /// different information to finalize the process:
+    ///  - f+1 to 2f+1 honest authorities will be included in the prefix and can
+    ///    immediately compute and sign the checkpoint.
+    ///  - the remaining honest authorities will instead have to use other strategies
+    ///    such as downloading the checkpoint, or using other links (off the consensus)
+    ///    to compute it.
+    pub fn add_fragment_to_span(
+        &mut self,
+        committee: &Committee,
+        next_checkpoint: CheckpointSequenceNumber,
+        frag: &CheckpointFragment,
+    ) {
+        if matches!(&self, Self::Uninitialized) {
+            self.initialize(committee, next_checkpoint);
+        }
+        if let Self::InProgress(span) = self {
+            debug!(
+                next_cp_seq=span.next_checkpoint,
+                frag_seq=frag.proposer.summary.sequence_number,
+                proposer=?frag.proposer.authority(),
+                other=?frag.other.authority(),
+                "Trying to add a new checkpoint fragment to the span graph.",
+            );
+
+            // Ignore if the fragment is for a different checkpoint.
+            if frag.proposer.summary.sequence_number != span.next_checkpoint {
+                return;
+            }
+
+            // Check the checkpoint summary of the proposal is the same as the previous one.
+            // Otherwise ignore the link.
+            let n1 = frag.proposer.authority();
+            if *span
+                .proposals_used
+                .entry(*n1)
+                .or_insert_with(|| frag.proposer.summary.clone())
+                != frag.proposer.summary
+            {
+                return;
+            }
+
+            let n2 = frag.other.authority();
+            if *span
+                .proposals_used
+                .entry(*n2)
+                .or_insert_with(|| frag.other.summary.clone())
+                != frag.other.summary
+            {
+                return;
+            }
+
+            // Add to the links we will consider.
+            span.fragments_used.push(frag.clone());
+
+            // Merge the link.
+            let (top_node, weight) = span.merge(n1, n2);
+            span.max_weight_seen = max(span.max_weight_seen, weight);
+            debug!(
+                next_cp_seq=span.next_checkpoint,
+                max_weight_seen=?span.max_weight_seen,
+                "Checkpoint fragment added",
+            );
+            if weight >= committee.quorum_threshold() {
+                // Get all links that are part of this component
+                let active_links: VecDeque<_> = std::mem::take(&mut span.fragments_used)
+                    .into_iter()
+                    .filter(|frag| span.top_node(frag.proposer.authority()).0 == top_node)
+                    .collect();
+
+                debug!(
+                    next_cp_seq = span.next_checkpoint,
+                    "Checkpoint construction completed"
+                );
+                *self = Self::Completed(CompletedSpanGraph { active_links });
+            }
+        }
+    }
+
+    pub fn is_completed(&self) -> bool {
+        matches!(self, Self::Completed(_))
+    }
+
+    pub fn construct_checkpoint(&self) -> FragmentReconstruction {
+        if let Self::Completed(span) = &self {
+            let mut global = GlobalCheckpoint::new();
+            let mut extra_transactions = BTreeMap::new();
+            let mut active_links = span.active_links.clone();
+            while let Some(link) = active_links.pop_front() {
+                match global.insert(link.diff.clone()) {
+                    Ok(_) | Err(WaypointError::NothingToDo) => {
+                        extra_transactions.extend(link.certs.clone());
+                    }
+                    Err(WaypointError::CannotConnect) => {
+                        // Reinsert the fragment at the end
+                        active_links.push_back(link);
+                    }
+                    other => {
+                        // This is bad news, we did not intend to fail here.
+                        // We should have checked all conditions to avoid being
+                        // in this situation. TODO: audit this.
+                        panic!("Unexpected result: {:?}", other);
+                        // Or: unreachable!();
+                    }
+                }
+            }
+
+            FragmentReconstruction {
+                global,
+                extra_transactions,
+            }
+        } else {
+            unreachable!("construct_checkpoint should only be called after completion check");
+        }
+    }
+
+    fn initialize(&mut self, committee: &Committee, next_checkpoint: CheckpointSequenceNumber) {
+        let nodes: HashMap<AuthorityName, (AuthorityName, StakeUnit)> =
+            committee.members().map(|(n, w)| (*n, (*n, *w))).collect();
+
+        *self = Self::InProgress(InProgressSpanGraph {
+            nodes,
+            next_checkpoint,
+            fragments_used: Vec::new(),
+            proposals_used: HashMap::new(),
+            max_weight_seen: 0,
+        })
     }
 }

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -85,7 +85,7 @@ fn random_ckpoint_store_num(
             let cps = CheckpointStore::open(
                 &path,
                 None,
-                committee.epoch,
+                &committee,
                 k.public().into(),
                 Arc::pin(k.copy()),
             )
@@ -114,7 +114,7 @@ fn crash_recovery() {
     let mut cps = CheckpointStore::open(
         &path,
         None,
-        committee.epoch,
+        &committee,
         k.public().into(),
         Arc::pin(k.copy()),
     )
@@ -158,7 +158,7 @@ fn crash_recovery() {
     let mut cps_new = CheckpointStore::open(
         &path,
         None,
-        committee.epoch,
+        &committee,
         k.public().into(),
         Arc::pin(k.copy()),
     )
@@ -838,7 +838,7 @@ fn checkpoint_integration() {
     let mut cps = CheckpointStore::open(
         &path,
         None,
-        committee.epoch,
+        &committee,
         k.public().into(),
         Arc::pin(k.copy()),
     )
@@ -1254,19 +1254,13 @@ fn set_fragment_reconstruct() {
     let fragment12 = p1.fragment_with(&p2);
     let fragment34 = p3.fragment_with(&p4);
 
-    let attempt1 = FragmentReconstruction::construct(
-        0,
-        committee.clone(),
-        &[fragment12.clone(), fragment34.clone()],
-    );
-    assert!(matches!(attempt1, Err(_)));
+    let span = SpanGraph::mew(&committee, 0, &[fragment12.clone(), fragment34.clone()]);
+    assert!(!span.is_completed());
 
     let fragment41 = p4.fragment_with(&p1);
-    let attempt2 =
-        FragmentReconstruction::construct(0, committee, &[fragment12, fragment34, fragment41]);
-    assert!(attempt2.is_ok());
-
-    let reconstruction = attempt2.unwrap();
+    let span = SpanGraph::mew(&committee, 0, &[fragment12, fragment34, fragment41]);
+    assert!(span.is_completed());
+    let reconstruction = span.construct_checkpoint();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 4);
 }
 
@@ -1294,8 +1288,8 @@ fn set_fragment_reconstruct_two_components() {
 
     let fragment_xy = p_x.fragment_with(&p_y);
 
-    let attempt1 = FragmentReconstruction::construct(0, committee.clone(), &[fragment_xy.clone()]);
-    assert!(matches!(attempt1, Err(_)));
+    let span = SpanGraph::mew(&committee, 0, &[fragment_xy.clone()]);
+    assert!(!span.is_completed());
 
     // Make a daisy chain of the other proposals
     let mut fragments = vec![fragment_xy];
@@ -1310,15 +1304,15 @@ fn set_fragment_reconstruct_two_components() {
             break;
         }
 
-        let attempt2 = FragmentReconstruction::construct(0, committee.clone(), &fragments);
-        // Error until we have the full 5 others
-        assert!(matches!(attempt2, Err(_)));
+        let span = SpanGraph::mew(&committee, 0, &fragments);
+        // Incomplete until we have the full 5 others
+        assert!(!span.is_completed());
     }
 
-    let attempt2 = FragmentReconstruction::construct(0, committee, &fragments);
-    assert!(attempt2.is_ok());
+    let span = SpanGraph::mew(&committee, 0, &fragments);
+    assert!(span.is_completed());
 
-    let reconstruction = attempt2.unwrap();
+    let reconstruction = span.construct_checkpoint();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 5);
 }
 
@@ -1346,8 +1340,8 @@ fn set_fragment_reconstruct_two_mutual() {
     let fragment_xy = p_x.fragment_with(&p_y);
     let fragment_yx = p_y.fragment_with(&p_x);
 
-    let attempt1 = FragmentReconstruction::construct(0, committee, &[fragment_xy, fragment_yx]);
-    assert!(matches!(attempt1, Err(_)));
+    let span = SpanGraph::mew(&committee, 0, &[fragment_xy, fragment_yx]);
+    assert!(!span.is_completed());
 }
 
 #[derive(Clone)]
@@ -1456,11 +1450,16 @@ fn test_fragment_full_flow() {
     while let Ok(fragment) = rx.try_recv() {
         all_fragments.push(fragment.clone());
         assert!(cps0
-            .handle_internal_fragment(seq.clone(), fragment, PendCertificateForExecutionNoop)
+            .handle_internal_fragment(
+                seq.clone(),
+                fragment,
+                PendCertificateForExecutionNoop,
+                &committee
+            )
             .is_ok());
         seq.next_transaction_index += 1;
     }
-    let transactions = cps0.attempt_to_construct_checkpoint(&committee).unwrap();
+    let transactions = cps0.attempt_to_construct_checkpoint().unwrap();
     cps0.sign_new_checkpoint(0, 0, transactions.iter(), TestCausalOrderPendCertNoop, None)
         .unwrap();
 
@@ -1489,6 +1488,7 @@ fn test_fragment_full_flow() {
             seq.clone(),
             fragment.clone(),
             PendCertificateForExecutionNoop,
+            &committee,
         );
         seq.next_transaction_index += 100;
     }
@@ -1507,6 +1507,7 @@ fn test_fragment_full_flow() {
             seq.clone(),
             fragment.clone(),
             PendCertificateForExecutionNoop,
+            &committee,
         );
         seq.next_transaction_index += 100;
     }
@@ -1658,6 +1659,7 @@ pub async fn checkpoint_tests_setup(
         .iter()
         .map(|a| (a.authority.clone(), a.checkpoint.clone()))
         .collect();
+    let c = committee.clone();
     let _join = tokio::task::spawn(async move {
         let mut seq = ExecutionIndices::default();
         while let Some(msg) = _rx.recv().await {
@@ -1667,6 +1669,7 @@ pub async fn checkpoint_tests_setup(
                         seq.clone(),
                         msg.clone(),
                         PendCertificateForExecutionNoop,
+                        &c,
                     ) {
                         println!("Error: {:?}", err);
                     }
@@ -1674,6 +1677,7 @@ pub async fn checkpoint_tests_setup(
                     seq.clone(),
                     msg.clone(),
                     authority.database.clone(),
+                    &c,
                 ) {
                     println!("Error: {:?}", err);
                 }
@@ -1811,7 +1815,7 @@ async fn checkpoint_messaging_flow() {
         let transactions = auth
             .checkpoint
             .lock()
-            .attempt_to_construct_checkpoint(&setup.committee)
+            .attempt_to_construct_checkpoint()
             .unwrap();
         auth.checkpoint
             .lock()
@@ -1956,7 +1960,7 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[0]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(&setup.committee)
+        .attempt_to_construct_checkpoint()
         .is_ok());
 
     // Expecting more fragments
@@ -1972,7 +1976,7 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(&setup.committee)
+        .attempt_to_construct_checkpoint()
         .is_err());
 
     // Expecting more fragments
@@ -1994,6 +1998,6 @@ async fn test_no_more_fragments() {
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
-        .attempt_to_construct_checkpoint(&setup.committee)
+        .attempt_to_construct_checkpoint()
         .is_ok());
 }

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -20,6 +20,7 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
+use crate::checkpoints::reconstruction::SpanGraph;
 use crate::{
     authority::TemporaryStore,
     authority_active::ActiveAuthority,
@@ -54,6 +55,11 @@ async fn test_start_epoch_change() {
             next_transaction_sequence: 0,
             no_more_fragments: true,
             current_proposal: None,
+            checkpoint_to_be_constructed: SpanGraph::mew(
+                &genesis_committee,
+                CHECKPOINT_COUNT_PER_EPOCH,
+                &[],
+            ),
         })
         .unwrap();
     // Create an active authority for the first authority state.
@@ -180,6 +186,7 @@ async fn test_finish_epoch_change() {
         .zip(actives.iter())
         .map(|(state, active)| {
             async {
+                let genesis_committee = state.committee_store().get_latest_committee();
                 // Set the checkpoint number to be near the end of epoch.
                 let mut locals = CheckpointLocals {
                     next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
@@ -187,6 +194,11 @@ async fn test_finish_epoch_change() {
                     next_transaction_sequence: 0,
                     no_more_fragments: true,
                     current_proposal: None,
+                    checkpoint_to_be_constructed: SpanGraph::mew(
+                        &genesis_committee,
+                        CHECKPOINT_COUNT_PER_EPOCH,
+                        &[],
+                    ),
                 };
                 state
                     .checkpoints

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -65,7 +65,7 @@ pub(crate) async fn init_state(
     let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = tokio::sync::mpsc::channel(10);
     let committee_store = Arc::new(CommitteeStore::new(epoch_path, &committee, None));
     let checkpoint_store = Arc::new(parking_lot::Mutex::new(
-        CheckpointStore::open(&checkpoint_path, None, 0, name, secrete.clone()).unwrap(),
+        CheckpointStore::open(&checkpoint_path, None, &committee, name, secrete.clone()).unwrap(),
     ));
     AuthorityState::new(
         name,

--- a/crates/sui-framework/sources/coin.move
+++ b/crates/sui-framework/sources/coin.move
@@ -40,7 +40,7 @@ module sui::coin {
     /// Contains currency metadata for off-chain discovery. Type parameter `T`
     /// matches the one in `Coin<T>`
     struct CurrencyCreated<phantom T> has copy, drop {
-        /// Number of decimal places the coin uses. 
+        /// Number of decimal places the coin uses.
         /// A coin with `value ` N and `decimals` D should be shown as N / 10^D
         /// E.g., a coin with `value` 7002 and decimals 3 should be displayed as 7.002
         /// This is metadata for display usage only.

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -100,7 +100,7 @@ impl SuiNode {
         let checkpoint_store = Arc::new(Mutex::new(CheckpointStore::open(
             &config.db_path().join("checkpoints"),
             None,
-            committee.epoch,
+            &committee,
             config.protocol_public_key(),
             secret.clone(),
         )?));


### PR DESCRIPTION
This PR changes how we construct checkpoint using fragments.
Previously we periodically wake up, go through all fragments and try to construct a checkpoint.
This PR makes it such that every time when we receive a new fragment, we try to expand the current spanning graph and see if checkpoint is ready.
This will allow us to eventually stop accepting consensus messages after the last checkpoint of the epoch is ready.
TODO: will add more comments