### PR TITLE
wallet-ext: clean up coin management logic

### DIFF
--- a/apps/explorer/src/__tests__/unit.test.ts
+++ b/apps/explorer/src/__tests__/unit.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import BN from 'bn.js';
 import { describe, it, expect } from 'vitest';
 
 import { presentBN } from '../utils/stringUtils';
@@ -39,7 +38,7 @@ describe('Unit Tests', () => {
             [1000000, '1,000,000'],
             [10000000, '10,000,000'],
         ])('handles increasing numbers', (input, output) => {
-            expect(presentBN(new BN(input, 10))).toEqual(output);
+            expect(presentBN(BigInt(input))).toEqual(output);
         });
     });
 });

--- a/apps/explorer/src/components/ownedobjects/OwnedObjectConstants.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjectConstants.tsx
@@ -1,15 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type BN from 'bn.js';
-
 export type DataType = {
     id: string;
     Type: string;
     _isCoin: boolean;
     Version?: string;
     display?: string;
-    balance?: BN;
+    balance?: bigint;
     name?: string;
 }[];
 

--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Coin, getObjectFields, getObjectId } from '@mysten/sui.js';
-import BN from 'bn.js';
 import React, {
     useCallback,
     useEffect,
@@ -67,13 +66,14 @@ function OwnedObjectStatic({ id }: { id: string }) {
     if (objects) {
         const results = objects.map(({ objectId }) => {
             const entry = findDataFromID(objectId, undefined);
-            const convertToBN = (balance: string): BN => new BN.BN(balance, 10);
             return {
                 id: entry?.id,
                 Type: entry?.objType,
                 Version: entry?.version,
                 display: entry?.data?.contents?.display,
-                balance: convertToBN(entry?.data?.contents?.balance),
+                balance: entry?.data?.contents?.balance
+                    ? BigInt(entry?.data?.contents?.balance)
+                    : undefined,
                 _isCoin: entry?.data?.contents?.balance !== undefined,
                 name: extractName(entry?.data?.contents),
             };

--- a/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
@@ -61,7 +61,7 @@ function SingleCoinView({
                     {subObjList[0]._isCoin &&
                     subObjList.every((el) => el.balance !== undefined)
                         ? `${subObjList.reduce(
-                              (prev, current) => prev.add(current.balance!),
+                              (prev, current) => prev + current.balance!,
                               Coin.getZero()
                           )}`
                         : ''}

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -15,7 +15,6 @@ import {
     type ExecutionStatusType,
     type TransactionKindName,
 } from '@mysten/sui.js';
-import BN from 'bn.js';
 
 import { DefaultRpcClient } from '../../utils/api/DefaultRpcClient';
 import { type Network } from '../../utils/api/rpcSetting';
@@ -32,17 +31,17 @@ export type TxnData = {
     txId: string;
     status: ExecutionStatusType;
     txGas: number;
-    suiAmount: BN;
+    suiAmount: bigint;
     kind: TransactionKindName | undefined;
     From: string;
     timestamp_ms?: number;
 };
 
-export function SuiAmount({ amount }: { amount: BN | string | undefined }) {
+export function SuiAmount({ amount }: { amount: bigint | string | undefined }) {
     if (amount) {
         const SuiSuffix = <abbr className={styles.suisuffix}>SUI</abbr>;
 
-        if (BN.isBN(amount)) {
+        if (typeof amount === 'bigint') {
             return (
                 <span>
                     {presentBN(amount)}

--- a/apps/explorer/src/utils/stringUtils.ts
+++ b/apps/explorer/src/utils/stringUtils.ts
@@ -97,7 +97,7 @@ export async function genFileTypeMsg(
 export const alttextgen = (value: number | string | boolean | BN): string =>
     truncate(String(value), 19);
 
-export const presentBN = (amount: BN) =>
+export const presentBN = (amount: bigint) =>
     amount.toString().replace(/(\d)(?=(\d{3})+$)/g, '$1,');
 
 // TODO: Use version of this function from the SDK when it is exposed.

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    getCoinAfterMerge,
-    getMoveObject,
-    isSuiMoveObject,
-} from '@mysten/sui.js';
+import { isSuiMoveObject, Coin as CoinAPI, SUI_TYPE_ARG } from '@mysten/sui.js';
 
 import type {
     ObjectId,
@@ -23,6 +19,7 @@ export const DEFAULT_GAS_BUDGET_FOR_SPLIT = 10000;
 export const DEFAULT_GAS_BUDGET_FOR_MERGE = 10000;
 export const DEFAULT_GAS_BUDGET_FOR_TRANSFER = 100;
 export const DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI = 100;
+export const DEFAULT_GAS_BUDGET_FOR_PAY = 150;
 export const DEFAULT_GAS_BUDGET_FOR_STAKE = 10000;
 export const GAS_TYPE_ARG = '0x2::sui::SUI';
 export const GAS_SYMBOL = 'SUI';
@@ -77,9 +74,20 @@ export class Coin {
         recipient: SuiAddress
     ): Promise<SuiTransactionResponse> {
         await signer.syncAccountState();
-        const coin = await Coin.selectCoin(signer, coins, amount);
+        const inputCoins =
+            await CoinAPI.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+                coins,
+                amount
+            );
+        if (inputCoins.length === 0) {
+            const totalBalance = CoinAPI.totalBalance(coins);
+            throw new Error(
+                `Coin balance ${totalBalance.toString()} is not sufficient to cover the transfer amount ` +
+                    `${amount.toString()}. Try reducing the transfer amount to ${totalBalance}.`
+            );
+        }
         return await signer.pay({
-            inputCoins: [coin],
+            inputCoins: inputCoins.map((c) => CoinAPI.getID(c)),
             recipients: [recipient],
             amounts: [Number(amount)],
             gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER,
@@ -101,17 +109,105 @@ export class Coin {
         recipient: SuiAddress
     ): Promise<SuiTransactionResponse> {
         await signer.syncAccountState();
-        const coin = await Coin.prepareCoinWithEnoughBalance(
-            signer,
+        const targetAmount =
+            amount + BigInt(DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI);
+        const coinsWithSufficientAmount =
+            await CoinAPI.selectCoinsWithBalanceGreaterThanOrEqual(
+                coins,
+                targetAmount
+            );
+        if (coinsWithSufficientAmount.length > 0) {
+            return await signer.transferSui({
+                suiObjectId: CoinAPI.getID(coinsWithSufficientAmount[0]),
+                gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI,
+                recipient: recipient,
+                amount: Number(amount),
+            });
+        }
+
+        // TODO: use PaySui Transaction when it is ready
+        // If there is not a coin with sufficient balance, use the pay API
+        const gasCostForPay =
+            // TODO: improve the gas budget estimation
+            DEFAULT_GAS_BUDGET_FOR_PAY *
+            Math.max(2, Math.min(100, coins.length / 2));
+        let inputCoins = await Coin.assertAndGetCoinsWithBalanceGte(
             coins,
-            amount + BigInt(DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI)
+            amount,
+            gasCostForPay
         );
-        return await signer.transferSui({
-            suiObjectId: Coin.getID(coin),
-            gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI,
-            recipient: recipient,
-            amount: Number(amount),
+
+        // In this case, all coins are needed to cover the transfer amount plus gas budget, leaving
+        // no coins for gas payment. This won't be a problem once we introduce `PaySui`. But for now,
+        // we address this case by splitting an extra coin.
+        if (inputCoins.length === coins.length) {
+            // We need to pay for an additional `transferSui` transaction now, assert that we have sufficient balance
+            // to cover the additional cost
+            await Coin.assertAndGetCoinsWithBalanceGte(
+                coins,
+                amount,
+                gasCostForPay + DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI
+            );
+
+            // Split the gas budget from the coin with largest balance for simplicity. We can also use any coin
+            // that has amount greater than or equal to `DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI * 2`
+            const coinWithLargestBalance = inputCoins[inputCoins.length - 1];
+
+            if (
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                CoinAPI.getBalance(coinWithLargestBalance)! <
+                gasCostForPay + DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI
+            ) {
+                throw new Error(
+                    `None of the coins has sufficient balance to cover gas fee`
+                );
+            }
+
+            await signer.transferSui({
+                suiObjectId: CoinAPI.getID(coinWithLargestBalance),
+                gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI,
+                recipient: await signer.getAddress(),
+                amount: gasCostForPay,
+            });
+
+            inputCoins =
+                await signer.provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+                    await signer.getAddress(),
+                    amount,
+                    SUI_TYPE_ARG,
+                    []
+                );
+        }
+
+        return await signer.pay({
+            inputCoins: inputCoins.map((c) => CoinAPI.getID(c)),
+            recipients: [recipient],
+            amounts: [Number(amount)],
+            gasBudget: gasCostForPay,
         });
+    }
+
+    private static async assertAndGetCoinsWithBalanceGte(
+        coins: SuiMoveObject[],
+        amount: bigint,
+        gasBudget?: number
+    ) {
+        const inputCoins =
+            await CoinAPI.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+                coins,
+                amount + BigInt(gasBudget ?? 0)
+            );
+        if (inputCoins.length === 0) {
+            const totalBalance = CoinAPI.totalBalance(coins);
+            const maxTransferAmount = totalBalance - BigInt(gasBudget ?? 0);
+            const gasText = gasBudget ? ` plus gas budget ${gasBudget}` : '';
+            throw new Error(
+                `Coin balance ${totalBalance.toString()} is not sufficient to cover the transfer amount ` +
+                    `${amount.toString()}${gasText}. ` +
+                    `Try reducing the transfer amount to ${maxTransferAmount.toString()}.`
+            );
+        }
+        return inputCoins;
     }
 
     /**
@@ -129,8 +225,12 @@ export class Coin {
         amount: bigint,
         validator: SuiAddress
     ): Promise<SuiTransactionResponse> {
-        const coin = await Coin.selectCoin(signer, coins, amount);
         await signer.syncAccountState();
+        const coin = await Coin.requestSuiCoinWithExactAmount(
+            signer,
+            coins,
+            amount
+        );
         return await signer.executeMoveCall({
             packageObjectId: '0x2',
             module: 'sui_system',
@@ -141,72 +241,66 @@ export class Coin {
         });
     }
 
-    private static async selectCoin(
+    private static async requestSuiCoinWithExactAmount(
         signer: RawSigner,
         coins: SuiMoveObject[],
         amount: bigint
     ): Promise<ObjectId> {
-        const coin = await Coin.prepareCoinWithEnoughBalance(
+        const coinWithExactAmount = await Coin.selectSuiCoinWithExactAmount(
             signer,
             coins,
             amount
         );
-        const coinID = Coin.getID(coin);
-        const balance = Coin.getBalance(coin);
-        if (balance === amount) {
-            return coinID;
-        } else if (balance > amount) {
-            await signer.splitCoin({
-                coinObjectId: coinID,
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_SPLIT,
-                splitAmounts: [Number(balance - amount)],
-            });
-            return coinID;
-        } else {
-            throw new Error(`Insufficient balance`);
+        if (coinWithExactAmount) {
+            return coinWithExactAmount;
         }
+        // use transferSui API to get a coin with the exact amount
+        await Coin.transferSui(
+            signer,
+            coins,
+            amount,
+            await signer.getAddress()
+        );
+
+        const coinWithExactAmount2 = await Coin.selectSuiCoinWithExactAmount(
+            signer,
+            coins,
+            amount,
+            true
+        );
+        if (!coinWithExactAmount2) {
+            throw new Error(`requestCoinWithExactAmount failed unexpectedly`);
+        }
+        return coinWithExactAmount2;
     }
 
-    private static async prepareCoinWithEnoughBalance(
+    private static async selectSuiCoinWithExactAmount(
         signer: RawSigner,
         coins: SuiMoveObject[],
-        amount: bigint
-    ): Promise<SuiMoveObject> {
-        // Sort coins by balance in an ascending order
-        coins.sort((a, b) =>
-            Coin.getBalance(a) - Coin.getBalance(b) > 0 ? 1 : -1
-        );
+        amount: bigint,
+        refreshData = false
+    ): Promise<ObjectId | undefined> {
+        const coinsWithSufficientAmount = refreshData
+            ? await signer.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+                  await signer.getAddress(),
+                  amount,
+                  SUI_TYPE_ARG,
+                  []
+              )
+            : await CoinAPI.selectCoinsWithBalanceGreaterThanOrEqual(
+                  coins,
+                  amount
+              );
 
-        // return the coin with the smallest balance that is greater than or equal to the amount
-        const coinWithSufficientBalance = coins.find(
-            (c) => Coin.getBalance(c) >= amount
-        );
-        if (coinWithSufficientBalance) {
-            return coinWithSufficientBalance;
-        }
-
-        // merge coins to have a coin with sufficient balance
-        // we will start from the coins with the largest balance
-        // and end with the coin with the second smallest balance(i.e., i > 0 instead of i >= 0)
-        // we cannot merge coins with the smallest balance because we
-        // need to have a separate coin to pay for the gas
-        // TODO: there's some edge cases here. e.g., the total balance is enough before spliting/merging
-        // but not enough if we consider the cost of splitting and merging.
-        let primaryCoin = coins[coins.length - 1];
-        for (let i = coins.length - 2; i > 0; i--) {
-            const mergeTxn = await signer.mergeCoin({
-                primaryCoin: Coin.getID(primaryCoin),
-                coinToMerge: Coin.getID(coins[i]),
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_MERGE,
-            });
+        if (
+            coinsWithSufficientAmount.length > 0 &&
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            primaryCoin = getMoveObject(getCoinAfterMerge(mergeTxn)!)!;
-            if (Coin.getBalance(primaryCoin) >= amount) {
-                return primaryCoin;
-            }
+            CoinAPI.getBalance(coinsWithSufficientAmount[0])! === amount
+        ) {
+            return CoinAPI.getID(coinsWithSufficientAmount[0]);
         }
-        // primary coin might have a balance smaller than the `amount`
-        return primaryCoin;
+
+        return undefined;
     }
 
     public static async getActiveValidators(

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -43,6 +43,7 @@ import {
   EVENT_QUERY_MAX_LIMIT,
   DEFAULT_START_TIME,
   DEFAULT_END_TIME,
+  SUI_TYPE_ARG,
 } from '../types';
 import { SignatureScheme } from '../cryptography/publickey';
 import {
@@ -217,6 +218,34 @@ export class JsonRpcProvider extends Provider {
       .map((c) => c.objectId);
 
     return await this.getObjectBatch(coinIds);
+  }
+
+  async selectCoinsWithBalanceGreaterThanOrEqual(
+    address: string,
+    amount: bigint,
+    typeArg: string = SUI_TYPE_ARG,
+    exclude: ObjectId[] = []
+  ): Promise<GetObjectDataResponse[]> {
+    const coins = await this.getCoinBalancesOwnedByAddress(address, typeArg);
+    return (await Coin.selectCoinsWithBalanceGreaterThanOrEqual(
+      coins,
+      amount,
+      exclude
+    )) as GetObjectDataResponse[];
+  }
+
+  async selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+    address: string,
+    amount: bigint,
+    typeArg: string = SUI_TYPE_ARG,
+    exclude: ObjectId[] = []
+  ): Promise<GetObjectDataResponse[]> {
+    const coins = await this.getCoinBalancesOwnedByAddress(address, typeArg);
+    return (await Coin.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+      coins,
+      amount,
+      exclude
+    )) as GetObjectDataResponse[];
   }
 
   async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -46,11 +46,43 @@ export abstract class Provider {
 
   /**
    * Convenience method for getting all coins objects owned by an address
-   * @param typeArg optional argument for filter by coin type
+   * @param typeArg optional argument for filter by coin type, e.g., '0x2::sui::SUI'
    */
   abstract getCoinBalancesOwnedByAddress(
     address: string,
     typeArg?: string
+  ): Promise<GetObjectDataResponse[]>;
+
+  /**
+   * Convenience method for select coin objects that has a balance greater than or equal to `amount`
+   *
+   * @param amount coin balance
+   * @param typeArg coin type, e.g., '0x2::sui::SUI'
+   * @param exclude object ids of the coins to exclude
+   * @return a list of coin objects that has balance greater than `amount` in an ascending order
+   */
+  abstract selectCoinsWithBalanceGreaterThanOrEqual(
+    address: string,
+    amount: bigint,
+    typeArg: string,
+    exclude: ObjectId[]
+  ): Promise<GetObjectDataResponse[]>;
+
+  /**
+   * Convenience method for select a minimal set of coin objects that has a balance greater than
+   * or equal to `amount`. The output can be used for `PayTransaction`
+   *
+   * @param amount coin balance
+   * @param typeArg coin type, e.g., '0x2::sui::SUI'
+   * @param exclude object ids of the coins to exclude
+   * @return a minimal list of coin objects that has a combined balance greater than or equal
+   * to`amount` in an ascending order. If no such set exists, an empty list is returned
+   */
+  abstract selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+    address: string,
+    amount: bigint,
+    typeArg: string,
+    exclude: ObjectId[]
   ): Promise<GetObjectDataResponse[]>;
 
   /**

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -47,6 +47,24 @@ export class VoidProvider extends Provider {
     throw this.newError('getCoinBalancesOwnedByAddress');
   }
 
+  async selectCoinsWithBalanceGreaterThanOrEqual(
+    _address: string,
+    _amount: bigint,
+    _typeArg: string,
+    _exclude: ObjectId[] = []
+  ): Promise<GetObjectDataResponse[]> {
+    throw this.newError('selectCoinsWithBalanceGreaterThanOrEqual');
+  }
+
+  async selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+    _address: string,
+    _amount: bigint,
+    _typeArg: string,
+    _exclude: ObjectId[]
+  ): Promise<GetObjectDataResponse[]> {
+    throw this.newError('selectCoinSetWithCombinedBalanceGreaterThanOrEqual');
+  }
+
   async getObject(_objectId: string): Promise<GetObjectDataResponse> {
     throw this.newError('getObject');
   }

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -21,6 +21,11 @@ export interface TransferSuiTransaction {
 }
 
 export interface PayTransaction {
+  /**
+   * use `provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual` to
+   * derive a minimal set of coins with combined balance greater than or
+   * equal to sent amounts
+   */
   inputCoins: ObjectId[];
   recipients: SuiAddress[];
   amounts: number[];

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -9,12 +9,14 @@ import {
   SuiObject,
   SuiData,
   getMoveObjectType,
+  ObjectId,
+  getObjectId,
 } from './objects';
 import { normalizeSuiObjectId, SuiAddress } from './common';
 
-import BN from 'bn.js';
 import { getOption, Option } from './option';
 import { StructTag } from './sui-bcs';
+import { isSuiMoveObject } from './index.guard';
 
 export const COIN_PACKAGE_ID = '0x2';
 export const COIN_MODULE_NAME = 'coin';
@@ -23,7 +25,10 @@ export const COIN_SPLIT_VEC_FUNC_NAME = 'split_vec';
 export const COIN_JOIN_FUNC_NAME = 'join';
 const COIN_TYPE_ARG_REGEX = /^0x2::coin::Coin<(.+)>$/;
 
-type ObjectData = GetObjectDataResponse | SuiMoveObject | SuiObjectInfo;
+export const SUI_TYPE_ARG = '0x2::sui::SUI';
+
+type ObjectData = ObjectDataFull | SuiObjectInfo;
+type ObjectDataFull = GetObjectDataResponse | SuiMoveObject;
 
 /**
  * Utility class for 0x2::coin
@@ -57,18 +62,109 @@ export class Coin {
     };
   }
 
-  static getBalance(
-    data: GetObjectDataResponse | SuiMoveObject
-  ): BN | undefined {
+  public static getID(obj: ObjectData): ObjectId {
+    if (isSuiMoveObject(obj)) {
+      return obj.fields.id.id;
+    }
+    return getObjectId(obj);
+  }
+
+  /**
+   * Convenience method for select coin objects that has a balance greater than or equal to `amount`
+   *
+   * @param amount coin balance
+   * @param exclude object ids of the coins to exclude
+   * @return a list of coin objects that has balance greater than `amount` in an ascending order
+   */
+  static selectCoinsWithBalanceGreaterThanOrEqual(
+    coins: ObjectDataFull[],
+    amount: bigint,
+    exclude: ObjectId[] = []
+  ): ObjectDataFull[] {
+    return Coin.sortByBalance(
+      coins.filter(
+        (c) => !exclude.includes(Coin.getID(c)) && Coin.getBalance(c)! >= amount
+      )
+    );
+  }
+
+  /**
+   * Convenience method for select a minimal set of coin objects that has a balance greater than
+   * or equal to `amount`. The output can be used for `PayTransaction`
+   *
+   * @param amount coin balance
+   * @param exclude object ids of the coins to exclude
+   * @return a minimal list of coin objects that has a combined balance greater than or equal
+   * to`amount` in an ascending order. If no such set exists, an empty list is returned
+   */
+  static selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+    coins: ObjectDataFull[],
+    amount: bigint,
+    exclude: ObjectId[] = []
+  ): ObjectDataFull[] {
+    const sortedCoins = Coin.sortByBalance(
+      coins.filter((c) => !exclude.includes(Coin.getID(c)))
+    );
+
+    const total = Coin.totalBalance(sortedCoins);
+    // return empty set if the aggregate balance of all coins is smaller than amount
+    if (total < amount) {
+      return [];
+    } else if (total === amount) {
+      return sortedCoins;
+    }
+
+    let sum = BigInt(0);
+    let ret = [];
+    while (sum < total) {
+      // prefer to add a coin with smallest sufficient balance
+      const target = amount - sum;
+      const coinWithSmallestSufficientBalance = sortedCoins.find(
+        (c) => Coin.getBalance(c)! >= target
+      );
+      if (coinWithSmallestSufficientBalance) {
+        ret.push(coinWithSmallestSufficientBalance);
+        break;
+      }
+
+      const coinWithLargestBalance = sortedCoins.pop()!;
+      ret.push(coinWithLargestBalance);
+      sum += Coin.getBalance(coinWithLargestBalance)!;
+    }
+
+    return Coin.sortByBalance(ret);
+  }
+
+  static totalBalance(coins: ObjectDataFull[]): bigint {
+    return coins.reduce(
+      (partialSum, c) => partialSum + Coin.getBalance(c)!,
+      BigInt(0)
+    );
+  }
+
+  /**
+   * Sort coin by balance in an ascending order
+   */
+  static sortByBalance(coins: ObjectDataFull[]): ObjectDataFull[] {
+    return coins.sort((a, b) =>
+      Coin.getBalance(a)! < Coin.getBalance(b)!
+        ? -1
+        : Coin.getBalance(a)! > Coin.getBalance(b)!
+        ? 1
+        : 0
+    );
+  }
+
+  static getBalance(data: ObjectDataFull): bigint | undefined {
     if (!Coin.isCoin(data)) {
       return undefined;
     }
     const balance = getObjectFields(data)?.balance;
-    return new BN.BN(balance, 10);
+    return BigInt(balance);
   }
 
-  static getZero(): BN {
-    return new BN.BN('0', 10);
+  static getZero(): bigint {
+    return BigInt(0);
   }
 
   private static getType(data: ObjectData): string | undefined {

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -4,8 +4,6 @@
 import { ObjectOwner, SuiAddress, TransactionDigest } from './common';
 import { SuiMovePackage, SuiObject, SuiObjectRef } from './objects';
 
-import BN from 'bn.js';
-
 export type TransferObject = {
   recipient: SuiAddress;
   objectRef: SuiObjectRef;
@@ -293,9 +291,9 @@ export function getTransactions(
   return data.data.transactions;
 }
 
-export function getTransferSuiAmount(data: SuiTransactionKind): BN | null {
+export function getTransferSuiAmount(data: SuiTransactionKind): bigint | null {
   return 'TransferSui' in data && data.TransferSui.amount
-    ? new BN.BN(data.TransferSui.amount, 10)
+    ? BigInt(data.TransferSui.amount)
     : null;
 }
 

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  Coin,
+  getObjectId,
+  LocalTxnDataSerializer,
+  ObjectId,
+  RawSigner,
+  SuiObjectInfo,
+  SUI_TYPE_ARG,
+} from '../../src';
+
+import { DEFAULT_GAS_BUDGET, setup, TestToolbox } from './utils/setup';
+
+const SPLIT_AMOUNTS = [BigInt(1), BigInt(2), BigInt(3)];
+
+describe('Coin related API', () => {
+  let toolbox: TestToolbox;
+  let signer: RawSigner;
+  let coinToSplit: ObjectId;
+  let coinsAfterSplit: SuiObjectInfo[];
+
+  beforeAll(async () => {
+    toolbox = await setup();
+    signer = new RawSigner(
+      toolbox.keypair,
+      toolbox.provider,
+      new LocalTxnDataSerializer(toolbox.provider)
+    );
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    coinToSplit = coins[0].objectId;
+    // split coins into desired amount
+    await signer.splitCoinWithRequestType({
+      coinObjectId: coinToSplit,
+      splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[1].objectId,
+    });
+    coinsAfterSplit = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    expect(coinsAfterSplit.length).toEqual(coins.length + SPLIT_AMOUNTS.length);
+  });
+
+  it('test selectCoinsWithBalanceGreaterThanOrEqual', async () => {
+    await Promise.all(
+      SPLIT_AMOUNTS.map(async (a, i) => {
+        const coins =
+          await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+            toolbox.address(),
+            BigInt(a)
+          );
+        expect(coins.length).toEqual(coinsAfterSplit.length - i);
+        const balances = coins.map((c) => Coin.getBalance(c)!);
+        // verify that the balances are in ascending order
+        expect(balances).toStrictEqual(balances.sort());
+        // verify that balances are all greater than or equal to the provided amount
+        expect(balances.every((b) => b >= a));
+      })
+    );
+  });
+
+  it('test selectCoinsWithBalanceGreaterThanOrEqual with exclude', async () => {
+    const coins =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        BigInt(1)
+      );
+    expect(coins.find((c) => getObjectId(c) === coinToSplit)).toBeDefined();
+
+    const coinsWithExclude =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        BigInt(1),
+        SUI_TYPE_ARG,
+        [coinToSplit]
+      );
+    expect(
+      coinsWithExclude.find((c) => getObjectId(c) === coinToSplit)
+    ).toBeUndefined();
+  });
+
+  it('test selectCoinSetWithCombinedBalanceGreaterThanOrEqual', async () => {
+    await Promise.all(
+      SPLIT_AMOUNTS.map(async (a, i) => {
+        const coins =
+          await toolbox.provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+            toolbox.address(),
+            BigInt(a)
+          );
+        const balances = coins.map((c) => Coin.getBalance(c)!);
+        expect(balances).toStrictEqual([SPLIT_AMOUNTS[i]]);
+      })
+    );
+    // test multiple coins
+    const allCoins =
+      await toolbox.provider.selectCoinsWithBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        BigInt(1)
+      );
+    const largestBalance = Coin.getBalance(allCoins[allCoins.length - 1])!;
+
+    const coins =
+      await toolbox.provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+        toolbox.address(),
+        largestBalance + SPLIT_AMOUNTS[0]
+      );
+    const balances = coins.map((c) => Coin.getBalance(c)!);
+    expect(balances).toStrictEqual([SPLIT_AMOUNTS[0], largestBalance]);
+  });
+});

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -13,6 +13,7 @@ const DEFAULT_FULLNODE_URL = 'http://127.0.0.1:9000';
 const DEFAULT_GATEWAY_URL = 'http://127.0.0.1:5001';
 
 export const DEFAULT_RECIPIENT = '0x36096be6a0314052931babed39f53c0666a6b0df';
+export const DEFAULT_RECIPIENT_2 = '0x46096be6a0314052931babed39f53c0666a6b0da';
 export const DEFAULT_GAS_BUDGET = 10000;
 
 export class TestToolbox {

--- a/sdk/typescript/test/unit/types/framework.test.ts
+++ b/sdk/typescript/test/unit/types/framework.test.ts
@@ -5,12 +5,10 @@ import { describe, it, expect } from 'vitest';
 import mockObjectData from '@mysten/sui-open-rpc/samples/objects.json';
 import { Coin, GetObjectDataResponse } from '../../../src';
 
-import BN from 'bn.js';
-
 describe('Test framework classes', () => {
   it('Test coin utils', () => {
     const data = mockObjectData['coin'] as GetObjectDataResponse;
     expect(Coin.isCoin(data)).toBeTruthy();
-    expect(Coin.getBalance(data)).toEqual(new BN.BN('100000000000000'));
+    expect(Coin.getBalance(data)).toEqual(BigInt('100000000000000'));
   });
 });


### PR DESCRIPTION
For the upcoming gateway deprecation, TS-SDK (used by the wallet-ext) would need to implement the gas coin selection algorithm. This PR adds some util methods and does some preliminary cleanup in the existing coin management logic in the wallet-ext

SDK
- added `selectCoinsWithBalanceGreaterThanOrEqual` (this can be added as an RPC endpoint later)
- added `selectCoinSetWithCombinedBalanceGreaterThanOrEqual` (this can be added as an RPC endpoint later)
- added end to end tests for Pay and coin selection

Wallet ext
- use pay API and the newly added coin selection methods to avoid multiple `MergeCoin` and `SplitCoin` transactions