### PR TITLE
[wallet-ext][wallet-adapter] Update to new wallet standard

### DIFF
--- a/.changeset/poor-pandas-hunt.md
+++ b/.changeset/poor-pandas-hunt.md
@@ -1,0 +1,6 @@
+---
+"@mysten/wallet-adapter-wallet-standard": minor
+"@mysten/wallet-standard": minor
+---
+
+Update wallet standard adapters to use new wallet registration logic.

--- a/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
+++ b/apps/wallet/src/dapp-interface/WalletStandardInterface.ts
@@ -122,10 +122,7 @@ export class SuiWallet implements Wallet {
                     // TODO: Expose public key instead of address:
                     publicKey: new Uint8Array(),
                     chains: SUI_CHAINS,
-                    features: [
-                        'sui:signAndExecuteTransaction',
-                        'standard:signMessage',
-                    ],
+                    features: ['sui:signAndExecuteTransaction'],
                 });
                 this.#events.emit('change', { accounts: this.accounts });
             }

--- a/apps/wallet/src/dapp-interface/index.ts
+++ b/apps/wallet/src/dapp-interface/index.ts
@@ -1,17 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { registerWallet } from '@mysten/wallet-standard';
+
 import { DAppInterface } from './DAppInterface';
 import { SuiWallet } from './WalletStandardInterface';
 
