### PR TITLE
[wallet-ext] Add feature-flagged denomination to wallet

### DIFF
--- a/apps/explorer/src/utils/growthbook.ts
+++ b/apps/explorer/src/utils/growthbook.ts
@@ -25,7 +25,9 @@ export async function loadFeatures() {
             throw new Error(res.statusText);
         }
 
-        growthbook.setFeatures(await res.json());
+        const data = await res.json();
+
+        growthbook.setFeatures(data.features);
     } catch (e) {
         console.warn('Failed to fetch feature definitions from Growthbook', e);
     }

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -55,6 +55,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.2.0",
+        "happy-dom": "^7.6.0",
         "html-webpack-plugin": "^5.5.0",
         "mini-css-extract-plugin": "^2.6.1",
         "onchange": "^7.1.0",
@@ -113,6 +114,7 @@
         "tailwindcss": "^3.0.23",
         "tweetnacl": "^1.0.3",
         "uuid": "^8.3.2",
+        "vite-tsconfig-paths": "^3.5.0",
         "webextension-polyfill": "^0.9.0",
         "yup": "^0.32.11",
         "zxcvbn": "^4.4.2"

--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -83,6 +83,7 @@
     "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.10.1",
         "@growthbook/growthbook": "^0.18.1",
+        "@growthbook/growthbook-react": "^0.9.1",
         "@metamask/browser-passworder": "^3.0.0",
         "@mysten/core": "workspace:*",
         "@mysten/sui.js": "workspace:*",
@@ -90,6 +91,8 @@
         "@reduxjs/toolkit": "^1.8.3",
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",
+        "@tanstack/react-query": "^4.0.10",
+        "bignumber.js": "^9.1.0",
         "bootstrap-icons": "^1.9.1",
         "buffer": "^6.0.3",
         "classnames": "^2.3.1",

--- a/apps/wallet/src/shared/formatting.ts
+++ b/apps/wallet/src/shared/formatting.ts
@@ -3,10 +3,6 @@
 
 import type { FormatNumberOptions } from 'react-intl';
 
