### PR TITLE
[narwhal] Tiny changes in the executor

### DIFF
--- a/narwhal/executor/src/notifier.rs
+++ b/narwhal/executor/src/notifier.rs
@@ -1,15 +1,15 @@
-use std::sync::Arc;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{ExecutionIndices, ExecutionState, ExecutorMetrics};
 use consensus::ConsensusOutput;
+use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 use types::{metered_channel, Batch};
 
 #[derive(Clone, Debug)]
 pub struct BatchIndex {
-    pub consensus_output: ConsensusOutput,
+    pub consensus_output: Arc<ConsensusOutput>,
     pub next_certificate_index: u64,
     pub batch_index: u64,
 }

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -120,8 +120,8 @@ impl<Network: SubscriberNetwork> Subscriber<Network> {
             for future in futures {
                 // todo - limit number pending futures on startup
                 waiting.push_back(future);
-                self.metrics.subscriber_recovered_certificates_count.inc();
             }
+            self.metrics.subscriber_recovered_certificates_count.inc();
         }
 
         // Listen to sequenced consensus message and process them.
@@ -174,7 +174,8 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
     ) -> Vec<impl Future<Output = (BatchIndex, Batch)> + '_> {
         self.metrics.subscriber_processed_certificates.inc();
         debug!("Fetching payload for {:?}", deliver);
-        let mut ret = vec![];
+        let mut ret = Vec::with_capacity(deliver.certificate.header.payload.len());
+        let deliver = Arc::new(deliver);
         for (batch_index, (digest, worker_id)) in
             deliver.certificate.header.payload.iter().enumerate()
         {
@@ -216,6 +217,8 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
         for worker in workers {
             let future = self.fetch_from_worker(stagger, worker, digest);
             futures.push(future.boxed());
+            // TODO: Make this a parameter, and also record workers / authorities that are down
+            //       to request from them batches later.
             stagger += Duration::from_millis(200);
         }
         let (batch, _, _) = futures::future::select_all(futures).await;
@@ -250,6 +253,7 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
         digest: BatchDigest,
     ) -> Batch {
         tokio::time::sleep(stagger_delay).await;
+        // TODO: Make these config parameters
         let max_timeout = Duration::from_secs(60);
         let mut timeout = Duration::from_secs(10);
         let mut attempt = 0usize;


### PR DESCRIPTION
A few tiny changes as I was reading executor code:
* Clean up copyright banner.
* Make a structure we clone a lot into an Arc to make cloning cheaper.
* Add a capacity to vector init.
* Add a few todos for future cleanup.