### PR TITLE
Split AuthorityStoreTables into AuthorityEpochTables and AuthorityPerpetualTables

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -50,6 +50,7 @@ use sui_json_rpc_types::{SuiEventEnvelope, SuiTransactionEffects};
 use sui_simulator::nondeterministic;
 use sui_storage::{
     event_store::{EventStore, EventStoreType, StoredEvent},
+    node_sync_store::NodeSyncStore,
     write_ahead_log::{DBTxGuard, TxGuard, WriteAheadLog},
     IndexStore,
 };
@@ -449,6 +450,8 @@ pub struct AuthorityState {
 
     /// The database
     pub(crate) database: Arc<AuthorityStore>, // TODO: remove pub
+
+    pub node_sync_store: Arc<NodeSyncStore>,
 
     indexes: Option<Arc<IndexStore>>,
 
@@ -1312,6 +1315,7 @@ impl AuthorityState {
         name: AuthorityName,
         secret: StableSyncAuthoritySigner,
         store: Arc<AuthorityStore>,
+        node_sync_store: Arc<NodeSyncStore>,
         committee_store: Arc<CommitteeStore>,
         indexes: Option<Arc<IndexStore>>,
         event_store: Option<Arc<EventStoreType>>,
@@ -1350,6 +1354,7 @@ impl AuthorityState {
             _native_functions: native_functions,
             move_vm,
             database: store.clone(),
+            node_sync_store,
             indexes,
             // `module_cache` uses a separate in-mem cache from `event_handler`
             // this is because they largely deal with different types of MoveStructs
@@ -1463,11 +1468,19 @@ impl AuthorityState {
             &genesis_committee,
             None,
         ));
+
+        let node_sync_store = Arc::new(NodeSyncStore::open_tables_read_write(
+            path.join("node_sync_db"),
+            None,
+            None,
+        ));
+
         // add the object_basics module
         AuthorityState::new(
             secret.public().into(),
             secret.clone(),
             store,
+            node_sync_store,
             epochs,
             None,
             None,
@@ -1478,6 +1491,21 @@ impl AuthorityState {
             tx_reconfigure_consensus,
         )
         .await
+    }
+
+    /// Add a number of certificates to the pending transactions as well as the
+    /// certificates structure if they are not already executed.
+    /// Certificates are optional, and if not provided, they will be eventually
+    /// downloaded in the execution driver.
+    pub fn add_pending_certificates(
+        &self,
+        certs: Vec<(TransactionDigest, Option<CertifiedTransaction>)>,
+    ) -> SuiResult<()> {
+        self.node_sync_store
+            .batch_store_certs(certs.iter().filter_map(|(_, cert_opt)| cert_opt.clone()))?;
+
+        self.database
+            .add_pending_digests(certs.iter().map(|(digest, _)| *digest).collect())
     }
 
     // Continually pop in-progress txes from the WAL and try to drive them to completion.
@@ -2095,8 +2123,15 @@ impl AuthorityState {
                     "handle_consensus_transaction UserTransaction",
                 );
 
+                // Schedule the certificate for execution
+                self.add_pending_certificates(vec![(
+                    *certificate.digest(),
+                    Some(*certificate.clone()),
+                )])
+                .map_err(NarwhalHandlerError::NodeError)?;
+
                 self.database
-                    .persist_certificate_and_lock_shared_objects(*certificate, consensus_index)
+                    .lock_shared_objects(*certificate, consensus_index)
                     // todo - potentially more errors from inside here needs to be mapped differently
                     .await
                     .map_err(NarwhalHandlerError::NodeError)?;
@@ -2123,7 +2158,7 @@ impl AuthorityState {
                     .handle_internal_fragment(
                         consensus_index.index,
                         *fragment,
-                        self.database.clone(),
+                        self,
                         &self.committee.load(),
                     )
                     .map_err(NarwhalHandlerError::NodeError)?;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1388,7 +1388,7 @@ impl AuthorityState {
         // Get all unprocessed checkpoints
         for (_seq, batch) in state
             .database
-            .tables
+            .perpetual_tables
             .batches
             .iter()
             .skip_to(&next_expected_tx)
@@ -1396,7 +1396,7 @@ impl AuthorityState {
         {
             let transactions: Vec<(TxSequenceNumber, ExecutionDigests)> = state
                 .database
-                .tables
+                .perpetual_tables
                 .executed_sequence
                 .iter()
                 .skip_to(&batch.data().initial_sequence_number)
@@ -1735,7 +1735,7 @@ impl AuthorityState {
                 .get_indexes()?
                 .get_transactions_to_addr(address, cursor, limit, reverse)?,
             TransactionQuery::All => {
-                let iter = self.database.tables.executed_sequence.iter();
+                let iter = self.database.perpetual_tables.executed_sequence.iter();
                 if reverse {
                     let iter = iter
                         .skip_prior_to(&cursor)?

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -156,7 +156,7 @@ impl TransactionNotifier {
                     if let Ok(iter) = transaction_notifier
                         .clone()
                         .state
-                        .tables
+                        .perpetual_tables
                         .executed_sequence
                         .iter()
                         .skip_to(&next_seq)

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{authority_store_tables::AuthorityStoreTables, *};
+use super::{
+    authority_store_tables::{AuthorityEpochTables, AuthorityPerpetualTables},
+    *,
+};
 use crate::authority::authority_store_tables::ExecutionIndicesWithHash;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
@@ -63,14 +66,23 @@ pub struct SuiDataStore<S> {
     // A notifier for new pending certificates
     pending_notifier: Arc<Notify>,
 
-    pub(crate) tables: AuthorityStoreTables<S>,
+    pub(crate) perpetual_tables: AuthorityPerpetualTables<S>,
+    pub(crate) epoch_tables: AuthorityEpochTables<S>,
 }
 
 impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// Open an authority store by directory path
     pub fn open(path: &Path, db_options: Option<Options>) -> Self {
-        let tables =
-            AuthorityStoreTables::open_tables_read_write(path.to_path_buf(), db_options, None);
+        let perpetual_tables_path = path.join("perpetual");
+        let epoch_tables_path = path.join("epoch");
+
+        let perpetual_tables = AuthorityPerpetualTables::open_tables_read_write(
+            perpetual_tables_path,
+            db_options.clone(),
+            None,
+        );
+        let epoch_tables =
+            AuthorityEpochTables::open_tables_read_write(epoch_tables_path, db_options, None);
 
         // For now, create one LockService for each SuiDataStore, and we use a specific
         // subdir of the data store directory
@@ -82,7 +94,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         let wal = Arc::new(DBWriteAheadLog::new(wal_path));
 
         // Get the last sequence item
-        let pending_seq = tables
+        let pending_seq = epoch_tables
             .pending_execution
             .iter()
             .skip_to_last()
@@ -97,7 +109,8 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             mutex_table: MutexTable::new(NUM_SHARDS, SHARD_SIZE),
             next_pending_seq,
             pending_notifier: Arc::new(Notify::new()),
-            tables,
+            perpetual_tables,
+            epoch_tables,
         }
     }
 
@@ -133,7 +146,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         transaction_digest: &TransactionDigest,
     ) -> SuiResult<TransactionEffects> {
-        self.tables
+        self.perpetual_tables
             .effects
             .get(transaction_digest)?
             .map(|data| data.effects)
@@ -144,7 +157,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     /// Returns true if we have an effects structure for this transaction digest
     pub fn effects_exists(&self, transaction_digest: &TransactionDigest) -> SuiResult<bool> {
-        self.tables
+        self.perpetual_tables
             .effects
             .contains_key(transaction_digest)
             .map_err(|e| e.into())
@@ -153,7 +166,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// Returns true if there are no objects in the database
     pub fn database_is_empty(&self) -> SuiResult<bool> {
         Ok(self
-            .tables
+            .perpetual_tables
             .objects
             .iter()
             .skip_to(&ObjectKey::ZERO)?
@@ -163,7 +176,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     pub fn next_sequence_number(&self) -> Result<TxSequenceNumber, SuiError> {
         Ok(self
-            .tables
+            .perpetual_tables
             .executed_sequence
             .iter()
             .skip_prior_to(&TxSequenceNumber::MAX)?
@@ -174,12 +187,15 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     #[cfg(test)]
     pub fn side_sequence(&self, seq: TxSequenceNumber, digest: &ExecutionDigests) {
-        self.tables.executed_sequence.insert(&seq, digest).unwrap();
+        self.perpetual_tables
+            .executed_sequence
+            .insert(&seq, digest)
+            .unwrap();
     }
 
     #[cfg(test)]
     pub fn get_next_object_version(&self, obj: &ObjectID) -> Option<SequenceNumber> {
-        self.tables.next_object_versions.get(obj).unwrap()
+        self.epoch_tables.next_object_versions.get(obj).unwrap()
     }
 
     /// Add a number of certificates to the pending transactions as well as the
@@ -226,13 +242,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn get_pending_digests(
         &self,
     ) -> SuiResult<Vec<(InternalSequenceNumber, TransactionDigest)>> {
-        Ok(self.tables.pending_execution.iter().collect())
+        Ok(self.epoch_tables.pending_execution.iter().collect())
     }
 
     /// Remove entries from pending certificates
     pub fn remove_pending_certificates(&self, seqs: Vec<InternalSequenceNumber>) -> SuiResult<()> {
-        let batch = self.tables.pending_execution.batch();
-        let batch = batch.delete_batch(&self.tables.pending_execution, seqs.iter())?;
+        let batch = self.epoch_tables.pending_execution.batch();
+        let batch = batch.delete_batch(&self.epoch_tables.pending_execution, seqs.iter())?;
         batch.write()?;
         Ok(())
     }
@@ -240,13 +256,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     // Empty the pending_execution table, and remove the certs from the certificates table.
     pub fn remove_all_pending_certificates(&self) -> SuiResult {
         let all_pending_tx = self.get_pending_digests()?;
-        let mut batch = self.tables.pending_execution.batch();
+        let mut batch = self.epoch_tables.pending_execution.batch();
         batch = batch.delete_batch(
-            &self.tables.certificates,
+            &self.perpetual_tables.certificates,
             all_pending_tx.iter().map(|(_, digest)| digest),
         )?;
         batch.write()?;
-        self.tables.pending_execution.clear()?;
+        self.epoch_tables.pending_execution.clear()?;
 
         Ok(())
     }
@@ -262,7 +278,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn get_owner_objects(&self, owner: Owner) -> Result<Vec<ObjectInfo>, SuiError> {
         debug!(?owner, "get_owner_objects");
         Ok(self
-            .tables
+            .perpetual_tables
             .owner_index
             .iter()
             // The object id 0 is the smallest possible
@@ -277,13 +293,16 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         object_id: &ObjectID,
         version: VersionNumber,
     ) -> Result<Option<Object>, SuiError> {
-        Ok(self.tables.objects.get(&ObjectKey(*object_id, version))?)
+        Ok(self
+            .perpetual_tables
+            .objects
+            .get(&ObjectKey(*object_id, version))?)
     }
 
     /// Read an object and return it, or Err(ObjectNotFound) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         let obj_entry = self
-            .tables
+            .perpetual_tables
             .objects
             .iter()
             .skip_prior_to(&ObjectKey::max_for_id(object_id))?
@@ -296,7 +315,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         // Note that the two reads in this function are (obviously) not atomic, and the
         // object may be deleted after we have read it. Hence we check get_latest_parent_entry
-        // last, so that the write to self.tables.parent_sync gets the last word.
+        // last, so that the write to self.perpetual_tables.parent_sync gets the last word.
         //
         // TODO: verify this race is ok.
         //
@@ -411,7 +430,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                     .factor(10)
                     .map(jitter)
                     .take(3);
-                let mut tx_option = self.tables.transactions.get(tx_digest)?;
+                let mut tx_option = self.epoch_tables.transactions.get(tx_digest)?;
                 while tx_option.is_none() {
                     if let Some(duration) = retry_strategy.next() {
                         // Wait to retry
@@ -421,7 +440,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                         // No more retries, just quit
                         break;
                     }
-                    tx_option = self.tables.transactions.get(tx_digest)?;
+                    tx_option = self.epoch_tables.transactions.get(tx_digest)?;
                 }
                 Ok(tx_option)
             }
@@ -434,13 +453,16 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<CertifiedTransaction>, SuiError> {
-        self.tables.certificates.get(digest).map_err(|e| e.into())
+        self.perpetual_tables
+            .certificates
+            .get(digest)
+            .map_err(|e| e.into())
     }
 
     /// Read the transactionDigest that is the parent of an object reference
     /// (ie. the transaction that created an object at this version.)
     pub fn parent(&self, object_ref: &ObjectRef) -> Result<Option<TransactionDigest>, SuiError> {
-        self.tables
+        self.perpetual_tables
             .parent_sync
             .get(object_ref)
             .map_err(|e| e.into())
@@ -451,7 +473,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         object_refs: &[ObjectRef],
     ) -> Result<Vec<Option<TransactionDigest>>, SuiError> {
-        self.tables
+        self.perpetual_tables
             .parent_sync
             .multi_get(object_refs)
             .map_err(|e| e.into())
@@ -468,7 +490,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         let obj_dig_inner = ObjectDigest::new([0; 32]);
 
         Ok(self
-            .tables
+            .perpetual_tables
             .parent_sync
             .iter()
             // The object id [0; 16] is the smallest possible
@@ -490,7 +512,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     ) -> Result<Vec<Option<SequenceNumber>>, SuiError> {
         let keys = object_ids.map(|objid| (*transaction_digest, *objid));
 
-        self.tables
+        self.epoch_tables
             .assigned_object_versions
             .multi_get(keys)
             .map_err(SuiError::from)
@@ -502,7 +524,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         transaction_digest: &TransactionDigest,
     ) -> Result<Vec<(ObjectID, SequenceNumber)>, SuiError> {
         Ok(self
-            .tables
+            .epoch_tables
             .assigned_object_versions
             .iter()
             .skip_to(&(*transaction_digest, ObjectID::ZERO))?
@@ -527,11 +549,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// TODO: We need this today because we don't have another way to sync an account.
     pub async fn insert_object_direct(&self, object_ref: ObjectRef, object: &Object) -> SuiResult {
         // Insert object
-        self.tables.objects.insert(&object_ref.into(), object)?;
+        self.perpetual_tables
+            .objects
+            .insert(&object_ref.into(), object)?;
 
         // Update the index
         if object.get_single_owner().is_some() {
-            self.tables.owner_index.insert(
+            self.perpetual_tables.owner_index.insert(
                 &(object.owner, object_ref.0),
                 &ObjectInfo::new(&object_ref, object),
             )?;
@@ -543,7 +567,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         }
 
         // Update the parent
-        self.tables
+        self.perpetual_tables
             .parent_sync
             .insert(&object_ref, &object.previous_transaction)?;
 
@@ -554,7 +578,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// In particular it does not check the old locks before inserting new ones, so the objects
     /// must be new.
     pub async fn bulk_object_insert(&self, objects: &[&Object]) -> SuiResult<()> {
-        let batch = self.tables.objects.batch();
+        let batch = self.perpetual_tables.objects.batch();
         let ref_and_objects: Vec<_> = objects
             .iter()
             .map(|o| (o.compute_object_reference(), o))
@@ -562,19 +586,19 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         batch
             .insert_batch(
-                &self.tables.objects,
+                &self.perpetual_tables.objects,
                 ref_and_objects
                     .iter()
                     .map(|(oref, o)| (ObjectKey::from(oref), **o)),
             )?
             .insert_batch(
-                &self.tables.owner_index,
+                &self.perpetual_tables.owner_index,
                 ref_and_objects
                     .iter()
                     .map(|(oref, o)| ((o.owner, oref.0), ObjectInfo::new(oref, o))),
             )?
             .insert_batch(
-                &self.tables.parent_sync,
+                &self.perpetual_tables.parent_sync,
                 ref_and_objects
                     .iter()
                     .map(|(oref, o)| (oref, o.previous_transaction)),
@@ -609,7 +633,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // For now write transactions after because if we write before, there is a chance the lock can fail
         // and this can cause invalid transactions to be inserted in the table.
         // https://github.com/MystenLabs/sui/issues/1990
-        self.tables.transactions.insert(&tx_digest, &transaction)?;
+        self.epoch_tables
+            .transactions
+            .insert(&tx_digest, &transaction)?;
 
         Ok(())
     }
@@ -638,12 +664,12 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     ) -> SuiResult {
         // Extract the new state from the execution
         // TODO: events are already stored in the TxDigest -> TransactionEffects store. Is that enough?
-        let mut write_batch = self.tables.certificates.batch();
+        let mut write_batch = self.perpetual_tables.certificates.batch();
 
         // Store the certificate indexed by transaction digest
         let transaction_digest: &TransactionDigest = certificate.digest();
         write_batch = write_batch.insert_batch(
-            &self.tables.certificates,
+            &self.perpetual_tables.certificates,
             iter::once((transaction_digest, certificate)),
         )?;
 
@@ -670,7 +696,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         transaction_digest: TransactionDigest,
     ) -> Result<(), SuiError> {
         debug_assert_eq!(transaction_digest, TransactionDigest::genesis());
-        let write_batch = self.tables.certificates.batch();
+        let write_batch = self.perpetual_tables.certificates.batch();
         self.batch_update_objects(
             write_batch,
             inner_temporary_store,
@@ -707,10 +733,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         }
         let (inner_temporary_store, _events) = temporary_store.into_inner();
 
-        let mut write_batch = self.tables.certificates.batch();
+        let mut write_batch = self.perpetual_tables.certificates.batch();
         // Store the certificate indexed by transaction digest
         write_batch = write_batch.insert_batch(
-            &self.tables.certificates,
+            &self.perpetual_tables.certificates,
             iter::once((transaction_digest, &certificate)),
         )?;
         self.sequence_tx(
@@ -748,9 +774,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // We can't write this until after sequencing succeeds (which happens in
         // batch_update_objects), as effects_exists is used as a check in many places
         // for "did the tx finish".
-        let batch = self.tables.effects.batch();
+        let batch = self.perpetual_tables.effects.batch();
         let batch = batch.insert_batch(
-            &self.tables.effects,
+            &self.perpetual_tables.effects,
             [(transaction_digest, effects)].into_iter(),
         )?;
 
@@ -772,7 +798,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             "storing sequence number to executed_sequence"
         );
         let batch = batch.insert_batch(
-            &self.tables.executed_sequence,
+            &self.perpetual_tables.executed_sequence,
             [(
                 assigned_seq,
                 ExecutionDigests::new(*transaction_digest, *effects_digest),
@@ -830,11 +856,12 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                 ));
 
         // Delete the old owner index entries
-        write_batch = write_batch.delete_batch(&self.tables.owner_index, old_object_owners)?;
+        write_batch =
+            write_batch.delete_batch(&self.perpetual_tables.owner_index, old_object_owners)?;
 
         // Index the certificate by the objects mutated
         write_batch = write_batch.insert_batch(
-            &self.tables.parent_sync,
+            &self.perpetual_tables.parent_sync,
             written
                 .iter()
                 .map(|(_, (object_ref, _object, _kind))| (object_ref, transaction_digest)),
@@ -842,7 +869,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         // Index the certificate by the objects deleted
         write_batch = write_batch.insert_batch(
-            &self.tables.parent_sync,
+            &self.perpetual_tables.parent_sync,
             deleted.iter().map(|(object_id, (version, kind))| {
                 (
                     (
@@ -862,12 +889,11 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // Once a transaction is done processing and effects committed, we no longer
         // need it in the transactions table. This also allows us to track pending
         // transactions.
-        write_batch =
-            write_batch.delete_batch(&self.tables.transactions, iter::once(transaction_digest))?;
+        self.epoch_tables.transactions.remove(&transaction_digest)?;
 
         // Update the indexes of the objects written
         write_batch = write_batch.insert_batch(
-            &self.tables.owner_index,
+            &self.perpetual_tables.owner_index,
             written
                 .iter()
                 .filter_map(|(_id, (object_ref, new_object, _kind))| {
@@ -880,7 +906,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         // Insert each output object into the stores
         write_batch = write_batch.insert_batch(
-            &self.tables.objects,
+            &self.perpetual_tables.objects,
             written
                 .iter()
                 .map(|(_, (obj_ref, new_object, _kind))| (ObjectKey::from(obj_ref), new_object)),
@@ -959,9 +985,11 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// 4. owner_index table change is reverted.
     pub fn revert_state_update(&self, tx_digest: &TransactionDigest) -> SuiResult {
         let effects = self.get_effects(tx_digest)?;
-        let mut write_batch = self.tables.certificates.batch();
-        write_batch = write_batch.delete_batch(&self.tables.certificates, iter::once(tx_digest))?;
-        write_batch = write_batch.delete_batch(&self.tables.effects, iter::once(tx_digest))?;
+        let mut write_batch = self.perpetual_tables.certificates.batch();
+        write_batch =
+            write_batch.delete_batch(&self.perpetual_tables.certificates, iter::once(tx_digest))?;
+        write_batch =
+            write_batch.delete_batch(&self.perpetual_tables.effects, iter::once(tx_digest))?;
 
         let all_new_refs = effects
             .mutated
@@ -971,7 +999,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .map(|(r, _)| r)
             .chain(effects.deleted.iter())
             .chain(effects.wrapped.iter());
-        write_batch = write_batch.delete_batch(&self.tables.parent_sync, all_new_refs)?;
+        write_batch = write_batch.delete_batch(&self.perpetual_tables.parent_sync, all_new_refs)?;
 
         let all_new_object_keys = effects
             .mutated
@@ -979,7 +1007,8 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .chain(effects.created.iter())
             .chain(effects.unwrapped.iter())
             .map(|((id, version, _), _)| ObjectKey(*id, *version));
-        write_batch = write_batch.delete_batch(&self.tables.objects, all_new_object_keys)?;
+        write_batch =
+            write_batch.delete_batch(&self.perpetual_tables.objects, all_new_object_keys)?;
 
         // Reverting the change to the owner_index table is most complex.
         // For each newly created (i.e. created and unwrapped) object, the entry in owner_index
@@ -993,7 +1022,8 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .chain(effects.unwrapped.iter())
             .chain(effects.mutated.iter())
             .map(|((id, _, _), owner)| (*owner, *id));
-        write_batch = write_batch.delete_batch(&self.tables.owner_index, owners_to_delete)?;
+        write_batch =
+            write_batch.delete_batch(&self.perpetual_tables.owner_index, owners_to_delete)?;
         let mutated_objects = effects
             .mutated
             .iter()
@@ -1009,7 +1039,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                 )
             });
         let old_objects = self
-            .tables
+            .perpetual_tables
             .objects
             .multi_get(mutated_objects)?
             .into_iter()
@@ -1020,7 +1050,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                     ObjectInfo::new(&obj.compute_object_reference(), &obj),
                 )
             });
-        write_batch = write_batch.insert_batch(&self.tables.owner_index, old_objects)?;
+        write_batch = write_batch.insert_batch(&self.perpetual_tables.owner_index, old_objects)?;
 
         write_batch.write()?;
         Ok(())
@@ -1042,7 +1072,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         object_id: ObjectID,
     ) -> Result<Option<(ObjectRef, TransactionDigest)>, SuiError> {
         let mut iterator = self
-            .tables
+            .perpetual_tables
             .parent_sync
             .iter()
             // Make the max possible entry for this object ID.
@@ -1071,11 +1101,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                 schedule_to_delete.push(*object_id);
             }
         }
-        let mut write_batch = self.tables.assigned_object_versions.batch();
-        write_batch =
-            write_batch.delete_batch(&self.tables.assigned_object_versions, sequenced_to_delete)?;
-        write_batch =
-            write_batch.delete_batch(&self.tables.next_object_versions, schedule_to_delete)?;
+        let mut write_batch = self.epoch_tables.assigned_object_versions.batch();
+        write_batch = write_batch.delete_batch(
+            &self.epoch_tables.assigned_object_versions,
+            sequenced_to_delete,
+        )?;
+        write_batch = write_batch
+            .delete_batch(&self.epoch_tables.next_object_versions, schedule_to_delete)?;
         write_batch.write()?;
         Ok(())
     }
@@ -1099,8 +1131,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .collect();
         debug!(?sequenced, "Shared object locks sequenced from effects");
 
-        let mut write_batch = self.tables.assigned_object_versions.batch();
-        write_batch = write_batch.insert_batch(&self.tables.assigned_object_versions, sequenced)?;
+        let mut write_batch = self.epoch_tables.assigned_object_versions.batch();
+        write_batch =
+            write_batch.insert_batch(&self.epoch_tables.assigned_object_versions, sequenced)?;
         write_batch.write()?;
 
         Ok(())
@@ -1111,7 +1144,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         digest: &TransactionDigest,
     ) -> Result<bool, SuiError> {
         Ok(self
-            .tables
+            .epoch_tables
             .consensus_message_processed
             .contains_key(digest)?)
     }
@@ -1131,7 +1164,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         // Make an iterator to update the locks of the transaction's shared objects.
         let ids = certificate.shared_input_objects();
-        let versions = self.tables.next_object_versions.multi_get(ids)?;
+        let versions = self.epoch_tables.next_object_versions.multi_get(ids)?;
 
         let ids = certificate.shared_input_objects();
         let (sequenced_to_write, schedule_to_write): (Vec<_>, Vec<_>) = ids
@@ -1172,7 +1205,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         //       it is ok to just update the pending list without updating the sequence.
 
         // Atomically store all elements.
-        let mut write_batch = self.tables.assigned_object_versions.batch();
+        let mut write_batch = self.epoch_tables.assigned_object_versions.batch();
 
         // If the tx has already been executed, we don't need to populate assigned_object_versions,
         // and indeed we shouldn't because it will never be cleaned up.
@@ -1192,16 +1225,18 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // (Both checkpoints and the node follower system ensure that at least one
         // honest validator has vouched for the TransactionEffects that were used).
         if !self.effects_exists(&transaction_digest)? {
-            write_batch = write_batch
-                .insert_batch(&self.tables.assigned_object_versions, sequenced_to_write)?;
+            write_batch = write_batch.insert_batch(
+                &self.epoch_tables.assigned_object_versions,
+                sequenced_to_write,
+            )?;
         }
 
         write_batch =
-            write_batch.insert_batch(&self.tables.next_object_versions, schedule_to_write)?;
+            write_batch.insert_batch(&self.epoch_tables.next_object_versions, schedule_to_write)?;
         write_batch =
-            write_batch.insert_batch(&self.tables.last_consensus_index, index_to_write)?;
+            write_batch.insert_batch(&self.epoch_tables.last_consensus_index, index_to_write)?;
         write_batch = write_batch.insert_batch(
-            &self.tables.consensus_message_processed,
+            &self.epoch_tables.consensus_message_processed,
             iter::once((transaction_digest, true)),
         )?;
         write_batch.write().map_err(SuiError::from)
@@ -1213,7 +1248,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         end: u64,
     ) -> SuiResult<Vec<(u64, ExecutionDigests)>> {
         Ok(self
-            .tables
+            .perpetual_tables
             .executed_sequence
             .iter()
             .skip_to(&start)?
@@ -1252,7 +1287,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         */
         let batches: Vec<SignedBatch> = self
-            .tables
+            .perpetual_tables
             .batches
             .iter()
             .skip_prior_to(&start)?
@@ -1300,7 +1335,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         callers to use the subscription API to catch the latest items in order. */
 
         let transactions: Vec<(TxSequenceNumber, ExecutionDigests)> = self
-            .tables
+            .perpetual_tables
             .executed_sequence
             .iter()
             .skip_to(&first_seq)?
@@ -1327,7 +1362,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
     /// Return the latest consensus index. It is used to bootstrap the consensus client.
     pub fn last_consensus_index(&self) -> SuiResult<ExecutionIndicesWithHash> {
-        self.tables
+        self.epoch_tables
             .last_consensus_index
             .get(&LAST_CONSENSUS_INDEX_ADDR)
             .map(|x| x.unwrap_or_default())
@@ -1338,7 +1373,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         transaction_digest: &TransactionDigest,
     ) -> SuiResult<Option<TransactionEnvelope<S>>> {
-        let transaction = self.tables.transactions.get(transaction_digest)?;
+        let transaction = self.epoch_tables.transactions.get(transaction_digest)?;
         Ok(transaction)
     }
 
@@ -1346,7 +1381,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         transaction_digest: &TransactionDigest,
     ) -> SuiResult<Option<CertifiedTransaction>> {
-        let transaction = self.tables.certificates.get(transaction_digest)?;
+        let transaction = self.perpetual_tables.certificates.get(transaction_digest)?;
         Ok(transaction)
     }
 
@@ -1354,7 +1389,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         &self,
         transaction_digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Option<CertifiedTransaction>>> {
-        Ok(self.tables.certificates.multi_get(transaction_digests)?)
+        Ok(self
+            .perpetual_tables
+            .certificates
+            .multi_get(transaction_digests)?)
     }
 
     pub fn get_sui_system_state_object(&self) -> SuiResult<SuiSystemState>
@@ -1381,7 +1419,7 @@ impl SuiDataStore<AuthoritySignInfo> {
         cur_epoch: EpochId,
         transaction_digest: &TransactionDigest,
     ) -> SuiResult<bool> {
-        let tx = self.tables.transactions.get(transaction_digest)?;
+        let tx = self.epoch_tables.transactions.get(transaction_digest)?;
         Ok(if let Some(signed_tx) = tx {
             signed_tx.auth_sign_info.epoch == cur_epoch
         } else {
@@ -1394,16 +1432,16 @@ impl SuiDataStore<AuthoritySignInfo> {
         transaction_digest: &TransactionDigest,
     ) -> Result<TransactionInfoResponse, SuiError> {
         Ok(TransactionInfoResponse {
-            signed_transaction: self.tables.transactions.get(transaction_digest)?,
-            certified_transaction: self.tables.certificates.get(transaction_digest)?,
-            signed_effects: self.tables.effects.get(transaction_digest)?,
+            signed_transaction: self.epoch_tables.transactions.get(transaction_digest)?,
+            certified_transaction: self.perpetual_tables.certificates.get(transaction_digest)?,
+            signed_effects: self.perpetual_tables.effects.get(transaction_digest)?,
         })
     }
 }
 
 impl SuiDataStore<EmptySignInfo> {
     pub fn pending_transactions(&self) -> &DBMap<TransactionDigest, Transaction> {
-        &self.tables.transactions
+        &self.epoch_tables.transactions
     }
 }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -73,16 +73,8 @@ pub struct SuiDataStore<S> {
 impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// Open an authority store by directory path
     pub fn open(path: &Path, db_options: Option<Options>) -> Self {
-        let perpetual_tables_path = path.join("perpetual");
-        let epoch_tables_path = path.join("epoch");
-
-        let perpetual_tables = AuthorityPerpetualTables::open_tables_read_write(
-            perpetual_tables_path,
-            db_options.clone(),
-            None,
-        );
-        let epoch_tables =
-            AuthorityEpochTables::open_tables_read_write(epoch_tables_path, db_options, None);
+        let perpetual_tables = AuthorityPerpetualTables::open(path, db_options.clone());
+        let epoch_tables = AuthorityEpochTables::open(path, db_options);
 
         // For now, create one LockService for each SuiDataStore, and we use a specific
         // subdir of the data store directory

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -15,8 +15,50 @@ use typed_store::rocks::DBMap;
 use typed_store::traits::TypedStoreDebug;
 
 use typed_store_derive::DBMapUtils;
+
+/// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
 #[derive(DBMapUtils)]
-pub struct AuthorityStoreTables<S> {
+pub struct AuthorityEpochTables<S> {
+    /// This is map between the transaction digest and transactions found in the `transaction_lock`.
+    #[default_options_override_fn = "transactions_table_default_config"]
+    pub(crate) transactions: DBMap<TransactionDigest, TransactionEnvelope<S>>,
+
+    /// The pending execution table holds a sequence of transactions that are present
+    /// in the certificates table, but may not have yet been executed, and should be executed.
+    /// The source of these certificates might be (1) the checkpoint proposal process (2) the
+    /// gossip processes (3) the shared object post-consensus task. An active authority process
+    /// reads this table and executes the certificates. The order is a hint as to their
+    /// causal dependencies. Note that there is no guarantee digests are unique. Once executed, and
+    /// effects are written the entry should be deleted.
+    pub(crate) pending_execution: DBMap<InternalSequenceNumber, TransactionDigest>,
+
+    /// Hold the lock for shared objects. These locks are written by a single task: upon receiving a valid
+    /// certified transaction from consensus, the authority assigns a lock to each shared objects of the
+    /// transaction. Note that all authorities are guaranteed to assign the same lock to these objects.
+    /// TODO: These two maps should be merged into a single one (no reason to have two).
+    pub(crate) assigned_object_versions: DBMap<(TransactionDigest, ObjectID), SequenceNumber>,
+    pub(crate) next_object_versions: DBMap<ObjectID, SequenceNumber>,
+
+    /// Track which transactions have been processed in handle_consensus_transaction. We must be
+    /// sure to advance next_object_versions exactly once for each transaction we receive from
+    /// consensus. But, we may also be processing transactions from checkpoints, so we need to
+    /// track this state separately.
+    ///
+    /// Entries in this table can be garbage collected whenever we can prove that we won't receive
+    /// another handle_consensus_transaction call for the given digest. This probably means at
+    /// epoch change.
+    pub(crate) consensus_message_processed: DBMap<TransactionDigest, bool>,
+
+    /// The following table is used to store a single value (the corresponding key is a constant). The value
+    /// represents the index of the latest consensus message this authority processed. This field is written
+    /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
+    /// every message output by consensus (and in the right order).
+    pub(crate) last_consensus_index: DBMap<u64, ExecutionIndicesWithHash>,
+}
+
+/// AuthorityPerpetualTables contains data that must be preserved from one epoch to the next.
+#[derive(DBMapUtils)]
+pub struct AuthorityPerpetualTables<S> {
     /// This is a map between the object (ID, version) and the latest state of the object, namely the
     /// state that is needed to process new transactions.
     ///
@@ -37,25 +79,12 @@ pub struct AuthorityStoreTables<S> {
     /// by a specific user, and their object reference.
     pub(crate) owner_index: DBMap<(Owner, ObjectID), ObjectInfo>,
 
-    /// This is map between the transaction digest and transactions found in the `transaction_lock`.
-    #[default_options_override_fn = "transactions_table_default_config"]
-    pub(crate) transactions: DBMap<TransactionDigest, TransactionEnvelope<S>>,
-
     /// This is a map between the transaction digest and the corresponding certificate for all
     /// certificates that have been successfully processed by this authority. This set of certificates
     /// along with the genesis allows the reconstruction of all other state, and a full sync to this
     /// authority.
     #[default_options_override_fn = "certificates_table_default_config"]
     pub(crate) certificates: DBMap<TransactionDigest, CertifiedTransaction>,
-
-    /// The pending execution table holds a sequence of transactions that are present
-    /// in the certificates table, but may not have yet been executed, and should be executed.
-    /// The source of these certificates might be (1) the checkpoint proposal process (2) the
-    /// gossip processes (3) the shared object post-consensus task. An active authority process
-    /// reads this table and executes the certificates. The order is a hint as to their
-    /// causal dependencies. Note that there is no guarantee digests are unique. Once executed, and
-    /// effects are written the entry should be deleted.
-    pub(crate) pending_execution: DBMap<InternalSequenceNumber, TransactionDigest>,
 
     /// The map between the object ref of objects processed at all versions and the transaction
     /// digest of the certificate that lead to the creation of this version of the object.
@@ -71,35 +100,25 @@ pub struct AuthorityStoreTables<S> {
     #[default_options_override_fn = "effects_table_default_config"]
     pub(crate) effects: DBMap<TransactionDigest, TransactionEffectsEnvelope<S>>,
 
-    /// Hold the lock for shared objects. These locks are written by a single task: upon receiving a valid
-    /// certified transaction from consensus, the authority assigns a lock to each shared objects of the
-    /// transaction. Note that all authorities are guaranteed to assign the same lock to these objects.
-    /// TODO: These two maps should be merged into a single one (no reason to have two).
-    pub(crate) assigned_object_versions: DBMap<(TransactionDigest, ObjectID), SequenceNumber>,
-    pub(crate) next_object_versions: DBMap<ObjectID, SequenceNumber>,
-
-    /// Track which transactions have been processed in handle_consensus_transaction. We must be
-    /// sure to advance next_object_versions exactly once for each transaction we receive from
-    /// consensus. But, we may also be processing transactions from checkpoints, so we need to
-    /// track this state separately.
-    ///
-    /// Entries in this table can be garbage collected whenever we can prove that we won't receive
-    /// another handle_consensus_transaction call for the given digest. This probably means at
-    /// epoch change.
-    pub(crate) consensus_message_processed: DBMap<TransactionDigest, bool>,
-
     // Tables used for authority batch structure
+    // TODO: executed_sequence and batches both conceptually belong in AuthorityEpochTables,
+    // but we currently require that effects and executed_sequence are written atomically.
+    // See https://github.com/MystenLabs/sui/pull/4395 for the reason why.
+    //
+    // This can be addressed when we do the WAL rework. Something similar to the following flow
+    // would be required:
+    // 1. First execute the tx and store the outputs in an intermediate location.
+    // 2. Note that execution has finished (e.g. in the WAL.)
+    // 3. Write intermediate outputs to their permanent locations.
+    // 4. Mark the tx as finished in the WAL.
+    // 5. Crucially: If step 3 is interrupted, we must restart at step 3 based solely on the fact
+    //    that the WAL indicates the tx is not written yet. This fixes the root cause of the issue,
+    //    which is that we currently exit early if effects have been written.
     /// A sequence on all executed certificates and effects.
     pub executed_sequence: DBMap<TxSequenceNumber, ExecutionDigests>,
 
     /// A sequence of batches indexing into the sequence of executed transactions.
     pub batches: DBMap<TxSequenceNumber, SignedBatch>,
-
-    /// The following table is used to store a single value (the corresponding key is a constant). The value
-    /// represents the index of the latest consensus message this authority processed. This field is written
-    /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
-    /// every message output by consensus (and in the right order).
-    pub(crate) last_consensus_index: DBMap<u64, ExecutionIndicesWithHash>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -8,6 +8,7 @@ use super::{
 use narwhal_executor::ExecutionIndices;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use sui_storage::default_db_options;
 use sui_types::base_types::{ExecutionDigests, SequenceNumber};
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
@@ -54,6 +55,23 @@ pub struct AuthorityEpochTables<S> {
     /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
     /// every message output by consensus (and in the right order).
     pub(crate) last_consensus_index: DBMap<u64, ExecutionIndicesWithHash>,
+}
+
+impl<S> AuthorityEpochTables<S>
+where
+    S: std::fmt::Debug + Serialize + for<'de> Deserialize<'de>,
+{
+    pub fn path(parent_path: &Path) -> PathBuf {
+        parent_path.join("epoch")
+    }
+
+    pub fn open(parent_path: &Path, db_options: Option<Options>) -> Self {
+        Self::open_tables_read_write(Self::path(parent_path), db_options, None)
+    }
+
+    pub fn open_readonly(parent_path: &Path) -> AuthorityEpochTablesReadOnly<S> {
+        Self::get_read_only_handle(Self::path(parent_path), None, None)
+    }
 }
 
 /// AuthorityPerpetualTables contains data that must be preserved from one epoch to the next.
@@ -119,6 +137,23 @@ pub struct AuthorityPerpetualTables<S> {
 
     /// A sequence of batches indexing into the sequence of executed transactions.
     pub batches: DBMap<TxSequenceNumber, SignedBatch>,
+}
+
+impl<S> AuthorityPerpetualTables<S>
+where
+    S: std::fmt::Debug + Serialize + for<'de> Deserialize<'de>,
+{
+    pub fn path(parent_path: &Path) -> PathBuf {
+        parent_path.join("perpetual")
+    }
+
+    pub fn open(parent_path: &Path, db_options: Option<Options>) -> Self {
+        Self::open_tables_read_write(Self::path(parent_path), db_options, None)
+    }
+
+    pub fn open_readonly(parent_path: &Path) -> AuthorityPerpetualTablesReadOnly<S> {
+        Self::get_read_only_handle(Self::path(parent_path), None, None)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -83,7 +83,6 @@ async fn pending_exec_storage_notify() {
     // Insert the certificates
     let num_certs = certs.len();
     authority_state
-        .database
         .add_pending_certificates(
             certs
                 .into_iter()
@@ -170,7 +169,6 @@ async fn pending_exec_full() {
     // Insert the certificates
     let num_certs = certs.len();
     authority_state
-        .database
         .add_pending_certificates(
             certs
                 .into_iter()
@@ -264,7 +262,6 @@ async fn test_parent_cert_exec() {
     active_state.clone().spawn_execute_process().await;
 
     authorities[3]
-        .database
         .add_pending_certificates(vec![(*tx2.digest(), None)])
         .unwrap();
 

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -325,7 +325,6 @@ impl GossipDigestHandler {
         if let Some(certificate) = response.certified_transaction {
             let digest = *certificate.digest();
             state
-                .database
                 .add_pending_certificates(vec![(digest, Some(certificate))])
                 .tap_err(|e| error!(?digest, "add_pending_certificates failed: {}", e))?;
 

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -60,7 +60,7 @@ impl crate::authority::AuthorityState {
     pub fn last_batch(&self) -> Result<Option<SignedBatch>, SuiError> {
         let last_batch = self
             .db()
-            .tables
+            .perpetual_tables
             .batches
             .iter()
             .skip_prior_to(&TxSequenceNumber::MAX)?
@@ -79,7 +79,7 @@ impl crate::authority::AuthorityState {
         // First read the last batch in the db
         let mut last_batch = match self
             .db()
-            .tables
+            .perpetual_tables
             .batches
             .iter()
             .skip_prior_to(&TxSequenceNumber::MAX)?
@@ -94,7 +94,7 @@ impl crate::authority::AuthorityState {
                     &*self.secret,
                     self.name,
                 );
-                self.db().tables.batches.insert(&0, &zero_batch)?;
+                self.db().perpetual_tables.batches.insert(&0, &zero_batch)?;
                 zero_batch.into_data()
             }
         };
@@ -102,7 +102,7 @@ impl crate::authority::AuthorityState {
         // See if there are any transactions in the database not in a batch
         let transactions: Vec<_> = self
             .db()
-            .tables
+            .perpetual_tables
             .executed_sequence
             .iter()
             .skip_to(&last_batch.next_sequence_number)?
@@ -117,7 +117,7 @@ impl crate::authority::AuthorityState {
                 &*self.secret,
                 self.name,
             );
-            self.db().tables.batches.insert(
+            self.db().perpetual_tables.batches.insert(
                 &last_signed_batch.data().next_sequence_number,
                 &last_signed_batch,
             )?;
@@ -136,7 +136,7 @@ impl crate::authority::AuthorityState {
         // This assumes we have initialized the database with a batch.
         let (next_sequence_number, prev_signed_batch) = self
             .db()
-            .tables
+            .perpetual_tables
             .batches
             .iter()
             .skip_prior_to(&TxSequenceNumber::MAX)?
@@ -214,7 +214,7 @@ impl crate::authority::AuthorityState {
                     self.name,
                 );
                 self.db()
-                    .tables
+                    .perpetual_tables
                     .batches
                     .insert(&new_batch.data().next_sequence_number, &new_batch)?;
                 debug!(next_sequence_number=?new_batch.data().next_sequence_number, "New batch created. Transactions: {:?}", current_batch);

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -455,7 +455,6 @@ impl ValidatorService {
                 // Record the cert for later execution, including causal completion if necessary.
                 let tx_digest = *tx_digest;
                 let _ = state
-                    .database
                     .add_pending_certificates(vec![(tx_digest, Some(certificate))])
                     .tap_err(|e| error!(?tx_digest, "add_pending_certificates failed: {}", e));
                 Err(e)

--- a/crates/sui-core/src/checkpoints/causal_order_effects.rs
+++ b/crates/sui-core/src/checkpoints/causal_order_effects.rs
@@ -183,7 +183,7 @@ impl EffectsStore for Arc<AuthorityStore> {
         transactions: impl Iterator<Item = &'a ExecutionDigests>,
     ) -> SuiResult<Vec<Option<TransactionEffects>>> {
         Ok(self
-            .tables
+            .perpetual_tables
             .effects
             .multi_get(transactions.map(|d| d.transaction))?
             .into_iter()

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1560,7 +1560,7 @@ pub async fn checkpoint_tests_setup(
                 } else if let Err(err) = cps.lock().handle_internal_fragment(
                     seq.clone(),
                     msg.clone(),
-                    authority.database.clone(),
+                    authority.as_ref(),
                     &c,
                 ) {
                     println!("Error: {:?}", err);

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2419,7 +2419,7 @@ async fn test_consensus_message_processed() {
                 .unwrap();
             authority2
                 .database
-                .tables
+                .perpetual_tables
                 .effects
                 .get(transaction_digest)
                 .unwrap()

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -120,7 +120,7 @@ async fn test_open_manager() {
         //         when we re-open the database.
 
         store
-            .tables
+            .perpetual_tables
             .executed_sequence
             .insert(&0, &ExecutionDigests::random())
             .expect("no error on write");
@@ -143,7 +143,7 @@ async fn test_open_manager() {
 
         // TEST 3: If the database contains out of order transactions we just make a block with gaps
         store
-            .tables
+            .perpetual_tables
             .executed_sequence
             .insert(&2, &ExecutionDigests::random())
             .expect("no error on write");
@@ -445,7 +445,7 @@ async fn test_batch_store_retrieval() {
     for _i in 0u64..105 {
         let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
         inner_store
-            .tables
+            .perpetual_tables
             .executed_sequence
             .insert(&t0.seq(), &tx_zero)
             .expect("Failed to write.");
@@ -462,7 +462,7 @@ async fn test_batch_store_retrieval() {
     for _i in 110u64..120 {
         let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
         inner_store
-            .tables
+            .perpetual_tables
             .executed_sequence
             .insert(&t0.seq(), &tx_zero)
             .expect("Failed to write.");

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -129,7 +129,7 @@ async fn test_subscription() {
     let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
         let ticket = state.batch_notifier.ticket(false).expect("all good");
-        db.tables
+        db.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
             .expect("Failed to write.");
@@ -184,7 +184,7 @@ async fn test_subscription() {
                 .batch_notifier
                 .ticket(false)
                 .expect("all good");
-            db2.tables
+            db2.perpetual_tables
                 .executed_sequence
                 .insert(&ticket.seq(), &tx_zero)
                 .expect("Failed to write.");
@@ -262,7 +262,7 @@ async fn test_subscription() {
             .batch_notifier
             .ticket(false)
             .expect("all good");
-        db3.tables
+        db3.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
             .expect("Failed to write.");
@@ -338,7 +338,7 @@ async fn test_subscription_safe_client() {
     let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
         let ticket = server.state.batch_notifier.ticket(false).expect("all good");
-        db.tables
+        db.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
             .expect("Failed to write.");
@@ -401,7 +401,7 @@ async fn test_subscription_safe_client() {
                 .batch_notifier
                 .ticket(false)
                 .expect("all good");
-            db2.tables
+            db2.perpetual_tables
                 .executed_sequence
                 .insert(&ticket.seq(), &tx_zero)
                 .expect("Failed to write.");
@@ -475,7 +475,7 @@ async fn test_subscription_safe_client() {
             .batch_notifier
             .ticket(false)
             .expect("all good");
-        db3.tables
+        db3.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
             .expect("Failed to write.");

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -133,11 +133,18 @@ impl SuiNode {
             .websocket_address
             .map(|_| Arc::new(TransactionStreamer::new()));
 
+        let node_sync_store = Arc::new(NodeSyncStore::open_tables_read_write(
+            config.db_path().join("node_sync_db"),
+            None,
+            None,
+        ));
+
         let state = Arc::new(
             AuthorityState::new(
                 config.protocol_public_key(),
                 secret,
                 store,
+                node_sync_store,
                 committee_store.clone(),
                 index_store.clone(),
                 event_store,
@@ -177,14 +184,8 @@ impl SuiNode {
             network_metrics.clone(),
         );
 
-        let node_sync_store = Arc::new(NodeSyncStore::open_tables_read_write(
-            config.db_path().join("node_sync_db"),
-            None,
-            None,
-        ));
         let active_authority = Arc::new(ActiveAuthority::new(
             state.clone(),
-            node_sync_store,
             net.clone(),
             GossipMetrics::new(&prometheus_registry),
             network_metrics.clone(),

--- a/crates/sui-storage/src/node_sync_store.rs
+++ b/crates/sui-storage/src/node_sync_store.rs
@@ -68,6 +68,18 @@ impl NodeSyncStore {
             .insert(&(epoch_id, *cert.digest()), cert)?)
     }
 
+    pub fn batch_store_certs(
+        &self,
+        certs: impl Iterator<Item = CertifiedTransaction>,
+    ) -> SuiResult {
+        let batch = self.pending_certs.batch().insert_batch(
+            &self.pending_certs,
+            certs.map(|cert| ((cert.epoch(), *cert.digest()), cert)),
+        )?;
+        batch.write()?;
+        Ok(())
+    }
+
     pub fn store_effects(
         &self,
         epoch_id: EpochId,

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -67,7 +67,7 @@ async fn test_full_node_follows_txes() -> Result<(), anyhow::Error> {
     wait_for_tx(digest, node.state().clone()).await;
 
     // verify that the intermediate sync data is cleared.
-    let sync_store = node.active().node_sync_store.clone();
+    let sync_store = node.state().node_sync_store.clone();
     let epoch_id = 0;
     assert!(sync_store.get_cert(epoch_id, &digest).unwrap().is_none());
     assert!(sync_store.get_effects(epoch_id, &digest).unwrap().is_none());


### PR DESCRIPTION
The intent here is to have clearer separation between data that is epoch specific and data that must last forever. There are many bugs possible if we improperly access data from old epochs, so this is intended to make such bugs much less likely.

This PR is just a first step, the next steps are:
- Create a fresh epoch db at the beginning of each epoch, by changing the pathname of the epoch db to include the epoch number. This will prevent data from being accessed cross-epoch.
- Audit all inserts into the perpetual table to make sure we never insert anything that should not be there. The main thing that can go wrong is if a cert is inserted despite not being fully executed, leading to a non-final cert with the wrong epoch number persisting into the next epoch.