### PR TITLE
[narwhal] fix cancellation safety for permit and future pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4957,6 +4957,7 @@ version = "0.1.0"
 dependencies = [
  "anemo",
  "anemo-build",
+ "async-trait",
  "base64",
  "bincode",
  "blake2",

--- a/narwhal/executor/src/errors.rs
+++ b/narwhal/executor/src/errors.rs
@@ -22,24 +22,6 @@ macro_rules! ensure {
     };
 }
 
-#[macro_export]
-macro_rules! try_fut_and_permit {
-    ($fut:expr, $sender:expr) => {
-        futures::future::TryFutureExt::unwrap_or_else(
-            futures::future::try_join(
-                $fut,
-                futures::TryFutureExt::map_err($sender.reserve(), |_e| {
-                    SubscriberError::ClosedChannel(stringify!(sender).to_owned())
-                }),
-            ),
-            |e| {
-                tracing::error!("{e}");
-                panic!("I/O failure, killing the node.");
-            },
-        )
-    };
-}
-
 pub type SubscriberResult<T> = Result<T, SubscriberError>;
 
 #[derive(Debug, Error, Clone)]

--- a/narwhal/primary/src/header_waiter.rs
+++ b/narwhal/primary/src/header_waiter.rs
@@ -22,13 +22,14 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration, Instant},
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
+use types::metered_channel::WithPermit;
 use types::{
     bounded_future_queue::BoundedFuturesUnordered,
     error::{DagError, DagResult},
     metered_channel::{Receiver, Sender},
-    try_fut_and_permit, BatchDigest, CertificateDigest, Header, HeaderDigest,
-    ReconfigureNotification, Round, WorkerSynchronizeMessage,
+    BatchDigest, CertificateDigest, Header, HeaderDigest, ReconfigureNotification, Round,
+    WorkerSynchronizeMessage,
 };
 
 #[cfg(test)]
@@ -281,15 +282,24 @@ impl HeaderWaiter {
                 },
 
                 // we poll the availability of a slot to send the result to the core simultaneously
-                (Some(result), permit) = try_fut_and_permit!(waiting.try_next(), self.tx_core) => if let Some(header) = result {
-                    let _ = self.pending.remove(&header.id);
-                    for x in header.payload.keys() {
-                        let _ = self.batch_requests.remove(x);
+                Some((permit, Some(header))) = self.tx_core.with_permit(waiting.next()) => {
+                    let header = match header{
+                        Err(err) => {
+                            warn!("Error fetching header {}", err);
+                            continue;
+                        },
+                        Ok(header) => header,
+                    };
+                    if let Some(header) = header {
+                        let _ = self.pending.remove(&header.id);
+                        for x in header.payload.keys() {
+                            let _ = self.batch_requests.remove(x);
+                        }
+                        for x in &header.parents {
+                            let _ = self.parent_requests.remove(x);
+                        }
+                        permit.send(header);
                     }
-                    for x in &header.parents {
-                        let _ = self.parent_requests.remove(x);
-                    }
-                    permit.send(header);
                 },  // This request has been canceled when result is None.
 
                 () = &mut timer => {

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 publish = false
 
 [dependencies]
+async-trait = "0.1.57"
 base64 = "0.13.0"
 bincode = "1.3.3"
 blake2 = "0.9"

--- a/narwhal/types/src/bounded_future_queue.rs
+++ b/narwhal/types/src/bounded_future_queue.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use futures::{
     stream::{FuturesOrdered, FuturesUnordered},
-    Future, TryFutureExt, TryStreamExt,
+    Future, StreamExt, TryFutureExt, TryStreamExt,
 };
 use tokio::sync::{AcquireError, Semaphore, SemaphorePermit};
 
@@ -96,6 +96,14 @@ impl<U, V, T: Future<Output = Result<U, V>>> BoundedFuturesUnordered<T> {
                 self.push_semaphore.add_permits(1)
             }
         })
+    }
+}
+
+impl<T: Future> BoundedFuturesUnordered<T> {
+    pub async fn next(&mut self) -> Option<T::Output> {
+        let result = self.queue.next().await;
+        self.push_semaphore.add_permits(1);
+        result
     }
 }
 

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -23,24 +23,6 @@ macro_rules! ensure {
     };
 }
 
-#[macro_export]
-macro_rules! try_fut_and_permit {
-    ($fut:expr, $sender:expr) => {
-        futures::future::TryFutureExt::unwrap_or_else(
-            futures::future::try_join(
-                $fut,
-                futures::TryFutureExt::map_err($sender.reserve(), |_e| {
-                    DagError::ClosedChannel(stringify!(sender).to_owned())
-                }),
-            ),
-            |e| {
-                tracing::error!("{e}");
-                panic!("I/O failure, killing the node.");
-            },
-        )
-    };
-}
-
 pub type DagResult<T> = Result<T, DagError>;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
We have a pattern where we need to poll the FuturesUnordered and wait for receiving channel to have a permit at the same time.

It was implemented with `try_fut_and_permit` which introduced `join(permit(), waiting.next()`. This join is not cancellation safe (see #5137 for more details) and will drop the message under load when permit is not available.

This PR fixes cancellation safety by chaining polling for the permit and polling `FuturesUnordered` which is cancellation safe.

To add a bit more flavor here - problem with previous implementation via join() is that join can resolve waiting.next() before permit is available and drops result, which is not safe. Polling permit first is safe because dropping permit 'reverts' the effects. (While dropping result from `FuturesUnordered` does not).

This PR also replaces macro with strongly typed `WithPermit` trait which seems like a more preferred approach - macro basically consumes anything that has method with name `reserve` which is not very sound.

Fixes #5137