### PR TITLE
validity check for Pay(All)Sui TransactionData

### DIFF
--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -63,6 +63,7 @@ pub async fn check_transaction_input<S, T>(
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
 {
+    transaction.signed_data.data.validity_check()?;
     transaction.signed_data.data.kind.validity_check()?;
     let gas_status = get_gas_status(store, transaction).await?;
     let input_objects = transaction.signed_data.data.input_objects()?;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -481,6 +481,9 @@ pub enum SuiError {
 
     #[error("Empty input coins for Pay related transaction")]
     EmptyInputCoins,
+
+    #[error("SUI payment transactions use first input coin for gas payment, but found a different gas object.")]
+    UnexpectedGasPaymentObject,
 }
 
 pub type SuiResult<T = ()> = Result<T, SuiError>;


### PR DESCRIPTION
For txn data constructed from Rust / TS SDK, this is not necessary, but if ppl construct TransactionData manually, this would have caused panic, thanks Patrick for flagging.