### PR TITLE
[narwhal] limit txn size accepted by workers

### DIFF
--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -105,6 +105,11 @@ async fn handle_clients_transactions() {
 
     // Wait for batch to be reported to primary.
     rx_await_batch.recv().await.unwrap();
+
+    let txn = TransactionProto {
+        transaction: Bytes::from(vec![8u8; 10 * 1024 * 1024]),
+    };
+    assert!(client.submit_transaction(txn).await.is_err());
 }
 
 #[tokio::test]


### PR DESCRIPTION
It seems for the health of Narwhal, a limit on transaction size is necessary. Otherwise, even if technically supported, many large transactions can cause OOMs or processing delays in Narwhal.

A 6MiB limit is chosen here, because outside of special cases in checkpoints no transaction seems to be as large. And anemo has a 8MiB size limit by default, so leaving some headroom.
