### PR TITLE
[epoch] Re-sign effects from previous epoch

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2062,8 +2062,29 @@ impl AuthorityState {
         &self,
         transaction_digest: &TransactionDigest,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
-        self.database
-            .get_signed_transaction_info(transaction_digest)
+        let mut info = self
+            .database
+            .get_signed_transaction_info(transaction_digest)?;
+        // If the transaction was executed in previous epochs, the validator will
+        // re-sign the effects with new current epoch so that a client is always able to
+        // obtain an effects certificate at the current epoch.
+        if let Some(effects) = info.signed_effects.take() {
+            let cur_epoch = self.epoch();
+            let new_effects = if effects.auth_signature.epoch < cur_epoch {
+                debug!(
+                    effects_epoch=?effects.auth_signature.epoch,
+                    ?cur_epoch,
+                    "Re-signing the effects with the current epoch"
+                );
+                effects
+                    .effects
+                    .to_sign_effects(cur_epoch, &self.name, &*self.secret)
+            } else {
+                effects
+            };
+            info.signed_effects = Some(new_effects);
+        }
+        Ok(info)
     }
 
     fn make_account_info(&self, account: SuiAddress) -> Result<AccountInfoResponse, SuiError> {

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -141,7 +141,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
             let client: SafeClient<LocalAuthorityClient> =
                 sender_aggregator.authority_clients[sample_authority].clone();
             let _response = client
-                .handle_certificate(new_certificate)
+                .handle_certificate(new_certificate.into())
                 .await
                 .expect("Problem processing certificate");
 
@@ -231,7 +231,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
             let client: SafeClient<LocalAuthorityClient> =
                 sender_aggregator.authority_clients[sample_authority].clone();
             let _response = client
-                .handle_certificate(new_certificate)
+                .handle_certificate(new_certificate.into())
                 .await
                 .expect("Problem processing certificate");
 

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -171,15 +171,12 @@ where
                 .process_transaction(advance_epoch_tx.clone().to_transaction())
                 .await
             {
-                Ok(certificate) => {
-                    let certificate = certificate.verify(&self.state.committee.load())?;
-                    match self.state.handle_certificate(&certificate).await {
-                        Ok(_) => {
-                            break;
-                        }
-                        Err(err) => err,
+                Ok(certificate) => match self.state.handle_certificate(&certificate).await {
+                    Ok(_) => {
+                        break;
                     }
-                }
+                    Err(err) => err,
+                },
                 Err(err) => err,
             };
             debug!(

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -326,6 +326,31 @@ async fn test_consensus_pause_after_last_fragment() {
     assert!(cp0.should_reject_consensus_transaction());
 }
 
+#[tokio::test]
+async fn test_cross_epoch_effects_cert() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let genesis_objects = vec![Object::with_owner_for_testing(sender)];
+    let (mut net, states, _) = init_local_authorities(4, genesis_objects.clone()).await;
+
+    let object_ref = genesis_objects[0].compute_object_reference();
+    let tx_data =
+        TransactionData::new_transfer_sui(SuiAddress::default(), sender, None, object_ref, 1000);
+    let transaction = to_sender_signed_transaction(tx_data, &sender_key);
+    net.execute_transaction(&transaction).await.unwrap();
+    for state in states {
+        // Manually update each validator's epoch to the next one for testing purpose.
+        let mut new_committee = (**state.committee.load()).clone();
+        new_committee.epoch += 1;
+        state.committee.store(Arc::new(new_committee));
+    }
+    // Also need to update the authority aggregator's committee.
+    net.committee.epoch += 1;
+    // Call to execute_transaction can still succeed.
+    let (tx_cert, effects_cert) = net.execute_transaction(&transaction).await.unwrap();
+    assert_eq!(tx_cert.auth_sign_info.epoch, 0);
+    assert_eq!(effects_cert.auth_signature.epoch, 1);
+}
+
 fn enable_reconfig(states: &[Arc<AuthorityState>]) {
     for state in states {
         state.checkpoints.lock().enable_reconfig = true;

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -92,7 +92,7 @@ where
         request: QuorumDriverRequest,
     ) -> SuiResult<QuorumDriverResponse> {
         let tx_digest = request.transaction.digest();
-        debug!(?tx_digest, "Received tranasction execution request");
+        debug!(?tx_digest, "Received transaction execution request");
         self.metrics.current_requests_in_flight.inc();
         let _metrics_guard = scopeguard::guard(self.metrics.clone(), |metrics| {
             metrics.current_requests_in_flight.dec();
@@ -191,6 +191,7 @@ where
             .process_transaction(transaction)
             .instrument(tracing::debug_span!("process_tx", ?tx_digest))
             .await
+            .map(|v| v.into())
     }
 
     pub async fn process_certificate(

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -427,7 +427,7 @@ async fn execute_transaction_with_fault_configs(
         get_local_client(&mut authorities, *index).fault_config = *config;
     }
 
-    authorities.process_certificate(cert).await?;
+    authorities.process_certificate(cert.into()).await?;
     Ok(())
 }
 
@@ -461,7 +461,9 @@ async fn test_quorum_map_and_reduce_timeout() {
     // Send request with a very small timeout to trigger timeout error
     authorities.timeouts.pre_quorum_timeout = Duration::from_millis(2);
     authorities.timeouts.post_quorum_timeout = Duration::from_millis(2);
-    let certified_effects = authorities.process_certificate(certificate.clone()).await;
+    let certified_effects = authorities
+        .process_certificate(certificate.clone().into())
+        .await;
     // Ensure it is an error
     assert!(certified_effects.is_err());
     assert!(matches!(


### PR DESCRIPTION
This PR allows a validator to re-sign an existing effects (that were signed in a previous epoch) at a new epoch.
This allows a client to be able to form a new effect certs when querying validators about a previously finalized transaction.