### PR TITLE
Fix bug in process_certificate

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -425,7 +425,7 @@ where
                 retries,
             )
             .await?;
-            client.handle_certificate(cert).instrument(tracing::trace_span!("handle_cert_after_sync", authority =? destination_authority, retry = true)).await
+            client.handle_certificate(cert).instrument(tracing::trace_span!("handle_cert_after_sync", authority =? destination_authority.concise(), retry = true)).await
         })).await {
             res.map_err(|e| SuiError::CertificateSyncError {
                 authority_name: destination_authority.to_string(),
@@ -649,7 +649,7 @@ where
                     (
                         *name,
                         execute(*name, client)
-                            .instrument(tracing::trace_span!("quorum_map_auth", authority =? name))
+                            .instrument(tracing::trace_span!("quorum_map_auth", authority =? name.concise()))
                             .await,
                     )
                 }
@@ -1476,13 +1476,13 @@ where
 
                         let res =
                             client.handle_certificate(cert_ref.clone())
-                                .instrument(tracing::trace_span!("handle_certificate", authority =? name))
+                                .instrument(tracing::trace_span!("handle_certificate", authority =? name.concise()))
                                 .await;
 
                         if res.is_ok() {
                             debug!(
                                 tx_digest = ?tx_digest,
-                                ?name,
+                                name = ?name.concise(),
                                 "Validator handled certificate successfully",
                             );
                             // We got an ok answer, so returning the result of processing
@@ -1496,7 +1496,7 @@ where
                         if !matches!(res, Err(SuiError::ObjectErrors { .. })) {
                             debug!(
                                 tx_digest = ?tx_digest,
-                                ?name,
+                                name = ?name.concise(),
                                 "Error from validator handle_confirmation_transaction: {:?}",
                                 res
                             );
@@ -1512,7 +1512,7 @@ where
                                 self.timeouts.authority_request_timeout,
                                 self.timeouts.pre_quorum_timeout,
                             )
-                            .instrument(tracing::trace_span!("sync_cert", authority =? name))
+                            .instrument(tracing::trace_span!("sync_cert", authority =? name.concise()))
                             .await
                             .map_err(|e| { info!(err =? e, "Error from sync_certificate"); e})
                     })

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1543,7 +1543,10 @@ where
                                         tx_digest = ?tx_digest,
                                         "Got quorum for validators handle_certificate."
                                     );
-                                    return Ok(ReduceOutput::End(state));
+                                    return Ok(ReduceOutput::ContinueWithTimeout(
+                                        state,
+                                        timeout_after_quorum,
+                                    ));
                                 }
                             }
                             Err(err) => {

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -333,6 +333,24 @@ impl AuthorityPublicKeyBytes {
         write!(f, "k#{}", s)?;
         Ok(())
     }
+
+    /// Get a ConciseAuthorityPublicKeyBytes. Usage:
+    ///
+    ///   debug!(name = ?authority.concise());
+    ///   format!("{:?}", authority.concise());
+    pub fn concise(&self) -> ConciseAuthorityPublicKeyBytes<'_> {
+        ConciseAuthorityPublicKeyBytes(self)
+    }
+}
+
+/// A wrapper around AuthorityPublicKeyBytes that provides a concise Debug impl.
+pub struct ConciseAuthorityPublicKeyBytes<'a>(&'a AuthorityPublicKeyBytes);
+
+impl std::fmt::Debug for ConciseAuthorityPublicKeyBytes<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        let s = hex::encode(&self.0 .0[0..4]);
+        write!(f, "k#{}..", s)
+    }
 }
 
 impl TryFrom<AuthorityPublicKeyBytes> for AuthorityPublicKey {


### PR DESCRIPTION
Fixes #5021 

This will probably cause client perceived latency to increase. If we don't want to do that, but we do want to attempt bringing all validators up to date, we will need to spawn a task to continue the work.