### PR TITLE
[Narwhal] use consistent channel names

### DIFF
--- a/narwhal/executor/src/lib.rs
+++ b/narwhal/executor/src/lib.rs
@@ -66,7 +66,7 @@ impl Executor {
 
         execution_state: State,
         tx_reconfigure: &watch::Sender<ReconfigureNotification>,
-        rx_consensus: metered_channel::Receiver<ConsensusOutput>,
+        rx_sequence: metered_channel::Receiver<ConsensusOutput>,
         registry: &Registry,
         restored_consensus_output: Vec<ConsensusOutput>,
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
@@ -88,7 +88,7 @@ impl Executor {
             worker_cache,
             committee,
             tx_reconfigure.subscribe(),
-            rx_consensus,
+            rx_sequence,
             tx_notifier,
             arc_metrics.clone(),
             restored_consensus_output,

--- a/narwhal/primary/src/block_remover.rs
+++ b/narwhal/primary/src/block_remover.rs
@@ -50,7 +50,7 @@ pub struct BlockRemover {
     worker_network: P2pNetwork,
 
     /// Outputs all the successfully deleted certificates
-    tx_removed_certificates: Sender<Certificate>,
+    tx_committed_certificates: Sender<Certificate>,
 }
 
 impl BlockRemover {
@@ -63,7 +63,7 @@ impl BlockRemover {
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         dag: Option<Arc<Dag>>,
         worker_network: P2pNetwork,
-        tx_removed_certificates: Sender<Certificate>,
+        tx_committed_certificates: Sender<Certificate>,
     ) -> BlockRemover {
         Self {
             name,
@@ -73,7 +73,7 @@ impl BlockRemover {
             payload_store,
             dag,
             worker_network,
-            tx_removed_certificates,
+            tx_committed_certificates,
         }
     }
 
@@ -161,7 +161,7 @@ impl BlockRemover {
 
         // Now output all the removed certificates
         for certificate in certificates.clone() {
-            self.tx_removed_certificates
+            self.tx_committed_certificates
                 .send(certificate)
                 .await
                 .expect("Couldn't forward removed certificates to channel");

--- a/narwhal/primary/src/block_synchronizer/handler.rs
+++ b/narwhal/primary/src/block_synchronizer/handler.rs
@@ -101,7 +101,7 @@ pub struct BlockSynchronizerHandler {
     /// Channel to send the fetched certificates to Core for
     /// further processing, validation and possibly causal
     /// completion.
-    tx_core: metered_channel::Sender<PrimaryMessage>,
+    tx_primary_messages: metered_channel::Sender<PrimaryMessage>,
 
     /// The store that holds the certificates.
     certificate_store: CertificateStore,
@@ -114,13 +114,13 @@ pub struct BlockSynchronizerHandler {
 impl BlockSynchronizerHandler {
     pub fn new(
         tx_block_synchronizer: metered_channel::Sender<Command>,
-        tx_core: metered_channel::Sender<PrimaryMessage>,
+        tx_primary_messages: metered_channel::Sender<PrimaryMessage>,
         certificate_store: CertificateStore,
         certificate_deliver_timeout: Duration,
     ) -> Self {
         Self {
             tx_block_synchronizer,
-            tx_core,
+            tx_primary_messages,
             certificate_store,
             certificate_deliver_timeout,
         }
@@ -183,7 +183,7 @@ impl Handler for BlockSynchronizerHandler {
                     if !block_header.fetched_from_storage {
                         // we need to perform causal completion since this
                         // entity has not been fetched from storage.
-                        self.tx_core
+                        self.tx_primary_messages
                             .send(PrimaryMessage::Certificate(
                                 block_header.certificate.clone(),
                             ))

--- a/narwhal/primary/src/block_synchronizer/mod.rs
+++ b/narwhal/primary/src/block_synchronizer/mod.rs
@@ -166,7 +166,7 @@ pub struct BlockSynchronizer {
     rx_reconfigure: watch::Receiver<ReconfigureNotification>,
 
     /// Receive the commands for the synchronizer
-    rx_commands: metered_channel::Receiver<Command>,
+    rx_block_synchronizer_commands: metered_channel::Receiver<Command>,
 
     /// Receive answers to requested assets (certificates, payloads) through this channel
     rx_availability_responses: metered_channel::Receiver<AvailabilityResponse>,
@@ -207,7 +207,7 @@ impl BlockSynchronizer {
         committee: Committee,
         worker_cache: SharedWorkerCache,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
-        rx_commands: metered_channel::Receiver<Command>,
+        rx_block_synchronizer_commands: metered_channel::Receiver<Command>,
         rx_availability_responses: metered_channel::Receiver<AvailabilityResponse>,
         network: P2pNetwork,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
@@ -221,7 +221,7 @@ impl BlockSynchronizer {
                 committee,
                 worker_cache,
                 rx_reconfigure,
-                rx_commands,
+                rx_block_synchronizer_commands,
                 rx_availability_responses,
                 pending_requests: HashMap::new(),
                 map_certificate_responses_senders: HashMap::new(),
@@ -260,7 +260,7 @@ impl BlockSynchronizer {
         );
         loop {
             tokio::select! {
-                Some(command) = self.rx_commands.recv() => {
+                Some(command) = self.rx_block_synchronizer_commands.recv() => {
                     match command {
                         Command::SynchronizeBlockHeaders { block_ids, respond_to } => {
                             let fut = self.handle_synchronize_block_headers_command(block_ids, respond_to).await;

--- a/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -47,7 +47,7 @@ async fn test_successful_headers_synchronization() {
 
     let (_tx_reconfigure, rx_reconfigure) =
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (tx_commands, rx_commands) = test_utils::test_channel!(10);
+    let (tx_commands, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (tx_availability_responses, rx_availability_responses) = test_utils::test_channel!(10);
 
     // AND some blocks (certificates)
@@ -100,7 +100,7 @@ async fn test_successful_headers_synchronization() {
         committee.clone(),
         worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         P2pNetwork::new(network.clone()),
         payload_store.clone(),
@@ -242,7 +242,7 @@ async fn test_successful_payload_synchronization() {
 
     let (_tx_reconfigure, rx_reconfigure) =
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (tx_commands, rx_commands) = test_utils::test_channel!(10);
+    let (tx_commands, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (tx_availability_responses, rx_availability_responses) = test_utils::test_channel!(10);
 
     // AND some blocks (certificates)
@@ -282,7 +282,7 @@ async fn test_successful_payload_synchronization() {
         committee.clone(),
         worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         P2pNetwork::new(network.clone()),
         payload_store.clone(),
@@ -450,7 +450,7 @@ async fn test_multiple_overlapping_requests() {
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
 
     let (_, rx_reconfigure) = watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (_, rx_commands) = test_utils::test_channel!(10);
+    let (_, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (_, rx_availability_responses) = test_utils::test_channel!(10);
 
     // AND some blocks (certificates)
@@ -484,7 +484,7 @@ async fn test_multiple_overlapping_requests() {
         committee: committee.clone(),
         worker_cache: worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         pending_requests: HashMap::new(),
         map_certificate_responses_senders: HashMap::new(),
@@ -579,7 +579,7 @@ async fn test_timeout_while_waiting_for_certificates() {
 
     let (_tx_reconfigure, rx_reconfigure) =
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (tx_commands, rx_commands) = test_utils::test_channel!(10);
+    let (tx_commands, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (_, rx_availability_responses) = test_utils::test_channel!(10);
 
     // AND some random block ids
@@ -617,7 +617,7 @@ async fn test_timeout_while_waiting_for_certificates() {
         committee.clone(),
         worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         P2pNetwork::new(network),
         payload_store.clone(),
@@ -689,7 +689,7 @@ async fn test_reply_with_certificates_already_in_storage() {
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
 
     let (_, rx_reconfigure) = watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (_, rx_commands) = test_utils::test_channel!(10);
+    let (_, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (_, rx_availability_responses) = test_utils::test_channel!(10);
 
     let own_address = network::multiaddr_to_address(&committee.primary(&name).unwrap()).unwrap();
@@ -705,7 +705,7 @@ async fn test_reply_with_certificates_already_in_storage() {
         committee: committee.clone(),
         worker_cache: worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         pending_requests: Default::default(),
         map_certificate_responses_senders: Default::default(),
@@ -793,7 +793,7 @@ async fn test_reply_with_payload_already_in_storage() {
     let network_key = primary.network_keypair().copy().private().0.to_bytes();
 
     let (_, rx_reconfigure) = watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (_, rx_commands) = test_utils::test_channel!(10);
+    let (_, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (_, rx_availability_responses) = test_utils::test_channel!(10);
 
     let own_address = network::multiaddr_to_address(&committee.primary(&name).unwrap()).unwrap();
@@ -808,7 +808,7 @@ async fn test_reply_with_payload_already_in_storage() {
         committee: committee.clone(),
         worker_cache: worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         pending_requests: Default::default(),
         map_certificate_responses_senders: Default::default(),
@@ -901,7 +901,7 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
     let name = primary.public_key();
 
     let (_, rx_reconfigure) = watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-    let (_, rx_commands) = test_utils::test_channel!(10);
+    let (_, rx_block_synchronizer_commands) = test_utils::test_channel!(10);
     let (_, rx_availability_responses) = test_utils::test_channel!(10);
 
     let own_address = network::multiaddr_to_address(&committee.primary(&name).unwrap()).unwrap();
@@ -916,7 +916,7 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
         committee: committee.clone(),
         worker_cache: worker_cache.clone(),
         rx_reconfigure,
-        rx_commands,
+        rx_block_synchronizer_commands,
         rx_availability_responses,
         pending_requests: Default::default(),
         map_certificate_responses_senders: Default::default(),

--- a/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/narwhal/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -18,11 +18,11 @@ async fn test_get_and_synchronize_block_headers_when_fetched_from_storage() {
     // GIVEN
     let (_, certificate_store, _) = create_db_stores();
     let (tx_block_synchronizer, rx_block_synchronizer) = test_utils::test_channel!(1);
-    let (tx_core, _rx_core) = test_utils::test_channel!(1);
+    let (tx_primary_messages, _rx_primary_messages) = test_utils::test_channel!(1);
 
     let synchronizer = BlockSynchronizerHandler {
         tx_block_synchronizer,
-        tx_core,
+        tx_primary_messages,
         certificate_store: certificate_store.clone(),
         certificate_deliver_timeout: Duration::from_millis(2_000),
     };
@@ -76,11 +76,11 @@ async fn test_get_and_synchronize_block_headers_when_fetched_from_peers() {
     // GIVEN
     let (_, certificate_store, _) = create_db_stores();
     let (tx_block_synchronizer, rx_block_synchronizer) = test_utils::test_channel!(1);
-    let (tx_core, mut rx_core) = test_utils::test_channel!(1);
+    let (tx_primary_messages, mut rx_primary_messages) = test_utils::test_channel!(1);
 
     let synchronizer = BlockSynchronizerHandler {
         tx_block_synchronizer,
-        tx_core,
+        tx_primary_messages,
         certificate_store: certificate_store.clone(),
         certificate_deliver_timeout: Duration::from_millis(2_000),
     };
@@ -138,7 +138,7 @@ async fn test_get_and_synchronize_block_headers_when_fetched_from_peers() {
     // AND mock the "core" module. We assume that the certificate will be
     // stored after validated and causally complete the history.
     tokio::spawn(async move {
-        match rx_core.recv().await {
+        match rx_primary_messages.recv().await {
             Some(PrimaryMessage::Certificate(c)) => {
                 assert_eq!(c.digest(), cert_missing.digest());
                 certificate_store.write(c).unwrap();
@@ -175,11 +175,11 @@ async fn test_get_and_synchronize_block_headers_timeout_on_causal_completion() {
     // GIVEN
     let (_, certificate_store, _) = create_db_stores();
     let (tx_block_synchronizer, rx_block_synchronizer) = test_utils::test_channel!(1);
-    let (tx_core, _rx_core) = test_utils::test_channel!(1);
+    let (tx_primary_messages, _rx_primary_messages) = test_utils::test_channel!(1);
 
     let synchronizer = BlockSynchronizerHandler {
         tx_block_synchronizer,
-        tx_core,
+        tx_primary_messages,
         certificate_store: certificate_store.clone(),
         certificate_deliver_timeout: Duration::from_millis(2_000),
     };
@@ -256,11 +256,11 @@ async fn test_synchronize_block_payload() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
     let (tx_block_synchronizer, rx_block_synchronizer) = test_utils::test_channel!(1);
-    let (tx_core, _rx_core) = test_utils::test_channel!(1);
+    let (tx_primary_messages, _rx_primary_messages) = test_utils::test_channel!(1);
 
     let synchronizer = BlockSynchronizerHandler {
         tx_block_synchronizer,
-        tx_core,
+        tx_primary_messages,
         certificate_store: certificate_store.clone(),
         certificate_deliver_timeout: Duration::from_millis(2_000),
     };
@@ -338,11 +338,11 @@ async fn test_call_methods_with_empty_input() {
     // GIVEN
     let (_, certificate_store, _) = create_db_stores();
     let (tx_block_synchronizer, _) = test_utils::test_channel!(1);
-    let (tx_core, _rx_core) = test_utils::test_channel!(1);
+    let (tx_primary_messages, _rx_primary_messages) = test_utils::test_channel!(1);
 
     let synchronizer = BlockSynchronizerHandler {
         tx_block_synchronizer,
-        tx_core,
+        tx_primary_messages,
         certificate_store: certificate_store.clone(),
         certificate_deliver_timeout: Duration::from_millis(2_000),
     };

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -66,7 +66,7 @@ pub struct PrimaryChannelMetrics {
     /// occupancy of the channel from the `primary::Proposer` to the `primary::Core`
     pub tx_headers: IntGauge,
     /// occupancy of the channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`
-    pub tx_sync_headers: IntGauge,
+    pub tx_header_waiter: IntGauge,
     /// occupancy of the channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`
     pub tx_certificate_waiter: IntGauge,
     /// occupancy of the channel from the `primary::HeaderWaiter` to the `primary::Core`
@@ -100,7 +100,7 @@ pub struct PrimaryChannelMetrics {
     /// total received on channel from the `primary::Proposer` to the `primary::Core`
     pub tx_headers_total: IntCounter,
     /// total received on channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`
-    pub tx_sync_headers_total: IntCounter,
+    pub tx_header_waiter_total: IntCounter,
     /// total received on channel from the `primary::Synchronizer` to the `primary::CertificaterWaiter`
     pub tx_certificate_waiter_total: IntCounter,
     /// total received on channel from the `primary::HeaderWaiter` to the `primary::Core`
@@ -170,7 +170,7 @@ impl PrimaryChannelMetrics {
                 "occupancy of the channel from the `primary::Proposer` to the `primary::Core`",
                 registry
             ).unwrap(),
-            tx_sync_headers: register_int_gauge_with_registry!(
+            tx_header_waiter: register_int_gauge_with_registry!(
                 "tx_sync_headers",
                 "occupancy of the channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`",
                 registry
@@ -252,7 +252,7 @@ impl PrimaryChannelMetrics {
                 "total received on channel from the `primary::Proposer` to the `primary::Core`",
                 registry
             ).unwrap(),
-            tx_sync_headers_total: register_int_counter_with_registry!(
+            tx_header_waiter_total: register_int_counter_with_registry!(
                 "tx_sync_headers_total",
                 "total received on channel from the `primary::Synchronizer` to the `primary::HeaderWaiter`",
                 registry

--- a/narwhal/worker/src/metrics.rs
+++ b/narwhal/worker/src/metrics.rs
@@ -98,10 +98,6 @@ pub struct WorkerChannelMetrics {
     pub tx_batch_maker: IntGauge,
     /// occupancy of the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`
     pub tx_quorum_waiter: IntGauge,
-    /// occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`
-    pub tx_worker_processor: IntGauge,
-    /// occupancy of the channel from the `worker::QuorumWaiter` to the `worker::Processor`
-    pub tx_client_processor: IntGauge,
 
     // Record the total events received to infer progress rates
     /// total received from the channel from various handlers to the `worker::PrimaryConnector`
@@ -112,10 +108,6 @@ pub struct WorkerChannelMetrics {
     pub tx_batch_maker_total: IntCounter,
     /// total received from the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`
     pub tx_quorum_waiter_total: IntCounter,
-    /// total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`
-    pub tx_worker_processor_total: IntCounter,
-    /// total received from the channel from the `worker::QuorumWaiter` to the `worker::Processor`
-    pub tx_client_processor_total: IntCounter,
 }
 
 impl WorkerChannelMetrics {
@@ -141,16 +133,6 @@ impl WorkerChannelMetrics {
                 "occupancy of the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`",
                 registry
             ).unwrap(),
-            tx_worker_processor: register_int_gauge_with_registry!(
-                "tx_worker_processor",
-                "occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`",
-                registry
-            ).unwrap(),
-            tx_client_processor: register_int_gauge_with_registry!(
-                "tx_client_processor",
-                "occupancy of the channel from the `worker::QuorumWaiter` to the `worker::Processor`",
-                registry
-            ).unwrap(),
 
             // Totals:
 
@@ -172,16 +154,6 @@ impl WorkerChannelMetrics {
             tx_quorum_waiter_total: register_int_counter_with_registry!(
                 "tx_quorum_waiter_total",
                 "total received from the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`",
-                registry
-            ).unwrap(),
-            tx_worker_processor_total: register_int_counter_with_registry!(
-                "tx_worker_processor_total",
-                "total received from the channel from the `worker::WorkerReceiverHandler` to the `worker::Processor`",
-                registry
-            ).unwrap(),
-            tx_client_processor_total: register_int_counter_with_registry!(
-                "tx_client_processor_total",
-                "total received from the channel from the `worker::QuorumWaiter` to the `worker::Processor`",
                 registry
             ).unwrap(),
         }

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -309,8 +309,8 @@ impl Worker {
             self.parameters.batch_size,
             self.parameters.max_batch_delay,
             rx_reconfigure.clone(),
-            /* rx_transaction */ rx_batch_maker,
-            /* tx_message */ tx_quorum_waiter,
+            rx_batch_maker,
+            tx_quorum_waiter,
             node_metrics,
         );
 
@@ -323,8 +323,8 @@ impl Worker {
             (*(*(*self.committee).load()).clone()).clone(),
             self.worker_cache.clone(),
             rx_reconfigure,
-            /* rx_message */ rx_quorum_waiter,
-            /* tx_batch */ tx_our_batch,
+            rx_quorum_waiter,
+            tx_our_batch,
             P2pNetwork::new(network),
         );
 


### PR DESCRIPTION
For each channel entity, make the name consistent in the following cases:
- Metric names related to the channel.
- Name of struct members storing the channel.
- Name of function args passing the channel.

In most cases, names referring to a channel is updated to the name of the metric monitoring the channel. This should help us know clearly which channel is being referred to when reading code.