### PR TITLE
[reconfig] Add enable_reconfig flag to checkpoint state

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1448,6 +1448,7 @@ impl AuthorityState {
             &genesis_committee,
             secret.public().into(),
             secret.clone(),
+            false,
         )
         .expect("Should not fail to open local checkpoint DB");
         if let Some(consensus_sender) = consensus_sender {

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -406,25 +406,19 @@ where
     pub async fn spawn_checkpoint_process(
         self: Arc<Self>,
         metrics: CheckpointMetrics,
-        enable_reconfig: bool,
     ) -> JoinHandle<()> {
-        self.spawn_checkpoint_process_with_config(
-            CheckpointProcessControl::default(),
-            metrics,
-            enable_reconfig,
-        )
-        .await
+        self.spawn_checkpoint_process_with_config(CheckpointProcessControl::default(), metrics)
+            .await
     }
 
     pub async fn spawn_checkpoint_process_with_config(
         self: Arc<Self>,
         checkpoint_process_control: CheckpointProcessControl,
         metrics: CheckpointMetrics,
-        enable_reconfig: bool,
     ) -> JoinHandle<()> {
         // Spawn task to take care of checkpointing
         tokio::task::spawn(async move {
-            checkpoint_process(self, &checkpoint_process_control, metrics, enable_reconfig).await;
+            checkpoint_process(self, &checkpoint_process_control, metrics).await;
         })
     }
 }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -41,7 +41,7 @@ async fn checkpoint_active_flow_happy_path() {
             .unwrap(),
         );
         let _active_handle = active_state
-            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests(), false)
+            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
             .await;
     }
 
@@ -121,7 +121,6 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
                 .spawn_checkpoint_process_with_config(
                     Default::default(),
                     CheckpointMetrics::new_for_tests(),
-                    false,
                 )
                 .await;
         });
@@ -213,7 +212,6 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
                 .spawn_checkpoint_process_with_config(
                     CheckpointProcessControl::default(),
                     CheckpointMetrics::new_for_tests(),
-                    false,
                 )
                 .await;
         });
@@ -303,7 +301,6 @@ async fn test_empty_checkpoint() {
                 .spawn_checkpoint_process_with_config(
                     CheckpointProcessControl::default(),
                     CheckpointMetrics::new_for_tests(),
-                    false,
                 )
                 .await;
         });

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -48,7 +48,7 @@ async fn pending_exec_storage_notify() {
             .unwrap(),
         );
         let _active_handle = active_state
-            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests(), false)
+            .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
             .await;
     }
 
@@ -134,7 +134,7 @@ async fn pending_exec_full() {
 
             active_state.clone().spawn_execute_process().await;
             active_state
-                .spawn_checkpoint_process(CheckpointMetrics::new_for_tests(), false)
+                .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
                 .await;
         });
     }

--- a/crates/sui-core/src/checkpoints/causal_order_effects.rs
+++ b/crates/sui-core/src/checkpoints/causal_order_effects.rs
@@ -301,6 +301,7 @@ mod tests {
             &committee,
             k.public().into(),
             Arc::pin(k.copy()),
+            false,
         )
         .unwrap();
 

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -68,6 +68,7 @@ fn random_ckpoint_store_num(
                 &committee,
                 k.public().into(),
                 Arc::pin(k.copy()),
+                false,
             )
             .unwrap();
             (path, cps)
@@ -97,6 +98,7 @@ fn crash_recovery() {
         &committee,
         k.public().into(),
         Arc::pin(k.copy()),
+        false,
     )
     .unwrap();
 
@@ -141,6 +143,7 @@ fn crash_recovery() {
         &committee,
         k.public().into(),
         Arc::pin(k.copy()),
+        false,
     )
     .unwrap();
 
