### PR TITLE
fix dump_bytecode_as_base64 which cause TS sdk e2e test failure

### DIFF
--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 
 use anyhow::anyhow;
@@ -158,9 +158,15 @@ impl Hex {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
 #[serde(try_from = "String")]
 pub struct Base64(String);
+
+impl Debug for Base64 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl TryFrom<String> for Base64 {
     type Error = anyhow::Error;

--- a/crates/sui-types/src/sui_serde.rs
+++ b/crates/sui-types/src/sui_serde.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use anyhow::anyhow;
@@ -158,15 +158,9 @@ impl Hex {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, JsonSchema)]
 #[serde(try_from = "String")]
 pub struct Base64(String);
-
-impl Debug for Base64 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 impl TryFrom<String> for Base64 {
     type Error = anyhow::Error;

--- a/crates/sui/src/sui_move/build.rs
+++ b/crates/sui/src/sui_move/build.rs
@@ -4,6 +4,7 @@
 use clap::Parser;
 use move_cli::base::{self, build};
 use move_package::BuildConfig as MoveBuildConfig;
+use serde_json::json;
 use std::path::{Path, PathBuf};
 use sui_framework_build::compiled_package::BuildConfig;
 
@@ -40,7 +41,7 @@ impl Build {
             },
         )?;
         if dump_bytecode_as_base64 {
-            println!("{:?}", pkg.get_package_base64())
+            println!("{}", json!(pkg.get_package_base64()))
         }
         Ok(())
     }


### PR DESCRIPTION
[recent commit](https://github.com/MystenLabs/sui/commit/9cdec4fec1895bb3cc9996fe842bf50c24753cf2) changed how we compile move package and it accidentally used Base64 object's debug print to print the base64 dump (which include extra `Base64()` parenthesis, this causes `sui move build --dump_bytecode_as_base64` to print out malformed byte code dump, and causing all test uses `sui move build` to fail.