### PR TITLE
Speed up event store ingestion + benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,6 +1411,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools",
  "lazy_static 1.4.0",
  "num-traits 0.2.15",
@@ -1423,6 +1424,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -8568,6 +8570,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
+ "criterion",
  "enum_dispatch",
  "eyre",
  "fdlimit",
@@ -9737,7 +9740,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -36,6 +36,7 @@ eyre = "0.6.8"
 
 [dev-dependencies]
 anyhow = "1.0.64"
+criterion = { version = "0.3.6", features = ["async", "async_tokio"] }
 tempfile = "3.3.0"
 num_cpus = "1.13.1"
 pretty_assertions = "1.2.0"
@@ -43,4 +44,8 @@ telemetry-subscribers.workspace = true
 
 [[bench]]
 name = "write_ahead_log"
+harness = false
+
+[[bench]]
+name = "event_store_bench"
 harness = false

--- a/crates/sui-storage/benches/event_store_bench.rs
+++ b/crates/sui-storage/benches/event_store_bench.rs
@@ -75,7 +75,7 @@ fn bench_sqlite_ingestion_varying_batch_size(c: &mut Criterion) {
             |b, db| {
                 // Note: each one of repeat_batch_insert inserts 100 events at a time
                 b.to_async(&runtime)
-                    .iter(|| repeat_batch_insert(&db, &events, *batch_size as usize))
+                    .iter(|| repeat_batch_insert(db, &events, *batch_size as usize))
             },
         );
     }

--- a/crates/sui-storage/benches/event_store_bench.rs
+++ b/crates/sui-storage/benches/event_store_bench.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
+use tempfile::NamedTempFile;
+use tokio::runtime::Builder;
+
+use sui_storage::event_store::{sql::SqlEventStore, test_utils, EventStore};
+use sui_types::{base_types::SuiAddress, event::{TransferType, EventEnvelope}};
+
+async fn repeat_batch_insert(db: &SqlEventStore, events: &[EventEnvelope], batch_size: usize) {
+    // Reset sequence number so we can insert events with old sequence numbers
+    db.testing_only_reset_seq_num();
+    for chunk in events.chunks(batch_size) {
+        db.add_events(chunk).await.expect("Inserts should not fail");
+    }
+}
+
+/// Try to see what kind of throughput is possible when we ingest a list of events of varying size
+fn bench_sqlite_ingestion_varying_batch_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SQLite ingestion varying batch size");
+
+    let runtime = Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(32 * 1024 * 1024)
+        .worker_threads(usize::min(num_cpus::get(), 24))
+        .build()
+        .unwrap();
+
+    // Initialize SQLite event store
+    let db_path = NamedTempFile::new().expect("Could not create temp file for SQlite db");
+    let db = runtime
+        .block_on(SqlEventStore::new_from_file(db_path.path()))
+        .expect("Could not create new disk SqlEventStore");
+    runtime
+        .block_on(db.initialize())
+        .expect("Could not initialize DB");
+
+    // Create events
+    let mut events = Vec::new();
+    let sender = SuiAddress::random_for_testing_only();
+    for n in 0..100 {
+        let transfer_obj = test_utils::new_test_transfer_event(
+            1_666_003 + n * 100,
+            4 + n,
+            n,
+            TransferType::ToAddress,
+            None,
+            Some(sender),
+            None,
+        );
+        events.push(transfer_obj);
+    }
+
+    group.throughput(Throughput::Elements(events.len() as u64));
+
+    for batch_size in [1, 5, 10, 20, 50, 100].iter() {
+
+        // Clear event store: TODO
+
+        // This should be increasing with each batch_size, verifies that inserts are happening
+        println!("Event store event count: {}", runtime.block_on(db.total_event_count()).unwrap());
+
+        group.bench_with_input(
+            BenchmarkId::new("SqlEventStore.add_events() with batch size: ", *batch_size),
+            &db,
+            |b, db| {
+                // Note: each one of repeat_batch_insert inserts 100 events at a time
+                b.to_async(&runtime).iter(|| repeat_batch_insert(&db, &events, *batch_size as usize))
+            },
+        );
+    }
+}
+
+criterion_group!(benches, bench_sqlite_ingestion_varying_batch_size);
+criterion_main!(benches);

