### PR TITLE
sui-node: start an anemo network on node startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=57c4af7d6cdbf47633e6715bcd67d98f300e2fd8#57c4af7d6cdbf47633e6715bcd67d98f300e2fd8"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=1b977fe20a615b7a7045f779f9aafa120389c2ab#1b977fe20a615b7a7045f779f9aafa120389c2ab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=57c4af7d6cdbf47633e6715bcd67d98f300e2fd8#57c4af7d6cdbf47633e6715bcd67d98f300e2fd8"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=1b977fe20a615b7a7045f779f9aafa120389c2ab#1b977fe20a615b7a7045f779f9aafa120389c2ab"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.43",
@@ -131,7 +131,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=57c4af7d6cdbf47633e6715bcd67d98f300e2fd8#57c4af7d6cdbf47633e6715bcd67d98f300e2fd8"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=1b977fe20a615b7a7045f779f9aafa120389c2ab#1b977fe20a615b7a7045f779f9aafa120389c2ab"
 dependencies = [
  "anemo",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8347,6 +8347,8 @@ dependencies = [
 name = "sui-node"
 version = "0.12.0"
 dependencies = [
+ "anemo",
+ "anemo-tower",
  "anyhow",
  "axum",
  "chrono",
@@ -8356,6 +8358,7 @@ dependencies = [
  "jemallocator",
  "multiaddr",
  "mysten-network",
+ "narwhal-network",
  "parking_lot 0.12.1",
  "prometheus",
  "sui-config",
@@ -8368,6 +8371,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers 0.2.0",
  "tokio",
+ "tower",
  "tracing",
  "typed-store",
  "workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8006,6 +8006,7 @@ dependencies = [
 name = "sui-config"
 version = "0.0.0"
 dependencies = [
+ "anemo",
  "anyhow",
  "arc-swap",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,9 @@ move-prover-boogie-backend = { git = "https://github.com/move-language/move", re
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4b7a06fe393003013489990dc2f4d3d2ebb32539" }
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab" }
 
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,5 +93,10 @@ move-prover-boogie-backend = { git = "https://github.com/move-language/move", re
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "4b7a06fe393003013489990dc2f4d3d2ebb32539" }
 
+# anemo dependencies
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+anemo.workspace = true
 bcs = "0.1.4"
 arc-swap = "1.5.1"
 camino = "1.1.1"

--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -4,6 +4,7 @@
 use crate::{
     genesis,
     genesis_config::{GenesisConfig, ValidatorGenesisInfo},
+    p2p::P2pConfig,
     utils, ConsensusConfig, NetworkConfig, NodeConfig, ValidatorInfo, AUTHORITIES_DB_NAME,
     CONSENSUS_DB_NAME,
 };
@@ -262,6 +263,11 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     narwhal_config: Default::default(),
                 };
 
+                let p2p_config = P2pConfig {
+                    listen_address: utils::available_local_socket_address(),
+                    ..Default::default()
+                };
+
                 NodeConfig {
                     protocol_key_pair: Arc::new(validator.key_pair),
                     worker_key_pair: Arc::new(validator.worker_key_pair),
@@ -281,6 +287,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     genesis: crate::node::Genesis::new(genesis.clone()),
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,
+                    p2p_config,
                 }
             })
             .collect();

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -15,6 +15,7 @@ pub mod gateway;
 pub mod genesis;
 pub mod genesis_config;
 pub mod node;
+pub mod p2p;
 mod swarm;
 pub mod utils;
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::genesis;
+use crate::p2p::P2pConfig;
 use crate::Config;
 use anyhow::Result;
 use multiaddr::Multiaddr;
@@ -78,6 +79,9 @@ pub struct NodeConfig {
 
     #[serde(default = "default_concurrency_limit")]
     pub grpc_concurrency_limit: Option<usize>,
+
+    #[serde(default)]
+    pub p2p_config: P2pConfig,
 
     pub genesis: Genesis,
 }

--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct P2pConfig {
+    #[serde(default = "default_listen_address")]
+    pub listen_address: SocketAddr,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anemo_config: Option<anemo::Config>,
+}
+
+fn default_listen_address() -> SocketAddr {
+    "0.0.0.0:8080".parse().unwrap()
+}
+
+impl Default for P2pConfig {
+    fn default() -> Self {
+        Self {
+            listen_address: default_listen_address(),
+            anemo_config: Default::default(),
+        }
+    }
+}

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::p2p::P2pConfig;
 use crate::{builder, genesis, utils, Config, NodeConfig, ValidatorInfo, FULL_NODE_DB_PATH};
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -95,13 +96,20 @@ impl NetworkConfig {
         } else {
             FULL_NODE_DB_PATH.to_string()
         };
+
+        let network_address = utils::new_network_address();
+        let p2p_config = P2pConfig {
+            listen_address: utils::available_local_socket_address(),
+            ..Default::default()
+        };
+
         NodeConfig {
             protocol_key_pair,
             worker_key_pair,
             account_key_pair,
             network_key_pair,
             db_path: db_path.join(dir_name),
-            network_address: utils::new_network_address(),
+            network_address,
             metrics_address: utils::available_local_socket_address(),
             admin_interface_port: utils::get_available_port(),
             json_rpc_address: utils::available_local_socket_address(),
@@ -118,6 +126,7 @@ impl NetworkConfig {
             genesis: validator_config.genesis.clone(),
             grpc_load_shed: None,
             grpc_concurrency_limit: None,
+            p2p_config,
         }
     }
 }

--- a/crates/sui-config/tests/snapshot_tests.rs
+++ b/crates/sui-config/tests/snapshot_tests.rs
@@ -113,6 +113,7 @@ fn network_config_snapshot_matches() {
         let fake_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 1);
         validator_config.json_rpc_address = fake_socket;
         validator_config.metrics_address = fake_socket;
+        validator_config.p2p_config.listen_address = fake_socket;
         validator_config.admin_interface_port = 8888;
         let metrics_addr: Multiaddr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
         let primary_network_admin_server_port = 5678;

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -48,6 +48,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
   - protocol-key-pair: LqPR5IijTDFVFUq2rCvOsiIO8dIRuXSAldAP+DYC1me2tykqD8b9TR5r1KXG1tk5NzsUp1pV97mzqOf4RZiHOuHRbC/7MTIsXXZZqIJo6WQCoJQf//aqfEwxf5hNpYWpnuGovtGTaPGU7tq29e9O7GmsMIAVjtZZHy3ribwbBb8=
@@ -95,6 +97,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
   - protocol-key-pair: Hiq/0Ct6fmLhv1nBMiPqovOB6sOCfo5729qmN08q5xqmoXf1i/SZl1hJgzwzhR0tHh1rEBWcoC23JZIvZTv5l61M6Do8FX6cWWirPwYkXz0JpmyKSWt+uTVCq3nJc6q7GWTWC0H8eafBj9shurYTrgUf8CSXw6dc8Pwr8R2ywIw=
@@ -142,6 +146,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
   - protocol-key-pair: GzzrEigjxChf2XnG0nSJuAfP6tSQo4A7/63k4hAOjOeL0OmML+RlsN3ntyxKDupYUwXe5MQI7aMEPczkE5dTxPsB5tOsw770PkhudQjw3uUWGaMSIoWHBQ6UUZvHWOR0/bXY9H9e+drIfENom4yTK3EAIGeyGL1OttmJk/XS2os=
@@ -189,6 +195,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
   - protocol-key-pair: NsLWImHeTmGIB9KvW1EAu3X+tW7Q/KkI5gk3COXONCmm1yzKunhYP2XGQ4HKxwLtN5RUod5uTWXZX7P1wdIn2g5MbKFtB3Rj74n7dbqnia8Oqz14vEoSNUoxrh+6xLgU9IDbBhMKOlyOcHFrDQVkXoV75fge2er7vrS7f8/5wCw=
@@ -236,6 +244,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
   - protocol-key-pair: CsRQrECMM8bjsounq/lp4HpZ78DfTEQ+8JZ8ep9Uwd2oUEn0LWkMFMIY2sZlOweOIHI1PV/hKGf74V8tdqFj1X3vaDCy7xCKXUrHW4MK4I8CQSs29yb3X//ssrVtkq3DHEUgHSiJu9bxRDABWZt1BPRnAJom/Ta3blmSnDSP0rE=
@@ -283,6 +293,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
   - protocol-key-pair: ATtFYSC+WduPcjkDb5W/0qmeY8rJakh27PTldLq+nuaoaYghGPn/1BWEWXhXazXPUQf8cN4uOBzwlLo6iPuLQNcbp2Pg5RHFiVKZxrNDM6wNbuWCIMktDH6wzEJFDLBAb6alikZSqgMsGoi5ZpmIdqI0p+jHsU8TyXZ5wHORhWA=
@@ -330,6 +342,8 @@ validator_configs:
     enable-reconfig: false
     grpc-load-shed: ~
     grpc-concurrency-limit: 20000000000
+    p2p-config:
+      listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
 account_keys:

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 edition = "2021"
 
 [dependencies]
+anemo.workspace = true
+anemo-tower.workspace = true
 axum = "0.5.16"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 clap = { version = "3.2.17", features = ["derive"] }
@@ -18,6 +20,7 @@ parking_lot = "0.12.1"
 futures = "0.3.23"
 typed-store.workspace = true
 chrono = "0.4.0"
+tower = "0.4.13"
 
 sui-config = { path = "../sui-config" }
 sui-core = { path = "../sui-core" }
@@ -26,6 +29,7 @@ sui-network = { path = "../sui-network" }
 sui-json-rpc = { path = "../sui-json-rpc" }
 sui-telemetry = { path = "../sui-telemetry" }
 sui-types = { path = "../sui-types" }
+narwhal-network = { path = "../../narwhal/network" }
 
 telemetry-subscribers.workspace = true
 mysten-network.workspace = true

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anemo_tower::callback::CallbackLayer;
+use anemo_tower::trace::TraceLayer;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Result;
 use futures::TryFutureExt;
 use mysten_network::server::ServerBuilder;
+use narwhal_network::metrics::MetricsMakeCallbackHandler;
+use narwhal_network::metrics::{NetworkConnectionMetrics, NetworkMetrics};
 use parking_lot::Mutex;
 use prometheus::Registry;
 use std::option::Option::None;
@@ -39,6 +43,7 @@ use sui_storage::{
 };
 use sui_types::messages::{CertifiedTransaction, CertifiedTransactionEffects};
 use tokio::sync::mpsc::channel;
+use tower::ServiceBuilder;
 use tracing::{error, info, warn};
 
 use crate::metrics::GrpcMetrics;
@@ -73,6 +78,8 @@ pub struct SuiNode {
     active: Arc<ActiveAuthority<NetworkAuthorityClient>>,
     transaction_orchestrator: Option<Arc<TransactiondOrchestrator<NetworkAuthorityClient>>>,
     _prometheus_registry: Registry,
+
+    _p2p_network: anemo::Network,
 
     #[cfg(msim)]
     sim_node: sui_simulator::runtime::NodeHandle,
@@ -294,6 +301,47 @@ impl SuiNode {
             tokio::spawn(server.serve().map_err(Into::into))
         };
 
+        let p2p_network = {
+            let inbound_network_metrics =
+                NetworkMetrics::new("sui", "inbound", &prometheus_registry);
+            let outbound_network_metrics =
+                NetworkMetrics::new("sui", "outbound", &prometheus_registry);
+            let network_connection_metrics =
+                NetworkConnectionMetrics::new("sui", &prometheus_registry);
+
+            let routes = anemo::Router::new();
+
+            let service = ServiceBuilder::new()
+                .layer(TraceLayer::new())
+                .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
+                    Arc::new(inbound_network_metrics),
+                )))
+                .service(routes);
+
+            let outbound_layer = ServiceBuilder::new()
+                .layer(TraceLayer::new())
+                .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
+                    Arc::new(outbound_network_metrics),
+                )))
+                .into_inner();
+
+            let network = anemo::Network::bind(config.p2p_config.listen_address)
+                .server_name("sui")
+                .private_key(config.network_key_pair.copy().private().0.to_bytes())
+                .config(config.p2p_config.anemo_config.clone().unwrap_or_default())
+                .outbound_request_layer(outbound_layer)
+                .start(service)?;
+            info!("P2p network started on {}", network.local_addr());
+
+            let _connection_monitor_handle =
+                narwhal_network::connectivity::ConnectionMonitor::spawn(
+                    network.downgrade(),
+                    network_connection_metrics,
+                );
+
+            network
+        };
+
         let (json_rpc_service, ws_subscription_service) = build_http_servers(
             state.clone(),
             &transaction_orchestrator.clone(),
@@ -315,6 +363,7 @@ impl SuiNode {
             active: active_authority,
             transaction_orchestrator,
             _prometheus_registry: prometheus_registry,
+            _p2p_network: p2p_network,
 
             #[cfg(msim)]
             sim_node: sui_simulator::runtime::NodeHandle::current(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -312,14 +312,14 @@ impl SuiNode {
             let routes = anemo::Router::new();
 
             let service = ServiceBuilder::new()
-                .layer(TraceLayer::new())
+                .layer(TraceLayer::new_for_server_errors())
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(inbound_network_metrics),
                 )))
                 .service(routes);
 
             let outbound_layer = ServiceBuilder::new()
-                .layer(TraceLayer::new())
+                .layer(TraceLayer::new_for_client_and_server_errors())
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(outbound_network_metrics),
                 )))

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -12,7 +12,7 @@ sui-framework = { path = "../sui-framework" }
 sui-types = { path = "../sui-types" }
 telemetry-subscribers.workspace = true
 tracing = "0.1"
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }
 
 [target.'cfg(msim)'.dependencies]

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -22,8 +22,8 @@ aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10", features = ["aes", "alloc", "getrandom"] }
 ahash = { version = "0.7", features = ["std"] }
 aho-corasick = { version = "0.7", features = ["std"] }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -626,9 +626,9 @@ aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10", features = ["aes", "alloc", "getrandom"] }
 ahash = { version = "0.7", features = ["std"] }
 aho-corasick = { version = "0.7", features = ["std"] }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8", default-features = false }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }

