### PR TITLE
wallet-ext: helper to unlock wallet

### DIFF
--- a/apps/wallet/src/ui/app/wallet/constants.ts
+++ b/apps/wallet/src/ui/app/wallet/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export const devQuickUnlockEnabled = process.env.NODE_ENV === 'development';


### PR DESCRIPTION
* this is enabled only in development mode and unlocks the wallet without having to enter the password all the time
* store the password in storage under the key `**dev**.pass` and click unlock when the password field is empty


https://user-images.githubusercontent.com/10210143/195731019-9dfefc82-8516-4f86-b24d-e8e9b17598f4.mov

