### PR TITLE
fixed bug to to use parse() from LosslessJSON.default instead directly.

### DIFF
--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -52,7 +52,7 @@ export class JsonRpcClient {
           let res: Response = await fetch(url, options);
           const text = await res.text();
           const result = JSON.stringify(
-            LosslessJSON.parse(text, (key, value) => {
+            LosslessJSON.default.parse(text, (key, value) => {
               if (value == null) {
                 return value;
               }


### PR DESCRIPTION
Fixed the following bug in the SDK in create RPC client:
Error:

_Error: Error executing a move call: TypeError: LosslessJSON.parse is not a function with args_
