### PR TITLE
[bullshark] fix sub-dag leader round calculation

### DIFF
--- a/narwhal/consensus/src/utils.rs
+++ b/narwhal/consensus/src/utils.rs
@@ -19,7 +19,8 @@ where
 {
     let mut to_commit = vec![leader.clone()];
     let mut leader = leader;
-    for r in (state.last_committed_round + 2..leader.round())
+    assert_eq!(leader.round() % 2, 0);
+    for r in (state.last_committed_round + 2..=leader.round() - 2)
         .rev()
         .step_by(2)
     {


### PR DESCRIPTION
Currently leaders / anchors for sub-dags are selected from odd rounds, because the first sub-dag leader is selected at leader's `round - 1` instead of `round - 2`. Fix the range expression to generate sub-dag leader rounds at even rounds.

Will try to see if a unit test can be added.