### PR TITLE
[Explorer] Implements changes to fix the display of capybaras on mobile and Firefox

### DIFF
--- a/apps/explorer/src/components/displaybox/DisplayBox.module.css
+++ b/apps/explorer/src/components/displaybox/DisplayBox.module.css
@@ -59,7 +59,7 @@ div.mobilecross {
 
 div.filetype,
 div.caption {
-    @apply relative text-offwhite z-50 text-center sm:text-left text-2xl font-semibold mt-5;
+    @apply break-words max-w-[90vw] relative text-offwhite z-50 text-center sm:text-left text-2xl font-semibold mt-5;
 }
 
 div.filetype {

--- a/apps/explorer/src/pages/object-result/views/ObjectView.module.css
+++ b/apps/explorer/src/pages/object-result/views/ObjectView.module.css
@@ -81,7 +81,7 @@ div.display {
 }
 
 div.display > div > img {
-    @apply max-h-[120px] w-full sm:max-w-[120px] ml-auto;
+    @apply max-h-[120px] w-[120px] ml-auto;
 }
 
 div.display > div > div > div,


### PR DESCRIPTION
The below video shows three web pages in the following order:
* the first webpage shows how capybaras are currently deployed and what this looks like on Firefox on Windows
* the second shows what the webpage looks like after the fix in this PR
* the third shows that other NFT displays still look the same

https://user-images.githubusercontent.com/11377188/194374869-120b9e9b-0608-4aee-bd16-4267c87aa147.mp4