### PR TITLE
Skip transactions with shared object in gossip

### DIFF
--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -324,6 +324,11 @@ impl GossipDigestHandler {
         response: VerifiedTransactionInfoResponse,
     ) -> Result<(), SuiError> {
         if let Some(certificate) = response.certified_transaction {
+            // Ignore certificates containing shared object, because they will be received via
+            // consensus later.
+            if certificate.contains_shared_object() {
+                return Ok(());
+            }
             let digest = *certificate.digest();
             state
                 .add_pending_certificates(vec![(digest, Some(certificate))])


### PR DESCRIPTION
This would help rule out the issue that shared transactions are arriving via gossip, triggering execution driver inefficiencies. I'm not sure about the best way to test this.

The filtering is done at the receiving side, because what is included by the sender cannot be guaranteed. For efficiency, we can add filtering on the sender's side as well.