### PR TITLE
Add index for move_event_name

### DIFF
--- a/crates/sui-storage/src/event_store/sql.rs
+++ b/crates/sui-storage/src/event_store/sql.rs
@@ -87,6 +87,7 @@ const INDEXED_COLUMNS: &[&str] = &[
     "sender",
     "recipient",
     "object_id",
+    "move_event_name",
 ];
 
 impl SqlEventStore {


### PR DESCRIPTION
There are a bunch of queries filtering on this column and it does not seem to have an index which is likely causing a full table scan. Adding an index to fix.