### PR TITLE
[explorer] Add react-hot-toast for notifications

### DIFF
--- a/apps/explorer/.stylelintrc.json
+++ b/apps/explorer/.stylelintrc.json
@@ -10,6 +10,12 @@
             {
                 "ignoreAtRules": ["tailwind"]
             }
+        ],
+        "function-no-unknown": [
+            true,
+            {
+                "ignoreFunctions": ["theme"]
+            }
         ]
     }
 }

--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -46,6 +46,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-ga4": "^1.4.1",
+        "react-hot-toast": "^2.4.0",
         "react-router-dom": "^6.2.1",
         "topojson-client": "^3.1.0",
         "vanilla-cookieconsent": "^2.8.0"

--- a/apps/explorer/src/app/App.tsx
+++ b/apps/explorer/src/app/App.tsx
@@ -4,6 +4,7 @@
 import { GrowthBookProvider } from '@growthbook/growthbook-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
+import { Toaster } from 'react-hot-toast';
 
 import Footer from '../components/footer/Footer';
 import Header from '../components/header/Header';
@@ -48,6 +49,28 @@ function App() {
                         </main>
                         <Footer />
                     </div>
+
+                    <Toaster
+                        position="bottom-center"
+                        gutter={8}
+                        toastOptions={{
+                            success: {
+                                className:
+                                    '!bg-success-light !text-success-dark',
+                                iconTheme: {
+                                    primary: 'var(--success-light)',
+                                    secondary: 'var(--success-dark)',
+                                },
+                            },
+                            error: {
+                                className: '!bg-issue-light !text-issue-dark',
+                                iconTheme: {
+                                    primary: 'var(--issue-light)',
+                                    secondary: 'var(--issue-dark)',
+                                },
+                            },
+                        }}
+                    />
                 </NetworkContext.Provider>
             </QueryClientProvider>
         </GrowthBookProvider>

--- a/apps/explorer/src/app/App.tsx
+++ b/apps/explorer/src/app/App.tsx
@@ -54,6 +54,7 @@ function App() {
                         position="bottom-center"
                         gutter={8}
                         toastOptions={{
+                            duration: 4000,
                             success: {
                                 className:
                                     '!bg-success-light !text-success-dark',

--- a/apps/explorer/src/components/longtext/Longtext.tsx
+++ b/apps/explorer/src/components/longtext/Longtext.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useState, useContext } from 'react';
+import toast from 'react-hot-toast';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ReactComponent as ContentArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
@@ -34,17 +35,14 @@ function Longtext({
     copyButton?: '16' | '24' | 'none';
     showIconButton?: boolean;
 }) {
-    const [isCopyIcon, setCopyIcon] = useState(true);
-
     const [pleaseWait, setPleaseWait] = useState(false);
     const [network] = useContext(NetworkContext);
     const navigate = useNavigate();
 
     const handleCopyEvent = useCallback(() => {
         navigator.clipboard.writeText(text);
-        setCopyIcon(false);
-        setTimeout(() => setCopyIcon(true), 1000);
-    }, [setCopyIcon, text]);
+        toast.success('Copied!');
+    }, [text]);
 
     let icon;
     let iconButton = <></>;
@@ -52,7 +50,7 @@ function Longtext({
     if (copyButton !== 'none') {
         if (pleaseWait) {
             icon = <div className={styles.copied}>&#8987; Please Wait</div>;
-        } else if (isCopyIcon) {
+        } else {
             icon = (
                 <div
                     className={
@@ -66,12 +64,6 @@ function Longtext({
                         <ContentCopyIcon24 />
                     )}
                 </div>
-            );
-        } else {
-            icon = (
-                <span className={styles.copied}>
-                    <span>&#10003;</span> <span>Copied</span>
-                </span>
             );
         }
     } else {

--- a/apps/explorer/src/index.css
+++ b/apps/explorer/src/index.css
@@ -21,8 +21,18 @@
     src: url('./assets/Fonts/SpaceMono-Regular.ttf') format('truetype');
 }
 
+/* Define some colors as CSS variables for use outside of the Tailwind class context: */
+:root {
+    --success-light: theme('colors.success.light');
+    --success-dark: theme('colors.success.dark');
+    --warning-light: theme('colors.warning.light');
+    --warning-dark: theme('colors.warning.dark');
+    --issue-light: theme('colors.issue.light');
+    --issue-dark: theme('colors.issue.dark');
+}
+
 body {
-    @apply m-0 text-offblack;
+    @apply m-0 text-offblack font-sans;
 }
 
 input:focus,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-ga4: ^1.4.1
+      react-hot-toast: ^2.4.0
       react-router-dom: ^6.2.1
       start-server-and-test: ^1.14.0
       stylelint: ^14.5.0
@@ -98,6 +99,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-ga4: 1.4.1
+      react-hot-toast: 2.4.0_biqbaboplfbrettd7655fr4n2y
       react-router-dom: 6.3.0_biqbaboplfbrettd7655fr4n2y
       topojson-client: 3.1.0
       vanilla-cookieconsent: 2.8.5
@@ -13275,6 +13277,12 @@ packages:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
 
+  /goober/2.1.11:
+    resolution: {integrity: sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dev: false
+
   /got/12.3.1:
     resolution: {integrity: sha512-tS6+JMhBh4iXMSXF6KkIsRxmloPln31QHDlcb6Ec3bzxjjFJFr/8aXdpyuLmVc9I4i2HyBHYw1QU5K1ruUdpkw==}
     engines: {node: '>=14.16'}
@@ -17977,6 +17985,20 @@ packages:
 
   /react-ga4/1.4.1:
     resolution: {integrity: sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==}
+    dev: false
+
+  /react-hot-toast/2.4.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      goober: 2.1.11
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    transitivePeerDependencies:
+      - csstype
     dev: false
 
   /react-inspector/5.1.1_react@18.2.0:


### PR DESCRIPTION
Based on the new notification system that's in the wallet, this implements `react-hot-toast` in the explorer to display notifications for events. This library supports several notification types, which should work well for all of our needs. for now, I just adjusted the copy button to use this.

Demo of this with the copy button:


https://user-images.githubusercontent.com/109986297/196062402-a9cb00e7-07c1-4850-8116-e9a33e204d5a.mp4

