### PR TITLE
Use workspace version in sui-sdk crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8389,7 +8389,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-# This version string will be inheritted by sui-core, sui-faucet, sui-node, sui-tools and sui crates
+# This version string will be inheritted by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, and sui crates
 version = "0.13.0"
 
 [profile.release]

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-sdk"
-version = "0.12.0"
+version.workspace = true
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
The version in sui-sdk is being use by the SDK client to check compatibility with the sui-node rpc api,  we need to keep it inline with the sui-node version