### PR TITLE
Add RPC API version check to Rust SDK,  Sui CLI and Sui Console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8451,27 +8451,22 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "0.6.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
- "hyper",
  "move-core-types",
- "move-package",
  "pretty_assertions",
  "rand 0.8.5",
  "schemars",
  "serde 1.0.145",
  "serde_json",
  "sui",
- "sui-config",
  "sui-core",
  "sui-json",
  "sui-json-rpc",
  "sui-json-rpc-types",
- "sui-sdk",
  "sui-types",
- "test-utils",
  "tokio",
  "workspace-hack",
 ]
@@ -8527,7 +8522,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "0.0.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -28,3 +28,5 @@ mod consensus_handler;
 mod histogram;
 mod node_sync;
 mod query_helpers;
+
+pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-gateway/src/main.rs
+++ b/crates/sui-gateway/src/main.rs
@@ -61,7 +61,8 @@ async fn main() -> anyhow::Result<()> {
     let client = GatewayState::create_client(&gateway_config, Some(&prometheus_registry))?;
 
     let address = SocketAddr::new(IpAddr::V4(options.host), options.port);
-    let mut server = JsonRpcServerBuilder::new(false, &prometheus_registry)?;
+    let mut server =
+        JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), false, &prometheus_registry)?;
     server.register_module(RpcGatewayImpl::new(client.clone()))?;
     server.register_module(GatewayReadApiImpl::new(client.clone()))?;
     server.register_module(TransactionBuilderImpl::new(client.clone()))?;

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -76,8 +76,9 @@ pub struct JsonRpcServerBuilder {
     rpc_doc: Project,
 }
 
