### PR TITLE
wallet-ext: fix color and spacing for backup view

### DIFF
--- a/apps/wallet/src/ui/app/pages/initialize/backup/Backup.module.scss
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/Backup.module.scss
@@ -6,15 +6,15 @@
     flex-flow: column nowrap;
     gap: 8px;
     align-self: stretch;
-    font-weight: 600;
+    font-weight: 500;
     font-size: 17px;
-    line-height: 140%;
+    line-height: 1.4;
     padding: 14px;
     border-radius: 15px;
     background: colors.$white;
     border: 1px solid #e9eaeb;
     box-shadow: 0 1px 2px rgba(16 24 40 / 5%);
-    color: colors.$gray-85;
+    color: colors.$gray-75;
 }
 
 .copy {
@@ -22,6 +22,7 @@
     color: colors.$sui-dark-blue;
     align-self: flex-end;
     cursor: pointer;
+    line-height: 1;
 
     @include utils.typography('Primary/CAPTION-SB');
 }
@@ -30,6 +31,7 @@
     text-align: center;
     color: colors.$gray-75;
     margin-top: 15px;
+    line-height: 1;
 
     @include utils.typography('ParagraphPrimary/P2-R');
 }
@@ -49,7 +51,7 @@
 .btn {
     display: flex;
     flex-flow: row nowrap;
-    margin-top: 45px;
+    margin-top: 16px;
     align-self: stretch;
     padding: 14px 20px;
 }

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.module.scss
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.module.scss
@@ -8,7 +8,7 @@
     box-shadow: 0 1px 2px rgba(16 24 40 / 5%);
     border-radius: 15px;
     font-size: 17px;
-    font-weight: 600;
+    font-weight: 500;
     line-height: 140%;
     color: colors.$gray-75;
     align-self: stretch;
@@ -17,7 +17,7 @@
 
     &::placeholder {
         color: colors.$gray-65;
-        font-weight: 500;
+        font-weight: 400;
     }
 }
 

--- a/apps/wallet/src/ui/app/shared/card-layout/CardLayout.module.scss
+++ b/apps/wallet/src/ui/app/shared/card-layout/CardLayout.module.scss
@@ -24,9 +24,8 @@
 
 .success-icon {
     border-radius: 50%;
-    width: 48px;
-    height: 48px;
-    min-height: 48px;
+    width: 46px;
+    height: 46px;
     border: 3px dotted colors.$success;
     display: flex;
     align-items: center;
@@ -81,6 +80,7 @@
     margin-bottom: 30px;
     color: colors.$gray-90;
     text-transform: capitalize;
+    line-height: 1;
 
     @include utils.typography('Primary/Heading1-B');
 }

--- a/apps/wallet/src/ui/styles/utils/index.scss
+++ b/apps/wallet/src/ui/styles/utils/index.scss
@@ -38,7 +38,7 @@ $main-extra-space: sizing.$main-bottom-space;
     word-break: break-all;
     padding-right: 20px;
     position: relative;
-    font-weight: 500;
+    font-weight: 400;
     font-size: 13px;
     line-height: 130%;
 
