### PR TITLE
[checkpoint] Separate checkpoint construction and checkpoint proposing

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -55,7 +55,8 @@ pub const CHECKPOINT_COUNT_PER_EPOCH: u64 = 3;
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct CheckpointLocals {
-    // The next checkpoint number expected.
+    /// The next checkpoint certificate number expected.
+    /// This gets updated only when a new checkpoint certificate is stored.
     pub next_checkpoint: CheckpointSequenceNumber,
 
     // The next transaction after what is included in the proposal.
@@ -66,24 +67,34 @@ pub struct CheckpointLocals {
     // The next transaction sequence number of transactions processed
     pub next_transaction_sequence: TxSequenceNumber,
 
-    // True if no more fragments are to be added.
-    pub no_more_fragments: bool,
-
     // The current checkpoint proposal if any
     #[serde(skip)]
     pub current_proposal: Option<CheckpointProposal>,
 
-    // When new fragments are received from consensus, they are added to the span graph for
-    // checkpoint construction. This continues until we have a tree that covers 2f+1 stake.
-    // The current state of the span graph is kept in memory, for two reasons:
-    // 1. It's more efficient, i.e. we don't have to reconstruct the span graph every time a new
-    // fragment is received.
-    // 2. We can determine whether we have received enough fragments to construct the next
-    // checkpoint after receiving each fragment. This is needed for consensus to tell when is
-    // the last fragment for the last checkpoint of the epoch. Consensus can then stop processing
-    // messages afterwards.
+    /// The checkpoint sequence number that we are currently actively constructing through
+    /// the span graph using fragments.
+    /// This field should always be consistent with checkpoint_to_be_constructed, and is updated
+    /// together. We keep this field separate to allow crash recovery (we don't serialize
+    /// checkpoint_to_be_constructed, so to recover we need a sequence number).
+    pub in_construction_checkpoint_seq: CheckpointSequenceNumber,
+
+    /// When new fragments are received from consensus, they are added to the span graph for
+    /// checkpoint construction. This continues until we have a tree that covers 2f+1 stake.
+    /// The current state of the span graph is kept in memory, for two reasons:
+    /// 1. It's more efficient, i.e. we don't have to reconstruct the span graph every time a new
+    /// fragment is received.
+    /// 2. We can determine whether we have received enough fragments to construct the next
+    /// checkpoint after receiving each fragment. This is needed for consensus to tell when is
+    /// the last fragment for the last checkpoint of the epoch. Consensus can then stop processing
+    /// messages afterwards.
+    /// This gets updated when the current span graph is complete (i.e. have seen enough fragments
+    /// to construct checkpoint content) and next_checkpoint os ahead. We need both conditions
+    /// because a validator with slow consensus may still be receiving old fragments when it has
+    /// already seen newer checkpoint cert. In such cases, we keep the span graph in-sync with
+    /// the fragments, not the checkpoint cert, otherwise we would not be able to know which
+    /// fragment is the last fragment of the second last checkpoint in the epoch.
     #[serde(skip)]
-    pub checkpoint_to_be_constructed: SpanGraph,
+    pub in_construction_checkpoint: SpanGraph,
 }
 
 /// A simple interface for sending a transaction to consensus for
@@ -156,6 +167,54 @@ fn locals_table_default_config() -> Options {
     default_db_options(None, None).1
 }
 
+impl CheckpointStoreTables {
+    /// The checkpoint construction state in `locals` should be for the next checkpoint cert as
+    /// much as possible. However we should also make sure that it's not ahead of consensus:
+    /// the construction state does not advance to the next checkpoint if it hasn't received enough
+    /// fragments to complete the current checkpoint.
+    fn advance_checkpoint_construction_state(
+        &self,
+        locals: &mut CheckpointLocals,
+        committee: &Committee,
+    ) -> SuiResult {
+        let mut in_construction_checkpoint = locals.in_construction_checkpoint_seq;
+        let next_checkpoint = locals.next_checkpoint;
+        let mut batch = self.fragments.batch();
+        while locals.in_construction_checkpoint.is_completed()
+            && in_construction_checkpoint < next_checkpoint
+        {
+            debug!(next_cp_seq=?next_checkpoint, ?in_construction_checkpoint, "Checkpoint construction span graph is complete, advancing to the next");
+            let next_checkpoint_fragments: Vec<_> = self
+                .fragments
+                .values()
+                .filter(|frag| {
+                    frag.proposer.summary.sequence_number == in_construction_checkpoint + 1
+                })
+                .collect();
+            locals.in_construction_checkpoint = SpanGraph::mew(
+                committee,
+                in_construction_checkpoint + 1,
+                &next_checkpoint_fragments,
+            );
+            locals.in_construction_checkpoint_seq += 1;
+            batch = batch.delete_batch(
+                &self.fragments,
+                self.fragments.iter().filter_map(|(k, v)| {
+                    // Delete all keys for checkpoints smaller than what we are committing now.
+                    if v.proposer.summary.sequence_number <= in_construction_checkpoint {
+                        Some(k)
+                    } else {
+                        None
+                    }
+                }),
+            )?;
+            in_construction_checkpoint += 1;
+        }
+        batch.write()?;
+        Ok(())
+    }
+}
+
 pub struct CheckpointStore {
     // Fixed size, static, identity of the authority
     /// The name of this authority.
@@ -224,11 +283,7 @@ impl CheckpointStore {
         // Loads locals from disk, or inserts initial locals
         let mut locals = match tables.locals.get(&LOCALS)? {
             Some(locals) => locals,
-            None => {
-                let locals = CheckpointLocals::default();
-                tables.locals.insert(&LOCALS, &locals)?;
-                locals
-            }
+            None => CheckpointLocals::default(),
         };
 
         let checkpoint_sequence = locals.next_checkpoint;
@@ -251,13 +306,8 @@ impl CheckpointStore {
             locals.current_proposal = Some(proposal);
         }
 
-        let fragments: Vec<_> = tables
-            .fragments
-            .values()
-            .filter(|frag| frag.proposer.summary.sequence_number == checkpoint_sequence)
-            .collect();
-        locals.checkpoint_to_be_constructed =
-            SpanGraph::mew(cur_committee, checkpoint_sequence, &fragments);
+        tables.advance_checkpoint_construction_state(&mut locals, cur_committee)?;
+        tables.locals.insert(&LOCALS, &locals)?;
 
         Ok(locals)
     }
@@ -458,18 +508,9 @@ impl CheckpointStore {
                 &self.tables.checkpoints,
                 [(&checkpoint_sequence_number, checkpoint)],
             )?
-            // Drop the fragments for the previous checkpoint
-            .delete_batch(
-                &self.tables.fragments,
-                self.tables.fragments.iter().filter_map(|(k, v)| {
-                    // Delete all keys for checkpoints smaller than what we are committing now.
-                    if v.proposer.summary.sequence_number <= checkpoint_sequence_number {
-                        Some(k)
-                    } else {
-                        None
-                    }
-                }),
-            )?
+            // Drop local fragments that are used to create proposals for old checkpoint.
+            // Note that we don't drop fragments table here, instead they are handled in the call
+            // to advance_checkpoint_construction_state.
             .delete_batch(
                 &self.tables.local_fragments,
                 self.tables
@@ -488,11 +529,7 @@ impl CheckpointStore {
         // Update the transactions databases.
         self.update_new_checkpoint_inner(checkpoint_sequence_number, contents, batch)?;
 
-        // TODO: Make the following atomic with above db writes.
-        let locals = self.get_locals();
-        let mut new_locals = locals.as_ref().clone();
-        new_locals.checkpoint_to_be_constructed.reset();
-        self.set_locals(locals, new_locals)
+        Ok(())
     }
 
     /// Call this function internally to register the latest batch of
@@ -625,13 +662,15 @@ impl CheckpointStore {
         }
 
         let locals = self.get_locals();
-        if !locals.checkpoint_to_be_constructed.is_completed() {
-            let mut new_locals = locals.as_ref().clone();
-            new_locals
-                .checkpoint_to_be_constructed
-                .add_fragment_to_span(committee, locals.next_checkpoint, &fragment);
-            self.set_locals(locals, new_locals)?;
-        }
+        let mut new_locals = locals.as_ref().clone();
+        new_locals.in_construction_checkpoint.add_fragment_to_span(
+            committee,
+            new_locals.in_construction_checkpoint_seq,
+            &fragment,
+        );
+        self.tables
+            .advance_checkpoint_construction_state(&mut new_locals, committee)?;
+        self.set_locals(locals, new_locals)?;
 
         Ok(())
     }
@@ -641,6 +680,11 @@ impl CheckpointStore {
     pub fn attempt_to_construct_checkpoint(&mut self) -> SuiResult<BTreeSet<ExecutionDigests>> {
         // We have a proposal so lets try to re-construct the checkpoint.
         let locals = self.get_locals();
+
+        fp_ensure!(
+            locals.next_checkpoint == locals.in_construction_checkpoint_seq,
+            SuiError::from("The checkpoint span graph under construction is for a different checkpoint than the next expected checkpoint. This means consensus is really behind.")
+        );
 
         // Ok to unwrap because we won't enter the checkpoint process unless we have a proposal.
         let our_proposal = locals.current_proposal.as_ref().unwrap();
@@ -684,17 +728,11 @@ impl CheckpointStore {
         our_proposal: &CheckpointProposal,
     ) -> SuiResult<BTreeSet<ExecutionDigests>> {
         let next_sequence_number = self.next_checkpoint();
-        fp_ensure!(
-            self.memory_locals
-                .checkpoint_to_be_constructed
-                .is_completed(),
-            SuiError::from("Not yet enough fragments to construct checkpoint")
-        );
 
         let reconstructed = self
             .memory_locals
-            .checkpoint_to_be_constructed
-            .construct_checkpoint();
+            .in_construction_checkpoint
+            .construct_checkpoint()?;
 
         // A little argument about how the fragment -> checkpoint process is live
         //
@@ -764,14 +802,6 @@ impl CheckpointStore {
             }
         }
 
-        // Sets the reconstruction to false, we have all fragments we need, but
-        // just cannot reconstruct the contents.
-        let locals = self.get_locals();
-        let mut new_locals = locals.as_ref().clone();
-        new_locals.no_more_fragments = true;
-        debug!("no_more_fragments is set");
-        self.set_locals(locals, new_locals)?;
-
         Err(SuiError::from(
             "Missing info to construct known checkpoint.",
         ))
@@ -804,7 +834,8 @@ impl CheckpointStore {
             .checkpoints
             .insert(seq, &AuthenticatedCheckpoint::Certified(checkpoint.clone()))?;
         self.notify_new_checkpoint(checkpoint.clone());
-        self.clear_proposal(*seq + 1)?;
+
+        self.clear_proposal(*seq + 1, committee)?;
         Ok(())
     }
 
@@ -840,7 +871,7 @@ impl CheckpointStore {
             contents,
         )?;
         self.notify_new_checkpoint(checkpoint.clone());
-        self.clear_proposal(*seq + 1)?;
+        self.clear_proposal(*seq + 1, committee)?;
         Ok(())
     }
 
@@ -854,17 +885,20 @@ impl CheckpointStore {
         });
     }
 
+    // TODO: We need to make the call to this atomic with the caller-side db changes.
     fn clear_proposal(
         &mut self,
         new_expected_next_checkpoint: CheckpointSequenceNumber,
+        committee: &Committee,
     ) -> SuiResult {
         let locals = self.get_locals();
 
         let mut new_locals = locals.as_ref().clone();
         new_locals.current_proposal = None;
         new_locals.proposal_next_transaction = None;
-        new_locals.no_more_fragments = false;
         new_locals.next_checkpoint = new_expected_next_checkpoint;
+        self.tables
+            .advance_checkpoint_construction_state(&mut new_locals, committee)?;
         self.set_locals(locals, new_locals)
     }
 
@@ -921,21 +955,27 @@ impl CheckpointStore {
         if !self.enable_reconfig {
             return false;
         }
-        let next_seq = self.next_checkpoint();
+        let in_construction = self.memory_locals.in_construction_checkpoint_seq;
         // Either we just finished constructing the second last checkpoint
-        if (next_seq + 1) % CHECKPOINT_COUNT_PER_EPOCH == 0
-            && self
-                .memory_locals
-                .checkpoint_to_be_constructed
-                .is_completed()
+        if (in_construction + 1) % CHECKPOINT_COUNT_PER_EPOCH == 0
+            && self.memory_locals.in_construction_checkpoint.is_completed()
         {
             return true;
         }
         // Or we are already in the process of constructing the last checkpoint.
-        if next_seq % CHECKPOINT_COUNT_PER_EPOCH == 0 && next_seq != 0 {
+        if in_construction % CHECKPOINT_COUNT_PER_EPOCH == 0 && in_construction != 0 {
             return true;
         }
         false
+    }
+
+    /// Whether we should try to create and sequence more fragments to help with checkpoint
+    /// construction. We should do so only if we are currently trying to build a span graph
+    /// for the next checkpoint, and the span graph is not yet complete.
+    pub fn should_sequence_more_fragments(&mut self) -> bool {
+        let locals = self.get_locals();
+        locals.next_checkpoint == locals.in_construction_checkpoint_seq
+            && !locals.in_construction_checkpoint.is_completed()
     }
 
     pub fn validators_already_fragmented_with(

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1238,8 +1238,7 @@ fn set_fragment_reconstruct() {
 
     let fragment41 = p4.fragment_with(&p1);
     let span = SpanGraph::mew(&committee, 0, &[fragment12, fragment34, fragment41]);
-    assert!(span.is_completed());
-    let reconstruction = span.construct_checkpoint();
+    let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 4);
 }
 
@@ -1289,9 +1288,8 @@ fn set_fragment_reconstruct_two_components() {
     }
 
     let span = SpanGraph::mew(&committee, 0, &fragments);
-    assert!(span.is_completed());
 
-    let reconstruction = span.construct_checkpoint();
+    let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 5);
 }
 
