### PR TITLE
Move book on build test md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7906,7 +7906,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "sui-core"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8214,7 +8214,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8417,7 +8417,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -8666,7 +8666,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "0.12.0"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "clap 3.2.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8231,6 +8231,7 @@ dependencies = [
  "sui-node",
  "sui-sdk",
  "sui-types",
+ "tap",
  "telemetry-subscribers 0.2.0",
  "test-utils",
  "thiserror",

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -9,7 +9,6 @@ use prometheus::Registry;
 use rand::seq::SliceRandom;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 use strum_macros::EnumString;
 use sui_benchmark::drivers::bench_driver::BenchDriver;
 use sui_benchmark::drivers::driver::Driver;
@@ -21,17 +20,9 @@ use sui_benchmark::workloads::workload::get_latest;
 use sui_benchmark::workloads::{
     make_combination_workload, make_shared_counter_workload, make_transfer_object_workload,
 };
-use sui_config::gateway::GatewayConfig;
-use sui_config::Config;
-use sui_config::PersistedConfig;
-use sui_core::authority_aggregator::AuthAggMetrics;
-use sui_core::authority_aggregator::{reconfig_from_genesis, AuthorityAggregator};
-use sui_core::authority_client::make_authority_clients;
+use sui_core::authority_aggregator::{reconfig_from_genesis, AuthorityAggregatorBuilder};
 use sui_core::authority_client::AuthorityAPI;
 use sui_core::authority_client::NetworkAuthorityClient;
-use sui_core::epoch::committee_store::CommitteeStore;
-use sui_core::safe_client::SafeClientMetrics;
-use sui_core::validator_info::make_committee;
 use sui_node::metrics;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
@@ -42,7 +33,6 @@ use sui_types::messages::BatchInfoResponseItem;
 use sui_types::messages::TransactionInfoRequest;
 use tracing::log::info;
 
-use sui_core::authority_client::NetworkAuthorityClientMetrics;
 use test_utils::authority::spawn_test_authorities;
 use test_utils::authority::test_and_configure_authority_configs;
 use test_utils::objects::generate_gas_objects_with_owner;
@@ -69,15 +59,16 @@ struct Opts {
     pub num_client_threads: u64,
     #[clap(long, default_value = "", global = true)]
     pub log_path: String,
-    /// Path where gateway config is stored when running remote benchmark
-    /// This is also the path where gateway config is stored during local
-    /// benchmark
-    #[clap(long, default_value = "/tmp/gateway.yaml", global = true)]
-    pub gateway_config_path: String,
+    /// [Required for remote benchmark]
+    /// Path where genesis.blob is stored when running remote benchmark
+    #[clap(long, default_value = "/tmp/genesis.blob", global = true)]
+    pub genesis_blob_path: String,
+    /// [Required for remote benchmark]
     /// Path where keypair for primary gas account is stored. The format of
     /// this file is same as what `sui keytool generate` outputs
     #[clap(long, default_value = "", global = true)]
     pub keystore_path: String,
+    /// [Required for remote benchmark]
     /// Object id of the primary gas coin used for benchmark
     /// NOTE: THe remote network should have this coin in its genesis config
     /// with large enough gas i.e. u64::MAX
@@ -87,7 +78,7 @@ struct Opts {
     pub primary_gas_objects: u64,
     /// Whether to run local or remote benchmark
     /// NOTE: For running remote benchmark we must have the following
-    /// gateway_config_path, keypair_path and primary_gas_id
+    /// genesis_blob_path, keypair_path and primary_gas_id
     #[clap(long, parse(try_from_str), default_value = "true", global = true)]
     pub local: bool,
     /// Default workload is 100% transfer object
@@ -253,12 +244,11 @@ async fn main() -> Result<()> {
         config.log_file = Some(opts.log_path);
     }
     let _guard = config.with_env().init();
-    let registry: Registry = metrics::start_prometheus_server(
+    let registry: Arc<Registry> = Arc::new(metrics::start_prometheus_server(
         format!("{}:{}", opts.client_metric_host, opts.client_metric_port)
             .parse()
             .unwrap(),
-    );
-    let network_authority_client_metrics = Arc::new(NetworkAuthorityClientMetrics::new(&registry));
+    ));
     let barrier = Arc::new(Barrier::new(2));
     let cloned_barrier = barrier.clone();
     let (primary_gas_id, owner, keypair, aggregator) = if opts.local {
@@ -274,39 +264,19 @@ async fn main() -> Result<()> {
             });
             Arc::new(configs)
         };
-        let gateway_config = GatewayConfig {
-            epoch: 0,
-            validator_set: configs.validator_set().to_vec(),
-            send_timeout: Duration::from_secs(4),
-            recv_timeout: Duration::from_secs(4),
-            buffer_size: 650000,
-            db_folder_path: PathBuf::from("/tmp/client_db"),
-        };
-        gateway_config.save(&opts.gateway_config_path)?;
+
         // bring up servers ..
         let (owner, keypair): (SuiAddress, AccountKeyPair) = test_account_keys().pop().unwrap();
         let primary_gas = generate_gas_objects_with_owner(1, owner);
         let primary_gas_id = primary_gas.get(0).unwrap().id();
         // Make the client runtime wait until we are done creating genesis objects
-        let cloned_config = configs;
+        let cloned_config = configs.clone();
         let cloned_gas = primary_gas;
-        let auth_clients = make_authority_clients(
-            &gateway_config.validator_set,
-            gateway_config.send_timeout,
-            gateway_config.recv_timeout,
-            network_authority_client_metrics.clone(),
-        );
 
-        let committee = make_committee(gateway_config.epoch, &gateway_config.validator_set)?;
-        let committee_store = Arc::new(CommitteeStore::new_for_testing(&committee));
-        let aggregator = Arc::new(AuthorityAggregator::new(
-            committee,
-            committee_store,
-            auth_clients.clone(),
-            AuthAggMetrics::new(&registry),
-            Arc::new(SafeClientMetrics::new(&registry)),
-            network_authority_client_metrics.clone(),
-        ));
+        let (aggregator, auth_clients) = AuthorityAggregatorBuilder::from_network_config(&configs)
+            .with_registry(registry.clone())
+            .build()
+            .unwrap();
 
         // spawn a thread to spin up sui nodes on the multi-threaded server runtime
         let _ = std::thread::spawn(move || {
@@ -341,7 +311,12 @@ async fn main() -> Result<()> {
                 join_all(follower_handles).await;
             });
         });
-        (primary_gas_id, owner, Arc::new(keypair), aggregator)
+        (
+            primary_gas_id,
+            owner,
+            Arc::new(keypair),
+            Arc::new(aggregator),
+        )
     } else {
         eprintln!("Configuring remote benchmark..");
         std::thread::spawn(move || {
@@ -352,33 +327,13 @@ async fn main() -> Result<()> {
                     cloned_barrier.wait().await;
                 });
         });
-        let config_path = Some(&opts.gateway_config_path)
-            .filter(|s| !s.is_empty())
-            .map(PathBuf::from)
-            .ok_or_else(|| {
-                anyhow!(format!(
-                    "Failed to find gateway config at path: {}",
-                    opts.gateway_config_path
-                ))
-            })?;
-        let config: GatewayConfig = PersistedConfig::read(&config_path)?;
-        let committee = make_committee(config.epoch, &config.validator_set)?;
+        let genesis = sui_config::node::Genesis::new_from_file(&opts.genesis_blob_path);
+        let genesis = genesis.genesis()?;
+        let (aggregator, _) = AuthorityAggregatorBuilder::from_genesis(genesis)
+            .with_registry(registry.clone())
+            .build()
+            .unwrap();
 
