### PR TITLE
[Post Processing] add metrics and do not break loop when lagged 

### DIFF
--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use move_bytecode_utils::module_cache::SyncModuleCache;
 use sui_json_rpc_types::SuiMoveStruct;
 use tokio_stream::Stream;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, instrument, trace};
 
 use sui_storage::event_store::{EventStore, EventStoreType};
 use sui_types::base_types::TransactionDigest;
@@ -42,6 +42,7 @@ impl EventHandler {
         }
     }
 
+    #[instrument(level = "debug", skip_all, fields(seq=?seq_num, tx_digest=?effects.transaction_digest), err)]
     pub async fn process_events(
         &self,
         effects: &TransactionEffects,


### PR DESCRIPTION
1. add metrics for post processing / batch service and 2. do not break loop when lagged

For 2:
Today when there's a lag, we break the loop and never resumes the post processing work. This PR makes it keep polling from the queue even when some txes have to be skipped. This is still far from perfect but is better than what we have presently. The long term solution is to have a WAL-like thing to keep track of the post processing watermark and resume the task from the last cursor that we failed to finish. https://github.com/MystenLabs/sui/issues/5025