### PR TITLE
wallet-ext: Support dapp interactions with locked wallets

### DIFF
--- a/apps/wallet/src/background/Permissions.ts
+++ b/apps/wallet/src/background/Permissions.ts
@@ -60,9 +60,12 @@ class Permissions {
         this.permissionReply = this._permissionResponses.pipe(
             mergeWith(
                 Tabs.onRemoved.pipe(
-                    filter((aTab) =>
-                        Permissions.isPermissionUiUrl(aTab.url || '')
-                    )
+                    filter((aTab) => {
+                        return (
+                            Permissions.isPermissionUiUrl(aTab.url || '') &&
+                            !aTab.nextUrl?.includes('/locked')
+                        );
+                    })
                 )
             ),
             concatMap((data) =>

--- a/apps/wallet/src/background/Tabs.ts
+++ b/apps/wallet/src/background/Tabs.ts
@@ -50,6 +50,7 @@ const onWindowFocusChanged = fromEventPattern<number>(
 type TabInfo = {
     id: number;
     url: string | null;
+    nextUrl?: string;
     closed?: boolean;
 };
 
@@ -89,6 +90,7 @@ class Tabs {
                         this._onRemoved.next({
                             id,
                             url: currentTab.url,
+                            nextUrl: url,
                             closed: false,
                         });
                     }

--- a/apps/wallet/src/ui/app/wallet/hooks.tsx
+++ b/apps/wallet/src/ui/app/wallet/hooks.tsx
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAppSelector } from '_hooks';
 
 export function useLockedGuard(requiredLockedStatus: boolean) {
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
     const { pathname, search, state } = useLocation();
     const { isInitialized, isLocked } = useAppSelector(
         ({ account: { isInitialized, isLocked } }) => ({
@@ -18,15 +19,25 @@ export function useLockedGuard(requiredLockedStatus: boolean) {
     const loading = isInitialized === null || isLocked === null;
     const guardAct =
         !loading && isInitialized && requiredLockedStatus !== isLocked;
+    const nextUrl = searchParams.get('url') || '/';
     useEffect(() => {
         if (guardAct) {
             navigate(
                 requiredLockedStatus
-                    ? '/'
+                    ? nextUrl
                     : `/locked?url=${encodeURIComponent(pathname + search)}`,
                 { replace: true, state }
             );
         }
-    }, [guardAct, navigate, requiredLockedStatus, pathname, search, state]);
+    }, [
+        guardAct,
+        navigate,
+        requiredLockedStatus,
+        pathname,
+        search,
+        state,
+        nextUrl,
+    ]);
+
     return loading || guardAct;
 }

--- a/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
+++ b/apps/wallet/src/ui/app/wallet/locked-page/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Field, Form, Formik } from 'formik';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
 
 import Alert from '_app/components/alert';
@@ -28,10 +28,7 @@ export default function LockedPage() {
     const initGuardLoading = useInitializedGuard(true);
     const lockedGuardLoading = useLockedGuard(true);
     const guardsLoading = initGuardLoading || lockedGuardLoading;
-    const [searchParams] = useSearchParams();
-    const navigate = useNavigate();
     const dispatch = useAppDispatch();
-    const nextUrl = searchParams.get('url') || '/';
     return (
         <Loading loading={guardsLoading}>
             <PageLayout limitToPopUpSize={true}>
@@ -54,7 +51,6 @@ export default function LockedPage() {
                                     await dispatch(
                                         unlockWallet({ password })
                                     ).unwrap();
-                                    navigate(nextUrl);
                                 } catch (e) {
                                     setFieldError(
                                         'password',


### PR DESCRIPTION
I noticed dapp interactions with locked wallets failed. This updates this so that it they work as expected