### PR TITLE
chore: update roadmap link in explore docs

### DIFF
--- a/doc/src/explore/index.md
+++ b/doc/src/explore/index.md
@@ -2,7 +2,7 @@
 title: Explore Sui
 ---
 
-Find answers to common questions about our [roadmap](https://github.com/MystenLabs/sui/blob/main/ROADMAP.md) and more in our [FAQ](../contribute/faq.md).
+Find answers to common questions about our [roadmap](https://github.com/MystenLabs/sui/blob/main/DEVX_ROADMAP.md) and more in our [FAQ](../contribute/faq.md).
 
 ## Tutorials
 

--- a/doc/src/learn/index.md
+++ b/doc/src/learn/index.md
@@ -6,7 +6,7 @@ title: Learn About Sui
 
 Welcome to the documentation for the Sui platform. Sui is built on the core [Move](https://github.com/MystenLabs/awesome-move) programming language. This documentation assumes that you have a basic working knowledge of Move. To learn more about the differences between core Move and Sui Move, see [How Sui Move differs from core Move](../learn/sui-move-diffs.md).
 
-For a deep dive into Sui technology, see the [Sui Smart Contracts Platform](https://github.com/MystenLabs/sui/blob/main/doc/paper/sui.pdf) white paper. Find answers to common questions about our [roadmap](https://github.com/MystenLabs/sui/blob/main/ROADMAP.md) and more in our [FAQ](../contribute/faq.md).
+For a deep dive into Sui technology, see the [Sui Smart Contracts Platform](https://github.com/MystenLabs/sui/blob/main/doc/paper/sui.pdf) white paper. Find answers to common questions about our [roadmap](https://github.com/MystenLabs/sui/blob/main/DEVX_ROADMAP.md) and more in our [FAQ](../contribute/faq.md).
 
 ## Versions of the documentation
 


### PR DESCRIPTION
- update `roadmap` link in explore docs

Hi team, I found that the document in the roadmap was linked to legacy. 
Since it is not core logic, I've submitted PR to the `main` branch.
Thank you :)