@@ -751,6 +754,7 @@ fn checkpoint_integration() {
         &committee,
         k.public().into(),
         Arc::pin(k.copy()),
+        false,
     )
     .unwrap();
 

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -20,6 +20,7 @@ use sui_types::{
     SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
+use crate::authority::AuthorityState;
 use crate::checkpoints::reconstruction::SpanGraph;
 use crate::{
     authority::TemporaryStore,
@@ -39,6 +40,7 @@ async fn test_start_epoch_change() {
     let genesis_objects = vec![object.clone(), gas_object.clone()];
     // Create authority_aggregator and authority states.
     let (net, states, _) = init_local_authorities(4, genesis_objects.clone()).await;
+    enable_reconfig(&states);
     let state = states[0].clone();
 
     // Check that we initialized the genesis epoch.
@@ -173,6 +175,7 @@ async fn test_finish_epoch_change() {
     // Create authority_aggregator and authority states.
     let genesis_objects = vec![];
     let (net, states, _) = init_local_authorities(4, genesis_objects.clone()).await;
+    enable_reconfig(&states);
     let actives: Vec<_> = states
         .iter()
         .map(|state| {
@@ -245,5 +248,11 @@ async fn test_finish_epoch_change() {
         assert!(response.signed_effects.is_some());
         assert!(response.certified_transaction.is_some());
         assert!(response.signed_effects.is_some());
+    }
+}
+
+fn enable_reconfig(states: &[Arc<AuthorityState>]) {
+    for state in states {
+        state.checkpoints.lock().enable_reconfig = true;
     }
 }

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -65,7 +65,15 @@ pub(crate) async fn init_state(
     let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = tokio::sync::mpsc::channel(10);
     let committee_store = Arc::new(CommitteeStore::new(epoch_path, &committee, None));
     let checkpoint_store = Arc::new(parking_lot::Mutex::new(
-        CheckpointStore::open(&checkpoint_path, None, &committee, name, secrete.clone()).unwrap(),
+        CheckpointStore::open(
+            &checkpoint_path,
+            None,
+            &committee,
+            name,
+            secrete.clone(),
+            false,
+        )
+        .unwrap(),
     ));
     AuthorityState::new(
         name,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -104,6 +104,7 @@ impl SuiNode {
             &committee,
             config.protocol_public_key(),
             secret.clone(),
+            config.enable_reconfig,
         )?));
 
         let index_store = if is_validator {
@@ -256,10 +257,7 @@ impl SuiNode {
             Some(
                 active_authority
                     .clone()
-                    .spawn_checkpoint_process(
-                        CheckpointMetrics::new(&prometheus_registry),
-                        config.enable_reconfig,
-                    )
+                    .spawn_checkpoint_process(CheckpointMetrics::new(&prometheus_registry))
                     .await,
             )
         } else {

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -35,6 +35,7 @@ async fn reconfig_end_to_end_tests() {
     for c in configs.validator_configs.iter_mut() {
         // Turn off checkpoint process so that we can have fine control over it in the test.
         c.enable_checkpoint = false;
+        c.enable_reconfig = true;
     }
 
     let configs = Arc::new(configs);
@@ -150,6 +151,7 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
     for c in configs.validator_configs.iter_mut() {
         // Turn off checkpoint process so that we can have fine control over it in the test.
         c.enable_checkpoint = false;
+        c.enable_reconfig = true;
     }
     let validator_info = configs.validator_set();
     let mut gas_objects = test_gas_objects();
@@ -200,12 +202,9 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {
-                let _ = checkpoint_process_step(
-                    active.clone(),
-                    &CheckpointProcessControl::default(),
-                    true,
-                )
-                .await;
+                let _ =
+                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
+                        .await;
             }
         })
     });
@@ -227,7 +226,6 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
                 let _ = checkpoint_process_step(
                     node.active().clone(),
                     &CheckpointProcessControl::default(),
-                    true,
                 )
                 .await;
             }
@@ -335,12 +333,9 @@ async fn fast_forward_to_ready_for_reconfig_start(handles: &[SuiNodeHandle]) {
                 .lock()
                 .is_ready_to_start_epoch_change()
             {
-                let _ = checkpoint_process_step(
-                    active.clone(),
-                    &CheckpointProcessControl::default(),
-                    true,
-                )
-                .await;
+                let _ =
+                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
+                        .await;
             }
         })
     });
@@ -358,12 +353,9 @@ async fn fast_forward_to_ready_for_reconfig_finish(handles: &[SuiNodeHandle]) {
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {
-                let _ = checkpoint_process_step(
-                    active.clone(),
-                    &CheckpointProcessControl::default(),
-                    true,
-                )
-                .await;
+                let _ =
+                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
+                        .await;
             }
         })
     });

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -141,7 +141,6 @@ pub async fn spawn_checkpoint_processes(configs: &NetworkConfig, handles: &[SuiN
                     .spawn_checkpoint_process_with_config(
                         checkpoint_process_control,
                         CheckpointMetrics::new_for_tests(),
-                        false,
                     )
                     .await;
             })


### PR DESCRIPTION
Previously enable_reconfig is a flag passed to the checkpoint driver process.
However the checkpoint state needs to be aware of the value enable_reconfig to decide whether we should reject consensus message after receiving the last fragment of the second last checkpoint in the epoch.
This PR moves the enable_reconfig flag into checkpoint state.