### PR TITLE
Refactor ConsensusHandler in preparation for parallel signature verification

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1114,7 +1114,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(())
     }
 
-    pub async fn consensus_message_processed(
+    pub fn consensus_message_processed(
         &self,
         digest: &TransactionDigest,
     ) -> Result<bool, SuiError> {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -34,7 +34,7 @@ use tokio::{
 use sui_types::messages_checkpoint::CheckpointRequest;
 use sui_types::messages_checkpoint::CheckpointResponse;
 
-use crate::authority::ConsensusHandler;
+use crate::consensus_handler::ConsensusHandler;
 use tracing::{error, info, Instrument};
 
 #[cfg(test)]

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::authority_store_tables::ExecutionIndicesWithHash;
+use crate::authority::AuthorityState;
+use crate::consensus_adapter::ConsensusListenerMessage;
+use async_trait::async_trait;
+use narwhal_executor::{ExecutionIndices, ExecutionState};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
+use sui_types::messages::ConsensusTransaction;
+use tokio::sync::mpsc;
+use tracing::{debug, instrument, warn};
+
+pub struct ConsensusHandler {
+    state: Arc<AuthorityState>,
+    sender: mpsc::Sender<ConsensusListenerMessage>,
+    hash: Mutex<u64>,
+}
+
+impl ConsensusHandler {
+    pub fn new(state: Arc<AuthorityState>, sender: mpsc::Sender<ConsensusListenerMessage>) -> Self {
+        let hash = Mutex::new(0);
+        Self {
+            state,
+            sender,
+            hash,
+        }
+    }
+
+    fn update_hash(&self, index: ExecutionIndices, v: &[u8]) -> ExecutionIndicesWithHash {
+        let mut hash_guard = self
+            .hash
+            .try_lock()
+            .expect("Should not have contention on ExecutionState::update_hash");
+        let mut hasher = DefaultHasher::new();
+        (*hash_guard).hash(&mut hasher);
+        v.hash(&mut hasher);
+        let hash = hasher.finish();
+        *hash_guard = hash;
+        // Log hash for every certificate
+        if index.next_transaction_index == 1 && index.next_batch_index == 1 {
+            debug!(
+                "Integrity hash for consensus output at certificate {} is {:016x}",
+                index.next_certificate_index, hash
+            );
+        }
+        ExecutionIndicesWithHash { index, hash }
+    }
+}
+
+#[async_trait]
+impl ExecutionState for ConsensusHandler {
+    /// This function will be called by Narwhal, after Narwhal sequenced this certificate.
+    #[instrument(level = "trace", skip_all)]
+    async fn handle_consensus_transaction(
+        &self,
+        // TODO [2533]: use this once integrating Narwhal reconfiguration
+        consensus_output: &Arc<narwhal_consensus::ConsensusOutput>,
+        consensus_index: ExecutionIndices,
+        serialized_transaction: Vec<u8>,
+    ) {
+        let consensus_index = self.update_hash(consensus_index, &serialized_transaction);
+        let transaction =
+            match bincode::deserialize::<ConsensusTransaction>(&serialized_transaction) {
+                Ok(transaction) => transaction,
+                Err(err) => {
+                    warn!(
+                        "Ignoring malformed transaction (failed to deserialize) from {}: {}",
+                        consensus_output.certificate.header.author, err
+                    );
+                    return;
+                }
+            };
+        let sequenced_transaction = SequencedConsensusTransaction {
+            consensus_output: consensus_output.clone(),
+            consensus_index,
+            transaction,
+        };
+        let verified_transaction = match self
+            .state
+            .verify_consensus_transaction(sequenced_transaction)
+        {
+            Ok(verified_transaction) => verified_transaction,
+            Err(()) => return,
+        };
+        self.state
+            .handle_consensus_transaction(verified_transaction)
+            .await
+            .expect("Unrecoverable error in consensus handler");
+        if self
+            .sender
+            .send(ConsensusListenerMessage::Processed(serialized_transaction))
+            .await
+            .is_err()
+        {
+            warn!("Consensus handler outbound channel closed");
+        }
+    }
+
+    async fn load_execution_indices(&self) -> ExecutionIndices {
+        let index_with_hash = self
+            .state
+            .database
+            .last_consensus_index()
+            .expect("Failed to load consensus indices");
+        *self
+            .hash
+            .try_lock()
+            .expect("Should not have contention on ExecutionState::load_execution_indices") =
+            index_with_hash.hash;
+        index_with_hash.index
+    }
+}
+
+pub struct SequencedConsensusTransaction {
+    pub consensus_output: Arc<narwhal_consensus::ConsensusOutput>,
+    pub consensus_index: ExecutionIndicesWithHash,
+    pub transaction: ConsensusTransaction,
+}
+
+pub struct VerifiedSequencedConsensusTransaction(pub SequencedConsensusTransaction);
+
+#[cfg(test)]
+impl VerifiedSequencedConsensusTransaction {
+    pub fn new_test(transaction: ConsensusTransaction) -> Self {
+        Self(SequencedConsensusTransaction::new_test(transaction))
+    }
+}
+
+#[cfg(test)]
+impl SequencedConsensusTransaction {
+    pub fn new_test(transaction: ConsensusTransaction) -> Self {
+        Self {
+            transaction,
+            consensus_output: Default::default(),
+            consensus_index: Default::default(),
+        }
+    }
+}

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod validator_info;
 
 pub mod test_utils;
 
+mod consensus_handler;
 mod histogram;
 mod node_sync;
 mod query_helpers;

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
+use crate::consensus_handler::VerifiedSequencedConsensusTransaction;
 use crate::test_utils::to_sender_signed_transaction;
 use move_core_types::{account_address::AccountAddress, ident_str};
 use narwhal_types::Transactions;
@@ -103,15 +104,9 @@ async fn listen_to_sequenced_transaction() {
 
     // Set the shared object locks.
     state
-        .handle_consensus_transaction(
-            // TODO [2533]: use this once integrating Narwhal reconfiguration
-            &narwhal_consensus::ConsensusOutput {
-                certificate: narwhal_types::Certificate::default(),
-                consensus_index: narwhal_types::SequenceNumber::default(),
-            },
-            Default::default(),
+        .handle_consensus_transaction(VerifiedSequencedConsensusTransaction::new_test(
             ConsensusTransaction::new_certificate_message(&state.name, certificate),
-        )
+        ))
         .await
         .unwrap();
 
@@ -183,15 +178,9 @@ async fn submit_transaction_to_consensus() {
 
             // Set the shared object locks.
             state_guard
-                .handle_consensus_transaction(
-                    // TODO [2533]: use this once integrating Narwhal reconfiguration
-                    &narwhal_consensus::ConsensusOutput {
-                        certificate: narwhal_types::Certificate::default(),
-                        consensus_index: narwhal_types::SequenceNumber::default(),
-                    },
-                    Default::default(),
+                .handle_consensus_transaction(VerifiedSequencedConsensusTransaction::new_test(
                     ConsensusTransaction::new_certificate_message(&name, *certificate),
-                )
+                ))
                 .await
                 .unwrap();
 

--- a/narwhal/consensus/src/lib.rs
+++ b/narwhal/consensus/src/lib.rs
@@ -23,7 +23,7 @@ use types::{Certificate, SequenceNumber};
 pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
 
 /// The output format of the consensus.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct ConsensusOutput {
     /// The sequenced certificate.
     pub certificate: Certificate,

--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -44,7 +44,7 @@ pub trait ExecutionState {
     /// also return a new committee to reconfigure the system.
     async fn handle_consensus_transaction(
         &self,
-        consensus_output: &ConsensusOutput,
+        consensus_output: &Arc<ConsensusOutput>,
         execution_indices: ExecutionIndices,
         transaction: Vec<u8>,
     );
@@ -143,7 +143,7 @@ pub async fn get_restored_consensus_output<State: ExecutionState>(
 impl<T: ExecutionState + 'static + Send + Sync> ExecutionState for Arc<T> {
     async fn handle_consensus_transaction(
         &self,
-        consensus_output: &ConsensusOutput,
+        consensus_output: &Arc<ConsensusOutput>,
         execution_indices: ExecutionIndices,
         transaction: Vec<u8>,
     ) {

--- a/narwhal/node/src/execution_state.rs
+++ b/narwhal/node/src/execution_state.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use async_trait::async_trait;
@@ -23,7 +24,7 @@ impl SimpleExecutionState {
 impl ExecutionState for SimpleExecutionState {
     async fn handle_consensus_transaction(
         &self,
-        _consensus_output: &ConsensusOutput,
+        _consensus_output: &Arc<ConsensusOutput>,
         _execution_indices: ExecutionIndices,
         transaction: Vec<u8>,
     ) {

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -72,7 +72,7 @@ impl SimpleExecutionState {
 impl ExecutionState for SimpleExecutionState {
     async fn handle_consensus_transaction(
         &self,
-        _consensus_output: &ConsensusOutput,
+        _consensus_output: &Arc<ConsensusOutput>,
         execution_indices: ExecutionIndices,
         transaction: Vec<u8>,
     ) {


### PR DESCRIPTION
This PR refactors ConsensusHandler in order to prepare for parallel verification of the transaction signatures.

On Sui side:
(1) Break down consensus handling into two independent functions on the `AuthorityState` - one for (potentially parallel) verification and one for sequential handling of the transaction.

(2) Move `ConsensusHandler` into separate file - `authority.rs` is growing big and parallel signature verification will add even more code to ConsensusHandler.

(3) Abolish `NarwhalHandlerError` - after separating `handle_consensus_transaction` and `verify_consensus_transaction`, `ConsensusHandler` can now decide what to do based on what function has failed. Note that in practice nothing has changed in how errors are processed by this PR - previously we were mapping errors from `verify_narwhal_transaction` into `NarwhalHandlerError::Skip`, and now we just call it directly from `ConsensusHandler`.

(4) Two utilization metrics on the `ConsensusHandler` side, namely `verify_narwhal_transaction_duration_mcs` and `handle_consensus_duration_mcs` slightly changed what they measure - previously verification metric was fraction of handle_consensus timer, now they are two independent steps. The total consensus utilization can now be measured as sum of those two metrics (until parallel verification is introduced).

On Narwhal side:
(1) Minor interface change - pass `Arc<ConsensusOutput>` instead of `&ConsensusOutput` from the narwhal executor - this will allow caller to cheaply clone Arc<ConsensusOutput> when it needs to pass it to verification thread