### PR TITLE
[explorer] Change explorer e2e tests to local transaction serializer

### DIFF
--- a/apps/explorer/cypress/e2e/localnet/objects.cy.ts
+++ b/apps/explorer/cypress/e2e/localnet/objects.cy.ts
@@ -7,8 +7,12 @@ describe('Objects', () => {
     it('can be reached through URL', () => {
         cy.task('faucet')
             .then((address) => cy.task('mint', address))
-            .then(({ effects }) => {
-                const { objectId } = effects.created![0].reference;
+            .then((tx) => {
+                if (!('EffectsCert' in tx)) {
+                    throw new Error('Missing effects cert');
+                }
+                const { objectId } =
+                    tx.EffectsCert.effects.effects.created![0].reference;
                 cy.visit(`/objects/${objectId}`);
                 cy.get('#objectID').contains(objectId);
             });
@@ -23,9 +27,13 @@ describe('Objects', () => {
         it('link going from address to object and back', () => {
             cy.task('faucet')
                 .then((address) => cy.task('mint', address))
-                .then(({ certificate, effects }) => {
-                    const address = certificate.data.sender;
-                    const [nft] = effects.created!;
+                .then((tx) => {
+                    if (!('EffectsCert' in tx)) {
+                        throw new Error('Missing effects cert');
+                    }
+
+                    const address = tx.EffectsCert.certificate.data.sender;
+                    const [nft] = tx.EffectsCert.effects.effects.created!;
                     cy.visit(`/addresses/${address}`);
 
                     // Find a reference to the NFT:

--- a/apps/explorer/cypress/e2e/localnet/search.cy.ts
+++ b/apps/explorer/cypress/e2e/localnet/search.cy.ts
@@ -15,8 +15,12 @@ describe('search', () => {
     it('can search for objects', () => {
         cy.task('faucet')
             .then((address) => cy.task('mint', address))
-            .then(({ effects }) => {
-                const { objectId } = effects.created![0].reference;
+            .then((tx) => {
+                if (!('EffectsCert' in tx)) {
+                    throw new Error('Missing effects cert');
+                }
+                const { objectId } =
+                    tx.EffectsCert.effects.effects.created![0].reference;
                 cy.visit('/');
                 cy.get('[data-testid=search]').type(objectId).type('{enter}');
                 cy.url().should('include', `/objects/${objectId}`);

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -33,7 +33,7 @@ export async function createLocalnetTasks() {
                 keypair.getPublicKey().toSuiAddress()
             );
 
-            const tx = await signer.executeMoveCall({
+            const tx = await signer.executeMoveCallWithRequestType({
                 packageObjectId: '0x2',
                 module: 'devnet_nft',
                 function: 'mint',

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -9,6 +9,7 @@ import {
     Ed25519Keypair,
     JsonRpcProvider,
     RawSigner,
+    LocalTxnDataSerializer,
     type Keypair,
 } from '../../../sdk/typescript/src';
 
@@ -21,8 +22,10 @@ export async function createLocalnetTasks() {
             if (!keypair) {
                 throw new Error('missing keypair');
             }
-            const provider = new JsonRpcProvider('http://localhost:5001');
-            const signer = new RawSigner(keypair, provider);
+            const provider = new JsonRpcProvider('http://localhost:9000');
+            const signer = new RawSigner(keypair, provider, new LocalTxnDataSerializer(provider))
+
+            const [gasPayment] = await provider.getGasObjectsOwnedByAddress(keypair.getPublicKey().toSuiAddress());
 
             const tx = await signer.executeMoveCall({
                 packageObjectId: '0x2',
@@ -34,6 +37,7 @@ export async function createLocalnetTasks() {
                     'An example NFT.',
                     'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
                 ],
+                gasPayment: gasPayment.objectId,
                 gasBudget: 30000,
             });
 

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -23,9 +23,15 @@ export async function createLocalnetTasks() {
                 throw new Error('missing keypair');
             }
             const provider = new JsonRpcProvider('http://localhost:9000');
-            const signer = new RawSigner(keypair, provider, new LocalTxnDataSerializer(provider))
+            const signer = new RawSigner(
+                keypair,
+                provider,
+                new LocalTxnDataSerializer(provider)
+            );
 
-            const [gasPayment] = await provider.getGasObjectsOwnedByAddress(keypair.getPublicKey().toSuiAddress());
+            const [gasPayment] = await provider.getGasObjectsOwnedByAddress(
+                keypair.getPublicKey().toSuiAddress()
+            );
 
             const tx = await signer.executeMoveCall({
                 packageObjectId: '0x2',

--- a/apps/explorer/cypress/support/commands.d.ts
+++ b/apps/explorer/cypress/support/commands.d.ts
@@ -11,6 +11,6 @@ declare namespace Cypress {
         task(
             name: 'mint',
             address?: string
-        ): Chainable<import('@mysten/sui.js').SuiTransactionResponse>;
+        ): Chainable<import('@mysten/sui.js').SuiExecuteTransactionResponse>;
     }
 }


### PR DESCRIPTION
This removes the use of gateway from the explorer end to end tests. 