### PR TITLE
[narwhal] fix benchmarks

### DIFF
--- a/narwhal/benchmark/benchmark/commands.py
+++ b/narwhal/benchmark/benchmark/commands.py
@@ -28,12 +28,12 @@ class CommandMaker:
     @staticmethod
     def generate_key(filename):
         assert isinstance(filename, str)
-        return f'./node generate_keys --filename {filename}'
+        return f'./narwhal-node generate_keys --filename {filename}'
 
     @staticmethod
     def generate_network_key(filename):
         assert isinstance(filename, str)
-        return f'./node generate_network_keys --filename {filename}'
+        return f'./narwhal-node generate_network_keys --filename {filename}'
 
     @staticmethod
     def run_primary(primary_keys, primary_network_keys, worker_keys, committee, workers, store, parameters, debug=False):
@@ -45,7 +45,7 @@ class CommandMaker:
         assert isinstance(parameters, str)
         assert isinstance(debug, bool)
         v = '-vvv' if debug else '-vv'
-        return (f'./node {v} run --primary-keys {primary_keys} --primary-network-keys {primary_network_keys} '
+        return (f'./narwhal-node {v} run --primary-keys {primary_keys} --primary-network-keys {primary_network_keys} '
                 f'--worker-keys {worker_keys} --committee {committee} --workers {workers} --store {store} '
                 f'--parameters {parameters} primary')
 
@@ -68,7 +68,7 @@ class CommandMaker:
         assert isinstance(parameters, str)
         assert isinstance(debug, bool)
         v = '-vvv' if debug else '-vv'
-        return (f'./node {v} run --primary-keys {primary_keys} --primary-network-keys {primary_network_keys} '
+        return (f'./narwhal-node {v} run --primary-keys {primary_keys} --primary-network-keys {primary_network_keys} '
                 f'--worker-keys {worker_keys} --committee {committee} --workers {workers} --store {store} '
                 f'--parameters {parameters} primary --consensus-disabled')
 
@@ -82,7 +82,7 @@ class CommandMaker:
         assert isinstance(parameters, str)
         assert isinstance(debug, bool)
         v = '-vvv' if debug else '-vv'
-        return (f'./node {v} run --primary-keys {primary_keys} --primary-network-keys {primary_network_keys} '
+        return (f'./narwhal-node {v} run --primary-keys {primary_keys} --primary-network-keys {primary_network_keys} '
                 f'--worker-keys {worker_keys} --committee {committee} --workers {workers} --store {store} '
                 f'--parameters {parameters} worker --id {id}')
 

--- a/narwhal/benchmark/benchmark/logs.py
+++ b/narwhal/benchmark/benchmark/logs.py
@@ -101,7 +101,7 @@ class LogParser:
         return size, rate, start, misses, samples
 
     def _parse_primaries(self, log):
-        if search(r'(?:panicked|ERROR)', log) is not None:
+        if search(r'(?:panicked)', log) is not None:
             raise ParseError('Primary(s) panicked')
 
         tmp = findall(r'(.*?) .* Created B\d+\([^ ]+\) -> ([^ ]+=)', log)
@@ -144,7 +144,7 @@ class LogParser:
         return proposals, commits, configs, ip
 
     def _parse_workers(self, log):
-        if search(r'(?:panic|ERROR)', log) is not None:
+        if search(r'(?:panicked)', log) is not None:
             raise ParseError('Worker(s) panicked')
 
         tmp = findall(r'Batch ([^ ]+) contains (\d+) B', log)

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -48,8 +48,9 @@ def local(ctx, debug=True):
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
         },
         "network_admin_server": {
-            "primary_network_admin_server_port": 6564,
-            "worker_network_admin_server_base_port": 6565
+            # Use a random available local port.
+            "primary_network_admin_server_port": 0,
+            "worker_network_admin_server_base_port": 0
         },
     }
     try:
@@ -216,8 +217,9 @@ def remote(ctx, debug=False):
             "socket_addr": "/ip4/0.0.0.0/tcp/0/http"
         },
         "network_admin_server": {
-            "primary_network_admin_server_port": 6564,
-            "worker_network_admin_server_base_port": 6565
+            # Use a random available local port.
+            "primary_network_admin_server_port": 0,
+            "worker_network_admin_server_base_port": 0
         },
     }
     try:

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -181,7 +181,7 @@ fn setup_benchmark_telemetry(
     tracing_level: &str,
     network_tracing_level: &str,
 ) -> Result<(), eyre::Report> {
-    let custom_directive = "executor::core=info";
+    let custom_directive = "narwhal_executor=info";
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .parse(format!(


### PR DESCRIPTION
Currently benchmarks don't work for a few reasons:
* python files run the `./node` binary, although now is named `narwhal-node`
* admin port is fixed causing overlaps on running nodes and causing them to `panic`
* logic in the log parsing is capturing `ERROR` log statements as fatal and refusing to produce benchmark results. So error logs like `2022-10-11T20:11:16.86894Z ERROR request{route=/narwhal.PrimaryToWorker/Synchronize version=V1}: anemo_tower::trace::on_failure: response failed error=connection lost latency=29 ms` will make benchmark result generation fail. However in our application logic might be completely acceptable to have those failures since we retry - basically what maters is the end throughput etc. I've removed capturing the `ERROR`  logs from making the benchmark fail and left only the `panicked` statements , which of course seem a valid reason to fail the benchmark since those are actually fatal.