### PR TITLE
[wallet-ext] Add warning for http connection requests

### DIFF
--- a/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
+++ b/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
@@ -33,12 +33,19 @@
 }
 
 .origin {
-    margin-top: 10px;
+    margin-bottom: 10px;
     font-size: 14px;
     line-height: 13px;
     font-weight: 500;
     text-decoration: none;
     color: colors.$sui-dark-blue;
+
+    &.warning {
+        color: colors.$issue-dark;
+        &:visited {
+            color: colors.$issue-dark;
+        }
+    }
 
     &:visited {
         color: colors.$sui-dark-blue;
@@ -62,6 +69,10 @@
     display: flex;
     align-items: center;
     gap: 10px;
+
+    &.flip-actions {
+        flex-direction: row-reverse;
+    }
 }
 
 .button {

--- a/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
+++ b/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
@@ -1,6 +1,7 @@
 @use '_values/colors';
 
 .container {
+    flex: 1;
     display: flex;
     flex-flow: column nowrap;
     height: 100%;

--- a/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
+++ b/apps/wallet/src/ui/app/components/user-approve-container/UserApproveContainer.module.scss
@@ -42,6 +42,7 @@
 
     &.warning {
         color: colors.$issue-dark;
+
         &:visited {
             color: colors.$issue-dark;
         }

--- a/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
+++ b/apps/wallet/src/ui/app/components/user-approve-container/index.tsx
@@ -21,6 +21,7 @@ type UserApproveContainerProps = {
     approveTitle: string;
     onSubmit: (approved: boolean) => void;
     isConnect?: boolean;
+    isWarning?: boolean;
 };
 
 function UserApproveContainer({
@@ -31,6 +32,7 @@ function UserApproveContainer({
     approveTitle,
     onSubmit,
     isConnect,
+    isWarning,
 }: UserApproveContainerProps) {
     const [submitting, setSubmitting] = useState(false);
     const handleOnResponse = useCallback<MouseEventHandler<HTMLButtonElement>>(
@@ -45,6 +47,8 @@ function UserApproveContainer({
 
     const parsedOrigin = useMemo(() => new URL(origin), [origin]);
 
+    const isSecure = parsedOrigin.protocol === 'https:';
+
     return (
         <div className={st.container}>
             <div className={st.scrollBody}>
@@ -57,22 +61,30 @@ function UserApproveContainer({
                         />
                     ) : null}
                     <div className={st.host}>{parsedOrigin.host}</div>
-                    <AccountAddress showLink={false} />
-                    <ExternalLink href={origin} className={st.origin}>
+                    <ExternalLink
+                        href={origin}
+                        className={cl(st.origin, !isSecure && st.warning)}
+                        showIcon={isSecure}
+                    >
                         {origin}
                     </ExternalLink>
+                    <AccountAddress showLink={false} />
                 </div>
                 <div className={st.children}>{children}</div>
             </div>
             <div className={st.actionsContainer}>
-                <div className={st.actions}>
+                <div className={cl(st.actions, isWarning && st.flipActions)}>
                     <button
                         type="button"
                         data-allow="false"
                         onClick={handleOnResponse}
                         className={cl(
                             st.button,
-                            isConnect ? st.cancel : st.reject
+                            isWarning
+                                ? st.reject
+                                : isConnect
+                                ? st.cancel
+                                : st.reject
                         )}
                         disabled={submitting}
                     >
@@ -81,19 +93,24 @@ function UserApproveContainer({
                     </button>
                     <button
                         type="button"
-                        className={cl(st.button, st.approve)}
+                        className={cl(
+                            st.button,
+                            isWarning ? st.cancel : st.approve
+                        )}
                         data-allow="true"
                         onClick={handleOnResponse}
                         disabled={submitting}
                     >
-                        {isConnect ? (
-                            <Icon icon="plus" />
-                        ) : (
-                            <Icon icon="check" />
-                        )}
+                        {!isWarning &&
+                            (isConnect ? (
+                                <Icon icon="plus" />
+                            ) : (
+                                <Icon icon="check" />
+                            ))}
                         <span>
                             {submitting ? <LoadingIndicator /> : approveTitle}
                         </span>
+                        {isWarning && <Icon icon="arrow-right" />}
                     </button>
                 </div>
             </div>

--- a/apps/wallet/src/ui/app/pages/site-connect/SiteConnectPage.module.scss
+++ b/apps/wallet/src/ui/app/pages/site-connect/SiteConnectPage.module.scss
@@ -40,6 +40,7 @@
 
 .warning-title {
     @include utils.typography('Primary/Body-SB');
+
     display: inline-block;
     margin-bottom: -1px;
     padding-bottom: 8px;
@@ -48,5 +49,6 @@
 
 .warning-message {
     @include utils.typography('Primary/BodySmall-M');
+
     color: colors.$gray-80;
 }

--- a/apps/wallet/src/ui/app/pages/site-connect/SiteConnectPage.module.scss
+++ b/apps/wallet/src/ui/app/pages/site-connect/SiteConnectPage.module.scss
@@ -1,3 +1,4 @@
+@use '_utils';
 @use '_values/colors';
 
 .label {
@@ -30,4 +31,22 @@
     line-height: 17px;
     margin-left: 0;
     color: colors.$gray-100;
+}
+
+.warning-wrapper {
+    border-bottom: 1px solid colors.$gray-45;
+    margin-bottom: 8px;
+}
+
+.warning-title {
+    @include utils.typography('Primary/Body-SB');
+    display: inline-block;
+    margin-bottom: -1px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid colors.$gray-90;
+}
+
+.warning-message {
+    @include utils.typography('Primary/BodySmall-M');
+    color: colors.$gray-80;
 }

--- a/apps/wallet/src/ui/app/pages/site-connect/index.tsx
+++ b/apps/wallet/src/ui/app/pages/site-connect/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import Icon, { SuiIcons } from '_components/icon';
@@ -62,31 +62,85 @@ function SiteConnectPage() {
         }
     }, [loading, permissionRequest]);
 
+    const parsedOrigin = useMemo(
+        () => (permissionRequest ? new URL(permissionRequest.origin) : null),
+        [permissionRequest]
+    );
+
+    const isSecure = parsedOrigin?.protocol === 'https:';
+    const [displayWarning, setDisplayWarning] = useState(!isSecure);
+
+    const handleHideWarning = useCallback(
+        (allowed: boolean) => {
+            if (allowed) {
+                setDisplayWarning(false);
+            } else {
+                handleOnSubmit(false);
+            }
+        },
+        [handleOnSubmit]
+    );
+
+    useEffect(() => {
+        setDisplayWarning(!isSecure);
+    }, [isSecure]);
+
     return (
         <Loading loading={loading}>
-            {permissionRequest ? (
-                <UserApproveContainer
-                    origin={permissionRequest.origin}
-                    originFavIcon={permissionRequest.favIcon}
-                    approveTitle="Connect"
-                    rejectTitle="Cancel"
-                    onSubmit={handleOnSubmit}
-                    isConnect
-                >
-                    <div className={st.label}>App Permissions</div>
-                    <ul className={st.permissions}>
-                        {permissionRequest.permissions.map((aPermission) => (
-                            <li key={aPermission} className={st.permission}>
-                                <Icon
-                                    icon={SuiIcons.Checkmark}
-                                    className={st.checkmark}
-                                />
-                                {permissionTypeToTxt[aPermission]}
-                            </li>
-                        ))}
-                    </ul>
-                </UserApproveContainer>
-            ) : null}
+            {permissionRequest &&
+                (displayWarning ? (
+                    <UserApproveContainer
+                        origin={permissionRequest.origin}
+                        originFavIcon={permissionRequest.favIcon}
+                        approveTitle="Continue"
+                        rejectTitle="Reject"
+                        onSubmit={handleHideWarning}
+                        isWarning
+                        isConnect
+                    >
+                        <div className={st.warningWrapper}>
+                            <h1 className={st.warningTitle}>
+                                Your Connection is Not Secure
+                            </h1>
+                        </div>
+
+                        <div className={st.warningMessage}>
+                            This site requesting this wallet connection is not
+                            secure, and attackers might be trying to steal your
+                            information.
+                            <br />
+                            <br />
+                            Continue at your own risk.
+                        </div>
+                    </UserApproveContainer>
+                ) : (
+                    <UserApproveContainer
+                        origin={permissionRequest.origin}
+                        originFavIcon={permissionRequest.favIcon}
+                        approveTitle="Connect"
+                        rejectTitle="Cancel"
+                        onSubmit={handleOnSubmit}
+                        isConnect
+                    >
+                        <div className={st.label}>App Permissions</div>
+                        <ul className={st.permissions}>
+                            {permissionRequest.permissions.map(
+                                (aPermission) => (
+                                    <li
+                                        key={aPermission}
+                                        className={st.permission}
+                                    >
+                                        <Icon
+                                            icon={SuiIcons.Checkmark}
+                                            className={st.checkmark}
+                                        />
+                                        {permissionTypeToTxt[aPermission]}
+                                    </li>
+                                )
+                            )}
+                        </ul>
+                    </UserApproveContainer>
+                ))}
         </Loading>
     );
 }

--- a/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
@@ -45,6 +45,8 @@
     overflow: auto;
     flex-grow: 1;
     width: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .with-nav {


### PR DESCRIPTION
When connecting from non-`https` sites, we will now display a warning to the user that the connection is not secure. I aligned the design to the figma, with subtle copy changes that should slightly more accurately reflect what is happening. This can still be clicked through to initiate a wallet connection.

<img width="472" alt="Screen Shot 2022-10-10 at 7 19 14 PM" src="https://user-images.githubusercontent.com/109986297/194982624-542dd0da-78a6-4410-b88c-c546da276720.png">
