### PR TITLE
[Explorer] Removes word ago from timestamps

### DIFF
--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -69,7 +69,7 @@ export const genTableDataFromTxData = (
 ) => {
     return {
         data: results.map((txn) => ({
-            date: `${timeAgo(txn.timestamp_ms, undefined, true)} ago`,
+            date: `${timeAgo(txn.timestamp_ms, undefined, true)}`,
             transactionId: [
                 {
                     url: txn.txId,


### PR DESCRIPTION
Following the updated Figma Design, this PR removes the word 'ago' from all timestamps.

Home Page:

![image](https://user-images.githubusercontent.com/11377188/195412758-fcbada6e-b36a-4b99-9f6e-25803546d4ad.png)

Transactions Page:

![image](https://user-images.githubusercontent.com/11377188/195412900-437b16d6-6bc7-4776-822a-2422ecd93ad6.png)

