### PR TITLE
narwhal: fix narwhal tests and stop primary handler from blocking on deadlock

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -7,9 +7,6 @@ outputs:
   isRust:
     description: True when changes happened to the Rust code
     value: "${{ steps.diff.outputs.isRust }}"
-  isNarwhal:
-    description: True when changes happened to the Narwhal code
-    value: "${{ steps.diff.outputs.isNarwhal }}"
 runs:
   using: composite
   steps:
@@ -29,5 +26,3 @@ runs:
           - 'doc/**'
           - '*.md'
           - '.github/workflows/docs.yml'
-        isNarwhal:
-          - 'narwhal/**'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: [ubuntu-latest]
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
-      isNarwhal: ${{ steps.diff.outputs.isNarwhal }}
     steps:
     - uses: actions/checkout@v3
     - name: Detect Changes
@@ -73,36 +72,14 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: cargo test
         run: |
-          cargo nextest run --profile ci -E 'not package(~narwhal)'
+          cargo nextest run --profile ci
+      - name: narwhal celo crypto tests
+        run: |
+          cargo nextest run --features celo --profile ci -p narwhal-crypto
+          cargo test --doc --features celo -p narwhal-crypto
       - name: Doctests
         run: |
           cargo test --doc
-      # Ensure there are no uncommitted changes in the repo after running tests
-      - run: scripts/changed-files.sh
-        shell: bash
-
-  test-narwhal:
-    needs: diff
-    if: needs.diff.outputs.isNarwhal == 'true'
-    timeout-minutes: 45
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - [ubuntu-ghcloud]
-      fail-fast: false
-    env:
-      RUSTFLAGS: -D warnings
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-      - uses: taiki-e/install-action@nextest
-      - name: cargo test
-        run: |
-          cargo nextest run --features celo --profile ci -E 'package(~narwhal)'
-      - name: Doctests
-        run: |
-          cargo test --doc --features celo
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -566,58 +566,47 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
         let message = request.into_body();
 
         match message {
-            PrimaryMessage::CertificatesRequest(_, _) => self
+            PrimaryMessage::CertificatesRequest(_, _)
+            | PrimaryMessage::CertificatesBatchRequest { .. }
+            | PrimaryMessage::PayloadAvailabilityRequest { .. } => self
                 .tx_helper_requests
-                .send(message)
-                .await
-                .map_err(|_| DagError::ShuttingDown),
+                .try_send(message)
+                .map_err(DagError::from),
+
             PrimaryMessage::CertificatesRangeResponse {
                 certificate_ids,
                 from,
             } => self
                 .tx_availability_responses
-                .send(AvailabilityResponse::CertificateDigest(
+                .try_send(AvailabilityResponse::CertificateDigest(
                     CertificateDigestsResponse {
                         certificate_ids,
                         from,
                     },
                 ))
-                .await
-                .map_err(|_| DagError::ShuttingDown),
-            PrimaryMessage::CertificatesBatchRequest { .. } => self
-                .tx_helper_requests
-                .send(message)
-                .await
-                .map_err(|_| DagError::ShuttingDown),
+                .map_err(DagError::from),
             PrimaryMessage::CertificatesBatchResponse { certificates, from } => self
                 .tx_availability_responses
-                .send(AvailabilityResponse::Certificate(CertificatesResponse {
+                .try_send(AvailabilityResponse::Certificate(CertificatesResponse {
                     certificates,
                     from,
                 }))
-                .await
-                .map_err(|_| DagError::ShuttingDown),
-            PrimaryMessage::PayloadAvailabilityRequest { .. } => self
-                .tx_helper_requests
-                .send(message)
-                .await
-                .map_err(|_| DagError::ShuttingDown),
+                .map_err(DagError::from),
             PrimaryMessage::PayloadAvailabilityResponse {
                 payload_availability,
                 from,
             } => self
                 .tx_availability_responses
-                .send(AvailabilityResponse::Payload(PayloadAvailabilityResponse {
+                .try_send(AvailabilityResponse::Payload(PayloadAvailabilityResponse {
                     block_ids: payload_availability.to_vec(),
-                    from: from.clone(),
+                    from,
                 }))
-                .await
-                .map_err(|_| DagError::ShuttingDown),
+                .map_err(DagError::from),
+
             _ => self
                 .tx_primary_messages
-                .send(message)
-                .await
-                .map_err(|_| DagError::ShuttingDown),
+                .try_send(message)
+                .map_err(DagError::from),
         }
         .map(|_| anemo::Response::new(()))
         .map_err(|e| anemo::rpc::Status::internal(e.to_string()))

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -92,4 +92,16 @@ pub enum DagError {
 
     #[error("System shutting down")]
     ShuttingDown,
+
+    #[error("Channel Full")]
+    ChannelFull,
+}
+
+impl<T> From<tokio::sync::mpsc::error::TrySendError<T>> for DagError {
+    fn from(err: tokio::sync::mpsc::error::TrySendError<T>) -> Self {
+        match err {
+            tokio::sync::mpsc::error::TrySendError::Full(_) => DagError::ChannelFull,
+            tokio::sync::mpsc::error::TrySendError::Closed(_) => DagError::ShuttingDown,
+        }
+    }
 }

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -160,7 +160,7 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
                 )));
             }
         };
-        let request = anemo::Request::new(WorkerBatchRequest {
+        let batch_request = anemo::Request::new(WorkerBatchRequest {
             digests: missing.iter().cloned().collect(),
         })
         .with_timeout(self.request_batches_timeout);
@@ -179,7 +179,7 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
         let peer_id = anemo::PeerId(worker_name.0.to_bytes());
         if let Some(peer) = network.peer(peer_id) {
             match WorkerToWorkerClient::new(peer)
-                .request_batches(request)
+                .request_batches(batch_request)
                 .await
             // TODO: duplicated code in the same file.
             {


### PR DESCRIPTION
Turns out that narwhal tests are not blocking today. Lets just merge the CI jobs together so that its easier to ensure they're all blocking.