### PR TITLE
[TypeScript SDK] fetch API version from fullnode

### DIFF
--- a/.changeset/few-geese-end.md
+++ b/.changeset/few-geese-end.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add deserialization util method to LocalTxnDataSerializer

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -25,8 +25,7 @@ export async function createLocalnetTasks() {
             }
             const provider = new JsonRpcProvider(
                 'http://localhost:9000',
-                false,
-                LATEST_RPC_API_VERSION
+                false
             );
             const signer = new RawSigner(
                 keypair,

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -11,7 +11,6 @@ import {
     RawSigner,
     LocalTxnDataSerializer,
     type Keypair,
-    LATEST_RPC_API_VERSION,
 } from '../../../sdk/typescript/src';
 
 export async function createLocalnetTasks() {
@@ -23,10 +22,9 @@ export async function createLocalnetTasks() {
             if (!keypair) {
                 throw new Error('missing keypair');
             }
-            const provider = new JsonRpcProvider(
-                'http://localhost:9000',
-                false
-            );
+            const provider = new JsonRpcProvider('http://localhost:9000', {
+                skipDataValidation: false,
+            });
             const signer = new RawSigner(
                 keypair,
                 provider,

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -56,12 +56,15 @@ export async function createLocalnetTasks() {
             const keypair = Ed25519Keypair.generate();
             const address = keypair.getPublicKey().toSuiAddress();
             addressToKeypair.set(address, keypair);
-            const res = await axios.post<{ ok: boolean }>(
+            const res = await axios.post<{ error: any }>(
                 'http://127.0.0.1:9123/faucet',
-                { recipient: address }
+                { FixedAmountRequest: { recipient: address } }
             );
-            if (!res.data.ok) {
-                throw new Error('Unable to invoke local faucet.');
+            if (res.data.error) {
+                throw new Error(
+                    'Unable to invoke local faucet.',
+                    res.data.error
+                );
             }
             return address;
         },

--- a/apps/explorer/src/utils/api/DefaultRpcClient.ts
+++ b/apps/explorer/src/utils/api/DefaultRpcClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { JsonRpcProvider, LATEST_RPC_API_VERSION } from '@mysten/sui.js';
+import { JsonRpcProvider } from '@mysten/sui.js';
 
 import { getEndpoint, Network } from './rpcSetting';
 
@@ -12,11 +12,7 @@ export const DefaultRpcClient = (network: Network | string) => {
     const existingClient = defaultRpcMap.get(network);
     if (existingClient) return existingClient;
 
-    const provider = new JsonRpcProvider(
-        getEndpoint(network),
-        true,
-        LATEST_RPC_API_VERSION
-    );
+    const provider = new JsonRpcProvider(getEndpoint(network), true);
     defaultRpcMap.set(network, provider);
     return provider;
 };

--- a/apps/explorer/src/utils/api/DefaultRpcClient.ts
+++ b/apps/explorer/src/utils/api/DefaultRpcClient.ts
@@ -12,7 +12,7 @@ export const DefaultRpcClient = (network: Network | string) => {
     const existingClient = defaultRpcMap.get(network);
     if (existingClient) return existingClient;
 
-    const provider = new JsonRpcProvider(getEndpoint(network), true);
+    const provider = new JsonRpcProvider(getEndpoint(network));
     defaultRpcMap.set(network, provider);
     return provider;
 };

--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -79,19 +79,13 @@ export default class ApiProvider {
     public setNewJsonRpcProvider(apiEnv: API_ENV = DEFAULT_API_ENV) {
         // We also clear the query client whenever set set a new API provider:
         queryClient.clear();
-        const apiVersion = growthbook.getFeatureValue(
-            FEATURES.RPC_API_VERSION,
-            '0.11.0'
-        );
         this._apiProvider = new JsonRpcProvider(
             getDefaultAPI(apiEnv).gateway,
-            true,
-            apiVersion
+            true
         );
         this._apiFullNodeProvider = new JsonRpcProvider(
             getDefaultAPI(apiEnv).fullNode,
-            true,
-            apiVersion
+            true
         );
         this._signer = null;
     }

--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -79,13 +79,9 @@ export default class ApiProvider {
     public setNewJsonRpcProvider(apiEnv: API_ENV = DEFAULT_API_ENV) {
         // We also clear the query client whenever set set a new API provider:
         queryClient.clear();
-        this._apiProvider = new JsonRpcProvider(
-            getDefaultAPI(apiEnv).gateway,
-            true
-        );
+        this._apiProvider = new JsonRpcProvider(getDefaultAPI(apiEnv).gateway);
         this._apiFullNodeProvider = new JsonRpcProvider(
-            getDefaultAPI(apiEnv).fullNode,
-            true
+            getDefaultAPI(apiEnv).fullNode
         );
         this._signer = null;
     }

--- a/apps/wallet/src/ui/app/experimentation/features.ts
+++ b/apps/wallet/src/ui/app/experimentation/features.ts
@@ -7,6 +7,5 @@
  */
 export enum FEATURES {
     DEPRECATE_GATEWAY = 'deprecate-gateway',
-    RPC_API_VERSION = 'rpc-api-version',
     SUI_DENOMINATION = 'sui-denomination',
 }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -58,11 +58,18 @@ pnpm run prepare:e2e
 pnpm run test:e2e
 ```
 
+To run E2E tests against DevNet
+
+```
+cd sdk/typescript
+VITE_FAUCET_URL='https://faucet.devnet.sui.io:443/gas' VITE_FULLNODE_URL='https://fullnode.devnet.sui.io' pnpm test:e2e
+```
+
 ## Usage
 
 The `JsonRpcProvider` class provides a connection to the JSON-RPC Server and should be used for all read-only operations. The default URLs to connect with the RPC server are:
 
-- local: http://127.0.0.1:5001
+- local: http://127.0.0.1:9000
 - DevNet: https://fullnode.devnet.sui.io:443
 
 Examples:

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -28,6 +28,7 @@ import {
   PaginatedTransactionDigests,
   TransactionQuery,
   Ordering,
+  RpcApiVersion,
 } from '../types';
 
 ///////////////////////////////
@@ -35,10 +36,10 @@ import {
 export abstract class Provider {
   // API Version
   /**
-   * Returns the current version of the RPC API that the provider is
-   * connected to
+   * @return the current version of the RPC API that the provider is
+   * connected to, or undefined if any error occurred
    */
-  abstract getRpcApiVersion(): Promise<string>;
+  abstract getRpcApiVersion(): Promise<RpcApiVersion | undefined>;
 
   // Objects
   /**
@@ -100,7 +101,7 @@ export abstract class Provider {
    * Method to look up denomination of a specific type of coin.
    * TODO: now only SUI coins are supported, will scale to other types
    * based on their definitions in Move.
-   * 
+   *
    * @param coin_type coin type, e.g., '0x2::sui::SUI'
    * @return denomination info of the coin including,
    * coin type, the same as input coin type
@@ -112,7 +113,7 @@ export abstract class Provider {
    * e.g., 9 here for SUI coin.
    */
   abstract getCoinDenominationInfo(
-    coin_type: string,
+    coin_type: string
   ): CoinDenominationInfoResponse;
 
   /**

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -36,9 +36,12 @@ import {
 export abstract class Provider {
   // API Version
   /**
+   * Fetch and cache the RPC API version number
+   *
    * @return the current version of the RPC API that the provider is
    * connected to, or undefined if any error occurred
    */
+
   abstract getRpcApiVersion(): Promise<RpcApiVersion | undefined>;
 
   // Objects

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -29,12 +29,13 @@ import {
   TransactionQuery,
   Ordering,
   PaginatedTransactionDigests,
+  RpcApiVersion,
 } from '../types';
 import { Provider } from './provider';
 
 export class VoidProvider extends Provider {
   // API Version
-  async getRpcApiVersion(): Promise<string> {
+  async getRpcApiVersion(): Promise<RpcApiVersion | undefined> {
     throw this.newError('getRpcApiVersion');
   }
 
@@ -49,9 +50,7 @@ export class VoidProvider extends Provider {
     throw this.newError('getGasObjectsOwnedByAddress');
   }
 
-  getCoinDenominationInfo(
-    _coin_type: string,
-  ): CoinDenominationInfoResponse {
+  getCoinDenominationInfo(_coin_type: string): CoinDenominationInfoResponse {
     throw this.newError('getCoinDenominationInfo');
   }
 

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -55,7 +55,7 @@ export abstract class SignerWithProvider implements Signer {
     let skipDataValidation = false;
     if (this.provider instanceof JsonRpcProvider) {
       endpoint = this.provider.endpoint;
-      skipDataValidation = this.provider.skipDataValidation;
+      skipDataValidation = this.provider.options.skipDataValidation!;
     }
     this.serializer =
       serializer || new RpcTxnDataSerializer(endpoint, skipDataValidation);

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -11,11 +11,11 @@ import {
   isValidSuiAddress,
   normalizeSuiObjectId,
   ObjectId,
-  shouldUseOldSharedObjectAPI,
   SuiJsonValue,
   SuiMoveNormalizedType,
 } from '../../types';
 import { bcs, CallArg, ObjectArg } from '../../types/sui-bcs';
+import { shouldUseOldSharedObjectAPI } from './local-txn-data-serializer';
 import { MoveCallTransaction } from './txn-data-serializer';
 
 const MOVE_CALL_SER_ERROR = 'Move call argument serialization error:';

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -14,7 +14,7 @@ import {
   SuiJsonValue,
   SuiMoveNormalizedType,
 } from '../../types';
-import { bcs, CallArg, ObjectArg } from '../../types/sui-bcs';
+import { bcs, CallArg, MoveCallTx, ObjectArg } from '../../types/sui-bcs';
 import { shouldUseOldSharedObjectAPI } from './local-txn-data-serializer';
 import { MoveCallTransaction } from './txn-data-serializer';
 
@@ -47,19 +47,11 @@ export class CallArgSerializer {
   async serializeMoveCallArguments(
     txn: MoveCallTransaction
   ): Promise<CallArg[]> {
-    const normalized = await this.provider.getNormalizedMoveFunction(
-      normalizeSuiObjectId(txn.packageObjectId),
+    const userParams = await this.extractNormalizedFunctionParams(
+      txn.packageObjectId,
       txn.module,
       txn.function
     );
-    const params = normalized.parameters;
-    // Entry functions can have a mutable reference to an instance of the TxContext
-    // struct defined in the TxContext module as the last parameter. The caller of
-    // the function does not need to pass it in as an argument.
-    const hasTxContext = params.length > 0 && this.isTxContext(params.at(-1)!);
-    const userParams = hasTxContext
-      ? params.slice(0, params.length - 1)
-      : params;
 
     if (userParams.length !== txn.arguments.length) {
       throw new Error(
@@ -72,6 +64,41 @@ export class CallArgSerializer {
         this.newCallArg(param, txn.arguments[i])
       )
     );
+  }
+
+  /**
+   * Deserialize Call Args used in `Transaction` into `SuiJsonValue` arguments
+   */
+  async deserializeCallArgs(txn: MoveCallTx): Promise<SuiJsonValue[]> {
+    const userParams = await this.extractNormalizedFunctionParams(
+      txn.Call.package.objectId,
+      txn.Call.module,
+      txn.Call.function
+    );
+
+    return Promise.all(
+      userParams.map(async (param, i) =>
+        this.deserializeCallArg(param, txn.Call.arguments[i])
+      )
+    );
+  }
+
+  private async extractNormalizedFunctionParams(
+    packageId: ObjectId,
+    module: string,
+    functionName: string
+  ) {
+    const normalized = await this.provider.getNormalizedMoveFunction(
+      normalizeSuiObjectId(packageId),
+      module,
+      functionName
+    );
+    const params = normalized.parameters;
+    // Entry functions can have a mutable reference to an instance of the TxContext
+    // struct defined in the TxContext module as the last parameter. The caller of
+    // the function does not need to pass it in as an argument.
+    const hasTxContext = params.length > 0 && this.isTxContext(params.at(-1)!);
+    return hasTxContext ? params.slice(0, params.length - 1) : params;
   }
 
   async newObjectArg(objectId: string): Promise<ObjectArg> {
@@ -130,6 +157,32 @@ export class CallArgSerializer {
     };
   }
 
+  private extractIdFromObjectArg(arg: ObjectArg) {
+    if ('ImmOrOwned' in arg) {
+      return arg.ImmOrOwned.objectId;
+    } else if ('Shared' in arg) {
+      return arg.Shared.objectId;
+    }
+    // TODO: remove after DevNet 0.13.0
+    return arg.Shared_Deprecated;
+  }
+
+  private async deserializeCallArg(
+    expectedType: SuiMoveNormalizedType,
+    argVal: CallArg
+  ): Promise<SuiJsonValue> {
+    if ('Object' in argVal) {
+      return this.extractIdFromObjectArg(argVal.Object);
+    } else if ('ObjVec' in argVal) {
+      return Array.from(argVal.ObjVec).map((o) =>
+        this.extractIdFromObjectArg(o)
+      );
+    }
+
+    const serType = this.getPureSerializationType(expectedType, undefined);
+    return bcs.de(serType, Uint8Array.from(argVal.Pure));
+  }
+
   /**
    *
    * @param argVal used to do additional data validation to make sure the argVal
@@ -165,11 +218,14 @@ export class CallArgSerializer {
     }
 
     if ('Vector' in normalizedType) {
-      if (typeof argVal === 'string' && normalizedType.Vector === 'U8') {
+      if (
+        (argVal === undefined || typeof argVal === 'string') &&
+        normalizedType.Vector === 'U8'
+      ) {
         return 'string';
       }
 
-      if (!Array.isArray(argVal)) {
+      if (argVal !== undefined && !Array.isArray(argVal)) {
         throw new Error(
           `Expect ${argVal} to be a array, received ${typeof argVal}`
         );
@@ -177,7 +233,7 @@ export class CallArgSerializer {
       const innerType = this.getPureSerializationType(
         normalizedType.Vector,
         // undefined when argVal is empty
-        argVal[0]
+        argVal ? argVal[0] : undefined
       );
       const res = `vector<${innerType}>`;
       // TODO: can we get rid of this call and make it happen automatically?

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -10,12 +10,12 @@ import {
   SUI_PACKAGE_ID,
   PAY_SPLIT_COIN_VEC_FUNC_NAME,
   ObjectId,
-  shouldUseOldSharedObjectAPI,
   SuiAddress,
   SUI_TYPE_ARG,
   Transaction,
   TransactionData,
   TypeTag,
+  RpcApiVersion,
 } from '../../types';
 import {
   MoveCallTransaction,
@@ -352,4 +352,8 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     serialized.set(dataBytes, TYPE_TAG.length);
     return new Base64DataBuffer(serialized);
   }
+}
+
+export function shouldUseOldSharedObjectAPI(version?: RpcApiVersion): boolean {
+  return version?.major === 0 && version?.minor <= 12;
 }

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -51,11 +51,6 @@ export interface MoveCallTransaction {
   packageObjectId: ObjectId;
   module: string;
   function: string;
-  /**
-   * Usage: pass in string[] if you use RpcTxnDataSerializer,
-   * Otherwise you need to pass in TypeTag[]. We will remove
-   * RpcTxnDataSerializer soon.
-   */
   typeArguments: string[] | TypeTag[];
   arguments: SuiJsonValue[];
   gasPayment?: ObjectId;

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -7,7 +7,7 @@
  * Generated type guards for "index.ts".
  * WARNING: Do not manually change this file.
  */
-import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, CoinDenominationInfoResponse, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, PaginatedTransactionDigests, TransactionQuery, Ordering, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, SharedObjectRef, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData } from "./index";
+import { TransactionDigest, SuiAddress, ObjectOwner, SuiObjectRef, SuiObjectInfo, ObjectContentFields, MovePackageContent, SuiData, SuiMoveObject, CoinDenominationInfoResponse, SuiMovePackage, SuiMoveFunctionArgTypesResponse, SuiMoveFunctionArgType, SuiMoveFunctionArgTypes, SuiMoveNormalizedModules, SuiMoveNormalizedModule, SuiMoveModuleId, SuiMoveNormalizedStruct, SuiMoveStructTypeParameter, SuiMoveNormalizedField, SuiMoveNormalizedFunction, SuiMoveVisibility, SuiMoveTypeParameterIndex, SuiMoveAbilitySet, SuiMoveNormalizedType, SuiMoveNormalizedTypeParameterType, SuiMoveNormalizedStructType, SuiObject, ObjectStatus, ObjectType, GetOwnedObjectsResponse, GetObjectDataResponse, ObjectDigest, ObjectId, SequenceNumber, MoveEvent, PublishEvent, TransferObjectEvent, DeleteObjectEvent, NewObjectEvent, SuiEvent, MoveEventField, EventType, SuiEventFilter, SuiEventEnvelope, SuiEvents, SubscriptionId, SubscriptionEvent, TransferObject, SuiTransferSui, SuiChangeEpoch, Pay, ExecuteTransactionRequestType, TransactionKindName, SuiTransactionKind, SuiTransactionData, EpochId, GenericAuthoritySignature, AuthorityQuorumSignInfo, CertifiedTransaction, GasCostSummary, ExecutionStatusType, ExecutionStatus, OwnedObjectRef, TransactionEffects, SuiTransactionResponse, SuiCertifiedTransactionEffects, SuiExecuteTransactionResponse, GatewayTxSeqNumber, GetTxnDigestsResponse, PaginatedTransactionDigests, TransactionQuery, Ordering, MoveCall, SuiJsonValue, EmptySignInfo, AuthorityName, AuthoritySignature, TransactionBytes, SuiParsedMergeCoinResponse, SuiParsedSplitCoinResponse, SuiParsedPublishResponse, SuiPackage, SuiParsedTransactionResponse, DelegationData, DelegationSuiObject, TransferObjectTx, TransferSuiTx, PayTx, PublishTx, SharedObjectRef, ObjectArg, CallArg, StructTag, TypeTag, MoveCallTx, Transaction, TransactionKind, TransactionData, RpcApiVersion } from "./index";
 
 export function isTransactionDigest(obj: any, _argumentName?: string): obj is TransactionDigest {
     return (
@@ -1430,5 +1430,16 @@ export function isTransactionData(obj: any, _argumentName?: string): obj is Tran
         isSuiMoveTypeParameterIndex(obj.gasPrice) as boolean &&
         isTransactionKind(obj.kind) as boolean &&
         isSuiObjectRef(obj.gasPayment) as boolean
+    )
+}
+
+export function isRpcApiVersion(obj: any, _argumentName?: string): obj is RpcApiVersion {
+    return (
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isSuiMoveTypeParameterIndex(obj.major) as boolean &&
+        isSuiMoveTypeParameterIndex(obj.minor) as boolean &&
+        isSuiMoveTypeParameterIndex(obj.patch) as boolean
     )
 }

--- a/sdk/typescript/src/types/index.ts
+++ b/sdk/typescript/src/types/index.ts
@@ -7,3 +7,4 @@ export * from './events';
 export * from './transactions';
 export * from './framework';
 export * from './sui-bcs';
+export * from './version';

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -46,7 +46,7 @@ export type CoinDenominationInfoResponse = {
   /** number of zeros in the denomination,
    * e.g., 9 here for SUI. */
   decimalNumber: number;
-}
+};
 
 export type SuiMovePackage = {
   /** A mapping from module name to disassembled Move bytecode */
@@ -213,10 +213,6 @@ export function getObjectVersion(
 }
 
 /* -------------------------------- SuiObject ------------------------------- */
-
-export function shouldUseOldSharedObjectAPI(version: string): boolean {
-  return version === '0.11.0' || version === '0.12.0';
-}
 
 export function getObjectType(
   resp: GetObjectDataResponse

--- a/sdk/typescript/src/types/version.ts
+++ b/sdk/typescript/src/types/version.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-const VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)$/;
-
 export type RpcApiVersion = {
   major: number;
   minor: number;
@@ -12,13 +10,10 @@ export type RpcApiVersion = {
 export function parseVersionFromString(
   version: string
 ): RpcApiVersion | undefined {
-  const match = version.match(VERSION_REGEX);
-  if (match) {
-    return {
-      major: Number(match[1]),
-      minor: Number(match[2]),
-      patch: Number(match[3]),
-    };
-  }
-  return undefined;
+  const versions = version.split('.');
+  return {
+    major: parseInt(versions[0], 10),
+    minor: parseInt(versions[1], 10),
+    patch: parseInt(versions[2], 10),
+  };
 }

--- a/sdk/typescript/src/types/version.ts
+++ b/sdk/typescript/src/types/version.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+const VERSION_REGEX = /^(\d+)\.(\d+)\.(\d+)$/;
+
+export type RpcApiVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+export function parseVersionFromString(
+  version: string
+): RpcApiVersion | undefined {
+  const match = version.match(VERSION_REGEX);
+  if (match) {
+    return {
+      major: Number(match[1]),
+      minor: Number(match[2]),
+      patch: Number(match[3]),
+    };
+  }
+  return undefined;
+}

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -85,7 +85,8 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       );
 
       const validators = await toolbox.getActiveValidators();
-      const validator_metadata = (validators[0] as SuiMoveObject).fields.metadata;
+      const validator_metadata = (validators[0] as SuiMoveObject).fields
+        .metadata;
       const validator_address = (validator_metadata as SuiMoveObject).fields
         .sui_address;
 

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  LocalTxnDataSerializer,
+  MoveCallTransaction,
+  RpcTxnDataSerializer,
+  SuiMoveObject,
+  UnserializedSignableTransaction,
+} from '../../src';
+import {
+  DEFAULT_GAS_BUDGET,
+  setup,
+  SUI_SYSTEM_STATE_OBJECT_ID,
+  TestToolbox,
+} from './utils/setup';
+
+describe('Transaction Serialization and deserialization', () => {
+  let toolbox: TestToolbox;
+  let localSerializer: LocalTxnDataSerializer;
+  let rpcSerializer: RpcTxnDataSerializer;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+    localSerializer = new LocalTxnDataSerializer(toolbox.provider);
+    rpcSerializer = new RpcTxnDataSerializer(toolbox.provider.endpoint);
+  });
+
+  async function serializeAndDeserialize(
+    moveCall: MoveCallTransaction
+  ): Promise<MoveCallTransaction> {
+    const rpcTxnBytes = await rpcSerializer.newMoveCall(
+      toolbox.address(),
+      moveCall
+    );
+    const localTxnBytes = await localSerializer.newMoveCall(
+      toolbox.address(),
+      moveCall
+    );
+    expect(rpcTxnBytes).toEqual(localTxnBytes);
+
+    const deserialized =
+      (await localSerializer.deserializeTransactionBytesToSignableTransaction(
+        localTxnBytes
+      )) as UnserializedSignableTransaction;
+    expect(deserialized.kind).toEqual('moveCall');
+    if ('moveCall' === deserialized.kind) {
+      const normalized = {
+        ...deserialized.data,
+        gasBudget: Number(deserialized.data.gasBudget.toString(10)),
+        gasPayment: '0x' + deserialized.data.gasPayment,
+      };
+      return normalized;
+    }
+
+    throw new Error('unreachable');
+  }
+
+  it('Move Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const moveCall = {
+      packageObjectId: '0000000000000000000000000000000000000002',
+      module: 'devnet_nft',
+      function: 'mint',
+      typeArguments: [],
+      arguments: [
+        'Example NFT',
+        'An NFT created by the wallet Command Line Tool',
+        'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+      ],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[0].objectId,
+    };
+
+    const deserialized = await serializeAndDeserialize(moveCall);
+    expect(deserialized).toEqual(moveCall);
+  });
+
+  it('Move Shared Object Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+
+    const validators = await toolbox.getActiveValidators();
+    const validator_metadata = (validators[0] as SuiMoveObject).fields.metadata;
+    const validator_address = (validator_metadata as SuiMoveObject).fields
+      .sui_address;
+
+    const moveCall = {
+      packageObjectId: '0000000000000000000000000000000000000002',
+      module: 'sui_system',
+      function: 'request_add_delegation',
+      typeArguments: [],
+      arguments: [
+        SUI_SYSTEM_STATE_OBJECT_ID,
+        coins[2].objectId,
+        validator_address,
+      ],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[3].objectId,
+    };
+
+    const deserialized = await serializeAndDeserialize(moveCall);
+    const normalized = {
+      ...deserialized,
+      arguments: deserialized.arguments.map((d) => '0x' + d),
+    };
+    expect(normalized).toEqual(moveCall);
+  });
+});

--- a/sdk/typescript/test/e2e/utils/env.d.ts
+++ b/sdk/typescript/test/e2e/utils/env.d.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Type definitions for import.meta.env
+// https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript
+/// <reference types="vite/client" />

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -57,8 +57,10 @@ type ProviderType = 'rpc' | 'rpc-with-cache';
 
 export function getProvider(providerType: ProviderType): JsonRpcProvider {
   return providerType === 'rpc'
-    ? new JsonRpcProvider(DEFAULT_FULLNODE_URL, false)
-    : new JsonRpcProviderWithCache(DEFAULT_FULLNODE_URL, false);
+    ? new JsonRpcProvider(DEFAULT_FULLNODE_URL, { skipDataValidation: false })
+    : new JsonRpcProviderWithCache(DEFAULT_FULLNODE_URL, {
+        skipDataValidation: false,
+      });
 }
 
 export async function setup(providerType: ProviderType = 'rpc') {

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -10,7 +10,6 @@ import {
   getExecutionStatusType,
   JsonRpcProvider,
   JsonRpcProviderWithCache,
-  LATEST_RPC_API_VERSION,
   ObjectId,
   RawSigner,
 } from '../../../src';
@@ -58,12 +57,8 @@ type ProviderType = 'rpc' | 'rpc-with-cache';
 
 export function getProvider(providerType: ProviderType): JsonRpcProvider {
   return providerType === 'rpc'
-    ? new JsonRpcProvider(DEFAULT_FULLNODE_URL, false, LATEST_RPC_API_VERSION)
-    : new JsonRpcProviderWithCache(
-        DEFAULT_FULLNODE_URL,
-        false,
-        LATEST_RPC_API_VERSION
-      );
+    ? new JsonRpcProvider(DEFAULT_FULLNODE_URL, false)
+    : new JsonRpcProviderWithCache(DEFAULT_FULLNODE_URL, false);
 }
 
 export async function setup(providerType: ProviderType = 'rpc') {

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -14,8 +14,10 @@ import {
   RawSigner,
 } from '../../../src';
 
-const DEFAULT_FAUCET_URL = 'http://127.0.0.1:9123/faucet';
-const DEFAULT_FULLNODE_URL = 'http://127.0.0.1:9000';
+const DEFAULT_FAUCET_URL =
+  import.meta.env.VITE_FAUCET_URL ?? 'http://127.0.0.1:9123/faucet';
+const DEFAULT_FULLNODE_URL =
+  import.meta.env.VITE_FULLNODE_URL ?? 'http://127.0.0.1:9000';
 
 export const DEFAULT_RECIPIENT = '0x36096be6a0314052931babed39f53c0666a6b0df';
 export const DEFAULT_RECIPIENT_2 = '0x46096be6a0314052931babed39f53c0666a6b0da';
@@ -45,11 +47,13 @@ export class TestToolbox {
 }
 
 export async function requestToken(recipient: string): Promise<void> {
-  const res = await axios.post<{ ok: boolean }>(DEFAULT_FAUCET_URL, {
-    recipient,
+  const res = await axios.post<{ error: any }>(DEFAULT_FAUCET_URL, {
+    FixedAmountRequest: {
+      recipient,
+    },
   });
-  if (!res.data.ok) {
-    throw new Error('Unable to invoke local faucet.');
+  if (res.data.error) {
+    throw new Error('Unable to invoke local faucet:', res.data.error);
   }
 }
 


### PR DESCRIPTION
As a follow up to https://github.com/MystenLabs/sui/pull/5350, this PR implements the logic for fetching RPC API version from fullnode. 

This new `getRpcApiVersion` method will be useful for applications to support backward-compatibility with multiple RPC versions(e.g., TestNet and DevNet) and minimize application down time during new network release. 

