### PR TITLE
[Move] Expose causes for Move build errors

### DIFF
--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -47,11 +47,12 @@ impl BuildConfig {
             self.config.compile_package_no_exit(&path, &mut Vec::new())
         };
 
-        // write build failure diagnostics to stderr
+        // write build failure diagnostics to stderr, convert `error` to `String` using `Debug`
+        // format to include anyhow's error context chain.
         let package = match res {
             Err(error) => {
                 return Err(SuiError::ModuleBuildFailure {
-                    error: error.to_string(),
+                    error: format!("{:?}", error),
                 })
             }
             Ok(package) => package,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -232,7 +232,7 @@ pub enum SuiError {
     ModuleDeserializationFailure { error: String },
     #[error("Failed to publish the Move module(s), reason: {error:?}.")]
     ModulePublishFailure { error: String },
-    #[error("Failed to build Move modules: {error:?}.")]
+    #[error("Failed to build Move modules: {error}.")]
     ModuleBuildFailure { error: String },
     #[error("Dependent package not found on-chain: {package_id:?}")]
     DependentPackageNotFound { package_id: ObjectID },


### PR DESCRIPTION
The error type returned by the move compiler keeps track of the reasons why the build failed, but within the Sui Adapter, we were losing that context when converting the error to String and printing it:

```
Failed to build Move modules: "Unable to resolve packages for package 'Parent'"
```

This change re-exposes the causes by using `anyhow::Error`'s `Debug` format, so the output now looks like this:

```
Failed to build Move modules: Unable to resolve packages for package 'Parent'

Caused by:
    0: Unable to resolve named address 'child' inpackage 'Parent' when resolving dependencies
    1: Attempted to assign a different value '0x10' to an a already-assigned named address '0x0'.
```