### PR TITLE
crypto: use one place to sign in test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8243,6 +8243,7 @@ dependencies = [
  "serde_json",
  "sui",
  "sui-config",
+ "sui-core",
  "sui-json",
  "sui-json-rpc",
  "sui-json-rpc-types",

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -12,10 +12,10 @@ use std::{
 
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
-    crypto::{get_key_pair, AccountKeyPair, AuthoritySignature, Signature, SuiAuthoritySignature},
+    crypto::{get_key_pair, AccountKeyPair, AuthoritySignature, SuiAuthoritySignature},
     error::SuiError,
     gas::SuiGasStatus,
-    messages::{InputObjects, SignatureAggregator, Transaction, TransactionData},
+    messages::{InputObjects, SignatureAggregator, TransactionData},
     object::Object,
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
@@ -27,6 +27,7 @@ use crate::{
     authority_aggregator::authority_aggregator_tests::init_local_authorities,
     checkpoints::{CheckpointLocals, CHECKPOINT_COUNT_PER_EPOCH},
     execution_engine,
+    test_utils::to_sender_signed_transaction,
 };
 
 #[tokio::test]
@@ -100,8 +101,7 @@ async fn test_start_epoch_change() {
         gas_object.compute_object_reference(),
         1000,
     );
-    let signature = Signature::new(&tx_data, &sender_key);
-    let transaction = Transaction::new(tx_data, signature);
+    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     assert_eq!(
         state
             .handle_transaction(transaction.clone())

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -1,10 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
-use std::time::Duration;
-
 use crate::{
     authority::AuthorityState,
     authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
@@ -12,6 +8,10 @@ use crate::{
     epoch::committee_store::CommitteeStore,
     safe_client::SafeClientMetrics,
 };
+use signature::Signer;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
 
 use sui_config::{NetworkConfig, ValidatorInfo};
 use sui_types::{
@@ -140,6 +140,15 @@ pub fn create_fake_transaction() -> Transaction {
         object.compute_object_reference(),
         10000,
     );
-    let signature = Signature::new(&data, &sender_key);
+    to_sender_signed_transaction(data, &sender_key)
+}
+
+// This is used to sign transaction with signer using default Intent.
+pub fn to_sender_signed_transaction(
+    data: TransactionData,
+    signer: &dyn Signer<Signature>,
+) -> Transaction {
+    let signature = Signature::new_temp(&data.to_bytes(), signer);
+    // let signature = Signature::new_secure(&data, Intent::default(), signer).unwrap();
     Transaction::new(data, signature)
 }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use move_core_types::{account_address::AccountAddress, ident_str};
 use move_package::BuildConfig;
-use signature::Signer;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -27,6 +26,7 @@ use crate::authority_client::{
     LocalAuthorityClientFaultConfig, NetworkAuthorityClient, NetworkAuthorityClientMetrics,
 };
 use crate::gateway_state::GatewayState;
+use crate::test_utils::to_sender_signed_transaction;
 
 use tokio::time::Instant;
 
@@ -176,7 +176,7 @@ pub fn transfer_coin_transaction(
     object_ref: ObjectRef,
     gas_object_ref: ObjectRef,
 ) -> Transaction {
-    to_transaction(
+    to_sender_signed_transaction(
         TransactionData::new_transfer(
             dest,
             object_ref,
@@ -201,7 +201,7 @@ pub fn transfer_object_move_transaction(
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(dest)).unwrap()),
     ];
 
-    to_transaction(
+    to_sender_signed_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -230,7 +230,7 @@ pub fn crate_object_move_transaction(
         CallArg::Pure(bcs::to_bytes(&AccountAddress::from(dest)).unwrap()),
     ];
 
-    to_transaction(
+    to_sender_signed_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -252,7 +252,7 @@ pub fn delete_object_move_transaction(
     framework_obj_ref: ObjectRef,
     gas_object_ref: ObjectRef,
 ) -> Transaction {
-    to_transaction(
+    to_sender_signed_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -280,7 +280,7 @@ pub fn set_object_move_transaction(
         CallArg::Pure(bcs::to_bytes(&value).unwrap()),
     ];
 
-    to_transaction(
+    to_sender_signed_transaction(
         TransactionData::new_move_call(
             src,
             framework_obj_ref,
@@ -293,11 +293,6 @@ pub fn set_object_move_transaction(
         ),
         secret,
     )
-}
-
-pub fn to_transaction(data: TransactionData, signer: &dyn Signer<Signature>) -> Transaction {
-    let signature = Signature::new(&data, signer);
-    Transaction::new(data, signature)
 }
 
 pub async fn do_transaction<A>(authority: &SafeClient<A>, transaction: &Transaction)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2,6 +2,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::test_utils::to_sender_signed_transaction;
+
 use super::*;
 use bcs;
 use move_binary_format::{
@@ -144,10 +146,9 @@ async fn construct_shared_object_transaction_with_sequence_number(
         ],
         MAX_GAS,
     );
-    let signature = Signature::new(&data, &keypair);
     (
         authority,
-        Transaction::new(data, signature),
+        to_sender_signed_transaction(data, &keypair),
         gas_object_id,
         shared_object_id,
     )
@@ -213,8 +214,17 @@ async fn test_handle_transfer_transaction_bad_signature() {
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone();
-    bad_signature_transfer_transaction.signed_data.tx_signature =
-        Signature::new(&transfer_transaction.signed_data.data, &unknown_key);
+    bad_signature_transfer_transaction.signed_data.tx_signature = Signature::new_temp(
+        &transfer_transaction.signed_data.data.to_bytes(),
+        &unknown_key,
+    );
+
+    // bad_signature_transfer_transaction.signed_data.tx_signature = Signature::new_secure(
+    //     &transfer_transaction.signed_data.data,
+    //     Intent::default(),
+    //     &unknown_key,
+    // )
+    // .unwrap();
     assert!(authority_state
         .handle_transaction(bad_signature_transfer_transaction)
         .await
@@ -543,11 +553,9 @@ async fn test_objected_owned_gas() {
         child_object.compute_object_reference(),
         10000,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let transfer_transaction = Transaction::new(data, signature);
-    let result = authority_state
-        .handle_transaction(transfer_transaction.clone())
-        .await;
+
+    let transaction = to_sender_signed_transaction(data, &sender_key);
+    let result = authority_state.handle_transaction(transaction).await;
     assert!(matches!(
         result.unwrap_err(),
         SuiError::InsufficientGas { .. }
@@ -638,8 +646,7 @@ async fn test_publish_dependent_module_ok() {
         vec![dependent_module_bytes],
         MAX_GAS,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let transaction = Transaction::new(data, signature);
+    let transaction = to_sender_signed_transaction(data, &sender_key);
 
     let dependent_module_id = TxContext::new(&sender, transaction.digest(), 0).fresh_id();
 
@@ -674,8 +681,7 @@ async fn test_publish_module_no_dependencies_ok() {
     module.serialize(&mut module_bytes).unwrap();
     let module_bytes = vec![module_bytes];
     let data = TransactionData::new_module(sender, gas_payment_object_ref, module_bytes, MAX_GAS);
-    let signature = Signature::new(&data, &sender_key);
-    let transaction = Transaction::new(data, signature);
+    let transaction = to_sender_signed_transaction(data, &sender_key);
     let _module_object_id = TxContext::new(&sender, transaction.digest(), 0).fresh_id();
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
@@ -723,9 +729,7 @@ async fn test_publish_non_existing_dependent_module() {
         vec![dependent_module_bytes],
         MAX_GAS,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let transaction = Transaction::new(data, signature);
-
+    let transaction = to_sender_signed_transaction(data, &sender_key);
     let response = authority.handle_transaction(transaction).await;
     assert!(std::string::ToString::to_string(&response.unwrap_err())
         .contains("DependentPackageNotFound"));
@@ -831,9 +835,7 @@ async fn test_handle_transfer_sui_with_amount_insufficient_gas() {
         object.compute_object_reference(),
         200,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let transaction = Transaction::new(data, signature);
-
+    let transaction = to_sender_signed_transaction(data, &sender_key);
     let result = authority_state.handle_transaction(transaction).await;
     assert!(matches!(
         result.unwrap_err(),
@@ -1404,9 +1406,7 @@ async fn test_move_call_insufficient_gas() {
         gas_used - 5,
     );
 
-    let signature = Signature::new(&data, &recipient_key);
-    let transaction = Transaction::new(data, signature);
-
+    let transaction = to_sender_signed_transaction(data, &recipient_key);
     let tx_digest = *transaction.digest();
     let response = send_and_confirm_transaction(&authority_state, transaction)
         .await
@@ -1787,10 +1787,9 @@ async fn test_transfer_sui_no_amount() {
         gas_object.compute_object_reference(),
         MAX_GAS,
     );
-    let signature = Signature::new(&tx_data, &sender_key);
-    let transaction = Transaction::new(tx_data, signature);
 
     // Make sure transaction handling works as usual.
+    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     authority_state
         .handle_transaction(transaction.clone())
         .await
@@ -1838,9 +1837,7 @@ async fn test_transfer_sui_with_amount() {
         gas_object.compute_object_reference(),
         MAX_GAS,
     );
-    let signature = Signature::new(&tx_data, &sender_key);
-    let transaction = Transaction::new(tx_data, signature);
-
+    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     let certificate = init_certified_transaction(transaction, &authority_state);
     let response = authority_state
         .handle_certificate(certificate)
@@ -1892,9 +1889,8 @@ async fn test_store_revert_state_update() {
         gas_object.compute_object_reference(),
         MAX_GAS,
     );
-    let signature = Signature::new(&tx_data, &sender_key);
-    let transaction = Transaction::new(tx_data, signature);
 
+    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     let certificate = init_certified_transaction(transaction, &authority_state);
     let tx_digest = *certificate.digest();
     authority_state
@@ -2072,8 +2068,7 @@ pub fn init_transfer_transaction(
     gas_object_ref: ObjectRef,
 ) -> Transaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object_ref, 10000);
-    let signature = Signature::new(&data, secret);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, secret)
 }
 
 #[cfg(test)]
@@ -2180,9 +2175,7 @@ pub async fn call_move_with_shared(
         MAX_GAS,
     );
 
-    let signature = Signature::new(&data, sender_key);
-    let transaction = Transaction::new(data, signature);
-
+    let transaction = to_sender_signed_transaction(data, sender_key);
     let response =
         send_and_confirm_transaction_with_shared(authority, transaction, with_shared).await?;
     Ok(response.signed_effects.unwrap().effects)
@@ -2240,8 +2233,8 @@ async fn make_test_transaction(
         ],
         MAX_GAS,
     );
-    let signature = Signature::new(&data, sender_key);
-    let transaction = Transaction::new(data, signature);
+
+    let transaction = to_sender_signed_transaction(data, sender_key);
 
     let committee = authorities[0].committee.load();
     let mut sig = SignatureAggregator::try_new(transaction.clone(), &committee).unwrap();

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority::authority_tests::init_state_with_ids_and_object_basics;
+use crate::{
+    authority::authority_tests::init_state_with_ids_and_object_basics,
+    test_utils::to_sender_signed_transaction,
+};
 
 use super::*;
 use bcs;
@@ -10,8 +13,7 @@ use authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use move_binary_format::file_format;
 use move_core_types::{account_address::AccountAddress, ident_str};
 use sui_types::{
-    crypto::{get_key_pair, AccountKeyPair, Signature},
-    messages::Transaction,
+    crypto::{get_key_pair, AccountKeyPair},
     object::Owner,
 };
 
@@ -61,8 +63,8 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
             .compute_object_reference(),
         100000,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+
+    let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
     let effects = response.signed_effects.unwrap().effects;
     assert!(effects.status.is_ok());
@@ -125,8 +127,9 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
             .compute_object_reference(),
         100000,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+
+    let tx = to_sender_signed_transaction(data, &sender_key);
+
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
     let effects = response.signed_effects.unwrap().effects;
     assert!(effects.status.is_err());
@@ -158,8 +161,7 @@ async fn test_batch_contains_publish() -> anyhow::Result<()> {
             .compute_object_reference(),
         100000,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+    let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),
@@ -188,8 +190,8 @@ async fn test_batch_contains_transfer_sui() -> anyhow::Result<()> {
             .compute_object_reference(),
         100000,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+
+    let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),
@@ -234,8 +236,8 @@ async fn test_batch_insufficient_gas_balance() -> anyhow::Result<()> {
         gas_object.compute_object_reference(),
         100000,
     );
-    let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+
+    let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await;
     assert!(matches!(
         response.unwrap_err(),

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
+use crate::test_utils::to_sender_signed_transaction;
 use move_core_types::{account_address::AccountAddress, ident_str};
 use narwhal_executor::ExecutionIndices;
 use narwhal_types::Transactions;
@@ -10,11 +11,10 @@ use narwhal_types::{Empty, TransactionProto};
 use sui_network::tonic;
 use sui_types::{
     base_types::{ObjectID, TransactionDigest},
-    crypto::Signature,
     gas_coin::GasCoin,
     messages::{
         CallArg, CertifiedTransaction, ConsensusTransactionKind, ObjectArg, SignatureAggregator,
-        Transaction, TransactionData,
+        TransactionData,
     },
     object::{MoveObject, Object, Owner, OBJECT_START_VERSION},
 };
@@ -69,8 +69,8 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
             ],
             /* max_gas */ 10_000,
         );
-        let signature = Signature::new(&data, &keypair);
-        let transaction = Transaction::new(data, signature);
+
+        let transaction = to_sender_signed_transaction(data, &keypair);
 
         // Submit the transaction and assemble a certificate.
         let response = authority

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::authority::authority_tests::{
-    call_move, call_move_with_shared, init_state_with_ids, send_and_confirm_transaction,
-    TestCallArg,
+use crate::{
+    authority::authority_tests::{
+        call_move, call_move_with_shared, init_state_with_ids, send_and_confirm_transaction,
+        TestCallArg,
+    },
+    test_utils::to_sender_signed_transaction,
 };
 
 use move_core_types::{
@@ -14,7 +17,7 @@ use move_core_types::{
 };
 use move_package::BuildConfig;
 use sui_types::{
-    crypto::{get_key_pair, AccountKeyPair, Signature},
+    crypto::{get_key_pair, AccountKeyPair},
     event::{Event, EventType, TransferType},
     messages::ExecutionStatus,
     object::OBJECT_START_VERSION,
@@ -1605,8 +1608,8 @@ pub async fn build_and_try_publish_test_package(
     let gas_object_ref = gas_object.unwrap().compute_object_reference();
 
     let data = TransactionData::new_module(*sender, gas_object_ref, all_module_bytes, gas_budget);
-    let signature = Signature::new(&data, sender_key);
-    let transaction = Transaction::new(data, signature);
+    let transaction = to_sender_signed_transaction(data, sender_key);
+
     send_and_confirm_transaction(authority, transaction)
         .await
         .unwrap()

--- a/crates/sui-cost/src/estimator.rs
+++ b/crates/sui-cost/src/estimator.rs
@@ -8,13 +8,13 @@ use strum_macros::Display;
 use strum_macros::EnumString;
 use sui_adapter::temporary_store::TemporaryStore;
 use sui_core::authority::AuthorityState;
+use sui_core::test_utils::to_sender_signed_transaction;
 use sui_core::transaction_input_checker;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::TransactionDigest;
 use sui_types::crypto::get_key_pair;
 use sui_types::crypto::AccountKeyPair;
-use sui_types::crypto::Signature as SuiSignature;
 use sui_types::error::SuiResult;
 use sui_types::gas::start_gas_metering;
 use sui_types::gas::GasCostSummary;
@@ -22,7 +22,6 @@ use sui_types::gas::SuiGas;
 use sui_types::gas::MAX_GAS_BUDGET;
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::SingleTransactionKind;
-use sui_types::messages::Transaction;
 use sui_types::messages::TransactionData;
 use sui_types::messages::TransactionKind;
 
@@ -138,8 +137,7 @@ pub async fn estimate_transaction_computation_cost(
 ) -> anyhow::Result<GasCostSummary> {
     // Make a dummy transaction
     let (_, keypair): (_, AccountKeyPair) = get_key_pair();
-    let dummy_sig = SuiSignature::new(&tx_data, &keypair);
-    let tx = Transaction::new(tx_data, dummy_sig);
+    let tx = to_sender_signed_transaction(tx_data, &keypair);
 
     let (_gas_status, input_objects) =
         transaction_input_checker::check_transaction_input(&state.db(), &tx).await?;

--- a/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
@@ -5,6 +5,7 @@ use move_package::BuildConfig;
 use std::{path::Path, str::FromStr};
 use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_core::gateway_state::GatewayTxSeqNumber;
+use sui_core::test_utils::to_sender_signed_transaction;
 use sui_framework::build_move_package_to_bytes;
 use sui_json::SuiJsonValue;
 use sui_json_rpc::api::{
@@ -17,7 +18,6 @@ use sui_sdk::crypto::Keystore;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::TransactionDigest;
 use sui_types::gas_coin::GAS;
-use sui_types::messages::Transaction;
 use sui_types::sui_serde::Base64;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 
@@ -55,10 +55,7 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
 
     let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-
-    let signature = keystore.sign(address, &transaction_bytes.tx_bytes.to_vec()?)?;
-    let tx = Transaction::new(transaction_bytes.to_data().unwrap(), signature);
-
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
     let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
     let tx_response = http_client
@@ -94,10 +91,7 @@ async fn test_publish() -> Result<(), anyhow::Error> {
 
     let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-    let signature = keystore.sign(address, &transaction_bytes.tx_bytes.to_vec()?)?;
-
-    let tx = Transaction::new(transaction_bytes.to_data().unwrap(), signature);
-
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
     let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
     let tx_response = http_client
@@ -142,10 +136,7 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
 
     let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-
-    let signature = keystore.sign(address, &transaction_bytes.tx_bytes.to_vec()?)?;
-
-    let tx = Transaction::new(transaction_bytes.to_data().unwrap(), signature);
+    let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
     let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
@@ -195,10 +186,8 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
 
         let keystore_path = test_network.network.dir().join(SUI_KEYSTORE_FILENAME);
         let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-
-        let signature = keystore.sign(address, &transaction_bytes.tx_bytes.to_vec()?)?;
-
-        let tx = Transaction::new(transaction_bytes.to_data().unwrap(), signature);
+        let tx =
+            to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
 
         let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1.20.1", features = ["full"] }
 hyper = { version = "0.14.20", features = ["full"] }
 
 sui = { path = "../sui" }
+sui-core = { path = "../sui-core"}
 sui-json-rpc = { path = "../sui-json-rpc" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-json = { path = "../sui-json" }

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -12,9 +12,9 @@ use serde_json::{json, Map, Value};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Write;
+use sui_core::test_utils::to_sender_signed_transaction;
 use sui_json_rpc::api::EventReadApiOpenRpc;
 use sui_sdk::crypto::AccountKeystore;
-use sui_types::messages::Transaction;
 
 use crate::examples::RpcExampleProvider;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands, WalletContext};
@@ -408,13 +408,10 @@ async fn create_error_response(
         )
         .await?;
 
-    let signature = context
-        .config
-        .keystore
-        .sign(&address, &response.tx_bytes.to_vec()?)?;
-
-    let tx = Transaction::new(response.to_data().unwrap(), signature);
-
+    let tx = to_sender_signed_transaction(
+        response.to_data()?,
+        context.config.keystore.get_key(&address)?,
+    );
     let (tx_data, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
     let client = Client::new();

--- a/crates/sui-sdk/src/crypto.rs
+++ b/crates/sui-sdk/src/crypto.rs
@@ -33,7 +33,6 @@ pub trait AccountKeystore: Send + Sync {
     fn add_key(&mut self, keypair: SuiKeyPair) -> Result<(), anyhow::Error>;
     fn keys(&self) -> Vec<PublicKey>;
     fn get_key(&self, address: &SuiAddress) -> Result<&SuiKeyPair, anyhow::Error>;
-
     fn addresses(&self) -> Vec<SuiAddress> {
         self.keys().iter().map(|k| k.into()).collect()
     }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -39,21 +39,20 @@ use std::{
 use sui_adapter::in_memory_storage::InMemoryStorage;
 use sui_adapter::temporary_store::TemporaryStore;
 use sui_adapter::{adapter::new_move_vm, genesis};
-use sui_core::execution_engine;
+use sui_core::{execution_engine, test_utils::to_sender_signed_transaction};
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_types::{
     base_types::{
         ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
         SUI_ADDRESS_LENGTH,
     },
-    crypto::{get_key_pair_from_rng, AccountKeyPair, Signature},
+    crypto::{get_key_pair_from_rng, AccountKeyPair},
     event::Event,
     gas,
     messages::{ExecutionStatus, InputObjects, Transaction, TransactionData, TransactionEffects},
     object::{self, Object, ObjectFormatOptions, GAS_VALUE_FOR_TESTING},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
-
 pub(crate) type FakeID = u64;
 
 // initial value for fake object ID mapping
@@ -449,8 +448,7 @@ impl<'a> SuiTestAdapter<'a> {
         let storage_mut = Arc::get_mut(&mut self.storage).unwrap();
         storage_mut.insert_object(gas_object);
         let data = txn_data(sender, gas_payment);
-        let signature = Signature::new(&data, sender_key);
-        Transaction::new(data, signature)
+        to_sender_signed_transaction(data, sender_key)
     }
 
     fn execute_txn(

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -756,7 +756,6 @@ impl<'de> Deserialize<'de> for Signature {
     }
 }
 
-// Can refactor this with a library
 impl Signature {
     pub fn new<T>(value: &T, secret: &dyn Signer<Signature>) -> Signature
     where
@@ -779,6 +778,9 @@ impl Signature {
             &bcs::to_bytes(&IntentMessage::new(intent, value))
                 .expect("Message serialization should not fail"),
         )
+    }
+    pub fn new_temp(value: &[u8], secret: &dyn signature::Signer<Signature>) -> Signature {
+        secret.sign(value)
     }
 }
 

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 use crate::objects::{test_gas_objects, test_gas_objects_with_owners, test_shared_object};
 use crate::{test_account_keys, test_committee, test_validator_keys};
 use move_core_types::account_address::AccountAddress;
@@ -11,10 +10,12 @@ use std::path::PathBuf;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_adapter::genesis;
+use sui_core::test_utils::to_sender_signed_transaction;
 use sui_json_rpc_types::SuiObjectInfo;
 use sui_sdk::crypto::AccountKeystore;
 use sui_sdk::crypto::Keystore;
 use sui_types::base_types::ObjectRef;
+use sui_types::base_types::SuiAddress;
 use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber};
 use sui_types::crypto::{
     get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, KeypairTraits,
@@ -29,7 +30,7 @@ use sui_types::messages::{
 };
 use sui_types::object::Object;
 use sui_types::object::Owner;
-use sui_types::{base_types::SuiAddress, crypto::Signature};
+
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 10_000;
 
@@ -144,13 +145,11 @@ pub async fn make_transactions_with_wallet_context(
                 obj.to_object_ref(),
                 MAX_GAS,
             );
-            let sig = context
-                .config
-                .keystore
-                .sign(address, &data.to_bytes())
-                .unwrap();
-
-            res.push(Transaction::new(data, sig));
+            let tx = to_sender_signed_transaction(
+                data,
+                context.config.keystore.get_key(address).unwrap(),
+            );
+            res.push(tx);
         }
     }
     res
@@ -179,12 +178,7 @@ pub async fn make_counter_increment_transaction_with_wallet_context(
         vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
         MAX_GAS,
     );
-    let signature = context
-        .config
-        .keystore
-        .sign(&sender, &data.to_bytes())
-        .unwrap();
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
 /// Make a few different single-writer test transactions owned by specific addresses.
@@ -220,8 +214,8 @@ pub fn make_transactions_with_pre_genesis_objects(
             /* gas_object_ref */ o2.compute_object_reference(),
             MAX_GAS,
         );
-        let signature = keys.sign(&sender, &data.to_bytes()).unwrap();
-        transactions.push(Transaction::new(data, signature));
+        let tx = to_sender_signed_transaction(data, keys.get_key(&sender).unwrap());
+        transactions.push(tx);
     }
     (transactions, gas_objects)
 }
@@ -254,8 +248,7 @@ pub fn test_shared_object_transactions() -> Vec<Transaction> {
             ],
             MAX_GAS,
         );
-        let signature = Signature::new(&data, &keypair);
-        transactions.push(Transaction::new(data, signature));
+        transactions.push(to_sender_signed_transaction(data, &keypair));
     }
     transactions
 }
@@ -279,8 +272,7 @@ pub fn create_publish_move_package_transaction(
         })
         .collect();
     let data = TransactionData::new_module(sender, gas_object_ref, all_module_bytes, MAX_GAS);
-    let signature = Signature::new(&data, keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, keypair)
 }
 
 pub fn make_transfer_sui_transaction(
@@ -291,8 +283,7 @@ pub fn make_transfer_sui_transaction(
     keypair: &AccountKeyPair,
 ) -> Transaction {
     let data = TransactionData::new_transfer_sui(recipient, sender, amount, gas_object, MAX_GAS);
-    let signature = Signature::new(&data, keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, keypair)
 }
 
 pub fn make_transfer_object_transaction(
@@ -303,8 +294,7 @@ pub fn make_transfer_object_transaction(
     recipient: SuiAddress,
 ) -> Transaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
-    let signature = Signature::new(&data, keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, keypair)
 }
 
 pub fn make_transfer_object_transaction_with_wallet_context(
@@ -315,12 +305,7 @@ pub fn make_transfer_object_transaction_with_wallet_context(
     recipient: SuiAddress,
 ) -> Transaction {
     let data = TransactionData::new_transfer(recipient, object_ref, sender, gas_object, MAX_GAS);
-    let sig = context
-        .config
-        .keystore
-        .sign(&sender, &data.to_bytes())
-        .unwrap();
-    Transaction::new(data, sig)
+    to_sender_signed_transaction(data, context.config.keystore.get_key(&sender).unwrap())
 }
 
 pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> Transaction {
@@ -338,8 +323,7 @@ pub fn make_publish_basics_transaction(gas_object: ObjectRef) -> Transaction {
         })
         .collect();
     let data = TransactionData::new_module(sender, gas_object, all_module_bytes, MAX_GAS);
-    let signature = Signature::new(&data, &keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, &keypair)
 }
 
 pub fn make_counter_create_transaction(
@@ -358,8 +342,7 @@ pub fn make_counter_create_transaction(
         vec![],
         MAX_GAS,
     );
-    let signature = Signature::new(&data, keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, keypair)
 }
 
 pub fn make_counter_increment_transaction(
@@ -379,8 +362,7 @@ pub fn make_counter_increment_transaction(
         vec![CallArg::Object(ObjectArg::SharedObject(counter_id))],
         MAX_GAS,
     );
-    let signature = Signature::new(&data, keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, keypair)
 }
 
 /// Make a transaction calling a specific move module & function.
@@ -416,8 +398,7 @@ pub fn move_transaction_with_type_tags(
         arguments,
         MAX_GAS,
     );
-    let signature = Signature::new(&data, &keypair);
-    Transaction::new(data, signature)
+    to_sender_signed_transaction(data, &keypair)
 }
 
 /// Make a test certificates for each input transaction.


### PR DESCRIPTION
this is to suppress `Signature::new` into one place. this helps to centralize all intent signing related change into one place. 