### PR TITLE
A module for shutting down tasks easily

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -51,6 +51,9 @@ use once_cell::sync::OnceCell;
 use tap::TapFallible;
 
 use tokio::time::Instant;
+
+pub mod cancellable_spawner;
+
 pub mod gossip;
 use gossip::{gossip_process, GossipMetrics};
 

--- a/crates/sui-core/src/authority_active/cancellable_spawner.rs
+++ b/crates/sui-core/src/authority_active/cancellable_spawner.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::sync::Arc;
+use tokio::sync::{broadcast, OwnedRwLockWriteGuard, RwLock};
+use tokio::task::JoinHandle;
+use tracing::{debug, trace};
+
+use tap::TapFallible;
+
+use sui_types::error::{SuiError, SuiResult};
+
+/// CancellableSpawner allows spawned tasks to be cancelled easily without keeping track of every
+/// JoinHandle that gets created.
+pub struct CancellableSpawner {
+    cancel_tx: broadcast::Sender<()>,
+    spawn_lock: Arc<RwLock<()>>,
+    task_lock: Arc<RwLock<()>>,
+}
+
+/// While a CancelGuard is held, no new tasks can be spawned on the CancellableSpawner.
+pub struct CancelGuard(OwnedRwLockWriteGuard<()>);
+
+impl CancellableSpawner {
+    pub fn new() -> Self {
+        let (cancel_tx, _) = broadcast::channel(1);
+        Self {
+            cancel_tx,
+            spawn_lock: Default::default(),
+            task_lock: Default::default(),
+        }
+    }
+
+    /// Spawn a future via tokio::spawn - may fail if cancel_all_tasks has been called.
+    pub fn spawn<F>(&self, fut: F) -> SuiResult<JoinHandle<()>>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        // if spawn_lock is held for write, the spawner is in the process of cancelling, so new
+        // spawn attempts must fail.
+        let _spawn_guard = self
+            .spawn_lock
+            .try_read()
+            .tap_err(|_| {
+                debug!("task could not be spawned, CancellableSpawner::cancel() is in progress")
+            })
+            .map_err(|_| SuiError::TaskSpawnError)?;
+
+        // While spawn_lock is held, task_lock.write() cannot be called, so try_read must succeed.
+        let task_guard = self.task_lock.clone().try_read_owned().unwrap();
+        let mut cancel_rx = self.cancel_tx.subscribe();
+
+        Ok(tokio::spawn(async move {
+            let _task_guard = task_guard;
+            let recv = cancel_rx.recv();
+            tokio::select! {
+                _ = recv => {
+                    debug!("task cancelled before completion");
+                }
+                _ = fut => {
+                    trace!("task finished normally");
+                }
+            }
+        }))
+    }
+
+    /// Cancel all tasks that were spawned via this instance.
+    /// Returns a guard which, while held, prevents new tasks from spawning.
+    pub async fn cancel_all_tasks(&self) -> CancelGuard {
+        debug!("cancelling all tasks");
+        // no new readers of task_lock can lock while spawn_lock is held for write, because
+        // task_lock.read() is only called while spawn_lock is held.
+        let spawn_guard = self.spawn_lock.clone().write_owned().await;
+
+        debug!("sending cancel broadcast");
+        let _ = self.cancel_tx.send(());
+
+        // await all tasks exiting.
+        let _ = self.task_lock.write().await;
+        debug!("all tasks exited");
+
+        CancelGuard(spawn_guard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{distributions::Uniform, rngs::OsRng, Rng};
+    use sui_macros::sui_test;
+    use tokio::time::{sleep, Duration};
+
+    #[sui_test]
+    async fn test_cancellable_spawner() {
+        telemetry_subscribers::init_for_testing();
+        let spawner = CancellableSpawner::new();
+        let dist = Uniform::new(10, 1000);
+
+        let handles: Vec<_> = (0..1000)
+            .map(|_| {
+                spawner
+                    .spawn(async move {
+                        sleep(Duration::from_millis(OsRng.sample(dist))).await;
+                    })
+                    .unwrap()
+            })
+            .collect();
+
+        sleep(Duration::from_millis(OsRng.sample(dist))).await;
+        let guard = spawner.cancel_all_tasks().await;
+
+        assert!(handles.into_iter().all(|h| h.is_finished()));
+
+        // can't spawn while guard is held.
+        spawner.spawn(async move {}).unwrap_err();
+        std::mem::drop(guard);
+        spawner.spawn(async move {}).unwrap();
+    }
+}

--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -28,35 +28,39 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
             // iteration of a multi-iteration test run.
             std::thread::spawn(|| {
                 ::sui_simulator::telemetry_subscribers::init_for_testing();
-                ::sui_simulator::sui_framework::get_move_stdlib();
-                ::sui_simulator::sui_framework::get_sui_framework();
-                ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered();
 
-                use ::sui_simulator::fastcrypto::traits::KeyPair;
+                #[cfg(msim)]
+                {
+                    ::sui_simulator::sui_framework::get_move_stdlib();
+                    ::sui_simulator::sui_framework::get_sui_framework();
+                    ::sui_simulator::sui_types::gas::SuiGasStatus::new_unmetered();
 
-                // anemo uses x509-parser, which has many lazy static variables. start a network to
-                // initialize all that static state before the first test.
-                let rt = ::sui_simulator::runtime::Runtime::new();
-                rt.block_on(async move {
-                    use ::sui_simulator::anemo::{Network, Request};
+                    use ::sui_simulator::fastcrypto::traits::KeyPair;
 
-                    let make_network = |port: u16| {
-                        Network::bind(format!("127.0.0.1:{}", port))
-                            .server_name("static-init-network")
-                            .private_key(
-                                ::sui_simulator::fastcrypto::ed25519::Ed25519KeyPair::generate(&mut rand::rngs::OsRng)
-                                    .private()
-                                    .0
-                                    .to_bytes(),
-                            )
-                            .start(::sui_simulator::anemo::Router::new())
-                            .unwrap()
-                    };
-                    let n1 = make_network(80);
-                    let n2 = make_network(81);
+                    // anemo uses x509-parser, which has many lazy static variables. start a network to
+                    // initialize all that static state before the first test.
+                    let rt = ::sui_simulator::runtime::Runtime::new();
+                    rt.block_on(async move {
+                        use ::sui_simulator::anemo::{Network, Request};
 
-                    let _peer = n1.connect(n2.local_addr()).await.unwrap();
-                });
+                        let make_network = |port: u16| {
+                            Network::bind(format!("127.0.0.1:{}", port))
+                                .server_name("static-init-network")
+                                .private_key(
+                                    ::sui_simulator::fastcrypto::ed25519::Ed25519KeyPair::generate(&mut rand::rngs::OsRng)
+                                        .private()
+                                        .0
+                                        .to_bytes(),
+                                )
+                                .start(::sui_simulator::anemo::Router::new())
+                                .unwrap()
+                        };
+                        let n1 = make_network(80);
+                        let n2 = make_network(81);
+
+                        let _peer = n1.connect(n2.local_addr()).await.unwrap();
+                    });
+                }
             }).join().unwrap();
 
             #body

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -443,6 +443,9 @@ pub enum SuiError {
     #[error("Operation timed out")]
     TimeoutError,
 
+    #[error("Task could not be spawned")]
+    TaskSpawnError,
+
     #[error("Error executing {0}")]
     ExecutionError(String),
 


### PR DESCRIPTION
The motivation for this is that we would like to forcibly cancel all ActiveAuthority processes during reconfiguration. Currently, it is possible for active processes to observe intermediate states during reconfiguration (for example, the committee and AuthorityAggregator are updated non-atomically).

Additionally, this should make it possible to use a destroy-and-rebuild pattern for active processes, which is much simpler and less error-prone than the current approach of reconfiguring processes on the fly.

The design intentionally avoids keeping track of every JoinHandle ever created and calling `abort()` on them.

Also, it currently only supports tasks that do not return a value. We can add that later if necessary.