-import type { WalletsWindow } from '@mysten/wallet-standard';
-
-declare const window: WalletsWindow;
-
-window.navigator.wallets = window.navigator.wallets || [];
-window.navigator.wallets.push(({ register }) => {
-    register(new SuiWallet());
-});
+registerWallet(new SuiWallet());
 
 Object.defineProperty(window, 'suiWallet', {
     enumerable: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,7 +533,6 @@ importers:
       '@mysten/sui.js': workspace:*
       '@mysten/wallet-adapter-base': workspace:*
       '@mysten/wallet-standard': workspace:*
-      '@wallet-standard/app': 0.1.0-alpha.6
       mitt: ^3.0.0
       tsup: ^6.2.2
       typescript: ^4.8.3
@@ -541,7 +540,6 @@ importers:
       '@mysten/sui.js': link:../../../../typescript
       '@mysten/wallet-adapter-base': link:../base-adapter
       '@mysten/wallet-standard': link:../../wallet-standard
-      '@wallet-standard/app': 0.1.0-alpha.6
       mitt: 3.0.0
     devDependencies:
       tsup: 6.2.2_typescript@4.8.3
@@ -592,16 +590,12 @@ importers:
   sdk/wallet-adapter/packages/wallet-standard:
     specifiers:
       '@mysten/sui.js': workspace:*
-      '@wallet-standard/features': 0.1.0-alpha.4
-      '@wallet-standard/standard': 0.1.0-alpha.5
-      '@wallet-standard/util': 0.1.0-alpha.6
+      '@wallet-standard/core': 1.0.0-rc.5
       tsup: ^6.2.2
       typescript: ^4.8.3
     dependencies:
       '@mysten/sui.js': link:../../../typescript
-      '@wallet-standard/features': 0.1.0-alpha.4
-      '@wallet-standard/standard': 0.1.0-alpha.5
-      '@wallet-standard/util': 0.1.0-alpha.6
+      '@wallet-standard/core': 1.0.0-rc.5
     devDependencies:
       tsup: 6.2.2_typescript@4.8.3
       typescript: 4.8.3
@@ -6166,26 +6160,40 @@ packages:
       sirv: 2.0.2
     dev: true
 
-  /@wallet-standard/app/0.1.0-alpha.6:
-    resolution: {integrity: sha512-Z/aTiMpI2qjh/YDS8GtmHrIwpsHhHlzYffkEvuiG3RY7j0ZNsQWOx38hNN/V6lOlKrh7S+azPcFL7ESiilqvcA==}
+  /@wallet-standard/app/1.0.0-rc.5:
+    resolution: {integrity: sha512-PZDZU+H8KfomWB7QjVXByMji3zs/LGbwmjCVIbSPvDIdUHA86Mn2Az1jb0ktL4mDYr3vXqEFbtoZ+pkFB5lcEw==}
+    engines: {node: '>=16'}
     dependencies:
-      '@wallet-standard/standard': 0.1.0-alpha.5
+      '@wallet-standard/base': 1.0.0-rc.5
     dev: false
 
-  /@wallet-standard/features/0.1.0-alpha.4:
-    resolution: {integrity: sha512-HF7i//1oqadV8269Jp8rEFxSf+nCxLZ+CGKT5giuavSb/hdbiPPDbQLMhWfyLRatSnssIZN1LtsyzGe9kDFJrg==}
-    dependencies:
-      '@wallet-standard/standard': 0.1.0-alpha.5
+  /@wallet-standard/base/1.0.0-rc.5:
+    resolution: {integrity: sha512-28FCazScjZtztvH+b4Tu30yDwe6D0oze0uKKrHXAOdzQ50O3ydqWICYuaz7jiq38Mt9TGNRiSOpePdsMC+qP8Q==}
+    engines: {node: '>=16'}
     dev: false
 
-  /@wallet-standard/standard/0.1.0-alpha.5:
-    resolution: {integrity: sha512-rqs9vD+Hww8kWtF8/8wi+hhLIWN1ank/ZfK7mGALen+9XhxAcgOJwl96l30MCSL2w1AHykOEELOZK6lUbg13gQ==}
+  /@wallet-standard/core/1.0.0-rc.5:
+    resolution: {integrity: sha512-nZVGhq/SXl/+IU+zVeiDWtALnkSqchik3aWoYg6XivanS4AD8xrHwOhAgnWvX4QKreTBUmKhgmIv4vE63eRjvQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/app': 1.0.0-rc.5
+      '@wallet-standard/base': 1.0.0-rc.5
+      '@wallet-standard/features': 1.0.0-rc.5
+      '@wallet-standard/wallet': 1.0.0-rc.5
     dev: false
 
-  /@wallet-standard/util/0.1.0-alpha.6:
-    resolution: {integrity: sha512-dyfgryEo5PU3XXZ20Zs9jRtyVuP/7qsKD9yNyPy9XlcZpB6HR3OtdqiXJQsm1KOxz8VsOsfRIdmzri4O/1MR7Q==}
+  /@wallet-standard/features/1.0.0-rc.5:
+    resolution: {integrity: sha512-xO1cl8U/mc9UZVkRV5743xmKHzUdTQ3K80djycczcLD07gsHuZ12GgFg7K04PbjO3Mr4til4Mc0zsoSJg+Z5JA==}
+    engines: {node: '>=16'}
     dependencies:
-      '@wallet-standard/standard': 0.1.0-alpha.5
+      '@wallet-standard/base': 1.0.0-rc.5
+    dev: false
+
+  /@wallet-standard/wallet/1.0.0-rc.5:
+    resolution: {integrity: sha512-PIE7J4lXMY/ZOh2NgMHrao4S6ZgVWtL50GBqYvFMRDh5hCPa5BF1Grs8czNggrsjboVbxEGjY6BJTy/vZ0mdZg==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@wallet-standard/base': 1.0.0-rc.5
     dev: false
 
   /@webassemblyjs/ast/1.11.1:

--- a/sdk/wallet-adapter/packages/adapters/wallet-standard-adapter/package.json
+++ b/sdk/wallet-adapter/packages/adapters/wallet-standard-adapter/package.json
@@ -29,7 +29,6 @@
     "@mysten/sui.js": "workspace:*",
     "@mysten/wallet-adapter-base": "workspace:*",
     "@mysten/wallet-standard": "workspace:*",
-    "@wallet-standard/app": "0.1.0-alpha.6",
     "mitt": "^3.0.0"
   },
   "devDependencies": {

--- a/sdk/wallet-adapter/packages/adapters/wallet-standard-adapter/src/index.ts
+++ b/sdk/wallet-adapter/packages/adapters/wallet-standard-adapter/src/index.ts
@@ -5,8 +5,9 @@ import { WalletAdapterProvider } from "@mysten/wallet-adapter-base";
 import {
   isStandardWalletAdapterCompatibleWallet,
   StandardWalletAdapterWallet,
+  DEPRECATED_getWallets,
+  Wallets,
 } from "@mysten/wallet-standard";
-import { initialize, InitializedWallets } from "@wallet-standard/app";
 import { StandardWalletAdapter } from "./StandardWalletAdapter";
 import mitt, { Emitter } from "mitt";
 
@@ -15,13 +16,13 @@ type Events = {
 };
 
 export class WalletStandardAdapterProvider implements WalletAdapterProvider {
-  #wallets: InitializedWallets;
+  #wallets: Wallets;
   #adapters: Map<StandardWalletAdapterWallet, StandardWalletAdapter>;
   #events: Emitter<Events>;
 
   constructor() {
     this.#adapters = new Map();
-    this.#wallets = initialize();
+    this.#wallets = DEPRECATED_getWallets();
     this.#events = mitt();
 
     this.#wallets.on("register", () => {

--- a/sdk/wallet-adapter/packages/wallet-standard/README.md
+++ b/sdk/wallet-adapter/packages/wallet-standard/README.md
@@ -72,13 +72,13 @@ class YourWallet implements Wallet {
     // Your wallet's events on implementation.
   };
 
-	#connect: ConnectMethod = () => {
-		// Your wallet's connect implementation
-	};
+  #connect: ConnectMethod = () => {
+    // Your wallet's connect implementation
+  };
 
-	#signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = () => {
-		// Your wallet's signAndExecuteTransaction implementation
-	};
+  #signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod = () => {
+    // Your wallet's signAndExecuteTransaction implementation
+  };
 }
 ```
 
@@ -113,15 +113,12 @@ class YourWallet implements Wallet {
 
 ### Registering in the window
 
-Once you have a compatible interface for your wallet, you can register it in the window under the `window.navigator.wallets` interface. Wallets self-register by pushing their standard wallet interface to this array-like interface.
+Once you have a compatible interface for your wallet, you can register it using the `registerWallet` function.
 
 ```typescript
-// This makes TypeScript aware of the `window.navigator.wallets` interface.
-declare const window: import("@mysten/wallet-standard").WalletsWindow;
+import { registerWallet } from '@mysten/wallet-standard';
 
-(window.navigator.wallets || []).push(({ register }) => {
-  register(new YourWallet());
-});
+registerWallet(new YourWallet());
 ```
 
-> Note that while this interface is array-like, it is not always an array, and the only method that should be called on it is `push`.
+> If you're interested in the internal implementation of the `registerWallet` method, you can [see how it works here](https://github.com/wallet-standard/wallet-standard/blob/b4794e761de688906827829d5380b24cb8ed5fd5/packages/core/wallet/src/register.ts#L9).

--- a/sdk/wallet-adapter/packages/wallet-standard/README.md
+++ b/sdk/wallet-adapter/packages/wallet-standard/README.md
@@ -104,7 +104,7 @@ class YourWallet implements Wallet {
           chains: [SUI_DEVNET_CHAIN],
           // The features that this account supports. This can be a subset of the wallet's supported features.
           // These features must exist on the wallet as well.
-          features: ["sui:signAndExecuteTransaction", "standard:signMessage"],
+          features: ["sui:signAndExecuteTransaction"],
         })
     );
   }

--- a/sdk/wallet-adapter/packages/wallet-standard/package.json
+++ b/sdk/wallet-adapter/packages/wallet-standard/package.json
@@ -27,9 +27,7 @@
   },
   "dependencies": {
     "@mysten/sui.js": "workspace:*",
-    "@wallet-standard/features": "0.1.0-alpha.4",
-    "@wallet-standard/standard": "0.1.0-alpha.5",
-    "@wallet-standard/util": "0.1.0-alpha.6"
+    "@wallet-standard/core": "1.0.0-rc.5"
   },
   "devDependencies": {
     "tsup": "^6.2.2",

--- a/sdk/wallet-adapter/packages/wallet-standard/src/detect.ts
+++ b/sdk/wallet-adapter/packages/wallet-standard/src/detect.ts
@@ -5,8 +5,9 @@ import {
   ConnectFeature,
   DisconnectFeature,
   EventsFeature,
-} from "@wallet-standard/features";
-import { Wallet, WalletWithFeatures } from "@wallet-standard/standard";
+  Wallet,
+  WalletWithFeatures,
+} from "@wallet-standard/core";
 import { SuiSignAndExecuteTransactionFeature } from "./features";
 
 export type StandardWalletAdapterWallet = WalletWithFeatures<

--- a/sdk/wallet-adapter/packages/wallet-standard/src/features/index.ts
+++ b/sdk/wallet-adapter/packages/wallet-standard/src/features/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { WalletWithFeatures } from "@wallet-standard/standard";
+import type { WalletWithFeatures } from "@wallet-standard/core";
 import type { SuiSignAndExecuteTransactionFeature } from "./suiSignAndExecuteTransaction";
 
 /**

--- a/sdk/wallet-adapter/packages/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
+++ b/sdk/wallet-adapter/packages/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
@@ -5,7 +5,7 @@ import type {
   SignableTransaction,
   SuiTransactionResponse,
 } from "@mysten/sui.js";
-import type { SignAndSendTransactionInput } from "@wallet-standard/features";
+import type { SignAndSendTransactionInput } from "@wallet-standard/core";
 
 /** The latest API version of the signAndExecuteTransaction API. */
 export type SuiSignAndExecuteTransactionVersion = "1.0.0";

--- a/sdk/wallet-adapter/packages/wallet-standard/src/index.ts
+++ b/sdk/wallet-adapter/packages/wallet-standard/src/index.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export * from '@wallet-standard/standard';
-export * from '@wallet-standard/features';
-export * from '@wallet-standard/util';
+export * from '@wallet-standard/core';
 
 export * from "./features";
 export * from "./detect";


### PR DESCRIPTION
This updates to the new wallet adapter, which is based on an event-registration system. I used the `DEPRECATED_` wallet methods in order to support the existing wallets while we migrate to the new setup.