### PR TITLE
[move] Extended txn testing framework to support vectors of objects

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -1,135 +1,73 @@
-processed 35 tasks
+processed 19 tasks
 
 init:
 A: object(100)
 
-task 1 'publish'. lines 6-210:
+task 1 'publish'. lines 8-116:
 created: object(104)
 written: object(103)
 
-task 2 'run'. lines 213-213:
+task 2 'run'. lines 118-118:
 written: object(105)
 
-task 3 'run'. lines 215-215:
+task 3 'run'. lines 120-124:
 created: object(107)
 written: object(106)
 
-task 4 'run'. lines 217-217:
+task 4 'run'. lines 126-126:
 written: object(108)
 deleted: object(107)
 
-task 5 'run'. lines 219-219:
+task 5 'run'. lines 128-128:
 created: object(110)
 written: object(109)
 
-task 6 'run'. lines 221-221:
+task 6 'run'. lines 130-130:
 created: object(112)
 written: object(110), object(111)
 
-task 7 'run'. lines 223-226:
+task 7 'run'. lines 132-136:
 written: object(113)
 deleted: object(110), object(112)
 
-task 8 'run'. lines 229-229:
+task 8 'run'. lines 138-138:
 created: object(115)
 written: object(114)
 
-task 9 'run'. lines 231-231:
+task 9 'run'. lines 140-143:
 Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::Obj, but found type Test::M::AnotherObj") } }
 
-task 10 'run'. lines 233-233:
+task 10 'run'. lines 145-145:
 created: object(118)
 written: object(117)
 
-task 11 'run'. lines 235-235:
+task 11 'run'. lines 147-147:
 created: object(120)
 written: object(119)
 
-task 12 'run'. lines 237-237:
+task 12 'run'. lines 149-152:
 Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::Obj, but found type Test::M::AnotherObj") } }
 
-task 13 'run'. lines 239-239:
+task 13 'run'. lines 154-154:
 created: object(123)
 written: object(122)
 
-task 14 'run'. lines 241-241:
+task 14 'run'. lines 156-159:
 Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
 
-task 15 'run'. lines 243-243:
+task 15 'run'. lines 161-161:
 created: object(126)
 written: object(125)
 
-task 16 'run'. lines 245-245:
+task 16 'run'. lines 163-166:
 Error: The transaction inputs contain duplicates ObjectRef's
 
-task 17 'run'. lines 247-247:
+task 17 'run'. lines 168-168:
 created: object(129)
 written: object(128)
 
