### PR TITLE
Consensus: calculate basic integrity hash on consensus messages

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{authority_store_tables::AuthorityStoreTables, *};
-use narwhal_executor::ExecutionIndices;
+use crate::authority::authority_store_tables::ExecutionIndicesWithHash;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -1124,7 +1124,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub async fn persist_certificate_and_lock_shared_objects(
         &self,
         certificate: CertifiedTransaction,
-        consensus_index: ExecutionIndices,
+        consensus_index: ExecutionIndicesWithHash,
     ) -> Result<(), SuiError> {
         // Make an iterator to save the certificate.
         let transaction_digest = *certificate.digest();
@@ -1326,7 +1326,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Return the latest consensus index. It is used to bootstrap the consensus client.
-    pub fn last_consensus_index(&self) -> SuiResult<ExecutionIndices> {
+    pub fn last_consensus_index(&self) -> SuiResult<ExecutionIndicesWithHash> {
         self.tables
             .last_consensus_index
             .get(&LAST_CONSENSUS_INDEX_ADDR)

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use narwhal_executor::ExecutionIndices;
 use rocksdb::Options;
+use serde::{Deserialize, Serialize};
 use sui_storage::default_db_options;
 use sui_types::base_types::{ExecutionDigests, SequenceNumber};
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
@@ -98,7 +99,13 @@ pub struct AuthorityStoreTables<S> {
     /// represents the index of the latest consensus message this authority processed. This field is written
     /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
     /// every message output by consensus (and in the right order).
-    pub(crate) last_consensus_index: DBMap<u64, ExecutionIndices>,
+    pub(crate) last_consensus_index: DBMap<u64, ExecutionIndicesWithHash>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ExecutionIndicesWithHash {
+    pub index: ExecutionIndices,
+    pub hash: u64,
 }
 
 // These functions are used to initialize the DB tables

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -13,7 +13,6 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, ident_str, identifier::Identifier, language_storage::TypeTag,
 };
-use narwhal_executor::ExecutionIndices;
 use rand::{
     distributions::{Distribution, Uniform},
     prelude::StdRng,
@@ -2113,7 +2112,7 @@ async fn send_consensus(authority: &AuthorityState, cert: &CertifiedTransaction)
                 certificate: narwhal_types::Certificate::default(),
                 consensus_index: narwhal_types::SequenceNumber::default(),
             },
-            /* last_consensus_index */ ExecutionIndices::default(),
+            /* last_consensus_index */ Default::default(),
             ConsensusTransaction::new_certificate_message(&authority.name, cert.clone()),
         )
         .await

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -4,7 +4,6 @@ use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use crate::test_utils::to_sender_signed_transaction;
 use move_core_types::{account_address::AccountAddress, ident_str};
-use narwhal_executor::ExecutionIndices;
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
@@ -110,7 +109,7 @@ async fn listen_to_sequenced_transaction() {
                 certificate: narwhal_types::Certificate::default(),
                 consensus_index: narwhal_types::SequenceNumber::default(),
             },
-            ExecutionIndices::default(),
+            Default::default(),
             ConsensusTransaction::new_certificate_message(&state.name, certificate),
         )
         .await
@@ -190,7 +189,7 @@ async fn submit_transaction_to_consensus() {
                         certificate: narwhal_types::Certificate::default(),
                         consensus_index: narwhal_types::SequenceNumber::default(),
                     },
-                    ExecutionIndices::default(),
+                    Default::default(),
                     ConsensusTransaction::new_certificate_message(&name, *certificate),
                 )
                 .await


### PR DESCRIPTION
This PR introduces rolling integrity hash in the consensus handler calculated as following:

```
IntegrityHash(transaction[n]) = hash(IntegrityHash(transaction[n-1]) || transaction[n].bytes)
```

This hash is then stored along with execution indexes and logged for every certificate.

The purpose of this hash is to quickly find if we have any violation on the narwhal side by examining nodes output.

The motivation to include it is:
(a) Since we are likely to start making significant changes to primary code it would be good to have some integrity check
(b) We have some strange NotFound errors on some nodes, while this was not debugged further it potentially can come from incorrect transaction sequence in narwhal and this hash would be able to (dis)prove this theory.

This should be fairly cheap non-cryptographic hash used for debugging purposes only.

Calculating hash is crash resilient as it basically persist ExecutionIndex -> Hash mapping in the db.

Side note: the hash implementation used in this PR is not strictly speaking guaranteed to be consistent across machines, but I think it will be (in practice) at least until we start using machines with significantly different architecture in the cluster.