### PR TITLE
[TypeScript SDK] Add method for getting the version number of RPC API

### DIFF
--- a/.changeset/big-dancers-clap.md
+++ b/.changeset/big-dancers-clap.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add `getRpcApiVersion` to Provider interface

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -98,6 +98,12 @@ export class JsonRpcProvider extends Provider {
     );
   }
 
+  async getRpcApiVersion(): Promise<string> {
+    // TODO: we should fetch the API version from
+    // the RPC endpoint instead
+    return this.rpcAPIVersion;
+  }
+
   // Move info
   async getMoveFunctionArgTypes(
     packageId: string,
@@ -333,7 +339,7 @@ export class JsonRpcProvider extends Provider {
     objectID: string
   ): Promise<GetTxnDigestsResponse> {
     // TODO: remove after we deploy 0.12.0 DevNet
-    if (this.rpcAPIVersion === PRE_PAGINATION_API_VERSION) {
+    if ((await this.getRpcApiVersion()) === PRE_PAGINATION_API_VERSION) {
       const requests = [
         {
           method: 'sui_getTransactionsByInputObject',
@@ -387,7 +393,7 @@ export class JsonRpcProvider extends Provider {
     addressID: string
   ): Promise<GetTxnDigestsResponse> {
     // TODO: remove after we deploy 0.12.0 DevNet
-    if (this.rpcAPIVersion === PRE_PAGINATION_API_VERSION) {
+    if ((await this.getRpcApiVersion()) === PRE_PAGINATION_API_VERSION) {
       const requests = [
         {
           method: 'sui_getTransactionsToAddress',

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -32,6 +32,13 @@ import {
 ///////////////////////////////
 // Exported Abstracts
 export abstract class Provider {
+  // API Version
+  /**
+   * Returns the current version of the RPC API that the provider is
+   * connected to
+   */
+  abstract getRpcApiVersion(): Promise<string>;
+
   // Objects
   /**
    * Get all objects owned by an address

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -24,11 +24,19 @@ import {
   ObjectOwner,
   SuiAddress,
   ObjectId,
-  SuiEvents, TransactionQuery, Ordering, PaginatedTransactionDigests,
+  SuiEvents,
+  TransactionQuery,
+  Ordering,
+  PaginatedTransactionDigests,
 } from '../types';
 import { Provider } from './provider';
 
 export class VoidProvider extends Provider {
+  // API Version
+  async getRpcApiVersion(): Promise<string> {
+    throw this.newError('getRpcApiVersion');
+  }
+
   // Objects
   async getObjectsOwnedByAddress(_address: string): Promise<SuiObjectInfo[]> {
     throw this.newError('getObjectsOwnedByAddress');
@@ -231,10 +239,11 @@ export class VoidProvider extends Provider {
     return new Error(`Please use a valid provider for ${operation}`);
   }
 
-  async getTransactions(_query: TransactionQuery,
-                        _cursor: TransactionDigest | null,
-                        _limit: number | null,
-                        _order: Ordering
+  async getTransactions(
+    _query: TransactionQuery,
+    _cursor: TransactionDigest | null,
+    _limit: number | null,
+    _order: Ordering
   ): Promise<PaginatedTransactionDigests> {
     throw this.newError('getTransactions');
   }


### PR DESCRIPTION
For backward compatibility, the client and the SDK need to know the version number of the fullnode it connects to so that they can support multiple fullnode versions. This PR adds a dummy interface method for getting version number to the TypeScript SDK first to unblock backward-compatibility work in https://github.com/MystenLabs/sui/pull/4878. 

In a subsequent PR, I will add a new RPC endpoint to return the cargo version of the fullnode binary and update the TS SDK to fetch from RPC endpoint instead of returning `this.rpcAPIVersion`. (https://github.com/MystenLabs/sui/issues/5346)