### PR TITLE
wallet-ext: use fullnode for executing transaction

### DIFF
--- a/.changeset/kind-dolphins-add.md
+++ b/.changeset/kind-dolphins-add.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add gas selection to LocalTxnSerializer

--- a/.changeset/new-dolls-nail.md
+++ b/.changeset/new-dolls-nail.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Deprecate Gateway related APIs

--- a/.changeset/smart-lies-trade.md
+++ b/.changeset/smart-lies-trade.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Add rpcAPIVersion to JsonRpcProvider to support multiple RPC API Versions

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -11,6 +11,7 @@ import {
     RawSigner,
     LocalTxnDataSerializer,
     type Keypair,
+    LATEST_RPC_API_VERSION,
 } from '../../../sdk/typescript/src';
 
 export async function createLocalnetTasks() {
@@ -22,7 +23,11 @@ export async function createLocalnetTasks() {
             if (!keypair) {
                 throw new Error('missing keypair');
             }
-            const provider = new JsonRpcProvider('http://localhost:9000');
+            const provider = new JsonRpcProvider(
+                'http://localhost:9000',
+                false,
+                LATEST_RPC_API_VERSION
+            );
             const signer = new RawSigner(
                 keypair,
                 provider,

--- a/apps/explorer/src/pages/transaction-result/TransactionResult.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionResult.tsx
@@ -111,7 +111,7 @@ const transformTransactionResponse = (
     return {
         ...txObj.certificate,
         status: getExecutionStatusType(txObj)!,
-        gasFee: getTotalGasUsed(txObj),
+        gasFee: getTotalGasUsed(txObj)!,
         txError: getExecutionStatusError(txObj) ?? '',
         txId: id,
         loadState: 'loaded',

--- a/apps/explorer/src/utils/api/DefaultRpcClient.ts
+++ b/apps/explorer/src/utils/api/DefaultRpcClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { JsonRpcProvider } from '@mysten/sui.js';
+import { JsonRpcProvider, LATEST_RPC_API_VERSION } from '@mysten/sui.js';
 
 import { getEndpoint, Network } from './rpcSetting';
 
@@ -12,7 +12,11 @@ export const DefaultRpcClient = (network: Network | string) => {
     const existingClient = defaultRpcMap.get(network);
     if (existingClient) return existingClient;
 
-    const provider = new JsonRpcProvider(getEndpoint(network));
+    const provider = new JsonRpcProvider(
+        getEndpoint(network),
+        true,
+        LATEST_RPC_API_VERSION
+    );
     defaultRpcMap.set(network, provider);
     return provider;
 };

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -3,9 +3,13 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
-const GROWTHBOOK_API_KEY =
-    process.env.GROWTH_BOOK_API_KEY ?? 'key_dev_dc2872e15e0c5f95';
+import type { JSONValue } from '@growthbook/growthbook';
+import type { WidenPrimitives } from '@growthbook/growthbook/dist/types/growthbook';
 
+const GROWTHBOOK_API_KEY =
+    process.env.NODE_ENV === 'production'
+        ? 'key_prod_ac59fe325855eb5f'
+        : 'key_dev_dc2872e15e0c5f95';
 export default class FeatureGating {
     #growthBook: GrowthBook;
 
@@ -38,5 +42,12 @@ export default class FeatureGating {
 
     public isOn(featureName: string): boolean {
         return this.#growthBook.isOn(featureName);
+    }
+
+    public getFeatureValue<T extends JSONValue>(
+        featureName: string,
+        defaultValue: T
+    ): WidenPrimitives<T> {
+        return this.#growthBook.getFeatureValue(featureName, defaultValue);
     }
 }

--- a/apps/wallet/src/ui/app/experimentation/features.ts
+++ b/apps/wallet/src/ui/app/experimentation/features.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * This is a list of feature keys that are used in
+ * in https://docs.growthbook.io/app/features#feature-keys
+ */
+export enum FEATURES {
+    DEPRECATE_GATEWAY = 'deprecate-gateway',
+    RPC_API_VERSION = 'rpc-api-version',
+}

--- a/apps/wallet/src/ui/app/pages/home/transaction-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transaction-details/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+    getCertifiedTransaction,
     getExecutionStatusType,
     getTransactionKindName,
     getTransactions,
@@ -46,7 +47,10 @@ function TransactionDetailsPage() {
     const statusIcon = status === 'success' ? 'check2-circle' : 'x-circle';
     const transferKind =
         txDetails &&
-        getTransactionKindName(getTransactions(txDetails.certificate)[0]);
+        getTransactionKindName(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            getTransactions(getCertifiedTransaction(txDetails)!)[0]
+        );
     return (
         <div className={cl('container')}>
             {txDetails ? (

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getTransactionDigest } from '@mysten/sui.js';
 import { Formik } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -120,7 +121,7 @@ function TransferCoinPage() {
                 ).unwrap();
 
                 resetForm();
-                const txDigest = response.certificate.transactionDigest;
+                const txDigest = getTransactionDigest(response);
                 const receiptUrl = `/receipt?txdigest=${encodeURIComponent(
                     txDigest
                 )}&transfer=coin`;

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiTransactionResponse, RawSigner } from '@mysten/sui.js';
+import type {
+    SuiTransactionResponse,
+    RawSigner,
+    SuiExecuteTransactionResponse,
+} from '@mysten/sui.js';
 
 // TODO: Remove this after internal dogfooding
 export class ExampleNFT {
@@ -32,6 +36,32 @@ export class ExampleNFT {
         });
     }
 
+    /**
+     * Mint a Example NFT. The wallet address must own enough gas tokens to pay for the transaction.
+     *
+     * @param signer A signer with connection to the fullnode
+     */
+    public static async mintExampleNFTWithFullnode(
+        signer: RawSigner,
+        name?: string,
+        description?: string,
+        imageUrl?: string
+    ): Promise<SuiExecuteTransactionResponse> {
+        return await signer.executeMoveCallWithRequestType({
+            packageObjectId: '0x2',
+            module: 'devnet_nft',
+            function: 'mint',
+            typeArguments: [],
+            arguments: [
+                name || 'Example NFT',
+                description || 'An NFT created by Sui Wallet',
+                imageUrl ||
+                    'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+            ],
+            gasBudget: 10000,
+        });
+    }
+
     // TODO marge this method with mintExampleNFT. Import type from @mysten/sui.js
     // transfer NFT to another address
     public static async TransferNFT(
@@ -42,6 +72,19 @@ export class ExampleNFT {
     ): Promise<SuiTransactionResponse> {
         await signer.syncAccountState();
         return await signer.transferObject({
+            objectId: nftId,
+            gasBudget: transferCost,
+            recipient: recipientID,
+        });
+    }
+
+    public static async TransferNFTWithFullnode(
+        signer: RawSigner,
+        nftId: string,
+        recipientID: string,
+        transferCost: number
+    ): Promise<SuiExecuteTransactionResponse> {
+        return await signer.transferObjectWithRequestType({
             objectId: nftId,
             gasBudget: transferCost,
             recipient: recipientID,

--- a/apps/wallet/src/ui/app/staking/stake/index.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getTransactionDigest } from '@mysten/sui.js';
 import { Formik } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -88,7 +89,7 @@ function StakePage() {
                         tokenTypeArg: coinType,
                     })
                 ).unwrap();
-                const txDigest = response.certificate.transactionDigest;
+                const txDigest = getTransactionDigest(response);
                 resetForm();
                 navigate(`/tx/${encodeURIComponent(txDigest)}`);
             } catch (e) {

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -53,7 +53,7 @@ pnpm run test
 The `JsonRpcProvider` class provides a connection to the JSON-RPC Server and should be used for all read-only operations. The default URLs to connect with the RPC server are:
 
 - local: http://127.0.0.1:5001
-- DevNet: https://gateway.devnet.sui.io:443
+- DevNet: https://fullnode.devnet.sui.io:443
 
 Examples:
 
@@ -61,7 +61,7 @@ Fetch objects owned by the address `0xbff6ccc8707aa517b4f1b95750a2a8c666012df3`
 
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:443');
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const objects = await provider.getOwnedObjectRefs(
   '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3'
 );
@@ -71,7 +71,7 @@ Fetch transaction details from a transaction digest:
 
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:443');
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const txn = await provider.getTransaction(
   '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME='
 );
@@ -81,7 +81,7 @@ Fetch transaction events from a transaction digest:
 
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:443');
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const txEvents = await provider.getEventsByTransaction(
   '6mn5W1CczLwitHCO9OIUbqirNrQ0cuKdyxaNe16SAME='
 );
@@ -91,7 +91,7 @@ Fetch events by sender address:
 
 ```typescript
 import { JsonRpcProvider } from '@mysten/sui.js';
-const provider = new JsonRpcProvider('https://gateway.devnet.sui.io:443');
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const senderEvents = await provider.getEventsBySender(
   '0xbff6ccc8707aa517b4f1b95750a2a8c666012df3'
 );
@@ -102,15 +102,21 @@ For any operations that involves signing or submitting transactions, you should 
 To transfer a `0x2::coin::Coin<SUI>`:
 
 ```typescript
-import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import {
+  Ed25519Keypair,
+  JsonRpcProvider,
+  RawSigner,
+  LocalTxnDataSerializer,
+} from '@mysten/sui.js';
 // Generate a new Ed25519 Keypair
 const keypair = new Ed25519Keypair();
-
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
+  provider,
+  new LocalTxnDataSerializer(provider)
 );
-const transferTxn = await signer.transferObject({
+const transferTxn = await signer.transferObjectWithRequestType({
   objectId: '0x5015b016ab570df14c87649eda918e09e5cc61e0',
   gasBudget: 1000,
   recipient: '0xd84058cb73bdeabe123b56632713dcd65e1a6c92',
@@ -121,14 +127,21 @@ console.log('transferTxn', transferTxn);
 To split a `0x2::coin::Coin<SUI>` into multiple coins
 
 ```typescript
-import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import {
+  Ed25519Keypair,
+  JsonRpcProvider,
+  RawSigner,
+  LocalTxnDataSerializer,
+} from '@mysten/sui.js';
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
+  provider,
+  new LocalTxnDataSerializer(provider)
 );
-const splitTxn = await signer.splitCoin({
+const splitTxn = await signer.splitCoinWithRequestType({
   coinObjectId: '0x5015b016ab570df14c87649eda918e09e5cc61e0',
   // Say if the original coin has a balance of 100,
   // This function will create three new coins of amount 10, 20, 30,
@@ -142,14 +155,21 @@ console.log('SplitCoin txn', splitTxn);
 To merge two coins:
 
 ```typescript
-import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import {
+  Ed25519Keypair,
+  JsonRpcProvider,
+  RawSigner,
+  LocalTxnDataSerializer,
+} from '@mysten/sui.js';
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
+  provider,
+  new LocalTxnDataSerializer(provider)
 );
-const mergeTxn = await signer.mergeCoin({
+const mergeTxn = await signer.mergeCoinWithRequestType({
   primaryCoin: '0x5015b016ab570df14c87649eda918e09e5cc61e0',
   coinToMerge: '0xcc460051569bfb888dedaf5182e76f473ee351af',
   gasBudget: 1000,
@@ -160,14 +180,21 @@ console.log('MergeCoin txn', mergeTxn);
 To make a move call:
 
 ```typescript
-import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import {
+  Ed25519Keypair,
+  JsonRpcProvider,
+  RawSigner,
+  LocalTxnDataSerializer,
+} from '@mysten/sui.js';
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
+  provider,
+  new LocalTxnDataSerializer(provider)
 );
-const moveCallTxn = await signer.executeMoveCall({
+const moveCallTxn = await signer.executeMoveCallWithRequestType({
   packageObjectId: '0x2',
   module: 'devnet_nft',
   function: 'mint',
@@ -185,13 +212,20 @@ console.log('moveCallTxn', moveCallTxn);
 To publish a package:
 
 ```typescript
-import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import {
+  Ed25519Keypair,
+  JsonRpcProvider,
+  RawSigner,
+  LocalTxnDataSerializer,
+} from '@mysten/sui.js';
 const { execSync } = require('child_process');
 // Generate a new Keypair
 const keypair = new Ed25519Keypair();
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
+  provider,
+  new LocalTxnDataSerializer(provider)
 );
 const compiledModules = JSON.parse(
   execSync(
@@ -199,8 +233,11 @@ const compiledModules = JSON.parse(
     { encoding: 'utf-8' }
   )
 );
-const publishTxn = await signer.publish({
-  compiledModules,
+const modulesInBytes = compiledModules.map((m) =>
+  Array.from(new Base64DataBuffer(m).getData())
+);
+const publishTxn = await signer.publishWithRequestType({
+  compiledModules: modulesInBytes,
   gasBudget: 10000,
 });
 console.log('publishTxn', publishTxn);
@@ -209,12 +246,19 @@ console.log('publishTxn', publishTxn);
 Alternatively, a Secp256k1 can be initiated:
 
 ```typescript
-import { Secp256k1Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
+import {
+  Secp256k1Keypair,
+  JsonRpcProvider,
+  RawSigner,
+  LocalTxnDataSerializer,
+} from '@mysten/sui.js';
 // Generate a new Secp256k1 Keypair
 const keypair = new Secp256k1Keypair();
 
+const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io:443');
 const signer = new RawSigner(
   keypair,
-  new JsonRpcProvider('https://gateway.devnet.sui.io:443')
+  provider,
+  new LocalTxnDataSerializer(provider)
 );
 ```

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -23,7 +23,10 @@ import {
   ObjectId,
   SuiAddress,
   ObjectOwner,
-  SuiEvents, PaginatedTransactionDigests, TransactionQuery, Ordering,
+  SuiEvents,
+  PaginatedTransactionDigests,
+  TransactionQuery,
+  Ordering,
 } from '../types';
 
 ///////////////////////////////
@@ -111,10 +114,10 @@ export abstract class Provider {
    * Get transactions for a given query criteria
    */
   abstract getTransactions(
-      query: TransactionQuery,
-      cursor: TransactionDigest | null,
-      limit: number | null,
-      order: Ordering
+    query: TransactionQuery,
+    cursor: TransactionDigest | null,
+    limit: number | null,
+    order: Ordering
   ): Promise<PaginatedTransactionDigests>;
 
   /**

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -62,6 +62,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `signAndExecuteTransactionWithRequestType`
+   *
    * Sign a transaction and submit to the Gateway for execution
    */
   async signAndExecuteTransaction(
@@ -99,6 +102,8 @@ export abstract class SignerWithProvider implements Signer {
         return this.splitCoin(transaction.data);
       case 'pay':
         return this.pay(transaction.data);
+      case 'publish':
+        return this.publish(transaction.data);
       default:
         throw new Error(
           `Unknown transaction kind: "${(transaction as any).kind}"`
@@ -107,11 +112,12 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Sign a transaction and submit to the Fullnode for execution
+   * Sign a transaction and submit to the Fullnode for execution. Only exists
+   * on Fullnode
    */
   async signAndExecuteTransactionWithRequestType(
     transaction: Base64DataBuffer | SignableTransaction,
-    requestType: ExecuteTransactionRequestType
+    requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
     // Handle submitting raw transaction bytes:
     if (
@@ -152,6 +158,8 @@ export abstract class SignerWithProvider implements Signer {
         return this.splitCoinWithRequestType(transaction.data, requestType);
       case 'pay':
         return this.payWithRequestType(transaction.data, requestType);
+      case 'publish':
+        return this.publishWithRequestType(transaction.data, requestType);
       default:
         throw new Error(
           `Unknown transaction kind: "${(transaction as any).kind}"`
@@ -160,6 +168,7 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This API will be removed soon after we deprecate gateway
    * Trigger gateway to sync account state related to the address,
    * based on the account state on validators.
    */
@@ -169,6 +178,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This API will be removed soon after we deprecate gateway. Prefer to use
+   * `signAndExecuteTransactionWithRequestType`
+   *
    * Serialize and Sign a `TransferObject` transaction and submit to the Gateway for execution
    */
   async transferObject(
@@ -183,6 +195,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `transferSuiWithRequestType`
+   *
    * Serialize and Sign a `TransferSui` transaction and submit to the Gateway for execution
    */
   async transferSui(
@@ -197,6 +212,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `payWithRequestType`
+   *
    * Serialize and Sign a `Pay` transaction and submit to the Gateway for execution
    */
   async pay(transaction: PayTransaction): Promise<SuiTransactionResponse> {
@@ -206,6 +224,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `mergeCoinWithRequestType`
+   *
    * Serialize and Sign a `MergeCoin` transaction and submit to the Gateway for execution
    */
   async mergeCoin(
@@ -220,6 +241,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `splitCoinWithRequestType`
+   *
    * Serialize and Sign a `SplitCoin` transaction and submit to the Gateway for execution
    */
   async splitCoin(
@@ -234,6 +258,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `executeMoveCallWithRequestType`
+   *
    * Serialize and Sign a `MoveCall` transaction and submit to the Gateway for execution
    */
   async executeMoveCall(
@@ -248,6 +275,9 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
+   * @deprecated This method will be removed soon after we deprecate gateway. Prefer to use
+   * `publishWithRequestType`
+   *
    * Publish a Move package on chain
    * @param transaction See {@link PublishTransaction}
    */
@@ -262,9 +292,9 @@ export abstract class SignerWithProvider implements Signer {
     return await this.signAndExecuteTransaction(txBytes);
   }
 
-  /* ---------------------------- Experimental API ---------------------------- */
   /**
-   * @experimental Serialize and sign a `TransferObject` transaction and submit to the Fullnode
+   *
+   * Serialize and sign a `TransferObject` transaction and submit to the Fullnode
    * for execution
    */
   async transferObjectWithRequestType(
@@ -283,7 +313,8 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Serialize and sign a `TransferSui` transaction and submit to the Fullnode
+   *
+   * Serialize and sign a `TransferSui` transaction and submit to the Fullnode
    * for execution
    */
   async transferSuiWithRequestType(
@@ -302,7 +333,8 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Serialize and Sign a `Pay` transaction and submit to the fullnode for execution
+   *
+   * Serialize and Sign a `Pay` transaction and submit to the fullnode for execution
    */
   async payWithRequestType(
     transaction: PayTransaction,
@@ -317,7 +349,8 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Serialize and sign a `MergeCoin` transaction and submit to the Fullnode
+   *
+   * Serialize and sign a `MergeCoin` transaction and submit to the Fullnode
    * for execution
    */
   async mergeCoinWithRequestType(
@@ -336,7 +369,8 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Serialize and sign a `SplitCoin` transaction and submit to the Fullnode
+   *
+   * Serialize and sign a `SplitCoin` transaction and submit to the Fullnode
    * for execution
    */
   async splitCoinWithRequestType(
@@ -355,7 +389,7 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Serialize and sign a `MoveCall` transaction and submit to the Fullnode
+   * Serialize and sign a `MoveCall` transaction and submit to the Fullnode
    * for execution
    */
   async executeMoveCallWithRequestType(
@@ -374,7 +408,8 @@ export abstract class SignerWithProvider implements Signer {
   }
 
   /**
-   * @experimental Serialize and sign a `Publish` transaction and submit to the Fullnode
+   *
+   * Serialize and sign a `Publish` transaction and submit to the Fullnode
    * for execution
    */
   async publishWithRequestType(

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -62,8 +62,7 @@ export interface MoveCallTransaction {
   gasBudget: number;
 }
 
-/** A type that represents the possible transactions that can be signed: */
-export type SignableTransaction =
+export type UnserializedSignableTransaction =
   | {
       kind: 'moveCall';
       data: MoveCallTransaction;
@@ -88,6 +87,14 @@ export type SignableTransaction =
       kind: 'pay';
       data: PayTransaction;
     }
+  | {
+      kind: 'publish';
+      data: PublishTransaction;
+    };
+
+/** A type that represents the possible transactions that can be signed: */
+export type SignableTransaction =
+  | UnserializedSignableTransaction
   | {
       kind: 'bytes';
       data: Uint8Array;

--- a/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/type-tag-serializer.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { normalizeSuiAddress, TypeTag } from '../../types';
+
+const VECTOR_REGEX = /^vector<(.+)>$/;
+const STRUCT_REGEX = /^([^:]+)::([^:]+)::(.+)/;
+const STRUCT_TYPE_TAG_REGEX = /^[^<]+<(.+)>$/;
+
+export class TypeTagSerializer {
+  parseFromStr(str: string): TypeTag {
+    if (str === 'address') {
+      return { address: null };
+    } else if (str === 'bool') {
+      return { bool: null };
+    } else if (str === 'u8') {
+      return { u8: null };
+    } else if (str === 'u64') {
+      return { u64: null };
+    } else if (str === 'signer') {
+      return { signer: null };
+    }
+    const vectorMatch = str.match(VECTOR_REGEX);
+    if (vectorMatch) {
+      return { vector: this.parseFromStr(vectorMatch[1]) };
+    }
+
+    const structMatch = str.match(STRUCT_REGEX);
+    if (structMatch) {
+      try {
+        return {
+          struct: {
+            address: normalizeSuiAddress(structMatch[1]),
+            module: structMatch[2],
+            name: structMatch[3].match(/^([^<]+)/)![1],
+            typeParams: this.parseStructTypeTag(structMatch[3]),
+          },
+        };
+      } catch (e) {
+        throw new Error(`Encounter error parsing type args for ${str}`);
+      }
+    }
+
+    throw new Error(
+      `Encounter unexpected token when parsing type args for ${str}`
+    );
+  }
+
+  parseStructTypeTag(str: string): TypeTag[] {
+    const typeTagsMatch = str.match(STRUCT_TYPE_TAG_REGEX);
+    if (!typeTagsMatch) {
+      return [];
+    }
+    // TODO: This will fail if the struct has nested type args with commas. Need
+    // to implement proper parsing for this case
+    const typeTags = typeTagsMatch[1].split(',');
+    return typeTags.map((tag) => this.parseFromStr(tag));
+  }
+}

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -91,6 +91,24 @@ export class Coin {
   }
 
   /**
+   * Convenience method for select an arbitrary coin object that has a balance greater than or
+   * equal to `amount`
+   *
+   * @param amount coin balance
+   * @param exclude object ids of the coins to exclude
+   * @return an arbitray coin with balance greater than or equal to `amount
+   */
+  static selectCoinWithBalanceGreaterThanOrEqual(
+    coins: ObjectDataFull[],
+    amount: bigint,
+    exclude: ObjectId[] = []
+  ): ObjectDataFull | undefined {
+    return coins.find(
+      (c) => !exclude.includes(Coin.getID(c)) && Coin.getBalance(c)! >= amount
+    );
+  }
+
+  /**
    * Convenience method for select a minimal set of coin objects that has a balance greater than
    * or equal to `amount`. The output can be used for `PayTransaction`
    *

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, PaginatedTransactionDigests, TransactionQuery, Ordering, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, GetTxnDigestsResponse__DEPRECATED, PaginatedTransactionDigests, TransactionQuery, Ordering, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -925,6 +925,17 @@ export function isGetTxnDigestsResponse(obj: any, _argumentName?: string): obj i
         Array.isArray(obj) &&
         obj.every((e: any) =>
             isTransactionDigest(e) as boolean
+        )
+    )
+}
+
+export function isGetTxnDigestsResponse__DEPRECATED(obj: any, _argumentName?: string): obj is GetTxnDigestsResponse__DEPRECATED {
+    return (
+        Array.isArray(obj) &&
+        obj.every((e: any) =>
+            Array.isArray(e) &&
+            isSuiMoveTypeParameterIndex(e[0]) as boolean &&
+            isTransactionDigest(e[1]) as boolean
         )
     )
 }

--- a/sdk/typescript/src/types/sui-bcs.ts
+++ b/sdk/typescript/src/types/sui-bcs.ts
@@ -266,7 +266,7 @@ bcs
   });
 
 /**
- * The TransactionData to be signed and sent to the Gateway service.
+ * The TransactionData to be signed and sent to the RPC service.
  *
  * Field `sender` is made optional as it can be added during the signing
  * process and there's no need to define it sooner.

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -17,21 +17,43 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transaction', async () => {
-    const resp = await toolbox.provider.getTransactions("All",null,1, "Descending");
+    const resp = await toolbox.provider.getTransactions(
+      'All',
+      null,
+      1,
+      'Descending'
+    );
     const digest = resp.data[0];
     const txn = await toolbox.provider.getTransactionWithEffects(digest);
     expect(txn.certificate.transactionDigest).toEqual(digest);
   });
 
   it('Get Transactions', async () => {
-    const resp = await toolbox.provider.getTransactionsForAddress(toolbox.address());
+    const resp = await toolbox.provider.getTransactionsForAddress(
+      toolbox.address()
+    );
     expect(resp.length).to.greaterThan(0);
 
-    const allTransactions = await toolbox.provider.getTransactions("All",null,10, "Ascending");
+    const allTransactions = await toolbox.provider.getTransactions(
+      'All',
+      null,
+      10,
+      'Ascending'
+    );
     expect(allTransactions.data.length).to.greaterThan(0);
 
-    const resp2 = await toolbox.provider.getTransactions({ToAddress:toolbox.address()},null,null, "Ascending");
-    const resp3 = await toolbox.provider.getTransactions({FromAddress:toolbox.address()},null,null, "Ascending");
+    const resp2 = await toolbox.provider.getTransactions(
+      { ToAddress: toolbox.address() },
+      null,
+      null,
+      'Ascending'
+    );
+    const resp3 = await toolbox.provider.getTransactions(
+      { FromAddress: toolbox.address() },
+      null,
+      null,
+      'Ascending'
+    );
     expect([...resp2.data, ...resp3.data]).toEqual(resp);
   });
 });

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -6,6 +6,7 @@ import {
   Ed25519Keypair,
   JsonRpcProvider,
   JsonRpcProviderWithCache,
+  LATEST_RPC_API_VERSION,
 } from '../../../src';
 
 const DEFAULT_FAUCET_URL = 'http://127.0.0.1:9123/faucet';
@@ -46,8 +47,8 @@ export function getProvider(
   const url =
     rpcType === 'fullnode' ? DEFAULT_FULLNODE_URL : DEFAULT_GATEWAY_URL;
   return providerType === 'rpc'
-    ? new JsonRpcProvider(url, false)
-    : new JsonRpcProviderWithCache(url, false);
+    ? new JsonRpcProvider(url, false, LATEST_RPC_API_VERSION)
+    : new JsonRpcProviderWithCache(url, false, LATEST_RPC_API_VERSION);
 }
 
 export async function setup(


### PR DESCRIPTION
This PR aims to add the ability to use fullnode for executing transactions on the Sui wallet. The feature is gated through a feature flag called `deprecate-gateway`. Other notable change in this PR include:

- make the breaking change in https://github.com/MystenLabs/sui/pull/4919 backward compatible. We would like to do a wallet release before the next DevNet release, therefore it's important that the upcoming wallet release works with both the current DevNet(0.11.0) and 0.12.0
- Add `rpcAPIVersion` to `JsonRpcProvider` to support multiple RPC versions. This is used together with the feature flag so that the wallet extension can work with multiple RPC versions by switching the [feature flag](https://app.growthbook.io/features)  on the server side without going through the chrome web store review
-  Add `TypeTagSerializer` that can convert a string to `TypeTag`, e.g., `0x2::sui::SUI` into `{
            "struct": {
              "address": "0x2",
              "module": "sui",
              "name": "SUI",
              "typeParams": []
            }
          }`. This make sure the DApp Move calls can continue working regardless whether using `LocalTxnDataSerializer` or not
- Add gas selection to `LocalTxnDataSerializer`. If the gas payment object is not provided to the transaction, the SDK will select a gas coin that is not used in the transaction input and with balance greater than or equal to the gas budget.

## Testing

Tested common wallet functionalities with feature flag turned on and off:
- send coins
- mint/transfer nft
- DApp: demo NFT app and https://gotbeef.app/


