### PR TITLE
Log skipped consensus transaction in a similar fashion to processed

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -69,8 +69,8 @@ use tap::TapFallible;
 use thiserror::Error;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc::Sender;
+use tracing::Instrument;
 use tracing::{debug, error, instrument, warn};
-use tracing::{trace, Instrument};
 use typed_store::Map;
 
 #[cfg(test)]
@@ -2054,7 +2054,12 @@ impl AuthorityState {
                     .await
                     .map_err(NarwhalHandlerError::NodeError)?
                 {
-                    trace!("Already processed {:?}", certificate.digest());
+                    debug!(
+                        ?consensus_index,
+                        ?tracking_id,
+                        tx_digest = ?certificate.digest(),
+                        "handle_consensus_transaction UserTransaction [skip]",
+                    );
                     self.metrics.skipped_consensus_txns.inc();
                     return Ok(());
                 }

--- a/narwhal/executor/src/notifier.rs
+++ b/narwhal/executor/src/notifier.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{ExecutionIndices, ExecutionState, ExecutorMetrics};
 use consensus::ConsensusOutput;
+use fastcrypto::Hash;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
+use tracing::debug;
 
 use types::{metered_channel, Batch};
 
@@ -36,6 +38,7 @@ impl<State: ExecutionState + Send + Sync + 'static> Notifier<State> {
 
     async fn run(mut self) {
         while let Some((index, batch)) = self.rx_notifier.recv().await {
+            debug!("Notifier processes batch {}", batch.digest());
             self.metrics.notifier_processed_batches.inc();
             let mut bytes = 0usize;
             for (transaction_index, transaction) in batch.0.into_iter().enumerate() {

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -191,6 +191,7 @@ impl<Network: SubscriberNetwork> Fetcher<Network> {
                 batch_index: batch_index as u64,
             };
             workers.shuffle(&mut ThreadRng::default());
+            debug!("Scheduling fetching batch {}", digest);
             ret.push(
                 self.fetch_payload(*digest, *worker_id, workers)
                     .map(move |batch| (batch_index, batch)),


### PR DESCRIPTION
Also add logs to nw executor when batch is scheduled/notified
