### PR TITLE
[wallet-adapter] Remove deprecated wallet adapter APIs

### DIFF
--- a/.changeset/tidy-gifts-search.md
+++ b/.changeset/tidy-gifts-search.md
@@ -1,0 +1,8 @@
+---
+"@mysten/wallet-adapter-base": minor
+"@mysten/wallet-adapter-mock-wallet": minor
+"@mysten/wallet-adapter-sui-wallet": minor
+"@mysten/wallet-adapter-react": minor
+---
+
+Remove deprecated executeMoveCall and executeSerializedMoveCall APIs.

--- a/sdk/wallet-adapter/packages/adapters/base-adapter/src/index.ts
+++ b/sdk/wallet-adapter/packages/adapters/base-adapter/src/index.ts
@@ -22,21 +22,11 @@ export interface WalletAdapter {
   /**
    * Suggest a transaction for the user to sign. Supports all valid transaction types.
    */
-  signAndExecuteTransaction?(
+  signAndExecuteTransaction(
     transaction: SignableTransaction
   ): Promise<SuiTransactionResponse>;
 
   getAccounts: () => Promise<SuiAddress[]>;
-
-  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
-  executeMoveCall?: (
-    transaction: MoveCallTransaction
-  ) => Promise<SuiTransactionResponse>;
-
-  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
-  executeSerializedMoveCall?: (
-    transactionBytes: Uint8Array
-  ) => Promise<SuiTransactionResponse>;
 }
 
 type WalletAdapterProviderUnsubscribe = () => void;

--- a/sdk/wallet-adapter/packages/adapters/mock-wallet/src/adapter.ts
+++ b/sdk/wallet-adapter/packages/adapters/mock-wallet/src/adapter.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  MoveCallTransaction,
+  SignableTransaction,
   SuiAddress,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
@@ -16,11 +16,8 @@ interface SuiWallet {
   hasPermissions(permissions: readonly PermissionType[]): Promise<boolean>;
   requestPermissions(): Promise<boolean>;
   getAccounts(): Promise<SuiAddress[]>;
-  executeMoveCall: (
-    transaction: MoveCallTransaction
-  ) => Promise<SuiTransactionResponse>;
-  executeSerializedMoveCall: (
-    transactionBytes: Uint8Array
+  signAndExecuteTransaction: (
+    transaction: SignableTransaction
   ) => Promise<SuiTransactionResponse>;
 }
 interface SuiWalletWindow {
@@ -37,15 +34,10 @@ export class MockWalletAdapter implements WalletAdapter {
   getAccounts(): Promise<string[]> {
     return window.suiWallet.getAccounts();
   }
-  executeMoveCall(
-    transaction: MoveCallTransaction
+  signAndExecuteTransaction(
+    transaction: SignableTransaction
   ): Promise<SuiTransactionResponse> {
-    return window.suiWallet.executeMoveCall(transaction);
-  }
-  executeSerializedMoveCall(
-    transactionBytes: Uint8Array
-  ): Promise<SuiTransactionResponse> {
-    return window.suiWallet.executeSerializedMoveCall(transactionBytes);
+    return window.suiWallet.signAndExecuteTransaction(transaction);
   }
 
   name: string;

--- a/sdk/wallet-adapter/packages/adapters/sui-wallet/src/adapter.ts
+++ b/sdk/wallet-adapter/packages/adapters/sui-wallet/src/adapter.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  MoveCallTransaction,
   SignableTransaction,
   SuiAddress,
   SuiTransactionResponse,
@@ -17,12 +16,6 @@ interface SuiWallet {
   hasPermissions(permissions: readonly PermissionType[]): Promise<boolean>;
   requestPermissions(): Promise<boolean>;
   getAccounts(): Promise<SuiAddress[]>;
-  executeMoveCall: (
-    transaction: MoveCallTransaction
-  ) => Promise<SuiTransactionResponse>;
-  executeSerializedMoveCall: (
-    transactionBytes: Uint8Array
-  ) => Promise<SuiTransactionResponse>;
   signAndExecuteTransaction: (
     transaction: SignableTransaction
   ) => Promise<SuiTransactionResponse>;
@@ -44,16 +37,7 @@ export class SuiWalletAdapter implements WalletAdapter {
   getAccounts(): Promise<string[]> {
     return window.suiWallet.getAccounts();
   }
-  executeMoveCall(
-    transaction: MoveCallTransaction
-  ): Promise<SuiTransactionResponse> {
-    return window.suiWallet.executeMoveCall(transaction);
-  }
-  executeSerializedMoveCall(
-    transactionBytes: Uint8Array
-  ): Promise<SuiTransactionResponse> {
-    return window.suiWallet.executeSerializedMoveCall(transactionBytes);
-  }
+
   signAndExecuteTransaction(
     transaction: SignableTransaction
   ): Promise<SuiTransactionResponse> {

--- a/sdk/wallet-adapter/packages/react-providers/src/WalletContext.tsx
+++ b/sdk/wallet-adapter/packages/react-providers/src/WalletContext.tsx
@@ -41,15 +41,6 @@ export interface WalletContextState {
   signAndExecuteTransaction(
     transaction: SignableTransaction
   ): Promise<SuiTransactionResponse>;
-
-  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
-  executeMoveCall: (
-    transaction: MoveCallTransaction
-  ) => Promise<SuiTransactionResponse>;
-  /** @deprecated Prefer `signAndExecuteTransaction` when available. */
-  executeSerializedMoveCall: (
-    transactionBytes: Uint8Array
-  ) => Promise<SuiTransactionResponse>;
 }
 
 export const WalletContext = createContext<WalletContextState | null>(null);
@@ -73,6 +64,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
   const [connecting, setConnecting] = useState(false);
 
   const disconnect = useCallback(async () => {
+    wallet?.disconnect();
     setConnected(false);
     setWallet(null);
     localStorage.removeItem(DEFAULT_STORAGE_KEY);
@@ -130,24 +122,6 @@ export const WalletProvider: FC<WalletProviderProps> = ({
       async getAccounts() {
         if (wallet == null) throw Error("Wallet Not Connected");
         return wallet.getAccounts();
-      },
-
-      async executeMoveCall(transaction) {
-        if (wallet == null) throw Error("Wallet Not Connected");
-        if (!wallet.executeMoveCall) {
-          throw new Error('Wallet does not support "executeMoveCall" method');
-        }
-        return wallet.executeMoveCall(transaction);
-      },
-
-      async executeSerializedMoveCall(transactionBytes) {
-        if (wallet == null) throw Error("Wallet Not Connected");
-        if (!wallet.executeSerializedMoveCall) {
-          throw new Error(
-            'Wallet does not support "executeSerializedMoveCall" method'
-          );
-        }
-        return wallet.executeSerializedMoveCall(transactionBytes);
       },
 
       async signAndExecuteTransaction(transaction) {


### PR DESCRIPTION
This removes the deprecated `executeMoveCall` and `executeSerializedMoveCall` APIs, and marks `signAndExecuteTransaction` as required. These APIs both can be performed through the new API.

Also fixes #5178. 