### PR TITLE
narwhal: require authorization for primary-to-worker and worker-to-primary interfaces

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,6 +8,8 @@ status-level = "skip"
 fail-fast = false
 # Retry failing tests in order to not block builds on flaky tests
 retries = 5
+# Timeout tests after 4 minutes
+slow-timeout = { period = "60s", terminate-after = 4 }
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=1b977fe20a615b7a7045f779f9aafa120389c2ab#1b977fe20a615b7a7045f779f9aafa120389c2ab"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e#7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=1b977fe20a615b7a7045f779f9aafa120389c2ab#1b977fe20a615b7a7045f779f9aafa120389c2ab"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e#7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.46",
@@ -131,7 +131,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=1b977fe20a615b7a7045f779f9aafa120389c2ab#1b977fe20a615b7a7045f779f9aafa120389c2ab"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e#7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e"
 dependencies = [
  "anemo",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4988,6 +4988,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "rand 0.8.5",
+ "reqwest",
  "serde-reflection",
  "serde_yaml",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,9 @@ move-prover-boogie-backend = { git = "https://github.com/move-language/move", re
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "7c685a4b67680ef3e5d48117f4e2e3aef5c50526" }
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e" }
 
 # Use the same workspace-hack across crates.
 workspace-hack = { path = "crates/workspace-hack" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -22,8 +22,8 @@ aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10", features = ["aes", "alloc", "getrandom"] }
 ahash = { version = "0.7", features = ["std"] }
 aho-corasick = { version = "0.7", features = ["std"] }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
@@ -627,9 +627,9 @@ aes = { version = "0.8", default-features = false }
 aes-gcm = { version = "0.10", features = ["aes", "alloc", "getrandom"] }
 ahash = { version = "0.7", features = ["std"] }
 aho-corasick = { version = "0.7", features = ["std"] }
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "1b977fe20a615b7a7045f779f9aafa120389c2ab", default-features = false }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e", default-features = false }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e", default-features = false }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "7da7c9a1913ed7fadbdd92ebc1b9f48e0c8cef0e", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
 anyhow = { version = "1", features = ["backtrace", "std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -12,7 +12,7 @@ use futures::FutureExt;
 use futures::StreamExt;
 
 use network::P2pNetwork;
-use network::PrimaryToWorkerRpc;
+use network::WorkerRpc;
 
 use anyhow::bail;
 use prometheus::IntGauge;

--- a/narwhal/network/src/lib.rs
+++ b/narwhal/network/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::{
     retry::RetryConfig,
     traits::{
         Lucky, LuckyNetwork, PrimaryToPrimaryRpc, PrimaryToWorkerRpc, ReliableNetwork,
-        UnreliableNetwork,
+        UnreliableNetwork, WorkerRpc,
     },
 };
 

--- a/narwhal/network/src/p2p.rs
+++ b/narwhal/network/src/p2p.rs
@@ -19,8 +19,8 @@ use types::{
     Batch, BatchDigest, FetchCertificatesRequest, FetchCertificatesResponse, PrimaryMessage,
     PrimaryToPrimaryClient, PrimaryToWorkerClient, RequestBatchRequest, WorkerBatchMessage,
     WorkerBatchRequest, WorkerBatchResponse, WorkerDeleteBatchesMessage, WorkerOthersBatchMessage,
-    WorkerOurBatchMessage, WorkerPrimaryMessage, WorkerReconfigureMessage,
-    WorkerSynchronizeMessage, WorkerToPrimaryClient, WorkerToWorkerClient,
+    WorkerOurBatchMessage, WorkerReconfigureMessage, WorkerSynchronizeMessage,
+    WorkerToPrimaryClient, WorkerToWorkerClient,
 };
 
 fn default_executor() -> BoundedExecutor {
@@ -297,38 +297,6 @@ impl ReliableNetwork<WorkerSynchronizeMessage> for P2pNetwork {
 //
 // Worker-to-Primary
 //
-
-impl UnreliableNetwork<WorkerPrimaryMessage> for P2pNetwork {
-    type Response = ();
-    fn unreliable_send(
-        &mut self,
-        peer: NetworkPublicKey,
-        message: &WorkerPrimaryMessage,
-    ) -> Result<JoinHandle<Result<anemo::Response<()>>>> {
-        let message = message.to_owned();
-        let f =
-            move |peer| async move { WorkerToPrimaryClient::new(peer).send_message(message).await };
-        self.unreliable_send(peer, f)
-    }
-}
-
-#[async_trait]
-impl ReliableNetwork<WorkerPrimaryMessage> for P2pNetwork {
-    type Response = ();
-    async fn send(
-        &mut self,
-        peer: NetworkPublicKey,
-        message: &WorkerPrimaryMessage,
-    ) -> CancelOnDropHandler<Result<anemo::Response<()>>> {
-        let message = message.to_owned();
-        let f = move |peer| {
-            let message = message.clone();
-            async move { WorkerToPrimaryClient::new(peer).send_message(message).await }
-        };
-
-        self.send(peer, f).await
-    }
-}
 
 #[async_trait]
 impl ReliableNetwork<WorkerOurBatchMessage> for P2pNetwork {

--- a/narwhal/network/src/traits.rs
+++ b/narwhal/network/src/traits.rs
@@ -103,11 +103,15 @@ pub trait PrimaryToPrimaryRpc {
 
 #[async_trait]
 pub trait PrimaryToWorkerRpc {
+    async fn delete_batches(&self, peer: NetworkPublicKey, digests: Vec<BatchDigest>)
+        -> Result<()>;
+}
+
+#[async_trait]
+pub trait WorkerRpc {
     async fn request_batch(
         &self,
         peer: NetworkPublicKey,
         batch: BatchDigest,
     ) -> Result<Option<Batch>>;
-    async fn delete_batches(&self, peer: NetworkPublicKey, digests: Vec<BatchDigest>)
-        -> Result<()>;
 }

--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -46,6 +46,7 @@ workspace-hack.workspace = true
 eyre = "0.6.8"
 
 anemo.workspace = true
+reqwest = { version = "0.11.12", features = ["json"] }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/narwhal/node/src/generate_format.rs
+++ b/narwhal/node/src/generate_format.rs
@@ -13,7 +13,7 @@ use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest,
-    ReconfigureNotification, WorkerOthersBatchMessage, WorkerOurBatchMessage, WorkerPrimaryMessage,
+    ReconfigureNotification, WorkerOthersBatchMessage, WorkerOurBatchMessage,
     WorkerReconfigureMessage, WorkerSynchronizeMessage,
 };
 
@@ -145,8 +145,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<HeaderDigest>(&samples)?;
     tracer.trace_type::<CertificateDigest>(&samples)?;
 
-    // The final entry points that we must document
-    tracer.trace_type::<WorkerPrimaryMessage>(&samples)?;
     tracer.registry()
 }
 

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -71,10 +71,6 @@ ReconfigureNotification:
       NewEpoch:
         NEWTYPE:
           TYPENAME: Committee
-    1:
-      UpdateCommittee:
-        NEWTYPE:
-          TYPENAME: Committee
     2:
       Shutdown: UNIT
 WorkerIndex:
@@ -99,12 +95,6 @@ WorkerOurBatchMessage:
     - digest:
         TYPENAME: BatchDigest
     - worker_id: U32
-WorkerPrimaryMessage:
-  ENUM:
-    0:
-      Reconfigure:
-        NEWTYPE:
-          TYPENAME: ReconfigureNotification
 WorkerReconfigureMessage:
   STRUCT:
     - message:
@@ -115,3 +105,4 @@ WorkerSynchronizeMessage:
         SEQ:
           TYPENAME: BatchDigest
     - target: STR
+

--- a/narwhal/primary/src/block_waiter.rs
+++ b/narwhal/primary/src/block_waiter.rs
@@ -9,7 +9,7 @@ use futures::{
     stream::{FuturesOrdered, StreamExt as _},
     FutureExt,
 };
-use network::{P2pNetwork, PrimaryToWorkerRpc};
+use network::{P2pNetwork, WorkerRpc};
 use std::{collections::HashSet, sync::Arc};
 
 use tracing::{debug, instrument};

--- a/narwhal/primary/src/tests/block_waiter_tests.rs
+++ b/narwhal/primary/src/tests/block_waiter_tests.rs
@@ -15,8 +15,8 @@ use test_utils::{
     fixture_batch_with_transactions, fixture_payload, test_network, CommitteeFixture,
 };
 use types::{
-    Batch, BatchMessage, Certificate, CertificateDigest, MockPrimaryToWorker,
-    PrimaryToWorkerServer, RequestBatchResponse,
+    Batch, BatchMessage, Certificate, CertificateDigest, MockWorkerToWorker, RequestBatchResponse,
+    WorkerToWorkerServer,
 };
 
 #[tokio::test]
@@ -46,7 +46,7 @@ async fn test_successfully_retrieve_block() {
     let network_key = worker.keypair();
     let worker_name = network_key.public().clone();
     let worker_address = &worker.info().worker_address;
-    let mut mock_server = MockPrimaryToWorker::new();
+    let mut mock_server = MockWorkerToWorker::new();
 
     // Mock the batch responses.
     let expected_block_count = header.payload.len();
@@ -60,7 +60,7 @@ async fn test_successfully_retrieve_block() {
                 }))
             });
     }
