### PR TITLE
use generate_network_key instead of generate_key on the benchmark demo

### DIFF
--- a/narwhal/benchmark/benchmark/full_demo.py
+++ b/narwhal/benchmark/benchmark/full_demo.py
@@ -99,7 +99,7 @@ class Demo:
             worker_key_files = [PathMaker.worker_key_file(
                 i) for i in range(self.workers*nodes)]
             for filename in worker_key_files:
-                cmd = CommandMaker.generate_key(filename).split()
+                cmd = CommandMaker.generate_network_key(filename).split()
                 subprocess.run(cmd, check=True)
                 worker_keys += [Key.from_file(filename)]
             worker_names = [x.name for x in worker_keys]


### PR DESCRIPTION
### Issue

https://github.com/MystenLabs/sui/issues/5072

### Work Contents

on `benchmark/benchmark/full_demo.py`

from

```python
            worker_keys = []
            worker_key_files = [PathMaker.worker_key_file(
                i) for i in range(self.workers*nodes)]
            for filename in worker_key_files:
                cmd = CommandMaker.generate_key(filename).split()
                subprocess.run(cmd, check=True)
                worker_keys += [Key.from_file(filename)]
            worker_names = [x.name for x in worker_keys]
```

to

```python
            worker_keys = []
            worker_key_files = [PathMaker.worker_key_file(
                i) for i in range(self.workers*nodes)]
            for filename in worker_key_files:
                cmd = CommandMaker.generate_network_key(filename).split()
                subprocess.run(cmd, check=True)
                worker_keys += [Key.from_file(filename)]
            worker_names = [x.name for x in worker_keys]
```

This is the same code as [benchmark/benchmark/local.py:L89](https://github.com/MystenLabs/narwhal/blob/103b9f481f321620ee3054e7964c7211f1a335d3/benchmark/benchmark/local.py#L89)

### how to check

```
$ cd benchmark
$ fab demo
```