### PR TITLE
sui: introduce state-sync process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8626,6 +8626,7 @@ version = "0.0.0"
 dependencies = [
  "anemo",
  "anemo-build",
+ "anyhow",
  "async-trait",
  "futures",
  "multiaddr",
@@ -8635,8 +8636,8 @@ dependencies = [
  "sui-config",
  "sui-types",
  "tap",
+ "telemetry-subscribers",
  "tokio",
- "tokio-stream",
  "tonic",
  "tonic-build",
  "tracing",

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
@@ -45,4 +45,74 @@ pub struct SeedPeer {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peer_id: Option<anemo::PeerId>,
     pub address: Multiaddr,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct StateSyncConfig {
+    /// Query peers for their latest checkpoint every interval period.
+    ///
+    /// If unspecified, this will default to `5,000` milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval_period_ms: Option<u64>,
+
+    /// Size of the StateSync actor's mailbox.
+    ///
+    /// If unspecified, this will default to `128`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mailbox_capacity: Option<usize>,
+
+    /// Size of the broadcast channel use for notifying other systems of newly sync'ed checkpoints.
+    ///
+    /// If unspecified, this will default to `128`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synced_checkpoint_broadcast_channel_capacity: Option<usize>,
+
+    /// Set the upper bound on the number of checkpoint headers to be downloaded concurrently.
+    ///
+    /// If unspecified, this will default to `100`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint_header_download_concurrency: Option<usize>,
+
+    /// Set the upper bound on the number of transactions to be downloaded concurrently from a
+    /// single checkpoint.
+    ///
+    /// If unspecified, this will default to `100`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_download_concurrency: Option<usize>,
+}
+
+impl StateSyncConfig {
+    pub fn interval_period(&self) -> Duration {
+        const INTERVAL_PERIOD_MS: u64 = 5_000; // 5 seconds
+
+        Duration::from_millis(self.interval_period_ms.unwrap_or(INTERVAL_PERIOD_MS))
+    }
+
+    pub fn mailbox_capacity(&self) -> usize {
+        const MAILBOX_CAPACITY: usize = 128;
+
+        self.mailbox_capacity.unwrap_or(MAILBOX_CAPACITY)
+    }
+
+    pub fn synced_checkpoint_broadcast_channel_capacity(&self) -> usize {
+        const SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY: usize = 128;
+
+        self.synced_checkpoint_broadcast_channel_capacity
+            .unwrap_or(SYNCED_CHECKPOINT_BROADCAST_CHANNEL_CAPACITY)
+    }
+
+    pub fn checkpoint_header_download_concurrency(&self) -> usize {
+        const CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY: usize = 100;
+
+        self.checkpoint_header_download_concurrency
+            .unwrap_or(CHECKPOINT_HEADER_DOWNLOAD_CONCURRENCY)
+    }
+
+    pub fn transaction_download_concurrency(&self) -> usize {
+        const TRANSACTION_DOWNLOAD_CONCURRENCY: usize = 100;
+
+        self.transaction_download_concurrency
+            .unwrap_or(TRANSACTION_DOWNLOAD_CONCURRENCY)
+    }
 }

--- a/crates/sui-network/Cargo.toml
+++ b/crates/sui-network/Cargo.toml
@@ -20,15 +20,15 @@ workspace-hack.workspace = true
 tokio = { version = "1.17.0", features = ["full"] }
 tracing = "0.1.37"
 futures = "0.3.24"
-tokio-stream = "0.1.11"
 multiaddr = "0.16.0"
 tap = "1.0.1"
 rand = "0.8.5"
+anyhow = "1.0.65"
 
 [build-dependencies]
 anemo-build.workspace = true
 tonic-build = { version = "0.8.2", features = [ "transport" ] }
 
 [dev-dependencies]
-rand = "0.8.5"
+telemetry-subscribers.workspace = true
 tokio = { version = "1.17.0", features = ["test-util"] }

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -133,7 +133,48 @@ fn build_anemo_services(out_dir: &Path) {
         )
         .build();
 
+    let state_sync = anemo_build::manual::Service::builder()
+        .name("StateSync")
+        .package("sui")
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("push_checkpoint_summary")
+                .route_name("PushCheckpointSummary")
+                .request_type("sui_types::messages_checkpoint::CertifiedCheckpointSummary")
+                .response_type("()")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_checkpoint_summary")
+                .route_name("GetCheckpointSummary")
+                .request_type("crate::state_sync::GetCheckpointSummaryRequest")
+                .response_type("Option<sui_types::messages_checkpoint::CertifiedCheckpointSummary>")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_checkpoint_contents")
+                .route_name("GetCheckpointContents")
+                .request_type("sui_types::messages_checkpoint::CheckpointContentsDigest")
+                .response_type("Option<sui_types::messages_checkpoint::CheckpointContents>")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_transaction_and_effects")
+                .route_name("GetTransactionAndEffects")
+                .request_type("sui_types::base_types::ExecutionDigests")
+                .response_type("Option<(sui_types::messages::Transaction, sui_types::messages::TransactionEffects)>")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
+        .build();
+
     anemo_build::manual::Builder::new()
         .out_dir(out_dir)
-        .compile(&[discovery]);
+        .compile(&[discovery, state_sync]);
 }

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -13,8 +13,10 @@ use std::{
 };
 use sui_config::p2p::{P2pConfig, SeedPeer};
 use tap::{Pipe, TapFallible};
-use tokio::sync::oneshot;
-use tokio::task::{AbortHandle, JoinSet};
+use tokio::{
+    sync::oneshot,
+    task::{AbortHandle, JoinSet},
+};
 use tracing::{debug, info, trace};
 
 const TIMEOUT: Duration = Duration::from_secs(1);

--- a/crates/sui-network/src/lib.rs
+++ b/crates/sui-network/src/lib.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 pub mod api;
 pub mod discovery;
+pub mod state_sync;
 pub mod utils;
 
 pub use tonic;

--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use sui_types::messages_checkpoint::VerifiedCheckpoint;
+use tap::Pipe;
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinSet,
+};
+
+use super::{
+    server::Server, Handle, PeerHeights, StateSync, StateSyncEventLoop, StateSyncMessage,
+    StateSyncServer,
+};
+use sui_types::storage::WriteStore;
+
+pub struct Builder<S> {
+    store: Option<S>,
+    // config: Option<Config>,
+}
+
+impl Builder<()> {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self { store: None }
+    }
+}
+
+impl<S> Builder<S> {
+    pub fn checkpoint_store<NewStore>(self, store: NewStore) -> Builder<NewStore> {
+        Builder { store: Some(store) }
+    }
+}
+
+impl<S> Builder<S>
+where
+    S: WriteStore + Clone + Send + Sync + 'static,
+{
+    pub fn build(self) -> (UnstartedStateSync<S>, StateSyncServer<impl StateSync>) {
+        let (builder, server) = self.build_internal();
+        (builder, StateSyncServer::new(server))
+    }
+
+    pub(super) fn build_internal(self) -> (UnstartedStateSync<S>, Server<S>) {
+        let Builder { store } = self;
+        let store = store.unwrap();
+
+        let (sender, mailbox) = mpsc::channel(128);
+        let (checkpoint_event_sender, _reciever) = tokio::sync::broadcast::channel(128);
+        let weak_sender = sender.downgrade();
+        let handle = Handle {
+            sender,
+            checkpoint_event_sender: checkpoint_event_sender.clone(),
+        };
+        let peer_heights = PeerHeights {
+            heights: HashMap::new(),
+            unprocessed_checkpoints: HashMap::new(),
+            sequence_number_to_digest: HashMap::new(),
+        }
+        .pipe(RwLock::new)
+        .pipe(Arc::new);
+
+        let server = Server {
+            store: store.clone(),
+            peer_heights: peer_heights.clone(),
+            sender: weak_sender,
+        };
+
+        (
+            UnstartedStateSync {
+                handle,
+                mailbox,
+                store,
+                peer_heights,
+                checkpoint_event_sender,
+            },
+            server,
+        )
+    }
+}
+
+pub struct UnstartedStateSync<S> {
+    pub(super) handle: Handle,
+    pub(super) mailbox: mpsc::Receiver<StateSyncMessage>,
+    pub(super) store: S,
+    pub(super) peer_heights: Arc<RwLock<PeerHeights>>,
+    pub(super) checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
+}
+
+impl<S> UnstartedStateSync<S>
+where
+    S: WriteStore + Clone + Send + Sync + 'static,
+{
+    pub(super) fn build(self, network: anemo::Network) -> (StateSyncEventLoop<S>, Handle) {
+        let Self {
+            handle,
+            mailbox,
+            store,
+            peer_heights,
+            checkpoint_event_sender,
+        } = self;
+
+        (
+            StateSyncEventLoop {
+                mailbox,
+                weak_sender: handle.sender.downgrade(),
+                tasks: JoinSet::new(),
+                sync_checkpoint_summaries_task: None,
+                sync_checkpoint_contents_task: None,
+                store,
+                peer_heights,
+                checkpoint_event_sender,
+                network,
+            },
+            handle,
+        )
+    }
+
+    pub fn start(self, network: anemo::Network) -> Handle {
+        let (event_loop, handle) = self.build(network);
+        tokio::spawn(event_loop.start());
+
+        handle
+    }
+}

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -1,0 +1,882 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Peer-to-peer data synchronization of checkpoints.
+//!
+//! This StateSync module is responsible for the synchronization and dissemination of checkpoints
+//! and the transactions, and their effects, contained within. This module is *not* responsible for
+//! the execution of the transactions included in a checkpoint, that process is left to another
+//! component in the system.
+//!
+//! # High-level Overview of StateSync
+//!
+//! StateSync discovers new checkpoints via a few different sources:
+//! 1. If this node is a Validator, checkpoints will be produced via consensus at which point
+//!    consensus can notify state-sync of the new checkpoint via [Handle::send_checkpoint].
+//! 2. A peer notifies us of the latest checkpoint which they have synchronized. State-Sync will
+//!    also periodically query its peers to discover what their latest checkpoint is.
+//!
+//! We keep track of two different watermarks:
+//! * highest_verified_checkpoint - This is the highest checkpoint header that we've locally
+//!   verified. This indicated that we have in our persistent store (and have verified) all
+//!   checkpoint headers up to and including this value.
+//! * highest_synced_checkpoint - This is the highest checkpoint that we've fully synchronized,
+//!   meaning we've downloaded and have in our persistent stores all of the transactions, and their
+//!   effects (but not the objects), for all checkpoints up to and including this point. This is
+//!   the watermark that is shared with other peers, either via notification or when they query for
+//!   our latest checkpoint, and is intended to be used as a guarantee of data availability.
+//!
+//! The [PeerHeights] struct is used to track the highest_synced_checkpoint watermark for all of
+//! our peers.
+//!
+//! When a new checkpoint is discovered, and we've determined that it is higher than our
+//! highest_verified_checkpoint, then StateSync will kick off a task to synchronize and verify all
+//! checkpoints between our highest_synced_checkpoint and the newly discovered checkpoint. This
+//! process is done by querying one of our peers for the checkpoints we're missing (using the
+//! [PeerHeights] struct as a way to intelligently select which peers have the data available for
+//! us to query) at which point we will locally verify the signatures on the checkpoint header with
+//! the appropriate committee (based on the epoch). As checkpoints are verified, the
+//! highest_synced_checkpoint watermark will be ratcheted up.
+//!
+//! Once we've ratcheted up our highest_verified_checkpoint, and if it is higher than
+//! highest_synced_checkpoint, StateSync will then kick off a task to synchronize the contents of
+//! all of the checkpoints from highest_synced_checkpoint..=highest_verified_checkpoint. After the
+//! contents of each checkpoint is fully downloaded, StateSync will update our
+//! highest_synced_checkpoint watermark and send out a notification on a broadcast channel
+//! indicating that a new checkpoint has been fully downloaded. Notifications on this broadcast
+//! channel will always be made in order. StateSync will also send out a notification to its peers
+//! of the newly synchronized checkpoint so that it can help other peers synchronize.
+
+// TODO
+// * When querying a peer make sure that we're sending to peers that are on the same "network" as
+// us. this means verifying their genesis or something else
+
+use anemo::{rpc::Status, types::PeerEvent, PeerId, Request, Response, Result};
+use anyhow::anyhow;
+use futures::{FutureExt, StreamExt};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+use sui_types::{
+    base_types::ExecutionDigests,
+    message_envelope::Message,
+    messages_checkpoint::{
+        CertifiedCheckpointSummary as Checkpoint, CheckpointContents, CheckpointContentsDigest,
+        CheckpointDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
+    },
+    storage::WriteStore,
+};
+use tap::{Pipe, TapFallible, TapOptional};
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::{AbortHandle, JoinSet},
+};
+use tracing::{debug, info, trace, warn};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/sui.StateSync.rs"));
+}
+mod builder;
+mod server;
+#[cfg(test)]
+mod tests;
+
+pub use builder::{Builder, UnstartedStateSync};
+pub use generated::{
+    state_sync_client::StateSyncClient,
+    state_sync_server::{StateSync, StateSyncServer},
+};
+pub use server::GetCheckpointSummaryRequest;
+
+/// A handle to the StateSync subsystem.
+///
+/// This handle can be cloned and shared. Once all copies of a StateSync system's Handle have been
+/// dropped, the StateSync system will be gracefully shutdown.
+#[derive(Clone, Debug)]
+pub struct Handle {
+    sender: mpsc::Sender<StateSyncMessage>,
+    checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
+}
+
+impl Handle {
+    /// Send a newly minted checkpoint from Consensus to StateSync so that it can be disseminated
+    /// to other nodes on the network.
+    ///
+    /// # Invariant
+    ///
+    /// Consensus must only notify StateSync of new checkpoints that have been fully committed to
+    /// persistent storage. This includes CheckpointContents and all Transactions and
+    /// TransactionEffects included therein.
+    pub async fn send_checkpoint(&self, checkpoint: VerifiedCheckpoint) {
+        self.sender
+            .send(StateSyncMessage::VerifiedCheckpoint(Box::new(checkpoint)))
+            .await
+            .unwrap()
+    }
+
+    /// Subscribe to the stream of checkpoints that have been fully synchronized and downloaded.
+    pub fn subscribe_to_synced_checkpoints(&self) -> broadcast::Receiver<VerifiedCheckpoint> {
+        self.checkpoint_event_sender.subscribe()
+    }
+}
+
+struct PeerHeights {
+    /// Table used to track the highest checkpoint for each of our peers.
+    ///
+    /// Today we don't have the concept of a "genesis checkpoint" so when a node starts up with an
+    /// empty db it won't have any checkpoints, the None case indicates this. If a node shows up in
+    /// this map then they support state-sync.
+    heights: HashMap<PeerId, Option<CheckpointSequenceNumber>>,
+    unprocessed_checkpoints: HashMap<CheckpointDigest, Checkpoint>,
+    sequence_number_to_digest: HashMap<CheckpointSequenceNumber, CheckpointDigest>,
+}
+
+impl PeerHeights {
+    pub fn highest_known_checkpoint(&self) -> Option<&Checkpoint> {
+        self.heights
+            .values()
+            .max()
+            .and_then(Clone::clone)
+            .and_then(|s| self.sequence_number_to_digest.get(&s))
+            .and_then(|digest| self.unprocessed_checkpoints.get(digest))
+    }
+
+    pub fn update_peer_height(&mut self, peer_id: PeerId, checkpoint: Option<Checkpoint>) {
+        use std::collections::hash_map::Entry;
+
+        let latest = checkpoint
+            .as_ref()
+            .map(|checkpoint| checkpoint.sequence_number());
+
+        match self.heights.entry(peer_id) {
+            Entry::Occupied(mut entry) => {
+                if latest > *entry.get() {
+                    entry.insert(latest);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(latest);
+            }
+        }
+
+        if let Some(checkpoint) = checkpoint {
+            self.insert_checkpoint(checkpoint);
+        }
+    }
+
+    pub fn cleanup_old_checkpoints(&mut self, sequence_number: CheckpointSequenceNumber) {
+        self.unprocessed_checkpoints
+            .retain(|_digest, checkpoint| checkpoint.sequence_number() > sequence_number);
+        self.sequence_number_to_digest
+            .retain(|&s, _digest| s > sequence_number);
+    }
+
+    pub fn insert_checkpoint(&mut self, checkpoint: Checkpoint) {
+        let digest = checkpoint.digest();
+        let sequence_number = checkpoint.sequence_number();
+        self.unprocessed_checkpoints.insert(digest, checkpoint);
+        self.sequence_number_to_digest
+            .insert(sequence_number, digest);
+    }
+
+    pub fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<&Checkpoint> {
+        self.sequence_number_to_digest
+            .get(&sequence_number)
+            .and_then(|digest| self.get_checkpoint_by_digest(digest))
+    }
+
+    pub fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<&Checkpoint> {
+        self.unprocessed_checkpoints.get(digest)
+    }
+}
+
+#[derive(Clone, Debug)]
+enum StateSyncMessage {
+    StartSyncJob,
+    // Validators will send this to the StateSyncEventLoop in order to kick off notifying our peers
+    // of the new checkpoint.
+    VerifiedCheckpoint(Box<VerifiedCheckpoint>),
+    // Notification that the checkpoint content sync task will send to the event loop in the event
+    // it was able to successfully sync a checkpoint's contents. If multiple checkpoints were
+    // synced at the same time, only the highest checkpoint is sent.
+    SyncedCheckpoint(Box<VerifiedCheckpoint>),
+}
+
+struct StateSyncEventLoop<S> {
+    mailbox: mpsc::Receiver<StateSyncMessage>,
+    /// Weak reference to our own mailbox
+    weak_sender: mpsc::WeakSender<StateSyncMessage>,
+
+    tasks: JoinSet<()>,
+    sync_checkpoint_summaries_task: Option<AbortHandle>,
+    sync_checkpoint_contents_task: Option<AbortHandle>,
+
+    store: S,
+    peer_heights: Arc<RwLock<PeerHeights>>,
+    checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
+    network: anemo::Network,
+}
+
+impl<S> StateSyncEventLoop<S>
+where
+    S: WriteStore + Clone + Send + Sync + 'static,
+{
+    // Note: A great deal of care is taken to ensure that all event handlers are non-asynchronous
+    // and that the only "await" points are from the select macro picking which event to handle.
+    // This ensures that the event loop is able to process events at a high speed and reduce the
+    // chance for building up a backlog of events to process.
+    pub async fn start(mut self) {
+        info!("State-Synchronizer started");
+
+        let mut interval = tokio::time::interval(Duration::from_secs(60 * 10));
+        let mut peer_events = {
+            let (subscriber, peers) = self.network.subscribe();
+            for peer_id in peers {
+                self.spawn_get_latest_from_peer(peer_id);
+            }
+            subscriber
+        };
+
+        loop {
+            tokio::select! {
+                now = interval.tick() => {
+                    self.handle_tick(now.into_std());
+                },
+                maybe_message = self.mailbox.recv() => {
+                    // Once all handles to our mailbox have been dropped this
+                    // will yield `None` and we can terminate the event loop
+                    if let Some(message) = maybe_message {
+                        self.handle_message(message);
+                    } else {
+                        break;
+                    }
+                },
+                peer_event = peer_events.recv() => {
+                    self.handle_peer_event(peer_event);
+                },
+                Some(task_result) = self.tasks.join_next() => {
+                    task_result.unwrap();
+
+                    if matches!(&self.sync_checkpoint_contents_task, Some(t) if t.is_finished()) {
+                        self.sync_checkpoint_contents_task = None;
+                    }
+
+                    if matches!(&self.sync_checkpoint_summaries_task, Some(t) if t.is_finished()) {
+                        self.sync_checkpoint_summaries_task = None;
+                    }
+                },
+            }
+
+            self.maybe_start_checkpoint_summary_sync_task();
+            self.maybe_start_checkpoint_contents_sync_task();
+        }
+
+        info!("State-Synchronizer ended");
+    }
+
+    fn handle_message(&mut self, message: StateSyncMessage) {
+        match message {
+            StateSyncMessage::StartSyncJob => self.maybe_start_checkpoint_summary_sync_task(),
+            StateSyncMessage::VerifiedCheckpoint(checkpoint) => {
+                self.handle_checkpoint_from_consensus(checkpoint)
+            }
+            // After we've successfully synced a checkpoint we can notify our peers
+            StateSyncMessage::SyncedCheckpoint(checkpoint) => {
+                self.spawn_notify_peers_of_checkpoint(*checkpoint)
+            }
+        }
+    }
+
+    // Handle a checkpoint that we received from consensus
+    fn handle_checkpoint_from_consensus(&mut self, checkpoint: Box<VerifiedCheckpoint>) {
+        let (next_sequence_number, previous_digest) = {
+            let latest_checkpoint = self.store.get_highest_verified_checkpoint();
+
+            // If this is an older checkpoint, just ignore it
+            if latest_checkpoint.as_ref().map(|x| x.sequence_number())
+                >= Some(checkpoint.sequence_number())
+            {
+                return;
+            }
+
+            let next_sequence_number = latest_checkpoint
+                .as_ref()
+                .map(|x| x.sequence_number().saturating_add(1))
+                .unwrap_or(0);
+            let previous_digest = latest_checkpoint.map(|x| x.digest());
+            (next_sequence_number, previous_digest)
+        };
+
+        // If this is exactly the next checkpoint then insert it and then notify our peers
+        if checkpoint.sequence_number() == next_sequence_number
+            && checkpoint.previous_digest() == previous_digest
+        {
+            let checkpoint = *checkpoint;
+
+            // Check invariant that consensus must only send state-sync fully synced checkpoints
+            #[cfg(debug_assertions)]
+            {
+                let contents = self
+                    .store
+                    .get_checkpoint_contents(&checkpoint.content_digest())
+                    .unwrap();
+                for digests in contents.into_inner() {
+                    debug_assert!(self.store.get_transaction(&digests.transaction).is_some());
+                    debug_assert!(self
+                        .store
+                        .get_transaction_effects(&digests.effects)
+                        .is_some());
+                }
+            }
+
+            self.store.insert_checkpoint(checkpoint.clone());
+            self.store.update_highest_synced_checkpoint(&checkpoint);
+
+            // We don't care if no one is listening as this is a broadcast channel
+            let _ = self.checkpoint_event_sender.send(checkpoint.clone());
+
+            self.spawn_notify_peers_of_checkpoint(checkpoint);
+        } else {
+            // Otherwise stick it with the other unprocessed checkpoints and we can try to sync the missing
+            // ones
+            self.peer_heights
+                .write()
+                .unwrap()
+                .insert_checkpoint(checkpoint.into_inner());
+            warn!("Consensus gave us too new of a checkpoint");
+        }
+    }
+
+    fn handle_peer_event(
+        &mut self,
+        peer_event: Result<PeerEvent, tokio::sync::broadcast::error::RecvError>,
+    ) {
+        use tokio::sync::broadcast::error::RecvError;
+
+        match peer_event {
+            Ok(PeerEvent::NewPeer(peer_id)) => {
+                self.spawn_get_latest_from_peer(peer_id);
+            }
+            Ok(PeerEvent::LostPeer(peer_id, _)) => {
+                self.peer_heights.write().unwrap().heights.remove(&peer_id);
+            }
+
+            Err(RecvError::Closed) => {
+                panic!("PeerEvent channel shouldn't be able to be closed");
+            }
+
+            Err(RecvError::Lagged(_)) => {
+                trace!("State-Sync fell behind processing PeerEvents");
+            }
+        }
+    }
+
+    fn spawn_get_latest_from_peer(&mut self, peer_id: PeerId) {
+        if let Some(peer) = self.network.peer(peer_id) {
+            let task = get_latest_from_peer(peer, self.peer_heights.clone());
+            self.tasks.spawn(task);
+        }
+    }
+
+    fn handle_tick(&mut self, _now: std::time::Instant) {
+        let task = query_peers_for_their_latest_checkpoint(
+            self.network.clone(),
+            self.peer_heights.clone(),
+            self.weak_sender.clone(),
+        );
+        self.tasks.spawn(task);
+    }
+
+    fn maybe_start_checkpoint_summary_sync_task(&mut self) {
+        // Only run one sync task at a time
+        if self.sync_checkpoint_summaries_task.is_some() {
+            return;
+        }
+
+        let highest_processed_checkpoint = self.store.get_highest_verified_checkpoint();
+
+        let highest_known_checkpoint = self
+            .peer_heights
+            .read()
+            .unwrap()
+            .highest_known_checkpoint()
+            .cloned();
+
+        if highest_processed_checkpoint.map(|x| x.sequence_number())
+            < highest_known_checkpoint
+                .as_ref()
+                .map(|x| x.sequence_number())
+        {
+            // start sync job
+            let task = sync_to_checkpoint(
+                self.network.clone(),
+                self.store.clone(),
+                self.peer_heights.clone(),
+                // The if condition should ensure that this is Some
+                highest_known_checkpoint.unwrap(),
+            )
+            .map(|result| match result {
+                Ok(()) => {}
+                Err(e) => {
+                    debug!("error syncing checkpoint {e}");
+                }
+            });
+            let task_handle = self.tasks.spawn(task);
+            self.sync_checkpoint_summaries_task = Some(task_handle);
+        }
+    }
+
+    fn maybe_start_checkpoint_contents_sync_task(&mut self) {
+        // Only run one sync task at a time
+        if self.sync_checkpoint_contents_task.is_some() {
+            return;
+        }
+
+        let highest_verified_checkpoint = self.store.get_highest_verified_checkpoint();
+        let highest_synced_checkpoint = self.store.get_highest_synced_checkpoint();
+
+        if highest_verified_checkpoint
+            .as_ref()
+            .map(|x| x.sequence_number())
+            > highest_synced_checkpoint
+                .as_ref()
+                .map(|x| x.sequence_number())
+        {
+            let task = sync_checkpoint_contents(
+                self.network.clone(),
+                self.store.clone(),
+                self.peer_heights.clone(),
+                self.weak_sender.clone(),
+                self.checkpoint_event_sender.clone(),
+                // The if condition should ensure that this is Some
+                highest_verified_checkpoint.unwrap(),
+            );
+
+            let task_handle = self.tasks.spawn(task);
+            self.sync_checkpoint_contents_task = Some(task_handle);
+        }
+    }
+
+    fn spawn_notify_peers_of_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
+        let task =
+            notify_peers_of_checkpoint(self.network.clone(), self.peer_heights.clone(), checkpoint);
+        self.tasks.spawn(task);
+    }
+}
+
+async fn notify_peers_of_checkpoint(
+    network: anemo::Network,
+    peer_heights: Arc<RwLock<PeerHeights>>,
+    checkpoint: VerifiedCheckpoint,
+) {
+    let futs = peer_heights
+        .read()
+        .unwrap()
+        .heights
+        .iter()
+        // Filter out any peers who we know already have a checkpoint higher than this one
+        .filter(|(_peer_id, &height)| Some(checkpoint.sequence_number()) > height)
+        .map(|(peer_id, _height)| peer_id)
+        // Filter out any peers who we aren't connected with
+        .flat_map(|peer_id| network.peer(*peer_id))
+        .map(StateSyncClient::new)
+        .map(|mut client| {
+            let request = Request::new(checkpoint.inner().clone()).with_timeout(DEFAULT_TIMEOUT);
+            async move { client.push_checkpoint_summary(request).await }
+        })
+        .collect::<Vec<_>>();
+    futures::future::join_all(futs).await;
+}
+
+async fn get_latest_from_peer(peer: anemo::Peer, peer_heights: Arc<RwLock<PeerHeights>>) {
+    let peer_id = peer.peer_id();
+    let request = Request::new(GetCheckpointSummaryRequest::Latest).with_timeout(DEFAULT_TIMEOUT);
+    let response = StateSyncClient::new(peer)
+        .get_checkpoint_summary(request)
+        .await
+        .map(Response::into_inner);
+    update_peer_height(&peer_heights, peer_id, &response);
+}
+
+fn update_peer_height(
+    peer_heights: &RwLock<PeerHeights>,
+    peer_id: PeerId,
+    response: &Result<Option<Checkpoint>, Status>,
+) {
+    match response {
+        Ok(latest) => {
+            peer_heights
+                .write()
+                .unwrap()
+                .update_peer_height(peer_id, latest.clone());
+        }
+        Err(status) => {
+            trace!("get_latest_checkpoint_summary request failed: {status:?}");
+            peer_heights.write().unwrap().heights.remove(&peer_id);
+        }
+    }
+}
+
+async fn query_peers_for_their_latest_checkpoint(
+    network: anemo::Network,
+    peer_heights: Arc<RwLock<PeerHeights>>,
+    sender: mpsc::WeakSender<StateSyncMessage>,
+) {
+    let peer_heights = &peer_heights;
+    let futs = peer_heights
+        .read()
+        .unwrap()
+        .heights
+        .keys()
+        // Filter out any peers who we aren't connected with
+        .flat_map(|peer_id| network.peer(*peer_id))
+        .map(|peer| {
+            let peer_id = peer.peer_id();
+            let mut client = StateSyncClient::new(peer);
+
+            let request =
+                Request::new(GetCheckpointSummaryRequest::Latest).with_timeout(DEFAULT_TIMEOUT);
+            async move {
+                let response = client
+                    .get_checkpoint_summary(request)
+                    .await
+                    .map(Response::into_inner);
+                update_peer_height(peer_heights, peer_id, &response);
+                response
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let checkpoints = futures::future::join_all(futs)
+        .await
+        .into_iter()
+        .flatten()
+        .flatten();
+
+    let highest_checkpoint = checkpoints.max_by_key(|checkpoint| checkpoint.sequence_number());
+
+    let our_highest_checkpoint = peer_heights
+        .read()
+        .unwrap()
+        .highest_known_checkpoint()
+        .cloned();
+
+    let _new_checkpoint = match (highest_checkpoint, our_highest_checkpoint) {
+        (Some(theirs), None) => theirs,
+        (Some(theirs), Some(ours)) if theirs.sequence_number() > ours.sequence_number() => theirs,
+        _ => return,
+    };
+
+    if let Some(sender) = sender.upgrade() {
+        let _ = sender.send(StateSyncMessage::StartSyncJob).await;
+    }
+}
+
+async fn sync_to_checkpoint<S: WriteStore>(
+    network: anemo::Network,
+    store: S,
+    peer_heights: Arc<RwLock<PeerHeights>>,
+    checkpoint: Checkpoint,
+) -> Result<()> {
+    let mut current = store.get_highest_verified_checkpoint();
+    if current.as_ref().map(|x| x.sequence_number()) >= Some(checkpoint.sequence_number()) {
+        return Err(anyhow::anyhow!(
+            "target checkpoint {} is older than highest verified checkpoint {}",
+            checkpoint.sequence_number(),
+            current.map(|x| x.sequence_number()).unwrap_or(0)
+        ));
+    }
+
+    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_entropy();
+    // get a list of peers that can help
+    let peers = peer_heights
+        .read()
+        .unwrap()
+        .heights
+        .iter()
+        // Filter out any peers who can't help
+        .filter(|(_peer_id, &height)| height > current.as_ref().map(|x| x.sequence_number()))
+        .map(|(&peer_id, &height)| (peer_id, height))
+        .collect::<Vec<_>>();
+
+    // range of the next sequence_numbers to fetch
+    let mut request_stream = (current
+        .as_ref()
+        .map(|x| x.sequence_number().saturating_add(1))
+        .unwrap_or(0)..=checkpoint.sequence_number())
+        .map(|next| {
+            let mut peers = peers
+                .iter()
+                // Filter out any peers who can't help with this particular checkpoint
+                .filter(|(_peer_id, height)| height >= &Some(next))
+                // Filter out any peers who we aren't connected with
+                .flat_map(|(peer_id, _height)| network.peer(*peer_id))
+                .map(StateSyncClient::new)
+                .collect::<Vec<_>>();
+            rand::seq::SliceRandom::shuffle(peers.as_mut_slice(), &mut rng);
+            let peer_heights = peer_heights.clone();
+            async move {
+                if let Some(checkpoint) = peer_heights
+                    .read()
+                    .unwrap()
+                    .get_checkpoint_by_sequence_number(next)
+                {
+                    return (Some(checkpoint.to_owned()), next);
+                }
+
+                // Iterate through our selected peers trying each one in turn until we're able to
+                // successfully get the target checkpoint
+                for mut peer in peers {
+                    let request = Request::new(GetCheckpointSummaryRequest::BySequenceNumber(next))
+                        .with_timeout(DEFAULT_TIMEOUT);
+                    if let Some(checkpoint) = peer
+                        .get_checkpoint_summary(request)
+                        .await
+                        .tap_err(|e| trace!("{e:?}"))
+                        .ok()
+                        .and_then(Response::into_inner)
+                        .tap_none(|| trace!("peer unable to help sync"))
+                    {
+                        // peer didn't give us a checkpoint with the height that we requested
+                        if checkpoint.sequence_number() != next {
+                            continue;
+                        }
+
+                        // Insert in our store in the event that things fail and we need to retry
+                        peer_heights
+                            .write()
+                            .unwrap()
+                            .insert_checkpoint(checkpoint.clone());
+                        return (Some(checkpoint), next);
+                    }
+                }
+
+                (None, next)
+            }
+        })
+        .pipe(futures::stream::iter)
+        .buffered(20);
+
+    while let Some((maybe_checkpoint, next)) = request_stream.next().await {
+        // Verify the checkpoint
+        let checkpoint = {
+            let checkpoint = maybe_checkpoint
+                .ok_or_else(|| anyhow::anyhow!("no peers where able to help sync"))?;
+
+            if checkpoint.sequence_number() != next
+                || current.as_ref().map(|x| x.digest()) != checkpoint.previous_digest()
+            {
+                return Err(anyhow::anyhow!("detected fork"));
+            }
+
+            let current_epoch = current.as_ref().map(|x| x.epoch()).unwrap_or(0);
+            if checkpoint.epoch() != current_epoch
+                && checkpoint.epoch() != current_epoch.saturating_add(1)
+            {
+                return Err(anyhow::anyhow!(
+                    "cannot verify checkpoint with too high of an epoch {}, current epoch {}",
+                    checkpoint.epoch(),
+                    current_epoch,
+                ));
+            }
+
+            if checkpoint.epoch() == current_epoch.saturating_add(1)
+                && current
+                    .as_ref()
+                    .and_then(|x| x.next_epoch_committee())
+                    .is_none()
+            {
+                return Err(anyhow::anyhow!(
+                    "next checkpoint claims to be from the next epoch but the latest verified \
+                    checkpoint does not indicate that it is the last checkpoint of an epoch"
+                ));
+            }
+
+            let committee = store
+                .get_committee(checkpoint.epoch())
+                .expect("BUG: should have a committee for an epoch before we try to verify checkpoints from an epoch");
+            VerifiedCheckpoint::new(checkpoint, &committee).map_err(|(_, e)| e)?
+        };
+
+        current = Some(checkpoint.clone());
+        // Insert the newly verified checkpoint into our store, which will bump our highest
+        // verified checkpoint watermark as well.
+        store.insert_checkpoint(checkpoint.clone());
+    }
+
+    peer_heights
+        .write()
+        .unwrap()
+        .cleanup_old_checkpoints(checkpoint.sequence_number());
+
+    Ok(())
+}
+
+async fn sync_checkpoint_contents<S: WriteStore + Clone>(
+    network: anemo::Network,
+    store: S,
+    peer_heights: Arc<RwLock<PeerHeights>>,
+    sender: mpsc::WeakSender<StateSyncMessage>,
+    checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
+    target_checkpoint: VerifiedCheckpoint,
+) {
+    let mut highest_synced = None;
+
+    for checkpoint in (store
+        .get_highest_synced_checkpoint()
+        .map(|x| x.sequence_number().saturating_add(1))
+        .unwrap_or(0)..=target_checkpoint.sequence_number())
+        .map(|next| {
+            store.get_checkpoint_by_sequence_number(next).expect(
+                "BUG: store should have all checkpoints older than highest_verified_checkpoint",
+            )
+        })
+    {
+        match sync_one_checkpoint_contents(
+            network.clone(),
+            &store,
+            peer_heights.clone(),
+            checkpoint,
+        )
+        .await
+        {
+            Ok(checkpoint) => {
+                store.update_highest_synced_checkpoint(&checkpoint);
+                // We don't care if no one is listening as this is a broadcast channel
+                let _ = checkpoint_event_sender.send(checkpoint.clone());
+                highest_synced = Some(checkpoint);
+            }
+            Err(err) => {
+                debug!("unable to sync contents of checkpoint: {err}");
+                break;
+            }
+        }
+    }
+
+    // Notify event loop to notify our peers that we've synced to a new checkpoint height
+    if let Some(checkpoint) = highest_synced {
+        if let Some(sender) = sender.upgrade() {
+            let message = StateSyncMessage::SyncedCheckpoint(Box::new(checkpoint));
+            let _ = sender.send(message).await;
+        }
+    }
+}
+
+async fn sync_one_checkpoint_contents<S: WriteStore + Clone>(
+    network: anemo::Network,
+    store: S,
+    peer_heights: Arc<RwLock<PeerHeights>>,
+    checkpoint: VerifiedCheckpoint,
+) -> Result<VerifiedCheckpoint> {
+    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::from_entropy();
+    // get a list of peers that can help
+    let mut peers = peer_heights
+        .read()
+        .unwrap()
+        .heights
+        .iter()
+        // Filter out any peers who can't help with this particular checkpoint
+        .filter(|(_peer_id, &height)| height >= Some(checkpoint.sequence_number()))
+        // Filter out any peers who we aren't connected with
+        .flat_map(|(peer_id, _height)| network.peer(*peer_id))
+        .map(StateSyncClient::new)
+        .collect::<Vec<_>>();
+    rand::seq::SliceRandom::shuffle(peers.as_mut_slice(), &mut rng);
+
+    let Some(contents) = get_checkpoint_contents(&mut peers, &store, checkpoint.content_digest()).await else {
+        return Err(anyhow!("unable to sync checkpoint contents for checkpoint {}", checkpoint.sequence_number()));
+    };
+
+    // Sync transactions and effects
+    let mut stream = contents
+        .into_inner()
+        .into_iter()
+        .map(|digests| get_transaction_and_effects(peers.clone(), store.clone(), digests))
+        .pipe(futures::stream::iter)
+        .buffer_unordered(100);
+
+    while let Some(result) = stream.next().await {
+        result?;
+    }
+
+    Ok(checkpoint)
+}
+
+async fn get_checkpoint_contents<S: WriteStore>(
+    peers: &mut [StateSyncClient<anemo::Peer>],
+    store: S,
+    digest: CheckpointContentsDigest,
+) -> Option<CheckpointContents> {
+    if let Some(contents) = store.get_checkpoint_contents(&digest) {
+        return Some(contents);
+    }
+
+    // Iterate through our selected peers trying each one in turn until we're able to
+    // successfully get the target checkpoint
+    for peer in peers.iter_mut() {
+        let request = Request::new(digest).with_timeout(DEFAULT_TIMEOUT);
+        if let Some(contents) = peer
+            .get_checkpoint_contents(request)
+            .await
+            .tap_err(|e| trace!("{e:?}"))
+            .ok()
+            .and_then(Response::into_inner)
+            .tap_none(|| trace!("peer unable to help sync"))
+        {
+            if digest == contents.digest() {
+                store.insert_checkpoint_contents(contents.clone());
+                return Some(contents);
+            }
+        }
+    }
+
+    None
+}
+
+async fn get_transaction_and_effects<S: WriteStore>(
+    peers: Vec<StateSyncClient<anemo::Peer>>,
+    store: S,
+    digests: ExecutionDigests,
+) -> Result<()> {
+    if let (Some(_transaction), Some(_effects)) = (
+        store.get_transaction(&digests.transaction),
+        store.get_transaction_effects(&digests.effects),
+    ) {
+        return Ok(());
+    }
+
+    // Iterate through our selected peers trying each one in turn until we're able to
+    // successfully get the target checkpoint
+    for mut peer in peers {
+        let request = Request::new(digests).with_timeout(DEFAULT_TIMEOUT);
+        if let Some((transaction, effects)) = peer
+            .get_transaction_and_effects(request)
+            .await
+            .tap_err(|e| trace!("{e:?}"))
+            .ok()
+            .and_then(Response::into_inner)
+            .tap_none(|| trace!("peer unable to help sync"))
+        {
+            if transaction.digest() == &digests.transaction
+                && effects.digest() == digests.effects
+                && effects.transaction_digest == digests.transaction
+            {
+                store.insert_transaction(transaction);
+                store.insert_transaction_effects(effects);
+                return Ok(());
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "unable to sync transaction {:?} from any of our peers",
+        digests.transaction
+    ))
+}

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{PeerHeights, StateSync, StateSyncMessage};
+use anemo::{rpc::Status, Request, Response, Result};
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, RwLock};
+use sui_types::{
+    base_types::ExecutionDigests,
+    messages::{Transaction, TransactionEffects},
+    messages_checkpoint::{
+        CertifiedCheckpointSummary as Checkpoint, CheckpointContents, CheckpointContentsDigest,
+        CheckpointDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
+    },
+    storage::WriteStore,
+};
+use tokio::sync::mpsc;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum GetCheckpointSummaryRequest {
+    Latest,
+    ByDigest(CheckpointDigest),
+    BySequenceNumber(CheckpointSequenceNumber),
+}
+
+pub(super) struct Server<S> {
+    pub(super) store: S,
+    pub(super) peer_heights: Arc<RwLock<PeerHeights>>,
+    pub(super) sender: mpsc::WeakSender<StateSyncMessage>,
+}
+
+#[anemo::async_trait]
+impl<S> StateSync for Server<S>
+where
+    S: WriteStore + Send + Sync + 'static,
+{
+    async fn push_checkpoint_summary(
+        &self,
+        request: Request<Checkpoint>,
+    ) -> Result<Response<()>, Status> {
+        let peer_id = request
+            .peer_id()
+            .copied()
+            .ok_or_else(|| Status::internal("unable to query sender's PeerId"))?;
+
+        let checkpoint = request.into_inner();
+
+        self.peer_heights
+            .write()
+            .unwrap()
+            .update_peer_height(peer_id, Some(checkpoint.clone()));
+
+        let highest_verified_checkpoint = self
+            .store
+            .get_highest_verified_checkpoint()
+            .map(|x| x.sequence_number());
+
+        // If this checkpoint is higher than our highest verified checkpoint notify the
+        // event loop to potentially sync it
+        if Some(checkpoint.sequence_number()) > highest_verified_checkpoint {
+            if let Some(sender) = self.sender.upgrade() {
+                sender.send(StateSyncMessage::StartSyncJob).await.unwrap();
+            }
+        }
+
+        Ok(Response::new(()))
+    }
+
+    async fn get_checkpoint_summary(
+        &self,
+        request: Request<GetCheckpointSummaryRequest>,
+    ) -> Result<Response<Option<Checkpoint>>, Status> {
+        let checkpoint = match request.inner() {
+            GetCheckpointSummaryRequest::Latest => self.store.get_highest_synced_checkpoint(),
+            GetCheckpointSummaryRequest::ByDigest(digest) => {
+                self.store.get_checkpoint_by_digest(digest)
+            }
+            GetCheckpointSummaryRequest::BySequenceNumber(sequence_number) => self
+                .store
+                .get_checkpoint_by_sequence_number(*sequence_number),
+        }
+        .map(VerifiedCheckpoint::into_inner);
+
+        Ok(Response::new(checkpoint))
+    }
+
+    async fn get_checkpoint_contents(
+        &self,
+        request: Request<CheckpointContentsDigest>,
+    ) -> Result<Response<Option<CheckpointContents>>, Status> {
+        let contents = self.store.get_checkpoint_contents(request.inner());
+
+        Ok(Response::new(contents))
+    }
+
+    async fn get_transaction_and_effects(
+        &self,
+        request: Request<ExecutionDigests>,
+    ) -> Result<Response<Option<(Transaction, TransactionEffects)>>, Status> {
+        let ExecutionDigests {
+            transaction,
+            effects,
+        } = request.into_inner();
+
+        let Some(transaction) = self.store.get_transaction(&transaction) else {
+            return Ok(Response::new(None));
+        };
+
+        let Some(effects) = self.store.get_transaction_effects(&effects) else {
+            return Ok(Response::new(None));
+        };
+
+        Ok(Response::new(Some((transaction, effects))))
+    }
+}

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -39,7 +39,7 @@ async fn server_push_checkpoint() {
             ..
         },
         server,
-    ) = Builder::new().checkpoint_store(store).build_internal();
+    ) = Builder::new().store(store).build_internal();
     let peer_id = PeerId([9; 32]); // fake PeerId
 
     let checkpoint = ordered_checkpoints[0].inner().to_owned();
@@ -78,7 +78,7 @@ async fn server_push_checkpoint() {
 #[tokio::test]
 async fn server_get_checkpoint() {
     let (builder, server) = Builder::new()
-        .checkpoint_store(SharedInMemoryStore::default())
+        .store(SharedInMemoryStore::default())
         .build_internal();
 
     // Requests for checkpoints that aren't in the server's store
@@ -146,14 +146,10 @@ async fn isolated_sync_job() {
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
 
     // Build and connect two nodes
-    let (builder, server) = Builder::new()
-        .checkpoint_store(SharedInMemoryStore::default())
-        .build();
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (mut event_loop_1, _handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new()
-        .checkpoint_store(SharedInMemoryStore::default())
-        .build();
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, _handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();
@@ -230,14 +226,10 @@ async fn sync_with_checkpoints_being_inserted() {
     let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
 
     // Build and connect two nodes
-    let (builder, server) = Builder::new()
-        .checkpoint_store(SharedInMemoryStore::default())
-        .build();
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new()
-        .checkpoint_store(SharedInMemoryStore::default())
-        .build();
+    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -1,0 +1,488 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    state_sync::{
+        Builder, GetCheckpointSummaryRequest, StateSync, StateSyncMessage, UnstartedStateSync,
+    },
+    utils::build_network,
+};
+use anemo::{PeerId, Request};
+use std::{collections::HashMap, time::Duration};
+use sui_types::{
+    base_types::AuthorityName,
+    committee::{Committee, EpochId, StakeUnit},
+    crypto::{
+        AuthorityKeyPair, AuthoritySignInfo, AuthoritySignature, AuthorityWeakQuorumSignInfo,
+        KeypairTraits, SuiAuthoritySignature,
+    },
+    messages_checkpoint::{
+        CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest, CheckpointSequenceNumber,
+        CheckpointSummary, VerifiedCheckpoint,
+    },
+    storage::{ReadStore, SharedInMemoryStore, WriteStore},
+};
+use tokio::time::timeout;
+
+#[tokio::test]
+async fn server_push_checkpoint() {
+    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
+    let (ordered_checkpoints, _sequence_number_to_digest, _checkpoints) =
+        committee.make_checkpoints(1, None);
+    let store = SharedInMemoryStore::default();
+
+    let (
+        UnstartedStateSync {
+            handle: _handle,
+            mut mailbox,
+            peer_heights,
+            ..
+        },
+        server,
+    ) = Builder::new().checkpoint_store(store).build_internal();
+    let peer_id = PeerId([9; 32]); // fake PeerId
+
+    let checkpoint = ordered_checkpoints[0].inner().to_owned();
+    let request = Request::new(checkpoint.clone()).with_extension(peer_id);
+    server.push_checkpoint_summary(request).await.unwrap();
+
+    assert_eq!(
+        peer_heights.read().unwrap().heights.get(&peer_id),
+        Some(&Some(0))
+    );
+    assert_eq!(
+        peer_heights
+            .read()
+            .unwrap()
+            .unprocessed_checkpoints
+            .get(&checkpoint.digest())
+            .unwrap()
+            .summary,
+        checkpoint.summary,
+    );
+    assert_eq!(
+        peer_heights
+            .read()
+            .unwrap()
+            .highest_known_checkpoint()
+            .unwrap()
+            .summary,
+        checkpoint.summary,
+    );
+    assert!(matches!(
+        mailbox.try_recv().unwrap(),
+        StateSyncMessage::StartSyncJob
+    ));
+}
+
+#[tokio::test]
+async fn server_get_checkpoint() {
+    let (builder, server) = Builder::new()
+        .checkpoint_store(SharedInMemoryStore::default())
+        .build_internal();
+
+    // Requests for checkpoints that aren't in the server's store
+    let requests = [
+        GetCheckpointSummaryRequest::Latest,
+        GetCheckpointSummaryRequest::BySequenceNumber(9),
+        GetCheckpointSummaryRequest::ByDigest([10; 32]),
+    ];
+    for request in requests {
+        let response = server
+            .get_checkpoint_summary(Request::new(request))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(response.is_none());
+    }
+
+    // Populate the node's store with some checkpoints
+    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
+    let (ordered_checkpoints, _sequence_number_to_digest, _checkpoints) =
+        committee.make_checkpoints(3, None);
+    for checkpoint in ordered_checkpoints.clone() {
+        builder.store.inner_mut().insert_checkpoint(checkpoint)
+    }
+    let latest = ordered_checkpoints.last().unwrap().clone();
+    builder
+        .store
+        .inner_mut()
+        .update_highest_synced_checkpoint(&latest);
+
+    let request = Request::new(GetCheckpointSummaryRequest::Latest);
+    let response = server
+        .get_checkpoint_summary(request)
+        .await
+        .unwrap()
+        .into_inner()
+        .unwrap();
+    assert_eq!(response.summary, latest.summary);
+
+    for checkpoint in ordered_checkpoints {
+        let request = Request::new(GetCheckpointSummaryRequest::ByDigest(checkpoint.digest()));
+        let response = server
+            .get_checkpoint_summary(request)
+            .await
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        assert_eq!(response.summary, checkpoint.summary);
+
+        let request = Request::new(GetCheckpointSummaryRequest::BySequenceNumber(
+            checkpoint.sequence_number(),
+        ));
+        let response = server
+            .get_checkpoint_summary(request)
+            .await
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        assert_eq!(response.summary, checkpoint.summary);
+    }
+}
+
+#[tokio::test]
+async fn isolated_sync_job() {
+    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
+
+    // Build and connect two nodes
+    let (builder, server) = Builder::new()
+        .checkpoint_store(SharedInMemoryStore::default())
+        .build();
+    let network_1 = build_network(|router| router.add_rpc_service(server));
+    let (mut event_loop_1, _handle_1) = builder.build(network_1.clone());
+    let (builder, server) = Builder::new()
+        .checkpoint_store(SharedInMemoryStore::default())
+        .build();
+    let network_2 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_2, _handle_2) = builder.build(network_2.clone());
+    network_1.connect(network_2.local_addr()).await.unwrap();
+
+    // Init the root committee in both nodes
+    event_loop_1
+        .store
+        .inner_mut()
+        .insert_committee(committee.committee().to_owned());
+    event_loop_2
+        .store
+        .inner_mut()
+        .insert_committee(committee.committee().to_owned());
+
+    // build mock data
+    let (ordered_checkpoints, sequence_number_to_digest, checkpoints) =
+        committee.make_checkpoints(100, None);
+
+    // Node 2 will have all the data
+    {
+        let mut store = event_loop_2.store.inner_mut();
+        for checkpoint in ordered_checkpoints.clone() {
+            store.insert_checkpoint(checkpoint);
+        }
+    }
+
+    // Node 1 will know that Node 2 has the data
+    event_loop_1
+        .peer_heights
+        .write()
+        .unwrap()
+        .update_peer_height(
+            network_2.peer_id(),
+            ordered_checkpoints
+                .last()
+                .cloned()
+                .map(VerifiedCheckpoint::into_inner),
+        );
+
+    // Sync the data
+    event_loop_1.maybe_start_checkpoint_summary_sync_task();
+    event_loop_1.tasks.join_next().await.unwrap().unwrap();
+    assert_eq!(
+        ordered_checkpoints.last().map(|x| &x.summary),
+        event_loop_1
+            .store
+            .get_highest_verified_checkpoint()
+            .as_ref()
+            .map(|x| &x.summary)
+    );
+
+    {
+        let store = event_loop_1.store.inner();
+        let expected = checkpoints
+            .iter()
+            .map(|(key, value)| (key, &value.summary))
+            .collect::<HashMap<_, _>>();
+        let actual = store
+            .checkpoints()
+            .iter()
+            .map(|(key, value)| (key, &value.summary))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(actual, expected);
+        assert_eq!(
+            store.checkpoint_sequence_number_to_digest(),
+            &sequence_number_to_digest
+        );
+    }
+}
+
+#[tokio::test]
+async fn sync_with_checkpoints_being_inserted() {
+    telemetry_subscribers::init_for_testing();
+    let committee = CommitteeFixture::generate(rand::rngs::OsRng, 0, 4);
+
+    // Build and connect two nodes
+    let (builder, server) = Builder::new()
+        .checkpoint_store(SharedInMemoryStore::default())
+        .build();
+    let network_1 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_1, handle_1) = builder.build(network_1.clone());
+    let (builder, server) = Builder::new()
+        .checkpoint_store(SharedInMemoryStore::default())
+        .build();
+    let network_2 = build_network(|router| router.add_rpc_service(server));
+    let (event_loop_2, handle_2) = builder.build(network_2.clone());
+    network_1.connect(network_2.local_addr()).await.unwrap();
+
+    // Init the root committee in both nodes
+    event_loop_1
+        .store
+        .inner_mut()
+        .insert_committee(committee.committee().to_owned());
+    event_loop_2
+        .store
+        .inner_mut()
+        .insert_committee(committee.committee().to_owned());
+
+    // get handles to each node's stores
+    let store_1 = event_loop_1.store.clone();
+    let store_2 = event_loop_2.store.clone();
+    // make sure that node_1 knows about node_2
+    event_loop_1
+        .peer_heights
+        .write()
+        .unwrap()
+        .heights
+        .insert(network_2.peer_id(), None);
+    // Start both event loops
+    tokio::spawn(event_loop_1.start());
+    tokio::spawn(event_loop_2.start());
+
+    // build mock data
+    let (ordered_checkpoints, sequence_number_to_digest, checkpoints) =
+        committee.make_checkpoints(4, None);
+
+    let mut subscriber_1 = handle_1.subscribe_to_synced_checkpoints();
+    let mut subscriber_2 = handle_2.subscribe_to_synced_checkpoints();
+
+    // Inject one checkpoint and verify that it was shared with the other node
+    let mut checkpoint_iter = ordered_checkpoints.clone().into_iter();
+    store_1.insert_checkpoint_contents(empty_contents());
+    handle_1
+        .send_checkpoint(checkpoint_iter.next().unwrap())
+        .await;
+
+    timeout(Duration::from_secs(1), async {
+        assert_eq!(
+            subscriber_1.recv().await.unwrap().summary(),
+            ordered_checkpoints[0].summary(),
+        );
+        assert_eq!(
+            subscriber_2.recv().await.unwrap().summary(),
+            ordered_checkpoints[0].summary()
+        );
+    })
+    .await
+    .unwrap();
+
+    // Inject all the checkpoints
+    for checkpoint in checkpoint_iter {
+        handle_1.send_checkpoint(checkpoint).await;
+    }
+
+    timeout(Duration::from_secs(1), async {
+        for checkpoint in &ordered_checkpoints[1..] {
+            assert_eq!(
+                subscriber_1.recv().await.unwrap().summary(),
+                checkpoint.summary()
+            );
+            assert_eq!(
+                subscriber_2.recv().await.unwrap().summary(),
+                checkpoint.summary()
+            );
+        }
+    })
+    .await
+    .unwrap();
+
+    let store_1 = store_1.inner();
+    let store_2 = store_2.inner();
+    assert_eq!(
+        ordered_checkpoints.last().map(|x| x.digest()),
+        store_1
+            .get_highest_verified_checkpoint()
+            .as_ref()
+            .map(|x| x.digest())
+    );
+    assert_eq!(
+        ordered_checkpoints.last().map(|x| x.digest()),
+        store_2
+            .get_highest_verified_checkpoint()
+            .as_ref()
+            .map(|x| x.digest())
+    );
+
+    let expected = checkpoints
+        .iter()
+        .map(|(key, value)| (key, &value.summary))
+        .collect::<HashMap<_, _>>();
+    let actual_1 = store_1
+        .checkpoints()
+        .iter()
+        .map(|(key, value)| (key, &value.summary))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(actual_1, expected);
+    assert_eq!(
+        store_1.checkpoint_sequence_number_to_digest(),
+        &sequence_number_to_digest
+    );
+
+    let actual_2 = store_2
+        .checkpoints()
+        .iter()
+        .map(|(key, value)| (key, &value.summary))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(actual_2, expected);
+    assert_eq!(
+        store_2.checkpoint_sequence_number_to_digest(),
+        &sequence_number_to_digest
+    );
+}
+
+struct CommitteeFixture {
+    epoch: EpochId,
+    validators: HashMap<AuthorityName, (AuthorityKeyPair, StakeUnit)>,
+    committee: Committee,
+}
+
+impl CommitteeFixture {
+    pub fn generate<R: ::rand::RngCore + ::rand::CryptoRng>(
+        mut rng: R,
+        epoch: EpochId,
+        committee_size: usize,
+    ) -> Self {
+        let validators = (0..committee_size)
+            .map(|_| sui_types::crypto::get_key_pair_from_rng::<AuthorityKeyPair, _>(&mut rng).1)
+            .map(|keypair| (keypair.public().into(), (keypair, 1)))
+            .collect::<HashMap<_, _>>();
+
+        let committee = Committee::new(
+            epoch,
+            validators
+                .iter()
+                .map(|(name, (_, stake))| (*name, *stake))
+                .collect(),
+        )
+        .unwrap();
+
+        Self {
+            epoch,
+            validators,
+            committee,
+        }
+    }
+
+    pub fn committee(&self) -> &Committee {
+        &self.committee
+    }
+
+    fn create_root_checkpoint(&self) -> VerifiedCheckpoint {
+        assert_eq!(self.epoch, 0, "root checkpoint must be epoch 0");
+        let checkpoint = CheckpointSummary {
+            epoch: 0,
+            sequence_number: 0,
+            content_digest: empty_contents().digest(),
+            previous_digest: None,
+            gas_cost_summary: Default::default(),
+            next_epoch_committee: None,
+        };
+
+        self.create_certified_checkpoint(checkpoint)
+    }
+
+    fn create_certified_checkpoint(&self, checkpoint: CheckpointSummary) -> VerifiedCheckpoint {
+        let signatures = self
+            .validators
+            .iter()
+            .map(|(name, (key, _))| {
+                let signature = AuthoritySignature::new(&checkpoint, checkpoint.epoch, key);
+                AuthoritySignInfo {
+                    epoch: checkpoint.epoch,
+                    authority: *name,
+                    signature,
+                }
+            })
+            .collect();
+
+        let checkpoint = CertifiedCheckpointSummary {
+            summary: checkpoint,
+            auth_signature: AuthorityWeakQuorumSignInfo::new_from_auth_sign_infos(
+                signatures,
+                self.committee(),
+            )
+            .unwrap(),
+        };
+
+        let checkpoint = VerifiedCheckpoint::new(checkpoint, self.committee()).unwrap();
+
+        checkpoint
+    }
+
+    pub fn make_checkpoints(
+        &self,
+        number_of_checkpoints: usize,
+        previous_checkpoint: Option<VerifiedCheckpoint>,
+    ) -> (
+        Vec<VerifiedCheckpoint>,
+        HashMap<CheckpointSequenceNumber, CheckpointDigest>,
+        HashMap<CheckpointDigest, VerifiedCheckpoint>,
+    ) {
+        // Only skip the first one if it was supplied
+        let skip = previous_checkpoint.is_some() as usize;
+        let first = previous_checkpoint.unwrap_or_else(|| self.create_root_checkpoint());
+
+        let ordered_checkpoints = std::iter::successors(Some(first), |prev| {
+            let summary = CheckpointSummary {
+                epoch: self.epoch,
+                sequence_number: prev.summary.sequence_number + 1,
+                content_digest: empty_contents().digest(),
+                previous_digest: Some(prev.summary.digest()),
+                gas_cost_summary: Default::default(),
+                next_epoch_committee: None,
+            };
+
+            let checkpoint = self.create_certified_checkpoint(summary);
+
+            Some(checkpoint)
+        })
+        .skip(skip)
+        .take(number_of_checkpoints)
+        .collect::<Vec<_>>();
+
+        let (sequence_number_to_digest, checkpoints) = ordered_checkpoints
+            .iter()
+            .cloned()
+            .map(|checkpoint| {
+                let digest = checkpoint.summary.digest();
+                (
+                    (checkpoint.summary.sequence_number, digest),
+                    (digest, checkpoint),
+                )
+            })
+            .unzip();
+
+        (ordered_checkpoints, sequence_number_to_digest, checkpoints)
+    }
+}
+
+pub fn empty_contents() -> CheckpointContents {
+    CheckpointContents::new_with_causally_ordered_transactions(std::iter::empty())
+}

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -1,7 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::base_types::SuiAddress;
+use crate::base_types::{SuiAddress, TransactionDigest, TransactionEffectsDigest};
+use crate::committee::{Committee, EpochId};
+use crate::message_envelope::Message;
+use crate::messages::{Transaction, TransactionEffects};
+use crate::messages_checkpoint::{
+    CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+    VerifiedCheckpoint,
+};
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::SuiResult,
@@ -12,7 +19,7 @@ use crate::{
 use move_core_types::ident_str;
 use move_core_types::identifier::{IdentStr, Identifier};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum WriteKind {
@@ -155,5 +162,331 @@ impl<S: ChildObjectResolver> ChildObjectResolver for std::sync::Arc<S> {
 impl<S: ChildObjectResolver> ChildObjectResolver for &S {
     fn read_child_object(&self, parent: &ObjectID, child: &ObjectID) -> SuiResult<Option<Object>> {
         ChildObjectResolver::read_child_object(*self, parent, child)
+    }
+}
+
+pub trait ReadStore {
+    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint>;
+
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<VerifiedCheckpoint>;
+
+    fn get_highest_verified_checkpoint(&self) -> Option<VerifiedCheckpoint>;
+
+    fn get_highest_synced_checkpoint(&self) -> Option<VerifiedCheckpoint>;
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<CheckpointContents>;
+
+    fn get_committee(&self, epoch: EpochId) -> Option<Committee>;
+
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Transaction>;
+
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionEffectsDigest,
+    ) -> Option<TransactionEffects>;
+}
+
+impl<T: ReadStore> ReadStore for &T {
+    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
+        ReadStore::get_checkpoint_by_digest(*self, digest)
+    }
+
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<VerifiedCheckpoint> {
+        ReadStore::get_checkpoint_by_sequence_number(*self, sequence_number)
+    }
+
+    fn get_highest_verified_checkpoint(&self) -> Option<VerifiedCheckpoint> {
+        ReadStore::get_highest_verified_checkpoint(*self)
+    }
+
+    fn get_highest_synced_checkpoint(&self) -> Option<VerifiedCheckpoint> {
+        ReadStore::get_highest_synced_checkpoint(*self)
+    }
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<CheckpointContents> {
+        ReadStore::get_checkpoint_contents(*self, digest)
+    }
+
+    fn get_committee(&self, epoch: EpochId) -> Option<Committee> {
+        ReadStore::get_committee(*self, epoch)
+    }
+
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Transaction> {
+        ReadStore::get_transaction(*self, digest)
+    }
+
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionEffectsDigest,
+    ) -> Option<TransactionEffects> {
+        ReadStore::get_transaction_effects(*self, digest)
+    }
+}
+
+pub trait WriteStore: ReadStore {
+    // Insert a verified checkpoint
+    fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint);
+    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint);
+    fn insert_checkpoint_contents(&self, contents: CheckpointContents);
+
+    fn insert_committee(&self, new_committee: Committee);
+
+    fn insert_transaction(&self, transaction: Transaction);
+    fn insert_transaction_effects(&self, transaction_effects: TransactionEffects);
+}
+
+impl<T: WriteStore> WriteStore for &T {
+    fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint) {
+        WriteStore::insert_checkpoint(*self, checkpoint)
+    }
+
+    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
+        WriteStore::update_highest_synced_checkpoint(*self, checkpoint)
+    }
+
+    fn insert_checkpoint_contents(&self, contents: CheckpointContents) {
+        WriteStore::insert_checkpoint_contents(*self, contents)
+    }
+
+    fn insert_committee(&self, new_committee: Committee) {
+        WriteStore::insert_committee(*self, new_committee)
+    }
+
+    fn insert_transaction(&self, transaction: Transaction) {
+        WriteStore::insert_transaction(*self, transaction)
+    }
+
+    fn insert_transaction_effects(&self, transaction_effects: TransactionEffects) {
+        WriteStore::insert_transaction_effects(*self, transaction_effects)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct InMemoryStore {
+    highest_verified_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
+    highest_synced_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
+    // highest_executed_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
+    checkpoints: HashMap<CheckpointDigest, VerifiedCheckpoint>,
+    sequence_number_to_digest: HashMap<CheckpointSequenceNumber, CheckpointDigest>,
+    checkpoint_contents: HashMap<CheckpointContentsDigest, CheckpointContents>,
+    transactions: HashMap<TransactionDigest, Transaction>,
+    effects: HashMap<TransactionEffectsDigest, TransactionEffects>,
+
+    epoch_to_committee: Vec<Committee>,
+}
+
+impl InMemoryStore {
+    pub fn get_checkpoint_by_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> Option<&VerifiedCheckpoint> {
+        self.checkpoints.get(digest)
+    }
+
+    pub fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<&VerifiedCheckpoint> {
+        self.sequence_number_to_digest
+            .get(&sequence_number)
+            .and_then(|digest| self.get_checkpoint_by_digest(digest))
+    }
+
+    pub fn get_highest_verified_checkpoint(&self) -> Option<&VerifiedCheckpoint> {
+        self.highest_verified_checkpoint
+            .as_ref()
+            .and_then(|(_, digest)| self.get_checkpoint_by_digest(digest))
+    }
+
+    pub fn get_highest_synced_checkpoint(&self) -> Option<&VerifiedCheckpoint> {
+        self.highest_synced_checkpoint
+            .as_ref()
+            .and_then(|(_, digest)| self.get_checkpoint_by_digest(digest))
+    }
+
+    pub fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<&CheckpointContents> {
+        self.checkpoint_contents.get(digest)
+    }
+
+    pub fn insert_checkpoint_contents(&mut self, contents: CheckpointContents) {
+        self.checkpoint_contents.insert(contents.digest(), contents);
+    }
+
+    // Insert a verified checkpoint
+    pub fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
+        let digest = checkpoint.digest();
+        let sequence_number = checkpoint.sequence_number();
+
+        if let Some(next_committee) = checkpoint.next_epoch_committee() {
+            let next_committee = next_committee.iter().cloned().collect();
+            let committee = Committee::new(checkpoint.epoch().saturating_add(1), next_committee)
+                .expect("new committee from consensus should be constructable");
+            self.insert_committee(committee);
+        }
+
+        // Update latest
+        if Some(sequence_number) > self.highest_verified_checkpoint.map(|x| x.0) {
+            self.highest_verified_checkpoint = Some((sequence_number, digest));
+        }
+
+        self.checkpoints.insert(digest, checkpoint);
+        self.sequence_number_to_digest
+            .insert(sequence_number, digest);
+    }
+
+    pub fn update_highest_synced_checkpoint(&mut self, checkpoint: &VerifiedCheckpoint) {
+        if !self.checkpoints.contains_key(&checkpoint.digest()) {
+            panic!("store should already contain checkpoint");
+        }
+
+        self.highest_synced_checkpoint = Some((checkpoint.sequence_number(), checkpoint.digest()));
+    }
+
+    pub fn checkpoints(&self) -> &HashMap<CheckpointDigest, VerifiedCheckpoint> {
+        &self.checkpoints
+    }
+
+    pub fn checkpoint_sequence_number_to_digest(
+        &self,
+    ) -> &HashMap<CheckpointSequenceNumber, CheckpointDigest> {
+        &self.sequence_number_to_digest
+    }
+
+    pub fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<&Committee> {
+        self.epoch_to_committee.get(epoch as usize)
+    }
+
+    pub fn insert_committee(&mut self, committee: Committee) {
+        let epoch = committee.epoch as usize;
+
+        if self.epoch_to_committee.get(epoch).is_some() {
+            return;
+        }
+
+        if self.epoch_to_committee.len() == epoch {
+            self.epoch_to_committee.push(committee);
+        } else {
+            panic!("committe was inserted into EpochCommitteeMap out of order");
+        }
+    }
+
+    pub fn get_transaction(&self, digest: &TransactionDigest) -> Option<&Transaction> {
+        self.transactions.get(digest)
+    }
+
+    pub fn get_transaction_effects(
+        &self,
+        digest: &TransactionEffectsDigest,
+    ) -> Option<&TransactionEffects> {
+        self.effects.get(digest)
+    }
+
+    pub fn insert_transaction(&mut self, transaction: Transaction) {
+        self.transactions.insert(*transaction.digest(), transaction);
+    }
+
+    pub fn insert_transaction_effects(&mut self, effects: TransactionEffects) {
+        self.effects.insert(effects.digest(), effects);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SharedInMemoryStore(std::sync::Arc<std::sync::RwLock<InMemoryStore>>);
+
+impl SharedInMemoryStore {
+    pub fn inner(&self) -> std::sync::RwLockReadGuard<'_, InMemoryStore> {
+        self.0.read().unwrap()
+    }
+
+    pub fn inner_mut(&self) -> std::sync::RwLockWriteGuard<'_, InMemoryStore> {
+        self.0.write().unwrap()
+    }
+}
+
+impl ReadStore for SharedInMemoryStore {
+    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
+        self.inner().get_checkpoint_by_digest(digest).cloned()
+    }
+
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<VerifiedCheckpoint> {
+        self.inner()
+            .get_checkpoint_by_sequence_number(sequence_number)
+            .cloned()
+    }
+
+    fn get_highest_verified_checkpoint(&self) -> Option<VerifiedCheckpoint> {
+        self.inner().get_highest_verified_checkpoint().cloned()
+    }
+
+    fn get_highest_synced_checkpoint(&self) -> Option<VerifiedCheckpoint> {
+        self.inner().get_highest_synced_checkpoint().cloned()
+    }
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<CheckpointContents> {
+        self.inner().get_checkpoint_contents(digest).cloned()
+    }
+
+    fn get_committee(&self, epoch: EpochId) -> Option<Committee> {
+        self.inner().get_committee_by_epoch(epoch).cloned()
+    }
+
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<Transaction> {
+        self.inner().get_transaction(digest).cloned()
+    }
+
+    fn get_transaction_effects(
+        &self,
+        digest: &TransactionEffectsDigest,
+    ) -> Option<TransactionEffects> {
+        self.inner().get_transaction_effects(digest).cloned()
+    }
+}
+
+impl WriteStore for SharedInMemoryStore {
+    fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint) {
+        self.inner_mut().insert_checkpoint(checkpoint)
+    }
+
+    fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
+        self.inner_mut()
+            .update_highest_synced_checkpoint(checkpoint)
+    }
+
+    fn insert_checkpoint_contents(&self, contents: CheckpointContents) {
+        self.inner_mut().insert_checkpoint_contents(contents)
+    }
+
+    fn insert_committee(&self, new_committee: Committee) {
+        self.inner_mut().insert_committee(new_committee)
+    }
+
+    fn insert_transaction(&self, transaction: Transaction) {
+        self.inner_mut().insert_transaction(transaction)
+    }
+
+    fn insert_transaction_effects(&self, transaction_effects: TransactionEffects) {
+        self.inner_mut()
+            .insert_transaction_effects(transaction_effects)
     }
 }