-task 18 'run'. lines 249-252:
-Error: The transaction inputs contain duplicates ObjectRef's
-
-task 19 'run'. lines 255-255:
-created: object(132)
-written: object(131)
-
-task 20 'run'. lines 257-257:
-written: object(133)
-deleted: object(132)
-
-task 21 'run'. lines 259-259:
-created: object(135)
-written: object(134)
-
-task 22 'run'. lines 261-261:
-created: object(137)
-written: object(135), object(136)
-
-task 23 'run'. lines 263-266:
-written: object(138)
-deleted: object(135), object(137)
-
-task 24 'run'. lines 269-269:
-created: object(140)
-written: object(139)
-
-task 25 'run'. lines 271-271:
-Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::ObjAny<T0>, but found type Test::M::AnotherObjAny<Test::M::Any>") } }
-
-task 26 'run'. lines 273-273:
-created: object(143)
-written: object(142)
-
-task 27 'run'. lines 275-275:
-created: object(145)
-written: object(144)
-
-task 28 'run'. lines 277-277:
-Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::ObjAny<T0>, but found type Test::M::AnotherObjAny<Test::M::Any>") } }
-
-task 29 'run'. lines 279-279:
-created: object(148)
-written: object(147)
-
-task 30 'run'. lines 281-281:
-Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
-
-task 31 'run'. lines 283-283:
-created: object(151)
-written: object(150)
-
-task 32 'run'. lines 285-285:
-Error: The transaction inputs contain duplicates ObjectRef's
-
-task 33 'run'. lines 287-287:
-created: object(154)
-written: object(153)
-
-task 34 'run'. lines 289-289:
+task 18 'run'. lines 170-170:
 Error: The transaction inputs contain duplicates ObjectRef's

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.exp
@@ -1,0 +1,135 @@
+processed 35 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 6-210:
+created: object(104)
+written: object(103)
+
+task 2 'run'. lines 213-213:
+written: object(105)
+
+task 3 'run'. lines 215-215:
+created: object(107)
+written: object(106)
+
+task 4 'run'. lines 217-217:
+written: object(108)
+deleted: object(107)
+
+task 5 'run'. lines 219-219:
+created: object(110)
+written: object(109)
+
+task 6 'run'. lines 221-221:
+created: object(112)
+written: object(110), object(111)
+
+task 7 'run'. lines 223-226:
+written: object(113)
+deleted: object(110), object(112)
+
+task 8 'run'. lines 229-229:
+created: object(115)
+written: object(114)
+
+task 9 'run'. lines 231-231:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::Obj, but found type Test::M::AnotherObj") } }
+
+task 10 'run'. lines 233-233:
+created: object(118)
+written: object(117)
+
+task 11 'run'. lines 235-235:
+created: object(120)
+written: object(119)
+
+task 12 'run'. lines 237-237:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::Obj, but found type Test::M::AnotherObj") } }
+
+task 13 'run'. lines 239-239:
+created: object(123)
+written: object(122)
+
+task 14 'run'. lines 241-241:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
+
+task 15 'run'. lines 243-243:
+created: object(126)
+written: object(125)
+
+task 16 'run'. lines 245-245:
+Error: The transaction inputs contain duplicates ObjectRef's
+
+task 17 'run'. lines 247-247:
+created: object(129)
+written: object(128)
+
+task 18 'run'. lines 249-252:
+Error: The transaction inputs contain duplicates ObjectRef's
+
+task 19 'run'. lines 255-255:
+created: object(132)
+written: object(131)
+
+task 20 'run'. lines 257-257:
+written: object(133)
+deleted: object(132)
+
+task 21 'run'. lines 259-259:
+created: object(135)
+written: object(134)
+
+task 22 'run'. lines 261-261:
+created: object(137)
+written: object(135), object(136)
+
+task 23 'run'. lines 263-266:
+written: object(138)
+deleted: object(135), object(137)
+
+task 24 'run'. lines 269-269:
+created: object(140)
+written: object(139)
+
+task 25 'run'. lines 271-271:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::ObjAny<T0>, but found type Test::M::AnotherObjAny<Test::M::Any>") } }
+
+task 26 'run'. lines 273-273:
+created: object(143)
+written: object(142)
+
+task 27 'run'. lines 275-275:
+created: object(145)
+written: object(144)
+
+task 28 'run'. lines 277-277:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::ObjAny<T0>, but found type Test::M::AnotherObjAny<Test::M::Any>") } }
+
+task 29 'run'. lines 279-279:
+created: object(148)
+written: object(147)
+
+task 30 'run'. lines 281-281:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
+
+task 31 'run'. lines 283-283:
+created: object(151)
+written: object(150)
+
+task 32 'run'. lines 285-285:
+Error: The transaction inputs contain duplicates ObjectRef's
+
+task 33 'run'. lines 287-287:
+created: object(154)
+written: object(153)
+
+task 34 'run'. lines 289-289:
+Error: The transaction inputs contain duplicates ObjectRef's

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Mysten Labs, Inc.
+// Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //# init --addresses Test=0x0 --accounts A

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector.move
@@ -1,0 +1,289 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 --accounts A
+
+//# publish
+module Test::M {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use std::vector;
+
+    struct Obj has key {
+        id: UID,
+        value: u64
+    }
+
+    struct AnotherObj has key {
+        id: UID,
+        value: u64
+    }
+
+    public entry fun mint(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            Obj {
+                id: object::new(ctx),
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_another(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            AnotherObj {
+                id: object::new(ctx),
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_child(v: u64, parent: &mut Obj, ctx: &mut TxContext) {
+        transfer::transfer_to_object(
+            Obj {
+                id: object::new(ctx),
+                value: v,
+            },
+            parent,
+        )
+    }
+
+    public entry fun mint_shared(v: u64, ctx: &mut TxContext) {
+        transfer::share_object(
+            Obj {
+                id: object::new(ctx),
+                value: v,
+            }
+        )
+    }
+
+    public entry fun prim_vec_len(v: vector<u64>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+    }
+
+    public entry fun obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 1, 0);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun two_obj_vec_destroy(v: vector<Obj>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 7, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun same_objects(o: Obj, v: vector<Obj>, _: &mut TxContext) {
+        let Obj {id, value} = o;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun same_objects_ref(o: &Obj, v: vector<Obj>, _: &mut TxContext) {
+        assert!(o.value == 42, 0);
+        let Obj {id, value: _} = vector::pop_back(&mut v);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun child_access(child: Obj, v: vector<Obj>, _: &mut TxContext) {
+        let Obj {id, value} = child;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let Obj {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    struct ObjAny<phantom Any> has key {
+        id: UID,
+        value: u64
+    }
+
+    struct AnotherObjAny<phantom Any> has key {
+        id: UID,
+        value: u64
+    }
+
+    struct Any {}
+
+    public entry fun mint_any<Any>(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            ObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_another_any<Any>(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            AnotherObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_child_any<Any>(v: u64, parent: &mut ObjAny<Any>, ctx: &mut TxContext) {
+        transfer::transfer_to_object(
+            ObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            },
+            parent,
+        )
+    }
+
+    public entry fun mint_shared_any<Any>(v: u64, ctx: &mut TxContext) {
+        transfer::share_object(
+            ObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            }
+        )
+    }
+
+    public entry fun obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 1, 0);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun two_obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 7, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun same_objects_any<Any>(o: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        let ObjAny<Any> {id, value} = o;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun same_objects_ref_any<Any>(o: &ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        assert!(o.value == 42, 0);
+        let ObjAny<Any> {id, value: _} = vector::pop_back(&mut v);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun child_access_any<Any>(child: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        let ObjAny<Any> {id, value} = child;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+}
+// "positive" tests start here
+
+
+//# run Test::M::prim_vec_len --sender A --args vector[7,42]
+
+//# run Test::M::mint --sender A --args 42
+
+//# run Test::M::obj_vec_destroy --sender A --args vector[object(107)]
+
+//# run Test::M::mint --sender A --args 42
+
+//# run Test::M::mint_child --sender A --args 42 object(110)
+
+//# run Test::M::child_access --sender A --args object(110) vector[object(112)]
+
+
+// "negative" tests start here
+
+
+//# run Test::M::mint_another --sender A --args 42
+
+//# run Test::M::obj_vec_destroy --sender A --args vector[object(115)]
+
+//# run Test::M::mint_another --sender A --args 42
+
+//# run Test::M::mint --sender A --args 42
+
+//# run Test::M::two_obj_vec_destroy --sender A --args vector[object(118),object(120)]
+
+//# run Test::M::mint_shared --sender A --args 42
+
+//# run Test::M::obj_vec_destroy --sender A --args vector[object(123)]
+
+//# run Test::M::mint --sender A --args 42
+
+//# run Test::M::same_objects --sender A --args object(126) vector[object(126)]
+
+//# run Test::M::mint --sender A --args 42
+
+//# run Test::M::same_objects_ref --sender A --args object(128) vector[object(128)]
+
+
+// "positive" tests start here (for generic vectors)
+
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(132)]
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::mint_child_any --sender A --type-args Test::M::Any --args 42 object(135)
+
+//# run Test::M::child_access_any --sender A --type-args Test::M::Any --args object(135) vector[object(137)]
+
+
+// "negative" tests start here (for generic vectors)
+
+
+//# run Test::M::mint_another_any --type-args Test::M::Any --sender A --args 42
+
+//# run Test::M::obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(140)]
+
+//# run Test::M::mint_another_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::two_obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(143),object(145)]
+
+//# run Test::M::mint_shared_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(148)]
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::same_objects_any --sender A --type-args Test::M::Any --args object(151) vector[object(151)]
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::same_objects_ref_any --sender A --type-args Test::M::Any --args object(154) vector[object(154)]

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.exp
@@ -1,0 +1,70 @@
+processed 18 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 8-114:
+created: object(104)
+written: object(103)
+
+task 2 'run'. lines 116-116:
+created: object(106)
+written: object(105)
+
+task 3 'run'. lines 118-122:
+written: object(107)
+deleted: object(106)
+
+task 4 'run'. lines 124-124:
+created: object(109)
+written: object(108)
+
+task 5 'run'. lines 126-126:
+created: object(111)
+written: object(109), object(110)
+
+task 6 'run'. lines 128-132:
+written: object(112)
+deleted: object(109), object(111)
+
+task 7 'run'. lines 134-134:
+created: object(114)
+written: object(113)
+
+task 8 'run'. lines 136-139:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::ObjAny<T0>, but found type Test::M::AnotherObjAny<Test::M::Any>") } }
+
+task 9 'run'. lines 141-141:
+created: object(117)
+written: object(116)
+
+task 10 'run'. lines 143-143:
+created: object(119)
+written: object(118)
+
+task 11 'run'. lines 145-148:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Type mismatch.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: TypeMismatch }), source: Some("Expected argument of type Test::M::ObjAny<T0>, but found type Test::M::AnotherObjAny<Test::M::Any>") } }
+
+task 12 'run'. lines 150-150:
+created: object(122)
+written: object(121)
+
+task 13 'run'. lines 152-155:
+Error: Transaction Effects Status: Entry Argument Type Error. Error for argument at index 0: Immutable and shared objects cannot be passed by-value.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: EntryArgumentError(EntryArgumentError { argument_idx: 0, kind: InvalidObjectByValue }), source: Some("Immutable and shared objects cannot be passed by-value, violation found in argument 0") } }
+
+task 14 'run'. lines 157-157:
+created: object(125)
+written: object(124)
+
+task 15 'run'. lines 159-162:
+Error: The transaction inputs contain duplicates ObjectRef's
+
+task 16 'run'. lines 164-164:
+created: object(128)
+written: object(127)
+
+task 17 'run'. lines 166-166:
+Error: The transaction inputs contain duplicates ObjectRef's

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/obj_vector_generic.move
@@ -1,0 +1,166 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests vector of objects where operations involve generics (type parameters)
+
+//# init --addresses Test=0x0 --accounts A
+
+//# publish
+module Test::M {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use std::vector;
+
+    struct ObjAny<phantom Any> has key {
+        id: UID,
+        value: u64
+    }
+
+    struct AnotherObjAny<phantom Any> has key {
+        id: UID,
+        value: u64
+    }
+
+    struct Any {}
+
+    public entry fun mint_any<Any>(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            ObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_another_any<Any>(v: u64, ctx: &mut TxContext) {
+        transfer::transfer(
+            AnotherObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun mint_child_any<Any>(v: u64, parent: &mut ObjAny<Any>, ctx: &mut TxContext) {
+        transfer::transfer_to_object(
+            ObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            },
+            parent,
+        )
+    }
+
+    public entry fun mint_shared_any<Any>(v: u64, ctx: &mut TxContext) {
+        transfer::share_object(
+            ObjAny<Any> {
+                id: object::new(ctx),
+                value: v,
+            }
+        )
+    }
+
+    public entry fun obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 1, 0);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun two_obj_vec_destroy_any<Any>(v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        assert!(vector::length(&v) == 2, 0);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 7, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun same_objects_any<Any>(o: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        let ObjAny<Any> {id, value} = o;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun same_objects_ref_any<Any>(o: &ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        assert!(o.value == 42, 0);
+        let ObjAny<Any> {id, value: _} = vector::pop_back(&mut v);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+    public entry fun child_access_any<Any>(child: ObjAny<Any>, v: vector<ObjAny<Any>>, _: &mut TxContext) {
+        let ObjAny<Any> {id, value} = child;
+        assert!(value == 42, 0);
+        object::delete(id);
+        let ObjAny<Any> {id, value} = vector::pop_back(&mut v);
+        assert!(value == 42, 0);
+        object::delete(id);
+        vector::destroy_empty(v);
+    }
+
+}
+
+// create an object and pass it as a single element of a vector (success)
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(106)]
+
+
+// create a parent/child object pair, pass child by-value and parent as a single element of a vector
+// to check if authentication works (success)
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::mint_child_any --sender A --type-args Test::M::Any --args 42 object(109)
+
+//# run Test::M::child_access_any --sender A --type-args Test::M::Any --args object(109) vector[object(111)]
+
+
+// create an object of one type and try to pass it as a single element of a vector whose elements
+// are of different type (failure)
+
+//# run Test::M::mint_another_any --type-args Test::M::Any --sender A --args 42
+
+//# run Test::M::obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(114)]
+
+
+// create two objects of different types and try to pass them both as elements of a vector (failure)
+
+//# run Test::M::mint_another_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::two_obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(117),object(119)]
+
+
+// create a shared object and try to pass it as a single element of a vector (failure)
+
+//# run Test::M::mint_shared_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::obj_vec_destroy_any --sender A --type-args Test::M::Any --args vector[object(122)]
+
+
+// create an object and pass it both by-value and as element of a vector (failure)
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::same_objects_any --sender A --type-args Test::M::Any --args object(125) vector[object(125)]
+
+
+// create an object and pass it both by-reference and as element of a vector (failure)
+
+//# run Test::M::mint_any --sender A --type-args Test::M::Any --args 42
+
+//# run Test::M::same_objects_ref_any --sender A --type-args Test::M::Any --args object(128) vector[object(128)]

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -601,99 +601,6 @@ async fn test_entry_point_vector() {
         effects.status
     );
 
-    // mint an owned object
-    let effects = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "mint",
-        vec![],
-        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
-    )
-    .await
-    .unwrap();
-    assert!(
-        matches!(effects.status, ExecutionStatus::Success { .. }),
-        "{:?}",
-        effects.status
-    );
-    let (obj_id, _, _) = effects.created[0].0;
-    // call a function with a vector containing the same owned object as another one passed as
-    // argument
-    let result = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "same_objects",
-        vec![],
-        vec![
-            TestCallArg::Object(obj_id),
-            TestCallArg::ObjVec(vec![obj_id]),
-        ],
-    )
-    .await;
-    // should fail as we have the same object passed in vector and as a separate by-value argument
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
-        result
-    );
-
-    // mint an owned object
-    let effects = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "mint",
-        vec![],
-        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
-    )
-    .await
-    .unwrap();
-    assert!(
-        matches!(effects.status, ExecutionStatus::Success { .. }),
-        "{:?}",
-        effects.status
-    );
-    let (obj_id, _, _) = effects.created[0].0;
-    // call a function with a vector containing the same owned object as another one passed as
-    // a reference argument
-    let result = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "same_objects_ref",
-        vec![],
-        vec![
-            TestCallArg::Object(obj_id),
-            TestCallArg::ObjVec(vec![obj_id]),
-        ],
-    )
-    .await;
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
-        result
-    );
-
     // mint a parent object and a child object and make sure that parent stored in the vector
     // authenticates the child passed by-value
     let effects = call_move(
@@ -919,6 +826,100 @@ async fn test_entry_point_vector_error() {
         "{:?}",
         effects.status
     );
+
+    // mint an owned object
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "mint",
+        vec![],
+        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    let (obj_id, _, _) = effects.created[0].0;
+    // call a function with a vector containing the same owned object as another one passed as
+    // argument
+    let result = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "same_objects",
+        vec![],
+        vec![
+            TestCallArg::Object(obj_id),
+            TestCallArg::ObjVec(vec![obj_id]),
+        ],
+    )
+    .await;
+    // should fail as we have the same object passed in vector and as a separate by-value argument
+    assert!(
+        matches!(
+            result.clone().err().unwrap(),
+            SuiError::DuplicateObjectRefInput { .. }
+        ),
+        "{:?}",
+        result
+    );
+
+    // mint an owned object
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "mint",
+        vec![],
+        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    let (obj_id, _, _) = effects.created[0].0;
+    // call a function with a vector containing the same owned object as another one passed as
+    // a reference argument
+    let result = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "same_objects_ref",
+        vec![],
+        vec![
+            TestCallArg::Object(obj_id),
+            TestCallArg::ObjVec(vec![obj_id]),
+        ],
+    )
+    .await;
+    // should fail as we have the same object passed in vector and as a separate by-reference argument
+    assert!(
+        matches!(
+            result.clone().err().unwrap(),
+            SuiError::DuplicateObjectRefInput { .. }
+        ),
+        "{:?}",
+        result
+    );
 }
 
 #[tokio::test]
