### PR TITLE
apps: fix txn ordering

### DIFF
--- a/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
+++ b/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
@@ -115,7 +115,8 @@ async function getRecentTransactions(
                 endGatewayTxSeqNumber
             )
             .then((res: GetTxnDigestsResponse) =>
-                getDataOnTxDigests(network, res)
+                // result returned by getTransactionDigestsInRange is in ascending order
+                getDataOnTxDigests(network, [...res].reverse())
             )) as TxnData[];
     } catch (error) {
         throw error;

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -180,7 +180,7 @@ export const getDataOnTxDigests = (
                                 : {}),
                         };
                     })
-                    // Remove failed transactions and sort by sequence number
+                    // Remove failed transactions
                     .filter((itm) => itm)
             );
         });

--- a/apps/explorer/src/components/transaction-card/TxForID.tsx
+++ b/apps/explorer/src/components/transaction-card/TxForID.tsx
@@ -33,8 +33,8 @@ const getTx = async (
     category: categoryType
 ): Promise<GetTxnDigestsResponse> =>
     category === 'address'
-        ? rpc(network).getTransactionsForAddress(id)
-        : rpc(network).getTransactionsForObject(id);
+        ? rpc(network).getTransactionsForAddress(id, 'Descending')
+        : rpc(network).getTransactionsForObject(id, 'Descending');
 
 const viewFn = (results: any) => <TxForIDView showData={results} />;
 

--- a/apps/wallet/src/ui/app/redux/slices/txresults/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/txresults/index.ts
@@ -95,7 +95,10 @@ export const getTransactionsByAddress = createAsyncThunk<
         }
         // Get all transactions txId for address
         const transactions: GetTxnDigestsResponse =
