### PR TITLE
Increase default connection and request timeout

### DIFF
--- a/crates/sui-network/src/lib.rs
+++ b/crates/sui-network/src/lib.rs
@@ -8,8 +8,8 @@ pub mod api;
 
 pub use tonic;
 
-pub const DEFAULT_CONNECT_TIMEOUT_SEC: Duration = Duration::from_secs(5);
-pub const DEFAULT_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(5);
+pub const DEFAULT_CONNECT_TIMEOUT_SEC: Duration = Duration::from_secs(10);
+pub const DEFAULT_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(30);
 pub const DEFAULT_HTTP2_KEEPALIVE_SEC: Duration = Duration::from_secs(5);
 
 pub fn default_mysten_network_config() -> Config {


### PR DESCRIPTION
Narwhal consensus latency is 5~6s in private testnet. Using a timeout of 5s is too low. Increasing the default value to avoid timeout errors. These defaults are used by AuthorityClients.

Verified that this fixes the timeout errors in private testnet:
<img width="1619" alt="image" src="https://user-images.githubusercontent.com/81660174/196827307-b486caf5-4a8f-45e1-823f-224269889fd0.png">
