### PR TITLE
Adding a top level version string for sui crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ members = [
     "narwhal/config", "narwhal/consensus", "narwhal/crypto", "narwhal/dag", "narwhal/examples", "narwhal/executor", "narwhal/network", "narwhal/node", "narwhal/primary", "narwhal/storage", "narwhal/test-utils", "narwhal/types", "narwhal/worker",
 ]
 
+[workspace.package]
+# This version string will be inheritted by sui-core, sui-faucet, sui-node, sui-tools and sui crates
+version = "0.13.0"
+
 [profile.release]
 # The following two lines add minimal symbol information, which helps certain profilers like Bytehound
 # without significantly increasing binary size

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-core"
-version = "0.13.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-faucet"
-version = "0.13.0"
+version.workspace = true
 edition = "2021"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-node"
-version = "0.13.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-tool"
-version = "0.13.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui"
-version = "0.13.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Ran `cargo build --release` and verified that the version from the top level cargo.toml is being used.