-            await api.instance.fullNode.getTransactionsForAddress(address);
+            await api.instance.fullNode.getTransactionsForAddress(
+                address,
+                'Descending'
+            );
 
         if (!transactions || !transactions.length) {
             return [];

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -7,7 +7,6 @@ import {
   isGetObjectDataResponse,
   isGetOwnedObjectsResponse,
   isGetTxnDigestsResponse,
-  isGetTxnDigestsResponse__DEPRECATED,
   isPaginatedTransactionDigests,
   isSuiEvents,
   isSuiExecuteTransactionResponse,
@@ -223,11 +222,13 @@ export class JsonRpcProvider extends Provider {
     return objects.filter((obj: SuiObjectInfo) => Coin.isSUI(obj));
   }
 
-  getCoinDenominationInfo(
-    coinType: string,
-  ): CoinDenominationInfoResponse {
+  getCoinDenominationInfo(coinType: string): CoinDenominationInfoResponse {
     const [packageId, module, symbol] = coinType.split('::');
-    if (normalizeSuiAddress(packageId) !== normalizeSuiAddress('0x2') || module != 'sui' || symbol !== 'SUI') {
+    if (
+      normalizeSuiAddress(packageId) !== normalizeSuiAddress('0x2') ||
+      module != 'sui' ||
+      symbol !== 'SUI'
+    ) {
       throw new Error(
         'only SUI coin is supported in getCoinDenominationInfo for now.'
       );
@@ -355,42 +356,17 @@ export class JsonRpcProvider extends Provider {
   }
 
   async getTransactionsForObject(
-    objectID: string
+    objectID: string,
+    ordering: Ordering = 'Descending'
   ): Promise<GetTxnDigestsResponse> {
-    // TODO: remove after we deploy 0.12.0 DevNet
-    if ((await this.getRpcApiVersion()) === PRE_PAGINATION_API_VERSION) {
-      const requests = [
-        {
-          method: 'sui_getTransactionsByInputObject',
-          args: [objectID],
-        },
-        {
-          method: 'sui_getTransactionsByMutatedObject',
-          args: [objectID],
-        },
-      ];
-
-      try {
-        const results = await this.client.batchRequestWithType(
-          requests,
-          isGetTxnDigestsResponse__DEPRECATED,
-          this.skipDataValidation
-        );
-        return [...results[0], ...results[1]].map((tx) => tx[1]);
-      } catch (err) {
-        throw new Error(
-          `Error getting transactions for object: ${err} for id ${objectID}`
-        );
-      }
-    }
     const requests = [
       {
         method: 'sui_getTransactions',
-        args: [{ InputObject: objectID }, null, null, 'Ascending'],
+        args: [{ InputObject: objectID }, null, null, ordering],
       },
       {
         method: 'sui_getTransactions',
-        args: [{ MutatedObject: objectID }, null, null, 'Ascending'],
+        args: [{ MutatedObject: objectID }, null, null, ordering],
       },
     ];
 
@@ -409,41 +385,17 @@ export class JsonRpcProvider extends Provider {
   }
 
   async getTransactionsForAddress(
-    addressID: string
+    addressID: string,
+    ordering: Ordering = 'Descending'
   ): Promise<GetTxnDigestsResponse> {
-    // TODO: remove after we deploy 0.12.0 DevNet
-    if ((await this.getRpcApiVersion()) === PRE_PAGINATION_API_VERSION) {
-      const requests = [
-        {
-          method: 'sui_getTransactionsToAddress',
-          args: [addressID],
-        },
-        {
-          method: 'sui_getTransactionsFromAddress',
-          args: [addressID],
-        },
-      ];
-      try {
-        const results = await this.client.batchRequestWithType(
-          requests,
-          isGetTxnDigestsResponse__DEPRECATED,
-          this.skipDataValidation
-        );
-        return [...results[0], ...results[1]].map((r) => r[1]);
-      } catch (err) {
-        throw new Error(
-          `Error getting transactions for address: ${err} for id ${addressID}`
-        );
-      }
-    }
     const requests = [
       {
         method: 'sui_getTransactions',
-        args: [{ ToAddress: addressID }, null, null, 'Ascending'],
+        args: [{ ToAddress: addressID }, null, null, ordering],
       },
       {
         method: 'sui_getTransactions',
-        args: [{ FromAddress: addressID }, null, null, 'Ascending'],
+        args: [{ FromAddress: addressID }, null, null, ordering],
       },
     ];
     try {

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, CoinDenominationInfoResponse, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, GetTxnDigestsResponse__DEPRECATED, PaginatedTransactionDigests, TransactionQuery, Ordering, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, SharedObjectRef, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, CoinDenominationInfoResponse, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, PaginatedTransactionDigests, TransactionQuery, Ordering, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, SharedObjectRef, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -944,17 +944,6 @@ export function isGetTxnDigestsResponse(obj: any, _argumentName?: string): obj i
         Array.isArray(obj) &&
         obj.every((e: any) =>
             isTransactionDigest(e) as boolean
-        )
-    )
-}
-
-export function isGetTxnDigestsResponse__DEPRECATED(obj: any, _argumentName?: string): obj is GetTxnDigestsResponse__DEPRECATED {
-    return (
-        Array.isArray(obj) &&
-        obj.every((e: any) =>
-            Array.isArray(e) &&
-            isSuiMoveTypeParameterIndex(e[0]) as boolean &&
-            isTransactionDigest(e[1]) as boolean
         )
     )
 }

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -153,11 +153,6 @@ export type SuiExecuteTransactionResponse =
 export type GatewayTxSeqNumber = number;
 
 export type GetTxnDigestsResponse = TransactionDigest[];
-// TODO: remove after we deploy 0.12.0 DevNet
-export type GetTxnDigestsResponse__DEPRECATED = [
-  GatewayTxSeqNumber,
-  TransactionDigest
-][];
 
 export type PaginatedTransactionDigests = {
   data: TransactionDigest[];

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -30,7 +30,8 @@ describe('Transaction Reading API', () => {
 
   it('Get Transactions', async () => {
     const resp = await toolbox.provider.getTransactionsForAddress(
-      toolbox.address()
+      toolbox.address(),
+      'Ascending'
     );
     expect(resp.length).to.greaterThan(0);
 


### PR DESCRIPTION
The sorting logic was accidentally removed in https://github.com/MystenLabs/sui/pull/4919/files#diff-ad6bd039b34c5e44ce22c8e1f9939f5d1b0a6b0af782c14b5cd810d0c079ade8 with the removal of sequence number.

# consideration
This fix relies on specifying the ordering(i.e., descending) when making fullnode requests. An alternative approach is to sort by timestamp on the frontend side. Given that we have noticed that fullnode sometimes returns null values for the timestamps due to post-processing lag, relying on fullnode for the sorting might be more reliable.