-pub fn sui_rpc_doc() -> Project {
+pub fn sui_rpc_doc(version: &str) -> Project {
     Project::new(
+        version,
         "Sui JSON-RPC",
         "Sui JSON-RPC API for interaction with Sui Full node.",
         "Mysten Labs",
@@ -90,6 +91,7 @@ pub fn sui_rpc_doc() -> Project {
 
 impl JsonRpcServerBuilder {
     pub fn new(
+        version: &str,
         use_websocket: bool,
         prometheus_registry: &prometheus::Registry,
     ) -> anyhow::Result<Self> {
@@ -128,7 +130,7 @@ impl JsonRpcServerBuilder {
         Ok(Self {
             module,
             server_builder,
-            rpc_doc: sui_rpc_doc(),
+            rpc_doc: sui_rpc_doc(version),
         })
     }
 
@@ -150,7 +152,7 @@ impl JsonRpcServerBuilder {
         Ok(Self {
             module,
             server_builder,
-            rpc_doc: sui_rpc_doc(),
+            rpc_doc: sui_rpc_doc("0.0.0"),
         })
     }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -424,7 +424,8 @@ pub async fn build_http_servers(
         return Ok((None, None));
     }
 
-    let mut server = JsonRpcServerBuilder::new(false, prometheus_registry)?;
+    let mut server =
+        JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), false, prometheus_registry)?;
 
     server.register_module(ReadApi::new(state.clone()))?;
     server.register_module(FullNodeApi::new(state.clone()))?;
@@ -450,7 +451,8 @@ pub async fn build_http_servers(
 
     let ws_server_handle = match config.websocket_address {
         Some(ws_addr) => {
-            let mut server = JsonRpcServerBuilder::new(true, prometheus_registry)?;
+            let mut server =
+                JsonRpcServerBuilder::new(env!("CARGO_PKG_VERSION"), true, prometheus_registry)?;
             if let Some(tx_streamer) = state.transaction_streamer.clone() {
                 server.register_module(TransactionStreamingApiImpl::new(
                     state.clone(),

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-open-rpc"
-version = "0.6.1"
+version = "0.0.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false
@@ -16,9 +16,7 @@ workspace-hack.workspace = true
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 clap = { version = "3.2.17", features = ["derive"] }
 pretty_assertions = "1.2.0"
-serde_json = "1.0.83"
 tokio = { version = "1.20.1", features = ["full"] }
-hyper = { version = "0.14.20", features = ["full"] }
 
 sui = { path = "../sui" }
 sui-core = { path = "../sui-core"}
@@ -26,12 +24,8 @@ sui-json-rpc = { path = "../sui-json-rpc" }
 sui-json-rpc-types = { path = "../sui-json-rpc-types" }
 sui-json = { path = "../sui-json" }
 sui-types = { path = "../sui-types" }
-sui-sdk = { path = "../sui-sdk" }
-sui-config = { path = "../sui-config" }
-test-utils = { path = "../test-utils" }
 rand = "0.8.5"
 
-move-package.workspace = true
 move-core-types.workspace = true
 
 [[example]]

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "0.6.1"
+    "version": "0.12.0"
   },
   "methods": [
     {

--- a/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
+++ b/crates/sui-open-rpc/src/generate_json_rpc_spec.rs
@@ -1,21 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs::File;
+use std::io::Write;
+
 use clap::ArgEnum;
 use clap::Parser;
 use pretty_assertions::assert_str_eq;
-use std::fs::File;
-use std::io::Write;
-use sui_json_rpc::api::EventReadApiOpenRpc;
-use sui_json_rpc::transaction_builder_api::FullNodeTransactionBuilderApi;
-use sui_json_rpc::transaction_execution_api::FullNodeTransactionExecutionApi;
+use sui_core::SUI_CORE_VERSION;
 
-use crate::examples::RpcExampleProvider;
+use sui_json_rpc::api::EventReadApiOpenRpc;
 use sui_json_rpc::api::EventStreamingApiOpenRpc;
 use sui_json_rpc::bcs_api::BcsApiImpl;
 use sui_json_rpc::read_api::{FullNodeApi, ReadApi};
 use sui_json_rpc::sui_rpc_doc;
+use sui_json_rpc::transaction_builder_api::FullNodeTransactionBuilderApi;
+use sui_json_rpc::transaction_execution_api::FullNodeTransactionExecutionApi;
 use sui_json_rpc::SuiRpcModule;
+
+use crate::examples::RpcExampleProvider;
 
 mod examples;
 
@@ -42,7 +45,7 @@ const FILE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/spec/openrpc.json"
 async fn main() {
     let options = Options::parse();
 
-    let mut open_rpc = sui_rpc_doc();
+    let mut open_rpc = sui_rpc_doc(SUI_CORE_VERSION);
     open_rpc.add_module(ReadApi::rpc_doc_module());
     open_rpc.add_module(FullNodeApi::rpc_doc_module());
     open_rpc.add_module(BcsApiImpl::rpc_doc_module());

--- a/crates/sui-open-rpc/src/lib.rs
+++ b/crates/sui-open-rpc/src/lib.rs
@@ -25,6 +25,7 @@ pub struct Project {
 
 impl Project {
     pub fn new(
+        version: &str,
         title: &str,
         description: &str,
         contact_name: &str,
@@ -33,7 +34,6 @@ impl Project {
         license: &str,
         license_url: &str,
     ) -> Self {
-        let version = env!("CARGO_PKG_VERSION").to_owned();
         let openrpc = "1.2.6".to_string();
         Self {
             openrpc,
@@ -49,7 +49,7 @@ impl Project {
                     name: license.to_string(),
                     url: Some(license_url.to_string()),
                 }),
-                version,
+                version: version.to_owned(),
                 ..Default::default()
             },
             methods: vec![],

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-sdk"
-version = "0.0.0"
+version = "0.12.0"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -220,11 +220,20 @@ impl SuiClient {
         }
     }
 
-    pub fn api_version(&self) -> String {
+    pub fn api_version(&self) -> &str {
         match &*self.api {
-            SuiClientApi::Rpc(c) => c.info.version.clone(),
-            SuiClientApi::Embedded(_) => env!("CARGO_PKG_VERSION").to_owned(),
+            SuiClientApi::Rpc(c) => &c.info.version,
+            SuiClientApi::Embedded(_) => env!("CARGO_PKG_VERSION"),
         }
+    }
+
+    pub fn check_api_version(&self) -> Result<(), anyhow::Error> {
+        let server_version = self.api_version();
+        let client_version = env!("CARGO_PKG_VERSION");
+        if server_version != client_version {
+            return Err(anyhow!("Client/Server api version mismatch, client api version : {client_version}, server api version : {server_version}"));
+        };
+        Ok(())
     }
 }
 

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -89,6 +89,11 @@ pub async fn start_console(
     writeln!(out, "Welcome to the Sui interactive console.")?;
     writeln!(out)?;
 
+    if let Err(e) = context.client.check_api_version() {
+        writeln!(out, "{}", format!("[warn] {e}").yellow().bold())?;
+        writeln!(out)?;
+    };
+
     let mut shell = Shell::new(
         "sui>-$ ",
         context,


### PR DESCRIPTION
* pass sui-node version into RPC server - to keep rpc.discover api version up-to-date
* add version check to Sui Rust SDK - user can use `SuiClient::check_api_version()` to check for version mismatch
* print warning in sui cli and sui console if version mismatch
<img width="692" alt="image" src="https://user-images.githubusercontent.com/1888654/196711585-043012a5-7a9d-4da9-b938-83381ba1a2dd.png">
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/1888654/196711652-ba95baeb-3812-40ac-ae43-826057ce8488.png">
