### PR TITLE
chore: increase end-to-end explorer ci retries

### DIFF
--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -70,6 +70,9 @@ jobs:
     if: needs.diff.outputs.isClient == 'true'
     runs-on: [ubuntu-ghcloud]
     steps:
+      - uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - uses: pnpm/action-setup@v2.2.2


### PR DESCRIPTION
to prevent a flakiness that i see once a month on 
```
Invalid public key input. Expected 32 bytes, got 31
```

i dont know the root cause, but usually just 1 retry would succeed from what i experienced