### PR TITLE
[ci] Move to new method of setting actions output

### DIFF
--- a/.github/actions/pnpm-diffs/action.yml
+++ b/.github/actions/pnpm-diffs/action.yml
@@ -16,7 +16,7 @@ runs:
     - id: changes
       name: Detect changes
       shell: bash
-      run: echo "::set-output name=packages::$(pnpm list --filter "...[origin/main]" --depth -1 --json | jq -c "[.[] | .name]")"
+      run: echo "packages=$(pnpm list --filter "...[origin/main]" --depth -1 --json | jq -c "[.[] | .name]")" >> $GITHUB_OUTPUT
     - name: Print changes for easy debugging
       shell: bash
       run: echo ${{ steps.changes.outputs.packages }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -74,8 +74,8 @@ jobs:
       run: |
         owned="Owned $(cat artifacts/owned.txt | grep -e '|' -e '-' -e 'Bench' -e '+')"
         shared="Shared $(cat artifacts/shared.txt | grep -e '|' -e '-' -e 'Bench' -e '+')"
-        echo ::set-output name=owned::$owned
-        echo ::set-output name=shared::$shared
+        echo "owned=$owned" >> $GITHUB_OUTPUT
+        echo "shared=$shared" >> $GITHUB_OUTPUT
     - name: Create commit comment
       uses: peter-evans/commit-comment@v2
       with:

--- a/.github/workflows/changesets-ci.yml
+++ b/.github/workflows/changesets-ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - id: diff
         name: Determine changed public packages from previous commit
-        run: echo "::set-output name=hasChanges::$(pnpm list --filter "...[$(git rev-parse HEAD^1)]" --depth -1 --json | jq "any(.[] | select(.private != true) ; length > 0)")"
+        run: echo "hasChanges=$(pnpm list --filter "...[$(git rev-parse HEAD^1)]" --depth -1 --json | jq "any(.[] | select(.private != true) ; length > 0)")" >> $GITHUB_OUTPUT
       - name: Get changed files in the changesets folder
         id: has-changesets
         uses: tj-actions/changed-files@v34

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -34,7 +34,7 @@ jobs:
           cargo hakari generate
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
       - name: Push changes
         if: steps.git-check.outputs.modified == 'true'
         # using secrets.AUTOMERGE_TOKEN in the below is key to re-trigger CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,11 @@ jobs:
         run: |
           cargo build --release
 
-          echo ::set-output name=BIN_SUI::"target/release/sui"
-          echo ::set-output name=BIN_SUI_NODE::"target/release/sui-node"
-          echo ::set-output name=BIN_SUI_TOOL::"target/release/sui-tool"
-          echo ::set-output name=BIN_SUI_FAUCET::"target/release/sui-faucet"
-          echo ::set-output name=BIN_RPC_SERVER::"target/release/rpc-server"
+          echo BIN_SUI="target/release/sui" >> $GITHUB_OUTPUT
+          echo BIN_SUI_NODE="target/release/sui-node" >> $GITHUB_OUTPUT
+          echo BIN_SUI_TOOL="target/release/sui-tool" >> $GITHUB_OUTPUT
+          echo BIN_SUI_FAUCET="target/release/sui-faucet" >> $GITHUB_OUTPUT
+          echo BIN_RPC_SERVER="target/release/rpc-server" >> $GITHUB_OUTPUT
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v3

--- a/narwhal/.github/workflows/bench.yml
+++ b/narwhal/.github/workflows/bench.yml
@@ -78,7 +78,7 @@ jobs:
         body="${body//'%'/'%25'}"
         body="${body//$'\n'/'%0A'}"
         body="${body//$'\r'/'%0D'}"
-        echo ::set-output name=body::$body
+        echo "body=$body" >> $GITHUB_OUTPUT
     - name: Create commit comment
       uses: peter-evans/commit-comment@v2
       with:

--- a/narwhal/.github/workflows/dependabot-auto-merge.yml
+++ b/narwhal/.github/workflows/dependabot-auto-merge.yml
@@ -34,7 +34,7 @@ jobs:
           cargo hakari generate
       - name: Check for modified files
         id: git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo "modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)"" >> $GITHUB_OUTPUT
       - name: Push changes
         if: steps.git-check.outputs.modified == 'true'
         # using secrets.AUTOMERGE_TOKEN in the below is key to re-trigger CI

--- a/narwhal/.github/workflows/dependabot-auto-merge.yml
+++ b/narwhal/.github/workflows/dependabot-auto-merge.yml
@@ -34,7 +34,7 @@ jobs:
           cargo hakari generate
       - name: Check for modified files
         id: git-check
-        run: echo "modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)"" >> $GITHUB_OUTPUT
+        run: echo "modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
       - name: Push changes
         if: steps.git-check.outputs.modified == 'true'
         # using secrets.AUTOMERGE_TOKEN in the below is key to re-trigger CI


### PR DESCRIPTION
Github recently deprecated the current method of setting command output. This updates the workflows that we own to use the new method, which will help remove a few of the warnings in the actions output.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter