### PR TITLE
[bullshark]: do not insert certificates past committed round

### DIFF
--- a/narwhal/consensus/src/bullshark.rs
+++ b/narwhal/consensus/src/bullshark.rs
@@ -7,10 +7,7 @@ use crate::{
 };
 use config::{Committee, Stake};
 use fastcrypto::{traits::EncodeDecodeBase64, Hash};
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 use tracing::{debug, error};
 use types::{Certificate, CertificateDigest, ConsensusStore, Round, SequenceNumber, StoreResult};
 
@@ -70,11 +67,9 @@ impl ConsensusProtocol for Bullshark {
         }
 
         // Add the new certificate to the local storage.
-        state
-            .dag
-            .entry(round)
-            .or_insert_with(HashMap::new)
-            .insert(certificate.origin(), (certificate.digest(), certificate));
+        if state.try_insert(certificate).is_err() {
+            return Ok(Vec::new());
+        }
 
         // Try to order the dag to commit. Start from the highest round for which we have at least
         // f+1 certificates. This is because we need them to reveal the common coin.


### PR DESCRIPTION
This check ensures that certificates past committed round for the given origin are not inserted in the consensus DAG.

This is believed to be a source of consensus fork we observe in the private testnet:

(1) Primary is assumed to be able to send repeating certificates to ConsensusProtocol::process_certificate
(2) Currently ConsensusProtocol::process_certificate inserts certificate to hashmap unconditionally
(3) When commit is processed, certificates with round *less than* last committed round are removed in ConsensusState::update
(4) When dag is ordered, certificates with round **equal to** last committed round are ignored during sequencing

The current sequence opens loophole when certificate to round **previous to** last committed is submitted into consensus, it might be sequenced again later. This is in line with current logs we observe in testnet.

This PR enforces invariant that dag does not contain nodes with round **less than** last committed for the given node.