--- a/crates/sui-storage/src/event_store/sql.rs
+++ b/crates/sui-storage/src/event_store/sql.rs
@@ -168,7 +168,7 @@ impl SqlEventStore {
 
     /// Returns total size of table.  Should really only be used for testing.
     #[allow(unused)]
-    async fn total_event_count(&self) -> Result<usize, SuiError> {
+    pub async fn total_event_count(&self) -> Result<usize, SuiError> {
         let result = sqlx::query("SELECT COUNT(*) FROM events")
             .fetch_one(&self.pool)
             .await
@@ -184,6 +184,13 @@ impl SqlEventStore {
             .map_err(convert_sqlx_err)?;
         let num_rows: i64 = result.get(0);
         Ok(num_rows as u64)
+    }
+
+    /// Only use for testing or benchmarking. Resets the last seq number to 0
+    /// so we can insert new events without increasing TX sequence number.
+    #[allow(unused)]
+    pub fn testing_only_reset_seq_num(&self) {
+        self.seq_num.store(0, Ordering::Relaxed);
     }
 
     fn try_extract_object_id(row: &SqliteRow, col: usize) -> Result<Option<ObjectID>, SuiError> {

--- a/crates/sui-storage/src/event_store/sql.rs
+++ b/crates/sui-storage/src/event_store/sql.rs
@@ -16,7 +16,7 @@ use sui_types::base_types::SuiAddress;
 use sui_types::object::Owner;
 
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteRow},
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteRow, SqliteSynchronous},
     Executor, Row, SqlitePool,
 };
 use sui_types::error::SuiError;
@@ -108,6 +108,10 @@ impl SqlEventStore {
         // TODO: configure other SQLite options
         let mut options = SqliteConnectOptions::new()
             .filename(db_path)
+            // SQLite turns off WAL by default and uses DELETE journaling.  WAL is at least 2x faster.
+            .journal_mode(SqliteJournalMode::Wal)
+            // Normal vs Full sync mode also speeds up writes
+            .synchronous(SqliteSynchronous::Normal)
             .create_if_missing(true);
         options.log_statements(log::LevelFilter::Off);
         let pool = SqlitePool::connect_with(options)

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -118,7 +118,7 @@ core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
 crc32fast = { version = "1", features = ["std"] }
-criterion = { version = "0.3", features = ["cargo_bench_support"] }
+criterion = { version = "0.3", features = ["async", "async_tokio", "cargo_bench_support", "futures", "tokio"] }
 criterion-plot = { version = "0.4", default-features = false }
 crossbeam = { version = "0.8", features = ["alloc", "crossbeam-channel", "crossbeam-deque", "crossbeam-epoch", "crossbeam-queue", "std"] }
 crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
@@ -741,7 +741,7 @@ core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
 crc32fast = { version = "1", features = ["std"] }
-criterion = { version = "0.3", features = ["cargo_bench_support"] }
+criterion = { version = "0.3", features = ["async", "async_tokio", "cargo_bench_support", "futures", "tokio"] }
 criterion-plot = { version = "0.4", default-features = false }
 crossbeam = { version = "0.8", features = ["alloc", "crossbeam-channel", "crossbeam-deque", "crossbeam-epoch", "crossbeam-queue", "std"] }
 crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }


### PR DESCRIPTION
We found that event store writes might be very slow in production full nodes.  It was discovered default SQLite configuration turns off WAL and has a per-commit sync policy, which is too slow esp for EBS type stores.  This adds a benchmark and benchmarks various improvements.

1. Add a benchmark (see output below) using Criterion for event store ingestion
2. Turns on WAL journal mode and normal synchronization.  This is shown using the benchmark to speed up writes by 120% or so.
3. Switches to using batch inserts instead of individual inserts.  For number of events > 1, has a significant boost to write speeds.

Originally, for all batch sizes (1 event to 100 events), write speeds locally benchmarked at ~2000 events/sec (1 event) to 1800 (100 events).  Now:

(TL/DR; optimum event batch size is around 50, when we get >8500 events/sec, more than 4x the original mark)

```
Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /1: Collecting 100 samples i                                                                                                                         SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /1
                        time:   [19.783 ms 20.148 ms 20.579 ms]
                        thrpt:  [4.8592 Kelem/s 4.9633 Kelem/s 5.0549 Kelem/s]
                 change:
                        time:   [-5.4342% -2.9743% -0.5123%] (p = 0.02 < 0.05)
                        thrpt:  [+0.5149% +3.0655% +5.7465%]
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
Event store event count: 65500
Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /5: Collecting 100 samples i                                                                                                                         SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /5
                        time:   [13.586 ms 13.841 ms 14.111 ms]
                        thrpt:  [7.0869 Kelem/s 7.2248 Kelem/s 7.3607 Kelem/s]
                 change:
                        time:   [-37.589% -35.635% -33.771%] (p = 0.00 < 0.05)
                        thrpt:  [+50.992% +55.364% +60.229%]
                        Performance has improved.
Event store event count: 131000
Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /10: Collecting 100 samples                                                                                                                          SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /10
                        time:   [12.706 ms 12.936 ms 13.178 ms]
                        thrpt:  [7.5884 Kelem/s 7.7305 Kelem/s 7.8700 Kelem/s]
                 change:
                        time:   [-43.952% -42.145% -40.505%] (p = 0.00 < 0.05)
                        thrpt:  [+68.081% +72.847% +78.420%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  4 (4.00%) low severe
  5 (5.00%) high mild
  9 (9.00%) high severe
Event store event count: 196500
Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /20: Collecting 100 samples                                                                                                                          SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /20
                        time:   [12.075 ms 12.377 ms 12.711 ms]
                        thrpt:  [7.8670 Kelem/s 8.0795 Kelem/s 8.2817 Kelem/s]
                 change:
                        time:   [-47.061% -45.238% -43.521%] (p = 0.00 < 0.05)
                        thrpt:  [+77.056% +82.610% +88.896%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
Event store event count: 272000
Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /50: Collecting 100 samples                                                                                                                          SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /50
                        time:   [11.475 ms 11.726 ms 11.999 ms]
                        thrpt:  [8.3341 Kelem/s 8.5278 Kelem/s 8.7146 Kelem/s]
                 change:
                        time:   [-48.718% -47.287% -45.826%] (p = 0.00 < 0.05)
                        thrpt:  [+84.591% +89.707% +95.000%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Event store event count: 347500
Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /100: Warming up for 3.0000                                                                                                                          Benchmarking SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /100: Collecting 100 samples                                                                                                                         SQLite ingestion varying batch size/SqlEventStore.add_events() with batch size: /100
                        time:   [11.687 ms 12.044 ms 12.419 ms]
                        thrpt:  [8.0522 Kelem/s 8.3031 Kelem/s 8.5567 Kelem/s]
                 change:
                        time:   [-48.997% -47.119% -45.238%] (p = 0.00 < 0.05)
                        thrpt:  [+82.608% +89.105% +96.068%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

Note that this PR does not batch events from multiple TXes, so this only benefits writes when transactions contain multiple events.  However, this can be turned on subsequently for another nice boost.