### PR TITLE
crypto: Sign with intent in wallet and keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,20 +836,20 @@ checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895adc16c8b3273fbbc32685a7d55227705eda08c01e77704020f3491924b44b"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq 0.2.4",
+ "constant_time_eq",
  "digest 0.10.5",
 ]
 
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 
 [[package]]
 name = "byteorder"
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -1225,7 +1225,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.2",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -1449,12 +1449,6 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "convert_case"
@@ -2627,7 +2621,7 @@ checksum = "e11dcc7e4d79a8c89b9ab4c6f5c30b1fc4a83c420792da3542fd31179ed5f517"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2796,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2806,15 +2800,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2834,15 +2828,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -2851,15 +2845,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-timer"
@@ -2873,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3095,9 +3089,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -3337,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
@@ -3495,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -3534,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.11.12"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2fa5a9ad16dedcfabbc87f048ee6dd40d4944736fe4c5d362fb01df1209de1"
+checksum = "65678bf692af3f4654f7baa7aab103fda889e37a84816cf3bd0aaa795277f6a3"
 dependencies = [
  "ahash",
  "atty",
@@ -3606,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
 name = "ipnet"
@@ -3881,12 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
-dependencies = [
- "cpufeatures",
-]
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "lazy_static"
@@ -3927,15 +3918,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -4155,7 +4146,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -6026,9 +6017,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "ouroboros"
@@ -6168,7 +6159,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -6227,9 +6218,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -6247,9 +6238,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6260,9 +6251,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
 dependencies = [
  "once_cell",
  "pest",
@@ -6372,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -6513,9 +6504,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.21"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+checksum = "83fead41e178796ef8274dc612a7d8ce4c7e10ca35cd2c5b5ad24cac63aeb6c0"
 dependencies = [
  "proc-macro2 1.0.47",
  "syn 1.0.103",
@@ -7009,9 +7000,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -7144,18 +7135,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b15debb4f9d60d767cd8ca9ef7abb2452922f3214671ff052defc7f3502c44"
+checksum = "12a733f1746c929b4913fe48f8697fcf9c55e3304ba251a79ffb41adfeaf49c2"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfa8511e9e94fd3de6585a3d3cd00e01ed556dc9814829280af0e8dc72a8f36"
+checksum = "5887de4a01acafd221861463be6113e6e87275e79804e56779f4cdc131c60368"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -7368,23 +7359,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
+version = "0.35.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",
@@ -7497,7 +7488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static 1.4.0",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -7737,9 +7728,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "indexmap",
  "itoa 1.0.4",
@@ -7797,9 +7788,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
 dependencies = [
  "darling",
  "proc-macro2 1.0.47",
@@ -8945,6 +8936,7 @@ name = "sui-open-rpc"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "clap 3.2.22",
  "fastcrypto",
  "move-core-types",
@@ -9324,9 +9316,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "10.1.2"
+version = "10.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492875918a6bcbae753a5fc6f39bc87566fc3c25182e76d7f128ef1c8a2375c6"
+checksum = "878e1296b4dbe9f77102748d66abc25f6089a020f03a4bba8530b48221e131f3"
 dependencies = [
  "debugid",
  "memmap2",
@@ -9336,9 +9328,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "10.1.2"
+version = "10.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214d3a420108471222e55268ef502ba0fc89cfd4de876ff26105c560729127af"
+checksum = "9cb721346d1f73b20c50b3122f1b1b519465894b9378e47762623dc05e44b5b3"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -9616,9 +9608,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "textwrap"
@@ -10833,33 +10825,12 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -10868,22 +10839,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10892,40 +10851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
@@ -11070,8 +11005,7 @@ dependencies = [
  "console-api",
  "console-subscriber",
  "const-oid",
- "constant_time_eq 0.1.5",
- "constant_time_eq 0.2.4",
+ "constant_time_eq",
  "convert_case",
  "core-foundation",
  "core-foundation-sys",
@@ -11632,7 +11566,7 @@ dependencies = [
  "test-fuzz-macro",
  "test-fuzz-runtime",
  "textwrap 0.11.0",
- "textwrap 0.15.2",
+ "textwrap 0.15.1",
  "textwrap 0.16.0",
  "thiserror",
  "thiserror-impl",
@@ -11738,8 +11672,8 @@ dependencies = [
  "widestring",
  "winapi",
  "winapi-util",
- "windows-sys 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows-sys",
+ "windows_x86_64_msvc",
  "winreg",
  "wyhash",
  "wyz",
@@ -11824,7 +11758,7 @@ dependencies = [
 [[package]]
 name = "ying-profiler"
 version = "0.1.0"
-source = "git+https://github.com/velvia/ying-profiler#1a3e476299bfc1ff4a3168edd9fcf1ccda521aea"
+source = "git+https://github.com/velvia/ying-profiler#d1763c711c4bcf1a98fa7d80c79f31fdafe88ad1"
 dependencies = [
  "backtrace",
  "chrono",

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -22,6 +22,7 @@ use test_utils::messages::make_transactions_with_wallet_context;
 
 use sui_sdk::SuiClient;
 use sui_types::gas_coin::GasCoin;
+use sui_types::intent::Intent;
 use sui_types::{
     base_types::SuiAddress,
     messages::{Transaction, TransactionData, VerifiedTransaction},
@@ -134,7 +135,7 @@ impl TestContext {
             .get_fullnode_client()
             .quorum_driver()
             .execute_transaction(
-                Transaction::from_data(txn_data, signature)
+                Transaction::from_data_and_sig(txn_data, Intent::default(), signature)
                     .verify()
                     .unwrap(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -9,6 +9,7 @@ use sui_keys::keystore::AccountKeystore;
 use sui_sdk::SuiClient;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{KeypairTraits, Signature};
+use sui_types::intent::Intent;
 use sui_types::messages::TransactionData;
 use tracing::{info, info_span, Instrument};
 
@@ -58,7 +59,7 @@ impl WalletClient {
         self.get_wallet()
             .config
             .keystore
-            .sign(&self.address, &txn_data.to_bytes())
+            .sign_secure(&self.address, txn_data, Intent::default())
             .unwrap_or_else(|e| panic!("Failed to sign transaction for {}. {}", desc, e))
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -604,7 +604,7 @@ impl AuthorityState {
 
         let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
             &self.database,
-            &transaction.data().data,
+            &transaction.data().intent_message.value,
         )
         .await?;
 
@@ -630,7 +630,7 @@ impl AuthorityState {
         transaction: VerifiedTransaction,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
         let transaction_digest = *transaction.digest();
-        debug!(tx_digest=?transaction_digest, "handle_transaction. Tx data: {:?}", transaction.data().data);
+        debug!(tx_digest=?transaction_digest, "handle_transaction. Tx data: {:?}", &transaction.data().intent_message.value);
 
         // Ensure an idempotent answer. This is checked before the system_tx check so that
         // a validator is able to return the signed system tx if it was already signed locally.
@@ -717,7 +717,7 @@ impl AuthorityState {
                 ?observed_effects_digest,
                 expected_effects=?effects.data(),
                 ?resp.signed_effects,
-                input_objects = ?certificate.data().data.input_objects(),
+                input_objects = ?certificate.data().intent_message.value.input_objects(),
                 "Locally executed effects do not match canonical effects!");
         }
         Ok(())
@@ -757,7 +757,7 @@ impl AuthorityState {
         let span = tracing::debug_span!(
             "validator_acquire_tx_guard",
             ?tx_digest,
-            tx_kind = certificate.data().data.kind_as_str()
+            tx_kind = certificate.data().intent_message.value.kind_as_str()
         );
         let tx_guard = self
             .database
@@ -1019,7 +1019,7 @@ impl AuthorityState {
             .observe(shared_object_count as f64);
         self.metrics
             .batch_size
-            .observe(certificate.data().data.kind.batch_size() as f64);
+            .observe(certificate.data().intent_message.value.kind.batch_size() as f64);
 
         Ok(VerifiedTransactionInfoResponse {
             signed_transaction: self.database.get_transaction(&digest)?,
@@ -1052,7 +1052,14 @@ impl AuthorityState {
         // At this point we need to check if any shared objects need locks,
         // and whether they have them.
         let shared_object_refs = input_objects.filter_shared_objects();
-        if !shared_object_refs.is_empty() && !certificate.data().data.kind.is_change_epoch_tx() {
+        if !shared_object_refs.is_empty()
+            && !certificate
+                .data()
+                .intent_message
+                .value
+                .kind
+                .is_change_epoch_tx()
+        {
             // If the transaction contains shared objects, we need to ensure they have been scheduled
             // for processing by the consensus protocol.
             // There is no need to go through consensus for system transactions that can
@@ -1075,7 +1082,7 @@ impl AuthorityState {
             execution_engine::execute_transaction_to_effects(
                 shared_object_refs,
                 temporary_store,
-                certificate.data().data.clone(),
+                certificate.data().intent_message.value.clone(),
                 *certificate.digest(),
                 transaction_dependencies,
                 &self.move_vm,
@@ -1147,7 +1154,8 @@ impl AuthorityState {
         indexes.index_tx(
             cert.sender_address(),
             cert.data()
-                .data
+                .intent_message
+                .value
                 .input_objects()?
                 .iter()
                 .map(|o| o.object_id()),
@@ -1156,7 +1164,8 @@ impl AuthorityState {
                 .all_mutated()
                 .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.data()
-                .data
+                .intent_message
+                .value
                 .move_calls()
                 .iter()
                 .map(|mc| (mc.package.0, mc.module.clone(), mc.function.clone())),

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1653,7 +1653,10 @@ where
             validity_threshold = validity,
             "Broadcasting transaction request to authorities"
         );
-        trace!("Transaction data: {:?}", transaction.data().data);
+        trace!(
+            "Transaction data: {:?}",
+            transaction.data().intent_message.value
+        );
 
         #[derive(Default)]
         struct ProcessTransactionState {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -362,7 +362,7 @@ impl ValidatorService {
         let span = tracing::debug_span!(
             "validator_state_process_tx",
             ?tx_digest,
-            tx_kind = transaction.data().data.kind_as_str()
+            tx_kind = transaction.data().intent_message.value.kind_as_str()
         );
 
         let info = state
@@ -441,7 +441,7 @@ impl ValidatorService {
             let span = tracing::debug_span!(
                 "validator_state_process_cert",
                 ?tx_digest,
-                tx_kind = certificate.data().data.kind_as_str()
+                tx_kind = certificate.data().intent_message.value.kind_as_str()
             );
             match state
                 .handle_certificate(&certificate)

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -24,14 +24,13 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
-use crate::authority::AuthorityState;
 use crate::checkpoints::causal_order_effects::TestEffectsStore;
 use crate::checkpoints::reconstruction::SpanGraph;
+use crate::{authority::AuthorityState, test_utils::to_verified_transaction};
 use crate::{
     authority_active::ActiveAuthority,
     authority_aggregator::authority_aggregator_tests::init_local_authorities,
     checkpoints::{CheckpointLocals, CHECKPOINT_COUNT_PER_EPOCH},
-    test_utils::to_sender_signed_transaction,
 };
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -106,7 +105,7 @@ async fn test_start_epoch_change() {
         gas_object.compute_object_reference(),
         1000,
     );
-    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    let transaction = to_verified_transaction(tx_data, &sender_key);
     assert_eq!(
         state
             .handle_transaction(transaction.clone())
@@ -330,7 +329,7 @@ async fn test_cross_epoch_effects_cert() {
     let object_ref = genesis_objects[0].compute_object_reference();
     let tx_data =
         TransactionData::new_transfer_sui(SuiAddress::default(), sender, None, object_ref, 1000);
-    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    let transaction = to_verified_transaction(tx_data, &sender_key);
     net.execute_transaction(&transaction).await.unwrap();
     for state in states {
         // Manually update each validator's epoch to the next one for testing purpose.

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -10,9 +10,8 @@ use std::time::Duration;
 use sui_types::{
     base_types::{dbg_addr, ObjectID, TransactionDigest},
     batch::UpdateItem,
-    crypto::{
-        get_key_pair, AccountKeyPair, AuthoritySignInfo, AuthoritySignature, Signable, Signature,
-    },
+    crypto::{get_key_pair, AccountKeyPair, AuthoritySignInfo, AuthoritySignature, Signature},
+    intent::{Intent, IntentMessage},
     messages::{
         BatchInfoRequest, BatchInfoResponseItem, Transaction, TransactionData, VerifiedTransaction,
     },
@@ -112,7 +111,7 @@ pub fn create_fake_transaction() -> VerifiedTransaction {
         object.compute_object_reference(),
         10000,
     );
-    to_sender_signed_transaction(data, &sender_key)
+    to_verified_transaction(data, &sender_key)
 }
 
 pub fn create_fake_cert_and_effect_digest<'a>(
@@ -146,20 +145,35 @@ pub fn create_fake_cert_and_effect_digest<'a>(
 pub fn to_sender_signed_transaction(
     data: TransactionData,
     signer: &dyn Signer<Signature>,
-) -> VerifiedTransaction {
-    let signature = Signature::new(&data, signer);
-    // let signature = Signature::new_secure(&data, Intent::default(), signer).unwrap();
-    VerifiedTransaction::new_unchecked(Transaction::from_data(data, signature))
+) -> Transaction {
+    let intent_message = IntentMessage::new(Intent::default(), data);
+    Transaction::from_data(intent_message, signer)
 }
 
-pub fn to_sender_signed_transaction_arc(
+// This is used to create a verified transaction from transaction data and signer signing with default intent.
+pub fn to_verified_transaction(
+    data: TransactionData,
+    signer: &dyn Signer<Signature>,
+) -> VerifiedTransaction {
+    let intent_message = IntentMessage::new(Intent::default(), data);
+    VerifiedTransaction::new_unchecked(Transaction::from_data(intent_message, signer))
+}
+
+// Workaround for benchmark setup.
+pub fn to_verified_transaction_arc(
     data: TransactionData,
     signer: &Arc<fastcrypto::ed25519::Ed25519KeyPair>,
 ) -> VerifiedTransaction {
-    let mut message = Vec::new();
-    data.write(&mut message);
-    let signature: Signature = signer.sign(&message);
-    VerifiedTransaction::new_unchecked(Transaction::from_data(data, signature))
+    let data1 = data.clone();
+    let intent_message = IntentMessage::new(Intent::default(), data);
+    // OK to unwrap because this is used for benchmark only.
+    let bytes = bcs::to_bytes(&intent_message).unwrap();
+    let signature: Signature = signer.sign(&bytes);
+    VerifiedTransaction::new_unchecked(Transaction::from_data_and_sig(
+        data1,
+        Intent::default(),
+        signature,
+    ))
 }
 
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
@@ -179,7 +193,7 @@ pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
         wrapped: Vec::new(),
         gas_object: (
             random_object_ref(),
-            Owner::AddressOwner(tx.data().data.signer()),
+            Owner::AddressOwner(tx.data().intent_message.value.signer()),
         ),
         events: Vec::new(),
         dependencies: Vec::new(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -78,9 +78,9 @@ pub async fn check_certificate_input<S>(
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
 {
-    let gas_status = get_gas_status(store, &cert.data().data).await?;
-    let input_object_kinds = cert.data().data.input_objects()?;
-    let tx_data = &cert.data().data;
+    let gas_status = get_gas_status(store, &cert.data().intent_message.value).await?;
+    let input_object_kinds = cert.data().intent_message.value.input_objects()?;
+    let tx_data = &cert.data().intent_message.value;
     let input_object_data = if tx_data.kind.is_change_epoch_tx() {
         // When changing the epoch, we update a the system object, which is shared, without going
         // through sequencing, so we must bypass the sequence checks here.
@@ -88,8 +88,12 @@ where
     } else {
         store.check_sequenced_input_objects(cert.digest(), &input_object_kinds)?
     };
-    let input_objects =
-        check_objects(&cert.data().data, input_object_kinds, input_object_data).await?;
+    let input_objects = check_objects(
+        &cert.data().intent_message.value,
+        input_object_kinds,
+        input_object_data,
+    )
+    .await?;
     Ok((gas_status, input_objects))
 }
 

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -79,7 +79,10 @@ impl TransactionManager {
             }
             let missing = self
                 .authority_store
-                .get_missing_input_objects(&digest, &cert.data().data.input_objects()?)
+                .get_missing_input_objects(
+                    &digest,
+                    &cert.data().intent_message.value.input_objects()?,
+                )
                 .await
                 .expect("Are shared object locks set prior to enqueueing certificates?");
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -31,7 +31,7 @@ use crate::authority_client::{
     AuthorityAPI, BatchInfoResponseItemStream, LocalAuthorityClient,
     LocalAuthorityClientFaultConfig, NetworkAuthorityClient, NetworkAuthorityClientMetrics,
 };
-use crate::test_utils::to_sender_signed_transaction;
+use crate::test_utils::to_verified_transaction;
 use crate::validator_info::make_committee;
 
 use tokio::time::Instant;
@@ -188,7 +188,7 @@ pub fn transfer_coin_transaction(
     object_ref: ObjectRef,
     gas_object_ref: ObjectRef,
 ) -> VerifiedTransaction {
-    to_sender_signed_transaction(
+    to_verified_transaction(
         TransactionData::new_transfer(
             dest,
             object_ref,
@@ -213,7 +213,7 @@ pub fn transfer_object_move_transaction(
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(dest)).unwrap()),
     ];
 
-    to_sender_signed_transaction(
+    to_verified_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -242,7 +242,7 @@ pub fn crate_object_move_transaction(
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(dest)).unwrap()),
     ];
 
-    to_sender_signed_transaction(
+    to_verified_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -264,7 +264,7 @@ pub fn delete_object_move_transaction(
     framework_obj_ref: ObjectRef,
     gas_object_ref: ObjectRef,
 ) -> VerifiedTransaction {
-    to_sender_signed_transaction(
+    to_verified_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -292,7 +292,7 @@ pub fn set_object_move_transaction(
         CallArg::Pure(bcs::to_bytes(&value).unwrap()),
     ];
 
-    to_sender_signed_transaction(
+    to_verified_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -337,7 +337,10 @@ where
         {
             votes.push(signed.auth_sig().clone());
             if let Some(inner_transaction) = transaction {
-                assert!(inner_transaction.data().data == signed.data().data);
+                assert!(
+                    inner_transaction.data().intent_message.value
+                        == signed.data().intent_message.value
+                );
             }
             transaction = Some(signed);
         }

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     authority::authority_tests::init_state_with_ids_and_object_basics,
-    test_utils::to_sender_signed_transaction,
+    test_utils::to_verified_transaction,
 };
 
 use super::*;
@@ -64,7 +64,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         1000000,
     );
 
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
     let effects = response.signed_effects.unwrap().into_data();
     assert!(effects.status.is_ok());
@@ -128,7 +128,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         100000,
     );
 
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
 
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
     let effects = response.signed_effects.unwrap().into_data();
@@ -161,7 +161,7 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
             .compute_object_reference(),
         100000,
     );
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),
@@ -191,7 +191,7 @@ async fn test_batch_contains_transfer_sui() -> anyhow::Result<()> {
         100000,
     );
 
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),
@@ -237,7 +237,7 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
         100000,
     );
 
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_handler::VerifiedSequencedConsensusTransaction;
-use crate::test_utils::to_sender_signed_transaction;
+use crate::test_utils::to_verified_transaction;
 use move_core_types::{account_address::AccountAddress, ident_str};
 use multiaddr::Multiaddr;
 use narwhal_types::TransactionsServer;
@@ -76,7 +76,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
             /* max_gas */ 10_000,
         );
 
-        let transaction = to_sender_signed_transaction(data, &keypair);
+        let transaction = to_verified_transaction(data, &keypair);
 
         // Submit the transaction and assemble a certificate.
         let response = authority

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use super::authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use super::move_integration_tests::build_and_try_publish_test_package;
 use crate::authority::authority_tests::{init_state, init_state_with_ids_and_object_basics};
-use crate::test_utils::to_sender_signed_transaction;
+use crate::test_utils::to_verified_transaction;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use sui_adapter::genesis;
@@ -172,7 +172,7 @@ async fn test_transfer_sui_insufficient_gas() {
         amount: None,
     }));
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, 50, 1);
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
 
     let effects = send_and_confirm_transaction(&authority_state, tx)
         .await
@@ -280,7 +280,8 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         .as_ref()
         .unwrap()
         .data()
-        .data
+        .intent_message
+        .value
         .kind
         .single_transactions()
         .next()
@@ -392,7 +393,7 @@ async fn test_move_call_gas() -> SuiResult {
         GAS_VALUE_FOR_TESTING,
     );
 
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
     let effects = response.signed_effects.unwrap().into_data();
     let created_object_ref = effects.created[0].0;
@@ -455,7 +456,7 @@ async fn test_move_call_gas() -> SuiResult {
         expected_gas_balance,
     );
 
-    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let transaction = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, transaction).await?;
     let effects = response.signed_effects.unwrap().into_data();
     assert!(effects.status.is_ok());
@@ -481,7 +482,7 @@ async fn test_move_call_gas() -> SuiResult {
         budget,
     );
 
-    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let transaction = to_verified_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, transaction).await?;
     let effects = response.signed_effects.unwrap().into_data();
     let gas_cost = effects.gas_used;
@@ -551,7 +552,7 @@ async fn execute_transfer_with_price(
     }));
     let data =
         TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, gas_price);
-    let tx = to_sender_signed_transaction(data, &sender_key);
+    let tx = to_verified_transaction(data, &sender_key);
 
     let response = if run_confirm {
         send_and_confirm_transaction(&authority_state, tx).await

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -1,0 +1,725 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::json;
+use std::{collections::HashSet, path::Path};
+
+use typed_store::Map;
+
+use sui_framework_build::compiled_package::BuildConfig;
+use sui_types::crypto::AccountKeyPair;
+use sui_types::gas_coin::GasCoin;
+use sui_types::object::{Object, GAS_VALUE_FOR_TESTING};
+use sui_types::{crypto::get_key_pair, object::Owner};
+
+use crate::authority_aggregator::authority_aggregator_tests::{
+    crate_object_move_transaction, get_local_client, init_local_authorities,
+};
+use crate::authority_client::LocalAuthorityClient;
+use crate::gateway_state::{GatewayAPI, GatewayState};
+use crate::test_utils::to_sender_signed_transaction;
+
+use super::*;
+
+async fn create_gateway_state_with_object_basics_ref(
+    genesis_objects: Vec<Object>,
+) -> (GatewayState<LocalAuthorityClient>, ObjectRef) {
+    let all_owners: HashSet<_> = genesis_objects
+        .iter()
+        .map(|o| o.get_single_owner().unwrap())
+        .collect();
+    let (authorities, _, pkg_ref) = init_local_authorities(4, genesis_objects).await;
+    let path = tempfile::tempdir().unwrap().into_path();
+    let gateway_store = Arc::new(GatewayStore::open(&path, None).unwrap());
+    let gateway = GatewayState::new_with_authorities(
+        gateway_store,
+        authorities,
+        GatewayMetrics::new_for_tests(),
+    )
+    .unwrap();
+    for owner in all_owners {
+        gateway.sync_account_state(owner).await.unwrap();
+    }
+    (gateway, pkg_ref)
+}
+
+async fn create_gateway_state(genesis_objects: Vec<Object>) -> GatewayState<LocalAuthorityClient> {
+    create_gateway_state_with_object_basics_ref(genesis_objects)
+        .await
+        .0
+}
+
+async fn public_transfer_object(
+    gateway: &GatewayState<LocalAuthorityClient>,
+    signer: SuiAddress,
+    key: &AccountKeyPair,
+    coin_object_id: ObjectID,
+    gas_object_id: ObjectID,
+    recipient: SuiAddress,
+) -> Result<SuiTransactionResponse, anyhow::Error> {
+    let data = gateway
+        .public_transfer_object(
+            signer,
+            coin_object_id,
+            Some(gas_object_id),
+            GAS_VALUE_FOR_TESTING / 10,
+            recipient,
+        )
+        .await?;
+
+    let result = gateway
+        .execute_transaction(to_sender_signed_transaction(data, key))
+        .await?;
+    Ok(result)
+}
+
+#[tokio::test]
+async fn test_public_transfer_object() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let (addr2, _key2): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+
+    let genesis_objects = vec![coin_object.clone(), gas_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    let effects = public_transfer_object(
+        &gateway,
+        addr1,
+        &key1,
+        coin_object.id(),
+        gas_object.id(),
+        addr2,
+    )
+    .await
+    .unwrap()
+    .effects;
+    assert_eq!(effects.mutated.len(), 2);
+    assert_eq!(
+        effects.mutated_excluding_gas().next().unwrap().owner,
+        Owner::AddressOwner(addr2)
+    );
+    assert_eq!(gateway.get_total_transaction_number().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn test_move_call() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let gas_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![gas_object.clone()];
+    let (gateway, pkg_ref) = create_gateway_state_with_object_basics_ref(genesis_objects).await;
+
+    let tx = crate_object_move_transaction(
+        addr1,
+        &key1,
+        addr1,
+        100,
+        pkg_ref,
+        gas_object.compute_object_reference(),
+    );
+
+    let effects = gateway
+        .execute_transaction(tx.into_inner())
+        .await
+        .unwrap()
+        .effects;
+    assert!(effects.status.is_ok());
+    assert_eq!(effects.mutated.len(), 1);
+    assert_eq!(effects.created.len(), 1);
+    assert_eq!(effects.created[0].owner, Owner::AddressOwner(addr1));
+}
+
+#[tokio::test]
+async fn test_publish() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let gas_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![gas_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    // Provide path to well formed package sources
+    let mut path = env!("CARGO_MANIFEST_DIR").to_owned();
+    path.push_str("/src/unit_tests/data/object_owner/");
+
+    let compiled_modules = BuildConfig::default()
+        .build(Path::new(&path).to_path_buf())
+        .unwrap()
+        .get_package_bytes();
+    let data = gateway
+        .publish(
+            addr1,
+            compiled_modules,
+            Some(gas_object.id()),
+            GAS_VALUE_FOR_TESTING,
+        )
+        .await
+        .unwrap();
+
+    gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_coin_split() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+
+    let genesis_objects = vec![coin_object.clone(), gas_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    let split_amounts = vec![100, 200, 300, 400, 500];
+    let total_amount: u64 = split_amounts.iter().sum();
+
+    let data = gateway
+        .split_coin(
+            addr1,
+            coin_object.id(),
+            split_amounts.clone(),
+            Some(gas_object.id()),
+            GAS_VALUE_FOR_TESTING,
+        )
+        .await
+        .unwrap();
+
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap()
+        .parsed_data
+        .unwrap()
+        .to_split_coin_response()
+        .unwrap();
+
+    assert_eq!(
+        (coin_object.id(), coin_object.version().increment()),
+        (response.updated_coin.id(), response.updated_coin.version())
+    );
+    assert_eq!(
+        (gas_object.id(), gas_object.version().increment()),
+        (response.updated_gas.id(), response.updated_gas.version())
+    );
+    let update_coin = GasCoin::try_from(&response.updated_coin).unwrap();
+    assert_eq!(update_coin.value(), GAS_VALUE_FOR_TESTING - total_amount);
+    let split_coin_values = response
+        .new_coins
+        .iter()
+        .map(|o| GasCoin::try_from(o).unwrap().value())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        split_amounts,
+        split_coin_values.into_iter().collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_coin_split_insufficient_gas() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+
+    let genesis_objects = vec![coin_object.clone(), gas_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    let split_amounts = vec![100, 200, 300, 400, 500];
+
+    let data = gateway
+        .split_coin(
+            addr1,
+            coin_object.id(),
+            split_amounts.clone(),
+            Some(gas_object.id()),
+            9, /* Insufficient gas */
+        )
+        .await
+        .unwrap();
+
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await;
+    // Tx should fail due to out of gas, and no transactions should remain pending.
+    // Objects are not locked either.
+    assert!(response.is_err());
+    assert_eq!(
+        gateway.store().epoch_tables().transactions.iter().count(),
+        0
+    );
+    assert_eq!(
+        gateway
+            .store()
+            .get_object_locking_transaction(&gas_object.compute_object_reference())
+            .await
+            .unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn test_coin_merge() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object1 = Object::with_owner_for_testing(addr1);
+    let coin_object2 = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![
+        coin_object1.clone(),
+        coin_object2.clone(),
+        gas_object.clone(),
+    ];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    let data = gateway
+        .merge_coins(
+            addr1,
+            coin_object1.id(),
+            coin_object2.id(),
+            Some(gas_object.id()),
+            GAS_VALUE_FOR_TESTING,
+        )
+        .await
+        .unwrap();
+
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap()
+        .parsed_data
+        .unwrap()
+        .to_merge_coin_response()
+        .unwrap();
+
+    assert_eq!(
+        (coin_object1.id(), coin_object1.version().increment()),
+        (response.updated_coin.id(), response.updated_coin.version())
+    );
+    assert_eq!(
+        (gas_object.id(), gas_object.version().increment()),
+        (response.updated_gas.id(), response.updated_gas.version())
+    );
+    let update_coin = GasCoin::try_from(&response.updated_coin).unwrap();
+    assert_eq!(update_coin.value(), GAS_VALUE_FOR_TESTING * 2);
+}
+
+#[tokio::test]
+async fn test_pay_sui_empty_input_coins() -> Result<(), anyhow::Error> {
+    let (addr1, _): (_, AccountKeyPair) = get_key_pair();
+    let (recipient, _): (_, AccountKeyPair) = get_key_pair();
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![coin_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    let res = gateway
+        .pay_sui(addr1, vec![], vec![recipient], vec![100], 1000)
+        .await;
+    assert!(res.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pay_all_sui_empty_input_coins() -> Result<(), anyhow::Error> {
+    let (addr1, _): (_, AccountKeyPair) = get_key_pair();
+    let (recipient, _): (_, AccountKeyPair) = get_key_pair();
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![coin_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    let res = gateway.pay_all_sui(addr1, vec![], recipient, 1000).await;
+    assert!(res.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_equivocation_resilient() {
+    telemetry_subscribers::init_for_testing();
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![coin_object.clone()];
+    let gateway = Arc::new(Box::new(create_gateway_state(genesis_objects).await));
+
+    let mut handles = vec![];
+    // We create 20 requests that try to touch the same object to the gateway.
+    // Make sure that one of them succeeds and there are no pending tx in the end.
+    for _ in 0..20 {
+        let (recipient, _): (_, AccountKeyPair) = get_key_pair();
+        let data = TransactionData::new_transfer_sui(
+            recipient,
+            addr1,
+            None,
+            coin_object.compute_object_reference(),
+            1000,
+        );
+        let tx = to_sender_signed_transaction(data, &key1);
+        let handle = tokio::task::spawn({
+            let gateway_copy = gateway.clone();
+            async move { gateway_copy.execute_transaction(tx).await }
+        });
+        handles.push(handle);
+    }
+    let results = futures::future::join_all(handles).await;
+    assert_eq!(
+        results
+            .into_iter()
+            .filter(|r| r.as_ref().unwrap().is_ok())
+            .count(),
+        1
+    );
+    println!(
+        "{:?}",
+        gateway.store().epoch_tables().transactions.iter().next()
+    );
+    assert_eq!(
+        gateway.store().epoch_tables().transactions.iter().count(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_public_transfer_object_with_retry() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let (addr2, _key2): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+
+    let genesis_objects = vec![coin_object.clone(), gas_object.clone()];
+    let mut gateway = create_gateway_state(genesis_objects).await;
+    // Make two authorities fail at the end of certificate processing.
+    get_local_client(&mut gateway.authorities, 0)
+        .fault_config
+        .fail_after_handle_confirmation = true;
+    get_local_client(&mut gateway.authorities, 1)
+        .fault_config
+        .fail_after_handle_confirmation = true;
+
+    // Transfer will fail because we would not be able to reach quorum on cert processing.
+    assert!(public_transfer_object(
+        &gateway,
+        addr1,
+        &key1,
+        coin_object.id(),
+        gas_object.id(),
+        addr2,
+    )
+    .await
+    .is_err());
+
+    // Since we never finished executing the transaction, the transaction is still in the
+    // transactions table.
+    // However objects in the transaction should no longer be locked since we reset
+    // them at the last failed retry.
+    assert_eq!(
+        gateway.store().epoch_tables().transactions.iter().count(),
+        1
+    );
+    let (tx_digest, tx) = gateway
+        .store()
+        .epoch_tables()
+        .transactions
+        .iter()
+        .next()
+        .unwrap();
+    assert_eq!(
+        gateway
+            .store()
+            .get_object_locking_transaction(&coin_object.compute_object_reference())
+            .await
+            .unwrap(),
+        None,
+    );
+
+    // Recover one of the authorities.
+    get_local_client(&mut gateway.authorities, 1)
+        .fault_config
+        .fail_after_handle_confirmation = false;
+
+    // Retry transaction, and this time it should succeed.
+    let effects = gateway
+        .execute_transaction(tx.into_inner())
+        .await
+        .unwrap()
+        .effects;
+    let oref = effects.mutated_excluding_gas().next().unwrap();
+    let updated_obj_ref = &oref.reference;
+    let new_owner = &oref.owner;
+    assert_eq!(new_owner, &Owner::AddressOwner(addr2));
+
+    assert_eq!(
+        gateway.store().epoch_tables().transactions.iter().count(),
+        0
+    );
+    assert!(gateway
+        .store()
+        .get_object_locking_transaction(&coin_object.compute_object_reference())
+        .await
+        .is_err());
+    assert!(gateway.store().effects_exists(&tx_digest).unwrap());
+    // The transaction is deleted after this is done.
+    assert!(gateway
+        .store()
+        .get_transaction(&tx_digest)
+        .unwrap()
+        .is_none());
+    assert_eq!(gateway.store().next_sequence_number().unwrap(), 1);
+    assert_eq!(
+        gateway
+            .store()
+            .get_owner_objects(Owner::AddressOwner(addr1))
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        gateway
+            .store()
+            .get_owner_objects(Owner::AddressOwner(addr2))
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        gateway
+            .store()
+            .read_certificate(&tx_digest)
+            .unwrap()
+            .unwrap()
+            .digest(),
+        &tx_digest
+    );
+    assert_eq!(
+        gateway
+            .store()
+            .parent(&updated_obj_ref.to_object_ref())
+            .unwrap()
+            .unwrap(),
+        tx_digest
+    );
+}
+
+#[tokio::test]
+async fn test_get_owner_object() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let gas_object = Object::with_owner_for_testing(addr1);
+    let genesis_objects = vec![gas_object.clone()];
+    let gateway = create_gateway_state(genesis_objects).await;
+
+    // Provide path to well formed package sources
+    let mut path = env!("CARGO_MANIFEST_DIR").to_owned();
+    path.push_str("/src/unit_tests/data/object_owner/");
+
+    // Publish object_owner package
+    let compiled_modules = BuildConfig::default()
+        .build(Path::new(&path).to_path_buf())
+        .unwrap()
+        .get_package_bytes();
+    let data = gateway
+        .publish(
+            addr1,
+            compiled_modules,
+            Some(gas_object.id()),
+            GAS_VALUE_FOR_TESTING,
+        )
+        .await
+        .unwrap();
+
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap()
+        .parsed_data
+        .unwrap()
+        .to_publish_response()
+        .unwrap();
+
+    // create parent and child object
+    let package = response.package.object_id;
+    let data = gateway
+        .move_call(
+            addr1,
+            package,
+            "object_owner".to_string(),
+            "create_parent".to_string(),
+            vec![],
+            vec![],
+            None,
+            10000,
+        )
+        .await
+        .unwrap();
+
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap();
+    let parent = &response.effects.created.first().unwrap().reference;
+    let data = gateway
+        .move_call(
+            addr1,
+            package,
+            "object_owner".to_string(),
+            "create_child".to_string(),
+            vec![],
+            vec![],
+            None,
+            10000,
+        )
+        .await
+        .unwrap();
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap();
+    let child = &response.effects.created.first().unwrap().reference;
+
+    // Make parent owns child
+    let data = gateway
+        .move_call(
+            addr1,
+            package,
+            "object_owner".to_string(),
+            "add_child".to_string(),
+            vec![],
+            vec![
+                SuiJsonValue::new(json!(parent.object_id.to_hex_literal())).unwrap(),
+                SuiJsonValue::new(json!(child.object_id.to_hex_literal())).unwrap(),
+            ],
+            None,
+            10000,
+        )
+        .await
+        .unwrap();
+    let response = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap();
+    let field_object = &response.effects.created.first().unwrap().reference;
+
+    // Query get_objects_owned_by_object
+    let objects = gateway
+        .get_objects_owned_by_object(parent.object_id)
+        .await
+        .unwrap();
+    assert_eq!(1, objects.len());
+    assert_eq!(field_object.object_id, objects.first().unwrap().object_id);
+    let objects = gateway
+        .get_objects_owned_by_object(field_object.object_id)
+        .await
+        .unwrap();
+    assert_eq!(1, objects.len());
+    assert_eq!(child.object_id, objects.first().unwrap().object_id);
+
+    // Query get_objects_owned_by_address should return nothing
+    let objects = gateway
+        .get_objects_owned_by_address(parent.object_id.into())
+        .await
+        .unwrap();
+    assert!(objects.is_empty())
+}
+
+#[tokio::test]
+async fn test_multiple_gateways() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let (addr2, _key2): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object1 = Object::with_owner_for_testing(addr1);
+    let coin_object2 = Object::with_owner_for_testing(addr1);
+    let coin_object3 = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+
+    let genesis_objects = vec![
+        coin_object1.clone(),
+        coin_object2.clone(),
+        coin_object3.clone(),
+        gas_object.clone(),
+    ];
+    let gateway1 = create_gateway_state(genesis_objects).await;
+    let path = tempfile::tempdir().unwrap().into_path();
+    // gateway2 shares the same set of authorities as gateway1.
+    let gateway2 = GatewayState::new_with_authorities(
+        Arc::new(GatewayStore::open(&path, None).unwrap()),
+        gateway1.authorities.clone(),
+        GatewayMetrics::new_for_tests(),
+    )
+    .unwrap();
+    let response = public_transfer_object(
+        &gateway1,
+        addr1,
+        &key1,
+        coin_object1.id(),
+        gas_object.id(),
+        addr2,
+    )
+    .await
+    .unwrap();
+    assert!(response.effects.status.is_ok());
+
+    // gas_object on gateway2 should be out-of-dated.
+    // Show that we can still handle the transaction successfully if we use it on gateway2.
+    let response = public_transfer_object(
+        &gateway2,
+        addr1,
+        &key1,
+        coin_object2.id(),
+        gas_object.id(),
+        addr2,
+    )
+    .await
+    .unwrap();
+    assert!(response.effects.status.is_ok());
+
+    // Now we try to use the same gas object on gateway1, and it will still work.
+    let response = public_transfer_object(
+        &gateway1,
+        addr1,
+        &key1,
+        coin_object3.id(),
+        gas_object.id(),
+        addr2,
+    )
+    .await
+    .unwrap();
+    assert!(response.effects.status.is_ok());
+}
+
+#[tokio::test]
+async fn test_batch_transaction() {
+    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
+    let (addr2, _key2): (_, AccountKeyPair) = get_key_pair();
+
+    let coin_object1 = Object::with_owner_for_testing(addr1);
+    let coin_object2 = Object::with_owner_for_testing(addr1);
+    let gas_object = Object::with_owner_for_testing(addr1);
+
+    let genesis_objects = vec![
+        coin_object1.clone(),
+        coin_object2.clone(),
+        gas_object.clone(),
+    ];
+    let gateway = create_gateway_state(genesis_objects).await;
+    let params = vec![
+        RPCTransactionRequestParams::TransferObjectRequestParams(TransferObjectParams {
+            object_id: coin_object1.id(),
+            recipient: addr2,
+        }),
+        RPCTransactionRequestParams::TransferObjectRequestParams(TransferObjectParams {
+            object_id: coin_object2.id(),
+            recipient: addr2,
+        }),
+    ];
+    // Gateway should be able to figure out the only usable gas object.
+    let data = gateway
+        .batch_transaction(addr1, params, None, 5000)
+        .await
+        .unwrap();
+    let effects = gateway
+        .execute_transaction(to_sender_signed_transaction(data, &key1))
+        .await
+        .unwrap()
+        .effects;
+    assert!(effects.created.is_empty());
+    assert_eq!(effects.mutated.len(), 3);
+}

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -8,7 +8,7 @@ use crate::{
         call_move, call_move_with_shared, init_state_with_ids, send_and_confirm_transaction,
         TestCallArg,
     },
-    test_utils::to_sender_signed_transaction,
+    test_utils::to_verified_transaction,
 };
 
 use move_core_types::{
@@ -1872,7 +1872,7 @@ pub async fn build_and_try_publish_test_package(
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
     let data = TransactionData::new_module(*sender, gas_object_ref, all_module_bytes, gas_budget);
-    let transaction = to_sender_signed_transaction(data, sender_key);
+    let transaction = to_verified_transaction(data, sender_key);
 
     send_and_confirm_transaction(authority, transaction)
         .await

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -5,14 +5,15 @@ use super::*;
 
 use crate::authority::authority_tests::{init_state, send_and_confirm_transaction};
 use crate::authority::AuthorityState;
+use crate::test_utils::to_verified_transaction;
 use futures::future::join_all;
 use std::collections::HashMap;
 use sui_types::crypto::AccountKeyPair;
 use sui_types::{
     base_types::dbg_addr,
-    crypto::{get_key_pair, Signature},
+    crypto::get_key_pair,
     error::SuiError,
-    messages::{Transaction, TransactionInfoResponse, TransactionKind},
+    messages::{TransactionInfoResponse, TransactionKind},
 };
 
 #[tokio::test]
@@ -448,9 +449,7 @@ async fn execute_pay_sui(
         amounts,
     }));
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
-
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::from_data(data, signature).verify().unwrap();
+    let tx = to_verified_transaction(data, &sender_key);
     let txn_result = send_and_confirm_transaction(&authority_state, tx)
         .await
         .map(|t| t.into());
@@ -484,13 +483,10 @@ async fn execute_pay_all_sui(
         recipient,
     }));
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::from_data(data, signature).verify().unwrap();
-
+    let tx = to_verified_transaction(data, &sender_key);
     let txn_result = send_and_confirm_transaction(&authority_state, tx)
         .await
         .map(|t| t.into());
-
     PaySuiTransactionExecutionResult {
         authority_state,
         txn_result,

--- a/crates/sui-cost/src/estimator.rs
+++ b/crates/sui-cost/src/estimator.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use strum_macros::Display;
 use strum_macros::EnumString;
 use sui_core::authority::AuthorityState;
-use sui_core::test_utils::to_sender_signed_transaction;
+use sui_core::test_utils::to_verified_transaction;
 use sui_core::transaction_input_checker;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
@@ -137,15 +137,18 @@ pub async fn estimate_transaction_computation_cost(
 ) -> anyhow::Result<GasCostSummary> {
     // Make a dummy transaction
     let (_, keypair): (_, AccountKeyPair) = get_key_pair();
-    let tx = to_sender_signed_transaction(tx_data, &keypair);
+    let tx = to_verified_transaction(tx_data, &keypair);
 
-    let (_gas_status, input_objects) =
-        transaction_input_checker::check_transaction_input(&state.db(), &tx.data().data).await?;
+    let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
+        &state.db(),
+        &tx.data().intent_message.value,
+    )
+    .await?;
     let in_mem_temporary_store =
         TemporaryStore::new(state.db(), input_objects, TransactionDigest::random());
 
     estimate_transaction_inner(
-        tx.into_inner().into_data().data.kind,
+        tx.into_inner().into_data().intent_message.value.kind,
         computation_gas_unit_price,
         storage_gas_unit_price,
         mutated_object_sizes_after,

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -255,8 +255,10 @@ async fn run_actual_and_estimate_costs(
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
     let tx_map = create_txes(sender, &keypair, &gas_objects, &configs).await;
-
+    println!("~~~tx_map {:?}", tx_map.values().len());
     for (tx_type, tx) in tx_map {
+        println!("~~~txx {:?}", tx);
+
         let gas_used = if tx_type.is_shared_object_tx() {
             submit_shared_object_transaction(tx.clone(), configs.validator_set())
                 .await
@@ -264,6 +266,8 @@ async fn run_actual_and_estimate_costs(
                 .gas_cost_summary()
                 .clone()
         } else {
+            println!("~~~verified_tz {:?}", tx);
+            println!("~~~submit_single_owner_transaction");
             submit_single_owner_transaction(tx.clone(), configs.validator_set())
                 .await
                 .gas_cost_summary()
@@ -274,7 +278,7 @@ async fn run_actual_and_estimate_costs(
             .with_async(|node| async move {
                 let state = node.state();
                 estimate_transaction_computation_cost(
-                    tx.into_inner().into_data().data,
+                    tx.into_inner().into_data().intent_message.value,
                     state.clone(),
                     None,
                     None,

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -19,6 +19,7 @@ use sui_types::object::Owner;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     gas_coin::GasCoin,
+    intent::Intent,
     messages::{ExecuteTransactionRequestType, Transaction, TransactionData},
 };
 use tokio::sync::{
@@ -318,15 +319,14 @@ impl SimpleFaucet {
         });
 
         let context = &self.wallet;
-        let txn_data = self
+        let data = self
             .build_pay_sui_txn(coin_id, signer, recipient, amounts, budget)
             .await?;
         let signature = context
             .config
             .keystore
-            .sign(&signer, &txn_data.to_bytes())?;
-
-        let tx = Transaction::from_data(txn_data, signature).verify()?;
+            .sign_secure(&signer, &data, Intent::default())?;
+        let tx = Transaction::from_data_and_sig(data, Intent::default(), signature).verify()?;
         let tx_digest = *tx.digest();
         info!(
             ?tx_digest,

--- a/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
@@ -6,7 +6,7 @@ use std::{path::Path, str::FromStr};
 
 use sui_config::utils::get_available_port;
 use sui_config::SUI_KEYSTORE_FILENAME;
-use sui_core::test_utils::to_sender_signed_transaction;
+use sui_core::test_utils::{to_sender_signed_transaction, to_verified_transaction};
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 use sui_json_rpc::api::TransactionExecutionApiClient;
@@ -284,7 +284,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
                 .transaction_builder()
                 .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
                 .await?;
-            let tx = to_sender_signed_transaction(data, keystore.get_key(address).unwrap());
+            let tx = to_verified_transaction(data, keystore.get_key(address).unwrap());
 
             let response = client
                 .quorum_driver()
@@ -420,7 +420,7 @@ async fn test_get_fullnode_events() -> Result<(), anyhow::Error> {
                 .transaction_builder()
                 .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
                 .await?;
-            let tx = to_sender_signed_transaction(data, keystore.get_key(address).unwrap());
+            let tx = to_verified_transaction(data, keystore.get_key(address).unwrap());
 
             let response = client
                 .quorum_driver()

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -479,7 +479,7 @@ pub trait TransactionExecutionApi {
     #[method(name = "executeTransaction")]
     async fn execute_transaction(
         &self,
-        /// transaction data bytes, as base-64 encoded string
+        /// intent message containing transaction data bytes, as base-64 encoded string
         tx_bytes: Base64,
         /// Flag of the signature scheme that is used.
         sig_scheme: SignatureScheme,

--- a/crates/sui-json-rpc/src/gateway_api.rs
+++ b/crates/sui-json-rpc/src/gateway_api.rs
@@ -20,11 +20,11 @@ use sui_json_rpc_types::{
 use sui_open_rpc::Module;
 use sui_types::batch::TxSequenceNumber;
 use sui_types::crypto::SignatureScheme;
+use sui_types::intent::IntentMessage;
 use sui_types::messages::SenderSignedData;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     crypto,
-    crypto::SignableBytes,
     messages::{Transaction, TransactionData},
 };
 use tracing::debug;
@@ -77,8 +77,9 @@ impl RpcGatewayApiServer for RpcGatewayImpl {
         signature: Base64,
         pub_key: Base64,
     ) -> RpcResult<SuiTransactionResponse> {
-        let data =
-            TransactionData::from_signable_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?)?;
+        let intent_msg = IntentMessage::<TransactionData>::from_bytes(
+            &tx_bytes.to_vec().map_err(|e| anyhow!(e))?,
+        )?;
         let flag = vec![sig_scheme.flag()];
         let signature = crypto::Signature::from_bytes(
             &[
@@ -91,7 +92,9 @@ impl RpcGatewayApiServer for RpcGatewayImpl {
         .map_err(|e| anyhow!(e))?;
         let result = self
             .client
-            .execute_transaction(Transaction::new(SenderSignedData::new(data, signature)))
+            .execute_transaction(Transaction::new(SenderSignedData::new(
+                intent_msg, signature,
+            )))
             .await;
         Ok(result?)
     }

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -18,12 +18,12 @@ use sui_json_rpc_types::SuiExecuteTransactionResponse;
 use sui_metrics::spawn_monitored_task;
 use sui_open_rpc::Module;
 use sui_types::crypto::SignatureScheme;
+use sui_types::intent::IntentMessage;
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, SenderSignedData,
 };
 use sui_types::{
     crypto,
-    crypto::SignableBytes,
     messages::{Transaction, TransactionData},
 };
 
@@ -54,8 +54,9 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
         pub_key: Base64,
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiExecuteTransactionResponse> {
-        let data =
-            TransactionData::from_signable_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?)?;
+        let intent_msg = IntentMessage::<TransactionData>::from_bytes(
+            &tx_bytes.to_vec().map_err(|e| anyhow!(e))?,
+        )?;
         let flag = vec![sig_scheme.flag()];
         let signature = crypto::Signature::from_bytes(
             &[
@@ -66,7 +67,7 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
             .concat(),
         )
         .map_err(|e| anyhow!(e))?;
-        let txn = Transaction::new(SenderSignedData::new(data, signature));
+        let txn = Transaction::new(SenderSignedData::new(intent_msg, signature));
         let txn_digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use sui_types::intent::{ChainId, Intent, IntentMessage};
 
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
@@ -31,10 +32,23 @@ pub enum Keystore {
 }
 #[enum_dispatch]
 pub trait AccountKeystore: Send + Sync {
+    #[warn(deprecated)]
     fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error>;
     fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error>;
     fn keys(&self) -> Vec<PublicKey>;
     fn get_key(&self, address: &SuiAddress) -> Result<&SuiKeyPair, anyhow::Error>;
+
+    fn sign_secure<T>(
+        &self,
+        address: &SuiAddress,
+        msg: &T,
+        intent: Intent,
+    ) -> Result<Signature, signature::Error>
+    where
+        T: Serialize;
+    fn set_chain_id(&mut self, chain_id: ChainId) -> Result<(), anyhow::Error>;
+    fn chain_id(&self) -> ChainId;
+
     fn addresses(&self) -> Vec<SuiAddress> {
         self.keys().iter().map(|k| k.into()).collect()
     }
@@ -98,6 +112,7 @@ impl Display for Keystore {
 pub struct FileBasedKeystore {
     keys: BTreeMap<SuiAddress, SuiKeyPair>,
     path: Option<PathBuf>,
+    chain_id: Option<ChainId>,
 }
 
 impl Serialize for FileBasedKeystore {
@@ -127,6 +142,7 @@ impl<'de> Deserialize<'de> for FileBasedKeystore {
 }
 
 impl AccountKeystore for FileBasedKeystore {
+    #[warn(deprecated)]
     fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error> {
         self.keys
             .get(address)
@@ -134,6 +150,24 @@ impl AccountKeystore for FileBasedKeystore {
                 signature::Error::from_source(format!("Cannot find key for address: [{address}]"))
             })?
             .try_sign(msg)
+    }
+
+    fn sign_secure<T>(
+        &self,
+        address: &SuiAddress,
+        msg: &T,
+        intent: Intent,
+    ) -> Result<Signature, signature::Error>
+    where
+        T: Serialize,
+    {
+        let intent = intent.with_chain_id(self.chain_id());
+        Ok(Signature::new_secure(
+            &IntentMessage::new(intent, msg),
+            self.keys.get(address).ok_or_else(|| {
+                signature::Error::from_source(format!("Cannot find key for address: [{address}]"))
+            })?,
+        ))
     }
 
     fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error> {
@@ -152,6 +186,15 @@ impl AccountKeystore for FileBasedKeystore {
             Some(key) => Ok(key),
             None => Err(anyhow!("Cannot find key for address: [{address}]")),
         }
+    }
+
+    fn set_chain_id(&mut self, chain_id: ChainId) -> Result<(), anyhow::Error> {
+        self.chain_id = Some(chain_id);
+        Ok(())
+    }
+
+    fn chain_id(&self) -> ChainId {
+        self.chain_id.unwrap_or_default()
     }
 }
 
@@ -175,6 +218,7 @@ impl FileBasedKeystore {
         Ok(Self {
             keys,
             path: Some(path.to_path_buf()),
+            chain_id: None,
         })
     }
 
@@ -205,9 +249,11 @@ impl FileBasedKeystore {
 #[derive(Default, Serialize, Deserialize)]
 pub struct InMemKeystore {
     keys: BTreeMap<SuiAddress, SuiKeyPair>,
+    chain_id: Option<ChainId>,
 }
 
 impl AccountKeystore for InMemKeystore {
+    #[warn(deprecated)]
     fn sign(&self, address: &SuiAddress, msg: &[u8]) -> Result<Signature, signature::Error> {
         self.keys
             .get(address)
@@ -215,6 +261,23 @@ impl AccountKeystore for InMemKeystore {
                 signature::Error::from_source(format!("Cannot find key for address: [{address}]"))
             })?
             .try_sign(msg)
+    }
+
+    fn sign_secure<T>(
+        &self,
+        address: &SuiAddress,
+        msg: &T,
+        intent: Intent,
+    ) -> Result<Signature, signature::Error>
+    where
+        T: Serialize,
+    {
+        Ok(Signature::new_secure(
+            &IntentMessage::new(intent, msg),
+            self.keys.get(address).ok_or_else(|| {
+                signature::Error::from_source(format!("Cannot find key for address: [{address}]"))
+            })?,
+        ))
     }
 
     fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error> {
@@ -233,6 +296,15 @@ impl AccountKeystore for InMemKeystore {
             None => Err(anyhow!("Cannot find key for address: [{address}]")),
         }
     }
+
+    fn set_chain_id(&mut self, chain_id: ChainId) -> Result<(), anyhow::Error> {
+        self.chain_id = Some(chain_id);
+        Ok(())
+    }
+
+    fn chain_id(&self) -> ChainId {
+        self.chain_id.unwrap_or_default()
+    }
 }
 
 impl InMemKeystore {
@@ -243,6 +315,9 @@ impl InMemKeystore {
             .map(|(ad, k)| (ad, SuiKeyPair::Ed25519SuiKeyPair(k)))
             .collect::<BTreeMap<SuiAddress, SuiKeyPair>>();
 
-        Self { keys }
+        Self {
+            keys,
+            chain_id: None,
+        }
     }
 }

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -11,6 +11,7 @@ schemars = "0.8.10"
 serde = "1.0.141"
 serde_json = "1.0.88"
 workspace-hack.workspace = true
+bcs = "0.1.3"
 
 [dev-dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -112,7 +112,7 @@
           "result": {
             "name": "Result",
             "value": {
-              "txBytes": "VHJhbnNhY3Rpb25EYXRhOjoBAgIAAAAAAAAAAAAAAAAAAAAAAAAAAgEAAAAAAAAAIJ0HWVK1gDbyp7VhRGWSQDxnLw2+Ep8eORE/n2Fk6ihnCmRldm5ldF9uZnQEbWludAADAAtFeGFtcGxlIE5GVAArQW4gTkZUIGNyZWF0ZWQgYnkgdGhlIFN1aSBDb21tYW5kIExpbmUgVG9vbABCaXBmczovL2JhZmtyZWlibmdxaGwzZ2FhN2Rhb2I0aTJ2Y2N6aWF5MmpqbHA0MzVjZjY2dmhvbm83bnJ2d3c1M3R5AMYZFUxCocYb6ZAnF7JLjsFo/kiW7++Sy/RLWB8jIiwQkWsXo2m02gMBAAAAAAAAACD43szzw8UY8UbelVTwPyeoPVsRhfOece81fivZ4TliUZsHgV8ESX4uBdIsrDqgYUELIIaM9bcMyxDxpwXgYdD9+hiWGNKLDUQBAAAAAAAAACBrCkFAMnZDeyXw/76JfPR2wHd+nSRv85dKxfGzUKoWxAEAAAAAAAAA6AMAAAAAAAA=",
+              "txBytes": "AAAAAQICAAAAAAAAAAAAAAAAAAAAAAAAAAIBAAAAAAAAACCdB1lStYA28qe1YURlkkA8Zy8NvhKfHjkRP59hZOooZwpkZXZuZXRfbmZ0BG1pbnQAAwALRXhhbXBsZSBORlQAK0FuIE5GVCBjcmVhdGVkIGJ5IHRoZSBTdWkgQ29tbWFuZCBMaW5lIFRvb2wAQmlwZnM6Ly9iYWZrcmVpYm5ncWhsM2dhYTdkYW9iNGkydmNjemlheTJqamxwNDM1Y2Y2NnZob25vN25ydnd3NTN0eQDGGRVMQqHGG+mQJxeyS47BaP5Ilu/vksv0S1gfIyIsEJFrF6NptNoDAQAAAAAAAAAg+N7M88PFGPFG3pVU8D8nqD1bEYXznnHvNX4r2eE5YlGbB4FfBEl+LgXSLKw6oGFBCyCGjPW3DMsQ8acF4GHQ/foYlhjSiw1EAQAAAAAAAAAgawpBQDJ2Q3sl8P++iXz0dsB3fp0kb/OXSsXxs1CqFsQBAAAAAAAAAOgDAAAAAAAA",
               "gas": {
                 "objectId": "0xf5b70ccb10f1a705e061d0fdfa189618d28b0d44",
                 "version": 1,
@@ -177,7 +177,7 @@
       "params": [
         {
           "name": "tx_bytes",
-          "description": "transaction data bytes, as base-64 encoded string",
+          "description": "intent message containing transaction data bytes, as base-64 encoded string",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/Base64"
@@ -229,7 +229,7 @@
           "params": [
             {
               "name": "tx_bytes",
-              "value": "VHJhbnNhY3Rpb25EYXRhOjoAAENs56klSzDSU+RWfMr6XzbOhMgKqLyb5k4NWueWiEJ0rvMAWuZzOAkCAAAAAAAAACAyE4rjTSLmOXrzqaceTvofutFssM+v3lsohIWOg/pBRhEgRALReoQVOKG0v7bv5ChQQhoKyOwdW4TdYonhk7n4jeSplDWMn4UCAAAAAAAAACBhNSNsPnWpJeHHesNBJ8i6776gk58VJHErTTegILKM3QEAAAAAAAAA6AMAAAAAAAA="
+              "value": "AAAAAABDbOepJUsw0lPkVnzK+l82zoTICqi8m+ZODVrnlohCdK7zAFrmczgJAgAAAAAAAAAgMhOK400i5jl686mnHk76H7rRbLDPr95bKISFjoP6QUageXdxuP4mL6ToOhqHzAZPI0Q+jcjsHVuE3WKJ4ZO5+I3kqZQ1jJ+FAgAAAAAAAAAgYTUjbD51qSXhx3rDQSfIuu++oJOfFSRxK003oCCyjN0BAAAAAAAAAOgDAAAAAAAA"
             },
             {
               "name": "sig_scheme",
@@ -237,7 +237,7 @@
             },
             {
               "name": "signature",
-              "value": "pD7Ih0rV6bwO7x0T3+cK8ySQS26jc/YHwMrPwXHvVyaqYUaaZ8e4NtWqF07mawgnFgUGP/X0s3pbEpxZEhdeAA=="
+              "value": "IKsVFCGOvfVLszUH9ZHSnDxzSDlcV871alhLCjDo/8rAUKeMn8kFjj1Py+6wcKEN+S0p0+nvXDI7Fsib23vfDA=="
             },
             {
               "name": "pub_key",
@@ -252,7 +252,7 @@
             "name": "Result",
             "value": {
               "certificate": {
-                "transactionDigest": "mWZpOe42hid/gGQ1t7lOY5ohuzIXEIuo1uemz/CT96s=",
+                "transactionDigest": "cQh1W8tzzWM8sEjI9DxisCBwA/1wykXp8ScNHIuNWfM=",
                 "data": {
                   "transactions": [
                     {
@@ -274,7 +274,7 @@
                   },
                   "gasBudget": 1000
                 },
-                "txSignature": "AKQ+yIdK1em8Du8dE9/nCvMkkEtuo3P2B8DKz8Fx71cmqmFGmmfHuDbVqhdO5msIJxYFBj/19LN6WxKcWRIXXgBx+rEBAzFCR9EqZuZwy6ymxQFHAR2C/1SDkX9nq7wm2w==",
+                "txSignature": "ACCrFRQhjr31S7M1B/WR0pw8c0g5XFfO9WpYSwow6P/KwFCnjJ/JBY49T8vusHChDfktKdPp71wyOxbIm9t73wyLhW8+xQtCFKb75H6GmzNpzkQ4ucluHTY0AxJw//j4vQ==",
                 "authSignInfo": {
                   "epoch": 0,
                   "signature": "",
@@ -463,7 +463,7 @@
             {
               "name": "query",
               "value": {
-                "Transaction": "Vi63z0O8cI/1smk/OYkxoECgOF4LxllfNwKQCDlHxmk="
+                "Transaction": "qdysAmF3MGi4O7WgvxksLXSDekRUu/HAQhQrdA19pD8="
               }
             },
             {
@@ -488,11 +488,7 @@
               "data": [
                 {
                   "timestamp": 0,
-                  "txDigest": "Vi63z0O8cI/1smk/OYkxoECgOF4LxllfNwKQCDlHxmk=",
-                  "id": {
-                    "txSeq": 0,
-                    "eventSeq": 0
-                  },
+                  "txDigest": "qdysAmF3MGi4O7WgvxksLXSDekRUu/HAQhQrdA19pD8=",
                   "event": {
                     "transferObject": {
                       "packageId": "0x0000000000000000000000000000000000000002",
@@ -1055,14 +1051,14 @@
           "params": [
             {
               "name": "digest",
-              "value": "6ufvFXow2DG/iI/8ApYbMxIWFKyDd+e8vpUf2gbfAAs="
+              "value": "XqE0oB5T9E2Co+nXmPcN15TbadzIbd+sng0HVJ2L1j8="
             }
           ],
           "result": {
             "name": "Result",
             "value": {
               "certificate": {
-                "transactionDigest": "6ufvFXow2DG/iI/8ApYbMxIWFKyDd+e8vpUf2gbfAAs=",
+                "transactionDigest": "XqE0oB5T9E2Co+nXmPcN15TbadzIbd+sng0HVJ2L1j8=",
                 "data": {
                   "transactions": [
                     {
@@ -1084,7 +1080,7 @@
                   },
                   "gasBudget": 1000
                 },
-                "txSignature": "AFQCA34QO71gy26f8WcfCWubJ/ght4OIucz3s/o9V1S6fk2pqdbdujEQzssUUG9vO40nAijUGJET4NOVSDpuHQ6k8MuV4Ujxl9xtOeYgzm8Jf2BS6d0xIUr4jebbcPvoqQ==",
+                "txSignature": "AB+BMCIV8S2kA8+fYgzc8hndWDrVGZETfaIrQZJ5dHYbvPYuK8cTvihMEMlsNVDQhPhIJz5RhGcMMyH4jw2K4wJqyhLtgKnHnWhcn29OfWPVM+1V64qSaQ1T7WG7+dB9iA==",
                 "authSignInfo": {
                   "epoch": 0,
                   "signature": "",
@@ -2121,7 +2117,7 @@
             "$ref": "#/components/schemas/TransactionDigest"
           },
           "txSignature": {
-            "description": "tx_signature is signed by the transaction sender, applied on `data`.",
+            "description": "tx_signature is signed by the transaction sender, committing to the intent message containing the transaction data and intent.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Signature"
@@ -4415,7 +4411,7 @@
             }
           },
           "txBytes": {
-            "description": "transaction data bytes, as base-64 encoded string",
+            "description": "intent message bytes, as base-64 encoded string",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Base64"

--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -45,7 +45,7 @@ pub async fn transaction(
     let digest = request.transaction_identifier.hash;
     let (cert, effects) = context.state.get_transaction(digest).await?;
     let hash = *cert.digest();
-    let data = &cert.data().data;
+    let data = &cert.data().intent_message.value;
 
     let operations = Operation::from_data_and_events(data, &effects.status, &effects.events)?;
 

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -7,7 +7,7 @@ use axum::{Extension, Json};
 use fastcrypto::encoding::{Encoding, Hex};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto;
-use sui_types::crypto::{SignableBytes, SignatureScheme, ToFromBytes};
+use sui_types::crypto::{SignatureScheme, ToFromBytes};
 use sui_types::messages::{
     QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, SenderSignedData,
     Transaction, TransactionData,
@@ -27,6 +27,8 @@ use crate::types::{
 };
 use crate::ErrorType::InternalError;
 use crate::{ErrorType, OnlineServerContext, SuiEnv};
+use anyhow::anyhow;
+use sui_types::intent::IntentMessage;
 
 /// This module implements the [Rosetta Construction API](https://www.rosetta-api.org/docs/ConstructionApi.html)
 
@@ -85,15 +87,11 @@ pub async fn combine(
     let unsigned_tx = request
         .unsigned_transaction
         .to_vec()
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let data = TransactionData::from_signable_bytes(&unsigned_tx)?;
+        .map_err(|e| anyhow!(e))?;
+    let intent_msg = IntentMessage::<TransactionData>::from_bytes(&unsigned_tx)?;
     let sig = request.signatures.first().unwrap();
-    let sig_bytes = sig.hex_bytes.to_vec().map_err(|e| anyhow::anyhow!(e))?;
-    let pub_key = sig
-        .public_key
-        .hex_bytes
-        .to_vec()
-        .map_err(|e| anyhow::anyhow!(e))?;
+    let sig_bytes = sig.hex_bytes.to_vec().map_err(|e| anyhow!(e))?;
+    let pub_key = sig.public_key.hex_bytes.to_vec().map_err(|e| anyhow!(e))?;
     let flag = vec![match sig.signature_type {
         SignatureType::Ed25519 => SignatureScheme::ED25519,
         SignatureType::Ecdsa => SignatureScheme::Secp256k1,
@@ -101,7 +99,7 @@ pub async fn combine(
     .flag()];
 
     let signed_tx = Transaction::new(SenderSignedData::new(
-        data,
+        intent_msg,
         crypto::Signature::from_bytes(&[&*flag, &*sig_bytes, &*pub_key].concat())?,
     ));
     signed_tx.verify_signature()?;
@@ -236,14 +234,12 @@ pub async fn parse(
                 .to_vec()
                 .map_err(|e| anyhow::anyhow!(e))?,
         )?;
-        tx.into_data().data
+        tx.into_data().intent_message.value
     } else {
-        TransactionData::from_signable_bytes(
-            &request
-                .transaction
-                .to_vec()
-                .map_err(|e| anyhow::anyhow!(e))?,
-        )?
+        let intent_msg = IntentMessage::<TransactionData>::from_bytes(
+            &request.transaction.to_vec().map_err(|e| anyhow!(e))?,
+        )?;
+        intent_msg.value
     };
     let account_identifier_signers = if request.signed {
         vec![AccountIdentifier {

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -248,7 +248,7 @@ impl PseudoBlockProvider {
                 let (tx, effect) = state.get_transaction(digest).await?;
 
                 let ops = Operation::from_data_and_events(
-                    &tx.data().data,
+                    &tx.data().intent_message.value,
                     &effect.status,
                     &effect.events,
                 )?;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -20,6 +20,7 @@ use sui_sdk::rpc_types::{
 use sui_sdk::TransactionExecutionResult;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::gas_coin::GasCoin;
+use sui_types::intent::Intent;
 use sui_types::messages::{
     CallArg, ExecuteTransactionRequestType, ExecutionStatus, InputObjectKind, MoveCall,
     MoveModulePublish, ObjectArg, Pay, PayAllSui, PaySui, SingleTransactionKind, Transaction,
@@ -281,7 +282,9 @@ async fn test_transaction(
 
     let data = TransactionData::new(TransactionKind::Single(tx.clone()), sender, gas, 10000);
 
-    let signature = keystore.sign(&data.signer(), &data.to_bytes()).unwrap();
+    let signature = keystore
+        .sign_secure(&data.signer(), &data, Intent::default())
+        .unwrap();
 
     // Balance before execution
     let mut balances = BTreeMap::new();
@@ -294,7 +297,7 @@ async fn test_transaction(
     let response = client
         .quorum_driver()
         .execute_transaction(
-            Transaction::from_data(data.clone(), signature)
+            Transaction::from_data_and_sig(data.clone(), Intent::default(), signature)
                 .verify()
                 .unwrap(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -24,6 +24,7 @@ use sui_sdk::{
     },
     SuiClient,
 };
+use sui_types::intent::Intent;
 use sui_types::messages::ExecuteTransactionRequestType;
 
 #[tokio::main]
@@ -89,9 +90,9 @@ impl TicTacToe {
             .await?;
 
         // Sign transaction.
-        let signature = self
-            .keystore
-            .sign(&player_x, &create_game_call.to_bytes())?;
+        let signature =
+            self.keystore
+                .sign_secure(&player_x, &create_game_call, Intent::default())?;
 
         // Execute the transaction.
 
@@ -99,7 +100,8 @@ impl TicTacToe {
             .client
             .quorum_driver()
             .execute_transaction(
-                Transaction::from_data(create_game_call, signature).verify()?,
+                Transaction::from_data_and_sig(create_game_call, Intent::default(), signature)
+                    .verify()?,
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -186,16 +188,17 @@ impl TicTacToe {
                 .await?;
 
             // Sign transaction.
-            let signature = self
-                .keystore
-                .sign(&my_identity, &place_mark_call.to_bytes())?;
+            let signature =
+                self.keystore
+                    .sign_secure(&my_identity, &place_mark_call, Intent::default())?;
 
             // Execute the transaction.
             let response = self
                 .client
                 .quorum_driver()
                 .execute_transaction(
-                    Transaction::from_data(place_mark_call, signature).verify()?,
+                    Transaction::from_data_and_sig(place_mark_call, Intent::default(), signature)
+                        .verify()?,
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await?;

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -10,6 +10,7 @@ use sui_sdk::{
     },
     SuiClient,
 };
+use sui_types::intent::Intent;
 use sui_types::messages::ExecuteTransactionRequestType;
 
 #[tokio::main]
@@ -33,13 +34,13 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Sign transaction
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let signature = keystore.sign(&my_address, &transfer_tx.to_bytes())?;
+    let signature = keystore.sign_secure(&my_address, &transfer_tx, Intent::default())?;
 
     // Execute the transaction
     let transaction_response = sui
         .quorum_driver()
         .execute_transaction(
-            Transaction::from_data(transfer_tx, signature).verify()?,
+            Transaction::from_data_and_sig(transfer_tx, Intent::default(), signature).verify()?,
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -33,7 +33,7 @@ use strum::EnumString;
 use crate::base_types::{AuthorityName, SuiAddress};
 use crate::committee::{Committee, EpochId, StakeUnit};
 use crate::error::{SuiError, SuiResult};
-use crate::intent::{Intent, IntentMessage};
+use crate::intent::IntentMessage;
 use crate::sui_serde::{AggrAuthSignature, Readable, SuiBitmap};
 use fastcrypto::encoding::{Base64, Encoding, Hex};
 use fastcrypto::hash::{HashFunction, Sha3_256};
@@ -76,6 +76,7 @@ pub fn generate_proof_of_possession<K: KeypairTraits>(
     domain_with_pk.extend_from_slice(PROOF_OF_POSSESSION_DOMAIN);
     domain_with_pk.extend_from_slice(keypair.public().as_bytes());
     domain_with_pk.extend_from_slice(address.as_ref());
+    // TODO (joyqvq): Use Signature::new_secure
     keypair.sign(&domain_with_pk[..])
 }
 
@@ -431,14 +432,13 @@ pub trait SuiAuthoritySignature {
 
     fn verify_secure<T>(
         &self,
-        value: &T,
-        intent: Intent,
+        value: &IntentMessage<T>,
         author: AuthorityPublicKeyBytes,
     ) -> Result<(), SuiError>
     where
         T: Serialize;
 
-    fn new_secure<T>(value: &T, intent: Intent, secret: &dyn signature::Signer<Self>) -> Self
+    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn signature::Signer<Self>) -> Self
     where
         T: Serialize;
 }
@@ -482,27 +482,22 @@ impl SuiAuthoritySignature for AuthoritySignature {
             })
     }
 
-    fn new_secure<T>(value: &T, intent: Intent, secret: &dyn signature::Signer<Self>) -> Self
+    fn new_secure<T>(value: &IntentMessage<T>, secret: &dyn signature::Signer<Self>) -> Self
     where
         T: Serialize,
     {
-        secret.sign(
-            &bcs::to_bytes(&IntentMessage::new(intent, value))
-                .expect("Message serialization should not fail"),
-        )
+        secret.sign(&bcs::to_bytes(&value).expect("Message serialization should not fail"))
     }
 
     fn verify_secure<T>(
         &self,
-        value: &T,
-        intent: Intent,
+        value: &IntentMessage<T>,
         author: AuthorityPublicKeyBytes,
     ) -> Result<(), SuiError>
     where
         T: Serialize,
     {
-        let message = bcs::to_bytes(&IntentMessage::new(intent, value))
-            .expect("Message serialization should not fail");
+        let message = bcs::to_bytes(&value).expect("Message serialization should not fail");
         let public_key = AuthorityPublicKey::try_from(author).map_err(|_| {
             SuiError::KeyConversionError(
                 "Failed to serialize public key bytes to valid public key".to_string(),
@@ -684,20 +679,13 @@ impl Signature {
     }
 
     pub fn new_secure<T>(
-        value: &T,
-        intent: Intent,
+        value: &IntentMessage<T>,
         secret: &dyn signature::Signer<Signature>,
     ) -> Self
     where
         T: Serialize,
     {
-        secret.sign(
-            &bcs::to_bytes(&IntentMessage::new(intent, value))
-                .expect("Message serialization should not fail"),
-        )
-    }
-    pub fn new_temp(value: &[u8], secret: &dyn signature::Signer<Signature>) -> Signature {
-        secret.sign(value)
+        secret.sign(&bcs::to_bytes(&value).expect("Message serialization should not fail"))
     }
 }
 
@@ -913,7 +901,7 @@ pub trait SuiSignature: Sized + signature::Signature {
     where
         T: Signable<Vec<u8>>;
 
-    fn verify_secure<T>(&self, value: &T, intent: Intent, author: SuiAddress) -> SuiResult<()>
+    fn verify_secure<T>(&self, value: &IntentMessage<T>, author: SuiAddress) -> SuiResult<()>
     where
         T: Serialize;
 
@@ -956,17 +944,11 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
             })
     }
 
-    fn verify_secure<T>(
-        &self,
-        value: &T,
-        intent: Intent,
-        author: SuiAddress,
-    ) -> Result<(), SuiError>
+    fn verify_secure<T>(&self, value: &IntentMessage<T>, author: SuiAddress) -> Result<(), SuiError>
     where
         T: Serialize,
     {
-        let message = bcs::to_bytes(&IntentMessage::new(intent, value))
-            .expect("Message serialization should not fail");
+        let message = bcs::to_bytes(&value).expect("Message serialization should not fail");
         let (sig, pk) = &self.get_verification_inputs(author)?;
         pk.verify(&message[..], sig)
             .map_err(|e| SuiError::InvalidSignature {

--- a/crates/sui-types/src/intent.rs
+++ b/crates/sui-types/src/intent.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::messages::TransactionData;
 use serde::{Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
@@ -9,21 +10,26 @@ use serde_repr::Serialize_repr;
 #[path = "unit_tests/intent_tests.rs"]
 mod intent_tests;
 
-#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[repr(u8)]
 pub enum IntentVersion {
     V0 = 0,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[repr(u8)]
 pub enum ChainId {
     Testing = 0,
 }
 
+impl Default for ChainId {
+    fn default() -> Self {
+        Self::Testing
+    }
+}
 pub trait SecureIntent: Serialize + private::SealedIntent {}
 
-#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize_repr, Deserialize_repr, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 #[repr(u8)]
 pub enum IntentScope {
     TransactionData = 0,
@@ -33,42 +39,82 @@ pub enum IntentScope {
     PersonalMessage = 4,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Hash)]
 pub struct Intent {
-    version: IntentVersion,
-    chain_id: ChainId,
     scope: IntentScope,
+    version: IntentVersion,
+    // Chain ID is not present if intent scope is TransactionData.
+    chain_id: Option<ChainId>,
 }
 
 impl Intent {
+    pub const LENGTH: usize = 3;
     pub fn new(version: IntentVersion, chain_id: ChainId, scope: IntentScope) -> Self {
         Self {
-            version,
-            chain_id,
             scope,
+            version,
+            chain_id: Some(chain_id),
         }
     }
 
-    pub fn default_with_scope(scope: IntentScope) -> Self {
+    pub fn with_chain_id(mut self, chain_id: ChainId) -> Self {
+        self.chain_id = Some(chain_id);
+        self
+    }
+
+    pub fn with_scope(mut self, scope: IntentScope) -> Self {
+        self.scope = scope;
+        self
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(self).unwrap()
+    }
+}
+
+impl Default for Intent {
+    fn default() -> Self {
         Self {
             version: IntentVersion::V0,
-            chain_id: ChainId::Testing,
-            scope,
+            chain_id: None,
+            scope: IntentScope::TransactionData,
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize)]
-pub struct IntentMessage<'a, T> {
-    intent: Intent,
-    value: &'a T,
+#[derive(Debug, PartialEq, Eq, Serialize, Clone, Hash, Deserialize)]
+pub struct IntentMessage<T> {
+    pub intent: Intent,
+    pub value: T,
 }
 
-impl<'a, T> IntentMessage<'a, T> {
-    pub fn new(intent: Intent, value: &'a T) -> Self {
+impl<T> IntentMessage<T> {
+    pub fn new(intent: Intent, value: T) -> Self {
         Self { intent, value }
     }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<IntentMessage<TransactionData>, anyhow::Error> {
+        let intent: Intent = match bcs::from_bytes(&bytes[..Intent::LENGTH]) {
+            Ok(intent) => intent,
+            Err(e) => return Err(anyhow::anyhow!("Failed to parse Intent: {:?}", e)),
+        };
+        fp_ensure!(
+            intent.version == IntentVersion::V0,
+            anyhow::anyhow!("Unsupported Intent version: {:?}", intent.version)
+        );
+
+        // TODO(joyqvq): Add ability to parse from other intent scope that is not TransactionData
+        fp_ensure!(
+            intent.scope == IntentScope::TransactionData,
+            anyhow::anyhow!("Unsupported Intent scope: {:?}", intent.scope)
+        );
+        match bcs::from_bytes(&bytes[Intent::LENGTH..]) {
+            Ok(tx_data) => Ok(IntentMessage::new(intent, tx_data)),
+            Err(e) => Err(anyhow::anyhow!("Failed to parse IntentMessage: {:?}", e)),
+        }
+    }
 }
+
 // --- PersonalMessage intent ---
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct PersonalMessage {
@@ -79,5 +125,5 @@ pub(crate) mod private {
     use super::IntentMessage;
 
     pub trait SealedIntent {}
-    impl<'a, T> SealedIntent for IntentMessage<'a, T> {}
+    impl<T> SealedIntent for IntentMessage<T> {}
 }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -10,6 +10,7 @@ use crate::crypto::{
     SuiSignatureInner, ToFromBytes,
 };
 use crate::gas::GasCostSummary;
+use crate::intent::{Intent, IntentMessage};
 use crate::message_envelope::{Envelope, Message, TrustedEnvelope, VerifiedEnvelope};
 use crate::messages_checkpoint::{
     AuthenticatedCheckpoint, CheckpointSequenceNumber, CheckpointSignatureMessage,
@@ -810,14 +811,16 @@ impl TransactionData {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct SenderSignedData {
-    pub data: TransactionData,
-    /// tx_signature is signed by the transaction sender, applied on `data`.
+    pub intent_message: IntentMessage<TransactionData>,
     pub tx_signature: Signature,
 }
 
 impl SenderSignedData {
-    pub fn new(data: TransactionData, tx_signature: Signature) -> Self {
-        Self { data, tx_signature }
+    pub fn new(intent_message: IntentMessage<TransactionData>, tx_signature: Signature) -> Self {
+        Self {
+            intent_message,
+            tx_signature,
+        }
     }
 }
 
@@ -829,20 +832,21 @@ impl Message for SenderSignedData {
     }
 
     fn verify(&self) -> SuiResult {
-        if self.data.kind.is_system_tx() {
+        if self.intent_message.value.kind.is_system_tx() {
             return Ok(());
         }
-        self.tx_signature.verify(&self.data, self.data.sender)
+        self.tx_signature
+            .verify_secure(&self.intent_message, self.intent_message.value.sender)
     }
 }
 
 impl<S> Envelope<SenderSignedData, S> {
     pub fn sender_address(&self) -> SuiAddress {
-        self.data().data.sender
+        self.data().intent_message.value.sender
     }
 
     pub fn gas_payment_object_ref(&self) -> &ObjectRef {
-        self.data().data.gas_payment_object_ref()
+        self.data().intent_message.value.gas_payment_object_ref()
     }
 
     pub fn contains_shared_object(&self) -> bool {
@@ -852,7 +856,7 @@ impl<S> Envelope<SenderSignedData, S> {
     pub fn shared_input_objects(
         &self,
     ) -> impl Iterator<Item = (&ObjectID, /* shared at version */ &SequenceNumber)> {
-        self.data().data.kind.shared_input_objects()
+        self.data().intent_message.value.kind.shared_input_objects()
     }
 
     pub fn input_objects_in_compiled_modules(
@@ -878,7 +882,7 @@ impl<S> Envelope<SenderSignedData, S> {
     }
 
     pub fn is_system_tx(&self) -> bool {
-        self.data().data.kind.is_system_tx()
+        self.data().intent_message.value.kind.is_system_tx()
     }
 }
 
@@ -887,25 +891,27 @@ pub type Transaction = Envelope<SenderSignedData, EmptySignInfo>;
 pub type VerifiedTransaction = VerifiedEnvelope<SenderSignedData, EmptySignInfo>;
 
 impl Transaction {
-    pub fn from_data(data: TransactionData, signature: Signature) -> Self {
+    pub fn from_data(
+        data: IntentMessage<TransactionData>,
+        signer: &dyn signature::Signer<Signature>,
+    ) -> Self {
+        let signature = Signature::new_secure(&data, signer);
         Self::new(SenderSignedData::new(data, signature))
     }
 
-    #[cfg(test)]
-    pub fn from_data_and_signer(
-        data: TransactionData,
-        signer: &dyn signature::Signer<Signature>,
-    ) -> Self {
-        let signature = Signature::new(&data, signer);
-        Self::from_data(data, signature)
+    pub fn from_data_and_sig(data: TransactionData, intent: Intent, signature: Signature) -> Self {
+        Self::new(SenderSignedData::new(
+            IntentMessage::new(intent, data),
+            signature,
+        ))
     }
 
     pub fn to_network_data_for_execution(&self) -> (Base64, SignatureScheme, Base64, Base64) {
         (
-            Base64::from_bytes(&self.data().data.to_bytes()),
-            self.data().tx_signature.scheme(),
-            Base64::from_bytes(self.data().tx_signature.signature_bytes()),
-            Base64::from_bytes(self.data().tx_signature.public_key_bytes()),
+            Base64::from_bytes(bcs::to_bytes(&self.intent_message).unwrap().as_slice()),
+            self.tx_signature.scheme(),
+            Base64::from_bytes(self.tx_signature.signature_bytes()),
+            Base64::from_bytes(self.tx_signature.public_key_bytes()),
         )
     }
 }
@@ -931,7 +937,8 @@ impl VerifiedTransaction {
             0,
         );
         let signed_data = SenderSignedData {
-            data,
+            // Default intent
+            intent_message: IntentMessage::new(Intent::default(), data),
             // Arbitrary keypair
             tx_signature: Ed25519SuiSignature::from_bytes(&[0; Ed25519SuiSignature::LENGTH])
                 .unwrap()
@@ -2034,7 +2041,7 @@ impl Display for CertifiedTransaction {
             "Signed Authorities Bitmap : {:?}",
             self.auth_sig().signers_map
         )?;
-        write!(writer, "{}", &self.data().data.kind)?;
+        write!(writer, "{}", &self.data().intent_message.value.kind)?;
         write!(f, "{}", writer)
     }
 }

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -10,15 +10,10 @@ use move_binary_format::file_format;
 
 use crate::crypto::bcs_signable_test::{Bar, Foo};
 use crate::crypto::{
-    get_key_pair_from_bytes, AccountKeyPair, AuthorityKeyPair, AuthoritySignature,
-    SuiAuthoritySignature, SuiSignature,
+    get_key_pair, get_key_pair_from_bytes, AccountKeyPair, AuthorityKeyPair, AuthoritySignature,
+    Signature, SuiAuthoritySignature, SuiSignature,
 };
-use crate::{
-    crypto::{get_key_pair, Signature},
-    gas_coin::GasCoin,
-    object::Object,
-    SUI_FRAMEWORK_ADDRESS,
-};
+use crate::{gas_coin::GasCoin, object::Object, SUI_FRAMEWORK_ADDRESS};
 
 use super::*;
 

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -20,9 +20,12 @@ fn test_personal_message_intent() {
     let (addr1, sec1): (_, AccountKeyPair) = get_key_pair();
     let message = "Hello".as_bytes().to_vec();
     let p_message = PersonalMessage { message };
+    let p_message_2 = p_message.clone();
     let p_message_bcs = bcs::to_bytes(&p_message).unwrap();
 
-    let intent = Intent::default_with_scope(IntentScope::PersonalMessage);
+    let intent = Intent::default().with_scope(IntentScope::PersonalMessage);
+    let intent1 = intent.clone();
+    let intent2 = intent.clone();
     let intent_bcs = bcs::to_bytes(&IntentMessage::new(intent, &p_message)).unwrap();
     assert_eq!(intent_bcs.len(), p_message_bcs.len() + 3);
 
@@ -30,9 +33,9 @@ fn test_personal_message_intent() {
     assert_eq!(
         &intent_bcs[..3],
         vec![
+            IntentScope::PersonalMessage as u8,
             IntentVersion::V0 as u8,
             ChainId::Testing as u8,
-            IntentScope::PersonalMessage as u8,
         ]
     );
 
@@ -40,8 +43,8 @@ fn test_personal_message_intent() {
     assert_eq!(&intent_bcs[3..], &p_message_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = Signature::new_secure(&p_message, intent, &sec1);
-    let verification = s.verify_secure(&p_message, intent, addr1);
+    let s = Signature::new_secure(&IntentMessage::new(intent1, p_message), &sec1);
+    let verification = s.verify_secure(&IntentMessage::new(intent2, p_message_2), addr1);
     assert!(verification.is_ok())
 }
 
@@ -63,11 +66,10 @@ fn test_authority_signature_intent() {
         10000,
     );
     let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::from_data(data, signature);
+    let tx = Transaction::from_data_and_sig(data, Intent::default(), signature);
 
     // Create an intent with signed data.
-    let intent = Intent::default_with_scope(IntentScope::TransactionData);
-    let intent_bcs = bcs::to_bytes(&IntentMessage::new(intent, tx.data())).unwrap();
+    let intent_bcs = bcs::to_bytes(&tx.intent_message).unwrap();
 
     // Check that the first 3 bytes are the domain separation information.
     assert_eq!(
@@ -80,11 +82,40 @@ fn test_authority_signature_intent() {
     );
 
     // Check that intent's last bytes match the signed_data's bsc bytes.
-    let signed_data_bcs = bcs::to_bytes(tx.data()).unwrap();
+    let signed_data_bcs = bcs::to_bytes(&tx.data().intent_message.value).unwrap();
     assert_eq!(&intent_bcs[3..], signed_data_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = AuthoritySignature::new_secure(tx.data(), intent, &kp);
-    let verification = s.verify_secure(tx.data(), intent, kp.public().into());
+    let s = AuthoritySignature::new_secure(&tx.data().intent_message, &kp);
+    let verification = s.verify_secure(&tx.data().intent_message, kp.public().into());
     assert!(verification.is_ok())
+}
+
+#[test]
+fn test_intent_message_to_from_bytes() {
+    use crate::crypto::get_key_pair;
+
+    // Create a signed user transaction.
+    let (sender, _): (_, AccountKeyPair) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let object = Object::immutable_with_id_for_testing(object_id);
+    let data = TransactionData::new_transfer_sui(
+        recipient,
+        sender,
+        None,
+        object.compute_object_reference(),
+        10000,
+    );
+    let data1 = data.clone();
+
+    // Serialize the intent message.
+    let bytes = &bcs::to_bytes(&IntentMessage::new(Intent::default(), data)).unwrap();
+
+    // Derialize the intent message back.
+    let intent_message = IntentMessage::<TransactionData>::from_bytes(bytes).unwrap();
+
+    // Intent and its value are expected.
+    assert_eq!(intent_message.intent, Intent::default());
+    assert_eq!(intent_message.value, data1);
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -25,7 +25,7 @@ use sui_framework::build_move_package;
 use sui_source_validation::BytecodeSourceVerifier;
 use tracing::info;
 
-use crate::config::{Config, PersistedConfig, SuiClientConfig};
+use crate::config::{Config, PersistedConfig, SuiClientConfig, SuiEnv};
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -35,7 +35,8 @@ use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData};
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::TransactionExecutionResult;
-use sui_types::crypto::SignableBytes;
+use sui_types::crypto::{Signature, SignatureScheme};
+use sui_types::intent::Intent;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     gas_coin::GasCoin,
@@ -43,17 +44,11 @@ use sui_types::{
     object::Owner,
     parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS,
 };
-use sui_types::{
-    crypto::{Signature, SignatureScheme},
-    messages::TransactionData,
-};
 
 #[cfg(msim)]
 use sui_sdk::embedded_gateway::SuiClient;
 #[cfg(not(msim))]
 use sui_sdk::SuiClient;
-
-use crate::config::SuiEnv;
 
 pub const EXAMPLE_NFT_NAME: &str = "Example NFT";
 pub const EXAMPLE_NFT_DESCRIPTION: &str = "An NFT created by the Sui Command Line Tool";
@@ -446,9 +441,16 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .publish(sender, compiled_modules, gas, gas_budget)
                     .await?;
-                let signature = context.config.keystore.sign(&sender, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&sender, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
 
                 SuiClientCommandResult::Publish(response)
@@ -489,9 +491,16 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .transfer_object(from, object_id, gas, gas_budget, to)
                     .await?;
-                let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&from, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -516,9 +525,16 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .transfer_sui(from, object_id, gas_budget, to, amount)
                     .await?;
-                let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&from, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -558,9 +574,16 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .pay(from, input_coins, recipients, amounts, gas, gas_budget)
                     .await?;
-                let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&from, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -601,9 +624,16 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .pay_sui(signer, input_coins, recipients, amounts, gas_budget)
                     .await?;
-                let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
 
                 let cert = response.certificate;
@@ -633,9 +663,16 @@ impl SuiClientCommands {
                     .pay_all_sui(signer, input_coins, recipient, gas_budget)
                     .await?;
 
-                let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
 
                 let cert = response.certificate;
@@ -721,9 +758,16 @@ impl SuiClientCommands {
                         return Err(anyhow!("Exactly one of `count` and `amounts` must be present for split-coin command."));
                     }
                 };
-                let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
                 SuiClientCommandResult::SplitCoin(response)
             }
@@ -739,9 +783,16 @@ impl SuiClientCommands {
                     .transaction_builder()
                     .merge_coins(signer, primary_coin, coin_to_merge, gas, gas_budget)
                     .await?;
-                let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
+                let signature =
+                    context
+                        .config
+                        .keystore
+                        .sign_secure(&signer, &data, Intent::default())?;
                 let response = context
-                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
+                    .execute_transaction(
+                        Transaction::from_data_and_sig(data, Intent::default(), signature)
+                            .verify()?,
+                    )
                     .await?;
 
                 SuiClientCommandResult::MergeCoin(response)
@@ -824,14 +875,15 @@ impl SuiClientCommands {
                 pubkey,
                 signature,
             } => {
-                let data = TransactionData::from_signable_bytes(
+                let data = bcs::from_bytes(
                     &Base64::try_from(tx_data)
                         .map_err(|e| anyhow!(e))?
                         .to_vec()
                         .map_err(|e| anyhow!(e))?,
                 )?;
-                let signed_tx = Transaction::from_data(
+                let signed_tx = Transaction::from_data_and_sig(
                     data,
+                    Intent::default(),
                     Signature::from_bytes(
                         &[
                             vec![scheme.flag()],
@@ -1234,8 +1286,13 @@ pub async fn call_move(
             gas_budget,
         )
         .await?;
-    let signature = context.config.keystore.sign(&sender, &data.to_bytes())?;
-    let transaction = Transaction::from_data(data, signature).verify()?;
+
+    let signature = context
+        .config
+        .keystore
+        .sign_secure(&sender, &data, Intent::default())?;
+    let transaction =
+        Transaction::from_data_and_sig(data, Intent::default(), signature).verify()?;
 
     let response = context.execute_transaction(transaction).await?;
     let cert = response.certificate;

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -11,6 +11,7 @@ use fastcrypto::encoding::{decode_bytes_hex, Base64, Encoding};
 use fastcrypto::traits::{ToFromBytes, VerifyingKey};
 use signature::rand_core::OsRng;
 use sui_keys::key_derive::derive_key_pair_from_path;
+use sui_types::intent::Intent;
 use tracing::info;
 
 use fastcrypto::ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey};
@@ -125,7 +126,7 @@ impl KeyToolCommand {
                 info!("Data to sign : {}", data);
                 info!("Address : {}", address);
                 let message = Base64::decode(&data).map_err(|e| anyhow!(e))?;
-                let signature = keystore.sign(&address, &message)?;
+                let signature = keystore.sign_secure(&address, &message, Intent::default())?;
                 // Separate pub key and signature string, signature and pub key are concatenated with an '@' symbol.
                 let signature_string = format!("{:?}", signature);
                 let sig_split = signature_string.split('@').collect::<Vec<_>>();

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -22,6 +22,7 @@ use sui_types::crypto::Signature;
 use sui_types::crypto::SignatureScheme;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::crypto::SuiSignatureInner;
+use sui_types::intent::Intent;
 use tempfile::TempDir;
 
 const TEST_MNEMONIC: &str = "result crisp session latin must fruit genuine question prevent start coconut brave speak student dismiss";
@@ -50,7 +51,7 @@ fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
 
     for pk in keystore.keys() {
         let pk1 = pk.clone();
-        let sig = keystore.sign(&(&pk).into(), b"hello")?;
+        let sig = keystore.sign_secure(&(&pk).into(), b"hello", Intent::default())?;
         match sig {
             Signature::Ed25519SuiSignature(_) => {
                 // signature contains corresponding flag

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -12,7 +12,7 @@ use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_adapter::genesis;
 use sui_core::test_utils::{
-    dummy_transaction_effects, to_sender_signed_transaction, to_sender_signed_transaction_arc,
+    dummy_transaction_effects, to_verified_transaction, to_verified_transaction_arc,
 };
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json_rpc_types::SuiObjectInfo;
@@ -141,10 +141,8 @@ pub async fn make_transactions_with_wallet_context(
                 obj.to_object_ref(),
                 MAX_GAS,
             );
-            let tx = to_sender_signed_transaction(
-                data,
-                context.config.keystore.get_key(address).unwrap(),
-            );
+            let tx =
+                to_verified_transaction(data, context.config.keystore.get_key(address).unwrap());
             res.push(tx);
         }
     }
@@ -178,7 +176,7 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
         })],
         MAX_GAS,
     );
-    to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
+    to_verified_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
 /// Make a few different single-writer test transactions owned by specific addresses.
@@ -214,7 +212,7 @@ pub fn make_transactions_with_pre_genesis_objects(
             /* gas_object_ref */ o2.compute_object_reference(),
             MAX_GAS,
         );
-        let tx = to_sender_signed_transaction(data, keys.get_key(&sender).unwrap());
+        let tx = to_verified_transaction(data, keys.get_key(&sender).unwrap());
         transactions.push(tx);
     }
     (transactions, gas_objects)
@@ -253,7 +251,7 @@ pub fn test_shared_object_transactions() -> Vec<VerifiedTransaction> {
             ],
             MAX_GAS,
         );
-        transactions.push(to_sender_signed_transaction(data, &keypair));
+        transactions.push(to_verified_transaction(data, &keypair));
     }
     transactions
 }
@@ -270,7 +268,8 @@ pub fn create_publish_move_package_transaction(
         .unwrap()
         .get_package_bytes();
     let data = TransactionData::new_module(sender, gas_object_ref, all_module_bytes, MAX_GAS);
-    to_sender_signed_transaction(data, keypair)
+    println!("~~create_publish_move_package_transaction");
+    to_verified_transaction(data, keypair)
 }
 
 pub fn make_transfer_sui_transaction(
@@ -281,7 +280,8 @@ pub fn make_transfer_sui_transaction(
     keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
     let data = TransactionData::new_transfer_sui(recipient, sender, amount, gas_object, MAX_GAS);
-    to_sender_signed_transaction(data, keypair)
+    println!("~~make_transfer_sui_transaction");
+    to_verified_transaction(data, keypair)
 }
 
 pub fn make_transfer_object_transaction(
@@ -292,7 +292,7 @@ pub fn make_transfer_object_transaction(
     recipient: SuiAddress,
 ) -> VerifiedTransaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
-    to_sender_signed_transaction(data, keypair)
+    to_verified_transaction(data, keypair)
 }
 
 pub fn make_transfer_object_transaction_with_wallet_context(
@@ -303,7 +303,7 @@ pub fn make_transfer_object_transaction_with_wallet_context(
     recipient: SuiAddress,
 ) -> VerifiedTransaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
-    to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
+    to_verified_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
 pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransaction {
@@ -315,7 +315,7 @@ pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> VerifiedTransac
         .unwrap()
         .get_package_bytes();
     let data = TransactionData::new_module(sender, gas_object, all_module_bytes, MAX_GAS);
-    to_sender_signed_transaction(data, &keypair)
+    to_verified_transaction(data, &keypair)
 }
 
 pub fn random_object_digest() -> ObjectRef {
@@ -349,7 +349,7 @@ pub fn make_counter_create_transaction(
         vec![],
         MAX_GAS,
     );
-    to_sender_signed_transaction(data, keypair)
+    to_verified_transaction(data, keypair)
 }
 
 pub fn make_counter_increment_transaction(
@@ -373,7 +373,7 @@ pub fn make_counter_increment_transaction(
         })],
         MAX_GAS,
     );
-    to_sender_signed_transaction_arc(data, keypair)
+    to_verified_transaction_arc(data, keypair)
 }
 
 /// Make a transaction calling a specific move module & function.
@@ -409,7 +409,7 @@ pub fn move_transaction_with_type_tags(
         arguments,
         MAX_GAS,
     );
-    to_sender_signed_transaction(data, &keypair)
+    to_verified_transaction(data, &keypair)
 }
 
 /// Make a test certificates for each input transaction.

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -21,6 +21,7 @@ use sui_types::base_types::ObjectRef;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::committee::Committee;
 use sui_types::error::SuiResult;
+use sui_types::intent::Intent;
 use sui_types::message_envelope::Message;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::messages::{
@@ -106,9 +107,11 @@ pub async fn publish_package_with_wallet(
         let signature = context
             .config
             .keystore
-            .sign(&sender, &data.to_bytes())
+            .sign_secure(&sender, &data, Intent::default())
             .unwrap();
-        Transaction::from_data(data, signature).verify().unwrap()
+        Transaction::from_data_and_sig(data, Intent::default(), signature)
+            .verify()
+            .unwrap()
     };
 
     let resp = context
@@ -163,9 +166,12 @@ pub async fn submit_move_transaction(
     let signature = context
         .config
         .keystore
-        .sign(&sender, &data.to_bytes())
+        .sign_secure(&sender, &data, Intent::default())
         .unwrap();
-    let tx = Transaction::from_data(data, signature).verify().unwrap();
+
+    let tx = Transaction::from_data_and_sig(data, Intent::default(), signature)
+        .verify()
+        .unwrap();
     let tx_digest = tx.digest();
     debug!(?tx_digest, "submitting move transaction");
 
@@ -389,9 +395,12 @@ pub async fn delete_devnet_nft(
     let signature = context
         .config
         .keystore
-        .sign(sender, &data.to_bytes())
+        .sign_secure(sender, &data, Intent::default())
         .unwrap();
-    let tx = Transaction::from_data(data, signature).verify().unwrap();
+
+    let tx = Transaction::from_data_and_sig(data, Intent::default(), signature)
+        .verify()
+        .unwrap();
 
     let resp = context
         .client
@@ -416,7 +425,7 @@ pub async fn submit_single_owner_transaction(
         .0
         .pop()
         .unwrap();
-
+    println!("~~cert {:?}", certificate);
     let mut responses = Vec::new();
     for config in configs {
         let client = get_client(config);
@@ -424,9 +433,13 @@ pub async fn submit_single_owner_transaction(
             .handle_certificate(certificate.clone().into())
             .await
             .unwrap();
+        println!("~~reply {:?}", reply);
         responses.push(reply);
     }
-    get_unique_effects(responses)
+    println!("~~responses {:?}", responses);
+    let x = get_unique_effects(responses);
+    println!("~~get_unique_effects {:?}", x);
+    x
 }
 
 /// Keep submitting the certificates of a shared-object transaction until it is sequenced by

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -123,8 +123,7 @@ console = { version = "0.15", default-features = false, features = ["ansi-parsin
 console-api = { version = "0.4", default-features = false, features = ["transport"] }
 console-subscriber = { version = "0.1", features = ["env-filter"] }
 const-oid = { version = "0.9", default-features = false }
-constant_time_eq-c65f7effa3be6d31 = { package = "constant_time_eq", version = "0.1", default-features = false }
-constant_time_eq-6f8ce4dd05d13bba = { package = "constant_time_eq", version = "0.2", default-features = false }
+constant_time_eq = { version = "0.1", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
@@ -779,8 +778,7 @@ console = { version = "0.15", default-features = false, features = ["ansi-parsin
 console-api = { version = "0.4", default-features = false, features = ["transport"] }
 console-subscriber = { version = "0.1", features = ["env-filter"] }
 const-oid = { version = "0.9", default-features = false }
-constant_time_eq-c65f7effa3be6d31 = { package = "constant_time_eq", version = "0.1", default-features = false }
-constant_time_eq-6f8ce4dd05d13bba = { package = "constant_time_eq", version = "0.2", default-features = false }
+constant_time_eq = { version = "0.1", default-features = false }
 convert_case = { version = "0.4", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -90,13 +90,12 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Sign transaction
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let signature = keystore.sign(&my_address, &transfer_tx)?;
-
+    let signature = keystore.sign_secure(&my_address, &transfer_tx, Intent::default())?;
+    
     // Execute the transaction
     let transaction_response = sui
         .quorum_driver()
-        .execute_transaction(Transaction::from_data(transfer_tx, signature))
-        .await?;
+        .execute_transaction(Transaction::from_data_and_sig(transfer_tx, Intent::default(), signature))
 
     println!("{:?}", transaction_response);
 


### PR DESCRIPTION
- Previously, signer commits a signature to a BCS serialized `TransactionData` with TYPE_TAG. 

- This change means, signer commits to a signature on `IntentMessage<TransactionData>`, which contains three bytes of intent (version, chain_id, scope) AND the BCS serialized `TransactionData` without type. This is because the type itself can be inferred from `IntentScope` byte. 
- Wallet is gated with RPC API version. Signs with intent only on version >= 0.14.0 (subject to change depends on when we deploy intent signing for sui).
- This PR only touches user signatures committing to `IntentMessage<TransactionData>`, this does not include AuthoritySignatures committing to other IntentMessage<T> types. 
- keystore.sign() is now deprecated in favor of `sign_secure`.

## Next Steps
1. Note the Wallet release for this change needs to happen before Sui release. 
2. Use actual chain_id, version_id when we can call RPC endpoint for chain_id instead of hardcoding it in the wallet and keystore. 
2. Currently validators do not check if intent == expected intent, only checks if the signature commits to an IntentMessage. Add support to validate on intent. 

## Test Plan
1. e2e test from wallet serializes and sign data, verifies by local validators successfully. 
2. CLI serializes data with intent and submitting the signature to local validators executed transaction successfully. 
3. Tested against artifact: https://github.com/MystenLabs/sui/actions/runs/3361617096#artifacts

```
target/debug/sui client transfer-sui --amount 10 --gas-budget 1000 --sui-coin-object-id 0x38c062e1cd88fa97c69cc2d498aaa4d3b366066e --to 0x581a119a6576d3b502b5dc47c5de497b774e68ca
----- Certificate ----
Transaction Hash: D1gA05BQybIR/UX0jCyFqE5a+Wj6wRuQeqhMhWx9D4M=
Transaction Signature: AA==@oJurKmAbfmMsjiGL1ex1k463/+wYZwnD6Q+xjBXeqjYTcIOdM6kHygq9zlt/qoVRBzOUiSQBbDnS9y3MrNG8DQ==@rJzjxQ+FCK9m8YDU8Dq1Yx931HkIArhcw33kUPL9P8c=
Signed Authorities Bitmap: RoaringBitmap<[0, 1, 3]>
Transaction Kind : Transfer SUI
Recipient : 0x581a119a6576d3b502b5dc47c5de497b774e68ca
Amount: 10

----- Transaction Effects ----
Status : Success
Created Objects:
  - ID: 0x97078393dae37ff73614cb5aeabb4364500d55c1 , Owner: Account Address ( 0x581a119a6576d3b502b5dc47c5de497b774e68ca )
Mutated Objects:
  - ID: 0x38c062e1cd88fa97c69cc2d498aaa4d3b366066e , Owner: Account Address ( 0x581a119a6576d3b502b5dc47c5de497b774e68ca )
 ```
  
Logs in validator
 ```
2022-10-20T16:25:36.436619Z  INFO node{name=0x77878e5863711cf66cecae32e6d061755022288a}: sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.436768Z  INFO node{name=0x49a81aee4d0c08d867d9bd88565ddc71d74a81b3}: sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.436919Z  INFO node{name=0x3b666d24a57e50efaaa3ea66865100cb72825dfd}: sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.437597Z  INFO node{name=0x2c7f8bc7d9042c3a4965a02c783f48792089fefc}: sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.438786Z  INFO sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.440239Z  INFO sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.440396Z  INFO sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.441637Z  INFO sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
2022-10-20T16:25:36.441871Z  INFO sui_types::messages: Received intent Intent { version: V0, chain_id: Testing, scope: TransactionData }
```