### PR TITLE
[wallet-ext] Skip wallet artifact upload for rust changes

### DIFF
--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       isWalletExt: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') || steps.diff.outputs.isRust }}
+      isSrcChange: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)
@@ -41,6 +42,7 @@ jobs:
       - name: Package
         run: pnpm wallet pack:zip
       - uses: actions/upload-artifact@v3
+        if: ${{ needs.diff.outputs.isSrcChange == 'true' }}
         with:
           name: wallet-extension
           path: apps/wallet/web-ext-artifacts/*


### PR DESCRIPTION
This should prevent the wallet extension build comment for rust-only PRs.