-        let authority_clients = make_authority_clients(
-            &config.validator_set,
-            config.send_timeout,
-            config.recv_timeout,
-            network_authority_client_metrics.clone(),
-        );
-        let committee_store = Arc::new(CommitteeStore::new_for_testing(&committee));
-        let aggregator = AuthorityAggregator::new(
-            committee,
-            committee_store,
-            authority_clients,
-            AuthAggMetrics::new(&registry),
-            Arc::new(SafeClientMetrics::new(&registry)),
-            network_authority_client_metrics.clone(),
-        );
         let aggregator = Arc::new(reconfig_from_genesis(aggregator).await?);
         eprintln!(
             "Reconfiguration - Reconfiguration to epoch {} is done",
@@ -426,6 +381,7 @@ async fn main() -> Result<()> {
     let prev_benchmark_stats_path = opts.compare_with.clone();
     let curr_benchmark_stats_path = opts.benchmark_stats_path.clone();
     let arc_agg = aggregator.clone();
+    let registry_clone = registry.clone();
     let handle = std::thread::spawn(move || {
         client_runtime.block_on(async move {
             match opts.run_spec {
@@ -502,7 +458,7 @@ async fn main() -> Result<()> {
                     let show_progress = interval.is_unbounded();
                     let driver = BenchDriver::new(stat_collection_interval);
                     driver
-                        .run(workloads, arc_agg, &registry, show_progress, interval)
+                        .run(workloads, arc_agg, &registry_clone, show_progress, interval)
                         .await
                 }
             }

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -17,6 +17,6 @@ pub fn get_ed25519_keypair_from_keystore(
     let keystore = FileBasedKeystore::new(&keystore_path)?;
     match keystore.get_key(requested_address) {
         Ok(SuiKeyPair::Ed25519SuiKeyPair(kp)) => Ok(kp.copy()),
-        _ => Err(anyhow::anyhow!("Unsupported key type")),
+        other => Err(anyhow::anyhow!("Invalid key type: {:?}", other)),
     }
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -8,7 +8,7 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
     use sui_config::SUI_KEYSTORE_FILENAME;
-    use sui_core::test_utils::test_authority_aggregator;
+    use sui_core::authority_aggregator::AuthorityAggregatorBuilder;
     use test_utils::{
         messages::get_gas_object_with_wallet_context, network::init_cluster_builder_env_aware,
     };
@@ -76,7 +76,10 @@ mod test {
             1,  // transfer_object_weight
         )];
 
-        let aggregator = Arc::new(test_authority_aggregator(swarm.config()));
+        let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(swarm.config())
+            .build()
+            .unwrap();
+        let aggregator = Arc::new(aggregator);
 
         for w in workloads.iter_mut() {
             w.workload.init(aggregator.clone()).await;

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -108,7 +108,7 @@ impl FaucetClient for LocalFaucetClient {
     async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
         let receipt = self
             .simple_faucet
-            .send(Uuid::new_v4(), request_address, &[100000; 5])
+            .send(Uuid::new_v4(), request_address, &[200000; 5])
             .await
             .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {}", err));
 

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -3,6 +3,7 @@
 use super::cluster::{new_wallet_context_from_cluster, Cluster};
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::env;
 use std::sync::Arc;
 use sui_faucet::{Faucet, FaucetResponse, SimpleFaucet};
 use sui_types::base_types::{encode_bytes_hex, SuiAddress};
@@ -66,8 +67,14 @@ impl FaucetClient for RemoteFaucetClient {
         let data = HashMap::from([("recipient", encode_bytes_hex(request_address))]);
         let map = HashMap::from([("FixedAmountRequest", data)]);
 
+        let auth_header = match env::var("FAUCET_AUTH_HEADER") {
+            Ok(val) => val,
+            _ => "".to_string(),
+        };
+
         let response = reqwest::Client::new()
             .post(&gas_url)
+            .header("Authorization", auth_header)
             .json(&map)
             .send()
             .await

--- a/crates/sui-cluster-test/src/test_case/call_contract_test.rs
+++ b/crates/sui-cluster-test/src/test_case/call_contract_test.rs
@@ -52,7 +52,7 @@ impl TestCaseImpl for CallContractTest {
             type_args,
             args,
             Some(*gas_obj.id()),
-            5000
+            20000
         ];
 
         let data = ctx

--- a/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_merge_split_test.rs
@@ -118,7 +118,7 @@ impl CoinMergeSplitTest {
         coin_to_merge: ObjectID,
         gas_obj_id: ObjectID,
     ) -> (SuiCertifiedTransaction, SuiTransactionEffects) {
-        let params = rpc_params![signer, primary_coin, coin_to_merge, Some(gas_obj_id), 5000];
+        let params = rpc_params![signer, primary_coin, coin_to_merge, Some(gas_obj_id), 20000];
 
         let data = ctx
             .build_transaction_remotely("sui_mergeCoins", params)
@@ -135,7 +135,7 @@ impl CoinMergeSplitTest {
         amounts: Vec<u64>,
         gas_obj_id: ObjectID,
     ) -> (SuiCertifiedTransaction, SuiTransactionEffects) {
-        let params = rpc_params![signer, primary_coin, amounts, Some(gas_obj_id), 5000];
+        let params = rpc_params![signer, primary_coin, amounts, Some(gas_obj_id), 20000];
 
         let data = ctx
             .build_transaction_remotely("sui_splitCoin", params)

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -502,14 +502,14 @@ fn process_package(
         &modules,
         package_id,
         natives,
-        &mut gas_status.create_move_gas_status(),
+        gas_status.create_move_gas_status(),
     )?;
     adapter::store_package_and_init_modules(
         &mut temporary_store,
         &vm,
         modules,
         ctx,
-        &mut gas_status.create_move_gas_status(),
+        gas_status.create_move_gas_status(),
     )?;
 
     let (
@@ -574,7 +574,7 @@ pub fn generate_genesis_system_object(
             CallArg::Pure(bcs::to_bytes(&stakes).unwrap()),
             CallArg::Pure(bcs::to_bytes(&gas_prices).unwrap()),
         ],
-        &mut SuiGasStatus::new_unmetered().create_move_gas_status(),
+        SuiGasStatus::new_unmetered().create_move_gas_status(),
         genesis_ctx,
     )?;
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -298,7 +298,7 @@ impl Genesis {
         }
     }
 
-    fn genesis(&self) -> Result<&genesis::Genesis> {
+    pub fn genesis(&self) -> Result<&genesis::Genesis> {
         match &self.location {
             GenesisLocation::InPlace { genesis } => Ok(genesis),
             GenesisLocation::File {

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-core"
-version = "0.12.0"
+version = "0.12.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -856,6 +856,7 @@ where
     // Get a client
     let client = active_authority.net.load().authority_clients[&authority].clone();
 
+    // TODO: We should make this a loop and exit until the first success.
     match client
         .handle_checkpoint(CheckpointRequest::proposal(true))
         .await
@@ -882,6 +883,10 @@ where
 
                 // For some reason the proposal is empty?
                 if proposal.is_none() || proposal_contents.is_none() {
+                    debug!(
+                        validator=?authority.concise(),
+                        "Queried validator doesn't have a proposal yet"
+                    );
                     return None;
                 }
 
@@ -890,6 +895,11 @@ where
                     != my_proposal.sequence_number()
                 {
                     // Target validator may be byzantine or behind, ignore it.
+                    debug!(
+                        validator=?authority.concise(),
+                        received_cp_seq=proposal.as_ref().unwrap().summary.sequence_number,
+                        "Queried validator is behind"
+                    );
                     return None;
                 }
 
@@ -941,6 +951,11 @@ where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
     let mut diff_certs: BTreeMap<ExecutionDigests, CertifiedTransaction> = BTreeMap::new();
+    debug!(
+        our_size = fragment.diff.second.items.len(),
+        other_size = fragment.diff.first.items.len(),
+        "Augmenting fragment with diff transactions"
+    );
 
     // These are the transactions that we have that the other validator does not
     // have, so we can read them from our local database.
@@ -962,6 +977,9 @@ where
         .load()
         .clone_client(fragment.other.authority());
     for tx_digest in &fragment.diff.first.items {
+        // TODO: It's possible that by the time we received the proposal we already have some of
+        // the certs. Should do a filter first before trying to download every of them.
+        // The downloading can probably also happen in parallel.
         let response = client
             .handle_transaction_info_request(TransactionInfoRequest::from(tx_digest.transaction))
             .await?;

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1616,7 +1616,7 @@ where
                             Err(err) => {
                                 // We have an error here.
                                 // Append to the list off errors
-                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed transaction from validator handle_transaction");
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed transaction from validator handle_transaction: {:?}", err);
                                 state.errors.push(err);
                                 state.bad_stake += weight; // This is the bad stake counter
                             }
@@ -1695,7 +1695,7 @@ where
             .await?;
 
         debug!(
-            tx_digest = ?tx_digest,
+            ?tx_digest,
             num_errors = state.errors.len(),
             good_stake = state.good_stake,
             bad_stake = state.bad_stake,
@@ -1704,7 +1704,7 @@ where
             "Received signatures response from validators handle_transaction"
         );
         if !state.errors.is_empty() {
-            trace!("Errors received: {:?}", state.errors);
+            debug!(?tx_digest, "Errors received: {:?}", state.errors);
         }
 
         // If we have some certificate return it, or return an error.
@@ -1817,6 +1817,7 @@ where
                                 }
                             }
                             Err(err) => {
+                                debug!(tx_digest = ?tx_digest, ?name, weight, "Failed to get signed effects from validator handle_certificate: {:?}", err);
                                 state.errors.push(err);
                                 state.bad_stake += weight;
                                 if state.bad_stake > validity {

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -851,7 +851,14 @@ where
             // - If serial_authority_request_interval elapses, we begin a new request even if the
             //   previous one is not finished, and schedule another future request.
 
-            let name = authorities_shuffled.next().unwrap();
+            let name = authorities_shuffled.next().ok_or_else(|| {
+                error!(
+                    ?preferences,
+                    ?restrict_to,
+                    "Available authorities list is empty."
+                );
+                SuiError::from("Available authorities list is empty")
+            })?;
             futures.push(start_req(*name, self.authority_clients[name].clone()));
             futures.push(schedule_next());
 

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -338,14 +338,14 @@ pub fn make_network_authority_client_sets_from_genesis(
 
 pub fn make_authority_clients(
     validator_set: &[ValidatorInfo],
-    send_timeout: Duration,
-    recv_timeout: Duration,
+    connect_timeout: Duration,
+    request_timeout: Duration,
     net_metrics: Arc<NetworkAuthorityClientMetrics>,
 ) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
     let mut authority_clients = BTreeMap::new();
     let mut network_config = mysten_network::config::Config::new();
-    network_config.connect_timeout = Some(send_timeout);
-    network_config.request_timeout = Some(recv_timeout);
+    network_config.connect_timeout = Some(connect_timeout);
+    network_config.request_timeout = Some(request_timeout);
     for authority in validator_set {
         let channel = network_config
             .connect_lazy(authority.network_address())

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -117,15 +117,15 @@ impl AuthorityServer {
         &self,
         min_batch_size: u64,
         max_delay: Duration,
-    ) -> SuiResult<JoinHandle<SuiResult<()>>> {
+    ) -> SuiResult<JoinHandle<()>> {
         // Start the batching subsystem, and register the handles with the authority.
         let state = self.state.clone();
-        let _batch_join_handle =
+        let batch_join_handle =
             tokio::task::spawn(
                 async move { state.run_batch_service(min_batch_size, max_delay).await },
             );
 
-        Ok(_batch_join_handle)
+        Ok(batch_join_handle)
     }
 
     pub async fn spawn_for_test(self) -> Result<AuthorityServerHandle, io::Error> {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1184,8 +1184,7 @@ fn set_fragment_reconstruct() {
 
     let fragment41 = p4.fragment_with(&p1);
     let span = SpanGraph::mew(&committee, 0, &[fragment12, fragment34, fragment41]);
-    assert!(span.is_completed());
-    let reconstruction = span.construct_checkpoint();
+    let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 4);
 }
 
@@ -1235,9 +1234,8 @@ fn set_fragment_reconstruct_two_components() {
     }
 
     let span = SpanGraph::mew(&committee, 0, &fragments);
-    assert!(span.is_completed());
 
-    let reconstruction = span.construct_checkpoint();
+    let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 5);
 }
 
@@ -1442,6 +1440,182 @@ fn test_fragment_full_flow() {
     // Cannot advance to next checkpoint
     assert_eq!(cps6.next_checkpoint(), 0);
     // But recording of fragments is closed
+}
+
+#[test]
+fn test_slow_fragment() {
+    let (committee, _keys, mut cp_stores) = random_ckpoint_store();
+    let proposals: Vec<_> = cp_stores
+        .iter_mut()
+        .map(|(_, cp)| cp.set_proposal(0).unwrap())
+        .collect();
+    let fragment12 = proposals[1].fragment_with(&proposals[2]);
+    let fragment23 = proposals[2].fragment_with(&proposals[3]);
+    let mut index = ExecutionIndices::default();
+    cp_stores.iter_mut().for_each(|(_, cp)| {
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment12.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment23.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        assert!(cp.memory_locals.in_construction_checkpoint.is_completed());
+    });
+    // Missing link on validator 0, even though the span graph is complete.
+    assert!(cp_stores[0].1.attempt_to_construct_checkpoint().is_err());
+    assert!(cp_stores[0]
+        .1
+        .memory_locals
+        .in_construction_checkpoint
+        .is_completed());
+
+    // All other validators can make the checkpoint.
+    // Collect signed checkpoints, create cert and update validator 1-3.
+    let signed: Vec<_> = cp_stores
+        .iter_mut()
+        .skip(1)
+        .map(|(_, cp)| {
+            assert!(cp.attempt_to_construct_checkpoint().is_ok());
+            cp.sign_new_checkpoint(0, 0, [].into_iter(), TestCausalOrderNoop, None)
+                .unwrap();
+            // This hasn't changed yet.
+            assert_eq!(cp.memory_locals.next_checkpoint, 0);
+            assert_eq!(cp.memory_locals.in_construction_checkpoint_seq, 0);
+            if let AuthenticatedCheckpoint::Signed(s) = cp.latest_stored_checkpoint().unwrap() {
+                s
+            } else {
+                unreachable!()
+            }
+        })
+        .collect();
+    let cert0 = CertifiedCheckpointSummary::aggregate(signed, &committee).unwrap();
+    cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
+        cp.promote_signed_checkpoint_to_cert(&cert0, &committee)
+            .unwrap();
+        assert_eq!(cp.memory_locals.next_checkpoint, 1);
+        assert_eq!(cp.memory_locals.in_construction_checkpoint_seq, 1);
+    });
+    // At this point, validator 0 still has a complete span graph with missing link, and doesn't
+    // yet know there is a checkpoint cert.
+
+    let proposals: Vec<_> = cp_stores
+        .iter_mut()
+        .map(|(_, cp)| cp.set_proposal(0).unwrap())
+        .collect();
+    let fragment12 = proposals[1].fragment_with(&proposals[2]);
+    let fragment23 = proposals[2].fragment_with(&proposals[3]);
+    cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment12.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        cp.handle_internal_fragment(
+            index.clone(),
+            fragment23.clone(),
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+        index.next_transaction_index += 1;
+        assert!(cp.memory_locals.in_construction_checkpoint.is_completed());
+    });
+    // Validator 0 is still at checkpoint 0, and haven't received any fragments for checkpoint 1.
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        0
+    );
+    let signed: Vec<_> = cp_stores
+        .iter_mut()
+        .skip(1)
+        .map(|(_, cp)| {
+            assert!(cp.attempt_to_construct_checkpoint().is_ok());
+            cp.sign_new_checkpoint(0, 1, [].into_iter(), TestCausalOrderNoop, None)
+                .unwrap();
+            if let AuthenticatedCheckpoint::Signed(s) = cp.latest_stored_checkpoint().unwrap() {
+                s
+            } else {
+                unreachable!()
+            }
+        })
+        .collect();
+    let cert1 = CertifiedCheckpointSummary::aggregate(signed, &committee).unwrap();
+    cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
+        cp.promote_signed_checkpoint_to_cert(&cert1, &committee)
+            .unwrap();
+    });
+    // Now update both certs on validator 0.
+    cp_stores[0]
+        .1
+        .process_synced_checkpoint_certificate(
+            &cert0,
+            &CheckpointContents::new_with_causally_ordered_transactions([].into_iter()),
+            &committee,
+        )
+        .unwrap();
+    assert_eq!(cp_stores[0].1.memory_locals.next_checkpoint, 1);
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        1
+    );
+    cp_stores[0]
+        .1
+        .process_synced_checkpoint_certificate(
+            &cert1,
+            &CheckpointContents::new_with_causally_ordered_transactions([].into_iter()),
+            &committee,
+        )
+        .unwrap();
+    // Although it has seen checkpoint cert 1, it hasn't seen enough fragments for checkpoint 1 yet.
+    // Hence it is still in the state of constructing checkpoint 1.
+    assert_eq!(cp_stores[0].1.memory_locals.next_checkpoint, 2);
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        1
+    );
+    cp_stores[0]
+        .1
+        .handle_internal_fragment(
+            index.clone(),
+            fragment12,
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+    index.next_transaction_index += 1;
+    cp_stores[0]
+        .1
+        .handle_internal_fragment(
+            index.clone(),
+            fragment23,
+            PendCertificateForExecutionNoop,
+            &committee,
+        )
+        .unwrap();
+    index.next_transaction_index += 1;
+    // Validator 0 should have automatically advanced to be constructing checkpoint 2.
+    assert_eq!(
+        cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
+        2
+    );
+    assert!(!cp_stores[0]
+        .1
+        .memory_locals
+        .in_construction_checkpoint
+        .is_completed());
 }
 
 #[derive(Clone)]
@@ -1858,14 +2032,13 @@ async fn test_no_more_fragments() {
     // Give time to the receiving task to process (so that consensus can sequence fragments).
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Expecting more fragments
-    assert!(
-        !setup.authorities[0]
-            .checkpoint
-            .lock()
-            .get_locals()
-            .no_more_fragments
-    );
+    // Expecting checkpoint construction still in progress.
+    assert!(!setup.authorities[0]
+        .checkpoint
+        .lock()
+        .get_locals()
+        .in_construction_checkpoint
+        .is_completed());
 
     // put in fragment 0-2, now node 0 can form a checkpoint but not node 3
 
@@ -1878,36 +2051,34 @@ async fn test_no_more_fragments() {
     // Give time to the receiving task to process (so that consensus can sequence fragments).
     tokio::time::sleep(Duration::from_secs(1)).await;
 
+    // Expecting checkpoint construction complete.
+    assert!(setup.authorities[0]
+        .checkpoint
+        .lock()
+        .get_locals()
+        .in_construction_checkpoint
+        .is_completed());
+
     assert!(setup.authorities[0]
         .checkpoint
         .lock()
         .attempt_to_construct_checkpoint()
         .is_ok());
 
-    // Expecting more fragments
-    assert!(
-        !setup.authorities[0]
-            .checkpoint
-            .lock()
-            .get_locals()
-            .no_more_fragments
-    );
-
-    // node 3 cannot make one
+    // node 3 cannot make one due to missing link.
     assert!(setup.authorities[3]
         .checkpoint
         .lock()
         .attempt_to_construct_checkpoint()
         .is_err());
 
-    // Expecting more fragments
-    assert!(
-        setup.authorities[3]
-            .checkpoint
-            .lock()
-            .get_locals()
-            .no_more_fragments
-    );
+    // But span graph has enough fragments, and hence is complete.
+    assert!(setup.authorities[3]
+        .checkpoint
+        .lock()
+        .get_locals()
+        .in_construction_checkpoint
+        .is_completed());
 
     // Now fie node 3 a link and it can make the checkpoint
     setup.authorities[3]

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -882,7 +882,7 @@ async fn test_batch_to_checkpointing() {
     let inner_state = authority_state.clone();
     let _join = tokio::task::spawn(async move {
         inner_state
-            .run_batch_service(1000, Duration::from_millis(500))
+            .run_batch_service_once(1000, Duration::from_millis(500))
             .await
     });
     // Send transactions out of order
@@ -982,7 +982,7 @@ async fn test_batch_to_checkpointing_init_crash() {
         let inner_state = authority_state.clone();
         let _join = tokio::task::spawn(async move {
             inner_state
-                .run_batch_service(1000, Duration::from_millis(500))
+                .run_batch_service_once(1000, Duration::from_millis(500))
                 .await
         });
 
@@ -1740,10 +1740,11 @@ pub async fn checkpoint_tests_setup(
             .await;
 
         let inner_state = authority.clone();
-        let _join =
-            tokio::task::spawn(
-                async move { inner_state.run_batch_service(1000, batch_interval).await },
-            );
+        let _join = tokio::task::spawn(async move {
+            inner_state
+                .run_batch_service_once(1000, batch_interval)
+                .await
+        });
 
         let checkpoint = authority.checkpoints.clone();
         authorities.push(TestAuthority {

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -52,9 +52,9 @@ async fn test_start_epoch_change() {
             next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
             proposal_next_transaction: None,
             next_transaction_sequence: 0,
-            no_more_fragments: true,
             current_proposal: None,
-            checkpoint_to_be_constructed: SpanGraph::mew(
+            in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH,
+            in_construction_checkpoint: SpanGraph::mew(
                 &genesis_committee,
                 CHECKPOINT_COUNT_PER_EPOCH,
                 &[],
@@ -158,9 +158,9 @@ async fn test_finish_epoch_change() {
                     next_checkpoint: CHECKPOINT_COUNT_PER_EPOCH,
                     proposal_next_transaction: None,
                     next_transaction_sequence: 0,
-                    no_more_fragments: true,
                     current_proposal: None,
-                    checkpoint_to_be_constructed: SpanGraph::mew(
+                    in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH,
+                    in_construction_checkpoint: SpanGraph::mew(
                         &genesis_committee,
                         CHECKPOINT_COUNT_PER_EPOCH,
                         &[],

--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -172,7 +172,7 @@ fn execute_transaction<S: BackingPackageStore + ParentSync>(
                         &function,
                         type_arguments,
                         arguments,
-                        &mut gas_status.create_move_gas_status(),
+                        gas_status.create_move_gas_status(),
                         tx_ctx,
                     )
                 }
@@ -194,7 +194,7 @@ fn execute_transaction<S: BackingPackageStore + ParentSync>(
                         native_functions.clone(),
                         modules,
                         tx_ctx,
-                        &mut gas_status.create_move_gas_status(),
+                        gas_status.create_move_gas_status(),
                     )
                 }
                 SingleTransactionKind::Pay(Pay {
@@ -232,7 +232,7 @@ fn execute_transaction<S: BackingPackageStore + ParentSync>(
                             CallArg::Pure(bcs::to_bytes(&storage_charge).unwrap()),
                             CallArg::Pure(bcs::to_bytes(&computation_charge).unwrap()),
                         ],
-                        &mut gas_status.create_move_gas_status(),
+                        gas_status.create_move_gas_status(),
                         tx_ctx,
                     )
                 }

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -324,8 +324,8 @@ where
 mod test {
     use super::*;
     use crate::{
-        authority_active::gossip::GossipMetrics, authority_client::NetworkAuthorityClient,
-        node_sync::SyncStatus, test_utils::test_authority_aggregator,
+        authority_active::gossip::GossipMetrics, authority_aggregator::AuthorityAggregatorBuilder,
+        authority_client::NetworkAuthorityClient, node_sync::SyncStatus,
     };
     use std::sync::{Arc, Mutex};
     use sui_macros::sim_test;
@@ -454,7 +454,10 @@ mod test {
         // Set up an authority
         let config = test_and_configure_authority_configs(1);
         let authorities = spawn_test_authorities(objects, &config).await;
-        let net = Arc::new(test_authority_aggregator(&config));
+        let (agg, _) = AuthorityAggregatorBuilder::from_network_config(&config)
+            .build()
+            .unwrap();
+        let net = Arc::new(agg);
 
         execute_transactions(&net, &transactions).await;
 

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -200,7 +200,7 @@ async fn test_batch_manager_happy_path() {
     let inner_state = authority_state.clone();
     let _join = tokio::task::spawn(async move {
         inner_state
-            .run_batch_service(1000, Duration::from_millis(500))
+            .run_batch_service_once(1000, Duration::from_millis(500))
             .await
     });
 
@@ -261,7 +261,7 @@ async fn test_batch_manager_out_of_order() {
     let inner_state = authority_state.clone();
     let _join = tokio::task::spawn(async move {
         inner_state
-            .run_batch_service(1000, Duration::from_millis(500))
+            .run_batch_service_once(1000, Duration::from_millis(500))
             .await
     });
     // Send transactions out of order
@@ -333,7 +333,7 @@ async fn test_batch_manager_drop_out_of_order() {
         inner_state
             // Make sure that a batch will not be formed due to time, but will be formed
             // when there are 4 transactions.
-            .run_batch_service(4, Duration::from_millis(10000))
+            .run_batch_service_once(4, Duration::from_millis(10000))
             .await
     });
     // Send transactions out of order
@@ -397,7 +397,7 @@ async fn test_handle_move_order_with_batch() {
     let inner_state = authority_state.clone();
     let _join = tokio::task::spawn(async move {
         inner_state
-            .run_batch_service(1000, Duration::from_millis(500))
+            .run_batch_service_once(1000, Duration::from_millis(500))
             .await
     });
     // Send transactions out of order
@@ -448,7 +448,7 @@ async fn test_batch_store_retrieval() {
     let inner_state = authority_state.clone();
     let _join = tokio::task::spawn(async move {
         inner_state
-            .run_batch_service(10, Duration::from_secs(6000))
+            .run_batch_service_once(10, Duration::from_secs(6000))
             .await
     });
     // Send transactions out of order

--- a/crates/sui-cost-tables/src/bytecode_tables.rs
+++ b/crates/sui-cost-tables/src/bytecode_tables.rs
@@ -25,7 +25,7 @@ use move_binary_format::{
 };
 
 /// VM flat fee
-pub const VM_FLAT_FEE: Gas = Gas::new(2_000);
+pub const VM_FLAT_FEE: Gas = Gas::new(8_000);
 
 /// The size in bytes for a non-string or address constant on the stack
 pub const CONST_SIZE: AbstractMemorySize = AbstractMemorySize::new(16);

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,14 +4,13 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-<<<<<<< HEAD
-    "computation_cost": 6289,
-    "storage_cost": 6324,
+    "computation_cost": 5985,
+    "storage_cost": 5873,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 6279,
-    "storage_cost": 6260,
+    "computation_cost": 5975,
+    "storage_cost": 5810,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
@@ -30,37 +29,8 @@ expression: common_costs_estimate
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 6268,
-    "storage_cost": 6292,
-=======
-    "computation_cost": 5239,
-    "storage_cost": 7731,
-    "storage_rebate": 0
-  },
-  "Publish": {
-    "computation_cost": 5228,
-    "storage_cost": 7666,
-    "storage_rebate": 0
-  },
-  "SharedCounterAssertValue": {
-    "computation_cost": 683,
-    "storage_cost": 833,
-    "storage_rebate": 0
-  },
-  "SharedCounterCreate": {
-    "computation_cost": 562,
-    "storage_cost": 802,
-    "storage_rebate": 0
-  },
-  "SharedCounterIncrement": {
-    "computation_cost": 683,
-    "storage_cost": 833,
-    "storage_rebate": 0
-  },
-  "SplitCoin": {
-    "computation_cost": 5217,
-    "storage_cost": 7699,
->>>>>>> f471bed71 (revert flat vm fee (#5458))
+    "computation_cost": 5964,
+    "storage_cost": 5842,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,6 +4,7 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
+<<<<<<< HEAD
     "computation_cost": 6289,
     "storage_cost": 6324,
     "storage_rebate": 0
@@ -31,6 +32,35 @@ expression: common_costs_estimate
   "SplitCoin": {
     "computation_cost": 6268,
     "storage_cost": 6292,
+=======
+    "computation_cost": 5239,
+    "storage_cost": 7731,
+    "storage_rebate": 0
+  },
+  "Publish": {
+    "computation_cost": 5228,
+    "storage_cost": 7666,
+    "storage_rebate": 0
+  },
+  "SharedCounterAssertValue": {
+    "computation_cost": 683,
+    "storage_cost": 833,
+    "storage_rebate": 0
+  },
+  "SharedCounterCreate": {
+    "computation_cost": 562,
+    "storage_cost": 802,
+    "storage_rebate": 0
+  },
+  "SharedCounterIncrement": {
+    "computation_cost": 683,
+    "storage_cost": 833,
+    "storage_rebate": 0
+  },
+  "SplitCoin": {
+    "computation_cost": 5217,
+    "storage_cost": 7699,
+>>>>>>> f471bed71 (revert flat vm fee (#5458))
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot-2.snap
@@ -4,33 +4,33 @@ expression: common_costs_estimate
 ---
 {
   "MergeCoin": {
-    "computation_cost": 5985,
-    "storage_cost": 5873,
+    "computation_cost": 4289,
+    "storage_cost": 6324,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 5975,
-    "storage_cost": 5810,
+    "computation_cost": 4279,
+    "storage_cost": 6260,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
-    "computation_cost": 2682,
+    "computation_cost": 682,
     "storage_cost": 832,
     "storage_rebate": 0
   },
   "SharedCounterCreate": {
-    "computation_cost": 2561,
+    "computation_cost": 561,
     "storage_cost": 801,
     "storage_rebate": 0
   },
   "SharedCounterIncrement": {
-    "computation_cost": 2682,
+    "computation_cost": 682,
     "storage_cost": 832,
     "storage_rebate": 0
   },
   "SplitCoin": {
-    "computation_cost": 5964,
-    "storage_cost": 5842,
+    "computation_cost": 4268,
+    "storage_cost": 6292,
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -4,32 +4,32 @@ expression: common_costs_actual
 ---
 {
   "MergeCoin": {
-    "computation_cost": 2481,
+    "computation_cost": 528,
     "storage_cost": 30,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 2517,
+    "computation_cost": 585,
     "storage_cost": 82,
     "storage_rebate": 0
   },
   "SharedCounterAssertValue": {
-    "computation_cost": 2197,
+    "computation_cost": 197,
     "storage_cost": 30,
     "storage_rebate": 15
   },
   "SharedCounterCreate": {
-    "computation_cost": 2088,
+    "computation_cost": 109,
     "storage_cost": 30,
     "storage_rebate": 0
   },
   "SharedCounterIncrement": {
-    "computation_cost": 2197,
+    "computation_cost": 197,
     "storage_cost": 30,
     "storage_rebate": 15
   },
   "SplitCoin": {
-    "computation_cost": 2492,
+    "computation_cost": 656,
     "storage_cost": 75,
     "storage_rebate": 0
   },

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -4,6 +4,7 @@ expression: common_costs_actual
 ---
 {
   "MergeCoin": {
+<<<<<<< HEAD
     "computation_cost": 2515,
     "storage_cost": 30,
     "storage_rebate": 0
@@ -31,6 +32,35 @@ expression: common_costs_actual
   "SplitCoin": {
     "computation_cost": 2525,
     "storage_cost": 75,
+=======
+    "computation_cost": 634,
+    "storage_cost": 32,
+    "storage_rebate": 0
+  },
+  "Publish": {
+    "computation_cost": 691,
+    "storage_cost": 83,
+    "storage_rebate": 0
+  },
+  "SharedCounterAssertValue": {
+    "computation_cost": 198,
+    "storage_cost": 31,
+    "storage_rebate": 15
+  },
+  "SharedCounterCreate": {
+    "computation_cost": 109,
+    "storage_cost": 31,
+    "storage_rebate": 0
+  },
+  "SharedCounterIncrement": {
+    "computation_cost": 198,
+    "storage_cost": 31,
+    "storage_rebate": 15
+  },
+  "SplitCoin": {
+    "computation_cost": 762,
+    "storage_cost": 80,
+>>>>>>> f471bed71 (revert flat vm fee (#5458))
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
+++ b/crates/sui-cost/tests/snapshots/empirical_transaction_cost__good_snapshot.snap
@@ -4,13 +4,12 @@ expression: common_costs_actual
 ---
 {
   "MergeCoin": {
-<<<<<<< HEAD
-    "computation_cost": 2515,
+    "computation_cost": 2481,
     "storage_cost": 30,
     "storage_rebate": 0
   },
   "Publish": {
-    "computation_cost": 2551,
+    "computation_cost": 2517,
     "storage_cost": 82,
     "storage_rebate": 0
   },
@@ -30,37 +29,8 @@ expression: common_costs_actual
     "storage_rebate": 15
   },
   "SplitCoin": {
-    "computation_cost": 2525,
+    "computation_cost": 2492,
     "storage_cost": 75,
-=======
-    "computation_cost": 634,
-    "storage_cost": 32,
-    "storage_rebate": 0
-  },
-  "Publish": {
-    "computation_cost": 691,
-    "storage_cost": 83,
-    "storage_rebate": 0
-  },
-  "SharedCounterAssertValue": {
-    "computation_cost": 198,
-    "storage_cost": 31,
-    "storage_rebate": 15
-  },
-  "SharedCounterCreate": {
-    "computation_cost": 109,
-    "storage_cost": 31,
-    "storage_rebate": 0
-  },
-  "SharedCounterIncrement": {
-    "computation_cost": 198,
-    "storage_cost": 31,
-    "storage_rebate": 15
-  },
-  "SplitCoin": {
-    "computation_cost": 762,
-    "storage_cost": 80,
->>>>>>> f471bed71 (revert flat vm fee (#5458))
     "storage_rebate": 0
   },
   "TransferPortionSuiCoin": {

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.23"
 uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.2"
 scopeguard = "1.1"
+tap = "1.0"
 
 sui = { path = "../sui" }
 sui-node = { path = "../sui-node" }

--- a/crates/sui-faucet/Cargo.toml
+++ b/crates/sui-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-faucet"
-version = "0.12.0"
+version = "0.12.2"
 edition = "2021"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"

--- a/crates/sui-network/src/lib.rs
+++ b/crates/sui-network/src/lib.rs
@@ -8,8 +8,8 @@ pub mod api;
 
 pub use tonic;
 
-pub const DEFAULT_CONNECT_TIMEOUT_SEC: Duration = Duration::from_secs(5);
-pub const DEFAULT_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(5);
+pub const DEFAULT_CONNECT_TIMEOUT_SEC: Duration = Duration::from_secs(10);
+pub const DEFAULT_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(30);
 pub const DEFAULT_HTTP2_KEEPALIVE_SEC: Duration = Duration::from_secs(5);
 
 pub fn default_mysten_network_config() -> Config {

--- a/crates/sui-network/src/lib.rs
+++ b/crates/sui-network/src/lib.rs
@@ -8,10 +8,14 @@ pub mod api;
 
 pub use tonic;
 
+pub const DEFAULT_CONNECT_TIMEOUT_SEC: Duration = Duration::from_secs(5);
+pub const DEFAULT_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(5);
+pub const DEFAULT_HTTP2_KEEPALIVE_SEC: Duration = Duration::from_secs(5);
+
 pub fn default_mysten_network_config() -> Config {
     let mut net_config = mysten_network::config::Config::new();
-    net_config.connect_timeout = Some(Duration::from_secs(5));
-    net_config.request_timeout = Some(Duration::from_secs(5));
-    net_config.http2_keepalive_interval = Some(Duration::from_secs(5));
+    net_config.connect_timeout = Some(DEFAULT_CONNECT_TIMEOUT_SEC);
+    net_config.request_timeout = Some(DEFAULT_REQUEST_TIMEOUT_SEC);
+    net_config.http2_keepalive_interval = Some(DEFAULT_HTTP2_KEEPALIVE_SEC);
     net_config
 }

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-node"
-version = "0.12.0"
+version = "0.12.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -69,7 +69,7 @@ pub struct SuiNode {
     grpc_server: tokio::task::JoinHandle<Result<()>>,
     _json_rpc_service: Option<HttpServerHandle>,
     _ws_subscription_service: Option<WsServerHandle>,
-    _batch_subsystem_handle: tokio::task::JoinHandle<Result<()>>,
+    _batch_subsystem_handle: tokio::task::JoinHandle<()>,
     _post_processing_subsystem_handle: Option<tokio::task::JoinHandle<Result<()>>>,
     _gossip_handle: Option<tokio::task::JoinHandle<()>>,
     _execute_driver_handle: tokio::task::JoinHandle<()>,
@@ -218,7 +218,6 @@ impl SuiNode {
                 batch_state
                     .run_batch_service(1000, Duration::from_secs(1))
                     .await
-                    .map_err(Into::into)
             })
         };
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "0.6.1"
+    "version": "0.12.2"
   },
   "methods": [
     {

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui-tool"
-version = "0.12.0"
+version = "0.12.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -20,7 +20,7 @@ use std::{
     ops::{Add, Deref, Mul},
 };
 use sui_cost_tables::{
-    bytecode_tables::{GasStatus, INITIAL_COST_SCHEDULE, VM_FLAT_FEE},
+    bytecode_tables::{GasStatus, INITIAL_COST_SCHEDULE},
     non_execution_tables::{
         BASE_TX_COST_FIXED, CONSENSUS_COST, MAXIMUM_TX_GAS, OBJ_ACCESS_COST_MUTATE_PER_BYTE,
         OBJ_ACCESS_COST_READ_PER_BYTE, OBJ_DATA_COST_REFUNDABLE, PACKAGE_PUBLISH_COST_PER_BYTE,
@@ -210,16 +210,14 @@ impl<'a> SuiGasStatus<'a> {
         !self.charge
     }
 
-    pub fn create_move_gas_status(&mut self) -> GasStatus<'a> {
-        if self.charge {
-            GasStatus::new(&INITIAL_COST_SCHEDULE, VM_FLAT_FEE)
-        } else {
-            GasStatus::new_unmetered()
-        }
+    pub fn create_move_gas_status(&mut self) -> &mut GasStatus<'a> {
+        &mut self.gas_status
     }
 
     pub fn charge_vm_gas(&mut self) -> Result<(), ExecutionError> {
-        self.deduct_computation_cost(&VM_FLAT_FEE.to_unit())
+        // Disable flat fee for now
+        // self.deduct_computation_cost(&VM_FLAT_FEE.to_unit())
+        Ok(())
     }
 
     pub fn charge_min_tx_gas(&mut self) -> Result<(), ExecutionError> {

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sui"
-version = "0.12.0"
+version = "0.12.2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 license = "Apache-2.0"
 publish = false

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -349,7 +349,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         package_path,
         build_config,
         gas: Some(gas_obj_id),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await?;
@@ -401,7 +401,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         type_args: vec![],
         args,
         gas: None,
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await?;
@@ -441,7 +441,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         type_args: vec![],
         args: args.to_vec(),
         gas: Some(gas),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await;
@@ -465,7 +465,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         type_args: vec![],
         args: args.to_vec(),
         gas: Some(gas),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await;
@@ -490,7 +490,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         type_args: vec![],
         args: args.to_vec(),
         gas: Some(gas),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await?;
@@ -522,7 +522,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         package_path,
         build_config,
         gas: Some(gas_obj_id),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await?;
@@ -909,7 +909,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
         primary_coin,
         coin_to_merge,
         gas: Some(gas),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
     }
     .execute(context)
     .await?;
@@ -1014,7 +1014,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     // Test with gas specified
     let resp = SuiClientCommands::SplitCoin {
         gas: Some(gas),
-        gas_budget: 10_000,
+        gas_budget: 20_000,
         coin_id: coin,
         amounts: Some(vec![1000, 10]),
         count: None,
@@ -1070,7 +1070,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     // Test split coin into equal parts
     let resp = SuiClientCommands::SplitCoin {
         gas: None,
-        gas_budget: 10_000,
+        gas_budget: 20_000,
         coin_id: coin,
         amounts: None,
         count: Some(3),
@@ -1129,7 +1129,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     // Test with no gas specified
     let resp = SuiClientCommands::SplitCoin {
         gas: None,
-        gas_budget: 10_000,
+        gas_budget: 20_000,
         coin_id: coin,
         amounts: Some(vec![1000, 10]),
         count: None,

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -6,7 +6,8 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use sui_config::NetworkConfig;
 use sui_core::{
-    authority::AuthorityState, authority_aggregator::AuthorityAggregator,
+    authority::AuthorityState,
+    authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder},
     authority_client::NetworkAuthorityClient,
 };
 use sui_macros::sim_test;
@@ -22,10 +23,7 @@ use sui_types::{
 };
 use test_utils::transaction::{publish_counter_package, submit_shared_object_transaction};
 use test_utils::{
-    authority::{
-        spawn_checkpoint_processes, spawn_test_authorities, test_authority_aggregator,
-        test_authority_configs,
-    },
+    authority::{spawn_checkpoint_processes, spawn_test_authorities, test_authority_configs},
     messages::{make_transactions_with_pre_genesis_objects, move_transaction},
     objects::test_gas_objects,
 };
@@ -116,7 +114,11 @@ fn make_aggregator(
     handles: &[SuiNodeHandle],
 ) -> AuthorityAggregator<NetworkAuthorityClient> {
     let committee_store = handles[0].with(|h| h.state().committee_store().clone());
-    test_authority_aggregator(configs, committee_store)
+    let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(configs)
+        .with_committee_store(committee_store)
+        .build()
+        .unwrap();
+    aggregator
 }
 
 #[sim_test]

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -3,22 +3,19 @@
 use crate::TEST_COMMITTEE_SIZE;
 use prometheus::Registry;
 use rand::{prelude::StdRng, SeedableRng};
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{NetworkConfig, NodeConfig, ValidatorInfo};
 use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClientMetrics};
-use sui_core::epoch::committee_store::CommitteeStore;
 use sui_core::{
     authority_active::{
         checkpoint_driver::{CheckpointMetrics, CheckpointProcessControl},
         ActiveAuthority,
     },
-    authority_aggregator::{AuthAggMetrics, AuthorityAggregator},
+    authority_aggregator::AuthorityAggregatorBuilder,
     authority_client::NetworkAuthorityClient,
-    safe_client::SafeClientMetrics,
 };
-use sui_types::{committee::Committee, object::Object};
+use sui_types::object::Object;
 
 pub use sui_node::{SuiNode, SuiNodeHandle};
 use sui_types::base_types::ObjectID;
@@ -126,8 +123,10 @@ pub async fn spawn_checkpoint_processes(configs: &NetworkConfig, handles: &[SuiN
             .with_async(|authority| async move {
                 let state = authority.state();
 
-                let aggregator =
-                    test_authority_aggregator(configs, authority.state().committee_store().clone());
+                let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(configs)
+                    .with_committee_store(authority.state().committee_store().clone())
+                    .build()
+                    .unwrap();
 
                 let inner_agg = aggregator.clone();
                 let active_state = Arc::new(
@@ -146,39 +145,6 @@ pub async fn spawn_checkpoint_processes(configs: &NetworkConfig, handles: &[SuiN
             })
             .await;
     }
-}
-
-/// Create a test authority aggregator.
-pub fn test_authority_aggregator(
-    config: &NetworkConfig,
-    committee_store: Arc<CommitteeStore>,
-) -> AuthorityAggregator<NetworkAuthorityClient> {
-    let validators_info = config.validator_set();
-    let committee = Committee::new(0, ValidatorInfo::voting_rights(validators_info)).unwrap();
-    // TODO: duplicated at test_utils.rs
-    let registry = prometheus::Registry::new();
-    let network_metrics = Arc::new(NetworkAuthorityClientMetrics::new(&registry));
-    let clients: BTreeMap<_, _> = validators_info
-        .iter()
-        .map(|config| {
-            (
-                config.protocol_key(),
-                NetworkAuthorityClient::connect_lazy(
-                    config.network_address(),
-                    network_metrics.clone(),
-                )
-                .unwrap(),
-            )
-        })
-        .collect();
-    AuthorityAggregator::new(
-        committee,
-        committee_store,
-        clients,
-        AuthAggMetrics::new(&registry),
-        Arc::new(SafeClientMetrics::new(&registry)),
-        network_metrics,
-    )
 }
 
 /// Get a network client to communicate with the consensus.

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -32,7 +32,7 @@ use sui_types::object::Object;
 use sui_types::object::Owner;
 
 /// The maximum gas per transaction.
-pub const MAX_GAS: u64 = 50_000;
+pub const MAX_GAS: u64 = 100_000;
 
 pub fn random_object_ref() -> ObjectRef {
     (

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -1,269 +1,85 @@
 ---
-title: Use Sui CLI to Start and Manage Network
+title: Sui Client CLI
 ---
 
-Welcome to the Sui tutorial on the Sui CLI developed
-to facilitate experimentation with Sui features using a
-command line interface. In this document, we describe how to set up
-the Sui client and execute commands through its command line
-interface, *Sui CLI*.
-
-Note, this is an advanced option and an alternative to simply connecting to our public
-[Devnet](../build/devnet.md). Use Devnet to build upon Sui. Use the Sui CLI here to
-[contribute](../contribute/index.md) to Sui itself.
+Learn how to set up, configure, and use the Sui Client Command Line Interface (CLI). You can use the CLI to experiment with Sui features using a command line interface.
 
 ## Set up
 
-Follow the instructions to [install Sui binaries](install.md#binaries).
-
-## Genesis
-
-The `genesis` command creates four validators and five user accounts
-each with five gas objects. These are Sui [objects](../learn/objects.md) used
-to pay for Sui [transactions](../learn/transactions.md#transaction-metadata),
-such other object transfers or smart contract (Move) calls. These
-numbers represent a sample configuration and have been chosen somewhat
-arbitrarily; the process of generating the genesis state can be
-customized with additional accounts, objects, code, etc. as described
-in [Genesis customization](#customize-genesis).
-
-1. Optionally, set `RUST_LOG=debug` for verbose logging.
-1. Initiate `genesis`:
-   ```shell
-   $ sui genesis
-   ```
-
-All of this is contained in configuration and keystore files and an `authorities_db`
-database directory. A `client_db` directory is also created upon running the
-`sui client new-address` command covered later.
-
-The network configuration is stored in `network.yaml` and can be used
-subsequently to start the network. The `client.yaml` and `sui.keystore`
-are also created to be used by the Sui client to manage the newly
-created accounts.
-
-By default, these files are placed in your home directory at
-`~/.sui/sui_config` (created automatically if it does not yet exist). But you
-can override this location by providing an alternative path to the `--working-dir`
-argument. Run the command like so to place the files in the `dir` directory:
-
-```shell
-$ sui genesis --working-dir /path/to/sui/config/dir
-```
-
-> **Note:** That path and directory must already exist and will not be created with the `--working-dir` argument.
-
-### Recreating genesis
-
-To recreate Sui genesis state in the same location, which will remove
-existing configuration files, pass the `--force` option to the `sui
-genesis` command and either run it in the default directory (`~/.sui/sui_config`) or specify
-it once again, using the `--working-dir` argument:
-
-```shell
-$ sui genesis --force --working-dir /path/to/sui/config/dir
-```
-
-## Client configuration
-
-The genesis process creates a configuration file `client.yaml`, and a keystore file `sui.keystore` for the
-Sui client.  The config file contains information of the accounts and
-the Sui Network server. The keystore file contains all the public-private key pairs of the created accounts.
-Sui client uses the network information in `client.yaml` to communicate
-with the Sui network validators  and create transactions using the key
-pairs residing in the keystore file.
-
-Here is an example of `client.yaml` showing the accounts and key pairs
-in the client configuration (with some values omitted):
-
-```yaml
----
-accounts:
-  - b02b5e57fe3572f94ad5ac2a17392bfb3261f7a0
-  - b4f5ed3cbe78c7969e6ac073f9a0c525fd07f05a
-  - 48ff0a932b12976caec91d521265b009ad5b2225
-  - 08da15bee6a3f5b01edbbd402654a75421d81397
-  - 3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75
-keystore:
-  File: /Users/user/.sui/sui_config/sui.keystore
-gateway:
-  embedded:
-    epoch: 0
-    validator_set:
-      - public-key: Ot3ov659M4tl59E9Tq1rUj5SccoXstXrMhQSJX7pFKQ=
-        stake: 1
-        network-address: /dns/localhost/tcp/57468/http
-      - public-key: UGfB4wzJ2Lntn+WJvv+83RSigpuf7Vv2AmCPQR28TVY=
-        stake: 1
-        network-address: /dns/localhost/tcp/57480/http
-      - public-key: 5bO8DUgmA9i1SiUka5BT6VjIclMNQBRnbVww2IXxFqw=
-        stake: 1
-        network-address: /dns/localhost/tcp/57492/http
-      - public-key: 8uV0ml/DPUXG9UbrnlP6v08XaBum9pcIDelRT04NanU=
-        stake: 1
-        network-address: /dns/localhost/tcp/57504/http
-    send_timeout:
-      secs: 4
-      nanos: 0
-    recv_timeout:
-      secs: 4
-      nanos: 0
-    buffer_size: 650000
-    db_folder_path: /Users/user/.sui/sui_config/client_db
-active_address: "0xb02b5e57fe3572f94ad5ac2a17392bfb3261f7a0"
-```
-
-The `accounts` variable contains the account's address that the client manages. The
-`gateway` variable contains the information of the Sui network that the client will
-be connecting to.
-
-The `authorities` variable is part of the embedded gateway configuration. It contains
-the Sui network validator's name, host and port information. It is used to establish connections
-to the Sui network.
-
-Note `send_timeout`, `recv_timeout` and `buffer_size` are the network
-parameters, and `db_folder_path` is the path to the account's client state
-database. This database stores all the transaction data, certificates
-and object data belonging to the account.
-
-### Sui Network Gateway
-
-The Sui Network Gateway (or simply, Sui Gateway) is an abstraction layer that acts as the entry
-point to the Sui network. Different gateway implementations can be used by the application layer
-based on their use cases.
-
-#### Embedded gateway
-
-As the name suggests, embedded gateway embeds the gateway logic into the application;
-all data will be stored locally and the application will make direct
-connection to the validators.
-
-#### RPC gateway
-You can also connect the client to the Sui network via an [RPC Gateway](json-rpc.md#start-local-rpc-server);
-To use the RPC gateway, update `client.yaml`'s `gateway` section to:
-```yaml
-...
-gateway:
-  rpc: "http://localhost:5001"
-...
-```
-
-### Key management
-
-The key pairs are stored in `sui.keystore`. However, this is not secure
-and shouldn't be used in a production environment. We have plans to
-implement more secure key management and support hardware signing in a future release.
-
-:warning: **Do not use in production**: Keys are stored in file!
-
-## Starting the network
-
-Run the following command to start the local Sui network, assuming you
-accepted the default location for configuration:
-
-```shell
-$ sui start
-```
-
-This command will look for the Sui network configuration file
-`network.yaml` in the `~/.sui/sui_config` directory. But you can
-override this setting by providing a path to the directory where
-this file is stored:
-
-```shell
-$ sui start --config /path/to/sui/network/config/file
-```
-
-For example:
-
-```shell
-$ sui start --config /Users/name/tmp/network.yaml
-```
-
-Executing any of these two commands in a terminal window will result
-in no output but the terminal will be "blocked" by the running Sui
-instance (it will not return the command prompt). The command can
-also be run in background.
-
-NOTE: For logs, set `RUST_LOG=debug` before invoking `sui start`.
-
-If you see errors when trying to start Sui network, particularly if you made some custom changes
- (e.g,
-[customized client configuration](#client-configuration)), you should [recreate Sui genesis state](#recreating-genesis).
+The SUI Client CLI installs when you install Sui. See the [Install Sui](install.md) topic for prerequisites and installation instructions.
 
 ## Using the Sui client
 
-Now start a new terminal since you have the Sui network running in the first terminal.
+The Sui Client CLI supports the following commands:
 
-The following commands are supported by the Sui client:
-
-    active-address        Default address used for commands when none specified
-    addresses             Obtain the Addresses managed by the client
-    call                  Call Move function
-    clear                 Clear screen
-    create-example-nft    Create an example NFT
-    echo                  Write arguments to the console output
-    env                   Print environment
-    exit                  Exit the interactive shell
-    gas                   Obtain all gas objects owned by the address
-    help                  Print this message or the help of the given subcommand(s)
-    history               Print history
-    merge-coin            Merge two coin objects into one coin
-    new-address           Generate new address and keypair
-    object                Get obj info
-    objects               Obtain all objects owned by the address
-    publish               Publish Move modules
-    split-coin            Split a coin object into multiple coins
-    switch                Switch active address and network (e.g., Devnet, local RPC server)
-    sync                  Synchronize client state with authorities
-    transfer              Transfer object
-    transfer-sui          Transfer SUI, and pay gas with the same SUI coin object. If amount is
-                              specified, only the amount is transferred; otherwise the entire object
-                              is transferred
+| Command | Description |
+| --- | --- |
+| `active-address` | Default address used for commands when none specified |
+| `addresses` | Obtain the Addresses managed by the client |
+| `call` | Call Move function |
+| `create-example-nft` | Create an example NFT |
+| `gas` | Obtain all gas objects owned by the address |
+| `help` | Print this message or the help of the given subcommand(s) |
+| `merge-coin` | Merge two coin objects into one coin |
+| `new-address` | Generate new address and keypair with keypair scheme flag {ed25519 or secp256k1} with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1 |
+| `object` | Get object info |
+| `objects` | Obtain all objects owned by the address |
+| `pay` | Pay SUI to recipients following specified amounts, with input coins. Length of recipients must be the same as that of amounts |
+| `publish` | Publish Move modules|
+| `split-coin` | Split a coin object into multiple coins |
+| `switch` | Switch active address and network(such as devnet, local rpc server) |
+| `sync` | Synchronize client state with authorities |
+| `transfer` | Transfer an object |
+| `transfer-sui` | Transfer SUI, and pay gas with the same SUI coin object. If amount is specified, transfers only the amount. If not specified, transfers the object. |
 
 > **Note:** The `clear`, `echo`, `env` and `exit` commands exist only in the interactive shell.
 
-Use `sui client -h` to see the most up-to-date list of commands.
+Use `sui client -h` to see a list of supported commands.
 
 Use `help <command>` to see more information on each command.
 
 You can start the client in two modes: interactive shell or command line interface.
 
+To configure the Sui client:
+```shell
+$ sui client
+```
+The Sui CLI prints the following line when the client starts up for the first time:
+```shell
+Config file ["/Users/dir/.sui/sui_config/client.yaml"] doesn't exist, do you want to connect to a Sui RPC server [y/n]?
+```
+Type `y` and then press `Enter`. You should see the following output:
+```shell
+Sui RPC server Url (Default to Sui Devnet if not specified) :
+```
+The Sui client prompts you for the RPC server URL. Press Enter to use the default value for Devnet. You can also enter a custom URL to connect to a custom RPC endpoint.
+
 ### Interactive shell
 
-To start the interactive shell, execute the following (in a different
-terminal window than one used to execute `sui start`). Assuming you
-accepted the default location for configuration:
+To start the interactive shell:
 
 ```shell
 $ sui console
 ```
 
-This command will look for the client configuration file
+The console command looks for the client configuration file
 `client.yaml` in the `~/.sui/sui_config` directory. But you can
 override this setting by providing a path to the directory where this
 file is stored:
 
 ```shell
-$ sui console --config /path/to/client/config/file
+$ sui console --config /workspace/config-files
 ```
 
 The Sui interactive client console supports the following shell functionality:
 
-* *Command history* -
-  The `history` command can be used to print the interactive shell's command history;
-  you can also use Up, Down or Ctrl-P, Ctrl-N to navigate previous or next matches from history.
-  History search is also supported using Ctrl-R.
-* *Tab completion* -
-  Tab completion is supported for all commands using Tab and Ctrl-I keys.
-* *Environment variable substitution* -
-  The Sui console will substitute inputs prefixed with `$` with environment variables,
-  you can use the `env` command to print out the entire list of variables and
-  use `echo` to preview the substitution without invoking any commands.
+  * *Command history* - use the `history` command to print the command history. You can also use Up, Down or Ctrl-P, Ctrl-N to display the previous or next in the history list. Use Ctrl-R to search the command history.
+  * *Tab completion* - supported for all commands using Tab and Ctrl-I keys.
+  * *Environment variable substitution* - the console substitutes input prefixed with `$` with environment variables. Use the `env` command to print out the entire list of variables and use `echo` to preview the substitution without invoking any commands.
 
 ### Command line mode
 
-The client can also be used without the interactive shell, which can be useful if
+You can use the client without the interactive shell. This is useful if
 you want to pipe the output of the client to another application or invoke client
 commands using scripts.
 
@@ -272,68 +88,43 @@ USAGE:
     sui client [SUBCOMMAND]
 ```
 
-For example, we can use the following command to see the list of
-accounts available on the platform:
+For example, the following command returns the list of
+account addresses available on the platform:
 
 ```shell
 $ sui client addresses
 ```
 
-The result of running this command should resemble the following output:
-
-```shell
-Showing 5 results.
-0x66af3898e7558b79e115ab61184a958497d1905a
-0xae6fb6036570fec1df71599740c132cdf5b45b9d
-0x45cda12e3bafe3017b4b3cd62c493e5fbaad7fb0
-0xef999dbdb19ccca504eef5432cec69ea8a1d4a1b
-0x4489ab46a230c1876578441d68f25bf968e6f2b0
-```
-
-But the actual address values will most likely differ
-in your case (as will other values, such as object IDs, in the latter
-parts of this tutorial). Consequently, **do not copy and paste
-the actual command from this tutorial as they are unlikely to work for
-you verbatim**. Each time you create a config for the client, addresses
-and object IDs will be assigned randomly. Consequently, you cannot rely
-on copy-pasting commands that include these values, as they will be different
-between different users/configs.
-
 ### Active address
 
-Since a Sui CLI client manages multiple disjointed addresses, one might need to specify
-which address they want to call a command on.
+You can specify an active address or default address to use to execute commands. 
 
-For convenience, one can choose to set a default, or active address that will be
-used for commands that require an address to operate on. A default address is picked
-at the start, but this can be changed later.
-
-In order to see what the current active address is, use the command `active-address`
+Sui sets a default address to use for commands. It uses the active address for commands that require an address. To view the current active address, use the `active-address` command.
 
 ```shell
 $ sui client active-address
 ```
 
-Which will reveal an address resembling:
+The response to the request resembles the following:
 
 ```shell
 0x562f07cf6369e8d22dbf226a5bfedc6300014837
 ```
 
-Changing the default address is as easy as calling the `switch` command:
+To change the default address, use the `switch` command:
 
 ```shell
 $ sui client switch --address 0x913cf36f370613ed131868ac6f9da2420166062e
 ```
 
-You will see output like:
+The response resembles the following:
 
 ```shell
 Active address switched to 0x913cf36f370613ed131868ac6f9da2420166062e
 ```
 
-One can call, for example, the `objects` command with or without an address specified.
-When not specified, the active address is used.
+You can call the `objects` command with or without specifying an address.
+Sui uses the active address if you do not specify one.
 
 ```shell
 $ sui client objects
@@ -348,221 +139,87 @@ $ sui client objects --address 0x913cf36f370613ed131868ac6f9da2420166062e
  0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 |     0      | j8qLxVk/Bm9iMdhPf9b7HcIMQIAM+qCd8LfPAwKYrFo= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
 ```
 
-All commands where `address` is omitted will now use the newly specified active address:
+All subsequent commands that omit `address` use the new active address:
 0x913cf36f370613ed131868ac6f9da2420166062e
 
-Note that if one calls a command that uses a gas object not owned by the active address,
-the address owned by the gas object is temporarily used for the transaction.
+If you call a command that uses a gas object that is not owned by the active address,
+Sui temporarily uses the address that owns the gas object for the transaction.
 
 ### Paying For transactions with gas objects
 
-All Sui transactions require a gas object for payment, as well as a budget. However, specifying
-the gas object can be cumbersome; so in the CLI, one is allowed to omit the gas object and leave
-the client to pick an object that meets the specified budget. This gas selection logic is currently
-rudimentary as it does not combine/split gas as needed but currently picks the first object it finds
-that meets the budget. Note that one can always specify their own gas if they want to manage the gas
-themselves.
+All Sui transactions require a gas object for payment, as well as a budget. However, specifying the gas object can be cumbersome; so in the CLI, one is allowed to omit the gas object and leave the client to pick an object that meets the specified budget. This gas selection logic is currently rudimentary as it does not combine/split gas as needed but currently picks the first object it finds that meets the budget. Note that one can always specify their own gas if they want to manage the gas themselves.
 
 :warning: A gas object cannot be part of the transaction while also being used to
 pay for the transaction. For example, one cannot try to transfer gas object X while paying for the
 transaction with gas object X. The gas selection logic checks for this and rejects such cases.
 
-To see how much gas is in an account, use the `gas` command. Note that this command uses the
-`active-address`, unless otherwise specified.
+To see how much gas is in an account, use the `gas` command. Note that this command uses the `active-address`, unless otherwise specified.
 
 ```shell
 $ sui client gas
 ```
 
-You will see output like:
-
-```shell
-                Object ID                   |  Version   |  Gas Value
-------------------------------------------------------------------------
- 0x0b8a4620426e526fa42995cf26eb610bfe6bf063 |     0      |   100000
- 0x3c0763ccdea4ff5a4557505a62ab5e1daf91f4a2 |     0      |   100000
- 0x45a589a9e760d7f75d399327ac0fcba21495c22e |     0      |   100000
- 0x4c377a3a9d4b1b9c92189dd12bb1dcd0302a954b |     0      |   100000
- 0xf2961464ac6860a05d21b48c020b7e121399965c |     0      |   100000
-```
-
-If one does not want to use the active address, the addresses can be specified:
+You can specify an address to see the amount of gas for that address instead of the active address.
 
 ```shell
 $ sui client gas --address 0x562f07cf6369e8d22dbf226a5bfedc6300014837
-                Object ID                   |  Version   |  Gas Value
-------------------------------------------------------------------------
- 0xa8ddc2661a19010e5f85cbf6d905ddfbe4dd0320 |     0      |   100000
- 0xb2683d0b592e5b002d110989a52943bc9da19158 |     0      |   100000
- 0xb41bf45b01c9befce3a0a371e2b98e062691438d |     0      |   100000
- 0xba9e10f319182f3bd584edb92c7899cc6d018723 |     0      |   100000
- 0xf8bfe77a5b21e7abfa3bc285991f9da4e5cc2d7b |     0      |   100000
-
 ```
 
-## Adding accounts to the client
+## Create new account addresses
 
-Sui's genesis process will create five accounts by default; if that's
-not enough, there are two ways to add accounts to the Sui CLI client if needed.
+Sui Client CLI includes 1 address by default. To add more, create new addresses for the client with the `new-address` command, or add existing accounts to the client.yaml.
 
-### Generating a new account
-
-To create a new account, execute the `new-address` command:
+### Create a new account address
 
 ```shell
 $ sui client new-address ed25519
 ```
-New address creation requires key scheme flag `{ed25519 | secp256k1}`. 
 
-The output shows a confirmation after the account has been created:
+You must specify the key scheme, either `ed25519` or `secp256k1`. 
 
-```
-Created new keypair for address with flag 0: [0xc72cf3adcc4d11c03079cef2c8992aea5268677a]
-```
+### Add existing accounts to client.yaml
 
-### Add existing accounts to `client.yaml` manually
+To add existing account addresses to your client, such as from a previous installation, edit the client.yaml file and add the accounts section. You must also add key pair to the keystore file.
 
-If you have an existing key pair from an old client config, you can copy the account
-address manually to the new `client.yaml`'s accounts section, and add the key pair to the keystore file;
-you won't be able to mutate objects if the account key is missing from the keystore.
+Restart the Sui console after you save the changes to the client.yaml file.
 
-Restart the Sui console after the modification; the new accounts will appear in the client if you query the addresses.
+## View objects an address owns
 
-## View objects owned by the address
-
-You can use the `objects` command to view the objects owned by the address.
-
-`objects` command usage:
+Use the `objects` command to view the objects an address owns.
 
 ```shell
-sui-client-objects
-Obtain all objects owned by the address
-
-USAGE:
-    sui client objects [OPTIONS]
-
-OPTIONS:
-        --address <ADDRESS>    Address owning the objects
-    -h, --help                 Print help information
-        --json                 Return command outputs in json format
+sui client objects
 ```
 
-To view the objects owned by the addresses created in genesis, run the following command (substituting the address with one of the genesis addresses in your client):
+To view the objects for a different address than the active address, use `--address` in the command and specify the address to see objects for.
 
 ```shell
 $ sui client objects --address 0x66af3898e7558b79e115ab61184a958497d1905a
 ```
 
-The result should resemble the following.
+To view more information about an object, use the `object` command.
 
 ```shell
-                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 |     0      | j8qLxVk/Bm9iMdhPf9b7HcIMQIAM+qCd8LfPAwKYrFo= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xc8add7b4073900ffb0a8b4fe7d70a7db454c2e19 |     0      | uCZNPmDWOksKhCKwEaMtST5T4HbTjcgXGHRXP4qTLC8= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xd1949864f94d87cf25e1fd7b1c8ab4bf685f7801 |     0      | OsTryyECAPW9mnSbWlYWELX+QlRg5er7s/DlkgqhDww= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xddb6119c320f52f3fef9fbc272af305d985b6883 |     0      | gBCDdel7iJZnXpuf4g9dqIPT4XjaAY/4knNcDxbTons= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xe1fe79ac8d900342e617e0986f54ff64e4e323de |     0      | qjsWIzAaomo0eqFwQt99EkARsiC/aw2hPDH8quM6pYg= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
-Showing 5 results.
-```
-
-If you want to view more information about the objects, you can use the `object` command.
-
-Usage of `object` command :
-
-```shell
-sui-client-object
-Get object info
-
-USAGE:
-    sui client object [OPTIONS] --id <ID>
-
-OPTIONS:
-    -h, --help       Print help information
-        --id <ID>    Object ID of the object to fetch
-        --json       Return command outputs in json format
-```
-
-To view the object, use the following command:
-
-```bash
-$ sui client object --id 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55
-```
-
-This should give you output similar to the following:
-
-```shell
------ Move Object (0x66eaa38c8ea99673a92a076a00101ab9b3a06b55[0]) -----
-Owner: Account Address ( 0xb02b5e57fe3572f94ad5ac2a17392bfb3261f7a0 )
-Version: 0
-Storage Rebate: 0
-Previous Transaction: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
------ Data -----
-type: 0x2::coin::Coin<0x2::sui::SUI>
-balance: 100000
-id: 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55[0]
+    sui client object --id <ID>
 ```
 
 The result shows some basic information about the object, the owner,
 version, ID, if the object is immutable and the type of the object.
 
-> **Important:** To gain a deeper view into the object, include the
-> `--json` flag in the `sui client` command to see the raw JSON representation
-> of the object.
-
-Here is example `json` output:
-
-```json
-{
-  "data": {
-    "dataType": "moveObject",
-    "type": "0x2::coin::Coin<0x2::sui::SUI>",
-    "has_public_transfer": true,
-    "fields": {
-      "balance": 100000,
-      "id": {
-        "id": "0x66eaa38c8ea99673a92a076a00101ab9b3a06b55",
-        "version": 0
-      }
-    }
-  },
-  "owner": {
-    "AddressOwner": "0xb02b5e57fe3572f94ad5ac2a17392bfb3261f7a0"
-  },
-  "previousTransaction": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-  "storageRebate": 0,
-  "reference": {
-    "objectId": "0x66eaa38c8ea99673a92a076a00101ab9b3a06b55",
-    "version": 0,
-    "digest": "j8qLxVk/Bm9iMdhPf9b7HcIMQIAM+qCd8LfPAwKYrFo="
-  }
-}
-```
-
-## Transferring coins
-
-Coins *are* objects, but they have a specific use case that allows you to use native commands such as `transfer`, `merge-coin`, and `split-coin`. This is different from non-coin objects that you can mutate only using [Move calls](#calling-move-code).
-
-If you inspect a newly created account, you would expect the account does not own any object. Let us inspect the fresh account we create in the [Generating a new account](#generating-a-new-account) section (`C72CF3ADCC4D11C03079CEF2C8992AEA5268677A`):
+To view the JSON representation of the object, include `--json` in the command.
 
 ```shell
-$ sui client objects --address 0xc72cf3adcc4d11c03079cef2c8992aea5268677a
-                 Object ID                  |  Version   |                                Digest
-------------------------------------------------------------------------------------------------------------------------------
-Showing 0 results.
+    sui client object --id <ID> --json
 ```
+
+## Transfer coins
+
+Coins are objects, but they have a specific use case that allows you to use native commands such as `transfer`, `merge-coin`, and `split-coin`. You can mutate other objects only using [Move calls](#calling-move-code).
 
 To add objects to the account, you can [invoke a Move function](#calling-move-code),
-or you can transfer one of the existing coins from the genesis account to the new account using a dedicated Sui client command.
-We will explore how to transfer coins using the Sui CLI client in this section.
-
-`transfer` command usage:
+transfer an object from another account address, create an example NFT, or use the Sui faucet to add coins to the address.
 
 ```shell
-sui-client-transfer
-Transfer object
-
-USAGE:
     sui client transfer [OPTIONS] --to <TO> --object-id <COIN_OBJECT_ID> --gas-budget <GAS_BUDGET>
 
 OPTIONS:
@@ -586,84 +243,27 @@ OPTIONS:
             Recipient address
 ```
 
-To transfer a coin object to a recipient, you will need the recipient's address,
-the object ID of the coin that you want to transfer,
-and optionally the coin object ID for the transaction fee payment. If a gas
-coin is not specified, one that meets the budget is picked. Gas budget sets a
-cap for how much gas you want to spend. We are still finalizing our gas metering
-mechanisms. For now, just set something large enough.
-
-Here is an example transfer of an object to account `0xf456ebef195e4a231488df56b762ac90695be2dd`:
+To transfer a coin object to a recipient, you need the recipient's address,
+the object ID of the coin to transfer, and, optionally, the ID of the coin object for the transaction fee payment. If not specified, a coin that meets the budget is picked. Gas budget sets a cap for how much gas to spend. We are still finalizing our gas metering mechanisms. For now, just set something large enough.
 
 ```shell
 $ sui client transfer --to 0xf456ebef195e4a231488df56b762ac90695be2dd --object-id 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 --gas-budget 100
 ```
 
-With output like:
+## Create an example NFT
 
-```
-Transfer confirmed after 16896 us
------ Certificate ----
-Transaction Hash: mjj1+0Wn+lER1oSD7fwXmoaxzoZW1pmMOqHQJgniy8U=
-Transaction Signature: YLbToj+MjgQnaix24ObbE+BdXna6bB9gSSm+YMa/VHsX5g68T9+5vRnGbvDECGoioluUQP0k/zSPvQU5Y/uXCA==@BE/TaOYjyEtJUqF0Db4FEcVT4umrPmp760gFLQIGA1E=
-Signed Authorities : [k#f2e5749a5fc33d45c6f546eb9e53fabf4f17681ba6f697080de9514f4e0d6a75, k#3adde8bfae7d338b65e7d13d4ead6b523e5271ca17b2d5eb321412257ee914a4, k#5067c1e30cc9d8b9ed9fe589beffbcdd14a2829b9fed5bf602608f411dbc4d56]
-Transaction Kind : Public Transfer Object
-Recipient : 0xf456ebef195e4a231488df56b762ac90695be2dd
-Object ID : 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55
-Version : SequenceNumber(1)
-Object Digest : NFDitxwq+bXetYmBxsw9RYEFqq+NWIbRxVoyv3JJXSE=
------ Transaction Effects ----
-Status : Success
-Mutated Objects:
-  - ID: 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 , Owner: Account Address ( 0xf456ebef195e4a231488df56b762ac90695be2dd )
-  - ID: 0xc8add7b4073900ffb0a8b4fe7d70a7db454c2e19 , Owner: Account Address ( 0xb02b5e57fe3572f94ad5ac2a17392bfb3261f7a0 )
-```
-
-The account will now have one object:
-
-```shell
-$ sui client objects --address 0xc72cf3adcc4d11c03079cef2c8992aea5268677a
-                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 |     1      | j8qLxVk/Bm9iMdhPf9b7HcIMQIAM+qCd8LfPAwKYrFo= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
-```
-
-## Creating example NFTs
-
-You may create an [NFT-like object](https://github.com/MystenLabs/sui/blob/main/crates/sui-framework/sources/devnet_nft.move#L16) on Sui using the following command:
+You can add an example NFT to an address using the `create-example-nft` command. The command adds an NFT to the active address.
 
 ```shell
 $ sui client create-example-nft
 ```
 
-You will see output resembling:
-
-```shell
-Successfully created an ExampleNFT:
-
------ Move Object (0x524f9fae3ca4554e01354415daf58a05e5bf26ac[1]) -----
-Owner: Account Address ( 0xb02b5e57fe3572f94ad5ac2a17392bfb3261f7a0 )
-Version: 1
-Storage Rebate: 25
-Previous Transaction: 98HbDxEwEUknQiJzyWM8AiYIM479BEKuGwxrZOGtAwk=
------ Data -----
-type: 0x2::devnet_nft::DevNetNFT
-description: An NFT created by the Sui Command Line Tool
-id: 0x524f9fae3ca4554e01354415daf58a05e5bf26ac[1]
-name: Example NFT
-url: ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty
-```
-
-The command will invoke the `mint` function in the `devnet_nft` module, which mints a Sui object with three attributes: name, description, and image URL with [default values](https://github.com/MystenLabs/sui/blob/27dff728a4c9cb65cd5d92a574105df20cb51887/sui/src/wallet_commands.rs#L39) and transfers the object to your address. You can also provide custom values using the following instructions:
+The command invokes the `mint` function in the `devnet_nft` module, which mints a Sui object with three attributes: name, description, and image URL with [default values](https://github.com/MystenLabs/sui/blob/27dff728a4c9cb65cd5d92a574105df20cb51887/sui/src/wallet_commands.rs#L39) and transfers the object to your address. You can also provide custom values using the following instructions:
 
 
 `create-example-nft` command usage:
 
 ```shell
-sui-client-create-example-nft
-Create an example NFT
-
-USAGE:
     sui client create-example-nft [OPTIONS]
 
 OPTIONS:
@@ -680,23 +280,15 @@ OPTIONS:
 ```
 
 
-## Merging and splitting coin objects
+## Merge and split coin objects
 
-Overtime, the account might receive coins from other accounts and will become unmanageable when
-the number of coins grows; contrarily, the account might need to split the coins for payment or
-for transfer to another account.
+You can merge coins to reduce the number of separate coin objects in an account, or split coins to create smaller coin objects to use for transfers or gas payments.
 
 We can use the `merge-coin` command and `split-coin` command to consolidate or split coins, respectively.
 
 ### Merge coins
 
-Usage of `merge-coin`:
-
 ```shell
-sui-client-merge-coin
-Merge two coin objects into one coin
-
-USAGE:
     sui client merge-coin [OPTIONS] --primary-coin <PRIMARY_COIN> --coin-to-merge <COIN_TO_MERGE> --gas-budget <GAS_BUDGET>
 
 OPTIONS:
@@ -720,61 +312,23 @@ OPTIONS:
             Coin to merge into, in 20 bytes Hex string
 ```
 
-Here is an example of how to merge coins. To merge coins, you will need at lease three coin objects -
-two coin objects for merging, and one for the gas payment.
-You also need to specify the maximum gas budget that should be expanded for the coin merge operations.
-Let us examine objects owned by address `0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75`
-and use the first coin (gas) object as the one to be the result of the merge, the second one to be merged, and the third one to be used as payment:
+You need at lease three coin objects to merge coins, two coins to merge and one to pay for gas payment. When you merge a coin, you specify maximum gas budget allowed for the merge transaction.
+
+Use the following command to view the objects that the specified address owns.
 
 ```shell
 $ sui client objects --address 0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75
 ```
 
-And its output:
+Use the IDs returns from the previous command in the `merge-coin` command.
 
-```
-                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 0x1e90389f5d70d7fa6ce973155460e1c04deae194 |     0      | BC5O8Bf6Uw8S1LV1y4RCI6+kz1KhZG/aOpeqq9kTAvs= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x351f08f03709cebea85dcd20e24b00fbc1851c92 |     0      | 9aYvavAzY6chYbOUtMtJj0g/5GNc+KBsqptCX5pmQ2Y= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x3c720502f9eabb17a52a999859fbbaeb408b1d14 |     0      | WUPT6P40veMZ/C7GiQpv92I4EH+hvh5BbkBt+7p9yH0= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x7438af4677b9cea2094848f611143346183c11d1 |     0      | 55B56RG/kCeHrN6GXdIq0IvnyYD/hng9J7I7FNRykQ4= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x9d5f2b2564ad2255c24a03556785bddc85381508 |     0      | rmyYjq/UEED0xR0hE3Da8OYgBAu3MYxKQ3v76pGTDek= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
-Showing 5 results.
-```
-
-Then we merge:
 ```shell
 $ sui client merge-coin --primary-coin 0x1e90389f5d70d7fa6ce973155460e1c04deae194 --coin-to-merge 0x351f08f03709cebea85dcd20e24b00fbc1851c92 --gas-budget 1000
 ```
 
-With results resembling:
-
-```
------ Certificate ----
-Transaction Hash: kxxpeggKaMpiWTpSrCNYcu3EDBfNWBJiIPnqae99Znw=
-Transaction Signature: /4jxUHC8iZRaHlgbgfOr962BqIRb7AavVJE8GUlY6EMehedF8iVxPf8URe5wFyrxD8IvEclN3Z1qJ4UweYCQAA==@cQeSjZ1xq4QC+7G5/MlAhnZuie6ZrukU/ps2LHmX3D8=
-Signed Authorities : [k#3adde8bfae7d338b65e7d13d4ead6b523e5271ca17b2d5eb321412257ee914a4, k#e5b3bc0d482603d8b54a25246b9053e958c872530d4014676d5c30d885f116ac, k#5067c1e30cc9d8b9ed9fe589beffbcdd14a2829b9fed5bf602608f411dbc4d56]
-Transaction Kind : Call
-Package ID : 0x2
-Module : coin
-Function : join
-Arguments : ["0x1e90389f5d70d7fa6ce973155460e1c04deae194", "0x351f08f03709cebea85dcd20e24b00fbc1851c92"]
-Type Arguments : ["0x2::sui::SUI"]
------ Merge Coin Results ----
-Updated Coin : Coin { id: 0x1e90389f5d70d7fa6ce973155460e1c04deae194, value: 200000 }
-Updated Gas : Coin { id: 0x3c720502f9eabb17a52a999859fbbaeb408b1d14, value: 99444 }
-```
-
 ### Split coins
 
-Usage of `split-coin`:
-
 ```shell
-sui-client-split-coin
-Split a coin object into multiple coins
-
-USAGE:
     sui client split-coin [OPTIONS] --coin-id <COIN_ID> --gas-budget <GAS_BUDGET> <--amounts <AMOUNTS>...|--count <COUNT>>
 
 OPTIONS:
@@ -789,102 +343,32 @@ OPTIONS:
         --json                       Return command outputs in json format
 ```
 
-For splitting coins, you will need at least two coins to execute the `split-coin` command,
-one coin to split, one for the gas payment.
+To split a coin you need at least 2 coin objects, one to split and one to pay for gas fees.
 
-Let us examine objects owned by address `0x08da15bee6a3f5b01edbbd402654a75421d81397`:
-
+Use the following command to view the objects the address owns.
 ```shell
 $ sui client objects --address 0x08da15bee6a3f5b01edbbd402654a75421d81397
 ```
 
-With output resembling:
+Then use the IDs returned in the `split-coin` command.
 
-```shell
-                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1 |     0      | uNcjv6KP8AXgQHTFmiEPV3tpWZcYHb1HmBR0B2pMsAo= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x692c179dc434ceb0eaa51cdd198bb905b5ab27c4 |     0      | /ug6IGGld90PqnmL9qijciCqn25V11nn5/PAsKjxMY0= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x7f7b7c1589aceb073a7c8740b1d47d05e4d89e3c |     0      | N5+qKRenKWqb7Y6WKZuFD+fRDB6pj/OtIyri+FSQ3Q0= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xe42558e82e315c9c81ee5b9f1ac3db819ece5c1d |     0      | toHeih0DeFrqxQhGzVUi9EkVwAZSbLx6hv2gpMgNBbs= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xfa322fee6a7f4c266ad4840e85bf3d87689b6de0 |     0      | DxjnkJTSl0o6HlzeOX5K/If61bbFwvRDydjzd2bq8ho= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
-Showing 5 results.
-```
-
-Here is an example of splitting coins using specific amounts. We are splitting out three new coins
-from the original coin (first one on the list above), with values of 1000, 5000 and 3000,
-respectively; note the `--amounts` argument accepts a list of values. We use the second coin on the
-list to pay for this transaction.
+The following example splits one coin into three coins of different amounts, 1000, 5000, and 3000. The `--amounts` argument accepts a list of values.
 
 ```shell
 $ sui client split-coin --coin-id 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1 --amounts 1000 5000 3000 --gas-budget 1000
 ```
 
-You will see output resembling:
-
-```
------ Certificate ----
-Transaction Hash: qpxpv+EySl6tkz7OZ+/h/cpOlC/q1kBepr/qrDHsg7k=
-Transaction Signature: BsuWPuG9iBnvc/cQBbpBvDsBnzLXrhxPpoblpZ7ZcTQ78X9AtPO7knOaPjEbLxEJMGpOCPTIWa0eMPpoqT/SDQ==@ZXB4tfniuC6Oir8aVtIR5C00Md/tG3WSZRNN7nDDZLs=
-Signed Authorities : [k#3adde8bfae7d338b65e7d13d4ead6b523e5271ca17b2d5eb321412257ee914a4, k#5067c1e30cc9d8b9ed9fe589beffbcdd14a2829b9fed5bf602608f411dbc4d56, k#f2e5749a5fc33d45c6f546eb9e53fabf4f17681ba6f697080de9514f4e0d6a75]
-Transaction Kind : Call
-Package ID : 0x2
-Module : coin
-Function : split_vec
-Arguments : ["0x4a2853304fd2c243dae7d1ba58260bb7c40724e1", [1000,5000,3000]]
-Type Arguments : ["0x2::sui::SUI"]
------ Split Coin Results ----
-Updated Coin : Coin { id: 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1, value: 91000 }
-New Coins : Coin { id: 0x1da8193ac29f94f8207b0222bd5941b7814c1668, value: 3000 },
-            Coin { id: 0x3653bae7851c36e0e5e827b7c1a2978ef78efd7e, value: 5000 },
-            Coin { id: 0xd5b694f67410d5b6cd293128cd48953aaa0a3dce, value: 1000 }
-Updated Gas : Coin { id: 0x692c179dc434ceb0eaa51cdd198bb905b5ab27c4, value: 99385 }
-```
+Use the `objects` command to view the new coin objects.
 
 ```
 $ sui client objects --address 0x08da15bee6a3f5b01edbbd402654a75421d81397
-                 Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- 0x1da8193ac29f94f8207b0222bd5941b7814c1668 |     1      | nAMEV3NZ0zscjO10QQUt1drLvhNXTk4MVLAg1FXTQxw= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x3653bae7851c36e0e5e827b7c1a2978ef78efd7e |     1      | blMuVATrI89PRvqA4Kuv6rNkbuAb+bYhmkMocY7pavw= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1 |     1      | uhfauig0guMidpxFyCO6FzhzDfucss+eA6xWzAVF3sU= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x692c179dc434ceb0eaa51cdd198bb905b5ab27c4 |     1      | sWTy2PUbt3UFEKx1Km32dEG7cQscSK+eVc3ChaZCkkA= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0x7f7b7c1589aceb073a7c8740b1d47d05e4d89e3c |     0      | N5+qKRenKWqb7Y6WKZuFD+fRDB6pj/OtIyri+FSQ3Q0= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xd5b694f67410d5b6cd293128cd48953aaa0a3dce |     1      | 4V0BC6eopxkN6wIOdm2FVgwN3psNbPvLKQ9/zrYtsDM= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xe42558e82e315c9c81ee5b9f1ac3db819ece5c1d |     0      | toHeih0DeFrqxQhGzVUi9EkVwAZSbLx6hv2gpMgNBbs= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
- 0xfa322fee6a7f4c266ad4840e85bf3d87689b6de0 |     0      | DxjnkJTSl0o6HlzeOX5K/If61bbFwvRDydjzd2bq8ho= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
-Showing 8 results.
 ```
 
-From the result, we can see three new coins were created in the transaction.
-
-Here is an example of splitting coins into equal parts without needing to specify the individual
-amount for every new coin.
+The following example splits a coin into three equal parts. To split a coin evenly, don't include the `--amount` argument in the command.
 
 ```shell
 $ sui client split-coin --coin-id 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1 --count 3 --gas-budget 1000
 ```
-
-You will see output resembling:
-
-```
------ Certificate ----
-Transaction Hash: qpxpv+EySl6tkz7OZ+/h/cpOlC/q1kBepr/qrDHsg7k=
-Transaction Signature: BsuWPuG9iBnvc/cQBbpBvDsBnzLXrhxPpoblpZ7ZcTQ78X9AtPO7knOaPjEbLxEJMGpOCPTIWa0eMPpoqT/SDQ==@ZXB4tfniuC6Oir8aVtIR5C00Md/tG3WSZRNN7nDDZLs=
-Signed Authorities : [k#3adde8bfae7d338b65e7d13d4ead6b523e5271ca17b2d5eb321412257ee914a4, k#5067c1e30cc9d8b9ed9fe589beffbcdd14a2829b9fed5bf602608f411dbc4d56, k#f2e5749a5fc33d45c6f546eb9e53fabf4f17681ba6f697080de9514f4e0d6a75]
-Transaction Kind : Call
-Package ID : 0x2
-Module : coin
-Function : split_n
-Arguments : ["0x4a2853304fd2c243dae7d1ba58260bb7c40724e1", 3]
-Type Arguments : ["0x2::sui::SUI"]
------ Split Coin Results ----
-Updated Coin : Coin { id: 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1, value: 33334 }
-New Coins : Coin { id: 0x1da8193ac29f94f8207b0222bd5941b7814c1668, value: 33333 },
-            Coin { id: 0x3653bae7851c36e0e5e827b7c1a2978ef78efd7e, value: 33333 }
-Updated Gas : Coin { id: 0x692c179dc434ceb0eaa51cdd198bb905b5ab27c4, value: 99385 }
-```
-From the result, we can see three coins with values of roughly one-third of 100000.
 
 ## Calling Move code
 

--- a/doc/src/build/comms.md
+++ b/doc/src/build/comms.md
@@ -1,16 +1,14 @@
 ---
-title: Connect and Communicate with the Sui Network
+title: Connect to the Sui Network
 ---
-
-Now that you have [installed Sui](install.md), [connected to Devnet](../build/devnet.md), and started to [create smart contracts in Move](move/index.md) and [program Sui objects](programming-with-objects/index.md), it's time to let your apps talk to Sui.
 
 The pages in this section provide various options for communicating with Sui:
 
-* Set up your [Sui RPC server and use the Sui JSON-RPC API](json-rpc.md) to interact with a local Sui network.
-* Optionally, use the [Sui CLI client](cli-client.md) to start and set up a local Sui network for contributing changes to the blockchain itself.
+* Use the [Sui JSON-RPC API](json-rpc.md) to interact with a Sui network.
+* Use the [Sui CLI client](cli-client.md).
 * Interact with the Sui network via the [Sui Rust SDK](rust-sdk.md), a collection of Rust language JSON-RPC wrapper and crypto utilities.
 * Sign transactions and interact with the Sui network using the [Sui TypeScript SDK](https://github.com/MystenLabs/sui/tree/main/sdk/typescript) built on the Sui JSON RPC API.
-* Run a [Sui Fullnode](fullnode.md) yourself to store the full Sui blockchain state and history and qualify as a [potential validator](https://sui.io/resources-sui/validator-registration-open/).
-* Filter and subscribe to a [real-time event stream](pubsub.md) on your Sui Fullnode using JSON-RPC notifications via the WebSocket API.
+* Run a [Sui Full node](fullnode.md) yourself to store the full Sui blockchain state and history.
+* Filter and subscribe to a [real-time event stream](pubsub.md) on your Sui Full node using the WebSocket API.
 
 See the [Sui Reference Documentation](reference.md) for information on our API and SuiJSON format.

--- a/doc/src/build/devnet.md
+++ b/doc/src/build/devnet.md
@@ -2,11 +2,11 @@
 title: Connect to Sui Devnet
 ---
 
-We are hosting a public Devnet for the community to experiment with Sui and provide feedback to help to shape the future of the Sui network.
+The Sui Devnet network lets you experiment with Sui and provide feedback to help to shape the future of the Sui network.
 
 The Sui Devnet network currently consists of:
 
-* Four validator nodes operated by Mysten Labs. Clients send transactions and read requests via this endpoint: fullnode.devnet.sui.io:443 using [JSON-RPC](../build/json-rpc.md)
+* Four validator nodes operated by Mysten Labs. Clients send transactions and read requests via this endpoint: `https://fullnode.devnet.sui.io:443` using [JSON-RPC](../build/json-rpc.md).
 * A public network [Sui Explorer](https://explorer.devnet.sui.io) for browsing transaction history.
 * A [Discord channel](https://discordapp.com/channels/916379725201563759/971488439931392130) for requesting test coins that can be used to pay for gas on the test network. These coins have no financial value and will disappear each time we reset the network.
 
@@ -24,33 +24,29 @@ We provide the following tools for users to interact with Sui Devnet:
     * call and publish Move modules
 * [Sui Explorer](https://github.com/MystenLabs/sui/blob/main/apps/explorer/README.md) - view transactions and objects
 
-
 ## Environment set up
 
-You can [install Sui](../build/install.md) and then request test tokens as described in the install docs. To use the Sui Devnet, you need:
+Learn how to install Sui and then request test tokens in the [Install Sui](topic). After you install Sui, request Sui [test coins](#request-gas-tokens) through [Discord](https://discordapp.com/channels/916379725201563759/971488439931392130).
 
-1. Sui [test coins (tokens)](#request-gas-tokens) requested through [Discord](https://discordapp.com/channels/916379725201563759/971488439931392130).
-1. the [`git` command line interface](https://git-scm.com/download/).
-1. [Sui binaries](../build/install.md#binaries) in your PATH environment variable, particularly `sui`.
-
-Remember, you can confirm the existence of a command in your PATH by running `which` followed by the command, for example:
+To check whether Sui is installed, run the following command:
 
 ```shell
 $ which sui
 ```
-You should see the path to the command. Otherwise, reinstall.
 
-> **Tip:** Check the [Sui Releases](https://github.com/MystenLabs/sui/releases) page to make sure you have the latest release.
+If the command doesn't return a path to the command you need to install Sui.
 
-## Configure the Sui client
+> **Tip:** Check the [Sui Releases](https://github.com/MystenLabs/sui/releases) page to see the changes in the latest release.
 
-Now set up your Sui CLI client and connect to Devnet. Note you can manually change the Gateway URL if you have already configured a Sui CLI client.
+## Configure Sui client
 
- To connect the Sui client to the Devnet, run the following command:
+Now set up your Sui Client CLI to connect to Sui Devnet.
+
+To connect the Sui client to Sui Devnet, run the following command:
 ```shell
 $ sui client
 ```
-The Sui CLI will print the following line if the client is starting up for the first time:
+The Sui CLI prints the following line when the client starts up for the first time:
 ```shell
 Config file ["/Users/dir/.sui/sui_config/client.yaml"] doesn't exist, do you want to connect to a Sui RPC server [y/n]?
 ```

--- a/doc/src/build/fullnode.md
+++ b/doc/src/build/fullnode.md
@@ -53,7 +53,7 @@ Minimum hardware requirements for running a Sui Full node:
 ### Software requirements
 
 We recommend running Sui Full nodes on Linux. Sui supports the Ubuntu and
-Debian distributions.
+Debian distributions. You can also run a Sui Full node on macOS.
 
 Make sure to update [Rust](../build/install.md#rust).
 

--- a/doc/src/build/fullnode.md
+++ b/doc/src/build/fullnode.md
@@ -1,71 +1,50 @@
 ---
-title: Run a Sui Fullnode
+title: Run a Sui Full node
 ---
 
-Sui full nodes run a service that
-stores the full blockchain state and history. They service reads, either for
-end clients or by helping other full nodes get up-to-date with the latest
-transactions that have been committed to the chain.
+Sui Full nodes validate blockchain activities, including transactions, checkpoints, and epoch changes. Each Full node stores and services the queries for the blockchain state and history.
 
-This role enables
-[validators](../learn/architecture/validators.md) (or miners in
-other networks) to focus on servicing the write path and processing
-transactions as fast as possible. Once a validator has committed a new set of
-transactions (or a block of transactions), the validator will push that block
-to a full node (potentially a number of full nodes) who will then in turn
-disseminate it to the rest of the network.
+This role enables [validators](../learn/architecture/validators.md) to focus on servicing and processing transactions. When a validator commits a new set of transactions (or a block of transactions), the validator pushes that block to all connected Full nodes that then service the queries from clients.
 
 ## Features
 
-Sui full nodes exist to:
+Sui Full nodes:
 
 * Track and verify the state of the blockchain, independently and locally.
 * Serve read requests from clients.
-* Conduct local app testing against verified data.
 
 ## State synchronization
 
-Today Sui full nodes sync with validators to be able to learn about newly
-committed transactions.
+Sui Full nodes sync with validators to receive new transactions on the network.
 
-The normal life of a transaction requires a few round trips to 2f+1 validators
-to be able to form a TxCert, at which point a transaction is guaranteed to be
-committed and executed.
+A transaction requires a few round trips to 2f+1 validators to form a transaction certificate (TxCert).
 
-Today, this synchronization process is performed by:
+This synchronization process includes:
 
 1. Following 2f+1 validators and listening for newly committed transactions.
-1. Requesting the transaction from one validator.
-1. Locally executing the transaction and updating the local DB.
+1. Making sure that 2f+1 validators recognize the transaction and that it reaches finality.
+1. Executing the transaction locally and updating the local DB.
 
-This synchronization process is far from ideal as it requires listening
-to at a minimum 2f+1 validators to ensure that a full node has properly seen all
-new transactions. Over time, we will improve this process (e.g. with the
-introduction of checkpoints, ability to synchronize with other full nodes,
-etc.) in order to have better guarantees around a full node’s ability to be
-confident it has seen all recent transactions.
+This synchronization process requires listening to at a minimum 2f+1 validators to ensure that a Full node has properly processed all new transactions. Sui will improve the synchronization process with the introduction of checkpoints and the ability to synchronize with other Full nodes.
 
 ## Architecture
 
-The Sui full node is essentially a read-only view of the network state. Unlike
+A Sui Full node is essentially a read-only view of the network state. Unlike
 validator nodes, full nodes cannot sign transactions, although they can validate
 the integrity of the chain by re-executing transactions that were previously
 committed by a quorum of validators.
 
-Today, a full node is expected to maintain the full history of the chain; in the
-future, sufficiently old history may need to be pruned and offloaded to cheaper
-storage.
+Today, a Sui Full node maintains the full history of the chain.
 
-Conversely, a validator needs to store only the latest transactions on the
-*frontier* of the object graph (e.g., txes with >0 unspent output objects).
+Validator nodes store only the latest transactions on the *frontier* of the object graph (for example, transactions with >0 unspent output objects).
 
 ## Full node setup
 
-Follow the instructions here to run your own Sui full node.
+Follow the instructions here to run your own Sui Full node.
 
 ### Hardware requirements
 
-We recommend the following minimum hardware requirements for running a full node:
+Minimum hardware requirements for running a Sui Full node:
 
 * CPUs: 2
 * RAM: 8GB
@@ -73,58 +52,34 @@ We recommend the following minimum hardware requirements for running a full node
 
 ### Software requirements
 
-We recommend running Sui full nodes on Linux. The Sui team supports the Ubuntu and
-Debian distributions and tests against
-[Ubuntu version 18.04 (Bionic Beaver)](https://releases.ubuntu.com/18.04/).
+We recommend running Sui Full nodes on Linux. Sui supports the Ubuntu and
+Debian distributions.
 
-That said, you are welcome to run a Sui full node on the operating system of your
-choosing and submit changes to accommodate that environment. See [Install Sui](../build/install.md)
-for setup instructions for each operating system.
+Make sure to update [Rust](../build/install.md#rust).
 
-Specifically, ensure the required tools are installed and updated in your environment as
-outlined in the [Prerequisites](../build/install.md#prerequisites) section. In particular,
-ensure [Rust](../build/install.md#rust) is up-to-date.
-
-Similarly, if you are using Windows Subsystem for Linux (WSL), install a fresh copy of
-[CLang/LLVM](https://releases.llvm.org/download.html), as described in [Prerequisites](../build/install.md#prerequisites).
-
-Note, you will fork the Sui repository here rather than clone it as described in
-*Prerequisites*. So you can skip that step.
-
-If you are using Linux, install these extra dependencies. For example, in Ubuntu, run:
+Use the following command to install additional Linux dependencies.
 ```shell
     $ apt-get update \
     && apt-get install -y --no-install-recommends \
     tzdata \
-    git \
     ca-certificates \
-    curl \
     build-essential \
-    libssl-dev \
     pkg-config \
-    libclang-dev \
     cmake
 ```
 
-If you are using macOS or Windows Subsystem for Linux (WSL), the command will be similar. Remember to install [CLang](https://clang.llvm.org/) in WSL.
+## Configure a Full node
 
-## Configure a full node
-
-You may run a full node either by employing Docker or by building from
+You can configure a Sui Full node either using Docker or by building from
 source.
 
 ### Using Docker Compose
 
-Follow the instructions in the
-[Full node Docker README](https://github.com/MystenLabs/sui/tree/main/docker/fullnode#readme)
-to run a Sui full node using Docker, including [resetting the environment](https://github.com/MystenLabs/sui/tree/main/docker/fullnode#reset-the-environment).
+Follow the instructions in the [Full node Docker README](https://github.com/MystenLabs/sui/tree/main/docker/fullnode#readme) to run a Sui Full node using Docker, including [resetting the environment](https://github.com/MystenLabs/sui/tree/main/docker/fullnode#reset-the-environment).
 
 ### Building from source
 
-1. Install the required tools in your environment as
-outlined in the [Prerequisites](../build/install.md#prerequisites) section if you
-haven't already. Make sure your entire toolchain stays up-to-date. If you encounter
-issues building and installing the Sui binaries, update all packages above and re-install.
+1. Install the required [Prerequisites](../build/install.md#prerequisites).
 1. Set up your fork of the Sui repository:
     1. Go to the [Sui repository](https://github.com/MystenLabs/sui) on GitHub
        and click the *Fork* button in the top right-hand corner of the screen.
@@ -149,70 +104,58 @@ issues building and installing the Sui binaries, update all packages above and r
     ```shell
     $ git checkout --track upstream/devnet
     ```
-1. Make a copy of the [full node configuration template](https://github.com/MystenLabs/sui/blob/main/crates/sui-config/data/fullnode-template.yaml):
+1. Make a copy of the [Full node YAML template](https://github.com/MystenLabs/sui/blob/main/crates/sui-config/data/fullnode-template.yaml):
    ```shell
    $ cp crates/sui-config/data/fullnode-template.yaml fullnode.yaml
    ```
-1. Download the latest
-   [`genesis`](https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob)
-   state for Devnet by clicking that link or by running the following in your
-   terminal:
+1. Download the [`genesis`](https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob) state for Devnet:
     ```shell
     $ curl -fLJO https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob
     ```
-1. Optional: You can skip this set of steps if you are willing to accept the default paths to
-    resources. If you need custom paths, edit your `fullnode.yaml` file to reflect the paths
-    you employ:
-    1. Update the `db-path` field with the path to where the full node's database
-       is located. By default this will create the database in a directory
-       `./suidb` relative to your current directory:
+1. Optional: Skip this step to accept the default paths to resources. Edit the `fullnode.yaml` file to use custom paths.
+   * Update the `db-path` field with the path to the Full node database.
        ```yaml
-       db-path: "/path/to/suidb"
+       db-path: "/db-files/sui-fullnode"
        ```
-    1. Update the `genesis-file-location` with the path to the `genesis` file.
-       By default, the config looks for the file `genesis.blob` in your
-       current directory:
+   * Update the `genesis-file-location` with the path to `genesis.blob`.
        ```yaml
        genesis:
-       genesis-file-location: "/path/to/genesis.blob"
+       genesis-file-location: "/sui-fullnode/genesis.blob"
        ```
-1. Start your Sui full node:
+1. Start your Sui Full node:
     ```shell
     $ cargo run --release --bin sui-node -- --config-path fullnode.yaml
     ```
-1. Post build, receive the success confirmation message, `SuiNode started!`
 1. Optional: [Publish / subscribe](pubsub.md) to notifications using JSON-RPC via websocket.
 
-Your full node will now be serving the read endpoints of the [Sui JSON-RPC
+Your Full node will now be serving the read endpoints of the [Sui JSON-RPC
 API](../build/json-rpc.md#sui-json-rpc-api) at:
 `http://127.0.0.1:9000`
 
-## Using Sui Explorer with your full node
+## Sui Explorer with your Full node
 
-[Sui Explorer](https://explorer.devnet.sui.io/) lets you configure where
-it should issue read requests to query the blockchain. This enables you to
-point the Explorer at your locally running full node and see the
-transactions it has synced from the network. To make this change:
+[Sui Explorer](https://explorer.devnet.sui.io/) supports connections to custom RPC URLS and local networks. You can point the Explorer to your local Full node and see the
+transactions it syncs from the network. To make this change:
 
 1. Open a browser and go to: https://explorer.devnet.sui.io/
 1. Click the **Devnet** button in the top right-hand corner of Sui Explorer and select
-   the *Local* network from the drop-down menu.
-1. Close the *Choose a Network* menu to see the latest transactions. 
+   **Local** from the drop-down menu.
+1. Close the **Choose a Network** menu to see the latest transactions. 
 
-Sui Explorer now uses your local full node to explore the state of the chain.
+Sui Explorer now uses your local Full node to explore the state of the chain.
 
 ## Monitoring
 
-Monitor your full node using the instructions at [Logging, Tracing, Metrics, and
-Observability](https://docs.sui.io/contribute/observability).
+Monitor your Full node using the instructions at [Logging, Tracing, Metrics, and
+Observability](../contribute/observability.md).
 
-Note the default metrics port is 9184 yet configurable in your `fullnode.yaml` file.
+Note the default metrics port is 9184. To change the port, edit your `fullnode.yaml` file.
 
-## Updating your full node with new releases
+## Update your Full node
 
-Whenever Sui releases a new version, Devnet restarts as a new network with no data. You must update your full node with each Sui release to ensure compatibility with the network.
+Whenever Sui releases a new version, Devnet restarts as a new network with no data. You must update your Full node with each Sui release to ensure compatibility with the network.
 
-### With Docker Compose
+### Update with Docker Compose
 
 Follow the instructions to [reset the environment](https://github.com/MystenLabs/sui/tree/main/docker/fullnode#reset-the-environment),
 namely by running the command:
@@ -220,12 +163,12 @@ namely by running the command:
 $ docker-compose down --volumes
 ```
 
-### Built from source
+### Update from source
 
 If you followed the instructions for [Building from
-Source](#building-from-source), update your full node as follows:
+Source](#building-from-source), update your Full node as follows:
 
-1. Shut down your currently running full node.
+1. Shut down your currently running Full node.
 1. `cd` into your local Sui repository:
     ```shell
     $ cd sui
@@ -242,22 +185,20 @@ Source](#building-from-source), update your full node as follows:
     ```shell
     $ git checkout -B devnet --track upstream/devnet
     ```
-1. Download the latest
-   [`genesis`](https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob)
-   state for Devnet as described above.
+1. Download the latest [`genesis`](https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob) state for Devnet as described above.
 1. Update your `fullnode.yaml` configuration file if needed.
-1. Restart your Sui full node:
+1. Restart your Sui Full node:
     ```shell
     $ cargo run --release --bin sui-node -- --config-path fullnode.yaml
     ```
-Your full node will once again be running at:
+Your Full node starts on:
 `http://127.0.0.1:9000`
 
 ## Future plans
 
-Today, a full node relies only on synchronizing with 2f+1 validators in order to
+Today, a Full node relies only on synchronizing with 2f+1 validators in order to
 ensure it has seen all committed transactions. In the future, we expect
-full nodes to fully participate in a peer-to-peer (p2p) environment where the
+Full nodes to fully participate in a peer-to-peer (p2p) environment where the
 load of disseminating new transactions can be shared with the whole network and
 not place the burden solely on the validators. We also expect future
 features, such as checkpoints, to enable improved performance of synchronizing the

--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -192,12 +192,12 @@ Sui requires the following additional tools on computers running Windows.
 After you install Cargo, use the following command to install Sui binaries:
 
 ```shell
-$ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch "devnet" sui sui-gateway
+$ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch devnet sui sui-node
 ```
 
 The command installs the following Sui components in `~/.cargo/bin`:
 * [`sui`](cli-client.md) - The Sui CLI tool contains subcommands for enabling `genesis` of validators and accounts, starting the Sui network, and [building and testing Move packages](move/index.md), as well as a [client](cli-client.md) for interacting with the Sui network.
-* [`rpc-server`](json-rpc.md) - run a local Sui gateway service accessible via an RPC interface.
+* `Sui node` - installs the Sui node binary.
 
 Trouble shooting:
 If the previous command fails, make sure you have the latest version of Rust installed:

--- a/doc/src/build/json-rpc.md
+++ b/doc/src/build/json-rpc.md
@@ -1,51 +1,22 @@
 ---
-title: RPC Server & JSON-RPC API Quick Start
+title: JSON-RPC API Quick Start
 ---
 
-Welcome to the guide for making remote procedure calls (RPC) to the Sui network. This document walks you through connecting to Sui and using the Sui JSON-RPC API to interact with the Sui network. Use the RPC layer to test your dApps, sending their transactions onto the [Sui validators](../learn/architecture/validators.md) for verification.
+Welcome to the guide for making remote procedure calls (RPC) to the Sui network. This document walks you through connecting to Sui and how to the Sui JSON-RPC API to interact with the Sui network. Use the RPC layer to send your dApp transactions to [Sui validators](../learn/architecture/validators.md) for verification.
 
 This guide is useful for developers interested in Sui network interactions via API and should be used in conjunction with the [SuiJSON format](sui-json.md) for aligning JSON inputs with Move Call arguments.
 
 For a similar guide on Sui network interactions via CLI, refer to the [Sui CLI client](cli-client.md) documentation.
 
-## Set up RPC server
 Follow the instructions to [install Sui binaries](install.md).
 
-### Connect to Sui network
+### Connect to a Sui network
 
-#### Remote Devnet
-Simply [connect to the Sui Devnet](../build/devnet.md) to start making RPC calls to our remote server, build on top of Sui.
+You can connect to a Sui Full node on Devnet. Follow the guidance in the [Connect to Sui Devnet](../build/devnet.md) topic to start making RPC calls to the Sui network.
 
-#### Local Sui Network
-Alternatively, to [contribute](../contribute/index.md) to Sui itself, you may follow the instructions to [create](cli-client.md#genesis) and [start](cli-client.md#starting-the-network) a local Sui network.
+To configure your own Sui Full node, see [Configure a Sui Full node](fullnode.md).
 
-The genesis process will create a `gateway.yaml` configuration file that will be used by the RPC server.
-
-### Start RPC server
-
-Use the following command to start an RPC server:
-```shell
-$ rpc-server
-```
-You will see output resembling:
-```
-2022-08-05T19:41:33.227478Z  INFO rpc_server: Gateway config file path config_path="/home/sui/.sui/sui_config/gateway.yaml"
-2022-08-05T19:41:33.227514Z  INFO rpc_server: Starting Prometheus HTTP endpoint at 0.0.0.0:9184
-2022-08-05T19:41:33.896152Z  INFO sui_storage::lock_service: LockService command processing loop started
-2022-08-05T19:41:33.896230Z  INFO sui_storage::lock_service: LockService queries processing loop started
-2022-08-05T19:41:34.615529Z  INFO sui_json_rpc: acl=AccessControl { allowed_hosts: Any, allowed_origins: None, allowed_headers: Any }
-2022-08-05T19:41:34.618762Z  INFO sui_json_rpc: Sui JSON-RPC server listening on 127.0.0.1:5001 local_addr=127.0.0.1:5001
-2022-08-05T19:41:34.618789Z  INFO sui_json_rpc: Available JSON-RPC methods : ["sui_moveCall", "sui_getTransaction", "sui_getObjectsOwnedByAddress", "sui_getTotalTransactionNumber", "sui_transferObject", "sui_transferSui", "sui_batchTransaction", "sui_executeTransaction", "sui_mergeCoins", "sui_getRecentTransactions", "sui_getTransactionsInRange", "sui_getObject", "sui_getObjectsOwnedByObject", "rpc.discover", "sui_splitCoin", "sui_getRawObject", "sui_publish", "sui_syncAccountState"]
-```
-
-> **Note:** For additional logs, set `RUST_LOG=debug` before invoking `rpc-server`.
-
-Export a local user variable to store the hardcoded hostname + port that the local RPC server starts with to be used when issuing the `curl` commands that follow.
-```shell
-export SUI_RPC_HOST=http://127.0.0.1:5001
-```
-
-## Use Sui software development kits
+## Sui SDKs
 
 You can sign transactions and interact with the Sui network using any of the following:
 
@@ -53,12 +24,12 @@ You can sign transactions and interact with the Sui network using any of the fol
 * [Sui TypeScript SDK](https://github.com/MystenLabs/sui/tree/main/sdk/typescript) and [reference files](https://www.npmjs.com/package/@mysten/sui.js).
 * [Sui API Reference](https://docs.sui.io/sui-jsonrpc) for all available methods.
 
-## Follow Sui JSON-RPC examples
+## Sui JSON-RPC examples
 
-In the following sections we will show how to use Sui's JSON-RPC API with
-the `curl` command. See the [Sui API Reference](https://docs.sui.io/sui-jsonrpc) for the latest list of all available methods.
+The following sections demonstrate how to use the Sui JSON-RPC API with cURL commands. See the [Sui API Reference](https://docs.sui.io/sui-jsonrpc) for the latest list of all available methods.
 
 ### RPC discover
+
 Sui RPC server supports OpenRPC’s [service discovery method](https://spec.open-rpc.org/#service-discovery-method).
 A `rpc.discover` method is added to provide documentation describing our JSON-RPC APIs service.
 
@@ -69,20 +40,30 @@ curl --location --request POST $SUI_RPC_HOST \
 ```
 
 ### Transfer object
-#### 1, Create an unsigned transaction to transfer a Sui coin from one address to another
+
+The examples in this section demonstrate how to create transfer transactions. To use the example commands, replace the values between double brackets ({{ example_ID }} with actual values.
+
+Objects IDs for `{{coin_object_id}}` and `{{gas_object_id}}` must
+be owned by the address specified for `{{owner_address}}` for the command to succeed. Use [`sui_getOwnedObjects`](#sui_getownedobjects) to return object IDs. 
+
+#### Create an unsigned transaction to transfer a Sui coin from one address to another
+
 ```shell
 curl --location --request POST $SUI_RPC_HOST \
 --header 'Content-Type: application/json' \
---data-raw '{ "jsonrpc":"2.0",
-              "method":"sui_transferObject",
-              "params":["{{owner_address}}",
-                        "{{object_id}}",
-                        "{{gas_object_id}}",
-                        {{gas_budget}},
-                        "{{to_address}}"],
-              "id":1}' | json_pp
+--data-raw '{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sui_transferObject",
+  "params":["{{owner_address}}",
+    "{{object_id}}",
+    "{{gas_object_id}}",
+    {{gas_budget}},
+    "{{to_address}}"],
+  ]
+}'
 ```
-A transaction data response will be returned from the gateway server.
+A response resembles the following:
 ```json
 {
   "id" : 1,
@@ -93,51 +74,40 @@ A transaction data response will be returned from the gateway server.
 }
 
 ```
-#### 2, Sign the transaction using the Sui keytool
+#### Sign a transaction using the Sui keytool
+
 ```shell
 sui keytool sign --address <owner_address> --data <tx_bytes>
 ```
-The signing tool will create and print out the signature and public key information.
-You will see output resembling:
-```shell
-2022-04-25T18:50:06.031722Z  INFO sui::sui_commands: Data to sign : VHJhbnNhY3Rpb25EYXRhOjoAAFHe8jecgzoGWyGlZ1sJ2KBFN8aZF7NIkDsM+3X8mrVCa7adg9HnVqUBAAAAAAAAACDOlrjlT0A18D0DqJLTU28ChUfRFtgHprmuOGCHYdv8YVHe8jecgzoGWyGlZ1sJ2KBFN8aZdZnY6h3kyWFtB38Wyg6zjN7KzAcBAAAAAAAAACDxI+LSHrFUxU0G8bPMXhF+46hpchJ22IHlpPv4FgNvGOgDAAAAAAAA
-2022-04-25T18:50:06.031765Z  INFO sui::sui_commands: Address : 0x51def2379c833a065b21a5675b09d8a04537c699
-2022-04-25T18:50:06.031911Z  INFO sui::sui_commands: Public Key Base64: H82FDLUZN1u0+6UdZilxu9HDT5rPd3khKo2UJoCPJFo=
-2022-04-25T18:50:06.031925Z  INFO sui::sui_commands: Signature : 6vc+ku0RsMKdky8DRfoy/hw6eCQ3YsadH6rZ9WUCwGTAumuWER3TOJRw7u7F4QaHkqUsIPfJN9GRraSX+N8ADQ==
-```
+The keytool creates a key and then returns the signature and public key information.
 
-#### 3, Execute the transaction using the transaction data, signature and public key
+
+#### Execute a transaction with a signature and a public key
+
 ```shell
 curl --location --request POST $SUI_RPC_HOST \
 --header 'Content-Type: application/json' \
---data-raw '{ "jsonrpc":"2.0",
-              "method":"sui_executeTransaction",
-              "params":[{
-                  "tx_bytes" : "{{tx_bytes}}",
-                  "signature" : "{{signature}}",
-                  "pub_key" : "{{pub_key}}"}],
-              "id":1}' | json_pp
+--data-raw '{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sui_executeTransaction",
+  "params": [ 
+    {{tx_bytes}},
+    {{sig_scheme}},
+    {{signature}},
+    {{pub_key}},
+    {{request_type}}
+  ]
+}'
 ```
 
-Native transfer by `sui_transferObject` is supported for any object that allows for public transfers. Refer to
-[transactions](transactions.md#native-transaction) documentation for
-more information about a native transfer. Some objects cannot be
-transferred natively and require a [Move call](#sui_movecall).
-
-You should replace `{{owner_address}}` and `{{to_address}}` in the
-command above with an actual address values, for example one obtained
-from `client.yaml`. You should also replace
-`{{object_id}}` and `{{gas_object_id}}` in the command above with
-an actual object ID, for example one obtained from `objectId` in the output
-of [`sui_getOwnedObjects`](#sui_getownedobjects). You can see that all gas objects generated
-during genesis are of `Coin/SUI` type). For this call to work, objects
-represented by both `{{coin_object_id}}` and `{{gas_object_id}}` must
-be owned by the address represented by `{{owner_address}}`.
-
+Native transfer by `sui_transferObject` supports any object that allows for public transfers. Some objects cannot be transferred natively and require a [Move call](#sui_movecall). See [Transactions](../learn/transactions.md#native-transaction) for more information about native transfers.
 
 ### Invoke Move functions
+The example command in this section demonstrate how to call Move functions.
 
-#### 1, Execute a Move call transaction
+#### Execute a Move call transaction
+
 Execute a Move call transaction by calling the specified function in
 the module of a given package (smart contracts in Sui are written in
 the [Move](move/index.md) language):
@@ -160,26 +130,40 @@ curl --location --request POST $SUI_RPC_HOST \
               "id": 1 }' | json_pp
 ```
 
-#### 2, Sign the transaction
-Follow the instructions to [sign the transaction](#2-sign-the-transaction-using-the-sui-keytool).
+#### Sign the transaction
 
-#### 3, Execute the transaction
-Follow the instructions to [execute the transaction](#3-execute-the-transaction-using-the-transaction-data-signature-and-public-key).
+```shell
+sui keytool sign --address <owner_address> --data <tx_bytes>
+```
+The keytool creates a key and then returns the signature and public key information.
 
-Arguments are passed in, and type will be inferred from function
-signature.  Gas usage is capped by the gas_budget. The `transfer`
-function is described in more detail in
-the [Sui CLI client](cli-client.md#calling-move-code) documentation.
+#### Execute the transaction
 
-Calling the `transfer` function in the `Coin` module serves the same
-purpose as the native transfer ([`sui_transferObject`](#sui_TransferObject)), and is mostly used for illustration
-purposes as native transfer is more efficient when it's applicable
-(i.e., we are simply transferring objects with no additional Move logic). Consequently, you should fill out argument placeholders
-(`{{owner_address}}`, `{{object_id}`, etc.) the same way you
-would for [`sui_transferObject`](#sui_TransferObject) - please note additional
-`0x` prepended to function arguments.
+```shell
+curl --location --request POST $SUI_RPC_HOST \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sui_executeTransaction",
+  "params": [ 
+    {{tx_bytes}},
+    {{sig_scheme}},
+    {{signature}},
+    {{pub_key}},
+    {{request_type}}
+  ]
+}'
+```
 
-To learn more about what `args` are accepted in a Move call, refer to the [SuiJSON](sui-json.md) documentation.
+Arguments are passed in, and type is inferred from the function
+signature.  Gas usage is capped by the `gas_budget`. The `transfer`
+function is described in more detail in the [Sui CLI client](cli-client.md#calling-move-code) documentation.
+
+The `transfer` function in the `Coin` module serves the same
+purpose as ([`sui_transferObject`](#sui_TransferObject)). It is used for illustration purposes, as a native transfer is more efficient.
+
+To learn more about which `args` a Move call accepts, see [SuiJSON](sui-json.md).
 
 ### Publish a Move package
 
@@ -195,28 +179,16 @@ curl --location --request POST $SUI_RPC_HOST \
               "id":1}' | json_pp
 ```
 
-This endpoint will perform proper verification and linking to make
-sure the package is valid. If some modules have [initializers](move/debug-publish.md#module-initializers), these initializers
-will also be executed in Move (which means new Move objects can be created in
-the process of publishing a Move package). Gas budget is required because of the
-need to execute module initializers.
+This endpoint performs proper verification and linking to make
+sure the package is valid. If some modules have [initializers](move/debug-publish.md#module-initializers), these initializers execute in Move (which means new Move objects can be created in the process of publishing a Move package). Gas budget is required because of the need to execute module initializers.
 
-You should replace `{{owner_address}}` in the
-command above with an actual address values, for example one obtained
-from `client.yaml`. You should also replace `{{gas_object_id}}` in the command above with
-an actual object ID, for example one obtained from `objectId` in the output
-of `sui_getObjectsOwnedByAddress`. You can see that all gas objects generated
-during genesis are of `Coin/SUI` type). For this call to work, the object
-represented by `{{gas_object_id}}` must be owned by the address represented by
-`{{owner_address}}`.
-
-To publish a Move module, you also need `{{vector_of_compiled_modules}}`. To generate the value of this field, use the `sui move` command. The `sui move` command supports printing the bytecodes as base64 with the following option
+To publish a Move module, you also need to include `{{vector_of_compiled_modules}}`. To generate the value of this field, use the `sui move` command. The `sui move` command supports printing the bytecode as base64:
 
 ```
 sui move --path <move-module-path> build --dump-bytecode-as-base64
 ```
 
-Assuming that the location of the package's sources is in the `PATH_TO_PACKAGE` environment variable an example command would resemble the following
+Assuming that the location of the package's sources is in the `PATH_TO_PACKAGE` environment variable an example command resembles the following:
 
 ```
 sui move --path $PATH_TO_PACKAGE/my_move_package build --dump-bytecode-as-base64
@@ -225,21 +197,33 @@ sui move --path $PATH_TO_PACKAGE/my_move_package build --dump-bytecode-as-base64
 Build Successful
 ```
 
-Copy the outputting base64 representation of the compiled Move module into the
+Copy the output base64 representation of the compiled Move module into the
 REST publish endpoint.
 
-#### 2, Sign the transaction
-Follow the instructions to [sign the transaction](#2-sign-the-transaction-using-the-sui-keytool).
+#### Sign the transaction
 
-#### 3, Execute the transaction
-Follow the instructions to [execute the transaction](#3-execute-the-transaction-using-the-transaction-data-signature-and-public-key).
-
-Below you can see a truncated sample output of [sui_publish](#sui_publish). One of the results of executing this command is generation of a package object representing the published Move code. An ID of the package object can be used as an argument for subsequent Move calls to functions defined in this package.
-
+```shell
+sui keytool sign --address <owner_address> --data <tx_bytes>
 ```
-{
-    "package": [
-            "0x13e3ec7279060663e1bbc45aaf5859113fc164d2",
-    ...
-}
+The keytool creates a key and then returns the signature and public key information.
+
+#### Execute the transaction
+
+```shell
+curl --location --request POST $SUI_RPC_HOST \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sui_executeTransaction",
+  "params": [ 
+    {{tx_bytes}},
+    {{sig_scheme}},
+    {{signature}},
+    {{pub_key}},
+    {{request_type}}
+  ]
+}'
 ```
+
+The command generates a package object that represents the published Move code. You can use the package ID as an argument for subsequent Move calls to functions defined in this package.

--- a/doc/src/build/move/build-test.md
+++ b/doc/src/build/move/build-test.md
@@ -262,39 +262,41 @@ have only one test defined. Let us change that by adding another test
 function.
 
 ``` rust
-    #[test]
-    fun test_sword_transactions() {
-        use sui::test_scenario;
+#[test]
+fun test_sword_transactions() {
+    use sui::test_scenario;
 
-        let admin = @0xABBA;
-        let initial_owner = @0xCAFE;
-        let final_owner = @0xFACE;
+    let admin = @0xABBA;
+    let initial_owner = @0xCAFE;
+    let final_owner = @0xFACE;
 
-        // first transaction executed by admin
-        let scenario = &mut test_scenario::begin(&admin);
-        {
-            // create the sword and transfer it to the initial owner
-            sword_create(42, 7, initial_owner, test_scenario::ctx(scenario));
-        };
-        // second transaction executed by the initial sword owner
-        test_scenario::next_tx(scenario, &initial_owner);
-        {
-            // extract the sword owned by the initial owner
-            let sword = test_scenario::take_owned<Sword>(scenario);
-            // transfer the sword to the final owner
-            sword_transfer(sword, final_owner, test_scenario::ctx(scenario));
-        };
-        // third transaction executed by the final sword owner
-        test_scenario::next_tx(scenario, &final_owner);
-        {
-            // extract the sword owned by the final owner
-            let sword = test_scenario::take_owned<Sword>(scenario);
-            // verify that the sword has expected properties
-            assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
-            // return the sword to the object pool (it cannot be simply "dropped")
-            test_scenario::return_owned(scenario, sword)
-        }
-    }
+    // first transaction executed by admin
+    let scenario = test_scenario::begin(admin);
+    {
+        // create the sword and transfer it to the initial owner
+        sword_create(42, 7, initial_owner, test_scenario::ctx(&mut scenario));
+    };
+    // second transaction executed by the initial sword owner
+    test_scenario::next_tx(&mut scenario, initial_owner);
+    {
+        // extract the sword owned by the initial owner
+        let sword = test_scenario::take_from_sender<Sword>(&mut scenario);
+        // transfer the sword to the final owner
+        sword_transfer(sword, final_owner, test_scenario::ctx(&mut scenario));
+    };
+    // third transaction executed by the final sword owner
+    test_scenario::next_tx(&mut scenario, final_owner);
+    {
+        // extract the sword owned by the final owner
+        let sword = test_scenario::take_from_sender<Sword>(&mut scenario);
+        // verify that the sword has expected properties
+        assert!(magic(&sword) == 42 && strength(&sword) == 7, 1);
+        // return the sword to the object pool (it cannot be simply "dropped")
+        test_scenario::return_to_sender(&mut scenario, sword);
+            
+    };
+    test_scenario::end(scenario);
+}
 ```
 
 Let us now dive into some details of the new testing function. The
@@ -311,8 +313,8 @@ the sword it now owns to its final owner. Please note that in *pure
 Move* we do not have the notion of Sui storage and, consequently, no
 easy way for the emulated Sui transaction to retrieve it from
 storage. This is where the `test_scenario` module comes to help - its
-`take_owned` function makes an object of a given type (in this case
-of type `Sword`) owned by an address executing the current transaction
+`take_from_sender` function makes an object of a given type (in this case
+of type `Sword`) owned by an address (here `sender`) executing the current transaction
 available for manipulation by the Move code. (For now, we assume that
 there is only one such object.) In this case, the object retrieved
 from storage is transferred to another address.
@@ -336,7 +338,7 @@ by transferring the sword object to the fake address. But the
 `test_scenario` package gives us a more elegant solution, which is
 closer to what happens when Move code is actually executed in the
 context of Sui - we can simply return the sword to the object pool
-using the `test_scenario::return_owned` function.
+using the `test_scenario::return_to_sender` function.
 
 We can now run the test command again and see that we now have two
 successful tests for our module:

--- a/doc/src/build/pubsub.md
+++ b/doc/src/build/pubsub.md
@@ -2,12 +2,9 @@
 title: Subscribe to JSON-RPC Real-Time Events
 ---
 
-Sui [fullnode](fullnode.md) supports publish / subscribe using [JSON-RPC](json-rpc.md) notifications via the WebSocket API.
-This service allows clients to filter and subscribe to a real-time event stream generated from Move or from the Sui
-network.
+Sui [Full nodes](fullnode.md) supports publish / subscribe using [JSON-RPC](json-rpc.md) notifications via the WebSocket API. This service allows clients to filter and subscribe to a real-time event stream generated from Move or from the Sui network.
 
-The client can provide an [event filter](#event-filters) to narrow the scope of events. For each event that matches
-the filter, a notification with the event data and subscription ID is returned to the client.
+The client can provide an [event filter](#event-filters) to narrow the scope of events. For each event that matches the filter, a notification with the event data and subscription ID is returned to the client.
 
 ## Events
 

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -3,7 +3,7 @@ title: Interact with Sui over Rust SDK
 ---
 
 ## Overview
-The [Sui SDK](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) is a collection of Rust language JSON-RPC wrapper and crypto utilities you can use to interact with the [Sui Devnet Gateway](../build/devnet.md) and [Sui Full Node](fullnode.md).
+The [Sui SDK](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) is a collection of Rust language JSON-RPC wrapper and crypto utilities you can use to interact with the [Sui Devnet](../build/devnet.md) and [Sui Full node](fullnode.md).
 
 The [`SuiClient`](cli-client.md) can be used to create an HTTP or a WebSocket client (`SuiClient::new_rpc_client`).  
 See our [JSON-RPC](json-rpc.md#sui-json-rpc-methods) doc for the list of available methods.
@@ -55,7 +55,7 @@ You can verify the result with the [Sui Explorer](https://explorer.devnet.sui.io
 
 ### Example 2 - Create and execute transaction
 
-Use this example to conduct a transaction in Sui using the Sui Devnet Gateway:
+Use this example to conduct a transaction in Sui using the Sui Devnet Full node:
 
 ```rust
 use std::str::FromStr;
@@ -122,7 +122,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 }
 ```
-> Note: You will need to connect to a fullnode for the Event subscription service, see [Fullnode setup](fullnode.md#fullnode-setup) if you want to run a Sui Fullnode.
+> Note: You will need to connect to a fullnode for the Event subscription service, see [Full node setup](fullnode.md#fullnode-setup) if you want to run a Sui Fullnode.
 
 
 ## Larger examples

--- a/doc/src/build/sui-local-network.md
+++ b/doc/src/build/sui-local-network.md
@@ -1,0 +1,59 @@
+---
+title: Create a local Sui network
+---
+
+Learn how to create a Sui network in your local environment. Use the [Sui Client CLI](cli-client.md) to interact with the local network.
+
+## Install Sui
+
+To create a local Sui network, first install Sui. See [Install Sui to Build](install.md).
+
+## Genesis
+
+To create the configuration files and objects for a local Sui network, run the `genesis` command. Genesis creates the network configuration files in the ~/.sui/sui_config folder. This includes a YAML file for fullnode, network, client, and each validator. It also creates a sui.keystore that stores client key pairs. 
+
+The network that genesis creates includes four validators and five user accounts that contain five coin objects each.
+
+   ```shell
+   $ sui genesis
+   ```
+
+### Run genesis after using the Client CLI
+If you used the Sui Client CLI before you create a local network, it created a client.yaml file in the .sui/sui_config directory. When you run genesis to create a local network, a warning displays that the .sui/sui_config folder is not empty because of the existing client.yaml file. You can use the `--force` argument to replace the configuration files, or use `--working-dir` to specify a different directory for the network configuration files.
+
+Use the following command to replace the configuration files in the .sui/sui_config directory.
+```shell
+$ sui genesis --force
+```
+
+Use the following command to use a different directory to store the configuration files.
+```shell
+$ sui genesis --working-dir /workspace/config-files
+```
+
+The directory must already exist, and be empty, before you run the command.
+
+#### Embedded gateway
+
+You can use an embedded gateway with your local network. The gateway.yaml file contains information about the embedded gateway. The embedded gateway will be deprecated in a future release of Sui.
+
+## Start the local network
+
+Run the following command to start the local Sui network, assuming you
+accepted the default location for configuration:
+
+```shell
+$ sui start
+```
+
+This command looks for the Sui network configuration file
+`network.yaml` in the `~/.sui/sui_config` directory. If you used a different directory when you ran `genesis`, use the `--network.config` argument to specify the path to that directory when you start the network.
+
+Use the following command to use a network.yaml file in a directory other than the default:
+
+```shell
+$ sui start --network.config /workspace/config-files/network.yaml
+```
+When you start the network, Sui generates an authorities_db directory that stores validator data, and a consensus_db directory that stores consensus data.
+
+After the process completes, use the [Sui Client CLI](cli-client.md) to interact with the local network.

--- a/doc/src/doc-updates/index.md
+++ b/doc/src/doc-updates/index.md
@@ -4,11 +4,27 @@ title: Sui Documentation Updates
 
 This topic lists the significant updates to the [Sui documentation](https://docs.sui.io) site so that you can easily identify new or updated information. 
 
+## Week ending 10/22/22
+
+| Topic | Update | 
+| :------ | :------- |
+| [Sui Wallet](../explore/wallet-browser.md) | Updates for version 0.2. |
+| [Multiple topics](https://github.com/MystenLabs/sui/pull/5266) | Updates related to gateway deprecation. |
+| [Sui Client CLI](../build/cli-client.md) | Moved information about creating a local network to a new [Sui Local Network](../build/sui-local-network.md) topic. General copyedit and updates for changes to Sui. |
+
+
+## Week ending 10/15/22
+
+| Topic | Update | 
+| :------ | :------- |
+| [Multiple topics](https://github.com/MystenLabs/sui/pull/4960/files) | Copyedits for improved readability and consistency. |
+
 ## Week ending 10/08/22
 
 | Topic | Update | 
 | :------ | :------- |
 | [Install Sui](../build/install.md) | Removed the setup script (sui-setup.sh) until we can resolve the errors with the latest version of Sui. |
+| [Explore Sui](../explore/index.md) | General copyedits for style, removed some stale images and examples. |
 
 
 ## Week ending 10/01/22

--- a/doc/src/learn/sui-glossary.md
+++ b/doc/src/learn/sui-glossary.md
@@ -4,10 +4,6 @@ title: Sui Glossary
 
 Find terms used in Sui defined below. Where possible, we link to a canonical definition and focus upon Sui’s use of the term.
 
-### Accumulator
-
-An *accumulator* makes sure the transaction is received by a quorum of validators, collects a quorum of votes, submits the certificate to the validators, and replies to the client. The accumulator enables transactions to be certified. Sui offers a gateway service that can assume the role of accumulator and collect votes on transactions from validators in Sui, saving end-users bandwidth.
-
 ### Causal history
 
 Causal history is the relationship between an object in Sui and its direct predecessors and successors. This history is essential to the causal order Sui uses to process transactions. In contrast, other blockchains read the entire state of their world for each transaction,
@@ -15,19 +11,17 @@ introducing latency.
 
 ### Causal order
 
-[Causal order](https://www.scattered-thoughts.net/writing/causal-ordering/) is a representation of the relationship between transactions
-and the objects they produce, laid out as dependencies. Validators cannot execute a transaction dependent on objects created by a prior
-transaction that has not finished. Rather than total order, Sui uses causal order (a partial order).
+[Causal order](https://www.scattered-thoughts.net/writing/causal-ordering/) is a representation of the relationship between transactions and the objects they produce, laid out as dependencies. Validators cannot execute a transaction dependent on objects created by a prior transaction that has not finished. Rather than total order, Sui uses causal order (a partial order).
 
 For more information, see [Causal order vs total order](sui-compared.md#causal-order-vs-total-order). 
 
 ### Certificate
 
-A certificate is the mechanism proving a transaction has been approved, or certified. Validators vote on transactions, and an aggregator collects a Byzantine-resistant-majority of these votes into a certificate and broadcasts it to all Sui validators, thereby ensuring finality.
+A certificate is the mechanism proving a transaction was approved or certified. Validators vote on transactions, and aggregators collect a Byzantine-resistant-majority of these votes into a certificate and broadcasts it to all Sui validators, thereby ensuring finality.
 
 ### Epoch
 
-Operation of the Sui network is temporally partitioned into non-overlapping, fixed-duration *epochs*. During a particular epoch, the set of validators participating in the network is fixed.
+Operation of the Sui network is temporally partitioned into non-overlapping, fixed-duration epochs. During a particular epoch, the set of validators participating in the network is fixed.
 
 For more information, see [Epochs](architecture/validators.md#epochs).
 
@@ -48,15 +42,11 @@ certifies the transaction, all of the other honest validators will too eventuall
 
 [Gas](https://ethereum.org/en/developers/docs/gas/) refers to the computational effort required for executing operations on the Sui network. In Sui, gas is paid with the network's native currency SUI. The cost of executing a transaction in SUI units is referred to as the transaction fee.
 
-### Gateway service
-
-Sui provides a gateway service that enables third parties, such as app or game developers, to route transactions on behalf of users. Because Sui never requires exchange of private keys, users can offload the bandwidth use of transaction submission (for example when operating from a mobile device) to an untrusted server.
-
 ### Genesis
 
-Genesis is the initial act of creating accounts and gas objects. Sui provides a `genesis` command that allows users to create and inspect the genesis object setting up the network for operation.
+Genesis is the initial act of creating accounts and gas objects for a Sui network. Sui provides a `genesis` command that allows users to create and inspect the genesis object setting up the network for operation.
 
-For more information, see [Genesis](../build/cli-client.md#genesis).
+For more information, see [Genesis](../build/sui-local-network.md#genesis).
 
 ### Multi-writer objects
 

--- a/doc/src/navconfig.json
+++ b/doc/src/navconfig.json
@@ -117,9 +117,13 @@
         "fileName": "build/devnet"
       },
       {
-        "label": "Optional - Run Locally with CLI",
+        "label": "Sui Client CLI",
         "fileName": "build/cli-client"
       },
+      {
+        "label": "Sui Local Network",
+        "fileName": "build/sui-local-network"
+      },      
       {
         "label": "Create Smart Contracts with Move",
         "fileName": "build/move/index",

--- a/nft_mirror/oracle_server/src/airdrop/airdropService.ts
+++ b/nft_mirror/oracle_server/src/airdrop/airdropService.ts
@@ -8,7 +8,7 @@ import { NFTFetcher, NFTInfo } from '../common/nftFetcher';
 import { ValidateError } from 'tsoa';
 import { Connection } from '../sdk/gateway';
 
-const DEFAULT_GAS_BUDGET = 10000;
+const DEFAULT_GAS_BUDGET = 20000;
 
 interface AirdropClaimInfo {
     /**

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -14,7 +14,7 @@ const DEFAULT_FULLNODE_URL = 'http://127.0.0.1:9000';
 
 export const DEFAULT_RECIPIENT = '0x36096be6a0314052931babed39f53c0666a6b0df';
 export const DEFAULT_RECIPIENT_2 = '0x46096be6a0314052931babed39f53c0666a6b0da';
-export const DEFAULT_GAS_BUDGET = 10000;
+export const DEFAULT_GAS_BUDGET = 20000;
 
 export class TestToolbox {
   constructor(


### PR DESCRIPTION
Update the functions used in the build_test.md to the functions that are available in test_scenarios.move, e.g. `take_owner(...)` to `take_from_sender(...)`. The altered tests still managed to run.