### PR TITLE
wallet-ext: fix dapp status url check

### DIFF
--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -25,10 +25,15 @@ import st from './DappStatus.module.scss';
 function DappStatus() {
     const dispatch = useAppDispatch();
     const activeOriginUrl = useAppSelector(({ app }) => app.activeOrigin);
-    const activeOrigin = useMemo(
-        () => (activeOriginUrl && new URL(activeOriginUrl).hostname) || null,
-        [activeOriginUrl]
-    );
+    const activeOrigin = useMemo(() => {
+        try {
+            return (
+                (activeOriginUrl && new URL(activeOriginUrl).hostname) || null
+            );
+        } catch (e) {
+            return null;
+        }
+    }, [activeOriginUrl]);
     const activeOriginFavIcon = useAppSelector(
         ({ app }) => app.activeOriginFavIcon
     );


### PR DESCRIPTION
* fixes the issue when the active tab is for example about:blank and that was breaking the app

Before

https://user-images.githubusercontent.com/10210143/197228011-c90cf9b0-3b73-43a2-81d7-6eea32647d3c.mov

After


https://user-images.githubusercontent.com/10210143/197228048-d8b03c61-2374-4fb3-9c5c-683ce319fb0b.mov

