### PR TITLE
[wallet-ext] Add wallet CI task

### DIFF
--- a/.github/workflows/wallet-ci.yml
+++ b/.github/workflows/wallet-ci.yml
@@ -1,4 +1,4 @@
-name: Wallet Extension PR Comment
+name: Wallet Extension CI Build
 
 on:
   push:

--- a/.github/workflows/wallet-ci.yml
+++ b/.github/workflows/wallet-ci.yml
@@ -1,0 +1,31 @@
+name: Wallet Extension PR Comment
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  wallet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7
+      - name: Install Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm wallet build:prod
+      - name: Package
+        run: pnpm wallet pack:zip
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wallet-extension
+          path: apps/wallet/web-ext-artifacts/*
+          retention-days: 1


### PR DESCRIPTION
This will build the wallet extension on any push to main, and upload it as an artifact, so that it can be used as a CI artifact.