### PR TITLE
ci: disable beta and cargo-udeps nightly jobs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,27 +28,6 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
-  beta:
-    name: Run test on the beta channel
-    runs-on: [ubuntu-ghcloud]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install beta toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          components: clippy
-          override: true
-      - uses: arduino/setup-protoc@v1
-      # See '.cargo/config' for list of enabled/disappled clippy lints
-      - name: cargo clippy
-        run: cargo xclippy -D warnings
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-
   release:
     name: build release binaries
     runs-on: [ubuntu-ghcloud]
@@ -61,42 +40,43 @@ jobs:
           command: build
           args: --all-targets --all-features --release --profile=release
 
-  cargo-udeps:
-    runs-on: [ubuntu-ghcloud]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-      # Enable caching of the 'librocksdb-sys' crate by additionally caching the
-      # 'librocksdb-sys' src directory which is managed by cargo
-      - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
-        with:
-          path: ~/.cargo/registry/src/**/librocksdb-sys-*
-      - name: Install cargo-udeps, and cache the binary
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-udeps
-          locked: true
-      - name: Install cargo-hakari, and cache the binary
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-hakari
-          locked: true
-      # Normally running cargo-udeps requires use of a nightly compiler
-      # In order to have a more stable and less noisy experience, lets instead
-      # opt to use the stable toolchain specified via the 'rust-toolchain' file
-      # and instead enable nightly features via 'RUSTC_BOOTSTRAP'
-      - name: run cargo-udeps
-        run: |
-          # First we need to disable the workspace-hack package
-          cargo hakari disable
-          cargo hakari remove-deps -y
-          RUSTC_BOOTSTRAP=1 cargo udeps
+  # This job seems to be consistently producing false-positives, lets disable for now
+  # cargo-udeps:
+  #   runs-on: [ubuntu-ghcloud]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions-rs/toolchain@v1
+  #     # Enable caching of the 'librocksdb-sys' crate by additionally caching the
+  #     # 'librocksdb-sys' src directory which is managed by cargo
+  #     - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
+  #       with:
+  #         path: ~/.cargo/registry/src/**/librocksdb-sys-*
+  #     - name: Install cargo-udeps, and cache the binary
+  #       uses: baptiste0928/cargo-install@v1
+  #       with:
+  #         crate: cargo-udeps
+  #         locked: true
+  #     - name: Install cargo-hakari, and cache the binary
+  #       uses: baptiste0928/cargo-install@v1
+  #       with:
+  #         crate: cargo-hakari
+  #         locked: true
+  #     # Normally running cargo-udeps requires use of a nightly compiler
+  #     # In order to have a more stable and less noisy experience, lets instead
+  #     # opt to use the stable toolchain specified via the 'rust-toolchain' file
+  #     # and instead enable nightly features via 'RUSTC_BOOTSTRAP'
+  #     - name: run cargo-udeps
+  #       run: |
+  #         # First we need to disable the workspace-hack package
+  #         cargo hakari disable
+  #         cargo hakari remove-deps -y
+  #         RUSTC_BOOTSTRAP=1 cargo udeps
 
   report-status:
     name: Report Status
     runs-on: ubuntu-latest
     if: always()
-    needs: [beta, release, cargo-udeps]
+    needs: [release]
     steps:
       - uses: technote-space/workflow-conclusion-action@v3
 


### PR DESCRIPTION
Disable the beta and cargo-udeps nightly jobs because they are very noisy and tend to not produce very valuable signals.