### PR TITLE
Remove `tokio-console` feature from telemetry-subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,42 +1286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
-dependencies = [
- "prost 0.11.0",
- "prost-types",
- "tonic",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures",
- "hdrhistogram",
- "humantime",
- "prost-types",
- "serde 1.0.147",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.15",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8945,7 +8909,6 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a01f8161eb6d52700ec8f82a9432b425db5d1729ac747b52d34dfc9f4f0902"
 dependencies = [
- "console-subscriber",
  "crossterm 0.25.0",
  "once_cell",
  "opentelemetry 0.18.0",
@@ -10449,8 +10412,6 @@ dependencies = [
  "comfy-table",
  "config",
  "console",
- "console-api",
- "console-subscriber",
  "const-oid",
  "constant_time_eq",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ opt-level = 1
 # github.com/MystenLabs/mysten-infra dependencies
 typed-store = "0.1.0"
 typed-store-derive = "0.1.0"
-telemetry-subscribers = { version = "0.2.0", features = ["jaeger", "tokio-console"] }
+telemetry-subscribers = { version = "0.2.0", features = ["jaeger"] }
 mysten-network = "0.2.0"
 name-variant = "0.1.0"
 store = { version = "0.1.0", package = "typed-store" }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -110,8 +110,6 @@ combine = { version = "4", features = ["alloc", "bytes", "std"] }
 comfy-table = { version = "6", features = ["crossterm", "tty"] }
 config = { version = "0.11", features = ["hjson", "ini", "json", "rust-ini", "serde-hjson", "serde_json", "toml", "yaml", "yaml-rust"] }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
-console-api = { version = "0.4", default-features = false, features = ["transport"] }
-console-subscriber = { version = "0.1", features = ["env-filter"] }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
@@ -407,7 +405,6 @@ prometheus = { version = "0.13", features = ["protobuf"] }
 proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 prost-93f6ce9d446188ac = { package = "prost", version = "0.10", features = ["prost-derive", "std"] }
 prost-a6292c17cd707f01 = { package = "prost", version = "0.11", features = ["prost-derive", "std"] }
-prost-types = { version = "0.11", features = ["std"] }
 protobuf = { version = "2", default-features = false }
 ptree = { version = "0.4", features = ["ansi", "ansi_term", "atty", "conf", "config", "directories", "petgraph", "serde-value", "tint", "value"] }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
@@ -520,7 +517,7 @@ tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "1", default-features = false, features = ["serde", "summaries"] }
 telemetry-subscribers-c65f7effa3be6d31 = { package = "telemetry-subscribers", version = "0.1", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
-telemetry-subscribers-6f8ce4dd05d13bba = { package = "telemetry-subscribers", version = "0.2", features = ["chrome", "console-subscriber", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tokio-console", "tracing-chrome", "tracing-opentelemetry"] }
+telemetry-subscribers-6f8ce4dd05d13bba = { package = "telemetry-subscribers", version = "0.2", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 tempfile = { version = "3", default-features = false }
 tera = { version = "1", features = ["builtins", "chrono", "chrono-tz", "humansize", "percent-encoding", "rand", "slug", "urlencode"] }
 termcolor = { version = "1", default-features = false }
@@ -733,8 +730,6 @@ combine = { version = "4", features = ["alloc", "bytes", "std"] }
 comfy-table = { version = "6", features = ["crossterm", "tty"] }
 config = { version = "0.11", features = ["hjson", "ini", "json", "rust-ini", "serde-hjson", "serde_json", "toml", "yaml", "yaml-rust"] }
 console = { version = "0.15", default-features = false, features = ["ansi-parsing", "unicode-width"] }
-console-api = { version = "0.4", default-features = false, features = ["transport"] }
-console-subscriber = { version = "0.1", features = ["env-filter"] }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
@@ -1083,7 +1078,7 @@ prost-a6292c17cd707f01 = { package = "prost", version = "0.11", features = ["pro
 prost-build = { version = "0.11" }
 prost-derive-93f6ce9d446188ac = { package = "prost-derive", version = "0.10", default-features = false }
 prost-derive-a6292c17cd707f01 = { package = "prost-derive", version = "0.11", default-features = false }
-prost-types = { version = "0.11", features = ["std"] }
+prost-types = { version = "0.11", default-features = false }
 protobuf = { version = "2", default-features = false }
 ptree = { version = "0.4", features = ["ansi", "ansi_term", "atty", "conf", "config", "directories", "petgraph", "serde-value", "tint", "value"] }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
@@ -1221,7 +1216,7 @@ tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "1", default-features = false, features = ["serde", "summaries"] }
 telemetry-subscribers-c65f7effa3be6d31 = { package = "telemetry-subscribers", version = "0.1", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
-telemetry-subscribers-6f8ce4dd05d13bba = { package = "telemetry-subscribers", version = "0.2", features = ["chrome", "console-subscriber", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tokio-console", "tracing-chrome", "tracing-opentelemetry"] }
+telemetry-subscribers-6f8ce4dd05d13bba = { package = "telemetry-subscribers", version = "0.2", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 tempfile = { version = "3", default-features = false }
 tera = { version = "1", features = ["builtins", "chrono", "chrono-tz", "humansize", "percent-encoding", "rand", "slug", "urlencode"] }
 termcolor = { version = "1", default-features = false }


### PR DESCRIPTION
This feature seems to depend on package `console-subscriber`, which requires unstable tokio.