### PR TITLE
discard gases with insufficient balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8223,6 +8223,7 @@ dependencies = [
  "sui-node",
  "sui-sdk",
  "sui-types",
+ "tap",
  "telemetry-subscribers 0.2.0",
  "test-utils",
  "thiserror",

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1616,7 +1616,7 @@ where
                             Err(err) => {
                                 // We have an error here.
                                 // Append to the list off errors
-                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed transaction from validator handle_transaction");
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed transaction from validator handle_transaction: {:?}", err);
                                 state.errors.push(err);
                                 state.bad_stake += weight; // This is the bad stake counter
                             }
@@ -1695,7 +1695,7 @@ where
             .await?;
 
         debug!(
-            tx_digest = ?tx_digest,
+            ?tx_digest,
             num_errors = state.errors.len(),
             good_stake = state.good_stake,
             bad_stake = state.bad_stake,
@@ -1704,7 +1704,7 @@ where
             "Received signatures response from validators handle_transaction"
         );
         if !state.errors.is_empty() {
-            trace!("Errors received: {:?}", state.errors);
+            debug!(?tx_digest, "Errors received: {:?}", state.errors);
         }
 
         // If we have some certificate return it, or return an error.
@@ -1817,6 +1817,7 @@ where
                                 }
                             }
                             Err(err) => {
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed effects from validator handle_certificate: {:?}", err);
                                 state.errors.push(err);
                                 state.bad_stake += weight;
                                 if state.bad_stake > validity {

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.23"
 uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.2"
 scopeguard = "1.1"
+tap = "1.0"
 
 sui = { path = "../sui" }
 sui-node = { path = "../sui-node" }


### PR DESCRIPTION
1. for low balances gas, instead of recycling it, directly discard
2. add a timeout when pulling coins from the gas queue
3. a lot of logs 