### PR TITLE
Change log level to debug for tx exec error due to validator halt

### DIFF
--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -432,7 +432,12 @@ where
 
                 let res = match res {
                     Err(error) | Ok(Err(error)) => {
-                        error!(?tx_digest, "process_digest failed: {}", error);
+                        if matches!(error, SuiError::ValidatorHaltedAtEpochEnd) {
+                            // This is not a real error.
+                            debug!(?tx_digest, "process_digest failed: {}", error);
+                        } else {
+                            error!(?tx_digest, "process_digest failed: {}", error);
+                        }
                         Err(error)
                     }
 


### PR DESCRIPTION
If tx failed to execute due to validator halt, there is no need to print an error message at error! or info!. debug! is sufficient.