### PR TITLE
wallet-ext: use font smoothing instead of less font-weight

### DIFF
--- a/apps/wallet/src/ui/app/pages/initialize/backup/Backup.module.scss
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/Backup.module.scss
@@ -6,7 +6,7 @@
     flex-flow: column nowrap;
     gap: 8px;
     align-self: stretch;
-    font-weight: 500;
+    font-weight: 600;
     font-size: 17px;
     line-height: 1.4;
     padding: 14px;

--- a/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.module.scss
+++ b/apps/wallet/src/ui/app/pages/initialize/import/steps/StepOne.module.scss
@@ -8,7 +8,7 @@
     box-shadow: 0 1px 2px rgba(16 24 40 / 5%);
     border-radius: 15px;
     font-size: 17px;
-    font-weight: 500;
+    font-weight: 600;
     line-height: 140%;
     color: colors.$gray-75;
     align-self: stretch;
@@ -17,7 +17,6 @@
 
     &::placeholder {
         color: colors.$gray-65;
-        font-weight: 400;
     }
 }
 

--- a/apps/wallet/src/ui/styles/global.scss
+++ b/apps/wallet/src/ui/styles/global.scss
@@ -15,6 +15,8 @@ body {
     min-height: 0;
     margin: 0;
     padding: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 
     /* to allow gradient color to work and show at least solid color when over-scroll */
     background: v.use(v.$colors-background);
@@ -64,4 +66,8 @@ body {
 input:focus,
 textarea {
     outline: none !important;
+}
+
+textarea {
+    font-family: Inter, sans-serif;
 }

--- a/apps/wallet/src/ui/styles/utils/index.scss
+++ b/apps/wallet/src/ui/styles/utils/index.scss
@@ -38,7 +38,7 @@ $main-extra-space: sizing.$main-bottom-space;
     word-break: break-all;
     padding-right: 20px;
     position: relative;
-    font-weight: 400;
+    font-weight: 500;
     font-size: 13px;
     line-height: 130%;
 
@@ -85,7 +85,7 @@ $main-extra-space: sizing.$main-bottom-space;
 
 @mixin angled-arrow($color: colors.$gray-65) {
     transform: rotate(135deg);
-    font-weight: 200;
+    font-weight: 300;
     margin: 0;
     margin-right: 10px;
     font-size: 14px;
@@ -95,58 +95,58 @@ $main-extra-space: sizing.$main-bottom-space;
 @mixin typography($type) {
     @if $type == 'stat/col-header' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 600;
         font-size: 12px;
         text-transform: uppercase;
         color: colors.$gray-75;
     } @else if $type == 'page-description' {
         font-style: normal;
-        font-weight: 300;
+        font-weight: 400;
         font-size: 12px;
         color: colors.$gray-80;
     } @else if $type == 'tooltip/label' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 600;
         font-size: 11px;
         text-transform: uppercase;
         color: colors.$gray-80;
     } @else if $type == 'stats/text-lg' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 600;
         font-size: 18px;
         color: colors.$gray-100;
     } @else if $type == 'header/search-text' {
         font-style: normal;
-        font-weight: 400;
+        font-weight: 500;
         font-size: 14px;
         color: colors.$gray-70;
     } @else if $type == 'table/text-xs' {
         font-style: normal;
-        font-weight: 400;
+        font-weight: 500;
         font-size: 12px;
         color: colors.$gray-75;
     } @else if $type == 'table/text-sm' {
         font-style: normal;
-        font-weight: 400;
+        font-weight: 500;
         font-size: 13px;
         color: colors.$white;
     } @else if $type == 'table/text-lg' {
         font-style: normal;
-        font-weight: 400;
+        font-weight: 500;
         font-size: 14px;
     } @else if $type == 'table/title-sm' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 600;
         font-size: 14px;
         color: colors.$gray-100;
     } @else if $type == 'page-title' {
         font-style: normal;
-        font-weight: 500;
+        font-weight: 600;
         font-size: 16px;
         color: colors.$gray-100;
     } @else if $type == 'empty' {
         font-style: italic;
-        font-weight: 300;
+        font-weight: 400;
         font-size: 12px;
         text-align: center;
         color: colors.$gray-70;
@@ -154,85 +154,85 @@ $main-extra-space: sizing.$main-bottom-space;
         letter-spacing: 0;
     } @else if $type == 'Primary/BodySmall-M' {
         font-size: 13px;
-        font-weight: 400;
+        font-weight: 500;
         letter-spacing: 0;
     } @else if $type == 'Primary/Body-M' {
         font-size: 14px;
-        font-weight: 400;
+        font-weight: 500;
         letter-spacing: 0;
     } @else if $type == 'Primary/SubtitleSmall-M' {
         font-size: 11px;
-        font-weight: 400;
+        font-weight: 500;
         letter-spacing: 0;
     } @else if $type == 'Primary/BodySmall-SB' {
         font-size: 13px;
-        font-weight: 500;
+        font-weight: 600;
     } @else if $type == 'Primary/CAPTIONSMALL-M' {
         font-size: 11px;
-        font-weight: 400;
+        font-weight: 500;
         letter-spacing: 0.05em;
     } @else if $type == 'Primary/CAPTION-SB' {
         font-size: 12px;
-        font-weight: 500;
+        font-weight: 600;
         letter-spacing: 0.05em;
         text-align: center;
     } @else if $type == 'Primary/CAPTIONSMALL-SB' {
         font-size: 11px;
-        font-weight: 500;
+        font-weight: 600;
         line-height: 11px;
         letter-spacing: 0.05em;
     } @else if $type == 'Primary/CAPTION-B' {
         font-size: 12px;
-        font-weight: 600;
+        font-weight: 700;
         letter-spacing: 0.05em;
         text-align: center;
     } @else if $type == 'Primary/CAPTION-M' {
         font-size: 12px;
-        font-weight: 400;
+        font-weight: 500;
         letter-spacing: 0.05em;
         text-align: center;
     } @else if $type == 'ParagraphPrimary/P2-R' {
         font-size: 13px;
-        font-weight: 300;
+        font-weight: 400;
         letter-spacing: 0;
     } @else if $type == 'page-ex-small' {
-        font-weight: 400;
+        font-weight: 500;
         font-size: 10px;
         letter-spacing: 0;
     } @else if $type == 'Primary/Heading1-B' {
         font-size: 28px;
-        font-weight: 600;
+        font-weight: 700;
         letter-spacing: 0;
         text-align: center;
     } @else if $type == 'Primary/Heading3-SB' {
         font-size: 20px;
-        font-weight: 500;
+        font-weight: 600;
         letter-spacing: 0;
         text-align: center;
     } @else if $type == 'ParagraphPrimary/P1-M' {
         font-size: 14px;
-        font-weight: 400;
+        font-weight: 500;
         line-height: 130%;
         letter-spacing: 0;
         text-align: center;
     } @else if $type == 'ParagraphPrimary/P1-SB' {
         font-size: 14px;
-        font-weight: 500;
+        font-weight: 600;
         line-height: 18px;
         letter-spacing: 0;
     } @else if $type == 'ParagraphPrimary/P2-M' {
         font-size: 13px;
-        font-weight: 400;
+        font-weight: 500;
         line-height: 17px;
         letter-spacing: 0;
     } @else if $type == 'Primary/Body-SB' {
         font-size: 14px;
-        font-weight: 500;
+        font-weight: 600;
         letter-spacing: 0;
     } @else if $type == 'mono-type' {
         // TODO chanage to mono font
         font-style: normal;
-        font-weight: 400;
+        font-weight: 500;
         font-size: 14px;
         text-decoration: none;
         line-height: 90%;


### PR DESCRIPTION
This reverts commit 977ef543bd08fb02b25b8b0f6d4c8ad39f75b4a4

| before (-100 font-weight) | after (font-smoothing) |
| -- | -- |
| <img width="391" alt="Screenshot 2022-10-19 at 17 58 31" src="https://user-images.githubusercontent.com/10210143/196757345-40e61b11-ebbf-4c9c-bedf-eb5918301b45.png"> | <img width="391" alt="Screenshot 2022-10-19 at 17 58 16" src="https://user-images.githubusercontent.com/10210143/196757386-1ac1ba25-9222-4f4d-96c6-91778ae502f9.png"> |
| <img width="391" alt="Screenshot 2022-10-19 at 18 00 15" src="https://user-images.githubusercontent.com/10210143/196757445-bf85d5ef-4f4b-4572-abdc-99cd910fb781.png"> | <img width="391" alt="Screenshot 2022-10-19 at 18 00 35" src="https://user-images.githubusercontent.com/10210143/196757488-524d4437-8ca3-4421-a567-81643a1b3930.png"> |
| <img width="391" alt="Screenshot 2022-10-19 at 18 00 46" src="https://user-images.githubusercontent.com/10210143/196757576-8d9cb30c-2908-43bf-b21e-e0df8c2f94f5.png"> | <img width="391" alt="Screenshot 2022-10-19 at 18 33 15" src="https://user-images.githubusercontent.com/10210143/196763895-9fc7551e-5b3c-40ce-ac83-e42a815d2bf7.png"> |