-    let routes = anemo::Router::new().add_rpc_service(PrimaryToWorkerServer::new(mock_server));
+    let routes = anemo::Router::new().add_rpc_service(WorkerToWorkerServer::new(mock_server));
     let _worker_network = worker.new_network(routes);
 
     let address = network::multiaddr_to_address(worker_address).unwrap();
@@ -114,7 +114,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     let name = primary.public_key();
 
     let mut block_ids = Vec::new();
-    let mut mock_server = MockPrimaryToWorker::new();
+    let mut mock_server = MockWorkerToWorker::new();
     let worker_id = 0;
     let mut expected_get_block_responses = Vec::new();
     let mut certificates = Vec::new();
@@ -225,7 +225,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     let network_key = worker.keypair();
     let worker_name = network_key.public().clone();
     let worker_address = &worker.info().worker_address;
-    let routes = anemo::Router::new().add_rpc_service(PrimaryToWorkerServer::new(mock_server));
+    let routes = anemo::Router::new().add_rpc_service(WorkerToWorkerServer::new(mock_server));
     let _worker_network = worker.new_network(routes);
 
     let address = network::multiaddr_to_address(worker_address).unwrap();

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -1,32 +1,42 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::mutable_key_type)]
+
 use arc_swap::ArcSwap;
 use config::{Committee, Parameters};
 use fastcrypto::traits::KeyPair;
