### PR TITLE
[move] Fixed framework version mismatch check via Move version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -3735,7 +3735,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3765,12 +3765,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3785,7 +3785,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3797,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "difference",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3953,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -3971,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "codespan",
@@ -3989,7 +3989,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4003,7 +4003,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "hex",
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -4266,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "log",
@@ -4288,7 +4288,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -4297,7 +4297,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "better_any",
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "better_any",
  "fail",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4406,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=05678c0533b6ffd5fcd91a6109648b6b089f55f3#05678c0533b6ffd5fcd91a6109648b6b089f55f3"
+source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,24 +71,24 @@ name-variant = "0.1.0"
 store = { version = "0.1.0", package = "typed-store" }
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-cli = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-package = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-prover = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-cli = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-package = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-prover = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
 
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -73,7 +73,7 @@ blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "check", "sha2", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -286,41 +286,41 @@ minimal-lexical = { version = "0.2", default-features = false, features = ["std"
 miniz_oxide = { version = "0.5", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-cli = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-cli = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 mysten-network = { version = "0.2", default-features = false }
@@ -417,8 +417,8 @@ rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen = { version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -680,7 +680,7 @@ bs58 = { version = "0.4", features = ["alloc", "check", "sha2", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 bumpalo = { version = "3" }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -923,41 +923,41 @@ miniz_oxide = { version = "0.5", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-cli = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-cli = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
@@ -1083,8 +1083,8 @@ rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen = { version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "05678c0533b6ffd5fcd91a6109648b6b089f55f3", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
This fixes a problem reported by @666lcz. The problem was related to the flakiness of the Sui framework version mismatch check implemented in https://github.com/MystenLabs/sui/pull/3967

In short, this check compares a version of Sui framework code "bundled" with the Sui binary (used to compile Move code) and a version of Sui framework code specified as a dependency in the code being compiled. If these two versions of the framework code are different, including the bytecode of all the framework modules, a version mismatch is reported, preventing the compilation process from succeeding.

The flakiness in this approach was related to a bug in the Move compiler fixed in https://github.com/move-language/move/pull/552 - an optimization pass (resulting in a different bytecode being generated) was being disabled if the compiler detected that any warnings were issues during the compilation process.

Consequently, if a warning was introduced in the user code, bytecode representing framework code representing a dependency was compiled without optimizations, whereas the framework code "bundled" with the binary was optimized - this resulted in spurious mismatch being reported despite the source of the framework code being the same in both cases.