### PR TITLE
Update local faucet path

### DIFF
--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -1,4 +1,4 @@
-"// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import axios from 'axios';

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -70,4 +70,3 @@ export async function createLocalnetTasks() {
         },
     };
 }
-"

--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+"// Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import axios from 'axios';
@@ -57,7 +57,7 @@ export async function createLocalnetTasks() {
             const address = keypair.getPublicKey().toSuiAddress();
             addressToKeypair.set(address, keypair);
             const res = await axios.post<{ error: any }>(
-                'http://127.0.0.1:9123/faucet',
+                'http://127.0.0.1:9123/gas',
                 { FixedAmountRequest: { recipient: address } }
             );
             if (res.data.error) {
@@ -70,3 +70,4 @@ export async function createLocalnetTasks() {
         },
     };
 }
+"

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -89,7 +89,7 @@ async fn start_faucet(cluster: &LocalNewCluster, port: u16) -> Result<()> {
 
     let app = Router::new()
         .route("/", get(health))
-        .route("/faucet", post(faucet_request))
+        .route("/gas", post(faucet_request))
         .layer(
             ServiceBuilder::new()
                 .layer(cors)

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../src';
 
 const DEFAULT_FAUCET_URL =
-  import.meta.env.VITE_FAUCET_URL ?? 'http://127.0.0.1:9123/faucet';
+  import.meta.env.VITE_FAUCET_URL ?? 'http://127.0.0.1:9123/gas';
 const DEFAULT_FULLNODE_URL =
   import.meta.env.VITE_FULLNODE_URL ?? 'http://127.0.0.1:9000';
 


### PR DESCRIPTION
This updates the localnet faucet path to use `/gas` to unify it with the deployed faucets. This should make `sui-test-validator` API-compatible with a deployed network.