### PR TITLE
[checkpoint] Revert the removal of extra transactions dependency

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -381,6 +381,9 @@ impl CheckpointStore {
         effects_store: impl CausalOrder,
         next_epoch_committee: Option<Committee>,
     ) -> SuiResult {
+        // Make sure that all transactions in the checkpoint have been executed locally.
+        self.check_checkpoint_transactions(transactions.clone())?;
+
         let previous_digest = self.get_prev_checkpoint_digest(sequence_number)?;
 
         // Create a causal order of all transactions in the checkpoint.
@@ -780,6 +783,20 @@ impl CheckpointStore {
         Ok(())
     }
 
+    /// Processes a checkpoint certificate that this validator just learned about.
+    /// Such certificate may either be created locally based on a quorum of signed checkpoints,
+    /// or downloaded from other validators to sync local checkpoint state.
+    #[cfg(test)]
+    pub fn process_new_checkpoint_certificate(
+        &mut self,
+        checkpoint: &CertifiedCheckpointSummary,
+        contents: &CheckpointContents,
+        committee: &Committee,
+    ) -> SuiResult {
+        self.check_checkpoint_transactions(contents.iter())?;
+        self.process_synced_checkpoint_certificate(checkpoint, contents, committee)
+    }
+
     /// Unlike process_new_checkpoint_certificate this does not verify that transactions are executed
     /// Checkpoint sync process executes it because it verifies transactions when downloading checkpoint
     pub fn process_synced_checkpoint_certificate(
@@ -955,12 +972,33 @@ impl CheckpointStore {
         Ok(checkpoint_proposal)
     }
 
+    fn check_checkpoint_transactions<'a>(
+        &self,
+        transactions: impl Iterator<Item = &'a ExecutionDigests> + Clone,
+    ) -> SuiResult {
+        fp_ensure!(
+            self.tables
+                .extra_transactions
+                .multi_get(transactions)?
+                .into_iter()
+                .all(|s| s.is_some()),
+            // This should never happen (unless called directly from tests).
+            SuiError::CheckpointingError {
+                error: "Some transactions are not in extra_transactions".to_string()
+            }
+        );
+        Ok(())
+    }
+
     #[cfg(test)]
     pub fn update_new_checkpoint(
         &mut self,
         seq: CheckpointSequenceNumber,
         transactions: &CheckpointContents,
     ) -> Result<(), SuiError> {
+        // Ensure we have processed all transactions contained in this checkpoint.
+        self.check_checkpoint_transactions(transactions.iter())?;
+
         let batch = self.tables.transactions_to_checkpoint.batch();
         self.update_new_checkpoint_inner(seq, transactions, batch)?;
         Ok(())

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -381,7 +381,12 @@ impl CheckpointStore {
         effects_store: impl CausalOrder,
         next_epoch_committee: Option<Committee>,
     ) -> SuiResult {
-        // Make sure that all transactions in the checkpoint have been executed locally.
+        // Make sure that all transactions in the checkpoint show up in extra_transactions.
+        // Although this is not needed when storing a new checkpoint certificate, it is required
+        // when signing a new checkpoint locally. This is because in order to sign a new checkpoint
+        // we need to causally order the transactions in it. The causal ordering process requires
+        // knowing whether all dependencies are either already checkpointed or included in the new
+        // checkpoint.
         self.check_checkpoint_transactions(transactions.clone())?;
 
         let previous_digest = self.get_prev_checkpoint_digest(sequence_number)?;

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -184,6 +184,16 @@ fn make_checkpoint_db() {
 
     assert_eq!(cps.next_checkpoint(), 0);
 
+    // You cannot make a checkpoint without processing all transactions
+    assert!(cps
+        .update_new_checkpoint(
+            0,
+            &CheckpointContents::new_with_causally_ordered_transactions(
+                [t1, t2, t4, t5].into_iter()
+            ),
+        )
+        .is_err());
+
     // Now process the extra transactions in the checkpoint
     cps.update_processed_transactions(&[(4, t4), (5, t5)])
         .unwrap();
@@ -246,6 +256,14 @@ fn make_proposals() {
         .chain(p3.transactions())
         .cloned()
         .collect();
+
+    // if not all transactions are processed we fail
+    assert!(cps1
+        .update_new_checkpoint(
+            0,
+            &CheckpointContents::new_with_causally_ordered_transactions(ckp_items.iter().cloned()),
+        )
+        .is_err());
 
     cps1.update_processed_transactions(&[(3, t1), (4, t4)])
         .unwrap();
@@ -449,6 +467,11 @@ fn latest_proposal() {
         .cloned()
         .collect();
 
+    // Fail to set if transactions not processed.
+    assert!(cps1
+        .sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderNoop, None)
+        .is_err());
+
     // Set the transactions as executed.
     let batch: Vec<_> = ckp_items
         .iter()
@@ -607,6 +630,10 @@ fn set_get_checkpoint() {
         .cloned()
         .collect();
 
+    // Need to load the transactions as processed, before getting a checkpoint.
+    assert!(cps1
+        .sign_new_checkpoint(epoch, 0, ckp_items.iter(), TestCausalOrderNoop, None)
+        .is_err());
     let batch: Vec<_> = ckp_items
         .iter()
         .enumerate()
@@ -682,10 +709,13 @@ fn set_get_checkpoint() {
     // Setting with contents succeeds BUT has not processed transactions
     let contents =
         CheckpointContents::new_with_causally_ordered_transactions(ckp_items.into_iter());
+    let response_ckp =
+        cps4.process_new_checkpoint_certificate(&checkpoint_cert, &contents, &committee);
+    assert!(response_ckp.is_err());
 
     // Process transactions and then ask for checkpoint.
     cps4.handle_internal_batch(0, &batch).unwrap();
-    cps4.process_synced_checkpoint_certificate(&checkpoint_cert, &contents, &committee)
+    cps4.process_new_checkpoint_certificate(&checkpoint_cert, &contents, &committee)
         .unwrap();
 
     // Now we have a certified checkpoint
@@ -801,6 +831,17 @@ fn checkpoint_integration() {
             .chain(unprocessed.clone().into_iter())
             .collect();
         let next_checkpoint = cps.get_locals().next_checkpoint;
+
+        // Cannot register the checkpoint while there are unprocessed transactions.
+        assert!(cps
+            .sign_new_checkpoint(
+                committee.epoch,
+                next_checkpoint,
+                transactions.iter(),
+                TestCausalOrderNoop,
+                None
+            )
+            .is_err());
 
         checkpoint_contents_opt = Some(transactions);
 
@@ -1750,11 +1791,7 @@ async fn checkpoint_messaging_flow() {
         if failed_authorities.contains(&auth.authority.name) {
             auth.checkpoint
                 .lock()
-                .process_synced_checkpoint_certificate(
-                    &checkpoint_cert,
-                    &contents,
-                    &setup.committee,
-                )
+                .process_new_checkpoint_certificate(&checkpoint_cert, &contents, &setup.committee)
                 .unwrap();
         } else {
             auth.checkpoint


### PR DESCRIPTION
https://github.com/MystenLabs/sui/pull/5132 made it such that signing a new checkpoint no longer depends on transactions showing up in extra_transactions. That was a mistake.
In order to sign a new checkpoint, we need to causally order the transactions in it. The causal ordering process requires knowing whether all dependencies are either already checkpointed or included in the new checkpoint. And that relies on extra_transactions.
Added comments in code.