### PR TITLE
[wip] Add full node to msim

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -9,6 +9,7 @@ mod test {
     use std::time::Duration;
     use sui_config::SUI_KEYSTORE_FILENAME;
     use sui_core::authority_aggregator::AuthorityAggregatorBuilder;
+    use test_utils::network::{start_a_fullnode, start_a_fullnode_with_handle};
     use test_utils::{
         messages::get_gas_object_with_wallet_context, network::init_cluster_builder_env_aware,
     };
@@ -52,6 +53,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load() {
         let test_cluster = init_cluster_builder_env_aware().build().await.unwrap();
+        let _sui_node = start_a_fullnode(&test_cluster.swarm, false).await.unwrap();
         let swarm = &test_cluster.swarm;
         let context = &test_cluster.wallet;
         let sender = test_cluster.get_address_0();

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -147,8 +147,8 @@ impl TestClusterBuilder {
         self
     }
 
-    pub fn do_not_build_fullnode(mut self) -> Self {
-        self.do_not_build_fullnode = true;
+    pub fn do_not_build_fullnode(mut self, value: bool) -> Self {
+        self.do_not_build_fullnode = value;
         self
     }
 
@@ -401,7 +401,7 @@ pub async fn start_a_fullnode_with_handle(
 pub fn init_cluster_builder_env_aware() -> TestClusterBuilder {
     let mut builder = TestClusterBuilder::new();
     if cfg!(msim) {
-        builder = builder.use_embedded_gateway().do_not_build_fullnode();
+        builder = builder.use_embedded_gateway().do_not_build_fullnode(true);
     }
     builder
 }


### PR DESCRIPTION
 USE_MOCK_CRYPTO=1 RUST_LOG=msim=error,sui=debug cargo simtest test_simulated_load
```
--- STDERR:                                            sui-benchmark::simtest test::test_simulated_load ---
------------------------------------------------------------
WARNING: Cryptographic signing/verification has been mocked,
         in order to speed up non-crypto-related tests. If
         you are not running a test, stop now!
------------------------------------------------------------
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Networking or low-level protocol error: Connection timeout exceeded: 10s

Caused by:
    Connection timeout exceeded: 10s', crates/sui-benchmark/tests/simtest.rs:54:104
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at 'there is no reactor running, must be called from the context of a Madsim runtime', /Users/sadhansood/.cargo/git/checkouts/mysten-sim-6c6e892b5d19dc47/982cf1a/msim/src/sim/runtime/context.rs:15:55
stack backtrace:
thread panicked while processing panic. aborting.
