### PR TITLE
[explorer] Add link component

### DIFF
--- a/apps/explorer/src/ui/Button.tsx
+++ b/apps/explorer/src/ui/Button.tsx
@@ -3,7 +3,7 @@
 
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import ButtonOrLink, { type ButtonOrLinkProps } from './utils/ButtonOrLink';
+import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
 
 const buttonStyles = cva(
     [

--- a/apps/explorer/src/ui/Link.tsx
+++ b/apps/explorer/src/ui/Link.tsx
@@ -14,7 +14,7 @@ const linkStyles = cva(
         variants: {
             variant: {
                 text: 'text-body font-semibold text-sui-grey-75 hover:text-sui-grey-90 active:text-sui-grey-100',
-								mono: 'font-mono text-bodySmall font-medium text-sui-dark'
+                mono: 'font-mono text-bodySmall font-medium text-sui-dark',
             },
             uppercase: {
                 true: 'uppercase',

--- a/apps/explorer/src/ui/Link.tsx
+++ b/apps/explorer/src/ui/Link.tsx
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { ButtonOrLink, type ButtonOrLinkProps } from './utils/ButtonOrLink';
+
+const linkStyles = cva(
+    [
+        // TODO: Remove when CSS reset is applied.
+        'cursor-pointer no-underline bg-transparent p-0 border-none',
+    ],
+    {
+        variants: {
+            variant: {
+                text: 'text-body font-semibold text-sui-grey-75 hover:text-sui-grey-90 active:text-sui-grey-100',
+								mono: 'font-mono text-bodySmall font-medium text-sui-dark'
+            },
+            uppercase: {
+                true: 'uppercase',
+            },
+        },
+    }
+);
+
+export interface LinkProps
+    extends ButtonOrLinkProps,
+        VariantProps<typeof linkStyles> {}
+
+export function Link({ variant, ...props }: LinkProps) {
+    return <ButtonOrLink className={linkStyles({ variant })} {...props} />;
+}

--- a/apps/explorer/src/ui/stories/Link.stories.tsx
+++ b/apps/explorer/src/ui/stories/Link.stories.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { Link, type LinkProps } from '../Link';
+
+export default {
+    component: Link,
+} as Meta;
+
+export const Text: StoryObj<LinkProps> = {
+    args: {
+        variant: 'text',
+        children: 'View more',
+    },
+};
+
+export const Mono: StoryObj<LinkProps> = {
+    args: {
+        variant: 'mono',
+        children: '0x0000000000000000000000000000000000000002',
+    },
+};

--- a/apps/explorer/src/ui/utils/ButtonOrLink.tsx
+++ b/apps/explorer/src/ui/utils/ButtonOrLink.tsx
@@ -10,7 +10,7 @@ export interface ButtonOrLinkProps
         'ref'
     > {}
 
-export default forwardRef<
+export const ButtonOrLink = forwardRef<
     HTMLAnchorElement | HTMLButtonElement,
     ButtonOrLinkProps
 >(({ href, to, ...props }, ref: any) => {


### PR DESCRIPTION
This adds a new "link" component. The difference between "Link" and "Button" is about visual presentation, not about functionality. Both `Link` and `Button` can be used as a button or a link under the hood (they use `ButtonOrLink`, which decides what to render based on the provided props).

I added two initial variants:
- `mono` - The variant used for addresses, objects, transaction IDs, etc. These all seem to be consistently styled.
- `text` - This is based on the [figma "button / text"](https://www.figma.com/file/Z5KaPvgurJJ9d4sZQTYBPT/01-Components-%3A-Explorer?node-id=1%3A117) component.

![Screen Shot 2022-10-19 at 1 05 09 PM](https://user-images.githubusercontent.com/109986297/196793313-938f08a2-cd16-43e9-a5ad-5164655be468.png)
