### PR TITLE
Exit before signature verification if a cert still requires sequencing

### DIFF
--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -573,6 +573,7 @@ where
         bypass_validator_halt: bool,
     ) -> SyncResult {
         trace!(?digest, "validator pending execution requested");
+
         let cert = self.get_cert(epoch_id, digest).await?;
 
         let result = if bypass_validator_halt {
@@ -584,9 +585,7 @@ where
         };
         match result {
             Ok(_) => Ok(SyncStatus::CertExecuted),
-            Err(SuiError::ObjectNotFound { .. })
-            | Err(SuiError::ObjectErrors { .. })
-            | Err(SuiError::SharedObjectLockNotSetError) => {
+            Err(SuiError::ObjectNotFound { .. }) | Err(SuiError::ObjectErrors { .. }) => {
                 debug!(?digest, "cert execution failed due to missing parents");
 
                 let effects = self.get_true_effects(epoch_id, &cert).await?;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2288,11 +2288,7 @@ async fn shared_object() {
     // Sending the certificate now fails since it was not sequenced.
     let result = authority.handle_certificate(&certificate).await;
     assert!(
-        matches!(
-            result,
-            Err(SuiError::ObjectErrors { ref errors })
-                if errors.len() == 1 && matches!(errors[0], SuiError::SharedObjectLockNotSetError)
-        ),
+        matches!(result, Err(SuiError::SharedObjectLockNotSetError)),
         "{:#?}",
         result
     );

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -721,6 +721,10 @@ impl<S> TransactionEnvelope<S> {
             .map(InputObjectKind::MovePackage)
             .collect::<Vec<_>>()
     }
+
+    pub fn is_system_tx(&self) -> bool {
+        self.signed_data.data.kind.is_system_tx()
+    }
 }
 
 // In combination with #[serde(remote = "TransactionEnvelope")].


### PR DESCRIPTION
This mitigates CPU issues caused by exec driver when consensus latency is high - until #4990 is fixed this can result in many attempts to execute certs that will immediately fail.