@@ -1496,6 +1494,182 @@ fn test_fragment_full_flow() {
     // Cannot advance to next checkpoint
     assert_eq!(cps6.next_checkpoint(), 0);
     // But recording of fragments is closed
+}
+
+#[test]
+fn test_slow_fragment() {
+    let (committee, _keys, mut cp_stores) = random_ckpoint_store();
+    let proposals: Vec<_> = cp_stores
+        .iter_mut()
+        .map(|(_, cp)| cp.set_proposal(0).unwrap())
+        .collect();
+    let fragment12 = proposals[1].fragment_with(&proposals[2]);
+    let fragment23 = proposals[2].fragment_with(&proposals[3]);
+    let mut index = ExecutionIndices::default();
+    cp_stores.iter_mut().for_each(|(_, cp)| {
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment12.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment23.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        assert!(cp.memory_locals.in_construction_checkpoint.is_completed());
+    });
+    // Missing link on validator 0, even though the span graph is complete.
+    assert!(cp_stores[0].1.attempt_to_construct_checkpoint().is_err());
+    assert!(cp_stores[0]
+        .1
+        .memory_locals
+        .in_construction_checkpoint
+        .is_completed());
+
+    // All other validators can make the checkpoint.
+    // Collect signed checkpoints, create cert and update validator 1-3.
+    let signed: Vec<_> = cp_stores
+        .iter_mut()
+        .skip(1)
+        .map(|(_, cp)| {
+            assert!(cp.attempt_to_construct_checkpoint().is_ok());
+            cp.sign_new_checkpoint(0, 0, [].into_iter(), TestCausalOrderNoop, None)
+                .unwrap();
+            // This hasn't changed yet.
+            assert_eq!(cp.memory_locals.next_checkpoint, 0);
+            assert_eq!(cp.memory_locals.in_construction_checkpoint_seq, 0);
+            if let AuthenticatedCheckpoint::Signed(s) = cp.latest_stored_checkpoint().unwrap() {
+                s
+            } else {
+                unreachable!()
+            }
+        })
+        .collect();
+    let cert0 = CertifiedCheckpointSummary::aggregate(signed, &committee).unwrap();
+    cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
+        cp.promote_signed_checkpoint_to_cert(&cert0, &committee)
+            .unwrap();
+        assert_eq!(cp.memory_locals.next_checkpoint, 1);
+        assert_eq!(cp.memory_locals.in_construction_checkpoint_seq, 1);
+    });
+    // At this point, validator 0 still has a complete span graph with missing link, and doesn't
+    // yet know there is a checkpoint cert.
+
+    let proposals: Vec<_> = cp_stores
+        .iter_mut()
+        .map(|(_, cp)| cp.set_proposal(0).unwrap())
+        .collect();
+    let fragment12 = proposals[1].fragment_with(&proposals[2]);
+    let fragment23 = proposals[2].fragment_with(&proposals[3]);
+    cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment12.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment23.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        assert!(cp.memory_locals.in_construction_checkpoint.is_completed());
+    });
+    // Validator 0 is still at checkpoint 0, and haven't received any fragments for checkpoint 1.
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        0
+    );
+    let signed: Vec<_> = cp_stores
+        .iter_mut()
+        .skip(1)
+        .map(|(_, cp)| {
+            assert!(cp.attempt_to_construct_checkpoint().is_ok());
+            cp.sign_new_checkpoint(0, 1, [].into_iter(), TestCausalOrderNoop, None)
+                .unwrap();
+            if let AuthenticatedCheckpoint::Signed(s) = cp.latest_stored_checkpoint().unwrap() {
+                s
+            } else {
+                unreachable!()
+            }
+        })
+        .collect();
+    let cert1 = CertifiedCheckpointSummary::aggregate(signed, &committee).unwrap();
+    cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
+        cp.promote_signed_checkpoint_to_cert(&cert1, &committee)
+            .unwrap();
+    });
+    // Now update both certs on validator 0.
+    cp_stores[0]
+        .1
+        .process_synced_checkpoint_certificate(
+            &cert0,
+            &CheckpointContents::new_with_causally_ordered_transactions([].into_iter()),
+            &committee,
+        )
+        .unwrap();
+    assert_eq!(cp_stores[0].1.memory_locals.next_checkpoint, 1);
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        1
+    );
+    cp_stores[0]
+        .1
+        .process_synced_checkpoint_certificate(
+            &cert1,
+            &CheckpointContents::new_with_causally_ordered_transactions([].into_iter()),
+            &committee,
+        )
+        .unwrap();
+    // Although it has seen checkpoint cert 1, it hasn't seen enough fragments for checkpoint 1 yet.
+    // Hence it is still in the state of constructing checkpoint 1.
+    assert_eq!(cp_stores[0].1.memory_locals.next_checkpoint, 2);
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        1
+    );
+    cp_stores[0]
+        .1
+        .handle_internal_fragment(
+            index.clone(),
+            fragment12,
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+    index.next_transaction_index += 1;
+    cp_stores[0]
+        .1
+        .handle_internal_fragment(
+            index.clone(),
+            fragment23,
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+    index.next_transaction_index += 1;
+    // Validator 0 should have automatically advanced to be constructing checkpoint 2.
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        2
+    );
+    assert!(!cp_stores[0]
+        .1
+        .memory_locals
+        .in_construction_checkpoint
+        .is_completed());
 }
 
 #[derive(Clone)]
