### PR TITLE
[move] Adjust verifier to accommodate recent core Move modifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -3877,12 +3877,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -3921,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "difference",
@@ -4001,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4045,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4065,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4115,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "hex",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "hex",
@@ -4180,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4242,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4279,7 +4279,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -4378,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "log",
@@ -4400,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "once_cell",
  "serde 1.0.145",
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4457,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "better_any",
@@ -4488,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "better_any",
  "fail",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=7c8552e0001c0c041c929e050c2d2959935485f1#7c8552e0001c0c041c929e050c2d2959935485f1"
+source = "git+https://github.com/move-language/move?rev=c9b5765f816d773618cc12a70a0095f644bbc68d#c9b5765f816d773618cc12a70a0095f644bbc68d"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,24 +72,24 @@ name-variant = "0.1.0"
 store = { version = "0.1.0", package = "typed-store" }
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-cli = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-package = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-prover = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-cli = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["address20"] }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-package = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-prover = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4b7a06fe393003013489990dc2f4d3d2ebb32539" }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-25:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function call.\") } }") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: PartialVMError with status VERIFICATION_ERROR and message ID leaked through function call.") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-25:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function call.\") } }") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: PartialVMError with status VERIFICATION_ERROR and message ID leaked through function call.") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-19:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function return.\") } }") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: PartialVMError with status VERIFICATION_ERROR and message ID leaked through function return.") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-19:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID leaked through function return.\") } }") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: PartialVMError with status VERIFICATION_ERROR and message ID leaked through function return.") } }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.exp
@@ -2,4 +2,4 @@ processed 1 task
 
 task 0 'publish'. lines 4-20:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some(\"ID is leaked into a vector\") } }") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("ID leak detected in function foo: PartialVMError with status VERIFICATION_ERROR and message ID is leaked into a vector") } }

--- a/crates/sui-verifier/src/id_leak_verifier.rs
+++ b/crates/sui-verifier/src/id_leak_verifier.rs
@@ -421,7 +421,7 @@ fn expect_ok<T>(res: Result<T, PartialVMError>) -> Result<T, String> {
                 Got error: {partial_vm_error:?}"
             );
             // This is an internal error, but we cannot accept the module as safe
-            Err("".to_string())
+            Err("Unexpected internal verifier error".to_string())
         }
     }
 }

--- a/crates/sui-verifier/src/id_leak_verifier.rs
+++ b/crates/sui-verifier/src/id_leak_verifier.rs
@@ -16,22 +16,18 @@
 use crate::verification_failure;
 use move_binary_format::{
     binary_views::{BinaryIndexedView, FunctionView},
-    errors::PartialVMError,
+    errors::{PartialVMError, PartialVMResult},
     file_format::{
         Bytecode, CodeOffset, CompiledModule, FunctionDefinitionIndex, FunctionHandle, LocalIndex,
         StructDefinition, StructFieldInformation,
     },
 };
 use move_bytecode_verifier::absint::{
-    AbstractDomain, AbstractInterpreter, BlockInvariant, BlockPostcondition, JoinResult,
-    TransferFunctions,
+    AbstractDomain, AbstractInterpreter, JoinResult, TransferFunctions,
 };
+use move_core_types::vm_status::StatusCode;
 use std::collections::BTreeMap;
