### PR TITLE
[reconfig] Avoid a data race in validator halt

### DIFF
--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -976,10 +976,10 @@ async fn test_batch_to_checkpointing() {
 
     // TODO: duplicated code in this file, in `test_batch_to_checkpointing_init_crash`
     {
-        let t0 = authority_state.batch_notifier.ticket().expect("ok");
-        let t1 = authority_state.batch_notifier.ticket().expect("ok");
-        let t2 = authority_state.batch_notifier.ticket().expect("ok");
-        let t3 = authority_state.batch_notifier.ticket().expect("ok");
+        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t1 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t2 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t3 = authority_state.batch_notifier.ticket(false).expect("ok");
 
         authority_state
             .database
@@ -1079,10 +1079,10 @@ async fn test_batch_to_checkpointing_init_crash() {
         let mut rx = authority_state.subscribe_batch();
 
         {
-            let t0 = authority_state.batch_notifier.ticket().expect("ok");
-            let t1 = authority_state.batch_notifier.ticket().expect("ok");
-            let t2 = authority_state.batch_notifier.ticket().expect("ok");
-            let t3 = authority_state.batch_notifier.ticket().expect("ok");
+            let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
+            let t1 = authority_state.batch_notifier.ticket(false).expect("ok");
+            let t2 = authority_state.batch_notifier.ticket(false).expect("ok");
+            let t3 = authority_state.batch_notifier.ticket(false).expect("ok");
 
             authority_state
                 .database

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -66,7 +66,7 @@ async fn test_start_epoch_change() {
     let active =
         ActiveAuthority::new_with_ephemeral_storage_for_test(state.clone(), net.clone()).unwrap();
     // Make the high watermark differ from low watermark.
-    let ticket = state.batch_notifier.ticket().unwrap();
+    let ticket = state.batch_notifier.ticket(false).unwrap();
 
     // Invoke start_epoch_change on the active authority.
     let epoch_change_started = Arc::new(AtomicBool::new(false));
@@ -161,7 +161,7 @@ async fn test_start_epoch_change() {
     let signed_effects = effects.to_sign_effects(0, &state.name, &*state.secret);
     assert_eq!(
         state
-            .commit_certificate(inner_temporary_store, &certificate, &signed_effects)
+            .commit_certificate(inner_temporary_store, &certificate, &signed_effects, false)
             .await
             .unwrap_err(),
         SuiError::ValidatorHaltedAtEpochEnd

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -187,7 +187,7 @@ async fn test_batch_manager_happy_path() {
 
     // Send a transaction.
     {
-        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
         store.side_sequence(t0.seq(), &ExecutionDigests::random());
         t0.notify();
     }
@@ -203,7 +203,7 @@ async fn test_batch_manager_happy_path() {
     assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
 
     {
-        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
         store.side_sequence(t0.seq(), &ExecutionDigests::random());
         t0.notify();
     }
@@ -247,10 +247,10 @@ async fn test_batch_manager_out_of_order() {
     let mut rx = authority_state.subscribe_batch();
 
     {
-        let t0 = authority_state.batch_notifier.ticket().expect("ok");
-        let t1 = authority_state.batch_notifier.ticket().expect("ok");
-        let t2 = authority_state.batch_notifier.ticket().expect("ok");
-        let t3 = authority_state.batch_notifier.ticket().expect("ok");
+        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t1 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t2 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t3 = authority_state.batch_notifier.ticket(false).expect("ok");
 
         store.side_sequence(t1.seq(), &ExecutionDigests::random());
         store.side_sequence(t3.seq(), &ExecutionDigests::random());
@@ -318,10 +318,10 @@ async fn test_batch_manager_drop_out_of_order() {
     // Send transactions out of order
     let mut rx = authority_state.subscribe_batch();
 
-    let t0 = authority_state.batch_notifier.ticket().expect("ok");
-    let t1 = authority_state.batch_notifier.ticket().expect("ok");
-    let t2 = authority_state.batch_notifier.ticket().expect("ok");
-    let t3 = authority_state.batch_notifier.ticket().expect("ok");
+    let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
+    let t1 = authority_state.batch_notifier.ticket(false).expect("ok");
+    let t2 = authority_state.batch_notifier.ticket(false).expect("ok");
+    let t3 = authority_state.batch_notifier.ticket(false).expect("ok");
 
     store.side_sequence(t1.seq(), &ExecutionDigests::random());
     t1.notify();
@@ -435,7 +435,7 @@ async fn test_batch_store_retrieval() {
 
     let inner_store = store.clone();
     for _i in 0u64..105 {
-        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
         inner_store
             .tables
             .executed_sequence
@@ -447,12 +447,12 @@ async fn test_batch_store_retrieval() {
     // Add a few out of order transactions that should be ignored
     // NOTE: gap between 105 and 110
     (105u64..110).into_iter().for_each(|_| {
-        let t = authority_state.batch_notifier.ticket().expect("ok");
+        let t = authority_state.batch_notifier.ticket(false).expect("ok");
         t.notify();
     });
 
     for _i in 110u64..120 {
-        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
         inner_store
             .tables
             .executed_sequence

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -128,7 +128,7 @@ async fn test_subscription() {
 
     let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
-        let ticket = state.batch_notifier.ticket().expect("all good");
+        let ticket = state.batch_notifier.ticket(false).expect("all good");
         db.tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
@@ -180,7 +180,10 @@ async fn test_subscription() {
     let _handle2 = tokio::spawn(async move {
         for i in 105..120 {
             tokio::time::sleep(Duration::from_millis(20)).await;
-            let ticket = inner_server2.batch_notifier.ticket().expect("all good");
+            let ticket = inner_server2
+                .batch_notifier
+                .ticket(false)
+                .expect("all good");
             db2.tables
                 .executed_sequence
                 .insert(&ticket.seq(), &tx_zero)
@@ -255,7 +258,10 @@ async fn test_subscription() {
 
     loop {
         // Send a transaction
-        let ticket = inner_server2.batch_notifier.ticket().expect("all good");
+        let ticket = inner_server2
+            .batch_notifier
+            .ticket(false)
+            .expect("all good");
         db3.tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
@@ -331,7 +337,7 @@ async fn test_subscription_safe_client() {
 
     let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
-        let ticket = server.state.batch_notifier.ticket().expect("all good");
+        let ticket = server.state.batch_notifier.ticket(false).expect("all good");
         db.tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
@@ -393,7 +399,7 @@ async fn test_subscription_safe_client() {
             let ticket = inner_server2
                 .state
                 .batch_notifier
-                .ticket()
+                .ticket(false)
                 .expect("all good");
             db2.tables
                 .executed_sequence
@@ -467,7 +473,7 @@ async fn test_subscription_safe_client() {
         let ticket = inner_server2
             .state
             .batch_notifier
-            .ticket()
+            .ticket(false)
             .expect("all good");
         db3.tables
             .executed_sequence


### PR DESCRIPTION
When the validator is halted, we check for it in a few places: when we enter handle_transaction / process _certificate; and when we are trying to acquire a ticket from batch notifier.
For the latter case, we first check if the validator is halted inside commit_certificate, and if not, we get a ticket.
A data race can happen if:
1. We first check if the validator is halted inside commit_certificate
2. The validator is halted
3. We then still can get a ticket.

To fix this, this PR moves the validator halt bool into the batch notifier, and rely on this single value to determine if the validator is halted.