### PR TITLE
wallet-ext: forgot page remove back arrow

### DIFF
--- a/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
@@ -61,17 +61,6 @@ const ImportPage = ({ mode = 'import' }: ImportPageProps) => {
             }
             headerCaption={mode === 'import' ? 'Wallet Setup' : undefined}
             mode={mode === 'import' ? 'box' : 'plain'}
-            goBackOnClick={
-                mode === 'forgot'
-                    ? () => {
-                          if (step > 0) {
-                              setStep((step) => step - 1);
-                          } else {
-                              navigate(-1);
-                          }
-                      }
-                    : undefined
-            }
         >
             {StepForm ? (
                 <StepForm

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.module.scss
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.module.scss
@@ -32,16 +32,19 @@
     flex: 1;
 }
 
-.btn {
-    width: 100%;
-    font-style: normal;
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 12px;
+.actions-container {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
     margin-top: 20px;
+    gap: 10px;
 }
 
-.next {
-    font-size: 12px;
-    font-weight: 500;
+.btn {
+    flex: 1;
+}
+
+.btn-icon {
+    font-size: 10px;
+    font-weight: 300;
 }

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Formik, Form } from 'formik';
+import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
 
 import Button from '_app/shared/button';
@@ -19,7 +20,8 @@ const validationSchema = Yup.object({
     mnemonic: mnemonicValidation,
 });
 
-export default function StepOne({ next, data }: StepProps) {
+export default function StepOne({ next, data, mode }: StepProps) {
+    const navigate = useNavigate();
     return (
         <Formik
             initialValues={data}
@@ -68,21 +70,41 @@ export default function StepOne({ next, data }: StepProps) {
                         )}
                     </FieldLabel>
                     <div className={st.fill} />
-                    <Button
-                        type="submit"
-                        disabled={isSubmitting || !isValid}
-                        mode="primary"
-                        className={st.btn}
-                        size="large"
-                    >
-                        <Loading loading={isSubmitting}>
-                            Continue
-                            <Icon
-                                icon={SuiIcons.ArrowRight}
-                                className={st.next}
-                            />
-                        </Loading>
-                    </Button>
+                    <div className={st.actionsContainer}>
+                        {mode === 'forgot' ? (
+                            <Button
+                                type="button"
+                                disabled={isSubmitting}
+                                mode="neutral"
+                                size="large"
+                                className={st.btn}
+                                onClick={() => {
+                                    navigate(-1);
+                                }}
+                            >
+                                <Icon
+                                    icon={SuiIcons.ArrowLeft}
+                                    className={st.btnIcon}
+                                />
+                                Back
+                            </Button>
+                        ) : null}
+                        <Button
+                            type="submit"
+                            disabled={isSubmitting || !isValid}
+                            mode="primary"
+                            className={st.btn}
+                            size="large"
+                        >
+                            <Loading loading={isSubmitting}>
+                                {mode === 'forgot' ? 'Next' : 'Continue'}
+                                <Icon
+                                    icon={SuiIcons.ArrowRight}
+                                    className={st.btnIcon}
+                                />
+                            </Loading>
+                        </Button>
+                    </div>
                 </Form>
             )}
         </Formik>


### PR DESCRIPTION
* add back button

| - | Forgot Step 1 | Forgot Step 2 |
| ---- | ---- | ---- |
| Before | <img width="303" alt="Screenshot 2022-10-18 at 13 57 51" src="https://user-images.githubusercontent.com/10210143/196437143-71282c6d-30e6-4ae3-a83f-b86d9351f273.png"> | <img width="303" alt="Screenshot 2022-10-18 at 13 58 06" src="https://user-images.githubusercontent.com/10210143/196437235-e1b9267d-1dd1-4648-a55b-4d96c3fd48d4.png"> |
| After | <img width="303" alt="Screenshot 2022-10-18 at 14 08 35" src="https://user-images.githubusercontent.com/10210143/196438446-f051fcc9-b225-424f-b46a-f8bae220cf6a.png"> | <img width="303" alt="Screenshot 2022-10-18 at 14 08 39" src="https://user-images.githubusercontent.com/10210143/196438509-b1d74d52-ec2f-43c8-a9ab-03aca8fc9fa7.png"> |

Import wallet view stays the same

<img width="303" alt="Screenshot 2022-10-18 at 13 53 07" src="https://user-images.githubusercontent.com/10210143/196438143-364e7683-0804-433d-adbd-2cb5e20739f3.png">
<img width="303" alt="Screenshot 2022-10-18 at 13 53 19" src="https://user-images.githubusercontent.com/10210143/196438150-72548dc7-b8e7-42fc-a9b0-5aaecad6476e.png">


closes #5123 