### PR TITLE
[narwhal] reject header with rounds too advanced

### DIFF
--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -33,9 +33,8 @@ use types::{
 #[path = "tests/core_tests.rs"]
 pub mod core_tests;
 
-// TODO: enable below.
 // Rejects a header if it requires catching up the following number of rounds.
-// const MAX_HEADER_ROUND_CATCHUP_THRESHOLD: u64 = 20;
+const MAX_HEADER_ROUND_CATCHUP_THRESHOLD: u64 = 20;
 
 pub struct Core {
     /// The public key of this primary.
@@ -580,13 +579,12 @@ impl Core {
             self.gc_round < header.round,
             DagError::TooOld(header.id.into(), header.round, self.gc_round)
         );
-        // TODO: enable below.
         // The header round is too high for this node, which is unlikely to acquire all
-        // parent certificates in time.
-        // ensure!(
-        //     self.highest_processed_round + MAX_HEADER_ROUND_CATCHUP_THRESHOLD > header.round,
-        //     DagError::TooNew(header.id.into(), header.round, self.gc_round)
-        // );
+        // parent certificates in time for voting.
+        ensure!(
+            self.highest_processed_round + MAX_HEADER_ROUND_CATCHUP_THRESHOLD > header.round,
+            DagError::TooNew(header.id.into(), header.round, self.gc_round)
+        );
 
         // Verify the header's signature.
         header.verify(&self.committee, self.worker_cache.clone())?;


### PR DESCRIPTION
When a narwhal node is falling behind or catching up after restarting, it will receive headers that have rounds much higher than its latest processed certificates. Trying to gather data and vote on these headers are not useful work: by the time this node has caught up on parent certificates, the vote on the header is likely no longer needed.

For liveness, I believe it should be the header proposing node's responsibility to retry the header again or at a higher round if it still needs votes for it.