### PR TITLE
[Narwhal] Simplify worker to give stronger client guarantees

### DIFF
--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -39,9 +39,7 @@ pub type SerializedTransactionDigest = u64;
 
 #[async_trait]
 pub trait ExecutionState {
-    /// Execute the transaction and atomically persist the consensus index. This function
-    /// returns an execution outcome that will be output by the executor channel. It may
-    /// also return a new committee to reconfigure the system.
+    /// Execute the transaction and atomically persist the consensus index.
     async fn handle_consensus_transaction(
         &self,
         consensus_output: &Arc<ConsensusOutput>,

--- a/narwhal/types/src/worker.rs
+++ b/narwhal/types/src/worker.rs
@@ -31,7 +31,6 @@ pub struct RequestBatchResponse {
 pub type TxResponse = tokio::sync::oneshot::Sender<BatchDigest>;
 pub type PrimaryResponse = Option<tokio::sync::oneshot::Sender<()>>;
 
-
 /// Hashes a serialized batch message without deserializing it into a batch.
 ///
 /// See the test `test_batch_and_serialized`, which guarantees that the output of this

--- a/narwhal/types/src/worker.rs
+++ b/narwhal/types/src/worker.rs
@@ -28,6 +28,10 @@ pub struct RequestBatchResponse {
     pub batch: Option<Batch>,
 }
 
+pub type TxResponse = tokio::sync::oneshot::Sender<BatchDigest>;
+pub type PrimaryResponse = Option<tokio::sync::oneshot::Sender<()>>;
+
+
 /// Hashes a serialized batch message without deserializing it into a batch.
 ///
 /// See the test `test_batch_and_serialized`, which guarantees that the output of this

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -191,8 +191,6 @@ impl BatchMaker {
         size: usize,
         responses: Vec<TxResponse>,
     ) -> impl Future<Output = ()> {
-        
-
         #[cfg(feature = "benchmark")]
         {
             use fastcrypto::hash::Hash;
@@ -334,7 +332,11 @@ impl BatchMaker {
 
             // Finally send to primary
             let (primary_response, batch_done) = tokio::sync::oneshot::channel();
-            let message = WorkerOurBatchMessage { digest, worker_id, metadata };
+            let message = WorkerOurBatchMessage {
+                digest,
+                worker_id,
+                metadata,
+            };
             if tx_digest
                 .send((message, Some(primary_response)))
                 .await

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -21,11 +21,8 @@ use tokio::{
 use types::{
     error::DagError,
     metered_channel::{Receiver, Sender},
-
-    Batch, BatchDigest, ReconfigureNotification, Transaction, WorkerOurBatchMessage,
-
-    PrimaryResponse, TxResponse,
-
+    Batch, BatchDigest, PrimaryResponse, ReconfigureNotification, Transaction, TxResponse,
+    WorkerOurBatchMessage,
 };
 
 #[cfg(test)]
@@ -258,7 +255,11 @@ impl BatchMaker {
 
         // Finally send to primary
         let (primary_response, batch_done) = tokio::sync::oneshot::channel();
-        let message = WorkerOurBatchMessage { digest, worker_id: self.id, metadata };
+        let message = WorkerOurBatchMessage {
+            digest,
+            worker_id: self.id,
+            metadata,
+        };
         if self
             .tx_digest
             .send((message, Some(primary_response)))

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -5,6 +5,11 @@ use crate::metrics::WorkerMetrics;
 #[cfg(feature = "trace_transaction")]
 use byteorder::{BigEndian, ReadBytesExt};
 use config::Committee;
+use fastcrypto::hash::Hash;
+use store::Store;
+
+use config::WorkerId;
+
 #[cfg(feature = "benchmark")]
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -16,7 +21,7 @@ use tokio::{
 use types::{
     error::DagError,
     metered_channel::{Receiver, Sender},
-    Batch, ReconfigureNotification, Transaction,
+    Batch, BatchDigest, ReconfigureNotification, Transaction, WorkerOurBatchMessage,
 };
 
 #[cfg(test)]
@@ -25,6 +30,8 @@ pub mod batch_maker_tests;
 
 /// Assemble clients transactions into batches.
 pub struct BatchMaker {
+    // Our worker's id.
+    id: WorkerId,
     /// The committee information.
     committee: Committee,
     /// The preferred batch size (in bytes).
@@ -36,7 +43,7 @@ pub struct BatchMaker {
     /// Channel to receive transactions from the network.
     rx_batch_maker: Receiver<Transaction>,
     /// Output channel to deliver sealed batches to the `QuorumWaiter`.
-    tx_quorum_waiter: Sender<Batch>,
+    tx_message: Sender<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
     /// Holds the current batch.
     current_batch: Batch,
     /// Holds the size of the current batch (in bytes).
@@ -46,31 +53,42 @@ pub struct BatchMaker {
     /// The timestamp of the first transaction received
     /// to be included on the next batch
     batch_start_timestamp: Instant,
+    /// The batch store to store our own batches.
+    store: Store<BatchDigest, Batch>,
+    // Output channel to send out batches' digests.
+    tx_digest: Sender<WorkerOurBatchMessage>,
+
 }
 
 impl BatchMaker {
     #[must_use]
     pub fn spawn(
+        id: WorkerId,
         committee: Committee,
         batch_size: usize,
         max_batch_delay: Duration,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         rx_batch_maker: Receiver<Transaction>,
-        tx_quorum_waiter: Sender<Batch>,
+        tx_message: Sender<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
         node_metrics: Arc<WorkerMetrics>,
+        store: Store<BatchDigest, Batch>,
+        tx_digest: Sender<WorkerOurBatchMessage>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
+                id,
                 committee,
                 batch_size,
                 max_batch_delay,
                 rx_reconfigure,
                 rx_batch_maker,
-                tx_quorum_waiter,
+                tx_message,
                 current_batch: Batch::new(Vec::with_capacity(batch_size * 2)),
                 current_batch_size: 0,
                 batch_start_timestamp: Instant::now(),
                 node_metrics,
+                store,
+                tx_digest,
             }
             .run()
             .await;
@@ -141,6 +159,7 @@ impl BatchMaker {
         // Serialize the batch.
         self.current_batch_size = 0;
         let batch: Batch = Batch::new(self.current_batch.transactions.drain(..).collect());
+        let metadata = batch.metadata.clone();
 
         #[cfg(feature = "benchmark")]
         {
@@ -200,7 +219,13 @@ impl BatchMaker {
             .observe(size as f64);
 
         // Send the batch through the deliver channel for further processing.
-        if self.tx_quorum_waiter.send(batch).await.is_err() {
+        let (notify_done, done_sending) = tokio::sync::oneshot::channel();
+        if self
+            .tx_message
+            .send((batch.clone(), Some(notify_done)))
+            .await
+            .is_err()
+        {
             tracing::debug!("{}", DagError::ShuttingDown);
         }
 
@@ -211,5 +236,21 @@ impl BatchMaker {
             .created_batch_latency
             .with_label_values(&[self.committee.epoch.to_string().as_str(), reason])
             .observe(self.batch_start_timestamp.elapsed().as_secs_f64());
+
+        // Now save it to disk
+        let digest = batch.digest();
+        self.store.sync_write(digest, batch).await;
+        // Wait until the batch was written
+        let _ = self.store.notify_read(digest).await;
+
+        // Also wait for sending to be done here
+        // (TODO: sending to others is an optimization, no need to wait.)
+        let _ = done_sending.await;
+
+        // Finally send to primary
+        let message = WorkerOurBatchMessage { digest, worker_id: self.id, metadata  };
+        if self.tx_digest.send(message).await.is_err() {
+            tracing::debug!("{}", DagError::ShuttingDown);
+        };
     }
 }

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -21,14 +21,16 @@ use tokio::{
 use types::{
     error::DagError,
     metered_channel::{Receiver, Sender},
+
     Batch, BatchDigest, ReconfigureNotification, Transaction, WorkerOurBatchMessage,
+
+    PrimaryResponse, TxResponse,
+
 };
 
 #[cfg(test)]
 #[path = "tests/batch_maker_tests.rs"]
 pub mod batch_maker_tests;
-
-pub type TxResponse = tokio::sync::oneshot::Sender<BatchDigest>;
 
 /// Assemble clients transactions into batches.
 pub struct BatchMaker {
@@ -54,8 +56,7 @@ pub struct BatchMaker {
     /// The batch store to store our own batches.
     store: Store<BatchDigest, Batch>,
     // Output channel to send out batches' digests.
-    tx_digest: Sender<WorkerOurBatchMessage>,
-
+    tx_digest: Sender<(WorkerOurBatchMessage, PrimaryResponse)>,
 }
 
 impl BatchMaker {
@@ -70,7 +71,7 @@ impl BatchMaker {
         tx_message: Sender<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
         node_metrics: Arc<WorkerMetrics>,
         store: Store<BatchDigest, Batch>,
-        tx_digest: Sender<WorkerOurBatchMessage>,
+        tx_digest: Sender<(WorkerOurBatchMessage, PrimaryResponse)>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -224,7 +225,7 @@ impl BatchMaker {
         // Note: the code below waits on the WAN to send messages to all others, the store
         // to write and confirm the write, and then the primary to respond to being notified
         // of a batch. While all this is going on the other batches are not being created and
-        // processed leading to an under utimization of resources.
+        // processed leading to an under utilization of resources.
 
         // Send the batch through the deliver channel for further processing.
         let (notify_done, done_sending) = tokio::sync::oneshot::channel();
@@ -256,10 +257,25 @@ impl BatchMaker {
         let _ = done_sending.await;
 
         // Finally send to primary
-        let message = WorkerOurBatchMessage { digest, worker_id: self.id, metadata  };
-        if self.tx_digest.send(message).await.is_err() {
+        let (primary_response, batch_done) = tokio::sync::oneshot::channel();
+        let message = WorkerOurBatchMessage { digest, worker_id: self.id, metadata };
+        if self
+            .tx_digest
+            .send((message, Some(primary_response)))
+            .await
+            .is_err()
+        {
             tracing::debug!("{}", DagError::ShuttingDown);
         };
+
+        // Wait for a primary response
+        if batch_done.await.is_err() {
+            // If there is an error it means the channel closed,
+            // and therefore we drop all response handers since we
+            // cannot ensure the primary has actually signaled the
+            // batch will eventually be sent.
+            return;
+        }
 
         // We now signal back to the transaction sender that the transaction is in a
         // batch and also the digest of the batch.

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -82,6 +82,7 @@ pub struct PrimaryReceiverHandler {
     pub committee: SharedCommittee,
     // The worker information cache.
     pub worker_cache: SharedWorkerCache,
+    // The batch store
     pub store: Store<BatchDigest, Batch>,
     // Timeout on RequestBatch RPC.
     pub request_batch_timeout: Duration,

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -59,6 +59,8 @@ pub struct WorkerMetrics {
     pub created_batch_size: HistogramVec,
     /// Time taken to create a batch
     pub created_batch_latency: HistogramVec,
+    /// The number of parallel worker batches currently processed by the worker
+    pub parallel_worker_batches: IntGauge,
 }
 
 impl WorkerMetrics {
@@ -91,6 +93,12 @@ impl WorkerMetrics {
                 &["epoch", "reason"],
                 // buckets in seconds
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry
+            )
+            .unwrap(),
+            parallel_worker_batches: register_int_gauge_with_registry!(
+                "parallel_worker_batches",
+                "The number of parallel worker batches currently processed by the worker",
                 registry
             )
             .unwrap(),

--- a/narwhal/worker/src/primary_connector.rs
+++ b/narwhal/worker/src/primary_connector.rs
@@ -4,12 +4,11 @@
 
 use crypto::NetworkPublicKey;
 use futures::{stream::FuturesUnordered, StreamExt};
-use network::{P2pNetwork, ReliableNetwork, CancelOnDropHandler};
+use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use tokio::{sync::watch, task::JoinHandle};
 use types::{
-    metered_channel::Receiver, ReconfigureNotification, WorkerOthersBatchMessage,
+    metered_channel::Receiver, PrimaryResponse, ReconfigureNotification, WorkerOthersBatchMessage,
     WorkerOurBatchMessage,
-   PrimaryResponse, 
 };
 
 /// The maximum number of digests kept in memory waiting to be sent to the primary.
@@ -90,8 +89,11 @@ impl PrimaryConnector {
     }
 }
 
-async fn handle_future(handle: CancelOnDropHandler<Result<anemo::Response<()>, anemo::Error>> , _response: PrimaryResponse) {
-    if handle.await.is_ok(){
+async fn handle_future(
+    handle: CancelOnDropHandler<Result<anemo::Response<()>, anemo::Error>>,
+    _response: PrimaryResponse,
+) {
+    if handle.await.is_ok() {
         if let Some(response_channel) = _response {
             let _ = response_channel.send(());
         }

--- a/narwhal/worker/src/primary_connector.rs
+++ b/narwhal/worker/src/primary_connector.rs
@@ -54,14 +54,14 @@ impl PrimaryConnector {
         loop {
             tokio::select! {
                 // Send the digest through the network.
-                Some((batch, _response)) = self.rx_our_batch.recv() => {
+                Some((batch, response)) = self.rx_our_batch.recv() => {
                     if futures.len() >= MAX_PENDING_DIGESTS {
                         tracing::warn!("Primary unreachable: dropping {batch:?}");
                         continue;
                     }
 
                     let handle = self.primary_client.send(self.primary_name.to_owned(), &batch).await;
-                    futures.push( handle_future(handle, _response) );
+                    futures.push( handle_future(handle, response) );
                 },
                 Some(batch) = self.rx_others_batch.recv() => {
                     if futures.len() >= MAX_PENDING_DIGESTS {

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -3,16 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 use config::{Committee, SharedWorkerCache, Stake, WorkerId};
 use crypto::PublicKey;
-use fastcrypto::hash::Hash;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use store::Store;
 use tokio::{sync::watch, task::JoinHandle};
 use types::{
-
-
-    metered_channel::{Receiver, },
-    Batch, BatchDigest, ReconfigureNotification, WorkerBatchMessage, WorkerOurBatchMessage,
+    metered_channel::Receiver, Batch, BatchDigest, ReconfigureNotification, WorkerBatchMessage,
 };
 
 #[cfg(test)]
@@ -25,8 +21,6 @@ pub struct QuorumWaiter {
     name: PublicKey,
     /// The id of this worker.
     id: WorkerId,
-    // The persistent storage.
-    store: Store<BatchDigest, Batch>,
     /// The committee information.
     committee: Committee,
     /// The worker information cache.
@@ -45,7 +39,7 @@ impl QuorumWaiter {
     pub fn spawn(
         name: PublicKey,
         id: WorkerId,
-        store: Store<BatchDigest, Batch>,
+        _store: Store<BatchDigest, Batch>,
         committee: Committee,
         worker_cache: SharedWorkerCache,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
@@ -56,7 +50,6 @@ impl QuorumWaiter {
             Self {
                 name,
                 id,
-                store,
                 committee,
                 worker_cache,
                 rx_reconfigure,

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -1,12 +1,17 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+use crate::batch_maker::MAX_PARALLEL_BATCH;
 use config::{Committee, SharedWorkerCache, Stake, WorkerId};
 use crypto::PublicKey;
-use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
+use fastcrypto::hash::Hash;
+use futures::stream::{futures_unordered::FuturesUnordered, FuturesOrdered, StreamExt as _};
 use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
+use std::time::Duration;
 use store::Store;
-use tokio::{sync::watch, task::JoinHandle};
+use tokio::{sync::watch, task::JoinHandle, time::timeout};
+use tracing::trace;
 use types::{
     metered_channel::Receiver, Batch, BatchDigest, ReconfigureNotification, WorkerBatchMessage,
 };
@@ -72,11 +77,18 @@ impl QuorumWaiter {
 
     /// Main loop.
     async fn run(&mut self) {
+        //
+        let mut pipeline = FuturesOrdered::new();
+        let mut best_effort_with_timeout = FuturesUnordered::new();
+
         loop {
             tokio::select! {
 
-                Some((batch, opt_channel)) = self.rx_message.recv() => {
-
+                // When a new batch is available, and the pipeline is not full, add a new
+                // task to the pipeline to send this batch to workers.
+                //
+                // TODO: make the constant a config parameter.
+                Some((batch, opt_channel)) = self.rx_message.recv(), if pipeline.len() < MAX_PARALLEL_BATCH => {
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
                         .worker_cache
@@ -86,7 +98,7 @@ impl QuorumWaiter {
                         .map(|(name, info)| (name, info.name))
                         .collect();
                     let (primary_names, worker_names): (Vec<_>, _) = workers.into_iter().unzip();
-                    let message = WorkerBatchMessage{batch: batch.clone()};
+                    let message  = WorkerBatchMessage{batch: batch.clone()};
                     let handlers = self.network.broadcast(worker_names, &message).await;
 
                     // Collect all the handlers to receive acknowledgements.
@@ -104,35 +116,58 @@ impl QuorumWaiter {
                     // the dag). This should reduce the amount of synching.
                     let threshold = self.committee.quorum_threshold();
                     let mut total_stake = self.committee.stake(&self.name);
-                    loop {
-                        tokio::select! {
-                            Some(stake) = wait_for_quorum.next() => {
+
+                    pipeline.push_back(async move {
+                        // A future that sends to 2/3 stake then returns. Also prints an error
+                        // if we terminate before we have managed to get to the full 2/3 stake.
+
+                        loop{
+                            if let Some(stake) = wait_for_quorum.next().await {
                                 total_stake += stake;
                                 if total_stake >= threshold {
+
                                     // Notify anyone waiting for this.
                                     if let Some(channel) = opt_channel {
                                         let _ = channel.send(());
                                     }
-                                    break;
+                                    break
                                 }
-                            }
-
-                            result = self.rx_reconfigure.changed() => {
-                                result.expect("Committee channel dropped");
-                                let message = self.rx_reconfigure.borrow().clone();
-                                match message {
-                                    ReconfigureNotification::NewEpoch(new_committee)
-                                        | ReconfigureNotification::UpdateCommittee(new_committee) => {
-                                            self.committee = new_committee;
-                                            tracing::debug!("Dropping batch: committee updated to {}", self.committee);
-                                            break; // Don't wait for acknowledgements.
-                                    },
-                                    ReconfigureNotification::Shutdown => return
-                                }
+                            } else {
+                                // TODO: maybe we should be stopping the system if that happens,
+                                //       since it seems serious. However, it may happen at the
+                                //       start of the epoch when not everyone is ready?
+                                tracing::error!("Batch dissemination ended without a quorum.");
+                                break;
                             }
                         }
-                    }
+                        (batch, wait_for_quorum)
+                    });
                 },
+
+                // Process futures in the pipeline. They complete when we have sent to >2/3
+                // of other worker by stake, but after that we still try to send to the remaining
+                // on a best effort basis.
+                Some((batch, mut remaining)) = pipeline.next() => {
+
+                    // Attempt to send messages to the remaining workers
+                    if !remaining.is_empty() {
+                        trace!("Best effort dissemination for batch {} for remaining {}", batch.digest(), remaining.len());
+                        best_effort_with_timeout.push(async move {
+                           // Bound the attempt to a few seconds to tolerate nodes that are
+                           // offline and will never succeed.
+                           //
+                           // TODO: make the constant a config parameter.
+                           timeout(Duration::from_secs(5), async move{
+                               while remaining.next().await.is_some() { }
+                           }).await
+                       });
+                    }
+
+                },
+
+                // Drive the best effort send efforts which may update remaining workers
+                // or timeout.
+                Some(_) = best_effort_with_timeout.next() => {}
 
                 // Trigger reconfigure.
                 result = self.rx_reconfigure.changed() => {
@@ -144,6 +179,13 @@ impl QuorumWaiter {
                         },
                         ReconfigureNotification::UpdateCommittee(new_committee) => {
                             self.committee = new_committee;
+
+                            // Upon reconfiguration we drop all current batches.
+                            // TODO: maybe re-send to new committee?
+                            tracing::error!("Batch dissemination dropped {} batches before quorum.", pipeline.len() );
+
+                            pipeline = FuturesOrdered::new();
+                            best_effort_with_timeout = FuturesUnordered::new()
 
                         },
                         ReconfigureNotification::Shutdown => return

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -9,8 +9,9 @@ use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use store::Store;
 use tokio::{sync::watch, task::JoinHandle};
 use types::{
-    error::DagError,
-    metered_channel::{Receiver, Sender},
+
+
+    metered_channel::{Receiver, },
     Batch, BatchDigest, ReconfigureNotification, WorkerBatchMessage, WorkerOurBatchMessage,
 };
 
@@ -33,9 +34,7 @@ pub struct QuorumWaiter {
     /// Receive reconfiguration updates.
     rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     /// Input Channel to receive commands.
-    rx_quorum_waiter: Receiver<Batch>,
-    /// Channel to deliver batches for which we have enough acknowledgments.
-    tx_our_batch: Sender<WorkerOurBatchMessage>,
+    rx_message: Receiver<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
     /// A network sender to broadcast the batches to the other workers.
     network: P2pNetwork,
 }
@@ -50,8 +49,7 @@ impl QuorumWaiter {
         committee: Committee,
         worker_cache: SharedWorkerCache,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
-        rx_quorum_waiter: Receiver<Batch>,
-        tx_our_batch: Sender<WorkerOurBatchMessage>,
+        rx_message: Receiver<(Batch, Option<tokio::sync::oneshot::Sender<()>>)>,
         network: P2pNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
@@ -62,8 +60,7 @@ impl QuorumWaiter {
                 committee,
                 worker_cache,
                 rx_reconfigure,
-                rx_quorum_waiter,
-                tx_our_batch,
+                rx_message,
                 network,
             }
             .run()
@@ -84,7 +81,9 @@ impl QuorumWaiter {
     async fn run(&mut self) {
         loop {
             tokio::select! {
-                Some(batch) = self.rx_quorum_waiter.recv() => {
+
+                Some((batch, opt_channel)) = self.rx_message.recv() => {
+
                     // Broadcast the batch to the other workers.
                     let workers: Vec<_> = self
                         .worker_cache
@@ -117,15 +116,9 @@ impl QuorumWaiter {
                             Some(stake) = wait_for_quorum.next() => {
                                 total_stake += stake;
                                 if total_stake >= threshold {
-                                    let digest = batch.digest();
-                                    let metadata = batch.metadata.clone();
-                                    self.store.async_write(digest, batch).await;
-                                    if self.tx_our_batch.send(WorkerOurBatchMessage{
-                                        digest,
-                                        worker_id: self.id,
-                                        metadata
-                                    }).await.is_err() {
-                                        tracing::debug!("{}", DagError::ShuttingDown);
+                                    // Notify anyone waiting for this.
+                                    if let Some(channel) = opt_channel {
+                                        let _ = channel.send(());
                                     }
                                     break;
                                 }

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -66,8 +66,11 @@ async fn make_batch() {
     assert!(r1.await.is_ok());
 
     // Ensure the batch is stored
-    assert!(store.notify_read(expected_batch.digest()).await.unwrap().is_some());
-
+    assert!(store
+        .notify_read(expected_batch.digest())
+        .await
+        .unwrap()
+        .is_some());
 }
 
 #[tokio::test]
@@ -120,6 +123,9 @@ async fn batch_timeout() {
     assert!(r0.await.is_ok());
 
     // Ensure the batch is stored
-    assert!(store.notify_read(expected_batch.digest()).await.unwrap().is_some());
-
+    assert!(store
+        .notify_read(expected_batch.digest())
+        .await
+        .unwrap()
+        .is_some());
 }

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -2,21 +2,32 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+
 use prometheus::Registry;
-use test_utils::{transaction, CommitteeFixture};
+use store::rocks;
+use test_utils::{temp_dir, transaction, CommitteeFixture};
+
+fn create_batches_store() -> Store<BatchDigest, Batch> {
+    let db = rocks::DBMap::<BatchDigest, Batch>::open(temp_dir(), None, Some("batches")).unwrap();
+    Store::new(db)
+}
 
 #[tokio::test]
 async fn make_batch() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
+    let store = create_batches_store();
     let (_tx_reconfiguration, rx_reconfiguration) =
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_message, mut rx_message) = test_utils::test_channel!(1);
+    let (tx_digest, mut rx_digest) = test_utils::test_channel!(1);
     let node_metrics = WorkerMetrics::new(&Registry::new());
 
     // Spawn a `BatchMaker` instance.
+    let id = 0;
     let _batch_maker_handle = BatchMaker::spawn(
+        id,
         committee,
         /* max_batch_size */ 200,
         /* max_batch_delay */
@@ -25,6 +36,8 @@ async fn make_batch() {
         rx_batch_maker,
         tx_message,
         Arc::new(node_metrics),
+        store,
+        tx_digest,
     );
 
     // Send enough transactions to seal a batch.
@@ -34,22 +47,35 @@ async fn make_batch() {
 
     // Ensure the batch is as expected.
     let expected_batch = Batch::new(vec![tx.clone(), tx.clone()]);
-    let batch = rx_message.recv().await.unwrap();
+    let (batch, overall_response) = rx_message.recv().await.unwrap();
+
     assert_eq!(batch.transactions, expected_batch.transactions);
+
+    // Eventually deliver message
+    if let Some(resp) = overall_response {
+        assert!(resp.send(()).is_ok());
+    }
+
+    // Now we send to primary
+    let _message = rx_digest.recv().await.unwrap();
 }
 
 #[tokio::test]
 async fn batch_timeout() {
     let fixture = CommitteeFixture::builder().build();
     let committee = fixture.committee();
+    let store = create_batches_store();
     let (_tx_reconfiguration, rx_reconfiguration) =
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_message, mut rx_message) = test_utils::test_channel!(1);
     let node_metrics = WorkerMetrics::new(&Registry::new());
+    let (tx_digest, _rx_digest) = test_utils::test_channel!(1);
 
     // Spawn a `BatchMaker` instance.
+    let id = 0;
     let _batch_maker_handle = BatchMaker::spawn(
+        id,
         committee,
         /* max_batch_size */ 200,
         /* max_batch_delay */
@@ -58,6 +84,8 @@ async fn batch_timeout() {
         rx_batch_maker,
         tx_message,
         Arc::new(node_metrics),
+        store,
+        tx_digest,
     );
 
     // Do not send enough transactions to seal a batch.
@@ -65,6 +93,7 @@ async fn batch_timeout() {
     tx_batch_maker.send(tx.clone()).await.unwrap();
 
     // Ensure the batch is as expected.
-    let batch = rx_message.recv().await.unwrap();
-    assert_eq!(batch.transactions, vec![tx]);
+    let (batch, overall_response) = rx_message.recv().await.unwrap();
+    let expected_batch = Batch::new(vec![tx.clone()]);
+    assert_eq!(batch.transactions, expected_batch.transactions);
 }

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -59,7 +59,9 @@ async fn make_batch() {
     }
 
     // Now we send to primary
-    let _message = rx_digest.recv().await.unwrap();
+    let (_message, respond) = rx_digest.recv().await.unwrap();
+    assert!(respond.unwrap().send(()).is_ok());
+
     assert!(r0.await.is_ok());
     assert!(r1.await.is_ok());
 }
@@ -74,7 +76,7 @@ async fn batch_timeout() {
     let (tx_batch_maker, rx_batch_maker) = test_utils::test_channel!(1);
     let (tx_message, mut rx_message) = test_utils::test_channel!(1);
     let node_metrics = WorkerMetrics::new(&Registry::new());
-    let (tx_digest, _rx_digest) = test_utils::test_channel!(1);
+    let (tx_digest, mut rx_digest) = test_utils::test_channel!(1);
 
     // Spawn a `BatchMaker` instance.
     let id = 0;
@@ -106,6 +108,10 @@ async fn batch_timeout() {
     if let Some(resp) = overall_response {
         assert!(resp.send(()).is_ok());
     }
+
+    // Now we send to primary
+    let (_message, respond) = rx_digest.recv().await.unwrap();
+    assert!(respond.unwrap().send(()).is_ok());
 
     assert!(r0.await.is_ok());
 }

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -123,9 +123,5 @@ async fn batch_timeout() {
     assert!(r0.await.is_ok());
 
     // Ensure the batch is stored
-    assert!(store
-        .notify_read(expected_batch.digest())
-        .await
-        .unwrap()
-        .is_some());
+    assert!(store.notify_read(batch.digest()).await.unwrap().is_some());
 }

--- a/narwhal/worker/src/tests/batch_maker_tests.rs
+++ b/narwhal/worker/src/tests/batch_maker_tests.rs
@@ -36,7 +36,7 @@ async fn make_batch() {
         rx_batch_maker,
         tx_message,
         Arc::new(node_metrics),
-        store,
+        store.clone(),
         tx_digest,
     );
 
@@ -64,6 +64,10 @@ async fn make_batch() {
 
     assert!(r0.await.is_ok());
     assert!(r1.await.is_ok());
+
+    // Ensure the batch is stored
+    assert!(store.notify_read(expected_batch.digest()).await.unwrap().is_some());
+
 }
 
 #[tokio::test]
@@ -90,7 +94,7 @@ async fn batch_timeout() {
         rx_batch_maker,
         tx_message,
         Arc::new(node_metrics),
-        store,
+        store.clone(),
         tx_digest,
     );
 
@@ -114,4 +118,8 @@ async fn batch_timeout() {
     assert!(respond.unwrap().send(()).is_ok());
 
     assert!(r0.await.is_ok());
+
+    // Ensure the batch is stored
+    assert!(store.notify_read(expected_batch.digest()).await.unwrap().is_some());
+
 }

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Facebook, Inc. and its affiliates_batch_processor
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) 2021, Facebook, Inc. and its affiliates_batch_processor
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
@@ -72,6 +72,9 @@ async fn synchronize() {
         .is_none());
     handler.synchronize(request).await.unwrap();
     assert_eq!(store.read(digest).await.unwrap().unwrap(), batch);
+
+    // let recv_batch = rx_primary.recv().await.unwrap();
+    // assert!(matches!(recv_batch, WorkerPrimaryMessage::OthersBatch(..)));
 }
 
 #[tokio::test]

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -71,10 +71,13 @@ async fn synchronize() {
         .insert(send_network.downgrade())
         .is_none());
     handler.synchronize(request).await.unwrap();
-    assert_eq!(store.read(digest).await.unwrap().unwrap(), batch);
 
-    // let recv_batch = rx_primary.recv().await.unwrap();
-    // assert!(matches!(recv_batch, WorkerPrimaryMessage::OthersBatch(..)));
+    let recv_batch = rx_primary.recv().await.unwrap();
+    assert!(matches!(
+        recv_batch,
+        ( WorkerPrimaryMessage::OthersBatch(..), None)
+    ));
+
 }
 
 #[tokio::test]
@@ -115,6 +118,19 @@ async fn synchronize_when_batch_exists() {
         digests: missing.clone(),
         target: target_primary.public_key(),
     };
+
+
+    let responder_handle = tokio::spawn(async move {
+        if let (WorkerOthersBatchMessage { digest: recv_digest, worker_id: recv_id}, _) =
+            rx_primary.recv().await.unwrap()
+        {
+            assert_eq!(recv_digest, batch_id);
+            assert_eq!(recv_id, id);
+        } else {
+            panic!("received unexpected WorkerPrimaryMessage");
+        }
+    });
+
 
     // Send a sync request.
     // Don't bother to inject a fake network because handler shouldn't need it.

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -56,6 +56,9 @@ async fn synchronize() {
     let target_worker = target_primary.worker(id);
     let _recv_network = target_worker.new_network(routes);
 
+    // Check not in store
+    assert!(store.read(digest).await.unwrap().is_none());
+
     // Send a sync request.
     let mut request = anemo::Request::new(message);
     let send_network = test_utils::random_network();
@@ -72,12 +75,8 @@ async fn synchronize() {
         .is_none());
     handler.synchronize(request).await.unwrap();
 
-    let recv_batch = rx_primary.recv().await.unwrap();
-    assert!(matches!(
-        recv_batch,
-        ( WorkerPrimaryMessage::OthersBatch(..), None)
-    ));
-
+    // Check its now stored
+    assert!(store.notify_read(digest).await.unwrap().is_some())
 }
 
 #[tokio::test]
@@ -119,7 +118,7 @@ async fn synchronize_when_batch_exists() {
         target: target_primary.public_key(),
     };
 
-
+    /*
     let responder_handle = tokio::spawn(async move {
         if let (WorkerOthersBatchMessage { digest: recv_digest, worker_id: recv_id}, _) =
             rx_primary.recv().await.unwrap()
@@ -130,7 +129,7 @@ async fn synchronize_when_batch_exists() {
             panic!("received unexpected WorkerPrimaryMessage");
         }
     });
-
+    */
 
     // Send a sync request.
     // Don't bother to inject a fake network because handler shouldn't need it.

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -118,19 +118,6 @@ async fn synchronize_when_batch_exists() {
         target: target_primary.public_key(),
     };
 
-    /*
-    let responder_handle = tokio::spawn(async move {
-        if let (WorkerOthersBatchMessage { digest: recv_digest, worker_id: recv_id}, _) =
-            rx_primary.recv().await.unwrap()
-        {
-            assert_eq!(recv_digest, batch_id);
-            assert_eq!(recv_id, id);
-        } else {
-            panic!("received unexpected WorkerPrimaryMessage");
-        }
-    });
-    */
-
     // Send a sync request.
     // Don't bother to inject a fake network because handler shouldn't need it.
     handler

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -63,3 +63,70 @@ async fn wait_for_quorum() {
         assert_eq!(handle.recv().await.unwrap(), message);
     }
 }
+
+#[tokio::test]
+async fn pipeline_for_quorum() {
+    let store = test_utils::open_batch_store();
+    let (tx_message, rx_message) = test_utils::test_channel!(1);
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let committee = fixture.committee();
+    let worker_cache = fixture.shared_worker_cache();
+    let my_primary = fixture.authorities().next().unwrap().public_key();
+    let myself = fixture.authorities().next().unwrap().worker(0);
+
+    let (_tx_reconfiguration, rx_reconfiguration) =
+        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
+
+    // setup network
+    let network = test_network(myself.keypair(), &myself.info().worker_address);
+    // Spawn a `QuorumWaiter` instance.
+    let _quorum_waiter_handler = QuorumWaiter::spawn(
+        my_primary.clone(),
+        /* worker_id */ 0,
+        store.clone(),
+        committee.clone(),
+        worker_cache.clone(),
+        rx_reconfiguration,
+        rx_message,
+        P2pNetwork::new(network.clone()),
+    );
+
+    // Make a batch.
+    let batch = batch();
+    let message = WorkerBatchMessage {
+        batch: batch.clone(),
+    };
+
+    // Spawn enough listeners to acknowledge our batches.
+    let mut listener_handles = Vec::new();
+    for worker in fixture.authorities().skip(1).map(|a| a.worker(0)) {
+        let handle =
+            WorkerToWorkerMockServer::spawn(worker.keypair(), worker.info().worker_address.clone());
+        listener_handles.push(handle);
+
+        // ensure that the networks are connected
+        network
+            .connect(network::multiaddr_to_address(&worker.info().worker_address).unwrap())
+            .await
+            .unwrap();
+    }
+
+    // Forward the batch along with the handlers to the `QuorumWaiter`.
+    let (s0, r0) = tokio::sync::oneshot::channel();
+    tx_message.send((batch.clone(), Some(s0))).await.unwrap();
+
+    // Forward the batch along with the handlers to the `QuorumWaiter`.
+    let (s1, r1) = tokio::sync::oneshot::channel();
+    tx_message.send((batch.clone(), Some(s1))).await.unwrap();
+
+    // Wait for the `QuorumWaiter` to gather enough acknowledgements and output the batch.
+    r0.await.unwrap();
+
+    // Ensure the other listeners correctly received the batch.
+    for (mut handle, _network) in listener_handles {
+        assert_eq!(handle.recv().await.unwrap(), message);
+        assert_eq!(handle.recv().await.unwrap(), message);
+    }
+
+    r1.await.unwrap();
+}

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -8,7 +8,6 @@ use test_utils::{batch, test_network, CommitteeFixture, WorkerToWorkerMockServer
 async fn wait_for_quorum() {
     let store = test_utils::open_batch_store();
     let (tx_message, rx_message) = test_utils::test_channel!(1);
-    let (tx_batch, mut rx_batch) = test_utils::test_channel!(1);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
     let worker_cache = fixture.shared_worker_cache();
@@ -29,7 +28,6 @@ async fn wait_for_quorum() {
         worker_cache.clone(),
         rx_reconfiguration,
         rx_message,
-        tx_batch,
         P2pNetwork::new(network.clone()),
     );
 
@@ -54,19 +52,14 @@ async fn wait_for_quorum() {
     }
 
     // Forward the batch along with the handlers to the `QuorumWaiter`.
-    tx_message.send(batch.clone()).await.unwrap();
+    let (s, r) = tokio::sync::oneshot::channel();
+    tx_message.send((batch.clone(), Some(s))).await.unwrap();
 
     // Wait for the `QuorumWaiter` to gather enough acknowledgements and output the batch.
-    let output = rx_batch.recv().await.unwrap();
-    assert_eq!(
-        output,
-        WorkerOurBatchMessage {
-            digest: batch.digest(),
-            worker_id: 0,
-            metadata: batch.metadata.clone()
-        }
-    );
-    assert_eq!(store.read(batch.digest()).await.unwrap().unwrap(), batch);
+    // assert_eq!(store.read(batch.digest()).await.unwrap().unwrap(), batch);
+
+    r.await.unwrap();
+
 
     // Ensure the other listeners correctly received the batch.
     for (mut handle, _network) in listener_handles {

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -6,7 +6,6 @@ use test_utils::{batch, test_network, CommitteeFixture, WorkerToWorkerMockServer
 
 #[tokio::test]
 async fn wait_for_quorum() {
-    let store = test_utils::open_batch_store();
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
@@ -23,7 +22,6 @@ async fn wait_for_quorum() {
     let _quorum_waiter_handler = QuorumWaiter::spawn(
         my_primary.clone(),
         /* worker_id */ 0,
-        store.clone(),
         committee.clone(),
         worker_cache.clone(),
         rx_reconfiguration,
@@ -66,7 +64,6 @@ async fn wait_for_quorum() {
 
 #[tokio::test]
 async fn pipeline_for_quorum() {
-    let store = test_utils::open_batch_store();
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
@@ -83,7 +80,6 @@ async fn pipeline_for_quorum() {
     let _quorum_waiter_handler = QuorumWaiter::spawn(
         my_primary.clone(),
         /* worker_id */ 0,
-        store.clone(),
         committee.clone(),
         worker_cache.clone(),
         rx_reconfiguration,

--- a/narwhal/worker/src/tests/quorum_waiter_tests.rs
+++ b/narwhal/worker/src/tests/quorum_waiter_tests.rs
@@ -56,10 +56,7 @@ async fn wait_for_quorum() {
     tx_message.send((batch.clone(), Some(s))).await.unwrap();
 
     // Wait for the `QuorumWaiter` to gather enough acknowledgements and output the batch.
-    // assert_eq!(store.read(batch.digest()).await.unwrap().unwrap(), batch);
-
     r.await.unwrap();
-
 
     // Ensure the other listeners correctly received the batch.
     for (mut handle, _network) in listener_handles {

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -118,7 +118,7 @@ async fn handle_clients_transactions() {
     });
 
     // Ensure the primary received the batch's digest (ie. it did not panic).
-    assert_eq!(rx_await_batch.recv().await.unwrap(), ());
+    rx_await_batch.recv().await.unwrap();
 
     // Ensure sending ended.
     assert!(join_handle.await.is_ok());

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -7,6 +7,7 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use fastcrypto::hash::Hash;
+use futures::stream::FuturesOrdered;
 use node::NodeStorage;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
@@ -95,21 +96,31 @@ async fn handle_clients_transactions() {
         .transactions;
     let config = mysten_network::config::Config::new();
     let channel = config.connect_lazy(&address).unwrap();
-    let mut client = TransactionsClient::new(channel);
-    for tx in batch.transactions {
-        let txn = TransactionProto {
-            transaction: Bytes::from(tx.clone()),
-        };
-        client.submit_transaction(txn).await.unwrap();
-    }
+    let client = TransactionsClient::new(channel);
 
-    // Wait for batch to be reported to primary.
-    rx_await_batch.recv().await.unwrap();
+    let join_handle = tokio::task::spawn(async move {
+        let mut fut_list = FuturesOrdered::new();
+        for tx in batch.transactions {
+            let txn = TransactionProto {
+                transaction: Bytes::from(tx.clone()),
+            };
 
-    let txn = TransactionProto {
-        transaction: Bytes::from(vec![8u8; 10 * 1024 * 1024]),
-    };
-    assert!(client.submit_transaction(txn).await.is_err());
+            // Calls to submit_transaction are now blocking, so we need to drive them
+            // all at the same time, rather than sequentially.
+            let mut inner_client = client.clone();
+            fut_list.push_back(async move {
+                inner_client.submit_transaction(txn).await.unwrap();
+            });
+        }
+
+        // Drive all sending in parallel.
+        while fut_list.next().await.is_some() {}
+    });
+
+    // Ensure the primary received the batch's digest (ie. it did not panic).
+    assert_eq!(rx_await_batch.recv().await.unwrap(), ());
+    // Ensure sending ended.
+    assert!(join_handle.await.is_ok());
 }
 
 #[tokio::test]

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -119,6 +119,7 @@ async fn handle_clients_transactions() {
 
     // Ensure the primary received the batch's digest (ie. it did not panic).
     assert_eq!(rx_await_batch.recv().await.unwrap(), ());
+
     // Ensure sending ended.
     assert!(join_handle.await.is_ok());
 }

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -33,6 +33,7 @@ use types::{
     Batch, BatchDigest, Empty, PrimaryToWorkerServer, ReconfigureNotification, Transaction,
     TransactionProto, Transactions, TransactionsServer, WorkerOurBatchMessage,
     WorkerToWorkerServer,
+   TxResponse,
 };
 
 #[cfg(test)]
@@ -287,7 +288,7 @@ impl Worker {
     fn handle_clients_transactions(
         &self,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
-        tx_our_batch: Sender<WorkerOurBatchMessage>,
+        tx_our_batch: Sender<(WorkerOurBatchMessage, Option<tokio::sync::oneshot::Sender<()>>)>,
         node_metrics: Arc<WorkerMetrics>,
         channel_metrics: Arc<WorkerChannelMetrics>,
         endpoint_metrics: WorkerEndpointMetrics,
@@ -370,7 +371,7 @@ impl Worker {
 /// Defines how the network receiver handles incoming transactions.
 #[derive(Clone)]
 struct TxReceiverHandler {
-    tx_batch_maker: Sender<(Transaction, crate::batch_maker::TxResponse)>,
+    tx_batch_maker: Sender<(Transaction, TxResponse)>,
 }
 
 impl TxReceiverHandler {

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -370,7 +370,7 @@ impl Worker {
 /// Defines how the network receiver handles incoming transactions.
 #[derive(Clone)]
 struct TxReceiverHandler {
-    tx_batch_maker: Sender<Transaction>,
+    tx_batch_maker: Sender<(Transaction, crate::batch_maker::TxResponse)>,
 }
 
 impl TxReceiverHandler {
@@ -423,11 +423,16 @@ impl Transactions for TxReceiverHandler {
             )));
         }
         // Send the transaction to the batch maker.
+        let (notifier, when_done) = tokio::sync::oneshot::channel();
         self.tx_batch_maker
-            .send(message.to_vec())
+            .send((message.to_vec(), notifier))
             .await
             .map_err(|_| DagError::ShuttingDown)
             .map_err(|e| Status::not_found(e.to_string()))?;
+
+        // TODO: distingush between a digest being returned vs the channel closing
+        // suggesting an error.
+        let _digest = when_done.await;
 
         Ok(Response::new(Empty {}))
     }
@@ -437,14 +442,29 @@ impl Transactions for TxReceiverHandler {
         request: Request<tonic::Streaming<types::TransactionProto>>,
     ) -> Result<Response<types::Empty>, Status> {
         let mut transactions = request.into_inner();
+        let mut responses = Vec::new();
 
         while let Some(Ok(txn)) = transactions.next().await {
             // Send the transaction to the batch maker.
+            let (notifier, when_done) = tokio::sync::oneshot::channel();
             self.tx_batch_maker
-                .send(txn.transaction.to_vec())
+                .send((txn.transaction.to_vec(), notifier))
                 .await
                 .expect("Failed to send transaction");
+
+            // Note that here we do not wait for a response because this would
+            // mean that we process only a single message from this stream at a
+            // time. Instead we gather them and resolve them once the stream is over.
+            responses.push(when_done);
         }
+
+        // TODO: activate when we provide a meaningful guarantee, and
+        // distingush between a digest being returned vs the channel closing
+        // suggesting an error.
+        // for response in responses {
+        //     let _digest = response.await;
+        // }
+
         Ok(Response::new(Empty {}))
     }
 }

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -31,9 +31,8 @@ use types::{
     error::DagError,
     metered_channel::{channel_with_total, Sender},
     Batch, BatchDigest, Empty, PrimaryToWorkerServer, ReconfigureNotification, Transaction,
-    TransactionProto, Transactions, TransactionsServer, WorkerOurBatchMessage,
+    TransactionProto, Transactions, TransactionsServer, TxResponse, WorkerOurBatchMessage,
     WorkerToWorkerServer,
-   TxResponse,
 };
 
 #[cfg(test)]
@@ -288,7 +287,10 @@ impl Worker {
     fn handle_clients_transactions(
         &self,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
-        tx_our_batch: Sender<(WorkerOurBatchMessage, Option<tokio::sync::oneshot::Sender<()>>)>,
+        tx_our_batch: Sender<(
+            WorkerOurBatchMessage,
+            Option<tokio::sync::oneshot::Sender<()>>,
+        )>,
         node_metrics: Arc<WorkerMetrics>,
         channel_metrics: Arc<WorkerChannelMetrics>,
         endpoint_metrics: WorkerEndpointMetrics,
@@ -345,11 +347,8 @@ impl Worker {
             self.store.clone(),
             (*(*(*self.committee).load()).clone()).clone(),
             self.worker_cache.clone(),
-
             rx_reconfigure,
-
             /* rx_message */ rx_quorum_waiter,
-
             P2pNetwork::new(network),
         );
 
@@ -358,14 +357,8 @@ impl Worker {
             self.id, address
         );
 
-
-        vec![
-            batch_maker_handle,
-            quorum_waiter_handle,
-            tx_receiver_handle,
-        ]
+        vec![batch_maker_handle, quorum_waiter_handle, tx_receiver_handle]
     }
-
 }
 
 /// Defines how the network receiver handles incoming transactions.

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -344,7 +344,6 @@ impl Worker {
         let quorum_waiter_handle = QuorumWaiter::spawn(
             self.primary_name.clone(),
             self.id,
-            self.store.clone(),
             (*(*(*self.committee).load()).clone()).clone(),
             self.worker_cache.clone(),
             rx_reconfigure,


### PR DESCRIPTION
Various changes to the Narwhal worker with the aim to provide stronger guarantees to a client submitting a transaction (and avoid re-tries from clients that trust this validator):
- Remove processor from all worker paths and delete. 
- Now each worker path writes to store batches, and sends digests to primary directly.
- Add storage with a notify to ensure writing happened in the batch maker.
- Batch maker sends directly to the primary connector.
- Client connections wait for the batch maker to notify them that the write was successful before returning.
- Batch maker waits for primary response to notify clients.
- A pipeline of batches is written / sent in parallel.

TODO (different PR):
- Improve primary to only respond to a own batch worker message when it ensures it will deliver it.
- Return the batch digest to the client or return an error if the worker returned without a batch digest indicating that the transaction is not included in a batch.