--- a/crates/sui-types/src/storage.rs
+++ b/crates/sui-types/src/storage.rs
@@ -236,7 +236,6 @@ impl<T: ReadStore> ReadStore for &T {
 }
 
 pub trait WriteStore: ReadStore {
-    // Insert a verified checkpoint
     fn insert_checkpoint(&self, checkpoint: VerifiedCheckpoint);
     fn update_highest_synced_checkpoint(&self, checkpoint: &VerifiedCheckpoint);
     fn insert_checkpoint_contents(&self, contents: CheckpointContents);
@@ -277,7 +276,6 @@ impl<T: WriteStore> WriteStore for &T {
 pub struct InMemoryStore {
     highest_verified_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
     highest_synced_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
-    // highest_executed_checkpoint: Option<(CheckpointSequenceNumber, CheckpointDigest)>,
     checkpoints: HashMap<CheckpointDigest, VerifiedCheckpoint>,
     sequence_number_to_digest: HashMap<CheckpointSequenceNumber, CheckpointDigest>,
     checkpoint_contents: HashMap<CheckpointContentsDigest, CheckpointContents>,
@@ -327,7 +325,6 @@ impl InMemoryStore {
         self.checkpoint_contents.insert(contents.digest(), contents);
     }
 
-    // Insert a verified checkpoint
     pub fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
         let digest = checkpoint.digest();
         let sequence_number = checkpoint.sequence_number();


### PR DESCRIPTION
Module comment which provides a high level overview of state-sync:

Peer-to-peer data synchronization of checkpoints.

This StateSync module is responsible for the synchronization and dissemination of checkpoints
and the transactions, and their effects, contained within. This module is *not* responsible for
the execution of the transactions included in a checkpoint, that process is left to another
component in the system.

# High-level Overview of StateSync

StateSync discovers new checkpoints via a few different sources:
1. If this node is a Validator, checkpoints will be produced via consensus at which point
   consensus can notify state-sync of the new checkpoint via [Handle::send_checkpoint].
2. A peer notifies us of the latest checkpoint which they have synchronized. State-Sync will
   also periodically query its peers to discover what their latest checkpoint is.

We keep track of two different watermarks:
* highest_trusted_checkpoint - This is the highest checkpoint header that we've locally
  verified. This indicated that we have in our persistent store (and have verified) all
  checkpoint headers up to and including this value.
* highest_synced_checkpoint - This is the highest checkpoint that we've fully synchronized,
  meaning we've downloaded and have in our persistent stores all of the transactions, and their
  effects (but not the objects), for all checkpoints up to and including this point. This is
  the watermark that is shared with other peers, either via notification or when they query for
  our latest checkpoint, and is intended to be used as a guarantee of data availability.

The [PeerHeights] struct is used to track the highest_synced_checkpoint watermark for all of
our peers.

When a new checkpoint is discovered, and we've determined that it is higher than our
highest_trusted_checkpoint, then StateSync will kick off a task to synchronize and verify all
checkpoints between our highest_synced_checkpoint and the newly discovered checkpoint. This
process is done by querying one of our peers for the checkpoints we're missing (using the
[PeerHeights] struct as a way to intelligently select which peers have the data available for
us to query) at which point we will locally verify the signatures on the checkpoint header with
the appropriate committee (based on the epoch). As checkpoints are verified, the
highest_synced_checkpoint watermark will be ratcheted up.

Once we've ratcheted up our highest_trusted_checkpoint, and if it is higher than
highest_synced_checkpoint, StateSync will then kick off a task to synchronize the contents of
all of the checkpoints from highest_synced_checkpoint..=highest_trusted_checkpoint. After the
contents of each checkpoint is fully downloaded, StateSync will update our
highest_synced_checkpoint watermark and send out a notification on a broadcast channel
indicating that a new checkpoint has been fully downloaded. Notifications on this broadcast
channel will always be made in order. StateSync will also send out a notification to its peers
of the newly synchronized checkpoint so that it can help other peers synchronize.