-use sui_types::{
-    error::{ExecutionError, ExecutionErrorKind},
-    id::OBJECT_MODULE_NAME,
-    SUI_FRAMEWORK_ADDRESS,
-};
+use sui_types::{error::ExecutionError, id::OBJECT_MODULE_NAME, SUI_FRAMEWORK_ADDRESS};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AbstractValue {
@@ -65,26 +61,15 @@ fn verify_id_leak(module: &CompiledModule) -> Result<(), ExecutionError> {
             FunctionView::function(module, FunctionDefinitionIndex(index as u16), code, handle);
         let initial_state = AbstractState::new(&func_view);
         let mut verifier = IDLeakAnalysis::new(&binary_view, &func_view);
-        let inv_map = verifier.analyze_function(initial_state, &func_view);
-        // Report all the join failures
-        for (_block_id, BlockInvariant { post, .. }) in inv_map {
-            match post {
-                BlockPostcondition::Error(error) => {
-                    debug_assert_eq!(
-                        error.kind(),
-                        &ExecutionErrorKind::SuiMoveVerificationError,
-                        "Unexpected error type"
-                    );
-                    return Err(verification_failure(format!(
-                        "ID leak detected in function {}: {}",
-                        binary_view.identifier_at(handle.name),
-                        error
-                    )));
-                }
-                // Block might be unprocessed if all predecessors had an error
-                BlockPostcondition::Unprocessed | BlockPostcondition::Success => (),
-            }
-        }
+        verifier
+            .analyze_function(initial_state, &func_view)
+            .map_err(|error| {
+                verification_failure(format!(
+                    "ID leak detected in function {}: {}",
+                    binary_view.identifier_at(handle.name),
+                    error
+                ))
+            })?;
     }
 
     Ok(())
@@ -147,7 +132,6 @@ impl<'a> IDLeakAnalysis<'a> {
 
 impl<'a> TransferFunctions for IDLeakAnalysis<'a> {
     type State = AbstractState;
-    type AnalysisError = ExecutionError;
 
     fn execute(
         &mut self,
@@ -155,8 +139,9 @@ impl<'a> TransferFunctions for IDLeakAnalysis<'a> {
         bytecode: &Bytecode,
         index: CodeOffset,
         _: CodeOffset,
-    ) -> Result<(), Self::AnalysisError> {
-        execute_inner(self, state, bytecode, index)?;
+    ) -> PartialVMResult<()> {
+        execute_inner(self, state, bytecode, index)
+            .map_err(|err| PartialVMError::new(StatusCode::VERIFICATION_ERROR).with_message(err))?;
         Ok(())
     }
 }
@@ -190,19 +175,14 @@ fn is_call_safe_to_leak(verifier: &IDLeakAnalysis, function_handle: &FunctionHan
                 == "delete_child_object")
 }
 
-fn call(
-    verifier: &mut IDLeakAnalysis,
-    function_handle: &FunctionHandle,
-) -> Result<(), ExecutionError> {
+fn call(verifier: &mut IDLeakAnalysis, function_handle: &FunctionHandle) -> Result<(), String> {
     let guaranteed_safe = is_call_safe_to_leak(verifier, function_handle);
     let parameters = verifier
         .binary_view
         .signature_at(function_handle.parameters);
     for _ in 0..parameters.len() {
         if verifier.stack.pop().unwrap() == AbstractValue::ID && !guaranteed_safe {
-            return Err(verification_failure(
-                "ID leaked through function call.".to_string(),
-            ));
+            return Err("ID leaked through function call.".to_string());
         }
     }
 
@@ -256,7 +236,7 @@ fn execute_inner(
     state: &mut AbstractState,
     bytecode: &Bytecode,
     _: CodeOffset,
-) -> Result<(), ExecutionError> {
+) -> Result<(), String> {
     // TODO: Better dianostics with location
     match bytecode {
         Bytecode::Pop => {
@@ -323,7 +303,7 @@ fn execute_inner(
             // Top of stack is the reference, and the second element is the value.
             verifier.stack.pop().unwrap();
             if verifier.stack.pop().unwrap() == AbstractValue::ID {
-                return Err(verification_failure("ID is leaked to a reference.".to_string()));
+                return Err("ID is leaked to a reference.".to_string());
             }
         }
 
@@ -365,7 +345,7 @@ fn execute_inner(
         Bytecode::Ret => {
             for _ in 0..verifier.function_view.return_().len() {
                 if verifier.stack.pop().unwrap() == AbstractValue::ID {
-                    return Err(verification_failure("ID leaked through function return.".to_string()));
+                    return Err("ID leaked through function return.".to_string());
                 }
             }
         }
@@ -401,7 +381,7 @@ fn execute_inner(
         Bytecode::VecPack(_, num) => {
             for _ in 0..*num {
                 if verifier.stack.pop().unwrap() == AbstractValue::ID {
-                    return Err(verification_failure("ID is leaked into a vector".to_string()));
+                    return Err("ID is leaked into a vector".to_string());
                 }
             }
             verifier.stack.push(AbstractValue::NonID);
@@ -409,7 +389,7 @@ fn execute_inner(
 
         Bytecode::VecPushBack(_) => {
             if verifier.stack.pop().unwrap() == AbstractValue::ID {
-                return Err(verification_failure("ID is leaked into a vector".to_string()));
+                return Err("ID is leaked into a vector".to_string());
             }
             verifier.stack.pop().unwrap();
         }
@@ -431,7 +411,7 @@ fn execute_inner(
     Ok(())
 }
 
-fn expect_ok<T>(res: Result<T, PartialVMError>) -> Result<T, ExecutionError> {
+fn expect_ok<T>(res: Result<T, PartialVMError>) -> Result<T, String> {
     match res {
         Ok(x) => Ok(x),
         Err(partial_vm_error) => {
@@ -441,7 +421,7 @@ fn expect_ok<T>(res: Result<T, PartialVMError>) -> Result<T, ExecutionError> {
                 Got error: {partial_vm_error:?}"
             );
             // This is an internal error, but we cannot accept the module as safe
-            Err(ExecutionErrorKind::SuiMoveVerificationError.into())
+            Err("".to_string())
         }
     }
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -77,7 +77,7 @@ blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "check", "sha2", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -295,41 +295,41 @@ minimal-lexical = { version = "0.2", default-features = false, features = ["std"
 miniz_oxide = { version = "0.5", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-cli = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-cli = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 mysten-network = { version = "0.2", default-features = false }
@@ -427,8 +427,8 @@ rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen = { version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -695,7 +695,7 @@ bs58 = { version = "0.4", features = ["alloc", "check", "sha2", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 bumpalo = { version = "3" }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -944,41 +944,41 @@ miniz_oxide = { version = "0.5", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-cli = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-borrow-graph = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-cli = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-compiler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["address20"] }
+move-coverage = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-disassembler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-ir-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-model = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-package = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-prover = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d" }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
@@ -1105,8 +1105,8 @@ rand_xoshiro = { version = "0.6", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen = { version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "7c8552e0001c0c041c929e050c2d2959935485f1", default-features = false }
+read-write-set = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c9b5765f816d773618cc12a70a0095f644bbc68d", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
Recent change to core Move (https://github.com/move-language/move/pull/561) requires modifications to Sui's bytecode verifier to accommodate new API. This PR brings Sui's verifier and core Move implementation in sync.