### PR TITLE
[validator] Do not reuse signed tx from previous epoch

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -451,7 +451,11 @@ impl AuthorityState {
     ) -> Result<TransactionInfoResponse, SuiError> {
         let transaction_digest = *transaction.digest();
         // Ensure an idempotent answer.
-        if self.database.transaction_exists(&transaction_digest)? {
+        // If a transaction was signed in a previous epoch, we should no longer reuse it.
+        if self
+            .database
+            .transaction_exists(self.epoch(), &transaction_digest)?
+        {
             self.metrics.tx_already_processed.inc();
             let transaction_info = self.make_transaction_info(&transaction_digest).await?;
             return Ok(transaction_info);

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -150,14 +150,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .map_err(|e| e.into())
     }
 
-    /// Returns true if we have a transaction structure for this transaction digest
-    pub fn transaction_exists(&self, transaction_digest: &TransactionDigest) -> SuiResult<bool> {
-        self.tables
-            .transactions
-            .contains_key(transaction_digest)
-            .map_err(|e| e.into())
-    }
-
     /// Returns true if there are no objects in the database
     pub fn database_is_empty(&self) -> SuiResult<bool> {
         Ok(self
@@ -1383,6 +1375,20 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 }
 
 impl SuiDataStore<AuthoritySignInfo> {
+    /// Returns true if we have a transaction structure for this transaction digest
+    pub fn transaction_exists(
+        &self,
+        cur_epoch: EpochId,
+        transaction_digest: &TransactionDigest,
+    ) -> SuiResult<bool> {
+        let tx = self.tables.transactions.get(transaction_digest)?;
+        Ok(if let Some(signed_tx) = tx {
+            signed_tx.auth_sign_info.epoch == cur_epoch
+        } else {
+            false
+        })
+    }
+
     pub fn get_signed_transaction_info(
         &self,
         transaction_digest: &TransactionDigest,

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -464,7 +464,11 @@ async fn test_public_transfer_object_with_retry() {
         .is_err());
     assert!(gateway.store().effects_exists(&tx_digest).unwrap());
     // The transaction is deleted after this is done.
-    assert!(!gateway.store().transaction_exists(&tx_digest).unwrap());
+    assert!(gateway
+        .store()
+        .get_transaction(&tx_digest)
+        .unwrap()
+        .is_none());
     assert_eq!(gateway.store().next_sequence_number().unwrap(), 1);
     assert_eq!(
         gateway


### PR DESCRIPTION
A validator can have transaction signed from previous epochs.
When the same transaction is asked again in a new epoch, we should not return the same old signed transaction, instead we should think that it doesn't exit.