### PR TITLE
[TypeScript SDK] Fix type definition for Normalized modules

### DIFF
--- a/.changeset/new-pumpkins-jump.md
+++ b/.changeset/new-pumpkins-jump.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Fix type definition of SuiMoveNormalizedType

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -88,61 +88,63 @@ export class JsonRpcProvider extends Provider {
 
   // Move info
   async getMoveFunctionArgTypes(
-    objectId: string,
+    packageId: string,
     moduleName: string,
     functionName: string
   ): Promise<SuiMoveFunctionArgTypes> {
     try {
       return await this.client.requestWithType(
         'sui_getMoveFunctionArgTypes',
-        [objectId, moduleName, functionName],
+        [packageId, moduleName, functionName],
         isSuiMoveFunctionArgTypes,
         this.skipDataValidation
       );
     } catch (err) {
       throw new Error(
-        `Error fetching Move function arg types with package object ID: ${objectId}, module name: ${moduleName}, function name: ${functionName}`
+        `Error fetching Move function arg types with package object ID: ${packageId}, module name: ${moduleName}, function name: ${functionName}`
       );
     }
   }
 
   async getNormalizedMoveModulesByPackage(
-    objectId: string
+    packageId: string
   ): Promise<SuiMoveNormalizedModules> {
     // TODO: Add caching since package object does not change
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveModulesByPackage',
-        [objectId],
+        [packageId],
         isSuiMoveNormalizedModules,
         this.skipDataValidation
       );
     } catch (err) {
-      throw new Error(`Error fetching package: ${err} for package ${objectId}`);
+      throw new Error(
+        `Error fetching package: ${err} for package ${packageId}`
+      );
     }
   }
 
   async getNormalizedMoveModule(
-    objectId: string,
+    packageId: string,
     moduleName: string
   ): Promise<SuiMoveNormalizedModule> {
     // TODO: Add caching since package object does not change
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveModule',
-        [objectId, moduleName],
+        [packageId, moduleName],
         isSuiMoveNormalizedModule,
         this.skipDataValidation
       );
     } catch (err) {
       throw new Error(
-        `Error fetching module: ${err} for package ${objectId}, module ${moduleName}}`
+        `Error fetching module: ${err} for package ${packageId}, module ${moduleName}}`
       );
     }
   }
 
   async getNormalizedMoveFunction(
-    objectId: string,
+    packageId: string,
     moduleName: string,
     functionName: string
   ): Promise<SuiMoveNormalizedFunction> {
@@ -150,32 +152,32 @@ export class JsonRpcProvider extends Provider {
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveFunction',
-        [objectId, moduleName, functionName],
+        [packageId, moduleName, functionName],
         isSuiMoveNormalizedFunction,
         this.skipDataValidation
       );
     } catch (err) {
       throw new Error(
-        `Error fetching function: ${err} for package ${objectId}, module ${moduleName} and function ${functionName}}`
+        `Error fetching function: ${err} for package ${packageId}, module ${moduleName} and function ${functionName}}`
       );
     }
   }
 
   async getNormalizedMoveStruct(
-    objectId: string,
+    packageId: string,
     moduleName: string,
     structName: string
   ): Promise<SuiMoveNormalizedStruct> {
     try {
       return await this.client.requestWithType(
         'sui_getNormalizedMoveStruct',
-        [objectId, moduleName, structName],
+        [packageId, moduleName, structName],
         isSuiMoveNormalizedStruct,
         this.skipDataValidation
       );
     } catch (err) {
       throw new Error(
-        `Error fetching struct: ${err} for package ${objectId}, module ${moduleName} and struct ${structName}}`
+        `Error fetching struct: ${err} for package ${packageId}, module ${moduleName} and struct ${structName}}`
       );
     }
   }

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -159,8 +159,9 @@ export class CallArgSerializer {
   }
 
   private isTxContext(param: SuiMoveNormalizedType): boolean {
-    const struct = extractMutableReference(param)?.Struct;
+    const struct = extractStructTag(param)?.Struct;
     return (
+      extractMutableReference(param) != null &&
       struct?.address === '0x2' &&
       struct?.module === 'tx_context' &&
       struct?.name === 'TxContext'

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -289,11 +289,11 @@ export function isSuiMoveNormalizedType(obj: any, _argumentName?: string): obj i
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&
-            isSuiMoveNormalizedStructType(obj.Reference) as boolean ||
+            isSuiMoveNormalizedType(obj.Reference) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&
-            isSuiMoveNormalizedStructType(obj.MutableReference) as boolean ||
+            isSuiMoveNormalizedType(obj.MutableReference) as boolean ||
             (obj !== null &&
                 typeof obj === "object" ||
                 typeof obj === "function") &&
@@ -324,7 +324,7 @@ export function isSuiMoveNormalizedStructType(obj: any, _argumentName?: string):
         isTransactionDigest(obj.Struct.name) as boolean &&
         Array.isArray(obj.Struct.type_arguments) &&
         obj.Struct.type_arguments.every((e: any) =>
-            isSuiMoveNormalizedTypeParameterType(e) as boolean
+            isSuiMoveNormalizedType(e) as boolean
         )
     )
 }

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -98,8 +98,8 @@ export type SuiMoveAbilitySet = {
 export type SuiMoveNormalizedType =
   | string
   | SuiMoveNormalizedTypeParameterType
-  | { Reference: SuiMoveNormalizedStructType }
-  | { MutableReference: SuiMoveNormalizedStructType }
+  | { Reference: SuiMoveNormalizedType }
+  | { MutableReference: SuiMoveNormalizedType }
   | { Vector: SuiMoveNormalizedType }
   | SuiMoveNormalizedStructType;
 
@@ -112,7 +112,7 @@ export type SuiMoveNormalizedStructType = {
     address: string;
     module: string;
     name: string;
-    type_arguments: SuiMoveNormalizedTypeParameterType[];
+    type_arguments: SuiMoveNormalizedType[];
   };
 };
 
