### PR TITLE
fixed broken image for Bluemove app icon

### DIFF
--- a/apps/wallet/apps/dapps.json
+++ b/apps/wallet/apps/dapps.json
@@ -39,7 +39,7 @@
         "name": "Bluemove",
         "description": "NFT Marketplace on blockchain Sui",
         "link": "https://sui.bluemove.net/",
-        "icon": "https://sui.bluemove.net/BlueMove_main_logo_RGB-Blue_250.png",
+        "icon": "https://storage.googleapis.com/sui-cms-content/thumbnail_bluemove_c7a0a3e528/thumbnail_bluemove_c7a0a3e528.png",
         "tags": ["Marketplace"]
     }
 ]

--- a/wallet/apps/dapps.json
+++ b/wallet/apps/dapps.json
@@ -39,7 +39,7 @@
 			"name": "Bluemove",
 			"description": "NFT Marketplace on blockchain Sui",
 			"link": "https://sui.bluemove.net/",
-			"icon": "https://sui.bluemove.net/BlueMove_main_logo_RGB-Blue_250.png",
+			"icon": "https://storage.googleapis.com/sui-cms-content/thumbnail_bluemove_c7a0a3e528/thumbnail_bluemove_c7a0a3e528.png",
 			"tags": ["Marketplace"]
 	}
 ]


### PR DESCRIPTION
Small PR to fix Bluemove broken icon

<img width="412" alt="Screen Shot 2022-10-06 at 9 31 53 AM" src="https://user-images.githubusercontent.com/8676844/194326589-c51fa72b-6d45-4b87-8505-f5e616e841ba.png">