@@ -1913,14 +2087,13 @@ async fn test_no_more_fragments() {
     // Give time to the receiving task to process (so that consensus can sequence fragments).
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Expecting more fragments
-    assert!(
-        !setup.authorities[0]
-            .checkpoint
-            .lock()
-            .get_locals()
-            .no_more_fragments
-    );
+    // Expecting checkpoint construction still in progress.
+    assert!(!setup.authorities[0]
+        .checkpoint
+        .lock()
+        .get_locals()
+        .in_construction_checkpoint
+        .is_completed());
 
     // put in fragment 0-2, now node 0 can form a checkpoint but not node 3
 
@@ -1933,36 +2106,34 @@ async fn test_no_more_fragments() {
     // Give time to the receiving task to process (so that consensus can sequence fragments).
     tokio::time::sleep(Duration::from_secs(1)).await;
 
+    // Expecting checkpoint construction complete.
+    assert!(setup.authorities[0]
+        .checkpoint
+        .lock()
+        .get_locals()
+        .in_construction_checkpoint
+        .is_completed());
+
     assert!(setup.authorities[0]
         .checkpoint
         .lock()
         .attempt_to_construct_checkpoint()
         .is_ok());
 
-    // Expecting more fragments
-    assert!(
-        !setup.authorities[0]
-            .checkpoint
-            .lock()
-            .get_locals()
-            .no_more_fragments
-    );
-
-    // node 3 cannot make one
+    // node 3 cannot make one due to missing link.
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
         .attempt_to_construct_checkpoint()
         .is_err());
 
-    // Expecting more fragments
-    assert!(
-        setup.authorities[3]
-            .checkpoint
-            .lock()
-            .get_locals()
-            .no_more_fragments
-    );
+    // But span graph has enough fragments, and hence is complete.
+    assert!(setup.authorities[3]
+        .checkpoint
+        .lock()
+        .get_locals()
+        .in_construction_checkpoint
+        .is_completed());
 
     // Now fie node 3 a link and it can make the checkpoint
     setup.authorities[3]

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1540,7 +1540,7 @@ fn test_slow_fragment() {
         .skip(1)
         .map(|(_, cp)| {
             assert!(cp.attempt_to_construct_checkpoint().is_ok());
-            cp.sign_new_checkpoint(0, 0, [].into_iter(), TestCausalOrderNoop, None)
+            cp.sign_new_checkpoint(0, 0, [].into_iter(), TestEffectsStore::default(), None)
                 .unwrap();
             // This hasn't changed yet.
             assert_eq!(cp.memory_locals.next_checkpoint, 0);
@@ -1597,7 +1597,7 @@ fn test_slow_fragment() {
         .skip(1)
         .map(|(_, cp)| {
             assert!(cp.attempt_to_construct_checkpoint().is_ok());
-            cp.sign_new_checkpoint(0, 1, [].into_iter(), TestCausalOrderNoop, None)
+            cp.sign_new_checkpoint(0, 1, [].into_iter(), TestEffectsStore::default(), None)
                 .unwrap();
             if let AuthenticatedCheckpoint::Signed(s) = cp.latest_stored_checkpoint().unwrap() {
                 s

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -52,9 +52,9 @@ async fn test_start_epoch_change() {
             next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
             proposal_next_transaction: None,
             next_transaction_sequence: 0,
-            no_more_fragments: true,
             current_proposal: None,
-            checkpoint_to_be_constructed: SpanGraph::mew(
+            in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH,
+            in_construction_checkpoint: SpanGraph::mew(
                 &genesis_committee,
                 CHECKPOINT_COUNT_PER_EPOCH,
                 &[],
@@ -155,9 +155,9 @@ async fn test_finish_epoch_change() {
                     next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
                     proposal_next_transaction: None,
                     next_transaction_sequence: 0,
-                    no_more_fragments: true,
                     current_proposal: None,
-                    checkpoint_to_be_constructed: SpanGraph::mew(
+                    in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH,
+                    in_construction_checkpoint: SpanGraph::mew(
                         &genesis_committee,
                         CHECKPOINT_COUNT_PER_EPOCH,
                         &[],

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use narwhal_executor::ExecutionIndices;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -9,6 +10,9 @@ use std::{
     time::Duration,
 };
 
+use sui_types::messages_checkpoint::{
+    AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents,
+};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     crypto::{get_key_pair, AccountKeyPair, AuthoritySignature, SuiAuthoritySignature},
@@ -19,6 +23,8 @@ use sui_types::{
 };
 
 use crate::authority::AuthorityState;
+use crate::authority_active::execution_driver::PendCertificateForExecutionNoop;
+use crate::checkpoints::causal_order_effects::TestCausalOrderNoop;
 use crate::checkpoints::reconstruction::SpanGraph;
 use crate::{
     authority_active::ActiveAuthority,
@@ -209,6 +215,128 @@ async fn test_finish_epoch_change() {
         assert!(response.certified_transaction.is_some());
         assert!(response.signed_effects.is_some());
     }
+}
+
+#[tokio::test]
+async fn test_consensus_pause_after_last_fragment() {
+    // Create authority_aggregator and authority states.
+    let genesis_objects = vec![];
+    let (net, states, _) = init_local_authorities(4, genesis_objects.clone()).await;
+    enable_reconfig(&states);
+
+    let proposals: Vec<_> = states
+        .iter()
+        .map(|state| {
+            let genesis_committee = state.committee_store().get_latest_committee();
+            // Set the checkpoint number to be about to construct the last second checkpoint.
+            let locals = CheckpointLocals {
+                next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH - 1,
+                proposal_next_transaction: None,
+                next_transaction_sequence: 0,
+                current_proposal: None,
+                in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH - 1,
+                in_construction_checkpoint: SpanGraph::mew(
+                    &genesis_committee,
+                    CHECKPOINT_COUNT_PER_EPOCH - 1,
+                    &[],
+                ),
+            };
+            state
+                .checkpoints
+                .lock()
+                .set_locals_for_testing(locals)
+                .unwrap();
+            assert!(!state
+                .checkpoints
+                .lock()
+                .should_reject_consensus_transaction());
+            state.checkpoints.lock().set_proposal(0).unwrap()
+        })
+        .collect();
+    let fragment01 = proposals[0].fragment_with(&proposals[1]);
+    let fragment12 = proposals[1].fragment_with(&proposals[2]);
+    let mut index = ExecutionIndices::default();
+    states.iter().for_each(|state| {
+        // Send the first fragment to every validator, and make sure ater this, none of them
+        // have a complete span graph, nor should they start rejecting consensus transactions.
+        let mut cp = state.checkpoints.lock();
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment01.clone(),
+            PendCertificateForExecutionNoop,
+            &net.committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        assert!(!cp.get_locals().in_construction_checkpoint.is_completed());
+        assert!(!cp.should_reject_consensus_transaction());
+    });
+    // Send the second fragment only to validator 1-3, leaving validator 0 behind.
+    // Validator 1-3 will complete the span graph. At this point they should all start rejecting
+    // consensus transactions. They are each able to sign the checkpoint.
+    let signed: Vec<_> = states
+        .iter()
+        .skip(1)
+        .map(|state| {
+            let mut cp = state.checkpoints.lock();
+            cp.handle_internal_fragment(
+                index.clone(),
+                fragment12.clone(),
+                PendCertificateForExecutionNoop,
+                &net.committee,
+            )
+            .unwrap();
+            index.next_transaction_index += 1;
+            assert!(cp.get_locals().in_construction_checkpoint.is_completed());
+            assert!(cp.should_reject_consensus_transaction());
+            cp.sign_new_checkpoint(
+                0,
+                CHECKPOINT_COUNT_PER_EPOCH - 1,
+                [].into_iter(),
+                TestCausalOrderNoop,
+                None,
+            )
+            .unwrap();
+            if let AuthenticatedCheckpoint::Signed(s) = cp.latest_stored_checkpoint().unwrap() {
+                s
+            } else {
+                unreachable!();
+            }
+        })
+        .collect();
+    let cert = CertifiedCheckpointSummary::aggregate(signed, &net.committee).unwrap();
+    // Even after we processed the checkpoint cert on validator 0, it still does not have a
+    // complete span graph, and hence not yet rejecting consensus transactions.
+    let mut cp0 = states[0].checkpoints.lock();
+    cp0.process_synced_checkpoint_certificate(
+        &cert,
+        &CheckpointContents::new_with_causally_ordered_transactions([].into_iter()),
+        &net.committee,
+    )
+    .unwrap();
+    assert!(!cp0.get_locals().in_construction_checkpoint.is_completed());
+    assert!(!cp0.should_reject_consensus_transaction());
+    states.iter().skip(1).for_each(|state| {
+        let mut cp = state.checkpoints.lock();
+        cp.promote_signed_checkpoint_to_cert(&cert, &net.committee)
+            .unwrap();
+        // Validator 1-3 will continue to reject consensus transactions after storing the cert.
+        assert!(cp.should_reject_consensus_transaction());
+        // The span graph is now empty, ready to construct the next checkpoint.
+        assert!(!cp.get_locals().in_construction_checkpoint.is_completed());
+    });
+    // Now send the second fragment to validator 0. It will complete the span graph, and since it's
+    // already at a new checkpoint, it will automatically clear the graph. It will also start
+    // rejecting consensus transactions.
+    cp0.handle_internal_fragment(
+        index,
+        fragment12,
+        PendCertificateForExecutionNoop,
+        &net.committee,
+    )
+    .unwrap();
+    assert!(!cp0.get_locals().in_construction_checkpoint.is_completed());
+    assert!(cp0.should_reject_consensus_transaction());
 }
 
 fn enable_reconfig(states: &[Arc<AuthorityState>]) {

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -24,7 +24,7 @@ use sui_types::{
 
 use crate::authority::AuthorityState;
 use crate::authority_active::execution_driver::PendCertificateForExecutionNoop;
-use crate::checkpoints::causal_order_effects::TestCausalOrderNoop;
+use crate::checkpoints::causal_order_effects::TestEffectsStore;
 use crate::checkpoints::reconstruction::SpanGraph;
 use crate::{
     authority_active::ActiveAuthority,
@@ -293,7 +293,7 @@ async fn test_consensus_pause_after_last_fragment() {
                 0,
                 CHECKPOINT_COUNT_PER_EPOCH - 1,
                 [].into_iter(),
-                TestCausalOrderNoop,
+                TestEffectsStore::default(),
                 None,
             )
             .unwrap();


### PR DESCRIPTION
So we want to be able to stop accepting consensus transactions right after we received the last fragment of the second last checkpoint. To do this, we must track where we are in terms of fragment receiving (i.e. span graph construction). This means that span graph construction must be an independent process from the checkpoint proposing/checkpoint store. For example, a validator that just received and updated a new checkpoint certificate, may not have yet received the last fragment for that checkpoint, and hence there will be a period of time where these two becomes out-of-sync. The implementation must support that.
This PR makes it happen: the checkpoint under construction can be different from the next expected checkpoint cert.