### PR TITLE
[narwhal] fix Narwhal Docker image build

### DIFF
--- a/narwhal/Docker/Dockerfile
+++ b/narwhal/Docker/Dockerfile
@@ -6,25 +6,13 @@ ARG BUILD_MODE="release"
 #################################################################
 # Stage 0
 #################################################################
-FROM rust:1.62-slim-bullseye as chef
+FROM rust:1.64.0 AS chef
 WORKDIR "$WORKDIR/sui"
 ARG BUILD_MODE
 
 # Install basic dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update \
-    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -qq install -y --no-install-recommends \
-    tzdata \
-    git \
-    ca-certificates \
-    curl \
-    build-essential \
-    libssl-dev \
-    pkg-config \
-    clang \
-    cmake > /dev/null 2>&1 \
-    && rm -rf /var/lib/apt/lists/*
-# Install the fmt
-RUN rustup component add rustfmt
+RUN apt-get update && apt-get install -y cmake clang
+
 RUN echo "Will build image with mode: ${BUILD_MODE}"
 
 #################################################################

--- a/narwhal/Docker/build.sh
+++ b/narwhal/Docker/build.sh
@@ -5,7 +5,7 @@
 # fast fail.
 set -e
 
-DIR="$( cd "$( dirname "$0" )" && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DOCKERFILE="$DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --dirty --exclude '*')"

--- a/narwhal/Docker/build.sh
+++ b/narwhal/Docker/build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+echo
+echo "Building narwhal docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	"$@"


### PR DESCRIPTION
When try to build the Narwhal Docker image the following error is produced:
```
 > [planner 3/3] RUN sed -i '/crates\/workspace-hack/b; /crates/d; /narwhal/d' Cargo.toml     && cargo metadata -q >/dev/null:
#15 339.3 error: no matching package found
#15 339.3 searched package name: `move-abigen`
#15 339.3 perhaps you meant:      move-docgen
```

https://github.com/MystenLabs/sui-operations/actions/runs/3297822824/jobs/5439131120

After looking on differences compared to the SUI dockerfile I've identified that we use a different version of the base image and rust tool kit. I've now aligned to what SUI does. In a follow up PR I'll get those Dockerfiles even closer to their functionality. Also a `build.sh` script file (similar to what we use for SUI) has been introduced to help easily build an image by just running `./narwhal/Docker/build.sh`