### PR TITLE
Enhance ObjectNotFound and add SharedObjectPriorVersionsPendingExecution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,6 +8364,7 @@ dependencies = [
  "sui-open-rpc-macros",
  "sui-transaction-builder",
  "sui-types",
+ "tap",
  "tokio",
  "tracing",
  "workspace-hack",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -785,7 +785,7 @@ impl AuthorityState {
             lock_errors.is_empty(),
             // NOTE: the error message here will say 'Error acquiring lock' but what it means is
             // 'error checking lock'.
-            SuiError::ObjectErrors {
+            SuiError::TransactionInputObjectsErrors {
                 errors: lock_errors
             }
         );
@@ -1725,6 +1725,7 @@ impl AuthorityState {
                             error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
                             Err(SuiError::ObjectNotFound {
                                 object_id: *object_id,
+                                version: Some(obj_ref.1),
                             })
                         }
                         Some(object) => {
@@ -1784,6 +1785,7 @@ impl AuthorityState {
                             error!("Object with in parent_entry is missing from object store, datastore is inconsistent");
                             Err(SuiError::ObjectNotFound {
                                 object_id: *object_id,
+                                version: Some(obj_ref.1),
                             })
                         }
                         Some(object) => {

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -396,7 +396,7 @@ where
                     processed_certificates.insert(cert_digest);
                     continue;
                 }
-                Err(SuiError::ObjectErrors { .. }) => {}
+                Err(SuiError::TransactionInputObjectsErrors { .. }) => {}
                 Err(e) => return Err(e),
             }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -441,7 +441,7 @@ impl ValidatorService {
 
         // 5) Execute the certificate.
         // Often we cannot execute a cert due to dependenties haven't been executed, and we will
-        // observe ObjectErrors. In such case, we can wait and retry. It should eventually
+        // observe TransactionInputObjectsErrors. In such case, we can wait and retry. It should eventually
         // succeed.
         // TODO: This is a quick hack. We should properly fix this through dependency-based
         // scheduling.
@@ -457,7 +457,7 @@ impl ValidatorService {
                 .instrument(span)
                 .await
             {
-                err @ Err(SuiError::ObjectErrors { .. }) => {
+                err @ Err(SuiError::TransactionInputObjectsErrors { .. }) => {
                     if retry_cnt >= 30 {
                         return Err(tonic::Status::internal(err.unwrap_err().to_string()));
                     }

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -1272,6 +1272,7 @@ where
             .map(|(obj_ref, _)| obj_ref)
             .ok_or(SuiError::ObjectNotFound {
                 object_id: *object_id,
+                version: None,
             })
     }
 }

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -585,8 +585,11 @@ where
         };
         match result {
             Ok(_) => Ok(SyncStatus::CertExecuted),
-            Err(SuiError::ObjectNotFound { .. }) | Err(SuiError::ObjectErrors { .. }) => {
-                debug!(?digest, "cert execution failed due to missing parents");
+            e @ Err(SuiError::TransactionInputObjectsErrors { .. }) => {
+                debug!(
+                    ?digest,
+                    "cert execution failed due to missing parents {:?}", e
+                );
 
                 let effects = self.get_true_effects(epoch_id, &cert).await?;
 

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -103,9 +103,10 @@ where
         Ok(SuiGasStatus::new_unmetered())
     } else {
         let gas_object = store.get_object_by_key(&gas_payment.0, gas_payment.1)?;
-        let gas_object = gas_object.ok_or(SuiError::ObjectErrors {
+        let gas_object = gas_object.ok_or(SuiError::TransactionInputObjectsErrors {
             errors: vec![SuiError::ObjectNotFound {
                 object_id: gas_payment.0,
+                version: Some(gas_payment.1),
             }],
         })?;
 
@@ -192,7 +193,7 @@ async fn check_objects(
     // If any errors with the locks were detected, we return all errors to give the client
     // a chance to update the authority if possible.
     if !errors.is_empty() {
-        return Err(SuiError::ObjectErrors { errors });
+        return Err(SuiError::TransactionInputObjectsErrors { errors });
     }
     fp_ensure!(!all_objects.is_empty(), SuiError::ObjectInputArityViolation);
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -306,7 +306,7 @@ async fn test_handle_transfer_transaction_with_max_sequence_number() {
     assert!(res.is_err());
     assert_eq!(
         res.err(),
-        Some(SuiError::ObjectErrors {
+        Some(SuiError::TransactionInputObjectsErrors {
             errors: vec![SuiError::InvalidSequenceNumber],
         })
     );
@@ -321,7 +321,7 @@ async fn test_handle_shared_object_with_max_sequence_number() {
     assert!(response.is_err());
     assert_eq!(
         response.err(),
-        Some(SuiError::ObjectErrors {
+        Some(SuiError::TransactionInputObjectsErrors {
             errors: vec![SuiError::InvalidSequenceNumber],
         })
     );

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -330,7 +330,8 @@ async fn test_object_owning_another_object() {
     )
     .await;
     assert!(effects.is_err());
-    assert!(format!("{effects:?}").contains("ObjectErrors { errors: [InvalidChildObjectArgument"));
+    assert!(format!("{effects:?}")
+        .contains("TransactionInputObjectsErrors { errors: [InvalidChildObjectArgument"));
 
     // Create another parent.
     let effects = call_move(
@@ -845,7 +846,8 @@ async fn test_entry_point_vector() {
     )
     .await;
     assert!(effects.is_err());
-    assert!(format!("{effects:?}").contains("ObjectErrors { errors: [InvalidChildObjectArgument"));
+    assert!(format!("{effects:?}")
+        .contains("TransactionInputObjectsErrors { errors: [InvalidChildObjectArgument"));
 }
 
 #[tokio::test]
@@ -1220,7 +1222,8 @@ async fn test_entry_point_vector_any() {
     )
     .await;
     assert!(effects.is_err());
-    assert!(format!("{effects:?}").contains("ObjectErrors { errors: [InvalidChildObjectArgument"));
+    assert!(format!("{effects:?}")
+        .contains("TransactionInputObjectsErrors { errors: [InvalidChildObjectArgument"));
 }
 
 #[tokio::test]

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -962,7 +962,10 @@ impl<T: SuiData> SuiObjectRead<T> {
             Self::Deleted(oref) => Err(SuiError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::NotExists(id) => Err(SuiError::ObjectNotFound { object_id: *id }),
+            Self::NotExists(id) => Err(SuiError::ObjectNotFound {
+                object_id: *id,
+                version: None,
+            }),
             Self::Exists(o) => Ok(o),
         }
     }
@@ -974,7 +977,10 @@ impl<T: SuiData> SuiObjectRead<T> {
             Self::Deleted(oref) => Err(SuiError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::NotExists(id) => Err(SuiError::ObjectNotFound { object_id: id }),
+            Self::NotExists(id) => Err(SuiError::ObjectNotFound {
+                object_id: id,
+                version: None,
+            }),
             Self::Exists(o) => Ok(o),
         }
     }
@@ -1022,11 +1028,14 @@ impl<T: SuiData> SuiPastObjectRead<T> {
             Self::ObjectDeleted(oref) => Err(SuiError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound { object_id: *id }),
-            Self::VersionFound(o) => Ok(o),
-            Self::VersionNotFound(id, seq_num) => Err(SuiError::ObjectVersionNotFound {
+            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound {
                 object_id: *id,
-                version: *seq_num,
+                version: None,
+            }),
+            Self::VersionFound(o) => Ok(o),
+            Self::VersionNotFound(id, seq_num) => Err(SuiError::ObjectNotFound {
+                object_id: *id,
+                version: Some(*seq_num),
             }),
             Self::VersionTooHigh {
                 object_id,
@@ -1046,11 +1055,15 @@ impl<T: SuiData> SuiPastObjectRead<T> {
             Self::ObjectDeleted(oref) => Err(SuiError::ObjectDeleted {
                 object_ref: oref.to_object_ref(),
             }),
-            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound { object_id: id }),
+            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound {
+                object_id: id,
+                version: None,
+            }),
             Self::VersionFound(o) => Ok(o),
-            Self::VersionNotFound(object_id, version) => {
-                Err(SuiError::ObjectVersionNotFound { object_id, version })
-            }
+            Self::VersionNotFound(object_id, version) => Err(SuiError::ObjectNotFound {
+                object_id,
+                version: Some(version),
+            }),
             Self::VersionTooHigh {
                 object_id,
                 asked_version,

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -22,6 +22,8 @@ futures = "0.3.23"
 tokio = { version = "1.20.1", features = ["full"] }
 signature = "1.6.0"
 
+tap = "1.0"
+
 sui-core = { path = "../sui-core" }
 sui-types = { path = "../sui-types" }
 sui-json = { path = "../sui-json" }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -53,7 +53,7 @@ const MISSING_COMMITTEE_ERROR_MSG: &str = "Missing committee information for epo
 pub enum SuiError {
     // Object misuse issues
     #[error("Error checking transaction input objects: {:?}", errors)]
-    ObjectErrors { errors: Vec<SuiError> },
+    TransactionInputObjectsErrors { errors: Vec<SuiError> },
     #[error("Attempt to transfer an object that's not owned.")]
     TransferUnownedError,
     #[error("Attempt to transfer an object that does not have public transfer. Object transfer must be done instead using a distinct Move function call.")]
@@ -297,16 +297,23 @@ pub enum SuiError {
     },
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{:?}].", digest)]
     TransactionNotFound { digest: TransactionDigest },
-    #[error("Could not find the referenced object {:?}.", object_id)]
-    ObjectNotFound { object_id: ObjectID },
     #[error(
-        "Could not find the referenced object {:?} at version {:?}",
+        "Could not find the referenced object {:?} at version {:?}.",
         object_id,
         version
     )]
-    ObjectVersionNotFound {
+    ObjectNotFound {
         object_id: ObjectID,
-        version: SequenceNumber,
+        version: Option<SequenceNumber>,
+    },
+    #[error(
+        "Transaction involving Shared Object {:?} at version {:?} is not ready for execution because prior transactions have yet to execute.",
+        object_id,
+        version_not_ready
+    )]
+    SharedObjectPriorVersionsPendingExecution {
+        object_id: ObjectID,
+        version_not_ready: SequenceNumber,
     },
     #[error("Could not find the referenced object {:?} as the asked version {:?} is higher than the latest {:?}", object_id, asked_version, latest_version)]
     ObjectSequenceNumberTooHigh {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1795,8 +1795,14 @@ impl InputObjectKind {
     pub fn object_not_found_error(&self) -> SuiError {
         match *self {
             Self::MovePackage(package_id) => SuiError::DependentPackageNotFound { package_id },
-            Self::ImmOrOwnedMoveObject((object_id, _, _)) => SuiError::ObjectNotFound { object_id },
-            Self::SharedMoveObject { id, .. } => SuiError::ObjectNotFound { object_id: id },
+            Self::ImmOrOwnedMoveObject((object_id, version, _)) => SuiError::ObjectNotFound {
+                object_id,
+                version: Some(version),
+            },
+            Self::SharedMoveObject { id, .. } => SuiError::ObjectNotFound {
+                object_id: id,
+                version: None,
+            },
         }
     }
 }

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -629,7 +629,10 @@ impl ObjectRead {
     pub fn into_object(self) -> Result<Object, SuiError> {
         match self {
             Self::Deleted(oref) => Err(SuiError::ObjectDeleted { object_ref: oref }),
-            Self::NotExists(id) => Err(SuiError::ObjectNotFound { object_id: id }),
+            Self::NotExists(id) => Err(SuiError::ObjectNotFound {
+                object_id: id,
+                version: None,
+            }),
             Self::Exists(_, o, _) => Ok(o),
         }
     }
@@ -684,11 +687,15 @@ impl PastObjectRead {
     pub fn into_object(self) -> Result<Object, SuiError> {
         match self {
             Self::ObjectDeleted(oref) => Err(SuiError::ObjectDeleted { object_ref: oref }),
-            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound { object_id: id }),
+            Self::ObjectNotExists(id) => Err(SuiError::ObjectNotFound {
+                object_id: id,
+                version: None,
+            }),
             Self::VersionFound(_, o, _) => Ok(o),
-            Self::VersionNotFound(object_id, version) => {
-                Err(SuiError::ObjectVersionNotFound { object_id, version })
-            }
+            Self::VersionNotFound(object_id, version) => Err(SuiError::ObjectNotFound {
+                object_id,
+                version: Some(version),
+            }),
             Self::VersionTooHigh {
                 object_id,
                 asked_version,


### PR DESCRIPTION
1. add `version` to `ObjectNotFound`
3. consolidate `ObjectVersionNotFound` and `ObjectNotFound`
4. rename `ObjectErrors` to `TransactionInputObjectsErrors` 
5. when txn with shared objects cannot be executed due to the dependent txns still pending, issue `SharedObjectPriorVersionsPendingExecution` error
6. in `fn get_sequenced_input_objects`, lazily get shared object locks only when there're shared objects in that txn.
7. add some logs