### PR TITLE
Add determinism check for a basic network, fix determinism issue.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8487,8 +8487,11 @@ dependencies = [
 name = "sui-simulator"
 version = "0.7.0"
 dependencies = [
+ "anemo",
+ "fastcrypto",
  "msim",
  "sui-framework",
+ "sui-types",
  "telemetry-subscribers 0.2.0",
  "tracing",
  "workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=305f0ca15fe77df5b92b7f4bb57b5472e568edc3#305f0ca15fe77df5b92b7f4bb57b5472e568edc3"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=982cf1a544ebd1e2818330f9b1247a4c3dd26c13#982cf1a544ebd1e2818330f9b1247a4c3dd26c13"
 dependencies = [
  "ahash",
  "async-task",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=305f0ca15fe77df5b92b7f4bb57b5472e568edc3#305f0ca15fe77df5b92b7f4bb57b5472e568edc3"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=982cf1a544ebd1e2818330f9b1247a4c3dd26c13#982cf1a544ebd1e2818330f9b1247a4c3dd26c13"
 dependencies = [
  "darling 0.14.1",
  "proc-macro2 1.0.43",

--- a/crates/sui-macros/Cargo.toml
+++ b/crates/sui-macros/Cargo.toml
@@ -16,4 +16,4 @@ syn = "1"
 workspace-hack.workspace = true
 
 [target.'cfg(msim)'.dependencies]
-msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3", package = "msim-macros" }
+msim-macros = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "982cf1a544ebd1e2818330f9b1247a4c3dd26c13", package = "msim-macros" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -16,4 +16,4 @@ anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf4
 fastcrypto = { workspace = true, features = ["copy_key"] }
 
 [target.'cfg(msim)'.dependencies]
-msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3", package = "msim" }
+msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "982cf1a544ebd1e2818330f9b1247a4c3dd26c13", package = "msim" }

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -9,8 +9,11 @@ edition = "2021"
 [dependencies]
 workspace-hack.workspace = true
 sui-framework = { path = "../sui-framework" }
+sui-types = { path = "../sui-types" }
 telemetry-subscribers.workspace = true
 tracing = "0.1"
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+fastcrypto = { workspace = true, features = ["copy_key"] }
 
 [target.'cfg(msim)'.dependencies]
 msim = { git = "https://github.com/MystenLabs/mysten-sim.git", rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3", package = "msim" }

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -5,7 +5,10 @@
 pub use msim::*;
 
 // Re-export things used by sui-macros
+pub use anemo;
+pub use fastcrypto;
 pub use sui_framework;
+pub use sui_types;
 pub use telemetry_subscribers;
 
 /// Evaluates an expression in a new thread which will not be subject to interception of

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -58,7 +58,7 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args+=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "305f0ca15fe77df5b92b7f4bb57b5472e568edc3"'
+    --config 'patch.crates-io.tokio.rev = "982cf1a544ebd1e2818330f9b1247a4c3dd26c13"'
   )
 fi
 


### PR DESCRIPTION
This change allows us to run repeated tests using `MSIM_TEST_NUM=N`, and then reproduce a failure that occurs at any iteration by using the seed from the failed iteration. Previously this did not work because of lazy static initialization that would occur only when running the failed test in isolation.

Depends on https://github.com/MystenLabs/mysten-sim/pull/10