@@ -276,7 +276,7 @@ export function getMovePackageContent(
 
 export function extractMutableReference(
   normalizedType: SuiMoveNormalizedType
-): SuiMoveNormalizedStructType | undefined {
+): SuiMoveNormalizedType | undefined {
   return typeof normalizedType === 'object' &&
     'MutableReference' in normalizedType
     ? normalizedType.MutableReference
@@ -285,7 +285,7 @@ export function extractMutableReference(
 
 export function extractReference(
   normalizedType: SuiMoveNormalizedType
-): SuiMoveNormalizedStructType | undefined {
+): SuiMoveNormalizedType | undefined {
   return typeof normalizedType === 'object' && 'Reference' in normalizedType
     ? normalizedType.Reference
     : undefined;
@@ -298,9 +298,15 @@ export function extractStructTag(
     return normalizedType;
   }
 
-  return (
-    (extractReference(normalizedType) ||
-      extractMutableReference(normalizedType)) ??
-    undefined
-  );
+  const ref = extractReference(normalizedType);
+  const mutRef = extractMutableReference(normalizedType);
+
+  if (typeof ref === 'object' && 'Struct' in ref) {
+    return ref;
+  }
+
+  if (typeof mutRef === 'object' && 'Struct' in mutRef) {
+    return mutRef;
+  }
+  return undefined;
 }

--- a/sdk/typescript/test/e2e/normalized-modules.test.ts
+++ b/sdk/typescript/test/e2e/normalized-modules.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { setup, TestToolbox } from './utils/setup';
+
+const DEFAULT_PACKAGE = '0x2';
+const DEFAULT_MODULE = 'coin';
+const DEFAULT_FUNCTION = 'balance';
+const DEFAULT_STRUCT = 'Coin';
+
+describe('Normalized modules API', () => {
+  let toolbox: TestToolbox;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+  });
+
+  it('Get Move function arg types', async () => {
+    const argTypes = await toolbox.provider.getMoveFunctionArgTypes(
+      DEFAULT_PACKAGE,
+      DEFAULT_MODULE,
+      DEFAULT_FUNCTION
+    );
+    expect(argTypes).toEqual([
+      {
+        Object: 'ByImmutableReference',
+      },
+    ]);
+  });
+
+  it('Get Normalized Modules by packages', async () => {
+    const modules = await toolbox.provider.getNormalizedMoveModulesByPackage(
+      DEFAULT_PACKAGE
+    );
+    expect(Object.keys(modules)).contains(DEFAULT_MODULE);
+  });
+
+  it('Get Normalized Move Module', async () => {
+    const normalized = await toolbox.provider.getNormalizedMoveModule(
+      DEFAULT_PACKAGE,
+      DEFAULT_MODULE
+    );
+    expect(Object.keys(normalized.exposed_functions)).toContain(
+      DEFAULT_FUNCTION
+    );
+  });
+
+  it('Get Normalized Move Function', async () => {
+    const normalized = await toolbox.provider.getNormalizedMoveFunction(
+      DEFAULT_PACKAGE,
+      DEFAULT_MODULE,
+      DEFAULT_FUNCTION
+    );
+    expect(normalized.is_entry).toEqual(false);
+  });
+
+  it('Get Normalized Move Struct ', async () => {
+    const struct = await toolbox.provider.getNormalizedMoveStruct(
+      DEFAULT_PACKAGE,
+      DEFAULT_MODULE,
+      DEFAULT_STRUCT
+    );
+    expect(struct.fields.length).toBeGreaterThan(1);
+  });
+});

--- a/sdk/typescript/test/e2e/rpc-txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/rpc-txn-builder.test.ts
@@ -7,7 +7,6 @@ import {
   getExecutionStatusType,
   getObjectId,
   RawSigner,
-  SuiObjectInfo,
 } from '../../src';
 import {
   DEFAULT_GAS_BUDGET,

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -45,8 +45,8 @@ export function getProvider(
   const url =
     rpcType === 'fullnode' ? DEFAULT_FULLNODE_URL : DEFAULT_GATEWAY_URL;
   return providerType === 'rpc'
-    ? new JsonRpcProvider(url)
-    : new JsonRpcProviderWithCache(url);
+    ? new JsonRpcProvider(url, false)
+    : new JsonRpcProviderWithCache(url, false);
 }
 
 export async function setup(


### PR DESCRIPTION
There's a mismatch between the TypeScript Definition of `SuiMoveNormalizedType` in `object.ts` and the data returned from the RPC server, causing the data validation to fail. This PR fixes the definition and adds e2e test to prevent regression in the future.