### PR TITLE
[reconfig] Stop accepting consensus tx after last fragment of C-1

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1968,6 +1968,13 @@ impl AuthorityState {
         match transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
                 if self
+                    .checkpoints
+                    .lock()
+                    .should_reject_consensus_transaction()
+                {
+                    return Err(NarwhalHandlerError::ValidatorHalted);
+                }
+                if self
                     .database
                     .consensus_message_processed(certificate.digest())
                     .await
@@ -2092,6 +2099,9 @@ impl ExecutionState for ConsensusHandler {
                     consensus_output.certificate.header.author, err
                 );
             }
+            Err(NarwhalHandlerError::ValidatorHalted) => {
+                debug!("Validator has stopped accepting consensus transactions, skipping");
+            }
             Err(NarwhalHandlerError::NodeError(err)) => {
                 Err(err).expect("Unrecoverable error in consensus handler")
             }
@@ -2116,4 +2126,6 @@ pub enum NarwhalHandlerError {
     /// narwhal can continue streaming next transactions to SUI
     #[error("Invalid transaction {}", 0)]
     SkipNarwhalTransaction(SuiError),
+    #[error("Validator halted and no longer accepts sequenced transactions")]
+    ValidatorHalted,
 }


### PR DESCRIPTION
This PR adds two constraints around reconfig:
1. Validator should stop sending tx to consensus once the validator is halted. This is an optimization. There is no safety concern here if we don't. Just to not waste the resource of NW.
2. After receiving the last fragment that could finish checkpoint construction of the second last checkpoint, we stop accepting consensus transactions.

A follow up PR would make sure all transactions received from consensus get executed and included by the last checkpoint.