-use futures::future::join_all;
+use futures::future::{join_all, try_join_all};
 use narwhal_primary as primary;
-use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use node::NodeStorage;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
-use std::{sync::Arc, time::Duration};
-use test_utils::{ensure_test_environment, random_network, temp_dir, CommitteeFixture};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use test_utils::{ensure_test_environment, temp_dir, CommitteeFixture};
 use tokio::sync::watch;
-use types::{ReconfigureNotification, WorkerPrimaryMessage};
+use types::ReconfigureNotification;
 
 /// The epoch changes but the stake distribution and network addresses stay the same.
 #[tokio::test]
 async fn test_simple_epoch_change() {
-    let parameters = Parameters {
-        header_num_of_batches_threshold: 1, // One batch digest
-        ..Parameters::default()
-    };
     ensure_test_environment();
 
     // The configuration of epoch 0.
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee_0 = fixture.committee();
     let worker_cache_0 = fixture.shared_worker_cache();
+    let parameters = fixture
+        .authorities()
+        .map(|a| {
+            (
+                a.public_key(),
+                Parameters {
+                    header_num_of_batches_threshold: 1, // One batch digest
+                    ..Parameters::default()
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     // Spawn the committee of epoch 0.
     let mut rx_channels = Vec::new();
@@ -47,13 +57,14 @@ async fn test_simple_epoch_change() {
 
         let store = NodeStorage::reopen(temp_dir());
 
+        let p = parameters.get(&name).unwrap().clone();
         Primary::spawn(
             name,
             signer.copy(),
             authority.network_keypair().copy(),
             Arc::new(ArcSwap::from_pointee(committee_0.clone())),
             worker_cache_0.clone(),
-            parameters.clone(),
+            p,
             store.header_store.clone(),
             store.certificate_store.clone(),
             store.proposer_store.clone(),
@@ -82,29 +93,8 @@ async fn test_simple_epoch_change() {
         }
     }
 
-    let network = anemo::Network::bind("127.0.0.1:0")
-        .server_name("narwhal")
-        .private_key(
-            crypto::NetworkKeyPair::generate(&mut rand::rngs::OsRng)
-                .private()
-                .0
-                .to_bytes(),
-        )
-        .start(anemo::Router::new())
-        .unwrap();
-
-    for authority in committee_0.authorities.values() {
-        let address = network::multiaddr_to_address(&authority.primary_address).unwrap();
-        let peer_id = anemo::PeerId(authority.network_key.0.to_bytes());
-
-        network
-            .connect_with_peer_id(address, peer_id)
-            .await
-            .unwrap();
-    }
-    let mut network = P2pNetwork::new(network);
-
     // Move to the next epochs.
+    let client = reqwest::Client::new();
     let mut old_committee = committee_0;
     for epoch in 1..=3 {
         // Move to the next epoch.
@@ -114,17 +104,24 @@ async fn test_simple_epoch_change() {
         };
 
         // Notify the old committee to change epoch.
-        let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::NewEpoch(
-            new_committee.clone(),
-        ));
-        let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
-        for authority in old_committee.authorities.values() {
-            _do_not_drop.push(
-                network
-                    .send(authority.network_key.to_owned(), &message)
-                    .await,
-            );
+        let message = ReconfigureNotification::NewEpoch(new_committee.clone());
+
+        let mut futs = Vec::new();
+        for authority in old_committee.authorities.keys() {
+            let fut = client
+                .post(format!(
+                    "http://127.0.0.1:{}/reconfigure",
+                    parameters
+                        .get(authority)
+                        .unwrap()
+                        .network_admin_server
+                        .primary_network_admin_server_port
+                ))
+                .json(&message)
+                .send();
+            futs.push(fut);
         }
+        try_join_all(futs).await.unwrap();
 
         // Run for a while.
         for rx in rx_channels.iter_mut() {
@@ -145,15 +142,23 @@ async fn test_simple_epoch_change() {
 async fn test_partial_committee_change() {
     telemetry_subscribers::init_for_testing();
     ensure_test_environment();
-    let parameters = Parameters {
-        header_num_of_batches_threshold: 1, // One batch digest
-        ..Parameters::default()
-    };
 
     // Make the committee of epoch 0.
     let mut fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee_0 = fixture.committee();
     let worker_cache_0 = fixture.shared_worker_cache();
+    let mut parameters = fixture
+        .authorities()
+        .map(|a| {
+            (
+                a.public_key(),
+                Parameters {
+                    header_num_of_batches_threshold: 1, // One batch digest
+                    ..Parameters::default()
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     // Spawn the committee of epoch 0.
     let mut epoch_0_rx_channels = Vec::new();
@@ -173,13 +178,14 @@ async fn test_partial_committee_change() {
 
         let store = NodeStorage::reopen(temp_dir());
 
+        let p = parameters.get(&name).unwrap().clone();
         Primary::spawn(
             name,
             signer.copy(),
             authority.network_keypair().copy(),
             Arc::new(ArcSwap::from_pointee(committee_0.clone())),
             worker_cache_0.clone(),
-            parameters.clone(),
+            p,
             store.header_store.clone(),
             store.certificate_store.clone(),
             store.proposer_store.clone(),
@@ -210,43 +216,37 @@ async fn test_partial_committee_change() {
 
     // Make the committee of epoch 1.
     fixture.add_authority();
+    parameters.insert(
+        fixture.authorities().last().unwrap().public_key(),
+        Parameters {
+            header_num_of_batches_threshold: 1, // One batch digest
+            ..Parameters::default()
+        },
+    );
     fixture.bump_epoch();
     let committee_1 = fixture.committee();
     let worker_cache_1 = fixture.shared_worker_cache();
 
     // Tell the nodes of epoch 0 to transition to epoch 1.
-    let network = anemo::Network::bind("127.0.0.1:0")
-        .server_name("narwhal")
-        .private_key(
-            crypto::NetworkKeyPair::generate(&mut rand::rngs::OsRng)
-                .private()
-                .0
-                .to_bytes(),
-        )
-        .start(anemo::Router::new())
-        .unwrap();
 
-    for authority in committee_0.authorities.values() {
-        let address = network::multiaddr_to_address(&authority.primary_address).unwrap();
-        let peer_id = anemo::PeerId(authority.network_key.0.to_bytes());
-
-        network
-            .connect_with_peer_id(address, peer_id)
-            .await
-            .unwrap();
+    let message = ReconfigureNotification::NewEpoch(committee_1.clone());
+    let client = reqwest::Client::new();
+    let mut futs = Vec::new();
+    for authority in committee_0.authorities.keys() {
+        let fut = client
+            .post(format!(
+                "http://127.0.0.1:{}/reconfigure",
+                parameters
+                    .get(authority)
+                    .unwrap()
+                    .network_admin_server
+                    .primary_network_admin_server_port
+            ))
+            .json(&message)
+            .send();
+        futs.push(fut);
     }
-    let mut network = P2pNetwork::new(network);
-
-    let message =
-        WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::NewEpoch(committee_1.clone()));
-    let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
-    for authority in committee_0.authorities.values() {
-        _do_not_drop.push(
-            network
-                .send(authority.network_key.to_owned(), &message)
-                .await,
-        );
-    }
+    try_join_all(futs).await.unwrap();
 
     // Spawn the committee of epoch 1 (only the node not already booted).
     let mut epoch_1_rx_channels = Vec::new();
@@ -267,13 +267,14 @@ async fn test_partial_committee_change() {
 
         let store = NodeStorage::reopen(temp_dir());
 
+        let p = parameters.get(&name).unwrap().clone();
         Primary::spawn(
             name,
             signer.copy(),
             authority.network_keypair().copy(),
             Arc::new(ArcSwap::from_pointee(committee_1.clone())),
             worker_cache_1.clone(),
-            parameters.clone(),
+            p,
             store.header_store.clone(),
             store.certificate_store.clone(),
             store.proposer_store.clone(),
@@ -309,17 +310,22 @@ async fn test_restart_with_new_committee_change() {
     telemetry_subscribers::init_for_testing();
     ensure_test_environment();
 
-    let parameters = Parameters {
-        header_num_of_batches_threshold: 1, // One batch digest
-        ..Parameters::default()
-    };
-
     // The configuration of epoch 0.
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee_0 = fixture.committee();
     let worker_cache_0 = fixture.shared_worker_cache();
-
-    let network = random_network();
+    let parameters = fixture
+        .authorities()
+        .map(|a| {
+            (
+                a.public_key(),
+                Parameters {
+                    header_num_of_batches_threshold: 1, // One batch digest
+                    ..Parameters::default()
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     // Spawn the committee of epoch 0.
     let mut rx_channels = Vec::new();
@@ -341,13 +347,14 @@ async fn test_restart_with_new_committee_change() {
 
         let store = NodeStorage::reopen(temp_dir());
 
+        let p = parameters.get(&name).unwrap().clone();
         let primary_handles = Primary::spawn(
             name,
             signer.copy(),
             authority.network_keypair().copy(),
             Arc::new(ArcSwap::new(Arc::new(committee_0.clone()))),
             worker_cache_0.clone(),
-            parameters.clone(),
+            p,
             store.header_store.clone(),
             store.certificate_store.clone(),
             store.proposer_store.clone(),
@@ -378,21 +385,22 @@ async fn test_restart_with_new_committee_change() {
     }
 
     // Shutdown the committee of the previous epoch;
-    let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::Shutdown);
-    let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
-    for authority in committee_0.authorities.values() {
-        network
-            .connect_with_peer_id(
-                network::multiaddr_to_address(&authority.primary_address).unwrap(),
-                anemo::PeerId(authority.network_key.0.to_bytes()),
-            )
+    let message = ReconfigureNotification::Shutdown;
+    let client = reqwest::Client::new();
+    for authority in committee_0.authorities.keys() {
+        client
+            .post(format!(
+                "http://127.0.0.1:{}/reconfigure",
+                parameters
+                    .get(authority)
+                    .unwrap()
+                    .network_admin_server
+                    .primary_network_admin_server_port
+            ))
+            .json(&message)
+            .send()
             .await
             .unwrap();
-        _do_not_drop.push(
-            P2pNetwork::new(network.clone())
-                .send(authority.network_key.to_owned(), &message)
-                .await,
-        );
     }
 
     // Wait for the committee to shutdown.
@@ -428,13 +436,14 @@ async fn test_restart_with_new_committee_change() {
 
             let store = NodeStorage::reopen(temp_dir());
 
+            let p = parameters.get(&name).unwrap().clone();
             let primary_handles = Primary::spawn(
                 name,
                 signer.copy(),
                 authority.network_keypair().copy(),
                 Arc::new(ArcSwap::new(Arc::new(new_committee.clone()))),
                 Arc::new(ArcSwap::new(Arc::new(new_worker_cache.clone()))),
-                parameters.clone(),
+                p,
                 store.header_store.clone(),
                 store.certificate_store.clone(),
                 store.proposer_store.clone(),
@@ -464,21 +473,22 @@ async fn test_restart_with_new_committee_change() {
         }
 
         // Shutdown the committee of the previous epoch;
-        let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::Shutdown);
-        let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
-        for authority in committee_0.authorities.values() {
-            network
-                .connect_with_peer_id(
-                    network::multiaddr_to_address(&authority.primary_address).unwrap(),
-                    anemo::PeerId(authority.network_key.0.to_bytes()),
-                )
+        let message = ReconfigureNotification::Shutdown;
+        let client = reqwest::Client::new();
+        for authority in committee_0.authorities.keys() {
+            client
+                .post(format!(
+                    "http://127.0.0.1:{}/reconfigure",
+                    parameters
+                        .get(authority)
+                        .unwrap()
+                        .network_admin_server
+                        .primary_network_admin_server_port
+                ))
+                .json(&message)
+                .send()
                 .await
                 .unwrap();
-            _do_not_drop.push(
-                P2pNetwork::new(network.clone())
-                    .send(authority.network_key.to_owned(), &message)
-                    .await,
-            );
         }
 
         // Wait for the committee to shutdown.
@@ -492,15 +502,23 @@ async fn test_restart_with_new_committee_change() {
 #[tokio::test]
 async fn test_simple_committee_update() {
     ensure_test_environment();
-    let parameters = Parameters {
-        header_num_of_batches_threshold: 1, // One batch digest
-        ..Parameters::default()
-    };
 
     // The configuration of epoch 0.
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee_0 = fixture.committee();
     let worker_cache_0 = fixture.shared_worker_cache();
+    let parameters = fixture
+        .authorities()
+        .map(|a| {
+            (
+                a.public_key(),
+                Parameters {
+                    header_num_of_batches_threshold: 1, // One batch digest
+                    ..Parameters::default()
+                },
+            )
+        })
+        .collect::<HashMap<_, _>>();
 
     // Spawn the committee of epoch 0.
     let mut rx_channels = Vec::new();
@@ -521,13 +539,14 @@ async fn test_simple_committee_update() {
 
         let store = NodeStorage::reopen(temp_dir());
 
+        let p = parameters.get(&name).unwrap().clone();
         Primary::spawn(
             name,
             signer.copy(),
             authority.network_keypair().copy(),
             Arc::new(ArcSwap::from_pointee(committee_0.clone())),
             worker_cache_0.clone(),
-            parameters.clone(),
+            p,
             store.header_store.clone(),
             store.certificate_store.clone(),
             store.proposer_store.clone(),
@@ -558,6 +577,7 @@ async fn test_simple_committee_update() {
 
     // Update the committee
     let mut old_committee = committee_0;
+    let client = reqwest::Client::new();
     for _ in 1..=3 {
         // Update the committee
         let mut new_committee = old_committee.clone();
@@ -566,21 +586,21 @@ async fn test_simple_committee_update() {
         }
 
         // Notify the old committee about the change in committee information.
-        let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::UpdateCommittee(
-            new_committee.clone(),
-        ));
-        let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
-        for authority in old_committee.authorities.values() {
-            let mut network = P2pNetwork::new_for_single_address(
-                authority.network_key.to_owned(),
-                network::multiaddr_to_address(&authority.primary_address).unwrap(),
-            )
-            .await;
-            _do_not_drop.push(
-                network
-                    .send(authority.network_key.to_owned(), &message)
-                    .await,
-            );
+        let message = ReconfigureNotification::UpdateCommittee(new_committee.clone());
+        for authority in old_committee.authorities.keys() {
+            client
+                .post(format!(
+                    "http://127.0.0.1:{}/reconfigure",
+                    parameters
+                        .get(authority)
+                        .unwrap()
+                        .network_admin_server
+                        .primary_network_admin_server_port
+                ))
+                .json(&message)
+                .send()
+                .await
+                .unwrap();
         }
 
         // Run for a while.

--- a/narwhal/test-utils/src/lib.rs
+++ b/narwhal/test-utils/src/lib.rs
@@ -258,13 +258,6 @@ impl PrimaryToWorker for PrimaryToWorkerMockServer {
         Ok(anemo::Response::new(()))
     }
 
-    async fn request_batch(
-        &self,
-        _request: anemo::Request<RequestBatchRequest>,
-    ) -> Result<anemo::Response<RequestBatchResponse>, anemo::rpc::Status> {
-        tracing::error!("Not implemented PrimaryToWorkerMockServer::request_batch");
-        Err(anemo::rpc::Status::internal("Unimplemented"))
-    }
     async fn delete_batches(
         &self,
         _request: anemo::Request<WorkerDeleteBatchesMessage>,
@@ -331,6 +324,14 @@ impl WorkerToWorker for WorkerToWorkerMockServer {
         Ok(anemo::Response::new(WorkerBatchResponse {
             batches: vec![],
         }))
+    }
+
+    async fn request_batch(
+        &self,
+        _request: anemo::Request<RequestBatchRequest>,
+    ) -> Result<anemo::Response<RequestBatchResponse>, anemo::rpc::Status> {
+        tracing::error!("Not implemented WorkerToWorkerMockServer::request_batch");
+        Err(anemo::rpc::Status::internal("Unimplemented"))
     }
 }
 

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -94,15 +94,6 @@ fn build_anemo_services(out_dir: &Path) {
         )
         .method(
             anemo_build::manual::Method::builder()
-                .name("request_batch")
-                .route_name("RequestBatch")
-                .request_type("crate::RequestBatchRequest")
-                .response_type("crate::RequestBatchResponse")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
                 .name("delete_batches")
                 .route_name("DeleteBatches")
                 .request_type("crate::WorkerDeleteBatchesMessage")
@@ -173,6 +164,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .route_name("RequestBatches")
                 .request_type("crate::WorkerBatchRequest")
                 .response_type("crate::WorkerBatchResponse")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("request_batch")
+                .route_name("RequestBatch")
+                .request_type("crate::RequestBatchRequest")
+                .response_type("crate::RequestBatchResponse")
                 .codec_path("anemo::rpc::codec::BincodeCodec")
                 .build(),
         )

--- a/narwhal/types/build.rs
+++ b/narwhal/types/build.rs
@@ -109,15 +109,6 @@ fn build_anemo_services(out_dir: &Path) {
         .attributes(automock_attribute.clone())
         .method(
             anemo_build::manual::Method::builder()
-                .name("send_message")
-                .route_name("SendMessage")
-                .request_type("crate::WorkerPrimaryMessage")
-                .response_type("()")
-                .codec_path("anemo::rpc::codec::BincodeCodec")
-                .build(),
-        )
-        .method(
-            anemo_build::manual::Method::builder()
                 .name("report_our_batch")
                 .route_name("ReportOurBatch")
                 .request_type("crate::WorkerOurBatchMessage")

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -775,13 +775,6 @@ impl fmt::Display for BlockErrorKind {
     }
 }
 
-/// The messages sent by the workers to their primary.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub enum WorkerPrimaryMessage {
-    /// Reconfiguration message sent by the executor (usually upon epoch change).
-    Reconfigure(ReconfigureNotification),
-}
-
 /// Used by worker to inform primary it sealed a new batch.
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct WorkerOurBatchMessage {

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -61,6 +61,12 @@ async fn synchronize() {
             assert_eq!(*request.body(), self.expected_request);
             Ok(anemo::Response::new(self.response.clone()))
         }
+        async fn request_batch(
+            &self,
+            _request: anemo::Request<RequestBatchRequest>,
+        ) -> Result<anemo::Response<RequestBatchResponse>, anemo::rpc::Status> {
+            unimplemented!();
+        }
     }
 
     let routes =

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -212,6 +212,7 @@ impl Worker {
             network_admin_server_base_port,
             network.clone(),
             rx_reconfigure.clone(),
+            None,
         );
 
         // Connect worker to its corresponding primary.


### PR DESCRIPTION
Require authorization for primary-to-worker and worker-to-primary
    interfaces by wrapping them in a `RequireAuthorizationLayer` which
    enforces that requests to the primary-to-worker service on a worker come
    from that worker's primary and that requests to the worker-to-primary
    service on a primary come from that primary's workers.