@@ -977,99 +978,6 @@ async fn test_entry_point_vector_any() {
         matches!(effects.status, ExecutionStatus::Success { .. }),
         "{:?}",
         effects.status
-    );
-
-    // mint an owned object
-    let effects = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "mint_any",
-        vec![any_type_tag.clone()],
-        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
-    )
-    .await
-    .unwrap();
-    assert!(
-        matches!(effects.status, ExecutionStatus::Success { .. }),
-        "{:?}",
-        effects.status
-    );
-    let (obj_id, _, _) = effects.created[0].0;
-    // call a function with a vector containing the same owned object as another one passed as
-    // argument
-    let result = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "same_objects_any",
-        vec![any_type_tag.clone()],
-        vec![
-            TestCallArg::Object(obj_id),
-            TestCallArg::ObjVec(vec![obj_id]),
-        ],
-    )
-    .await;
-    // should fail as we have the same object passed in vector and as a separate by-value argument
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
-        result
-    );
-
-    // mint an owned object
-    let effects = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "mint_any",
-        vec![any_type_tag.clone()],
-        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
-    )
-    .await
-    .unwrap();
-    assert!(
-        matches!(effects.status, ExecutionStatus::Success { .. }),
-        "{:?}",
-        effects.status
-    );
-    let (obj_id, _, _) = effects.created[0].0;
-    // call a function with a vector containing the same owned object as another one passed as
-    // a reference argument
-    let result = call_move(
-        &authority,
-        &gas,
-        &sender,
-        &sender_key,
-        &package,
-        "entry_point_vector",
-        "same_objects_ref_any",
-        vec![any_type_tag.clone()],
-        vec![
-            TestCallArg::Object(obj_id),
-            TestCallArg::ObjVec(vec![obj_id]),
-        ],
-    )
-    .await;
-    assert!(
-        matches!(
-            result.clone().err().unwrap(),
-            SuiError::DuplicateObjectRefInput { .. }
-        ),
-        "{:?}",
-        result
     );
 
     // mint a parent object and a child object and make sure that parent stored in the vector
