### PR TITLE
a janky rpc load gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8694,6 +8694,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-network",
+ "sui-sdk",
  "sui-storage",
  "sui-types",
  "telemetry-subscribers 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8684,6 +8684,7 @@ dependencies = [
  "colored",
  "eyre",
  "futures",
+ "jsonrpsee",
  "mysten-network",
  "narwhal-executor",
  "rocksdb",

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -101,7 +101,7 @@ struct ServerInfo {
 
 impl RpcClient {
     pub async fn new(http: &str, ws: Option<&str>) -> Result<Self, anyhow::Error> {
-        let http = HttpClientBuilder::default().build(http)?;
+        let http = HttpClientBuilder::default().max_concurrent_requests(20000).build(http)?;
         let ws = if let Some(url) = ws {
             Some(WsClientBuilder::default().build(url).await?)
         } else {

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -101,7 +101,9 @@ struct ServerInfo {
 
 impl RpcClient {
     pub async fn new(http: &str, ws: Option<&str>) -> Result<Self, anyhow::Error> {
-        let http = HttpClientBuilder::default().max_concurrent_requests(20000).build(http)?;
+        let http = HttpClientBuilder::default()
+            .max_concurrent_requests(20000)
+            .build(http)?;
         let ws = if let Some(url) = ws {
             Some(WsClientBuilder::default().build(url).await?)
         } else {

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -26,6 +26,7 @@ sui-storage = { path = "../sui-storage" }
 strum_macros = "^0.24"
 strum = "0.24.1"
 serde = { version = "1.0.144", features = ["derive"] }
+jsonrpsee = { version = "0.15.1", features = ["full"] }
 eyre = "0.6.8"
 
 sui-core = { path = "../sui-core" }

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 eyre = "0.6.8"
 
 sui-core = { path = "../sui-core" }
+sui-sdk = { path = "../sui-sdk" }
 sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }
 sui-network = { path = "../sui-network" }


### PR DESCRIPTION
./sui-tool spam-fullnode-rpc --input-list ~/addresslist --url https://fullnode.staging.sui.io:443 --target-api get-objects-owned-by-address

[addresslist](https://gist.github.com/longbowlu/fa63b88af84aafef7245d4195152b1c8)

./sui-tool spam-fullnode-rpc --input-list ~/objlist --url https://fullnode.staging.sui.io:443 --target-api get-object

[objlist](https://gist.github.com/longbowlu/34e1d66aba0888dc2c53d015bc0e65cc)