### PR TITLE
[explorer] Support dynamic field names

### DIFF
--- a/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
@@ -18,7 +18,11 @@ export default function OwnedNFTView({ results }: { results: DataType }) {
                     </div>
                     <div className={styles.textitem}>
                         {entryObj.name && (
-                            <div className={styles.name}>{entryObj.name}</div>
+                            <div className={styles.name}>
+                                {typeof entryObj.name === 'string'
+                                    ? entryObj.name
+                                    : entryObj.name.fields.name}
+                            </div>
                         )}
                         <div>
                             <Longtext

--- a/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
@@ -18,11 +18,7 @@ export default function OwnedNFTView({ results }: { results: DataType }) {
                     </div>
                     <div className={styles.textitem}>
                         {entryObj.name && (
-                            <div className={styles.name}>
-                                {typeof entryObj.name === 'string'
-                                    ? entryObj.name
-                                    : entryObj.name.fields.name}
-                            </div>
+                            <div className={styles.name}>{entryObj.name}</div>
                         )}
                         <div>
                             <Longtext

--- a/apps/explorer/src/utils/objectUtils.ts
+++ b/apps/explorer/src/utils/objectUtils.ts
@@ -57,10 +57,17 @@ export const checkIsPropertyType = (value: any) =>
     ['number', 'string'].includes(typeof value);
 
 export const extractName = (
-    contents: object | undefined
+    contents: Record<string, any> | undefined
 ): string | undefined => {
-    if (!contents) return undefined;
-    return Object.entries(contents)
-        .filter(([key, _]) => key === 'name')
-        .map(([_, value]) => value)?.[0];
+    if (!contents || !('name' in contents)) return undefined;
+    const name = contents.name;
+
+    if (typeof name === 'string') {
+        return name;
+    }
+
+    // Dynamic fields
+    if (typeof name === 'object' && name?.fields?.name) {
+        return name?.fields?.name;
+    }
 };

--- a/apps/explorer/src/utils/objectUtils.ts
+++ b/apps/explorer/src/utils/objectUtils.ts
@@ -67,7 +67,7 @@ export const extractName = (
     }
 
     // Dynamic fields
-    if (typeof name === 'object' && name?.fields?.name) {
+    if (typeof name === 'object' && typeof name?.fields?.name === 'string') {
         return name?.fields?.name;
     }
 };


### PR DESCRIPTION
This updates the explorer to not break on non-string names, and directly support dynamic field names.