### PR TITLE
Add more metrics in transaction notifier

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -185,6 +185,7 @@ pub struct AuthorityMetrics {
     /// Batch service metrics
     pub(crate) batch_service_total_tx_broadcasted: IntCounter,
     pub(crate) batch_service_latest_seq_broadcasted: IntGauge,
+    pub(crate) batch_svc_is_running: IntCounter,
 }
 
 // Override default Prom buckets for positive numbers in 0-50k range
@@ -441,6 +442,11 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
+            batch_svc_is_running: register_int_counter_with_registry!(
+                "batch_svc_is_running",
+                "Sanity check to ensure batch service is running",
+                registry,
+            ).unwrap(),
         }
     }
 }
@@ -840,6 +846,7 @@ impl AuthorityState {
         // If commit_certificate returns an error, tx_guard will be dropped and the certificate
         // will be persisted in the log for later recovery.
         let notifier_ticket = self.batch_notifier.ticket(bypass_validator_halt)?;
+        let seq = notifier_ticket.seq();
         if let Err(err) = self
             .commit_certificate(
                 inner_temporary_store,
@@ -858,6 +865,7 @@ impl AuthorityState {
             } else {
                 error!(?digest, "commit_certificate failed: {}", err);
             }
+            debug!("Failed to notify ticket with sequence number: {}", seq);
             return Err(err);
         }
 
@@ -1473,7 +1481,7 @@ impl AuthorityState {
             committee_store,
             batch_channels: tx,
             batch_notifier: Arc::new(
-                authority_notifier::TransactionNotifier::new(store.clone())
+                authority_notifier::TransactionNotifier::new(store.clone(), prometheus_registry)
                     .expect("Notifier cannot start."),
             ),
             consensus_guardrail: AtomicUsize::new(0),

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -183,6 +183,9 @@ impl crate::authority::AuthorityState {
                 error!("batch service exited!");
                 break;
             }
+            // Update the running counter
+            self.metrics.batch_svc_is_running.inc();
+
             // Reset the flags.
             make_batch = false;
 


### PR DESCRIPTION
As title says, this PR just adds some metrics to track low and high watermarks, and what sequence number batch system is currently at