### PR TITLE
crypto: use sui-types Base64 wrapper everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7911,7 +7911,6 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64ct",
  "bcs",
  "bip32",
  "camino",

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::anyhow;
-use base64ct::Encoding;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use digest::Digest;
 use hex::FromHex;
@@ -33,9 +32,9 @@ use crate::error::ExecutionError;
 use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
 use crate::object::{Object, Owner};
-use crate::sui_serde::Base64;
 use crate::sui_serde::Hex;
 use crate::sui_serde::Readable;
+use crate::sui_serde::{Base64, Encoding};
 use crate::waypoint::IntoPoint;
 
 #[cfg(test)]
@@ -617,7 +616,7 @@ impl TryFrom<&[u8]> for ObjectDigest {
 
 impl std::fmt::Debug for TransactionDigest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let s = base64ct::Base64::encode_string(&self.0);
+        let s = Base64::encode(&self.0);
         write!(f, "{}", s)?;
         Ok(())
     }
@@ -625,7 +624,7 @@ impl std::fmt::Debug for TransactionDigest {
 
 impl std::fmt::Debug for TransactionEffectsDigest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        let s = base64ct::Base64::encode_string(&self.0);
+        let s = Base64::encode(&self.0);
         write!(f, "{}", s)?;
         Ok(())
     }
@@ -978,11 +977,11 @@ impl FromStr for ObjectID {
 }
 
 impl FromStr for TransactionDigest {
-    type Err = base64ct::Error;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut result = [0u8; TRANSACTION_DIGEST_LENGTH];
-        base64ct::Base64::decode(s, &mut result)?;
+        result.copy_from_slice(&Base64::decode(s)?);
         Ok(TransactionDigest(result))
     }
 }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -15,9 +15,8 @@ use crate::messages_checkpoint::{
 };
 use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
 use crate::storage::{DeleteKind, WriteKind};
-use crate::sui_serde::Base64;
+use crate::sui_serde::{Base64, Encoding};
 use crate::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
-use base64ct::Encoding;
 use byteorder::{BigEndian, ReadBytesExt};
 use itertools::Either;
 use move_binary_format::access::ModuleAccess;
@@ -618,7 +617,7 @@ impl TransactionData {
     }
 
     pub fn to_base64(&self) -> String {
-        base64ct::Base64::encode_string(&self.to_bytes())
+        Base64::encode(&self.to_bytes())
     }
 
     pub fn gas_payment_object_ref(&self) -> &ObjectRef {

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -310,7 +310,7 @@ impl SerializeAs<AuthoritySignature> for AuthSignature {
     where
         S: Serializer,
     {
-        base64ct::Base64::encode_string(value.as_ref()).serialize(serializer)
+        Base64::encode(value.as_ref()).serialize(serializer)
     }
 }
 
@@ -320,7 +320,7 @@ impl<'de> DeserializeAs<'de, AuthoritySignature> for AuthSignature {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let sig_bytes = base64ct::Base64::decode_vec(&s).map_err(to_custom_error::<'de, D, _>)?;
+        let sig_bytes = Base64::decode(&s).map_err(to_custom_error::<'de, D, _>)?;
         AuthoritySignature::from_bytes(&sig_bytes[..]).map_err(to_custom_error::<'de, D, _>)
     }
 }
@@ -335,7 +335,7 @@ impl SerializeAs<AggregateAuthoritySignature> for AggrAuthSignature {
     where
         S: Serializer,
     {
-        base64ct::Base64::encode_string(value.as_ref()).serialize(serializer)
+        Base64::encode(value.as_ref()).serialize(serializer)
     }
 }
 
@@ -345,7 +345,7 @@ impl<'de> DeserializeAs<'de, AggregateAuthoritySignature> for AggrAuthSignature 
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        let sig_bytes = base64ct::Base64::decode_vec(&s).map_err(to_custom_error::<'de, D, _>)?;
+        let sig_bytes = Base64::decode(&s).map_err(to_custom_error::<'de, D, _>)?;
         AggregateAuthoritySignature::from_bytes(&sig_bytes[..])
             .map_err(to_custom_error::<'de, D, _>)
     }

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -6,7 +6,6 @@
 
 use std::str::FromStr;
 
-use base64ct::{Base64, Encoding};
 use move_binary_format::file_format;
 
 use crate::crypto::bcs_signable_test::{Bar, Foo};
@@ -14,6 +13,7 @@ use crate::crypto::{
     get_key_pair_from_bytes, AccountKeyPair, AuthorityKeyPair, AuthoritySignature,
     SuiAuthoritySignature, SuiSignature,
 };
+use crate::sui_serde::Encoding;
 use crate::{
     crypto::{get_key_pair, Signature},
     gas_coin::GasCoin,
@@ -281,10 +281,7 @@ fn test_transaction_digest_serde_not_human_readable() {
 fn test_transaction_digest_serde_human_readable() {
     let digest = TransactionDigest::random();
     let serialized = serde_json::to_string(&digest).unwrap();
-    assert_eq!(
-        format!("\"{}\"", Base64::encode_string(&digest.0)),
-        serialized
-    );
+    assert_eq!(format!("\"{}\"", Base64::encode(&digest.0)), serialized);
     let deserialized: TransactionDigest = serde_json::from_str(&serialized).unwrap();
     assert_eq!(deserialized, digest);
 }
@@ -307,7 +304,7 @@ fn test_authority_signature_serde_human_readable() {
     let sig = AuthoritySignature::new(&Foo("some data".to_string()), &key);
     let serialized = serde_json::to_string(&sig).unwrap();
     assert_eq!(
-        format!(r#"{{"sig":"{}"}}"#, Base64::encode_string(sig.as_ref())),
+        format!(r#"{{"sig":"{}"}}"#, Base64::encode(sig.as_ref())),
         serialized
     );
     let deserialized: AuthoritySignature = serde_json::from_str(&serialized).unwrap();

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.83"
 signature = "1.6.0"
 camino = "1.1.1"
-base64ct = "1.5.2"
 tokio = { version = "1.20.1", features = ["full"] }
 async-trait = "0.1.57"
 serde_with = { version = "1.14.0", features = ["hex"] }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -5,7 +5,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
-use base64ct::Encoding as _;
 use bip32::{DerivationPath, Mnemonic};
 use clap::*;
 use fastcrypto::traits::{ToFromBytes, VerifyingKey};
@@ -230,8 +229,7 @@ pub fn read_network_keypair_from_file<P: AsRef<std::path::Path>>(
     path: P,
 ) -> anyhow::Result<NetworkKeyPair> {
     let value = std::fs::read_to_string(path)?;
-    let bytes =
-        base64ct::Base64::decode_vec(value.as_str()).map_err(|e| anyhow!("{}", e.to_string()))?;
+    let bytes = Base64::decode(value.as_str())?;
     if let Some(flag) = bytes.first() {
         if flag == &Ed25519SuiSignature::SCHEME.flag() {
             let sk = Ed25519PrivateKey::from_bytes(&bytes[1 + Ed25519PublicKey::LENGTH..])?;


### PR DESCRIPTION
investigating base64 usage and use our own base64 wrapper makes it a little easier to find all of usages.