### PR TITLE
Add panic=abort to release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ members = [
 # without significantly increasing binary size
 debug = true
 strip = 'debuginfo'
+# Exit process with SIGABRT when any thread panics
+panic = 'abort'
 
 [profile.bench]
 # Do not strip any debug info.  This helps the widest set of profiling tools


### PR DESCRIPTION
By default, panic only terminate current thread and keep everything else running.

This likely will create confusion in our system since it's not really designed to have some pieces of system working while some threads are dead. It can even cause problems in places like handling consensus messages.

It seems safer option is to just halt validator if any thread panics.

Some software around the validator, like kubernetes or init daemon can take care of restarting validator if it is halted.


Some blog post with details: https://ddanilov.me/panic-in-rust
