### PR TITLE
Unify the faucet interface in sui-test-validator

### DIFF
--- a/.changeset/few-geese-end.md
+++ b/.changeset/few-geese-end.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Add deserialization util method to LocalTxnDataSerializer

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -56,12 +56,15 @@ export async function createLocalnetTasks() {
             const keypair = Ed25519Keypair.generate();
             const address = keypair.getPublicKey().toSuiAddress();
             addressToKeypair.set(address, keypair);
-            const res = await axios.post<{ ok: boolean }>(
+            const res = await axios.post<{ error: any }>(
                 'http://127.0.0.1:9123/faucet',
-                { recipient: address }
+                { FixedAmountRequest: { recipient: address } }
             );
-            if (!res.data.ok) {
-                throw new Error('Unable to invoke local faucet.');
+            if (res.data.error) {
+                throw new Error(
+                    'Unable to invoke local faucet.',
+                    res.data.error
+                );
             }
             return address;
         },

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -58,11 +58,18 @@ pnpm run prepare:e2e
 pnpm run test:e2e
 ```
 
+To run E2E tests against DevNet
+
+```
+cd sdk/typescript
+VITE_FAUCET_URL='https://faucet.devnet.sui.io:443/gas' VITE_FULLNODE_URL='https://fullnode.devnet.sui.io' pnpm test:e2e
+```
+
 ## Usage
 
 The `JsonRpcProvider` class provides a connection to the JSON-RPC Server and should be used for all read-only operations. The default URLs to connect with the RPC server are:
 
-- local: http://127.0.0.1:5001
+- local: http://127.0.0.1:9000
 - DevNet: https://fullnode.devnet.sui.io:443
 
 Examples:

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -14,7 +14,7 @@ import {
   SuiJsonValue,
   SuiMoveNormalizedType,
 } from '../../types';
-import { bcs, CallArg, ObjectArg } from '../../types/sui-bcs';
+import { bcs, CallArg, MoveCallTx, ObjectArg } from '../../types/sui-bcs';
 import { shouldUseOldSharedObjectAPI } from './local-txn-data-serializer';
 import { MoveCallTransaction } from './txn-data-serializer';
 
@@ -47,19 +47,11 @@ export class CallArgSerializer {
   async serializeMoveCallArguments(
     txn: MoveCallTransaction
   ): Promise<CallArg[]> {
-    const normalized = await this.provider.getNormalizedMoveFunction(
-      normalizeSuiObjectId(txn.packageObjectId),
+    const userParams = await this.extractNormalizedFunctionParams(
+      txn.packageObjectId,
       txn.module,
       txn.function
     );
-    const params = normalized.parameters;
-    // Entry functions can have a mutable reference to an instance of the TxContext
-    // struct defined in the TxContext module as the last parameter. The caller of
-    // the function does not need to pass it in as an argument.
-    const hasTxContext = params.length > 0 && this.isTxContext(params.at(-1)!);
-    const userParams = hasTxContext
-      ? params.slice(0, params.length - 1)
-      : params;
 
     if (userParams.length !== txn.arguments.length) {
       throw new Error(
@@ -72,6 +64,41 @@ export class CallArgSerializer {
         this.newCallArg(param, txn.arguments[i])
       )
     );
+  }
+
+  /**
+   * Deserialize Call Args used in `Transaction` into `SuiJsonValue` arguments
+   */
+  async deserializeCallArgs(txn: MoveCallTx): Promise<SuiJsonValue[]> {
+    const userParams = await this.extractNormalizedFunctionParams(
+      txn.Call.package.objectId,
+      txn.Call.module,
+      txn.Call.function
+    );
+
+    return Promise.all(
+      userParams.map(async (param, i) =>
+        this.deserializeCallArg(param, txn.Call.arguments[i])
+      )
+    );
+  }
+
+  private async extractNormalizedFunctionParams(
+    packageId: ObjectId,
+    module: string,
+    functionName: string
+  ) {
+    const normalized = await this.provider.getNormalizedMoveFunction(
+      normalizeSuiObjectId(packageId),
+      module,
+      functionName
+    );
+    const params = normalized.parameters;
+    // Entry functions can have a mutable reference to an instance of the TxContext
+    // struct defined in the TxContext module as the last parameter. The caller of
+    // the function does not need to pass it in as an argument.
+    const hasTxContext = params.length > 0 && this.isTxContext(params.at(-1)!);
+    return hasTxContext ? params.slice(0, params.length - 1) : params;
   }
 
   async newObjectArg(objectId: string): Promise<ObjectArg> {
@@ -130,6 +157,32 @@ export class CallArgSerializer {
     };
   }
 
+  private extractIdFromObjectArg(arg: ObjectArg) {
+    if ('ImmOrOwned' in arg) {
+      return arg.ImmOrOwned.objectId;
+    } else if ('Shared' in arg) {
+      return arg.Shared.objectId;
+    }
+    // TODO: remove after DevNet 0.13.0
+    return arg.Shared_Deprecated;
+  }
+
+  private async deserializeCallArg(
+    expectedType: SuiMoveNormalizedType,
+    argVal: CallArg
+  ): Promise<SuiJsonValue> {
+    if ('Object' in argVal) {
+      return this.extractIdFromObjectArg(argVal.Object);
+    } else if ('ObjVec' in argVal) {
+      return Array.from(argVal.ObjVec).map((o) =>
+        this.extractIdFromObjectArg(o)
+      );
+    }
+
+    const serType = this.getPureSerializationType(expectedType, undefined);
+    return bcs.de(serType, Uint8Array.from(argVal.Pure));
+  }
+
   /**
    *
    * @param argVal used to do additional data validation to make sure the argVal
@@ -165,11 +218,14 @@ export class CallArgSerializer {
     }
 
     if ('Vector' in normalizedType) {
-      if (typeof argVal === 'string' && normalizedType.Vector === 'U8') {
+      if (
+        (argVal === undefined || typeof argVal === 'string') &&
+        normalizedType.Vector === 'U8'
+      ) {
         return 'string';
       }
 
-      if (!Array.isArray(argVal)) {
+      if (argVal !== undefined && !Array.isArray(argVal)) {
         throw new Error(
           `Expect ${argVal} to be a array, received ${typeof argVal}`
         );
@@ -177,7 +233,7 @@ export class CallArgSerializer {
       const innerType = this.getPureSerializationType(
         normalizedType.Vector,
         // undefined when argVal is empty
-        argVal[0]
+        argVal ? argVal[0] : undefined
       );
       const res = `vector<${innerType}>`;
       // TODO: can we get rid of this call and make it happen automatically?

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -51,11 +51,6 @@ export interface MoveCallTransaction {
   packageObjectId: ObjectId;
   module: string;
   function: string;
-  /**
-   * Usage: pass in string[] if you use RpcTxnDataSerializer,
-   * Otherwise you need to pass in TypeTag[]. We will remove
-   * RpcTxnDataSerializer soon.
-   */
   typeArguments: string[] | TypeTag[];
   arguments: SuiJsonValue[];
   gasPayment?: ObjectId;

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -85,7 +85,8 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       );
 
       const validators = await toolbox.getActiveValidators();
-      const validator_metadata = (validators[0] as SuiMoveObject).fields.metadata;
+      const validator_metadata = (validators[0] as SuiMoveObject).fields
+        .metadata;
       const validator_address = (validator_metadata as SuiMoveObject).fields
         .sui_address;
 

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  LocalTxnDataSerializer,
+  MoveCallTransaction,
+  RpcTxnDataSerializer,
+  SuiMoveObject,
+  UnserializedSignableTransaction,
+} from '../../src';
+import {
+  DEFAULT_GAS_BUDGET,
+  setup,
+  SUI_SYSTEM_STATE_OBJECT_ID,
+  TestToolbox,
+} from './utils/setup';
+
+describe('Transaction Serialization and deserialization', () => {
+  let toolbox: TestToolbox;
+  let localSerializer: LocalTxnDataSerializer;
+  let rpcSerializer: RpcTxnDataSerializer;
+
+  beforeAll(async () => {
+    toolbox = await setup();
+    localSerializer = new LocalTxnDataSerializer(toolbox.provider);
+    rpcSerializer = new RpcTxnDataSerializer(toolbox.provider.endpoint);
+  });
+
+  async function serializeAndDeserialize(
+    moveCall: MoveCallTransaction
+  ): Promise<MoveCallTransaction> {
+    const rpcTxnBytes = await rpcSerializer.newMoveCall(
+      toolbox.address(),
+      moveCall
+    );
+    const localTxnBytes = await localSerializer.newMoveCall(
+      toolbox.address(),
+      moveCall
+    );
+    expect(rpcTxnBytes).toEqual(localTxnBytes);
+
+    const deserialized =
+      (await localSerializer.deserializeTransactionBytesToSignableTransaction(
+        localTxnBytes
+      )) as UnserializedSignableTransaction;
+    expect(deserialized.kind).toEqual('moveCall');
+    if ('moveCall' === deserialized.kind) {
+      const normalized = {
+        ...deserialized.data,
+        gasBudget: Number(deserialized.data.gasBudget.toString(10)),
+        gasPayment: '0x' + deserialized.data.gasPayment,
+      };
+      return normalized;
+    }
+
+    throw new Error('unreachable');
+  }
+
+  it('Move Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+    const moveCall = {
+      packageObjectId: '0000000000000000000000000000000000000002',
+      module: 'devnet_nft',
+      function: 'mint',
+      typeArguments: [],
+      arguments: [
+        'Example NFT',
+        'An NFT created by the wallet Command Line Tool',
+        'ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
+      ],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[0].objectId,
+    };
+
+    const deserialized = await serializeAndDeserialize(moveCall);
+    expect(deserialized).toEqual(moveCall);
+  });
+
+  it('Move Shared Object Call', async () => {
+    const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
+      toolbox.address()
+    );
+
+    const validators = await toolbox.getActiveValidators();
+    const validator_metadata = (validators[0] as SuiMoveObject).fields.metadata;
+    const validator_address = (validator_metadata as SuiMoveObject).fields
+      .sui_address;
+
+    const moveCall = {
+      packageObjectId: '0000000000000000000000000000000000000002',
+      module: 'sui_system',
+      function: 'request_add_delegation',
+      typeArguments: [],
+      arguments: [
+        SUI_SYSTEM_STATE_OBJECT_ID,
+        coins[2].objectId,
+        validator_address,
+      ],
+      gasBudget: DEFAULT_GAS_BUDGET,
+      gasPayment: coins[3].objectId,
+    };
+
+    const deserialized = await serializeAndDeserialize(moveCall);
+    const normalized = {
+      ...deserialized,
+      arguments: deserialized.arguments.map((d) => '0x' + d),
+    };
+    expect(normalized).toEqual(moveCall);
+  });
+});

--- a/sdk/typescript/test/e2e/utils/env.d.ts
+++ b/sdk/typescript/test/e2e/utils/env.d.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Type definitions for import.meta.env
+// https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript
+/// <reference types="vite/client" />

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -14,8 +14,10 @@ import {
   RawSigner,
 } from '../../../src';
 
-const DEFAULT_FAUCET_URL = 'http://127.0.0.1:9123/faucet';
-const DEFAULT_FULLNODE_URL = 'http://127.0.0.1:9000';
+const DEFAULT_FAUCET_URL =
+  import.meta.env.VITE_FAUCET_URL ?? 'http://127.0.0.1:9123/faucet';
+const DEFAULT_FULLNODE_URL =
+  import.meta.env.VITE_FULLNODE_URL ?? 'http://127.0.0.1:9000';
 
 export const DEFAULT_RECIPIENT = '0x36096be6a0314052931babed39f53c0666a6b0df';
 export const DEFAULT_RECIPIENT_2 = '0x46096be6a0314052931babed39f53c0666a6b0da';
@@ -45,11 +47,13 @@ export class TestToolbox {
 }
 
 export async function requestToken(recipient: string): Promise<void> {
-  const res = await axios.post<{ ok: boolean }>(DEFAULT_FAUCET_URL, {
-    recipient,
+  const res = await axios.post<{ error: any }>(DEFAULT_FAUCET_URL, {
+    FixedAmountRequest: {
+      recipient,
+    },
   });
-  if (!res.data.ok) {
-    throw new Error('Unable to invoke local faucet.');
+  if (res.data.error) {
+    throw new Error('Unable to invoke local faucet:', res.data.error);
   }
 }
 


### PR DESCRIPTION
The faucet in `sui-test-validator` has a different interface than the DevNet faucet server. This PR unifies them so that the same e2e test can work with both the local network and DevNet.