--- a/narwhal/network/Cargo.toml
+++ b/narwhal/network/Cargo.toml
@@ -27,8 +27,8 @@ serde = "1.0.144"
 workspace-hack.workspace = true
 eyre = "0.6.8"
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
+anemo-tower.workspace = true
 anyhow = "1.0.65"
 axum = "0.5.16"
 axum-server = "0.4.2"

--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -45,7 +45,7 @@ worker = { path = "../worker", package = "narwhal-worker" }
 workspace-hack.workspace = true
 eyre = "0.6.8"
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -45,8 +45,8 @@ mysten-network.workspace = true
 store.workspace = true
 workspace-hack.workspace = true
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
+anemo-tower.workspace = true
 
 [dev-dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -225,14 +225,14 @@ impl Primary {
             .add_rpc_service(worker_service);
 
         let service = ServiceBuilder::new()
-            .layer(TraceLayer::new())
+            .layer(TraceLayer::new_for_server_errors())
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 inbound_network_metrics,
             )))
             .service(routes);
 
         let outbound_layer = ServiceBuilder::new()
-            .layer(TraceLayer::new())
+            .layer(TraceLayer::new_for_client_and_server_errors())
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 outbound_network_metrics,
             )))

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -264,9 +264,8 @@ impl Primary {
         info!("Primary {} listening on {}", name.encode_base64(), address);
 
         let connection_monitor_handle = network::connectivity::ConnectionMonitor::spawn(
-            network.clone(),
+            network.downgrade(),
             network_connection_metrics,
-            tx_reconfigure.subscribe(),
         );
 
         let primaries = committee

--- a/narwhal/test-utils/Cargo.toml
+++ b/narwhal/test-utils/Cargo.toml
@@ -43,5 +43,5 @@ store = { version = "0.1.0", package = "typed-store"}
 workspace-hack.workspace = true
 telemetry-subscribers.workspace = true
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
 tower = { version = "0.4.13", features = ["full"] }

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -38,7 +38,7 @@ config = { path = "../config", package = "narwhal-config" }
 fastcrypto.workspace = true
 crypto = { path = "../crypto", package = "narwhal-crypto" }
 dag = { path = "../dag", package = "narwhal-dag" }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
@@ -54,7 +54,7 @@ protobuf-src = "1.1.0"
 prost-build = "0.11.1"
 rustversion = "1.0.9"
 tonic-build = { version = "0.8.2", features = [ "prost", "transport" ] }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo-build.workspace = true
 
 [features]
 default = []

--- a/narwhal/worker/Cargo.toml
+++ b/narwhal/worker/Cargo.toml
@@ -33,8 +33,8 @@ types = { path = "../types", package = "narwhal-types" }
 mysten-network.workspace = true
 prometheus = "0.13.2"
 
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "57c4af7d6cdbf47633e6715bcd67d98f300e2fd8" }
+anemo.workspace = true
+anemo-tower.workspace = true
 anyhow = "1.0.65"
 
 store.workspace = true

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -174,9 +174,8 @@ impl Worker {
         info!("Worker {} listening to worker messages on {}", id, address);
 
         let connection_monitor_handle = network::connectivity::ConnectionMonitor::spawn(
-            network.clone(),
+            network.downgrade(),
             network_connection_metrics,
-            rx_reconfigure.clone(),
         );
 
         let other_workers = worker

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -139,14 +139,14 @@ impl Worker {
             .add_rpc_service(primary_service);
 
         let service = ServiceBuilder::new()
-            .layer(TraceLayer::new())
+            .layer(TraceLayer::new_for_server_errors())
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 inbound_network_metrics,
             )))
             .service(routes);
 
         let outbound_layer = ServiceBuilder::new()
-            .layer(TraceLayer::new())
+            .layer(TraceLayer::new_for_client_and_server_errors())
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 outbound_network_metrics,
             )))


### PR DESCRIPTION
This PR lays the ground work for building p2p services by starting an anemo network on node startup. To start there won't be any services running on this interface and the port that the network is bound on wont be advertised anywhere or even opened for any traffic in any production environments.

A later set of PRs will introduce a discovery mechanism as well as a way to do distributed state-sync of checkpoints.