### PR TITLE
[bug fix][Rosetta API] TransferSui with None amount is not handled correctly 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7835,7 +7835,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8038,7 +8038,7 @@ dependencies = [
 
 [[package]]
 name = "sui-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8142,7 +8142,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8344,7 +8344,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -8588,7 +8588,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 3.2.17",

--- a/crates/sui-rosetta/resources/sui.ros
+++ b/crates/sui-rosetta/resources/sui.ros
@@ -13,7 +13,6 @@ transfer(10){
     print_message({"recipient_amount":{{recipient_amount}}});
 
     // Find recipient and construct operations
-    sender_amount = 0 - {{recipient_amount}};
     recipient = find_balance({
       "not_account_identifier":[{{sender.account_identifier}}],
       "minimum_balance":{
@@ -27,23 +26,11 @@ transfer(10){
         "operation_identifier":{"index":0},
         "type":"TransferSUI",
         "account":{{sender.account_identifier}},
-        "amount":{
-          "value":{{sender_amount}},
-          "currency":{{currency}}
-        },
-        "coin_change":{"coin_action":"coin_spent", "coin_identifier":{{sender.coin}}}
+        "coin_change":{"coin_action":"coin_spent", "coin_identifier":{{sender.coin}}},
+        "metadata":{"recipient":{{recipient.account_identifier.address}}, "amount": {{recipient_amount}}}
       },
       {
         "operation_identifier":{"index":1},
-        "type":"TransferSUI",
-        "account":{{recipient.account_identifier}},
-        "amount":{
-          "value":{{recipient_amount}},
-          "currency":{{currency}}
-        }
-      },
-      {
-        "operation_identifier":{"index":2},
         "type":"GasBudget",
         "account":{{sender.account_identifier}},
         "coin_change":{"coin_action":"coin_spent", "coin_identifier":{{sender.coin}}},

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -31,6 +31,10 @@ use crate::types::{
 use crate::ErrorType::{BlockNotFound, InternalError};
 use crate::{Error, ErrorType, SUI};
 
+#[cfg(test)]
+#[path = "unit_tests/balance_changing_tx_tests.rs"]
+mod balance_changing_tx_tests;
+
 pub struct OnlineServerContext {
     pub state: Arc<AuthorityState>,
     pub quorum_driver: Arc<QuorumDriver<NetworkAuthorityClient>>,
@@ -319,7 +323,7 @@ fn extract_balance_changes_from_ops(
     let mut changes: BTreeMap<SuiAddress, SignedValue> = BTreeMap::new();
     for op in ops {
         match op.type_ {
-            OperationType::TransferSUI | OperationType::GasSpent | OperationType::Genesis => {
+            OperationType::SuiBalanceChange | OperationType::GasSpent | OperationType::Genesis => {
                 let addr = op
                     .account
                     .ok_or_else(|| anyhow!("Account address cannot be null for {:?}", op.type_))?

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -127,7 +127,7 @@ pub struct Amount {
     pub currency: Currency,
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct SignedValue {
     negative: bool,
     value: u128,

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -400,10 +400,12 @@ pub struct ConstructionPayloadsRequest {
 
 #[derive(Deserialize, Serialize, Copy, Clone, Debug, EnumIter)]
 pub enum OperationType {
+    // Balance changing operations from TransactionEffect
+    GasSpent,
+    SuiBalanceChange,
+    // Sui transaction types, readonly
     GasBudget,
     TransferSUI,
-    // Readonly
-    GasSpent,
     Pay,
     TransferObject,
     Publish,

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -1,28 +1,29 @@
+use move_core_types::identifier::Identifier;
+use std::str::FromStr;
 use sui_types::base_types::{
     ObjectDigest, ObjectID, SequenceNumber, SuiAddress, TransactionDigest,
 };
+use sui_types::event::Event::TransferObject;
+use sui_types::event::TransferType;
 use sui_types::gas::GasCostSummary;
 use sui_types::messages::{ExecutionStatus, TransactionData, TransactionEffects};
 use sui_types::object::Owner;
+use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 
 use crate::operations::Operation;
 use crate::state::extract_balance_changes_from_ops;
+use crate::types::SignedValue;
 
 #[test]
 fn test_transfer_sui_null_amount() {
     let sender = SuiAddress::random_for_testing_only();
+    let recipient = SuiAddress::random_for_testing_only();
     let gas = (
         ObjectID::random(),
         SequenceNumber::new(),
         ObjectDigest::random(),
     );
-    let data = TransactionData::new_transfer_sui(
-        SuiAddress::random_for_testing_only(),
-        sender,
-        None,
-        gas,
-        1000,
-    );
+    let data = TransactionData::new_transfer_sui(recipient, sender, None, gas, 1000);
 
     let effect = TransactionEffects {
         status: ExecutionStatus::Success,
@@ -39,11 +40,21 @@ fn test_transfer_sui_null_amount() {
         deleted: vec![],
         wrapped: vec![],
         gas_object: (gas, Owner::AddressOwner(sender)),
-        events: vec![],
+        events: vec![TransferObject {
+            package_id: SUI_FRAMEWORK_OBJECT_ID,
+            transaction_module: Identifier::from_str("test").unwrap(),
+            sender,
+            recipient: Owner::AddressOwner(recipient),
+            object_id: ObjectID::random(),
+            version: Default::default(),
+            type_: TransferType::Coin,
+            amount: Some(10000),
+        }],
         dependencies: vec![],
     };
     let ops = Operation::from_data_and_effect(&data, &effect, &[]).unwrap();
     let balances = extract_balance_changes_from_ops(ops).unwrap();
 
-    println!("{:?}", balances)
+    assert_eq!(SignedValue::neg(10150), balances[&sender]);
+    assert_eq!(SignedValue::from(10000u64), balances[&recipient]);
 }

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use move_core_types::identifier::Identifier;
 use std::str::FromStr;
 use sui_types::base_types::{

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Mysten Labs, Inc.
+// Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::identifier::Identifier;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -1,0 +1,49 @@
+use sui_types::base_types::{
+    ObjectDigest, ObjectID, SequenceNumber, SuiAddress, TransactionDigest,
+};
+use sui_types::gas::GasCostSummary;
+use sui_types::messages::{ExecutionStatus, TransactionData, TransactionEffects};
+use sui_types::object::Owner;
+
+use crate::operations::Operation;
+use crate::state::extract_balance_changes_from_ops;
+
+#[test]
+fn test_transfer_sui_null_amount() {
+    let sender = SuiAddress::random_for_testing_only();
+    let gas = (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::random(),
+    );
+    let data = TransactionData::new_transfer_sui(
+        SuiAddress::random_for_testing_only(),
+        sender,
+        None,
+        gas,
+        1000,
+    );
+
+    let effect = TransactionEffects {
+        status: ExecutionStatus::Success,
+        gas_used: GasCostSummary {
+            computation_cost: 100,
+            storage_cost: 100,
+            storage_rebate: 50,
+        },
+        shared_objects: vec![],
+        transaction_digest: TransactionDigest::random(),
+        created: vec![],
+        mutated: vec![],
+        unwrapped: vec![],
+        deleted: vec![],
+        wrapped: vec![],
+        gas_object: (gas, Owner::AddressOwner(sender)),
+        events: vec![],
+        dependencies: vec![],
+    };
+    let ops = Operation::from_data_and_effect(&data, &effect, &[]).unwrap();
+    let balances = extract_balance_changes_from_ops(ops).unwrap();
+
+    println!("{:?}", balances)
+}


### PR DESCRIPTION
In the previous implementation, I mistakenly assumed TransferSui's amount is non None, this causes balance reconciliation to fail when running against the Devnet.

To fix this issue, I removed amount field from the TransferSui rosetta operation (the recipient and amount data are added to the metadata field), by doing so, the TransferSui operations no longer consider as a balance changing operations, which makes it more consistent with other operations (transfer object, move call etc), all unsigned transactions are non balance changing. Balance changing operations are now solely created from effect and event for all Transaction types.
