### PR TITLE
Update msim pointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4403,7 +4403,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=e7773753dcb5becda0ea27b10694eb9c11e7af4a#e7773753dcb5becda0ea27b10694eb9c11e7af4a"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=305f0ca15fe77df5b92b7f4bb57b5472e568edc3#305f0ca15fe77df5b92b7f4bb57b5472e568edc3"
 dependencies = [
  "ahash",
  "async-task",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=e7773753dcb5becda0ea27b10694eb9c11e7af4a#e7773753dcb5becda0ea27b10694eb9c11e7af4a"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=305f0ca15fe77df5b92b7f4bb57b5472e568edc3#305f0ca15fe77df5b92b7f4bb57b5472e568edc3"
 dependencies = [
  "darling 0.14.1",
  "proc-macro2 1.0.43",

--- a/crates/sui-config/src/utils.rs
+++ b/crates/sui-config/src/utils.rs
@@ -1,82 +1,42 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(msim))]
-mod inner {
-    use std::net::{TcpListener, TcpStream};
+use std::net::{TcpListener, TcpStream};
 
-    /// Return an ephemeral, available port. On unix systems, the port returned will be in the
-    /// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.
-    /// Callers should be able to bind to this port given they use SO_REUSEADDR.
-    pub fn get_available_port() -> u16 {
-        const MAX_PORT_RETRIES: u32 = 1000;
+/// Return an ephemeral, available port. On unix systems, the port returned will be in the
+/// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.
+/// Callers should be able to bind to this port given they use SO_REUSEADDR.
+pub fn get_available_port() -> u16 {
+    const MAX_PORT_RETRIES: u32 = 1000;
 
-        for _ in 0..MAX_PORT_RETRIES {
-            if let Ok(port) = get_ephemeral_port() {
-                return port;
-            }
+    for _ in 0..MAX_PORT_RETRIES {
+        if let Ok(port) = get_ephemeral_port() {
+            return port;
         }
-
-        panic!("Error: could not find an available port");
     }
 
-    fn get_ephemeral_port() -> ::std::io::Result<u16> {
-        // Request a random available port from the OS
-        let listener = TcpListener::bind(("localhost", 0))?;
-        let addr = listener.local_addr()?;
-
-        // Create and accept a connection (which we'll promptly drop) in order to force the port
-        // into the TIME_WAIT state, ensuring that the port will be reserved from some limited
-        // amount of time (roughly 60s on some Linux systems)
-        let _sender = TcpStream::connect(addr)?;
-        let _incoming = listener.accept()?;
-
-        Ok(addr.port())
-    }
-
-    pub fn new_network_address() -> multiaddr::Multiaddr {
-        format!("/ip4/127.0.0.1/tcp/{}/http", get_available_port())
-            .parse()
-            .unwrap()
-    }
+    panic!("Error: could not find an available port");
 }
 
-#[cfg(msim)]
-mod inner {
-    use std::cell::Cell;
+fn get_ephemeral_port() -> ::std::io::Result<u16> {
+    // Request a random available port from the OS
+    let listener = TcpListener::bind(("localhost", 0))?;
+    let addr = listener.local_addr()?;
 
-    pub fn get_available_port() -> u16 {
-        thread_local! {
-            static PORT: Cell<u32> = Cell::new(32768);
-        }
+    // Create and accept a connection (which we'll promptly drop) in order to force the port
+    // into the TIME_WAIT state, ensuring that the port will be reserved from some limited
+    // amount of time (roughly 60s on some Linux systems)
+    let _sender = TcpStream::connect(addr)?;
+    let _incoming = listener.accept()?;
 
-        // TODO: This is a bit of a hack - there is nothing to say that other services haven't already
-        // used this port for something else, which could cause problems. We should add a way to ask
-        // the simulator for an unused port.
-        PORT.with(|port| {
-            let ret = port.get();
-            port.set(ret + 1);
-            ret
-        })
-        .try_into()
-        .expect("ran out of ports")
-    }
-
-    pub fn new_network_address() -> multiaddr::Multiaddr {
-        let ip_addr = sui_simulator::runtime::NodeHandle::try_current()
-            .map(|node| {
-                node.ip()
-                    .expect("expected to be called within a simulator node")
-            })
-            .unwrap_or_else(|| "127.0.0.1".parse().unwrap());
-
-        format!("/ip4/{}/tcp/{}/http", ip_addr, get_available_port())
-            .parse()
-            .unwrap()
-    }
+    Ok(addr.port())
 }
 
-pub use inner::*;
+pub fn new_network_address() -> multiaddr::Multiaddr {
+    format!("/ip4/127.0.0.1/tcp/{}/http", get_available_port())
+        .parse()
+        .unwrap()
+}
 
 pub fn available_local_socket_address() -> std::net::SocketAddr {
     format!("127.0.0.1:{}", get_available_port())

--- a/crates/sui-macros/Cargo.toml
+++ b/crates/sui-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1"
 workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "e7773753dcb5becda0ea27b10694eb9c11e7af4a", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -13,4 +13,4 @@ telemetry-subscribers.workspace = true
 tracing = "0.1"
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "e7773753dcb5becda0ea27b10694eb9c11e7af4a", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3", package = "msim" }

--- a/crates/sui-swarm/src/memory/container-sim.rs
+++ b/crates/sui-swarm/src/memory/container-sim.rs
@@ -58,7 +58,7 @@ impl Container {
 
         let node = builder
             .ip(ip)
-            .name(format!("{}", config.protocol_public_key()))
+            .name(&format!("{}", config.protocol_public_key()).as_str()[0..8])
             .init(|| async {
                 tracing::info!("node restarted");
             })

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -58,7 +58,7 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args+=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "e7773753dcb5becda0ea27b10694eb9c11e7af4a"'
+    --config 'patch.crates-io.tokio.rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3"'
   )
 fi
 


### PR DESCRIPTION
- Update to include https://github.com/MystenLabs/mysten-sim/pull/9 which makes ephemeral ports easier to work with.
- Simplify get_available_port()
- abbreviate node name as node spans will now be visible always.