### PR TITLE
wallet-ext: make ui more responsive

### DIFF
--- a/apps/wallet/src/ui/app/components/sui-apps/ConnectedAppsCard.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/ConnectedAppsCard.tsx
@@ -54,37 +54,34 @@ function ConnectedDapps() {
         [];
 
     return (
-        <>
-            <div className={cl(st.container)}>
-                <div className={st.desc}>
-                    <div className={st.title}>
-                        {filteredApps.length
-                            ? `Connected apps (${filteredApps.length})`
-                            : 'No APPS connected'}
-                    </div>
-                    Apps you connect to through the SUI wallet in this browser
-                    will show up here.
+        <div className={cl(st.container)}>
+            <div className={st.desc}>
+                <div className={st.title}>
+                    {filteredApps.length
+                        ? `Connected apps (${filteredApps.length})`
+                        : 'No APPS connected'}
                 </div>
-
-                <div className={cl(st.apps, st.appCards)}>
-                    {filteredApps.length ? (
-                        filteredApps.map((app, index) => (
-                            <SuiApp
-                                key={index}
-                                {...app}
-                                displaytype="card"
-                                disconnect={true}
-                            />
-                        ))
-                    ) : (
-                        <>
-                            <SuiAppEmpty displaytype="card" />
-                            <SuiAppEmpty displaytype="card" />
-                        </>
-                    )}
-                </div>
+                Apps you connect to through the SUI wallet in this browser will
+                show up here.
             </div>
-        </>
+            <div className={st.appCards}>
+                {filteredApps.length ? (
+                    filteredApps.map((app, index) => (
+                        <SuiApp
+                            key={index}
+                            {...app}
+                            displaytype="card"
+                            disconnect={true}
+                        />
+                    ))
+                ) : (
+                    <>
+                        <SuiAppEmpty displaytype="card" />
+                        <SuiAppEmpty displaytype="card" />
+                    </>
+                )}
+            </div>
+        </div>
     );
 }
 

--- a/apps/wallet/src/ui/app/components/sui-apps/Playground.module.scss
+++ b/apps/wallet/src/ui/app/components/sui-apps/Playground.module.scss
@@ -65,10 +65,6 @@
     }
 }
 
-.apps {
-    margin-bottom: 120px;
-}
-
 .app-cards {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/apps/wallet/src/ui/app/components/sui-apps/index.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/index.tsx
@@ -87,7 +87,7 @@ function AppsPlayGround() {
         mintStatus !== null ? (mintStatus ? 'check2' : 'x-lg') : null;
 
     return (
-        <div className={cl(st.container)}>
+        <>
             <h4 className={st.activeSectionTitle}>Playground</h4>
             <div className={st.groupButtons}>
                 <Button
@@ -147,12 +147,9 @@ function AppsPlayGround() {
                         endorsement or relationship with Sui Wallet. Please
                         DYOR.
                     </div>
-
-                    <div className={st.apps}>
-                        {curatedDapps.map((app, index) => (
-                            <SuiApp key={index} {...app} displaytype="full" />
-                        ))}
-                    </div>
+                    {curatedDapps.map((app, index) => (
+                        <SuiApp key={index} {...app} displaytype="full" />
+                    ))}
                 </>
             ) : (
                 <>
@@ -166,7 +163,7 @@ function AppsPlayGround() {
                     <SuiAppEmpty displaytype="full" />
                 </>
             )}
-        </div>
+        </>
     );
 }
 

--- a/apps/wallet/src/ui/app/pages/home/apps/AppsPage.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/apps/AppsPage.module.scss
@@ -11,5 +11,5 @@
     display: flex;
     flex-flow: column nowrap;
     overflow-x: visible;
-    height: 100%;
+    margin-bottom: 25px; // account for the extra height of the bottom nav, because of the filters
 }

--- a/apps/wallet/src/ui/app/pages/home/apps/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/apps/index.tsx
@@ -3,7 +3,6 @@
 
 import { Route, Routes } from 'react-router-dom';
 
-import { Content } from '_app/shared/bottom-menu-layout';
 import FiltersPortal from '_components/filters-tags';
 import AppsPlayGround, { ConnectedAppsCard } from '_components/sui-apps';
 