@@ -85,7 +85,7 @@ $main-extra-space: sizing.$main-bottom-space;
 
 @mixin angled-arrow($color: colors.$gray-65) {
     transform: rotate(135deg);
-    font-weight: 300;
+    font-weight: 200;
     margin: 0;
     margin-right: 10px;
     font-size: 14px;
@@ -95,58 +95,58 @@ $main-extra-space: sizing.$main-bottom-space;
 @mixin typography($type) {
     @if $type == 'stat/col-header' {
         font-style: normal;
-        font-weight: 600;
+        font-weight: 500;
         font-size: 12px;
         text-transform: uppercase;
         color: colors.$gray-75;
     } @else if $type == 'page-description' {
         font-style: normal;
-        font-weight: 400;
+        font-weight: 300;
         font-size: 12px;
         color: colors.$gray-80;
     } @else if $type == 'tooltip/label' {
         font-style: normal;
-        font-weight: 600;
+        font-weight: 500;
         font-size: 11px;
         text-transform: uppercase;
         color: colors.$gray-80;
     } @else if $type == 'stats/text-lg' {
         font-style: normal;
-        font-weight: 600;
+        font-weight: 500;
         font-size: 18px;
         color: colors.$gray-100;
     } @else if $type == 'header/search-text' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 400;
         font-size: 14px;
         color: colors.$gray-70;
     } @else if $type == 'table/text-xs' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 400;
         font-size: 12px;
         color: colors.$gray-75;
     } @else if $type == 'table/text-sm' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 400;
         font-size: 13px;
         color: colors.$white;
     } @else if $type == 'table/text-lg' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 400;
         font-size: 14px;
     } @else if $type == 'table/title-sm' {
         font-style: normal;
-        font-weight: 600;
+        font-weight: 500;
         font-size: 14px;
         color: colors.$gray-100;
     } @else if $type == 'page-title' {
         font-style: normal;
-        font-weight: 600;
+        font-weight: 500;
         font-size: 16px;
         color: colors.$gray-100;
     } @else if $type == 'empty' {
         font-style: italic;
-        font-weight: 400;
+        font-weight: 300;
         font-size: 12px;
         text-align: center;
         color: colors.$gray-70;
@@ -154,85 +154,85 @@ $main-extra-space: sizing.$main-bottom-space;
         letter-spacing: 0;
     } @else if $type == 'Primary/BodySmall-M' {
         font-size: 13px;
-        font-weight: 500;
+        font-weight: 400;
         letter-spacing: 0;
     } @else if $type == 'Primary/Body-M' {
         font-size: 14px;
-        font-weight: 500;
+        font-weight: 400;
         letter-spacing: 0;
     } @else if $type == 'Primary/SubtitleSmall-M' {
         font-size: 11px;
-        font-weight: 500;
+        font-weight: 400;
         letter-spacing: 0;
     } @else if $type == 'Primary/BodySmall-SB' {
         font-size: 13px;
-        font-weight: 600;
+        font-weight: 500;
     } @else if $type == 'Primary/CAPTIONSMALL-M' {
         font-size: 11px;
-        font-weight: 500;
+        font-weight: 400;
         letter-spacing: 0.05em;
     } @else if $type == 'Primary/CAPTION-SB' {
         font-size: 12px;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0.05em;
         text-align: center;
     } @else if $type == 'Primary/CAPTIONSMALL-SB' {
         font-size: 11px;
-        font-weight: 600;
+        font-weight: 500;
         line-height: 11px;
         letter-spacing: 0.05em;
     } @else if $type == 'Primary/CAPTION-B' {
         font-size: 12px;
-        font-weight: 700;
+        font-weight: 600;
         letter-spacing: 0.05em;
         text-align: center;
     } @else if $type == 'Primary/CAPTION-M' {
         font-size: 12px;
-        font-weight: 500;
+        font-weight: 400;
         letter-spacing: 0.05em;
         text-align: center;
     } @else if $type == 'ParagraphPrimary/P2-R' {
         font-size: 13px;
-        font-weight: 400;
+        font-weight: 300;
         letter-spacing: 0;
     } @else if $type == 'page-ex-small' {
-        font-weight: 500;
+        font-weight: 400;
         font-size: 10px;
         letter-spacing: 0;
     } @else if $type == 'Primary/Heading1-B' {
         font-size: 28px;
-        font-weight: 700;
+        font-weight: 600;
         letter-spacing: 0;
         text-align: center;
     } @else if $type == 'Primary/Heading3-SB' {
         font-size: 20px;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0;
         text-align: center;
     } @else if $type == 'ParagraphPrimary/P1-M' {
         font-size: 14px;
-        font-weight: 500;
+        font-weight: 400;
         line-height: 130%;
         letter-spacing: 0;
         text-align: center;
     } @else if $type == 'ParagraphPrimary/P1-SB' {
         font-size: 14px;
-        font-weight: 600;
+        font-weight: 500;
         line-height: 18px;
         letter-spacing: 0;
     } @else if $type == 'ParagraphPrimary/P2-M' {
         font-size: 13px;
-        font-weight: 500;
+        font-weight: 400;
         line-height: 17px;
         letter-spacing: 0;
     } @else if $type == 'Primary/Body-SB' {
         font-size: 14px;
-        font-weight: 600;
+        font-weight: 500;
         letter-spacing: 0;
     } @else if $type == 'mono-type' {
         // TODO chanage to mono font
         font-style: normal;
-        font-weight: 500;
+        font-weight: 400;
         font-size: 14px;
         text-decoration: none;
         line-height: 90%;


### PR DESCRIPTION
* subtract 100 from font-weight to match figma rendering. (in browser the font seems a bit thicker)
* fix colour of mnemonic in backup view
* fix padding of COPY

| before | after |
| -- | -- |
| <img width="325" alt="Screenshot 2022-10-19 at 12 19 12" src="https://user-images.githubusercontent.com/10210143/196680418-f0e3232f-d279-44ad-90f0-fa100e4f718b.png">| <img width="325" alt="Screenshot 2022-10-19 at 12 22 03" src="https://user-images.githubusercontent.com/10210143/196681121-72b2f0c9-7e4b-4a90-8db4-10d18dd10fda.png"> |
| <img width="325" alt="Screenshot 2022-10-19 at 12 19 24" src="https://user-images.githubusercontent.com/10210143/196680513-db15ef0e-9c1b-44f3-9c37-dc3c89b5b07e.png"> | <img width="325" alt="Screenshot 2022-10-19 at 12 21 47" src="https://user-images.githubusercontent.com/10210143/196681253-5c7a8423-56cd-4fb9-b624-c4c779d21961.png"> |
| <img width="325" alt="Screenshot 2022-10-19 at 12 19 35" src="https://user-images.githubusercontent.com/10210143/196680566-e5626435-3f64-4d80-af25-2b407dfc53a3.png"> | <img width="325" alt="Screenshot 2022-10-19 at 12 21 38" src="https://user-images.githubusercontent.com/10210143/196681537-f19d5ca7-9693-4072-b6b0-dc80055c17a3.png"> |
| <img width="325" alt="Screenshot 2022-10-19 at 12 19 40" src="https://user-images.githubusercontent.com/10210143/196680633-6e2ddd82-a61b-4f25-b048-2a76ccf52af0.png"> | <img width="325" alt="Screenshot 2022-10-19 at 12 21 30" src="https://user-images.githubusercontent.com/10210143/196681602-a75c9c87-a03f-46e7-86f9-fedbe9c11f9d.png"> |
| <img width="325" alt="Screenshot 2022-10-19 at 12 19 47" src="https://user-images.githubusercontent.com/10210143/196680686-f40cd62d-9f16-4273-8b5c-438159aa4435.png"> | <img width="325" alt="Screenshot 2022-10-19 at 12 21 24" src="https://user-images.githubusercontent.com/10210143/196681709-10ca362c-4e49-4e61-88a2-ec8979952626.png"> |


closes: #5126 