@@ -1299,6 +1207,99 @@ async fn test_entry_point_vector_any_error() {
         matches!(effects.status, ExecutionStatus::Failure { .. }),
         "{:?}",
         effects.status
+    );
+
+    // mint an owned object
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "mint_any",
+        vec![any_type_tag.clone()],
+        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    let (obj_id, _, _) = effects.created[0].0;
+    // call a function with a vector containing the same owned object as another one passed as
+    // argument
+    let result = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "same_objects_any",
+        vec![any_type_tag.clone()],
+        vec![
+            TestCallArg::Object(obj_id),
+            TestCallArg::ObjVec(vec![obj_id]),
+        ],
+    )
+    .await;
+    // should fail as we have the same object passed in vector and as a separate by-value argument
+    assert!(
+        matches!(
+            result.clone().err().unwrap(),
+            SuiError::DuplicateObjectRefInput { .. }
+        ),
+        "{:?}",
+        result
+    );
+
+    // mint an owned object
+    let effects = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "mint_any",
+        vec![any_type_tag.clone()],
+        vec![TestCallArg::Pure(bcs::to_bytes(&(42_u64)).unwrap())],
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(effects.status, ExecutionStatus::Success { .. }),
+        "{:?}",
+        effects.status
+    );
+    let (obj_id, _, _) = effects.created[0].0;
+    // call a function with a vector containing the same owned object as another one passed as
+    // a reference argument
+    let result = call_move(
+        &authority,
+        &gas,
+        &sender,
+        &sender_key,
+        &package,
+        "entry_point_vector",
+        "same_objects_ref_any",
+        vec![any_type_tag.clone()],
+        vec![
+            TestCallArg::Object(obj_id),
+            TestCallArg::ObjVec(vec![obj_id]),
+        ],
+    )
+    .await;
+    assert!(
+        matches!(
+            result.clone().err().unwrap(),
+            SuiError::DuplicateObjectRefInput { .. }
+        ),
+        "{:?}",
+        result
     );
 }
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -463,8 +463,7 @@ impl<'a> SuiTestAdapter<'a> {
         let objects_by_kind = transaction
             .signed_data
             .data
-            .input_objects()
-            .unwrap()
+            .input_objects()?
             .into_iter()
             .flat_map(|kind| {
                 let id = kind.object_id();


### PR DESCRIPTION
This is part 1 of transactional testing framework extension, this one to cover vectors of objects.

A diff for the changes in `move_integration_tests.rs` looks a bit odd but the only thing that happened there was moving "negative" tests (accidentally left in the "positive" tests section) to where they belong.