-export const balanceFormatOptions: FormatNumberOptions = {
-    maximumFractionDigits: 0,
-};
-
 export const percentageFormatOptions: FormatNumberOptions = {
     style: 'percent',
     maximumFractionDigits: 2,

--- a/apps/wallet/src/shared/validation.ts
+++ b/apps/wallet/src/shared/validation.ts
@@ -19,10 +19,10 @@ export function createTokenValidation(
     decimals: number
 ) {
     return Yup.mixed()
-        .required()
         .transform((_, original) => {
             return new BigNumber(original);
         })
+        .test('required', `\${path} is a required field`, (value) => !!value)
         .test(
             'valid',
             'The value provided is not valid.',

--- a/apps/wallet/src/shared/validation.ts
+++ b/apps/wallet/src/shared/validation.ts
@@ -16,7 +16,9 @@ export function createTokenValidation(
     coinBalance: bigint,
     coinSymbol: string,
     gasBalance: bigint,
-    decimals: number
+    decimals: number,
+    // TODO: We can move this to a constant when MIST is fully rolled out.
+    gasDecimals: number
 ) {
     return Yup.mixed()
         .transform((_, original) => {
@@ -58,7 +60,7 @@ export function createTokenValidation(
             'gas-balance-check',
             `Insufficient ${GAS_SYMBOL} balance to cover gas fee (${formatBalance(
                 DEFAULT_GAS_BUDGET_FOR_TRANSFER,
-                decimals
+                gasDecimals
             )} ${GAS_SYMBOL})`,
             (amount: BigNumber) => {
                 try {

--- a/apps/wallet/src/shared/validation.ts
+++ b/apps/wallet/src/shared/validation.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import BigNumber from 'bignumber.js';
+import * as Yup from 'yup';
+
+import { formatBalance } from '_src/ui/app/hooks/useFormatCoin';
+import {
+    DEFAULT_GAS_BUDGET_FOR_TRANSFER,
+    GAS_SYMBOL,
+    GAS_TYPE_ARG,
+} from '_src/ui/app/redux/slices/sui-objects/Coin';
+
+export function createTokenValidation(
+    coinType: string,
+    coinBalance: bigint,
+    coinSymbol: string,
+    gasBalance: bigint,
+    decimals: number
+) {
+    return Yup.mixed()
+        .required()
+        .transform((_, original) => {
+            return new BigNumber(original);
+        })
+        .test(
+            'valid',
+            'The value provided is not valid.',
+            (value: BigNumber) => {
+                if (value.isNaN() || !value.isFinite()) {
+                    return false;
+                }
+                return true;
+            }
+        )
+        .test(
+            'min',
+            `\${path} must be greater than 0 ${coinSymbol}`,
+            (amount: BigNumber) => amount.gt(0)
+        )
+        .test(
+            'max',
+            `\${path} must be less than ${formatBalance(
+                coinBalance,
+                decimals
+            )} ${coinSymbol}`,
+            (amount: BigNumber) =>
+                amount.shiftedBy(decimals).lte(coinBalance.toString())
+        )
+        .test(
+            'max-decimals',
+            `The value exeeds the maximum decimals (${decimals}).`,
+            (value: BigNumber) => {
+                return value.shiftedBy(decimals).isInteger();
+            }
+        )
+        .test(
+            'gas-balance-check',
+            `Insufficient ${GAS_SYMBOL} balance to cover gas fee (${formatBalance(
+                DEFAULT_GAS_BUDGET_FOR_TRANSFER,
+                decimals
+            )} ${GAS_SYMBOL})`,
+            (amount: BigNumber) => {
+                try {
+                    let availableGas = gasBalance;
+                    if (coinType === GAS_TYPE_ARG) {
+                        availableGas -= BigInt(
+                            amount.shiftedBy(decimals).toString()
+                        );
+                    }
+                    // TODO: implement more sophisticated validation by taking
+                    // the splitting/merging fee into account
+                    return availableGas >= DEFAULT_GAS_BUDGET_FOR_TRANSFER;
+                } catch (e) {
+                    return false;
+                }
+            }
+        )
+        .label('Amount');
+}

--- a/apps/wallet/src/shared/validation.ts
+++ b/apps/wallet/src/shared/validation.ts
@@ -4,12 +4,12 @@
 import BigNumber from 'bignumber.js';
 import * as Yup from 'yup';
 
-import { formatBalance } from '_src/ui/app/hooks/useFormatCoin';
+import { formatBalance } from '_app/hooks/useFormatCoin';
 import {
     DEFAULT_GAS_BUDGET_FOR_TRANSFER,
     GAS_SYMBOL,
     GAS_TYPE_ARG,
-} from '_src/ui/app/redux/slices/sui-objects/Coin';
+} from '_redux/slices/sui-objects/Coin';
 
 export function createTokenValidation(
     coinType: string,

--- a/apps/wallet/src/ui/app/components/active-coins-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/active-coins-card/index.tsx
@@ -5,9 +5,8 @@ import cl from 'classnames';
 import { useMemo, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 
-import { useFormatCoin } from '../../hooks/useFormatCoin';
 import Icon, { SuiIcons } from '_components/icon';
-import { useAppSelector } from '_hooks';
+import { useAppSelector, useFormatCoin } from '_hooks';
 import { accountAggregateBalancesSelector } from '_redux/slices/account';
 import { GAS_TYPE_ARG, Coin } from '_redux/slices/sui-objects/Coin';
 

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -3,11 +3,10 @@
 
 import cl from 'classnames';
 
-import { useFormatCoin } from '../../hooks/useFormatCoin';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
 import { formatDate } from '_helpers';
-import { useMiddleEllipsis } from '_hooks';
+import { useMiddleEllipsis, useFormatCoin } from '_hooks';
 import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 import type { TxResultState } from '_redux/slices/txresults';

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { useIntl } from 'react-intl';
 
 import { useFormatCoin } from '../../hooks/useFormatCoin';
 import ExplorerLink from '_components/explorer-link';
@@ -88,8 +87,6 @@ function ReceiptCard({ txDigest }: TxResponseProps) {
             failedMsg: '',
         },
     };
-
-    const intl = useIntl();
 
     const imgUrl = txDigest?.url
         ? txDigest?.url.replace(/^ipfs:\/\//, 'https://ipfs.io/ipfs/')

--- a/apps/wallet/src/ui/app/components/receipt-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/receipt-card/index.tsx
@@ -4,12 +4,12 @@
 import cl from 'classnames';
 import { useIntl } from 'react-intl';
 
+import { useFormatCoin } from '../../hooks/useFormatCoin';
 import ExplorerLink from '_components/explorer-link';
 import { ExplorerLinkType } from '_components/explorer-link/ExplorerLinkType';
 import { formatDate } from '_helpers';
 import { useMiddleEllipsis } from '_hooks';
-import { GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
-import { balanceFormatOptions } from '_shared/formatting';
+import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 import type { TxResultState } from '_redux/slices/txresults';
 
@@ -122,6 +122,20 @@ function ReceiptCard({ txDigest }: TxResponseProps) {
     const statusClassName =
         txDigest.status === 'success' ? st.success : st.failed;
 
+    const [formatted, symbol] = useFormatCoin(
+        txDigest.amount || txDigest.balance || 0,
+        txDigest.coinType
+    );
+
+    const [gas, gasSymbol] = useFormatCoin(txDigest.txGas, GAS_TYPE_ARG);
+
+    const [total, totalSymbol] = useFormatCoin(
+        txDigest.amount && txDigest.isSender
+            ? txDigest.amount + txDigest.txGas
+            : null,
+        GAS_TYPE_ARG
+    );
+
     return (
         <>
             <div className={cl(st.txnResponse, statusClassName)}>
@@ -142,15 +156,8 @@ function ReceiptCard({ txDigest }: TxResponseProps) {
                             </div>
                             {(txDigest.amount || txDigest.balance) && (
                                 <div className={st.amount}>
-                                    {intl.formatNumber(
-                                        BigInt(
-                                            txDigest.amount ||
-                                                txDigest.balance ||
-                                                0
-                                        ),
-                                        balanceFormatOptions
-                                    )}
-                                    <span>{txDigest.coinSymbol}</span>
+                                    {formatted}
+                                    <span>{symbol}</span>
                                 </div>
                             )}
                         </div>
@@ -190,7 +197,7 @@ function ReceiptCard({ txDigest }: TxResponseProps) {
                         >
                             <div className={st.label}>Gas Fees</div>
                             <div className={st.value}>
-                                {txDigest.txGas} {GAS_SYMBOL}
+                                {gas} {gasSymbol}
                             </div>
                         </div>
                     )}
@@ -199,13 +206,7 @@ function ReceiptCard({ txDigest }: TxResponseProps) {
                         <div className={cl(st.txFees, st.txnItem)}>
                             <div className={st.txInfoLabel}>Total Amount</div>
                             <div className={st.walletInfoValue}>
-                                {intl.formatNumber(
-                                    BigInt(
-                                        txDigest.amount + txDigest.txGas || 0
-                                    ),
-                                    balanceFormatOptions
-                                )}{' '}
-                                {GAS_SYMBOL}
+                                {total} {totalSymbol}
                             </div>
                         </div>
                     )}

--- a/apps/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -3,14 +3,13 @@
 
 import cl from 'classnames';
 import { memo } from 'react';
-import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import { useFormatCoin } from '../../hooks/useFormatCoin';
+import { GAS_TYPE_ARG } from '../../redux/slices/sui-objects/Coin';
 import Icon, { SuiIcons } from '_components/icon';
 import { formatDate } from '_helpers';
 import { useMiddleEllipsis } from '_hooks';
-import { GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
-import { balanceFormatOptions } from '_shared/formatting';
 
 import type { TxResultState } from '_redux/slices/txresults';
 
@@ -23,8 +22,6 @@ const TRUNCATE_PREFIX_LENGTH = 4;
 const TRUNCATE_MAX_CHAR = 35;
 
 function TransactionCard({ txn }: { txn: TxResultState }) {
-    const intl = useIntl();
-
     const toAddrStr = useMiddleEllipsis(
         txn.to || '',
         TRUNCATE_MAX_LENGTH,
@@ -46,8 +43,6 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
         TRUNCATE_MAX_CHAR,
         TRUNCATE_MAX_CHAR - 1
     );
-
-    const coinSymbol = txn.coinSymbol || GAS_SYMBOL;
 
     // TODO: update to account for bought, minted, swapped, etc
     const transferType =
@@ -107,6 +102,11 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
         <span className={st.callFnName}>({txn?.callFunctionName})</span>
     ) : null;
 
+    const [formattedAmount, symbol] = useFormatCoin(
+        transferMeta[transferType].amount,
+        txn.coinType || GAS_TYPE_ARG
+    );
+
     return (
         <Link
             to={`/receipt?${new URLSearchParams({
@@ -133,11 +133,7 @@ function TransactionCard({ txn }: { txn: TxResultState }) {
 
                         <div className={st.txTransferred}>
                             <div className={st.txAmount}>
-                                {intl.formatNumber(
-                                    BigInt(transferMeta[transferType].amount),
-                                    balanceFormatOptions
-                                )}{' '}
-                                <span>{coinSymbol}</span>
+                                {formattedAmount} <span>{symbol}</span>
                             </div>
                         </div>
                     </div>

--- a/apps/wallet/src/ui/app/components/transactions-card/index.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/index.tsx
@@ -5,11 +5,10 @@ import cl from 'classnames';
 import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
-import { useFormatCoin } from '../../hooks/useFormatCoin';
-import { GAS_TYPE_ARG } from '../../redux/slices/sui-objects/Coin';
 import Icon, { SuiIcons } from '_components/icon';
 import { formatDate } from '_helpers';
-import { useMiddleEllipsis } from '_hooks';
+import { useMiddleEllipsis, useFormatCoin } from '_hooks';
+import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 import type { TxResultState } from '_redux/slices/txresults';
 

--- a/apps/wallet/src/ui/app/experimentation/feature-gating.ts
+++ b/apps/wallet/src/ui/app/experimentation/feature-gating.ts
@@ -3,50 +3,28 @@
 
 import { GrowthBook } from '@growthbook/growthbook';
 
-import type { JSONValue } from '@growthbook/growthbook';
-
 const GROWTHBOOK_API_KEY =
     process.env.NODE_ENV === 'production'
         ? 'key_prod_ac59fe325855eb5f'
         : 'key_dev_dc2872e15e0c5f95';
-export default class FeatureGating {
-    #growthBook: GrowthBook;
 
-    constructor() {
-        // Create a GrowthBook context
-        this.#growthBook = new GrowthBook();
-    }
+export const growthbook = new GrowthBook();
 
-    public async init() {
-        // Load feature definitions
-        await fetch(
+export async function loadFeatures() {
+    try {
+        const res = await fetch(
             `https://cdn.growthbook.io/api/features/${GROWTHBOOK_API_KEY}`
-        )
-            .then((res) => {
-                if (res.ok) {
-                    return res.json();
-                }
-                throw new Error(res.statusText);
-            })
-            .then((parsed) => {
-                this.#growthBook.setFeatures(parsed.features);
-            })
-            .catch(() => {
-                // eslint-disable-next-line no-console
-                console.warn(
-                    `Failed to fetch feature definitions from GrowthBook with API_KEY ${process.env.GROWTH_BOOK_API_KEY}`
-                );
-            });
-    }
+        );
 
-    public isOn(featureName: string): boolean {
-        return this.#growthBook.isOn(featureName);
-    }
+        if (!res.ok) {
+            throw new Error(res.statusText);
+        }
 
-    public getFeatureValue<T extends JSONValue>(
-        featureName: string,
-        defaultValue: T
-    ) {
-        return this.#growthBook.getFeatureValue(featureName, defaultValue);
+        const data = await res.json();
+
+        growthbook.setFeatures(data.features);
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to fetch feature definitions from Growthbook', e);
     }
 }

--- a/apps/wallet/src/ui/app/experimentation/features.ts
+++ b/apps/wallet/src/ui/app/experimentation/features.ts
@@ -8,4 +8,5 @@
 export enum FEATURES {
     DEPRECATE_GATEWAY = 'deprecate-gateway',
     RPC_API_VERSION = 'rpc-api-version',
+    SUI_DENOMINATION = 'sui-denomination',
 }

--- a/apps/wallet/src/ui/app/helpers/queryClient.ts
+++ b/apps/wallet/src/ui/app/helpers/queryClient.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { QueryClient } from '@tanstack/react-query';
 
 export const queryClient = new QueryClient({

--- a/apps/wallet/src/ui/app/helpers/queryClient.ts
+++ b/apps/wallet/src/ui/app/helpers/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            // Only retry once by default:
+            retry: 1,
+            // TODO: Rather than disabling all automatic refetching, we should find sane defaults here:
+            refetchOnMount: false,
+            refetchOnWindowFocus: false,
+            refetchInterval: 0,
+            refetchIntervalInBackground: false,
+        },
+    },
+});

--- a/apps/wallet/src/ui/app/hooks/index.ts
+++ b/apps/wallet/src/ui/app/hooks/index.ts
@@ -15,3 +15,4 @@ export { default as useFileExtentionType } from './useFileExtentionType';
 export { default as useNFTBasicData } from './useNFTBasicData';
 export { useObjectsState } from './useObjectsState';
 export { useWaitForElement } from './useWaitForElement';
+export { useFormatCoin, useCoinDecimals } from './useFormatCoin';

--- a/apps/wallet/src/ui/app/hooks/useFormatCoin.test.ts
+++ b/apps/wallet/src/ui/app/hooks/useFormatCoin.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import BigNumber from 'bignumber.js';
+import { describe, it, expect } from 'vitest';
+
+import { formatBalance } from './useFormatCoin';
+
+const SUI_DECIMALS = 9;
+
+function toMist(sui: string) {
+    return new BigNumber(sui).shiftedBy(SUI_DECIMALS).toString();
+}
+
+describe('formatBalance', () => {
+    it('formats zero amounts correctly', () => {
+        expect(formatBalance('0', 0)).toEqual('0');
+        expect(formatBalance('0', SUI_DECIMALS)).toEqual('0');
+    });
+
+    it('formats decimal amounts correctly', () => {
+        expect(formatBalance('0', SUI_DECIMALS)).toEqual('0');
+        expect(formatBalance('0.000', SUI_DECIMALS)).toEqual('0');
+    });
+
+    it('formats integer amounts correctly', () => {
+        expect(formatBalance(toMist('1'), SUI_DECIMALS)).toEqual('1');
+        expect(formatBalance(toMist('1.0001'), SUI_DECIMALS)).toEqual('1');
+        expect(formatBalance(toMist('1.1201'), SUI_DECIMALS)).toEqual('1.12');
+        expect(formatBalance(toMist('1.1234'), SUI_DECIMALS)).toEqual('1.123');
+        expect(formatBalance(toMist('1.1239'), SUI_DECIMALS)).toEqual('1.123');
+
+        expect(formatBalance(toMist('9999.9999'), SUI_DECIMALS)).toEqual(
+            '9,999.999'
+        );
+        // 10k + handling:
+        expect(formatBalance(toMist('10000'), SUI_DECIMALS)).toEqual('10 K');
+        expect(formatBalance(toMist('12345'), SUI_DECIMALS)).toEqual(
+            '12.345 K'
+        );
+        // Millions:
+        expect(formatBalance(toMist('1234000'), SUI_DECIMALS)).toEqual(
+            '1.234 M'
+        );
+        // Billions:
+        expect(formatBalance(toMist('1234000000'), SUI_DECIMALS)).toEqual(
+            '1.234 B'
+        );
+    });
+});

--- a/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
+++ b/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
@@ -1,0 +1,77 @@
+import { useFeature } from '@growthbook/growthbook-react';
+import { useQuery } from '@tanstack/react-query';
+import BigNumber from 'bignumber.js';
+import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
+
+import { FEATURES } from '../experimentation/features';
+import { Coin } from '../redux/slices/sui-objects/Coin';
+import { api } from '../redux/store/thunk-extras';
+
+type FormattedCoin = [formattedBalance: string, coinSymbol: string];
+
+export function useCoinDecimals(coinType?: string | null) {
+    const suiDenomination = useFeature(FEATURES.SUI_DENOMINATION).on;
+
+    const queryResult = useQuery(
+        ['denomination', coinType],
+        async () => {
+            if (!coinType) {
+                throw new Error(
+                    'Fetching coin denomination should be disabled when coin type is disabled.'
+                );
+            }
+
+            return api.instance.fullNode.getCoinDenominationInfo(coinType);
+        },
+        {
+            // This is expected to fail, so disable retries:
+            retry: false,
+            enabled: suiDenomination && !!coinType,
+        }
+    );
+
+    return [queryResult.data?.decimalNumber || 0, queryResult] as const;
+}
+
+export function formatBalance(
+    balance: bigint | number | string,
+    decimals: number
+) {
+    const bn = new BigNumber(balance.toString()).shiftedBy(-1 * decimals);
+
+    return bn.toFormat(bn.gte(1) ? 2 : undefined);
+}
+
+// TODO: This handles undefined values to make it easier to integrate with the reset of the app as it is
+// today, but it really shouldn't in a perfect world.
+export function useFormatCoin(
+    balance?: bigint | number | string | null,
+    coinType?: string | null
+): FormattedCoin {
+    const intl = useIntl();
+    const suiDenomination = useFeature(FEATURES.SUI_DENOMINATION).on;
+    const symbol = useMemo(
+        () => (coinType ? Coin.getCoinSymbol(coinType) : ''),
+        [coinType]
+    );
+
+    const [decimals, { isFetched, isError }] = useCoinDecimals(coinType);
+
+    const formatted = useMemo(() => {
+        if (!balance) return '';
+
+        if (!suiDenomination || isError) {
+            return intl.formatNumber(BigInt(balance), {
+                maximumFractionDigits: 0,
+            });
+        }
+
+        // TODO: Figure out more ideal loading state:
+        if (!isFetched) return '...';
+
+        return formatBalance(balance, decimals);
+    }, [decimals, isError, isFetched, suiDenomination, intl, balance]);
+
+    return [formatted, symbol];
+}

--- a/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
+++ b/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useFeature } from '@growthbook/growthbook-react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
@@ -11,7 +11,11 @@ import { FEATURES } from '../experimentation/features';
 import { Coin } from '../redux/slices/sui-objects/Coin';
 import { api } from '../redux/store/thunk-extras';
 
-type FormattedCoin = [formattedBalance: string, coinSymbol: string];
+type FormattedCoin = [
+    formattedBalance: string,
+    coinSymbol: string,
+    queryResult: UseQueryResult
+];
 
 /**
  * Formats a coin balance based on our standard coin display logic.
@@ -85,7 +89,8 @@ export function useFormatCoin(
         [coinType]
     );
 
-    const [decimals, { isFetched, isError }] = useCoinDecimals(coinType);
+    const [decimals, queryResult] = useCoinDecimals(coinType);
+    const { isFetched, isError } = queryResult;
 
     const formatted = useMemo(() => {
         if (typeof balance === 'undefined' || balance === null) return '';
@@ -96,11 +101,10 @@ export function useFormatCoin(
             });
         }
 
-        // TODO: Figure out more ideal loading state:
         if (!isFetched) return '...';
 
         return formatBalance(balance, decimals);
     }, [decimals, isError, isFetched, suiDenomination, intl, balance]);
 
-    return [formatted, symbol];
+    return [formatted, symbol, queryResult];
 }

--- a/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
+++ b/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 import { useFeature } from '@growthbook/growthbook-react';
 import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';

--- a/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
+++ b/apps/wallet/src/ui/app/hooks/useFormatCoin.ts
@@ -13,13 +13,22 @@ import { api } from '../redux/store/thunk-extras';
 
 type FormattedCoin = [formattedBalance: string, coinSymbol: string];
 
+/**
+ * Formats a coin balance based on our standard coin display logic.
+ * If the balance is less than 1, it will be displayed in its full decimal form.
+ * For values greater than 1, it will be truncated to 3 decimal places.
+ */
 export function formatBalance(
     balance: bigint | number | string,
     decimals: number
 ) {
     const bn = new BigNumber(balance.toString()).shiftedBy(-1 * decimals);
 
-    return bn.toFormat(bn.gte(1) ? 2 : undefined);
+    // NOTE: This double-format will trim any trailing 0's.
+    return new BigNumber(
+        // @ts-expect-error: The BigNumber types are wrong.
+        bn.toFormat(bn.gte(1) ? 3 : undefined, BigNumber.ROUND_DOWN)
+    ).toFormat();
 }
 
 export function useCoinDecimals(coinType?: string | null) {

--- a/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import cl from 'classnames';
-import { memo, useMemo } from 'react';
-import { useIntl } from 'react-intl';
+import { memo } from 'react';
 
 import { useMiddleEllipsis } from '_hooks';
-import { Coin } from '_redux/slices/sui-objects/Coin';
-import { balanceFormatOptions } from '_shared/formatting';
+import { useFormatCoin } from '_src/ui/app/hooks/useFormatCoin';
 
 import st from './CoinBalance.module.scss';
 
@@ -19,20 +17,13 @@ export type CoinProps = {
 };
 
 function CoinBalance({ type, balance, mode = 'row-item' }: CoinProps) {
-    const symbol = useMemo(() => Coin.getCoinSymbol(type), [type]);
-    const intl = useIntl();
-    const balanceFormatted = useMemo(
-        () => intl.formatNumber(balance, balanceFormatOptions),
-        [intl, balance]
-    );
+    const [formatted, symbol] = useFormatCoin(balance, type);
 
     const shortenType = useMiddleEllipsis(type, 30);
     return (
         <div className={cl(st.container, st[mode])}>
             <div className={cl(st.valuesContainer, st[mode])}>
-                <span className={cl(st.value, st[mode])}>
-                    {balanceFormatted}
-                </span>
+                <span className={cl(st.value, st[mode])}>{formatted}</span>
                 <span className={cl(st.symbol, st[mode])}>{symbol}</span>
             </div>
             <div className={cl(st.typeActionsContainer, st[mode])}>

--- a/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/tokens/coin-balance/index.tsx
@@ -4,8 +4,7 @@
 import cl from 'classnames';
 import { memo } from 'react';
 
-import { useMiddleEllipsis } from '_hooks';
-import { useFormatCoin } from '_src/ui/app/hooks/useFormatCoin';
+import { useMiddleEllipsis, useFormatCoin } from '_hooks';
 
 import st from './CoinBalance.module.scss';
 

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepOne.tsx
@@ -55,6 +55,7 @@ function StepOne({
                         name="amount"
                         placeholder={`Total ${coinSymbol.toLocaleUpperCase()} to send`}
                         className={st.input}
+                        decimals
                     />
 
                     <ErrorMessage

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
@@ -11,15 +11,12 @@ import Button from '_app/shared/button';
 import AddressInput from '_components/address-input';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
+import { useCoinDecimals, useFormatCoin } from '_hooks';
 import {
     DEFAULT_GAS_BUDGET_FOR_TRANSFER,
     GAS_SYMBOL,
     GAS_TYPE_ARG,
 } from '_redux/slices/sui-objects/Coin';
-import {
-    useCoinDecimals,
-    useFormatCoin,
-} from '_src/ui/app/hooks/useFormatCoin';
 
 import type { FormValues } from '../';
 

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
@@ -52,7 +52,8 @@ function StepTwo({
 
     const [decimals] = useCoinDecimals(coinType);
     const amountWithoutDecimals = useMemo(
-        () => new BigNumber(amount).shiftedBy(decimals).toString(),
+        () =>
+            new BigNumber(amount).shiftedBy(decimals).integerValue().toString(),
         [amount, decimals]
     );
 

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -62,6 +62,7 @@ function TransferCoinPage() {
     const [formData] = useState<FormValues>(initialValues);
 
     const [coinDecimals] = useCoinDecimals(coinType);
+    const [gasDecimals] = useCoinDecimals(GAS_TYPE_ARG);
 
     const validationSchemaStepOne = useMemo(
         () =>
@@ -70,9 +71,17 @@ function TransferCoinPage() {
                 coinBalance,
                 coinSymbol,
                 gasAggregateBalance,
-                coinDecimals
+                coinDecimals,
+                gasDecimals
             ),
-        [coinType, coinBalance, coinSymbol, coinDecimals, gasAggregateBalance]
+        [
+            coinType,
+            coinBalance,
+            coinSymbol,
+            coinDecimals,
+            gasDecimals,
+            gasAggregateBalance,
+        ]
     );
     const validationSchemaStepTwo = useMemo(
         () => createValidationSchemaStepTwo(),

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -16,12 +16,11 @@ import { Content } from '_app/shared/bottom-menu-layout';
 import PageTitle from '_app/shared/page-title';
 import Loading from '_components/loading';
 import ProgressBar from '_components/progress-bar';
-import { useAppSelector, useAppDispatch } from '_hooks';
+import { useAppSelector, useAppDispatch, useCoinDecimals } from '_hooks';
 import { accountAggregateBalancesSelector } from '_redux/slices/account';
 import { Coin, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 import { sendTokens } from '_redux/slices/transactions';
 import { trackEvent } from '_src/shared/plausible';
-import { useCoinDecimals } from '_src/ui/app/hooks/useFormatCoin';
 
 import type { SerializedError } from '@reduxjs/toolkit';
 import type { FormikHelpers } from 'formik';

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getTransactionDigest } from '@mysten/sui.js';
+import BigNumber from 'bignumber.js';
 import { Formik } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
@@ -103,9 +104,15 @@ function TransferCoinPage() {
                 props: { coinType },
             });
             try {
+                const bigIntAmount = BigInt(
+                    new BigNumber(amount)
+                        .shiftedBy(coinDecimals)
+                        .integerValue()
+                        .toString()
+                );
                 const response = await dispatch(
                     sendTokens({
-                        amount: BigInt(amount),
+                        amount: bigIntAmount,
                         recipientAddress: to,
                         tokenTypeArg: coinType,
                     })
@@ -122,7 +129,7 @@ function TransferCoinPage() {
                 setSendError((e as SerializedError).message || null);
             }
         },
-        [dispatch, navigate, coinType]
+        [dispatch, navigate, coinType, coinDecimals]
     );
 
     const handleNextStep = useCallback(

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -17,7 +17,8 @@ export function createValidationSchemaStepOne(
     coinBalance: bigint,
     coinSymbol: string,
     gasBalance: bigint,
-    decimals: number
+    decimals: number,
+    gasDecimals: number,
 ) {
     return Yup.object({
         amount: createTokenValidation(
@@ -25,7 +26,8 @@ export function createValidationSchemaStepOne(
             coinBalance,
             coinSymbol,
             gasBalance,
-            decimals
+            decimals,
+            gasDecimals
         ),
     });
 }

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -4,13 +4,7 @@
 import * as Yup from 'yup';
 
 import { SUI_ADDRESS_VALIDATION } from '_components/address-input/validation';
-import {
-    DEFAULT_GAS_BUDGET_FOR_TRANSFER,
-    GAS_TYPE_ARG,
-    GAS_SYMBOL,
-} from '_redux/slices/sui-objects/Coin';
-
-import type { FormatNumberOptions, IntlShape } from 'react-intl';
+import { createTokenValidation } from '_src/shared/validation';
 
 export function createValidationSchemaStepTwo() {
     return Yup.object({
@@ -23,45 +17,15 @@ export function createValidationSchemaStepOne(
     coinBalance: bigint,
     coinSymbol: string,
     gasBalance: bigint,
-    totalGasCoins: number,
-    intl: IntlShape,
-    formatOptions: FormatNumberOptions
+    decimals: number
 ) {
     return Yup.object({
-        amount: Yup.number()
-            .integer()
-            .required()
-            .min(
-                1,
-                `\${path} must be greater than or equal to \${min} ${coinSymbol}`
-            )
-            .test(
-                'max',
-                `\${path} must be less than ${intl.formatNumber(
-                    coinBalance,
-                    formatOptions
-                )} ${coinSymbol}`,
-                (amount) =>
-                    typeof amount === 'undefined' ||
-                    BigInt(amount) <= coinBalance
-            )
-            .test(
-                'gas-balance-check',
-                `Insufficient ${GAS_SYMBOL} balance to cover gas fee (${DEFAULT_GAS_BUDGET_FOR_TRANSFER} ${GAS_SYMBOL})`,
-                (amount) => {
-                    try {
-                        let availableGas = gasBalance;
-                        if (coinType === GAS_TYPE_ARG) {
-                            availableGas -= BigInt(amount || 0);
-                        }
-                        // TODO: implement more sophisticated validation by taking
-                        // the splitting/merging fee into account
-                        return availableGas >= DEFAULT_GAS_BUDGET_FOR_TRANSFER;
-                    } catch (e) {
-                        return false;
-                    }
-                }
-            )
-            .label('Amount'),
+        amount: createTokenValidation(
+            coinType,
+            coinBalance,
+            coinSymbol,
+            gasBalance,
+            decimals
+        ),
     });
 }

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -18,7 +18,7 @@ export function createValidationSchemaStepOne(
     coinSymbol: string,
     gasBalance: bigint,
     decimals: number,
-    gasDecimals: number,
+    gasDecimals: number
 ) {
     return Yup.object({
         amount: createTokenValidation(

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -96,9 +96,9 @@ export const batchFetchObject = createAsyncThunk<
 
 export const mintDemoNFT = createAsyncThunk<void, void, AppThunkConfig>(
     'mintDemoNFT',
-    async (_, { extra: { api, keypairVault, featureGating }, dispatch }) => {
+    async (_, { extra: { api, keypairVault, growthbook }, dispatch }) => {
         const signer = api.getSignerInstance(keypairVault.getKeyPair());
-        if (featureGating.isOn(FEATURES.DEPRECATE_GATEWAY)) {
+        if (growthbook.isOn(FEATURES.DEPRECATE_GATEWAY)) {
             await ExampleNFT.mintExampleNFTWithFullnode(signer);
         } else {
             await ExampleNFT.mintExampleNFT(signer);
@@ -121,10 +121,10 @@ export const transferSuiNFT = createAsyncThunk<
     AppThunkConfig
 >(
     'transferSuiNFT',
-    async (data, { extra: { api, keypairVault, featureGating }, dispatch }) => {
+    async (data, { extra: { api, keypairVault, growthbook }, dispatch }) => {
         let txn: SuiTransactionResponse | SuiExecuteTransactionResponse;
         const signer = api.getSignerInstance(keypairVault.getKeyPair());
-        if (featureGating.isOn(FEATURES.DEPRECATE_GATEWAY)) {
+        if (growthbook.isOn(FEATURES.DEPRECATE_GATEWAY)) {
             txn = await ExampleNFT.TransferNFTWithFullnode(
                 signer,
                 data.nftId,

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -76,7 +76,7 @@ export const respondToTransactionRequest = createAsyncThunk<
     'respond-to-transaction-request',
     async (
         { txRequestID, approved },
-        { extra: { background, api, keypairVault, featureGating }, getState }
+        { extra: { background, api, keypairVault, growthbook }, getState }
     ) => {
         const state = getState();
         const txRequest = txRequestsSelectors.selectById(state, txRequestID);
@@ -88,7 +88,7 @@ export const respondToTransactionRequest = createAsyncThunk<
         if (approved) {
             const signer = api.getSignerInstance(keypairVault.getKeyPair());
             try {
-                if (featureGating.isOn(FEATURES.DEPRECATE_GATEWAY)) {
+                if (growthbook.isOn(FEATURES.DEPRECATE_GATEWAY)) {
                     let response: SuiExecuteTransactionResponse;
                     if (
                         txRequest.tx.type === 'v2' ||

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -39,7 +39,7 @@ export const sendTokens = createAsyncThunk<
     'sui-objects/send-tokens',
     async (
         { tokenTypeArg, amount, recipientAddress },
-        { getState, extra: { api, keypairVault, featureGating }, dispatch }
+        { getState, extra: { api, keypairVault, growthbook }, dispatch }
     ) => {
         const state = getState();
         const coinType = Coin.getCoinTypeFromArg(tokenTypeArg);
@@ -60,14 +60,14 @@ export const sendTokens = createAsyncThunk<
                       coins,
                       amount,
                       recipientAddress,
-                      featureGating.isOn(FEATURES.DEPRECATE_GATEWAY)
+                      growthbook.isOn(FEATURES.DEPRECATE_GATEWAY)
                   )
                 : await Coin.transferCoin(
                       signer,
                       coins,
                       amount,
                       recipientAddress,
-                      featureGating.isOn(FEATURES.DEPRECATE_GATEWAY)
+                      growthbook.isOn(FEATURES.DEPRECATE_GATEWAY)
                   );
 
         // TODO: better way to sync latest objects
@@ -90,7 +90,7 @@ export const StakeTokens = createAsyncThunk<
     'sui-objects/stake',
     async (
         { tokenTypeArg, amount },
-        { getState, extra: { api, keypairVault, featureGating }, dispatch }
+        { getState, extra: { api, keypairVault, growthbook }, dispatch }
     ) => {
         const state = getState();
         const coinType = Coin.getCoinTypeFromArg(tokenTypeArg);
@@ -116,7 +116,7 @@ export const StakeTokens = createAsyncThunk<
             coins,
             amount,
             validatorAddress,
-            featureGating.isOn(FEATURES.DEPRECATE_GATEWAY)
+            growthbook.isOn(FEATURES.DEPRECATE_GATEWAY)
         );
         dispatch(fetchAllOwnedAndRequiredObjects());
         return response;

--- a/apps/wallet/src/ui/app/redux/slices/txresults/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/txresults/index.ts
@@ -45,6 +45,7 @@ export type TxResultState = {
     balance?: number;
     callFunctionName?: string;
     coinSymbol?: string;
+    coinType?: string;
 };
 
 interface TransactionManualState {
@@ -197,6 +198,7 @@ export const getTransactionsByAddress = createAsyncThunk<
                           name: objectTxObj.data.fields.name,
                           url: objectTxObj.data.fields.url,
                           balance: objectTxObj.data.fields.balance,
+                          coinType,
                           coinSymbol: coinType && Coin.getCoinSymbol(coinType),
                       }
                     : {}),

--- a/apps/wallet/src/ui/app/redux/store/thunk-extras.ts
+++ b/apps/wallet/src/ui/app/redux/store/thunk-extras.ts
@@ -4,18 +4,18 @@
 import ApiProvider from '_app/ApiProvider';
 import KeypairVault from '_app/KeypairVault';
 import { BackgroundClient } from '_app/background-client';
-import FeatureGating from '_app/experimentation/feature-gating';
+import { growthbook } from '_app/experimentation/feature-gating';
 
 import type { RootState } from '_redux/RootReducer';
 import type { AppDispatch } from '_store';
 
-const featureGating = new FeatureGating();
+export const api = new ApiProvider();
 
 export const thunkExtras = {
+    api,
+    growthbook,
     keypairVault: new KeypairVault(),
-    api: new ApiProvider(featureGating),
     background: new BackgroundClient(),
-    featureGating: featureGating,
 };
 
 type ThunkExtras = typeof thunkExtras;

--- a/apps/wallet/src/ui/app/shared/coin-balance/index.tsx
+++ b/apps/wallet/src/ui/app/shared/coin-balance/index.tsx
@@ -4,7 +4,7 @@
 import cl from 'classnames';
 import { memo } from 'react';
 
-import { useFormatCoin } from '../../hooks/useFormatCoin';
+import { useFormatCoin } from '_hooks';
 
 import st from './CoinBalance.module.scss';
 

--- a/apps/wallet/src/ui/app/shared/coin-balance/index.tsx
+++ b/apps/wallet/src/ui/app/shared/coin-balance/index.tsx
@@ -3,16 +3,15 @@
 
 import cl from 'classnames';
 import { memo } from 'react';
-import { useIntl } from 'react-intl';
 
-import { balanceFormatOptions } from '_shared/formatting';
+import { useFormatCoin } from '../../hooks/useFormatCoin';
 
 import st from './CoinBalance.module.scss';
 
 export type CoinBalanceProps = {
     className?: string;
     balance: bigint;
-    symbol: string;
+    type: string;
     mode?: 'neutral' | 'positive' | 'negative';
     diffSymbol?: boolean;
     title?: string;
@@ -20,16 +19,17 @@ export type CoinBalanceProps = {
 
 function CoinBalance({
     balance,
-    symbol,
+    type,
     className,
     mode = 'neutral',
     diffSymbol = false,
     title,
 }: CoinBalanceProps) {
-    const intl = useIntl();
+    const [formatted, symbol] = useFormatCoin(balance, type);
+
     return (
         <div className={cl(className, st.container, st[mode])} title={title}>
-            <span>{intl.formatNumber(balance, balanceFormatOptions)}</span>
+            <span>{formatted}</span>
             <span className={cl(st.symbol, { [st.diffSymbol]: diffSymbol })}>
                 {symbol}
             </span>

--- a/apps/wallet/src/ui/app/staking/home/delegation-card/index.tsx
+++ b/apps/wallet/src/ui/app/staking/home/delegation-card/index.tsx
@@ -9,7 +9,7 @@ import CoinBalance from '_app/shared/coin-balance';
 import { epochSelector, getValidatorSelector } from '_app/staking/selectors';
 import Icon, { SuiIcons } from '_components/icon';
 import { useAppSelector } from '_hooks';
-import { GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
+import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 import { suiObjectsAdapterSelectors } from '_redux/slices/sui-objects/index';
 
 import type { RootState } from '_redux/RootReducer';
@@ -59,7 +59,7 @@ function DelegationCard({ className, id }: DelegationCardProps) {
             <div className={st.balance}>
                 <CoinBalance
                     balance={BigInt(delegation?.delegateAmount?.() || 0)}
-                    symbol={GAS_SYMBOL}
+                    type={GAS_TYPE_ARG}
                     className={st.balance}
                 />
             </div>

--- a/apps/wallet/src/ui/app/staking/home/index.tsx
+++ b/apps/wallet/src/ui/app/staking/home/index.tsx
@@ -21,7 +21,7 @@ import Alert from '_components/alert';
 import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppSelector, useObjectsState } from '_hooks';
-import { GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
+import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 import st from './StakeHome.module.scss';
 
@@ -52,7 +52,7 @@ function StakeHome() {
                                     <Loading loading={loading}>
                                         <CoinBalance
                                             balance={totalStaked}
-                                            symbol={GAS_SYMBOL}
+                                            type={GAS_TYPE_ARG}
                                             diffSymbol={true}
                                         />
                                     </Loading>
@@ -64,7 +64,7 @@ function StakeHome() {
                                 value={
                                     <CoinBalance
                                         balance={BigInt(0)}
-                                        symbol={GAS_SYMBOL}
+                                        type={GAS_TYPE_ARG}
                                         mode="positive"
                                         diffSymbol={true}
                                         title="This value currently is not available"

--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -3,8 +3,8 @@
 
 import { ErrorMessage, Field, Form, useFormikContext } from 'formik';
 import { useEffect, useRef, memo } from 'react';
-import { useIntl } from 'react-intl';
 
+import { useFormatCoin } from '../../hooks/useFormatCoin';
 import Alert from '_components/alert';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
 import NumberInput from '_components/number-input';
@@ -12,7 +12,6 @@ import {
     DEFAULT_GAS_BUDGET_FOR_STAKE,
     GAS_SYMBOL,
 } from '_redux/slices/sui-objects/Coin';
-import { balanceFormatOptions } from '_shared/formatting';
 
 import type { FormValues } from '.';
 
@@ -22,7 +21,7 @@ export type StakeFromProps = {
     submitError: string | null;
     // TODO(ggao): remove this if needed
     coinBalance: string;
-    coinSymbol: string;
+    coinType: string;
     onClearSubmitError: () => void;
 };
 
@@ -30,7 +29,7 @@ function StakeForm({
     submitError,
     // TODO(ggao): remove this if needed
     coinBalance,
-    coinSymbol,
+    coinType,
     onClearSubmitError,
 }: StakeFromProps) {
     const {
@@ -44,7 +43,9 @@ function StakeForm({
     useEffect(() => {
         onClearRef.current();
     }, [amount]);
-    const intl = useIntl();
+
+    const [formatted, symbol] = useFormatCoin(coinBalance, coinType);
+
     return (
         <Form className={st.container} autoComplete="off" noValidate={true}>
             <div className={st.group}>
@@ -53,16 +54,11 @@ function StakeForm({
                     component={NumberInput}
                     allowNegative={false}
                     name="amount"
-                    placeholder={`Total ${coinSymbol.toLocaleUpperCase()} to stake`}
+                    placeholder={`Total ${symbol} to stake`}
                     className={st.input}
                 />
                 <div className={st.muted}>
-                    Available balance:{' '}
-                    {intl.formatNumber(
-                        BigInt(coinBalance),
-                        balanceFormatOptions
-                    )}{' '}
-                    {coinSymbol}
+                    Available balance: {formatted} {symbol}
                 </div>
                 <ErrorMessage
                     className={st.error}

--- a/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/StakeForm.tsx
@@ -4,10 +4,10 @@
 import { ErrorMessage, Field, Form, useFormikContext } from 'formik';
 import { useEffect, useRef, memo } from 'react';
 
-import { useFormatCoin } from '../../hooks/useFormatCoin';
 import Alert from '_components/alert';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
 import NumberInput from '_components/number-input';
+import { useFormatCoin } from '_hooks';
 import {
     DEFAULT_GAS_BUDGET_FOR_STAKE,
     GAS_SYMBOL,

--- a/apps/wallet/src/ui/app/staking/stake/index.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/index.tsx
@@ -6,11 +6,10 @@ import { Formik } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
-import { useCoinDecimals } from '../../hooks/useFormatCoin';
 import StakeForm from './StakeForm';
 import { createValidationSchema } from './validation';
 import Loading from '_components/loading';
-import { useAppSelector, useAppDispatch } from '_hooks';
+import { useAppSelector, useAppDispatch, useCoinDecimals } from '_hooks';
 import {
     accountAggregateBalancesSelector,
     accountItemizedBalancesSelector,

--- a/apps/wallet/src/ui/app/staking/stake/index.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/index.tsx
@@ -48,6 +48,7 @@ function StakePage() {
     );
     const [sendError, setSendError] = useState<string | null>(null);
     const [coinDecimals] = useCoinDecimals(coinType);
+    const [gasDecimals] = useCoinDecimals(GAS_TYPE_ARG);
     const validationSchema = useMemo(
         () =>
             createValidationSchema(
@@ -56,7 +57,8 @@ function StakePage() {
                 coinSymbol,
                 gasAggregateBalance,
                 totalGasCoins,
-                coinDecimals
+                coinDecimals,
+                gasDecimals
             ),
         [
             coinType,
@@ -65,6 +67,7 @@ function StakePage() {
             gasAggregateBalance,
             totalGasCoins,
             coinDecimals,
+            gasDecimals,
         ]
     );
 

--- a/apps/wallet/src/ui/app/staking/stake/index.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/index.tsx
@@ -4,9 +4,9 @@
 import { getTransactionDigest } from '@mysten/sui.js';
 import { Formik } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
-import { useIntl } from 'react-intl';
 import { Navigate, useNavigate } from 'react-router-dom';
 
+import { useCoinDecimals } from '../../hooks/useFormatCoin';
 import StakeForm from './StakeForm';
 import { createValidationSchema } from './validation';
 import Loading from '_components/loading';
@@ -17,7 +17,6 @@ import {
 } from '_redux/slices/account';
 import { Coin, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 import { StakeTokens } from '_redux/slices/transactions';
-import { balanceFormatOptions } from '_shared/formatting';
 
 import type { SerializedError } from '@reduxjs/toolkit';
 import type { FormikHelpers } from 'formik';
@@ -49,7 +48,7 @@ function StakePage() {
         [coinType]
     );
     const [sendError, setSendError] = useState<string | null>(null);
-    const intl = useIntl();
+    const [coinDecimals] = useCoinDecimals(coinType);
     const validationSchema = useMemo(
         () =>
             createValidationSchema(
@@ -58,8 +57,7 @@ function StakePage() {
                 coinSymbol,
                 gasAggregateBalance,
                 totalGasCoins,
-                intl,
-                balanceFormatOptions
+                coinDecimals
             ),
         [
             coinType,
@@ -67,7 +65,7 @@ function StakePage() {
             coinSymbol,
             gasAggregateBalance,
             totalGasCoins,
-            intl,
+            coinDecimals,
         ]
     );
 
@@ -122,7 +120,7 @@ function StakePage() {
                     <StakeForm
                         submitError={sendError}
                         coinBalance={coinBalance.toString()}
-                        coinSymbol={coinSymbol}
+                        coinType={coinType}
                         onClearSubmitError={handleOnClearSubmitError}
                     />
                 </Formik>

--- a/apps/wallet/src/ui/app/staking/stake/index.tsx
+++ b/apps/wallet/src/ui/app/staking/stake/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getTransactionDigest } from '@mysten/sui.js';
+import BigNumber from 'bignumber.js';
 import { Formik } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
@@ -83,9 +84,16 @@ function StakePage() {
             }
             setSendError(null);
             try {
+                const bigIntAmount = BigInt(
+                    new BigNumber(amount)
+                        .shiftedBy(coinDecimals)
+                        .integerValue()
+                        .toString()
+                );
+
                 const response = await dispatch(
                     StakeTokens({
-                        amount: BigInt(amount),
+                        amount: bigIntAmount,
                         tokenTypeArg: coinType,
                     })
                 ).unwrap();
@@ -96,7 +104,7 @@ function StakePage() {
                 setSendError((e as SerializedError).message || null);
             }
         },
-        [dispatch, navigate, coinType]
+        [dispatch, navigate, coinType, coinDecimals]
     );
     const handleOnClearSubmitError = useCallback(() => {
         setSendError(null);

--- a/apps/wallet/src/ui/app/staking/stake/validation.ts
+++ b/apps/wallet/src/ui/app/staking/stake/validation.ts
@@ -12,7 +12,8 @@ export function createValidationSchema(
     coinSymbol: string,
     gasBalance: bigint,
     totalGasCoins: number,
-    decimals: number
+    decimals: number,
+    gasDecimals: number
 ) {
     return Yup.object({
         amount: createTokenValidation(
@@ -20,7 +21,8 @@ export function createValidationSchema(
             coinBalance,
             coinSymbol,
             gasBalance,
-            decimals
+            decimals,
+            gasDecimals
         ).test(
             'num-gas-coins-check',
             `Need at least 2 ${GAS_SYMBOL} coins to stake a ${GAS_SYMBOL} coin`,

--- a/apps/wallet/src/ui/app/staking/stake/validation.ts
+++ b/apps/wallet/src/ui/app/staking/stake/validation.ts
@@ -3,13 +3,8 @@
 
 import * as Yup from 'yup';
 
-import {
-    DEFAULT_GAS_BUDGET_FOR_STAKE,
-    GAS_TYPE_ARG,
-    GAS_SYMBOL,
-} from '_redux/slices/sui-objects/Coin';
-
-import type { FormatNumberOptions, IntlShape } from 'react-intl';
+import { GAS_TYPE_ARG, GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
+import { createTokenValidation } from '_src/shared/validation';
 
 export function createValidationSchema(
     coinType: string,
@@ -17,49 +12,21 @@ export function createValidationSchema(
     coinSymbol: string,
     gasBalance: bigint,
     totalGasCoins: number,
-    intl: IntlShape,
-    formatOptions: FormatNumberOptions
+    decimals: number
 ) {
     return Yup.object({
-        amount: Yup.number()
-            .integer()
-            .required()
-            .min(
-                1,
-                `\${path} must be greater than or equal to \${min} ${coinSymbol}`
-            )
-            .test(
-                'max',
-                `\${path} must be less than or equal to ${intl.formatNumber(
-                    coinBalance,
-                    formatOptions
-                )} ${coinSymbol}`,
-                (amount) =>
-                    typeof amount === 'undefined' ||
-                    BigInt(amount) <= coinBalance
-            )
-            .test(
-                'gas-balance-check',
-                `Insufficient ${GAS_SYMBOL} balance to cover gas fee`,
-                (amount) => {
-                    try {
-                        let availableGas = gasBalance;
-                        if (coinType === GAS_TYPE_ARG) {
-                            availableGas -= BigInt(amount || 0);
-                        }
-                        return availableGas >= DEFAULT_GAS_BUDGET_FOR_STAKE;
-                    } catch (e) {
-                        return false;
-                    }
-                }
-            )
-            .test(
-                'num-gas-coins-check',
-                `Need at least 2 ${GAS_SYMBOL} coins to stake a ${GAS_SYMBOL} coin`,
-                () => {
-                    return coinType !== GAS_TYPE_ARG || totalGasCoins >= 2;
-                }
-            )
-            .label('Amount'),
+        amount: createTokenValidation(
+            coinType,
+            coinBalance,
+            coinSymbol,
+            gasBalance,
+            decimals
+        ).test(
+            'num-gas-coins-check',
+            `Need at least 2 ${GAS_SYMBOL} coins to stake a ${GAS_SYMBOL} coin`,
+            () => {
+                return coinType !== GAS_TYPE_ARG || totalGasCoins >= 2;
+            }
+        ),
     });
 }

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -1,12 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { GrowthBookProvider } from '@growthbook/growthbook-react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 import { HashRouter } from 'react-router-dom';
 
 import App from './app';
+import { growthbook, loadFeatures } from './app/experimentation/feature-gating';
+import { queryClient } from './app/helpers/queryClient';
 import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
 import { getFromLocationSearch } from '_redux/slices/app/AppType';
 import store from '_store';
@@ -20,7 +24,7 @@ async function init() {
     if (process.env.NODE_ENV === 'development') {
         Object.defineProperty(window, 'store', { value: store });
     }
-    await thunkExtras.featureGating.init();
+    await loadFeatures();
     store.dispatch(initAppType(getFromLocationSearch(window.location.search)));
     await store.dispatch(initNetworkFromStorage()).unwrap();
     await thunkExtras.background.init(store.dispatch);
@@ -33,13 +37,17 @@ function renderApp() {
     }
     const root = createRoot(rootDom);
     root.render(
-        <HashRouter>
-            <Provider store={store}>
-                <IntlProvider locale={navigator.language}>
-                    <App />
-                </IntlProvider>
-            </Provider>
-        </HashRouter>
+        <GrowthBookProvider growthbook={growthbook}>
+            <HashRouter>
+                <Provider store={store}>
+                    <IntlProvider locale={navigator.language}>
+                        <QueryClientProvider client={queryClient}>
+                            <App />
+                        </QueryClientProvider>
+                    </IntlProvider>
+                </Provider>
+            </HashRouter>
+        </GrowthBookProvider>
     );
 }
 

--- a/apps/wallet/testSetup.ts
+++ b/apps/wallet/testSetup.ts
@@ -6,3 +6,10 @@ import { webcrypto } from 'crypto';
 if (!globalThis.defined) {
     globalThis.crypto = webcrypto as Crypto;
 }
+
+// Create a fake chrome object so that the webextension polyfill can load:
+globalThis.chrome = {
+    runtime: {
+        id: 'some-test-id-from-test-setup',
+    },
+};

--- a/apps/wallet/vitest.config.ts
+++ b/apps/wallet/vitest.config.ts
@@ -1,24 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
+const alias = (folder: string) => new URL(folder, import.meta.url).pathname;
+
 export default defineConfig({
+    plugins: [tsconfigPaths()],
     test: {
+        // TODO: Create custom extension environment.
+        environment: 'happy-dom',
         minThreads: 1,
-        setupFiles: ['./test_setup.ts'],
+        setupFiles: ['./testSetup.ts'],
     },
     resolve: {
         alias: {
-            '@mysten/sui.js': new URL(
-                '../../sdk/typescript/src',
-                import.meta.url
-            ).toString(),
-
-            '@mysten/bcs': new URL(
-                '../../sdk/bcs/src',
-                import.meta.url
-            ).toString(),
+            '@mysten/sui.js': alias('../../sdk/typescript/src'),
+            '@mysten/bcs': alias('../../sdk/bcs/src'),
         },
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,7 @@ importers:
     specifiers:
       '@floating-ui/react-dom-interactions': ^0.10.1
       '@growthbook/growthbook': ^0.18.1
+      '@growthbook/growthbook-react': ^0.9.1
       '@metamask/browser-passworder': ^3.0.0
       '@mysten/core': workspace:*
       '@mysten/sui.js': workspace:*
@@ -169,6 +170,7 @@ importers:
       '@reduxjs/toolkit': ^1.8.3
       '@scure/bip32': ^1.1.0
       '@scure/bip39': ^1.1.0
+      '@tanstack/react-query': ^4.0.10
       '@types/dotenv-webpack': ^7.0.3
       '@types/node': ^18.0.6
       '@types/react': ^18.0.20
@@ -180,6 +182,7 @@ importers:
       '@types/zxcvbn': ^4.4.1
       '@typescript-eslint/eslint-plugin': ^5.38.1
       '@typescript-eslint/parser': ^5.38.1
+      bignumber.js: ^9.1.0
       bootstrap-icons: ^1.9.1
       buffer: ^6.0.3
       classnames: ^2.3.1
@@ -239,6 +242,7 @@ importers:
     dependencies:
       '@floating-ui/react-dom-interactions': 0.10.1_7ey2zzynotv32rpkwno45fsx4e
       '@growthbook/growthbook': 0.18.1
+      '@growthbook/growthbook-react': 0.9.1_react@18.2.0
       '@metamask/browser-passworder': 3.0.0
       '@mysten/core': link:../core
       '@mysten/sui.js': link:../../sdk/typescript
@@ -246,6 +250,8 @@ importers:
       '@reduxjs/toolkit': 1.8.5_kkwg4cbsojnjnupd3btipussee
       '@scure/bip32': 1.1.0
       '@scure/bip39': 1.1.0
+      '@tanstack/react-query': 4.2.1_biqbaboplfbrettd7655fr4n2y
+      bignumber.js: 9.1.0
       bootstrap-icons: 1.9.1
       buffer: 6.0.3
       classnames: 2.3.1
@@ -263,7 +269,7 @@ importers:
       rxjs: 7.5.6
       semver: 7.3.8
       stream-browserify: 3.0.0
-      tailwindcss: 3.1.8_ts-node@10.9.1
+      tailwindcss: 3.1.8_57znarxsqwmnneadci5z5fd5gu
       tweetnacl: 1.0.3
       uuid: 8.3.2
       webextension-polyfill: 0.9.0
@@ -6921,7 +6927,7 @@ packages:
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -6929,7 +6935,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -6937,7 +6943,7 @@ packages:
   /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -7148,6 +7154,10 @@ packages:
   /big.js/5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
     dev: true
+
+  /bignumber.js/9.1.0:
+    resolution: {integrity: sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==}
+    dev: false
 
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -10842,7 +10852,7 @@ packages:
     engines: {node: '>=8.9.0'}
     dev: true
 
-  /follow-redirects/1.15.1_debug@4.3.2:
+  /follow-redirects/1.15.1:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -10850,8 +10860,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dependencies:
-      debug: 4.3.2
     dev: true
 
   /for-each/0.3.3:
@@ -15270,6 +15278,17 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
+  /postcss-import/14.1.0:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
+
   /postcss-import/14.1.0_postcss@8.4.16:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
@@ -15287,6 +15306,15 @@ packages:
       postcss: ^8.0.0
     dependencies:
       postcss: 8.4.16
+    dev: true
+
+  /postcss-js/4.0.0:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
     dev: true
 
   /postcss-js/4.0.0_postcss@8.4.16:
@@ -15452,6 +15480,15 @@ packages:
     dependencies:
       icss-utils: 5.1.0_postcss@8.4.16
       postcss: 8.4.16
+    dev: true
+
+  /postcss-nested/5.0.6:
+    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss-selector-parser: 6.0.10
     dev: true
 
   /postcss-nested/5.0.6_postcss@8.4.16:
@@ -18107,6 +18144,41 @@ packages:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.11
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.16
+      postcss-import: 14.1.0
+      postcss-js: 4.0.0
+      postcss-load-config: 3.1.4
+      postcss-nested: 5.0.6
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
+
+  /tailwindcss/3.1.8_57znarxsqwmnneadci5z5fd5gu:
+    resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -18124,7 +18196,7 @@ packages:
       postcss: 8.4.16
       postcss-import: 14.1.0_postcss@8.4.16
       postcss-js: 4.0.0_postcss@8.4.16
-      postcss-load-config: 3.1.4_postcss@8.4.16
+      postcss-load-config: 3.1.4_57znarxsqwmnneadci5z5fd5gu
       postcss-nested: 5.0.6_postcss@8.4.16
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
@@ -18132,7 +18204,7 @@ packages:
       resolve: 1.22.1
     transitivePeerDependencies:
       - ts-node
-    dev: true
+    dev: false
 
   /tailwindcss/3.1.8_postcss@8.4.16:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
@@ -18166,37 +18238,6 @@ packages:
     transitivePeerDependencies:
       - ts-node
     dev: true
-
-  /tailwindcss/3.1.8_ts-node@10.9.1:
-    resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-    dependencies:
-      arg: 5.0.2
-      chokidar: 3.5.3
-      color-name: 1.1.4
-      detective: 5.2.1
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.11
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      lilconfig: 2.0.6
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.16
-      postcss-import: 14.1.0_postcss@8.4.16
-      postcss-js: 4.0.0_postcss@8.4.16
-      postcss-load-config: 3.1.4_57znarxsqwmnneadci5z5fd5gu
-      postcss-nested: 5.0.6_postcss@8.4.16
-      postcss-selector-parser: 6.0.10
-      postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - ts-node
-    dev: false
 
   /tapable/2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,7 @@ importers:
       eslint-webpack-plugin: ^3.2.0
       formik: ^2.2.9
       framer-motion: ^7.5.1
+      happy-dom: ^7.6.0
       html-webpack-plugin: ^5.5.0
       mini-css-extract-plugin: ^2.6.1
       mitt: ^3.0.0
@@ -231,6 +232,7 @@ importers:
       tweetnacl: ^1.0.3
       typescript: ^4.8.3
       uuid: ^8.3.2
+      vite-tsconfig-paths: ^3.5.0
       vitest: ^0.22.1
       web-ext: ^7.2.0
       webextension-polyfill: ^0.9.0
@@ -272,6 +274,7 @@ importers:
       tailwindcss: 3.1.8_57znarxsqwmnneadci5z5fd5gu
       tweetnacl: 1.0.3
       uuid: 8.3.2
+      vite-tsconfig-paths: 3.5.0
       webextension-polyfill: 0.9.0
       yup: 0.32.11
       zxcvbn: 4.4.2
@@ -296,6 +299,7 @@ importers:
       eslint-config-prettier: 8.5.0_eslint@8.23.0
       eslint-config-react-app: 7.0.1_itqs5654cmlnjraw6gjzqacppi
       eslint-webpack-plugin: 3.2.0_skpnekq7gq3zdkwzxpcrmjcczy
+      happy-dom: 7.6.0
       html-webpack-plugin: 5.5.0_webpack@5.74.0
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
       onchange: 7.1.0
@@ -315,7 +319,7 @@ importers:
       ts-node: 10.9.1_mbccaw7wm5e4marg7gk24f4eme
       tsconfig-paths: 4.1.0
       typescript: 4.8.3
-      vitest: 0.22.1_sass@1.54.5
+      vitest: 0.22.1_cxfoebqz2dlumlyxbuhyeuhxki
       web-ext: 7.2.0
       webpack: 5.74.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.74.0
@@ -2474,7 +2478,6 @@ packages:
 
   /@cush/relative/1.0.0:
     resolution: {integrity: sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==}
-    dev: true
 
   /@cypress/request/2.88.10:
     resolution: {integrity: sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==}
@@ -5324,6 +5327,12 @@ packages:
     resolution: {integrity: sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==}
     dev: true
 
+  /@types/concat-stream/1.6.1:
+    resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
+    dependencies:
+      '@types/node': 18.7.6
+    dev: true
+
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
@@ -5405,6 +5414,12 @@ packages:
       '@types/express-serve-static-core': 4.17.31
       '@types/qs': 6.9.7
       '@types/serve-static': 1.15.0
+    dev: true
+
+  /@types/form-data/0.0.33:
+    resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
+    dependencies:
+      '@types/node': 18.7.6
     dev: true
 
   /@types/fs-extra/9.0.13:
@@ -5541,6 +5556,10 @@ packages:
       form-data: 3.0.1
     dev: true
 
+  /@types/node/10.17.60:
+    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+    dev: true
+
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -5553,6 +5572,10 @@ packages:
 
   /@types/node/18.7.6:
     resolution: {integrity: sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==}
+
+  /@types/node/8.10.66:
+    resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -6807,6 +6830,10 @@ packages:
   /arrify/2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
+    dev: true
+
+  /asap/2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
     dev: true
 
   /asn1/0.2.6:
@@ -11138,6 +11165,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
+  /get-port/3.2.0:
+    resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
+    engines: {node: '>=4'}
+    dev: true
+
   /get-port/5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
@@ -11228,7 +11260,6 @@ packages:
 
   /glob-regex/0.3.2:
     resolution: {integrity: sha512-m5blUd3/OqDTWwzBBtWBPrGlAzatRywHameHeekAZyZrskYouOGdNB8T/q6JucucvJXtOuyHIn0/Yia7iDasDw==}
-    dev: true
 
   /glob-to-regexp/0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -11346,7 +11377,6 @@ packages:
 
   /globrex/0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-    dev: true
 
   /goober/2.1.11:
     resolution: {integrity: sha512-5SS2lmxbhqH0u9ABEWq7WPU69a4i2pYcHeCxqaNq6Cw3mnrF0ghWNM4tEGid4dKy8XNIAUbuThuozDHHKJVh3A==}
@@ -11441,6 +11471,20 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.17.4
+    dev: true
+
+  /happy-dom/7.6.0:
+    resolution: {integrity: sha512-QnNsiblZdyVDzW5ts6E7ub79JnabqHJeJgt+1WGNq9fSYqS/r/RzzTVXCZSDl6EVkipdwI48B4bgXAnMZPecIw==}
+    dependencies:
+      css.escape: 1.5.1
+      he: 1.2.0
+      node-fetch: 2.6.7
+      sync-request: 6.1.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+    transitivePeerDependencies:
+      - encoding
     dev: true
 
   /har-schema/2.0.0:
@@ -11718,6 +11762,16 @@ packages:
       entities: 4.3.1
     dev: true
 
+  /http-basic/8.1.3:
+    resolution: {integrity: sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      caseless: 0.12.0
+      concat-stream: 1.6.2
+      http-response-object: 3.0.2
+      parse-cache-control: 1.0.1
+    dev: true
+
   /http-cache-semantics/4.1.0:
     resolution: {integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==}
     dev: true
@@ -11772,6 +11826,12 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /http-response-object/3.0.2:
+    resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
+    dependencies:
+      '@types/node': 10.17.60
     dev: true
 
   /http-signature/1.2.0:
@@ -11867,7 +11927,6 @@ packages:
     dependencies:
       safer-buffer: 2.1.2
     dev: true
-    optional: true
 
   /icss-utils/5.1.0_postcss@8.4.16:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -12844,7 +12903,6 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: true
 
   /jsonc-parser/3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -14874,6 +14932,10 @@ packages:
     dependencies:
       callsites: 3.1.0
 
+  /parse-cache-control/1.0.1:
+    resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
+    dev: true
+
   /parse-entities/2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
     dependencies:
@@ -15832,6 +15894,12 @@ packages:
       make-error: 1.3.6
     dev: true
 
+  /promise/8.2.0:
+    resolution: {integrity: sha512-+CMAlLHqwRYwBMXKCP+o8ns7DN+xHDUiI+0nArsiJ9y+kJVPLFxEaSw6Ha9s9H0tftxg2Yzl25wqj9G7m5wLZg==}
+    dependencies:
+      asap: 2.0.6
+    dev: true
+
   /prompts/2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -16396,7 +16464,6 @@ packages:
       glob-regex: 0.3.2
       slash: 3.0.0
       tslib: 1.14.1
-    dev: true
 
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -17706,7 +17773,6 @@ packages:
   /strip-bom/3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-    dev: true
 
   /strip-bom/5.0.0:
     resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
@@ -18115,6 +18181,21 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /sync-request/6.1.0:
+    resolution: {integrity: sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      http-response-object: 3.0.2
+      sync-rpc: 1.3.6
+      then-request: 6.0.2
+    dev: true
+
+  /sync-rpc/1.3.6:
+    resolution: {integrity: sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==}
+    dependencies:
+      get-port: 3.2.0
+    dev: true
+
   /synchronous-promise/2.0.16:
     resolution: {integrity: sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A==}
     dev: true
@@ -18327,6 +18408,23 @@ packages:
 
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  /then-request/6.0.2:
+    resolution: {integrity: sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@types/concat-stream': 1.6.1
+      '@types/form-data': 0.0.33
+      '@types/node': 8.10.66
+      '@types/qs': 6.9.7
+      caseless: 0.12.0
+      concat-stream: 1.6.2
+      form-data: 2.3.3
+      http-basic: 8.1.3
+      http-response-object: 3.0.2
+      promise: 8.2.0
+      qs: 6.10.3
+    dev: true
 
   /thenify-all/1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -18636,7 +18734,6 @@ packages:
       json5: 2.2.1
       minimist: 1.2.6
       strip-bom: 3.0.0
-    dev: true
 
   /tsconfig/7.0.0:
     resolution: {integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==}
@@ -19453,6 +19550,19 @@ packages:
       - supports-color
     dev: true
 
+  /vite-tsconfig-paths/3.5.0:
+    resolution: {integrity: sha512-NKIubr7gXgh/3uniQaOytSg+aKWPrjquP6anAy+zCWEn6h9fB8z2/qdlfQrTgZWaXJ2pHVlllrSdRZltHn9P4g==}
+    peerDependencies:
+      vite: '>2.0.0-0'
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      recrawl-sync: 2.2.2
+      tsconfig-paths: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /vite-tsconfig-paths/3.5.0_vite@3.0.9:
     resolution: {integrity: sha512-NKIubr7gXgh/3uniQaOytSg+aKWPrjquP6anAy+zCWEn6h9fB8z2/qdlfQrTgZWaXJ2pHVlllrSdRZltHn9P4g==}
     peerDependencies:
@@ -19628,7 +19738,7 @@ packages:
       - terser
     dev: true
 
-  /vitest/0.22.1_sass@1.54.5:
+  /vitest/0.22.1_cxfoebqz2dlumlyxbuhyeuhxki:
     resolution: {integrity: sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
@@ -19655,6 +19765,7 @@ packages:
       '@types/node': 18.7.6
       chai: 4.3.6
       debug: 4.3.4
+      happy-dom: 7.6.0
       local-pkg: 0.4.2
       tinypool: 0.2.4
       tinyspy: 1.0.2
@@ -19793,6 +19904,11 @@ packages:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
 
+  /webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
   /webpack-cli/4.10.0_webpack@5.74.0:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
     engines: {node: '>=10.13.0'}
@@ -19880,6 +19996,18 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
+
+  /whatwg-encoding/2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-mimetype/3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
     dev: true
 
   /whatwg-url/5.0.0:


### PR DESCRIPTION
This is an extension of #4661, updated based on recent SDK changes.

The key change here from the previous PR:
- Added feature gating, based on our existing feature gating setup (I simplified the setup a bit though). This is enabled in dev and disabled in prod.
- Moves all formatting logic to be async and hook-based. We need to fetch denomination from the API (it currently only supports SUI but will be updated to call RPC for other token types). I opted to pull in [Tanstack Query](https://tanstack.com/query/v4) to do the data fetching, which we've recently started to do on the Explorer, and I've been meaning to add it to the wallet as well. It keeps this information in cache (for up to 24 hours, although we need to set up cache persisting at some point), and de-dupes requests.
- Pull in bignumber.js for all number formatting and parsing. This solves the precision loss with the previous number-based approach.