@@ -23,18 +22,11 @@ function AppsPage() {
 
     return (
         <div className={st.container}>
-            <Content>
-                <section>
-                    <FiltersPortal tags={filterTags} />
-                    <Routes>
-                        <Route path="/" element={<AppsPlayGround />} />
-                        <Route
-                            path="/connected"
-                            element={<ConnectedAppsCard />}
-                        />
-                    </Routes>
-                </section>
-            </Content>
+            <FiltersPortal tags={filterTags} />
+            <Routes>
+                <Route path="/" element={<AppsPlayGround />} />
+                <Route path="/connected" element={<ConnectedAppsCard />} />
+            </Routes>
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/pages/home/nft-details/NFTDetails.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/NFTDetails.module.scss
@@ -6,7 +6,8 @@
     display: flex;
     flex-flow: column nowrap;
     overflow-x: visible;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
 
     .send-nft-btn {
         @include utils.typography('table/title-sm');
@@ -35,7 +36,7 @@
 }
 
 .page-title {
-    margin-bottom: 8px;
+    margin-bottom: 28px;
     text-transform: capitalize;
 }
 
@@ -96,23 +97,17 @@
     box-shadow: 0 0 44px rgb(0 0 0 / 15%);
 }
 
-.nft-detail {
-    margin-top: 20px;
-}
-
 /* TODO use either css or svg so the div can */
 .nft-details {
     margin-top: 20px;
     padding: 20px;
     background-image: url('_assets/images/nft-detail-bg.png');
-    height: 104px;
     background-size: cover;
     background-position: bottom;
     background-repeat: no-repeat;
     width: 100%;
 
     .nft-details-inner {
-        height: 64px;
         overflow: auto;
     }
 

--- a/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/index.tsx
@@ -95,14 +95,12 @@ function NFTdetailsContent({
             />
             <BottomMenuLayout>
                 <Content>
-                    <section className={st.nftDetail}>
-                        <NFTDisplayCard
-                            nftobj={nft}
-                            size="large"
-                            expandable={true}
-                        />
-                        {NFTDetails}
-                    </section>
+                    <NFTDisplayCard
+                        nftobj={nft}
+                        size="large"
+                        expandable={true}
+                    />
+                    {NFTDetails}
                 </Content>
                 <Menu stuckClass={st.shadow} className={st.shadow}>
                     <button

--- a/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.module.scss
@@ -4,12 +4,14 @@
 .container {
     display: flex;
     flex-flow: column nowrap;
-    overflow-x: visible;
-    height: 100%;
+    flex: 1;
 }
 
 .content {
     margin-top: 20px;
+    display: flex;
+    flex-flow: column nowrap;
+    flex: 1;
 }
 
 .shadow {
@@ -32,9 +34,8 @@
 
 .label-info {
     text-align: center;
-    width: 90%;
+    padding: 0 16px;
     color: colors.$gray-80;
-    margin: auto;
     margin-bottom: 10px;
 }
 
@@ -63,14 +64,11 @@
 .formcta {
     display: flex;
     flex-flow: row nowrap;
-    height: 76px;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    align-items: center;
-    justify-content: stretch;
     padding: 5px 25px;
-    left: 0;
+    flex: 1;
+    align-items: flex-end;
+    margin-top: 10px;
+    margin-bottom: 10px;
 
     .action,
     .done {

--- a/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.tsx
@@ -5,7 +5,6 @@ import cl from 'classnames';
 import { Form, Field, useFormikContext } from 'formik';
 import { useEffect, useRef, memo } from 'react';
 
-import { Content } from '_app/shared/bottom-menu-layout';
 import Button from '_app/shared/button';
 import AddressInput from '_components/address-input';
 import Icon, { SuiIcons } from '_components/icon';
@@ -40,60 +39,53 @@ function TransferNFTForm({
     }, [to, amount]);
 
     return (
-        <div className={st.sendNft}>
-            <Content>
-                <Form
-                    className={st.container}
-                    autoComplete="off"
-                    noValidate={true}
+        <Form
+            className={cl(st.sendNft, st.container)}
+            autoComplete="off"
+            noValidate={true}
+        >
+            <label className={st.labelInfo}>
+                Enter the address of the recipient to start sending the NFT
+            </label>
+            <div className={st.group}>
+                <Field
+                    component={AddressInput}
+                    name="to"
+                    as="div"
+                    id="to"
+                    placeholder="Enter Address"
+                    className={st.input}
+                />
+            </div>
+
+            {BigInt(gasBalance) < DEFAULT_NFT_TRANSFER_GAS_FEE && (
+                <div className={st.error}>
+                    * Insufficient balance to cover transfer cost
+                </div>
+            )}
+
+            {submitError ? <div className={st.error}>{submitError}</div> : null}
+
+            <div className={st.formcta}>
+                <Button
+                    size="large"
+                    mode="primary"
+                    type="submit"
+                    disabled={!isValid || isSubmitting}
+                    className={cl(st.action, 'btn', st.sendNftBtn)}
                 >
-                    <label className={st.labelInfo}>
-                        Enter the address of the recipient to start sending the
-                        NFT
-                    </label>
-                    <div className={st.group}>
-                        <Field
-                            component={AddressInput}
-                            name="to"
-                            as="div"
-                            id="to"
-                            placeholder="Enter Address"
-                            className={st.input}
+                    Send NFT Now
+                    {isSubmitting ? (
+                        <LoadingIndicator />
+                    ) : (
+                        <Icon
+                            icon={SuiIcons.ArrowRight}
+                            className={st.arrowActionIcon}
                         />
-                    </div>
-
-                    {BigInt(gasBalance) < DEFAULT_NFT_TRANSFER_GAS_FEE && (
-                        <div className={st.error}>
-                            * Insufficient balance to cover transfer cost
-                        </div>
                     )}
-
-                    {submitError ? (
-                        <div className={st.error}>{submitError}</div>
-                    ) : null}
-
-                    <div className={st.formcta}>
-                        <Button
-                            size="large"
-                            mode="primary"
-                            type="submit"
-                            disabled={!isValid || isSubmitting}
-                            className={cl(st.action, 'btn', st.sendNftBtn)}
-                        >
-                            Send NFT Now
-                            {isSubmitting ? (
-                                <LoadingIndicator />
-                            ) : (
-                                <Icon
-                                    icon={SuiIcons.ArrowRight}
-                                    className={st.arrowActionIcon}
-                                />
-                            )}
-                        </Button>
-                    </div>
-                </Form>
-            </Content>
-        </div>
+                </Button>
+            </div>
+        </Form>
     );
 }
 

--- a/apps/wallet/src/ui/app/pages/home/nfts/NFTPage.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/nfts/NFTPage.module.scss
@@ -1,33 +1,26 @@
-.nft-gallery-container {
-    margin-top: 20px;
-    padding-bottom: 65px;
-    flex-grow: 1;
-    padding-left: 25px;
-    padding-right: 25px;
-    margin-left: -25px;
-    margin-right: -25px;
-    height: 450px;
-    overflow-y: auto;
-
-    .nft-gallery {
-        display: grid;
-        grid-template-columns: repeat(1, 1fr) 50%;
-        grid-gap: 16px 10px;
-
-        a {
-            text-decoration: none;
-            text-transform: capitalize;
-        }
-    }
-}
-
-.page-title {
-    justify-content: center;
-}
+@use '_utils';
 
 .container {
     display: flex;
     flex-flow: column nowrap;
-    overflow-x: visible;
-    height: 100%;
+    min-height: 0;
+}
+
+.nft-gallery {
+    margin-top: 20px;
+    display: grid;
+    grid-template-columns: repeat(1, 1fr) 50%;
+    grid-gap: 16px 10px;
+    overflow: hidden auto;
+
+    @include utils.override-main-padding;
+}
+
+.gallery-item {
+    text-decoration: none;
+    text-transform: capitalize;
+}
+
+.page-title {
+    justify-content: center;
 }

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -3,7 +3,6 @@
 
 import { Link } from 'react-router-dom';
 
-import { Content } from '_app/shared/bottom-menu-layout';
 import PageTitle from '_app/shared/page-title';
 import NFTdisplay from '_components/nft-display';
 import { useAppSelector } from '_hooks';
@@ -21,22 +20,19 @@ function NftsPage() {
                 stats={`${nfts.length}`}
                 className={st.pageTitle}
             />
-            <Content>
-                <section className={st.nftGalleryContainer}>
-                    <section className={st.nftGallery}>
-                        {nfts.map((nft) => (
-                            <Link
-                                to={`/nft-details?${new URLSearchParams({
-                                    objectId: nft.reference.objectId,
-                                }).toString()}`}
-                                key={nft.reference.objectId}
-                            >
-                                <NFTdisplay nftobj={nft} showlabel={true} />
-                            </Link>
-                        ))}
-                    </section>
-                </section>
-            </Content>
+            <div className={st.nftGallery}>
+                {nfts.map((nft) => (
+                    <Link
+                        to={`/nft-details?${new URLSearchParams({
+                            objectId: nft.reference.objectId,
+                        }).toString()}`}
+                        key={nft.reference.objectId}
+                        className={st.galleryItem}
+                    >
+                        <NFTdisplay nftobj={nft} showlabel={true} />
+                    </Link>
+                ))}
+            </div>
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/pages/home/tokens/TokensPage.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/tokens/TokensPage.module.scss
@@ -6,7 +6,8 @@
     flex-flow: column nowrap;
     max-width: 100%;
     align-items: center;
-    height: 100%;
+    min-height: 0;
+    flex: 1;
 }
 
 .balance-container {
@@ -38,7 +39,6 @@
 .other-coins {
     display: flex;
     flex-flow: column nowrap;
-    max-height: 100%;
     overflow-y: auto;
     flex-grow: 1;
     align-self: stretch;

--- a/apps/wallet/src/ui/app/pages/home/transactions/Transactions.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/transactions/Transactions.module.scss
@@ -1,20 +1,17 @@
+@use '_utils';
+
 .container {
     display: flex;
     flex-flow: column nowrap;
-    overflow-x: visible;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
+}
 
-    .tx-content {
-        margin-top: 20px;
-        padding-bottom: 50px;
-        flex-grow: 1;
-        padding-left: 25px;
-        padding-right: 25px;
-        margin-left: -25px;
-        margin-right: -25px;
-        height: 450px;
-        overflow-y: auto;
-    }
+.tx-content {
+    margin-top: 20px;
+    overflow-y: auto;
+
+    @include utils.override-main-padding;
 }
 
 .center-loading {

--- a/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transactions/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import { memo, useEffect } from 'react';
 
-import { Content } from '_app/shared/bottom-menu-layout';
 import PageTitle from '_app/shared/page-title';
 import Loading from '_components/loading';
 import TransactionCard from '_components/transactions-card';
@@ -32,13 +31,11 @@ function TransactionsPage() {
             {txByAddress && txByAddress.length ? (
                 <div className={st.container}>
                     <PageTitle title="Your Activity" />
-                    <Content>
-                        <section className={st.txContent}>
-                            {txByAddress.map((txn) => (
-                                <TransactionCard txn={txn} key={txn.txId} />
-                            ))}
-                        </section>
-                    </Content>
+                    <div className={st.txContent}>
+                        {txByAddress.map((txn) => (
+                            <TransactionCard txn={txn} key={txn.txId} />
+                        ))}
+                    </div>
                 </div>
             ) : null}
         </Loading>

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/CoinSelector.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/CoinSelector.module.scss
@@ -3,42 +3,35 @@
 @use '_values/colors';
 
 .container {
-    height: 100%;
     display: flex;
     flex-flow: column nowrap;
     flex: 1;
-    align-self: stretch;
+}
 
-    .selector-content {
-        margin-top: 25px;
-        height: 100%;
-    }
+.page-title {
+    margin-bottom: 25px;
+}
 
-    .search-coin {
-        .search-input {
-            width: 100%;
-            border: 1px solid colors.$gray-50;
-            height: 36px;
-            border-radius: 10px;
-            padding: 14px 10px;
+.search-coin {
+    position: relative;
 
-            &::placeholder {
-                color: colors.$gray-70;
-            }
-        }
-
-        &::before {
-            position: absolute;
-            right: 0;
-            margin-right: 30px;
-            margin-top: 12px;
-            color: colors.$gray-70;
-        }
+    &::before {
+        position: absolute;
+        right: 0;
+        margin-right: 14px;
+        margin-top: 12px;
+        color: colors.$gray-70;
     }
 }
 
-.default-coin {
-    i {
-        font-size: 24px;
+.search-input {
+    width: 100%;
+    border: 1px solid colors.$gray-50;
+    height: 36px;
+    border-radius: 10px;
+    padding: 14px 10px;
+
+    &::placeholder {
+        color: colors.$gray-70;
     }
 }

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/CoinSelector.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/CoinSelector.tsx
@@ -4,7 +4,6 @@
 import cl from 'classnames';
 import { useSearchParams } from 'react-router-dom';
 
-import { Content } from '_app/shared/bottom-menu-layout';
 import PageTitle from '_app/shared/page-title';
 import ActiveCoinsCard from '_components/active-coins-card';
 import { GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
@@ -24,20 +23,15 @@ function CoinsSelectorPage() {
                 }).toString()}`}
                 className={st.pageTitle}
             />
-            <Content className={st.selectorContent}>
-                <div className={cl(st.searchCoin, 'sui-icons-search')}>
-                    <input
-                        type="text"
-                        name="name"
-                        placeholder="Search coins"
-                        className={st.searchInput}
-                    />
-                </div>
-                <ActiveCoinsCard
-                    activeCoinType={coinType}
-                    showActiveCoin={false}
+            <div className={cl(st.searchCoin, 'sui-icons-search')}>
+                <input
+                    type="text"
+                    name="name"
+                    placeholder="Search coins"
+                    className={st.searchInput}
                 />
-            </Content>
+            </div>
+            <ActiveCoinsCard activeCoinType={coinType} showActiveCoin={false} />
         </div>
     );
 }

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinPage.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinPage.module.scss
@@ -7,7 +7,6 @@
     flex-flow: column nowrap;
     flex: 1;
     align-self: stretch;
-    height: 100%;
 
     .page-title {
         margin-bottom: 8px;
@@ -37,6 +36,7 @@
         @include utils.override-main-sides-space;
 
         overflow-y: auto;
-        height: 100%;
+        display: flex;
+        flex-flow: column nowrap;
     }
 }

--- a/apps/wallet/src/ui/app/pages/layout/Layout.module.scss
+++ b/apps/wallet/src/ui/app/pages/layout/Layout.module.scss
@@ -7,7 +7,6 @@
     align-items: center;
     justify-content: center;
     flex-flow: column nowrap;
-    background-color: v.use(v.$colors-main-content-background);
 
     @include v.set(v.$sizing-nav-height-placeholder, val.$sizing-nav-height);
 
@@ -15,14 +14,19 @@
         @include v.set(v.$sizing-nav-height-placeholder, 0);
     }
 
-    &.forced-popup-size,
+    &.forced-popup-size {
+        flex-grow: 1;
+        width: val.$sizing-popup-width;
+        max-height: val.$sizing-popup-height;
+    }
+
     :global(.is-popup) & {
         width: val.$sizing-popup-width;
         height: val.$sizing-popup-height;
     }
 
     &.dynamic-size {
-        width: 100%;
-        min-height: 100vh;
+        flex-grow: 1;
+        align-self: stretch;
     }
 }

--- a/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/PageMainLayout.module.scss
@@ -6,10 +6,10 @@
 .container {
     display: flex;
     flex-flow: column nowrap;
-    flex-grow: 1;
+    flex: 1;
     width: 100%;
     max-height: 100%;
-    background-color: colors.$gray-40;
+    min-height: 0;
 }
 
 .header {

--- a/apps/wallet/src/ui/app/wallet/locked-page/LockedPage.module.scss
+++ b/apps/wallet/src/ui/app/wallet/locked-page/LockedPage.module.scss
@@ -14,6 +14,7 @@
 }
 
 .fill {
+    margin-top: 15px;
     flex: 1;
 }
 

--- a/apps/wallet/src/ui/styles/global.scss
+++ b/apps/wallet/src/ui/styles/global.scss
@@ -20,8 +20,7 @@
 
 html,
 body {
-    min-width: 0;
-    min-height: 0;
+    min-height: 100vh;
     margin: 0;
     padding: 0;
     -webkit-font-smoothing: antialiased;
@@ -35,10 +34,14 @@ body {
     font-family: Inter, sans-serif;
 }
 
+html,
+body,
 #root {
     display: flex;
-    align-items: center;
     flex-flow: column nowrap;
+    align-items: center;
+    align-self: stretch;
+    flex: 1;
 }
 
 * {


### PR DESCRIPTION
Draft to wait for https://github.com/MystenLabs/sui/pull/5568 before merging this one

* allows ui to shrink if possible to the height of the tab/view when not in-popup mode
* also fixes locked-wallet view to no need to scroll when in the window that opens to process dapp request
before

https://user-images.githubusercontent.com/10210143/198157223-60440d73-c887-4343-b9ba-d8cb8a35835b.mov

after


https://user-images.githubusercontent.com/10210143/198157258-e61086d1-92ef-4b5a-8e52-52fe6444f196.mov


https://user-images.githubusercontent.com/10210143/198158112-d3c0089d-edbc-420d-a192-3f0c1512bfe9.mov




closes https://mysten.atlassian.net/browse/APPS-87?atlOrigin=eyJpIjoiZjk2OGQ2NTIxZDliNGI1NGFiM2U5ODAwZWQ1MzczYjgiLCJwIjoiaiJ9