### PR TITLE
[wip] Use generics to improve API response

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -12,10 +12,10 @@ import {
   TransactionEffects,
   normalizeSuiObjectId,
   ExecuteTransactionRequestType,
-  SuiExecuteTransactionResponse,
   getTransactionEffects,
 } from '../types';
 import { JsonRpcProvider } from './json-rpc-provider';
+import { SuiExecuteTransactionResponseTyped } from '../types/autoguard-workaround';
 
 export class JsonRpcProviderWithCache extends JsonRpcProvider {
   /**
@@ -83,14 +83,19 @@ export class JsonRpcProviderWithCache extends JsonRpcProvider {
     return resp;
   }
 
-  async executeTransactionWithRequestType(
+  async executeTransactionWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     txnBytes: string,
     signatureScheme: SignatureScheme,
     signature: string,
     pubkey: string,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
-    if (requestType !== 'WaitForEffectsCert') {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
+    if (
+      requestType &&
+      requestType !== ExecuteTransactionRequestType.WaitForEffectsCert
+    ) {
       console.warn(
         `It's not recommended to use JsonRpcProviderWithCache with the request ` +
           `type other than 'WaitForEffectsCert' for executeTransactionWithRequestType. Using ` +

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -18,13 +18,13 @@ import {
   SuiEventEnvelope,
   SubscriptionId,
   ExecuteTransactionRequestType,
-  SuiExecuteTransactionResponse,
   TransactionDigest,
   ObjectId,
   SuiAddress,
   ObjectOwner,
   SuiEvents,
 } from '../types';
+import { SuiExecuteTransactionResponseTyped } from '../types/autoguard-workaround';
 
 ///////////////////////////////
 // Exported Abstracts
@@ -100,13 +100,15 @@ export abstract class Provider {
    * replace the other `executeTransaction` that's only available on the
    * Gateway
    */
-  abstract executeTransactionWithRequestType(
+  abstract executeTransactionWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     txnBytes: string,
     signatureScheme: SignatureScheme,
     signature: string,
     pubkey: string,
-    requestType: ExecuteTransactionRequestType
-  ): Promise<SuiExecuteTransactionResponse>;
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>>;
 
   // Move info
   /**

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -20,12 +20,12 @@ import {
   SuiEventEnvelope,
   SubscriptionId,
   ExecuteTransactionRequestType,
-  SuiExecuteTransactionResponse,
   ObjectOwner,
   SuiAddress,
   ObjectId,
   SuiEvents,
 } from '../types';
+import { SuiExecuteTransactionResponseTyped } from '../types/autoguard-workaround';
 import { Provider } from './provider';
 
 export class VoidProvider extends Provider {
@@ -71,13 +71,15 @@ export class VoidProvider extends Provider {
     throw this.newError('executeTransaction');
   }
 
-  async executeTransactionWithRequestType(
+  async executeTransactionWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     _txnBytes: string,
     _signatureScheme: SignatureScheme,
     _signature: string,
     _pubkey: string,
-    _requestType: ExecuteTransactionRequestType
-  ): Promise<SuiExecuteTransactionResponse> {
+    _requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     throw this.newError('executeTransaction with request Type');
   }
 

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -8,9 +8,9 @@ import { Base64DataBuffer } from '../serialization/base64';
 import {
   ExecuteTransactionRequestType,
   SuiAddress,
-  SuiExecuteTransactionResponse,
   SuiTransactionResponse,
 } from '../types';
+import { SuiExecuteTransactionResponseTyped } from '../types/autoguard-workaround';
 import { SignaturePubkeyPair, Signer } from './signer';
 import { RpcTxnDataSerializer } from './txn-data-serializers/rpc-txn-data-serializer';
 import {
@@ -109,10 +109,12 @@ export abstract class SignerWithProvider implements Signer {
   /**
    * @experimental Sign a transaction and submit to the Fullnode for execution
    */
-  async signAndExecuteTransactionWithRequestType(
+  async signAndExecuteTransactionWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: Base64DataBuffer | SignableTransaction,
-    requestType: ExecuteTransactionRequestType
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     // Handle submitting raw transaction bytes:
     if (
       transaction instanceof Base64DataBuffer ||
@@ -124,7 +126,7 @@ export abstract class SignerWithProvider implements Signer {
           : new Base64DataBuffer(transaction.data);
 
       const sig = await this.signData(txBytes);
-      return await this.provider.executeTransactionWithRequestType(
+      return await this.provider.executeTransactionWithRequestType<RequestType>(
         txBytes.toString(),
         sig.signatureScheme,
         sig.signature.toString(),
@@ -135,7 +137,7 @@ export abstract class SignerWithProvider implements Signer {
 
     switch (transaction.kind) {
       case 'moveCall':
-        return this.executeMoveCallWithRequestType(
+        return this.executeMoveCallWithRequestType<RequestType>(
           transaction.data,
           requestType
         );
@@ -267,10 +269,12 @@ export abstract class SignerWithProvider implements Signer {
    * @experimental Serialize and sign a `TransferObject` transaction and submit to the Fullnode
    * for execution
    */
-  async transferObjectWithRequestType(
+  async transferObjectWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: TransferObjectTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newTransferObject(
       signerAddress,
@@ -286,10 +290,12 @@ export abstract class SignerWithProvider implements Signer {
    * @experimental Serialize and sign a `TransferSui` transaction and submit to the Fullnode
    * for execution
    */
-  async transferSuiWithRequestType(
+  async transferSuiWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: TransferSuiTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newTransferSui(
       signerAddress,
@@ -304,10 +310,12 @@ export abstract class SignerWithProvider implements Signer {
   /**
    * @experimental Serialize and Sign a `Pay` transaction and submit to the fullnode for execution
    */
-  async payWithRequestType(
+  async payWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: PayTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newPay(signerAddress, transaction);
     return await this.signAndExecuteTransactionWithRequestType(
@@ -320,10 +328,12 @@ export abstract class SignerWithProvider implements Signer {
    * @experimental Serialize and sign a `MergeCoin` transaction and submit to the Fullnode
    * for execution
    */
-  async mergeCoinWithRequestType(
+  async mergeCoinWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: MergeCoinTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newMergeCoin(
       signerAddress,
@@ -339,10 +349,12 @@ export abstract class SignerWithProvider implements Signer {
    * @experimental Serialize and sign a `SplitCoin` transaction and submit to the Fullnode
    * for execution
    */
-  async splitCoinWithRequestType(
+  async splitCoinWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: SplitCoinTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newSplitCoin(
       signerAddress,
@@ -358,10 +370,12 @@ export abstract class SignerWithProvider implements Signer {
    * @experimental Serialize and sign a `MoveCall` transaction and submit to the Fullnode
    * for execution
    */
-  async executeMoveCallWithRequestType(
+  async executeMoveCallWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: MoveCallTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newMoveCall(
       signerAddress,
@@ -377,10 +391,12 @@ export abstract class SignerWithProvider implements Signer {
    * @experimental Serialize and sign a `Publish` transaction and submit to the Fullnode
    * for execution
    */
-  async publishWithRequestType(
+  async publishWithRequestType<
+    RequestType extends ExecuteTransactionRequestType = ExecuteTransactionRequestType.WaitForEffectsCert
+  >(
     transaction: PublishTransaction,
-    requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
-  ): Promise<SuiExecuteTransactionResponse> {
+    requestType?: RequestType
+  ): Promise<SuiExecuteTransactionResponseTyped<RequestType>> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newPublish(
       signerAddress,

--- a/sdk/typescript/src/types/autoguard-workaround.ts
+++ b/sdk/typescript/src/types/autoguard-workaround.ts
@@ -1,0 +1,17 @@
+import {
+  ExecuteTransactionRequestType,
+  SuiExecuteTransactionResponseImmediateReturn,
+  SuiExecuteTransactionResponseWaitForEffectsCert,
+  SuiExecuteTransactionResponseWaitForTxCert,
+} from './transactions';
+
+// NOTE: This file cannot be exported from `./types` because it will cause ts-auto-guard to fail.
+export type SuiExecuteTransactionResponseTyped<
+  RequestType extends ExecuteTransactionRequestType
+> = RequestType extends ExecuteTransactionRequestType.ImmediateReturn
+  ? SuiExecuteTransactionResponseImmediateReturn
+  : RequestType extends ExecuteTransactionRequestType.WaitForTxCert
+  ? SuiExecuteTransactionResponseWaitForTxCert
+  : RequestType extends ExecuteTransactionRequestType.WaitForEffectsCert
+  ? SuiExecuteTransactionResponseWaitForEffectsCert
+  : never;

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponseImmediateReturn, SuiExecuteTransactionResponseWaitForTxCert, SuiExecuteTransactionResponseWaitForEffectsCert, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -665,9 +665,9 @@ export function isPay(obj: any, _argumentName?: string): obj is Pay {
 
 export function isExecuteTransactionRequestType(obj: any, _argumentName?: string): obj is ExecuteTransactionRequestType {
     return (
-        (obj === "ImmediateReturn" ||
-            obj === "WaitForTxCert" ||
-            obj === "WaitForEffectsCert")
+        (obj === ExecuteTransactionRequestType.ImmediateReturn ||
+            obj === ExecuteTransactionRequestType.WaitForTxCert ||
+            obj === ExecuteTransactionRequestType.WaitForEffectsCert)
     )
 }
 
@@ -886,30 +886,48 @@ export function isSuiCertifiedTransactionEffects(obj: any, _argumentName?: strin
     )
 }
 
-export function isSuiExecuteTransactionResponse(obj: any, _argumentName?: string): obj is SuiExecuteTransactionResponse {
+export function isSuiExecuteTransactionResponseImmediateReturn(obj: any, _argumentName?: string): obj is SuiExecuteTransactionResponseImmediateReturn {
     return (
-        ((obj !== null &&
+        (obj !== null &&
             typeof obj === "object" ||
             typeof obj === "function") &&
-            (obj.ImmediateReturn !== null &&
-                typeof obj.ImmediateReturn === "object" ||
-                typeof obj.ImmediateReturn === "function") &&
-            isTransactionDigest(obj.ImmediateReturn.tx_digest) as boolean ||
-            (obj !== null &&
-                typeof obj === "object" ||
-                typeof obj === "function") &&
-            (obj.TxCert !== null &&
-                typeof obj.TxCert === "object" ||
-                typeof obj.TxCert === "function") &&
-            isCertifiedTransaction(obj.TxCert.certificate) as boolean ||
-            (obj !== null &&
-                typeof obj === "object" ||
-                typeof obj === "function") &&
-            (obj.EffectsCert !== null &&
-                typeof obj.EffectsCert === "object" ||
-                typeof obj.EffectsCert === "function") &&
-            isCertifiedTransaction(obj.EffectsCert.certificate) as boolean &&
-            isSuiCertifiedTransactionEffects(obj.EffectsCert.effects) as boolean)
+        (obj.ImmediateReturn !== null &&
+            typeof obj.ImmediateReturn === "object" ||
+            typeof obj.ImmediateReturn === "function") &&
+        isTransactionDigest(obj.ImmediateReturn.tx_digest) as boolean
+    )
+}
+
+export function isSuiExecuteTransactionResponseWaitForTxCert(obj: any, _argumentName?: string): obj is SuiExecuteTransactionResponseWaitForTxCert {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.TxCert !== null &&
+            typeof obj.TxCert === "object" ||
+            typeof obj.TxCert === "function") &&
+        isCertifiedTransaction(obj.TxCert.certificate) as boolean
+    )
+}
+
+export function isSuiExecuteTransactionResponseWaitForEffectsCert(obj: any, _argumentName?: string): obj is SuiExecuteTransactionResponseWaitForEffectsCert {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        (obj.EffectsCert !== null &&
+            typeof obj.EffectsCert === "object" ||
+            typeof obj.EffectsCert === "function") &&
+        isCertifiedTransaction(obj.EffectsCert.certificate) as boolean &&
+        isSuiCertifiedTransactionEffects(obj.EffectsCert.effects) as boolean
+    )
+}
+
+export function isSuiExecuteTransactionResponse(obj: any, _argumentName?: string): obj is SuiExecuteTransactionResponse {
+    return (
+        (isSuiExecuteTransactionResponseImmediateReturn(obj) as boolean ||
+            isSuiExecuteTransactionResponseWaitForTxCert(obj) as boolean ||
+            isSuiExecuteTransactionResponseWaitForEffectsCert(obj) as boolean)
     )
 }
 

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -28,10 +28,11 @@ export type Pay = {
   amounts: number[];
 };
 
-export type ExecuteTransactionRequestType =
-  | 'ImmediateReturn'
-  | 'WaitForTxCert'
-  | 'WaitForEffectsCert';
+export enum ExecuteTransactionRequestType {
+  ImmediateReturn = 'ImmediateReturn',
+  WaitForTxCert = 'WaitForTxCert',
+  WaitForEffectsCert = 'WaitForEffectsCert',
+}
 
 export type TransactionKindName =
   | 'TransferObject'
@@ -137,19 +138,27 @@ export type SuiCertifiedTransactionEffects = {
   effects: TransactionEffects;
 };
 
+export type SuiExecuteTransactionResponseImmediateReturn = {
+  ImmediateReturn: {
+    tx_digest: string;
+  };
+};
+
+export type SuiExecuteTransactionResponseWaitForTxCert = {
+  TxCert: { certificate: CertifiedTransaction };
+};
+
+export type SuiExecuteTransactionResponseWaitForEffectsCert = {
+  EffectsCert: {
+    certificate: CertifiedTransaction;
+    effects: SuiCertifiedTransactionEffects;
+  };
+};
+
 export type SuiExecuteTransactionResponse =
-  | {
-      ImmediateReturn: {
-        tx_digest: string;
-      };
-    }
-  | { TxCert: { certificate: CertifiedTransaction } }
-  | {
-      EffectsCert: {
-        certificate: CertifiedTransaction;
-        effects: SuiCertifiedTransactionEffects;
-      };
-    };
+  | SuiExecuteTransactionResponseImmediateReturn
+  | SuiExecuteTransactionResponseWaitForTxCert
+  | SuiExecuteTransactionResponseWaitForEffectsCert;
 
 export type GatewayTxSeqNumber = number;
 

--- a/sdk/typescript/type_guards.mjs
+++ b/sdk/typescript/type_guards.mjs
@@ -29,10 +29,12 @@ async function main() {
       writeFile(
         fileName,
         LICENSE +
-          file.replace(
-            /import { BN } from ".*";\n/g,
-            'import { BN } from "bn.js";\nimport { Buffer } from "buffer";\n'
-          )
+          file
+            // Fix incorrect enum import:
+            .replace(
+              'import { ExecuteTransactionRequestType } from "./transactions";\n',
+              ''
+            )
       );
     })
   );


### PR DESCRIPTION
This demonstrates how we can use generics to improve. I ran into issues with `ts-auto-guard`, it doesn't like the generic in the type, so I had to extract this type out and keep it separate from the others. I'd recommend we evaluate a different way to do this type of schema validation that doesn't require code generation.