### PR TITLE
update install doc

### DIFF
--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -58,7 +58,9 @@ Install the prerequisites and tools you need to work with Sui.
 Sui requires Rust and Cargo on all supported operating systems. 
 
 Use the following command to install Rust:
-`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+```shell
+$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
 
 For additional installation options, see [Install Rust](https://www.rust-lang.org/tools/install).
 
@@ -79,44 +81,53 @@ After you install Rust, proceed to the prerequisites for your operating system.
 
 ## Linux prerequisites 
 
-Install the prerequisites listed in this section. You should make sure that your system has the latest version of `apt`. Use the following command to update it:
-`sudo apt-get update`
+Take Ubuntu as an example, install the prerequisites listed in this section. You should make sure that your system has the latest version of `apt-get`. Use the following command to update it:
+
+```shell
+$ sudo apt-get update
+```
 
 ### cURL
 
 Install cURL with the following command:
-`sudo apt install curl`
+```shell
+$ sudo apt install curl
+```
 
 Verify that cURL installed correctly with the following command:
-`curl --version`
+```shell
+$ curl --version
+```
 
 ### Git CLI
 
 Run the following command to install Git, including the Git CLI:
 
-`sudo apt-get install git-all`
+```shell
+$ sudo apt-get install git-all
+```
 
-For more information, see [Install Git on Linux](https://github.com/git-guides/install-git#install-git-on-linux)
+For more information, see [Install Git on Linux](https://github.com/git-guides/install-git#install-git-on-linux).
 
 ### CMake
 
-Install CMake with the following commands:
-
-`./bootstrap`
-`make`
-`make install`
-
-For more information, see [Install CMake](https://cmake.org/install/)
+Install CMake, see [Install CMake](https://cmake.org/install/)
 
 ### libssl-dev
 
 use the following command to install `libssl-dev`:
-`sudo apt-get install libssl-dev`
+
+```shell
+$ sudo apt-get install libssl-dev
+```
 
 ### libclang-dev
 
 use the following command to install `libclang-dev`:
-`sudo apt-get install libclang-dev`
+
+```shell
+$ sudo apt-get install libclang-dev
+```
 
 Proceed to [Install Sui binaries](#binaries) to continue installing Sui.
 
@@ -135,17 +146,23 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 ### cURL
 
 Use the following command to install [cURL](https://curl.se):
-`brew install curl`
+```shell
+$ brew install curl
+```
 
 ### CMake
 
 Use the following command to install CMake:
-`brew install cmake`
+```shell
+$ brew install cmake
+```
 
 ### Git CLI
 
 Use the following command to install Git:
-`brew install git`
+```shell
+$ brew install git
+```
 
 You can also Download and install the [Git command line interface](https://git-scm.com/download/) for your operating system.
 


### PR DESCRIPTION
1. consolidate the command style - always use code block "```" for a command. Add `shell" to indicate shell command
2. remove the cmake commands for Linux because it's very confusing.
3. In the linux section, explicitly say that the commands for for ubuntu.