### PR TITLE
crypto: Use Base64 and Hex from fastcrypto instead of sui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,36 +1729,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
- "darling_core 0.14.1",
- "darling_macro 0.14.1",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "strsim 0.10.0",
- "syn 1.0.103",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1777,22 +1753,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote 1.0.21",
- "syn 1.0.103",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
- "darling_core 0.14.1",
+ "darling_core",
  "quote 1.0.21",
  "syn 1.0.103",
 ]
@@ -1903,7 +1868,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
@@ -2313,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d#7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=223ccb31da34823f6f7d940517872b37df08736a#223ccb31da34823f6f7d940517872b37df08736a"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2342,10 +2307,11 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "readonly",
+ "schemars",
  "secp256k1",
  "serde 1.0.147",
  "serde_bytes",
- "serde_with 2.0.1",
+ "serde_with",
  "sha2 0.10.6",
  "sha3 0.10.6",
  "signature",
@@ -2358,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.2"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d#7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=223ccb31da34823f6f7d940517872b37df08736a#223ccb31da34823f6f7d940517872b37df08736a"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -4607,7 +4573,7 @@ name = "msim-macros"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=b28d77f88434535b166cc60bd3e5018aa75cd705#b28d77f88434535b166cc60bd3e5018aa75cd705"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
@@ -4687,7 +4653,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/mysten-infra/?rev=2d031b1ba014b63a2680a1980d79fd808af3c3a0#2d031b1ba014b63a2680a1980d79fd808af3c3a0"
+source = "git+https://github.com/MystenLabs/mysten-infra/?rev=d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2#d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -4704,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-infra/?rev=2d031b1ba014b63a2680a1980d79fd808af3c3a0#2d031b1ba014b63a2680a1980d79fd808af3c3a0"
+source = "git+https://github.com/MystenLabs/mysten-infra/?rev=d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2#d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2"
 dependencies = [
  "proc-macro2 1.0.47",
  "syn 1.0.103",
@@ -4756,7 +4722,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.147",
  "serde_json",
- "serde_with 2.0.1",
+ "serde_with",
  "tempfile",
  "thiserror",
  "tracing",
@@ -4800,6 +4766,26 @@ name = "narwhal-crypto"
 version = "0.1.0"
 dependencies = [
  "fastcrypto",
+ "ark-bls12-377",
+ "bincode",
+ "criterion",
+ "eyre",
+ "fastcrypto",
+ "hex",
+ "hex-literal",
+ "merlin",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.8.5",
+ "readonly",
+ "serde 1.0.147",
+ "serde-reflection",
+ "serde_bytes",
+ "serde_json",
+ "serde_with",
+ "tokio",
+>>>>>>> 85b52e588 (crypto: Use Base64 and Hex from fastcrypto instead of sui)
  "workspace-hack",
 ]
 
@@ -5107,7 +5093,7 @@ dependencies = [
  "rustversion",
  "serde 1.0.147",
  "serde_test",
- "serde_with 2.0.1",
+ "serde_with",
  "signature",
  "thiserror",
  "tokio",
@@ -7250,17 +7236,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "hex",
- "serde 1.0.147",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
@@ -7271,20 +7246,8 @@ dependencies = [
  "indexmap",
  "serde 1.0.147",
  "serde_json",
- "serde_with_macros 2.0.1",
+ "serde_with_macros",
  "time 0.3.15",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.103",
 ]
 
 [[package]]
@@ -7293,7 +7256,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
@@ -7823,7 +7786,7 @@ dependencies = [
  "rustyline-derive",
  "serde 1.0.147",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "shell-words",
  "signature",
  "sui-config",
@@ -7906,7 +7869,7 @@ dependencies = [
  "rocksdb",
  "serde 1.0.147",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "strum",
  "strum_macros",
  "sui-config",
@@ -7937,6 +7900,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "clap 3.2.22",
+ "fastcrypto",
  "futures",
  "jsonrpsee",
  "move-core-types",
@@ -7987,7 +7951,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "serde 1.0.147",
- "serde_with 1.14.0",
+ "serde_with",
  "serde_yaml",
  "sha3 0.10.6",
  "sui-adapter",
@@ -8036,7 +8000,7 @@ dependencies = [
  "serde 1.0.147",
  "serde-reflection",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "serde_yaml",
  "signature",
  "sui-adapter",
@@ -8171,6 +8135,7 @@ name = "sui-framework-build"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "fastcrypto",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -8237,6 +8202,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "fastcrypto",
  "futures",
  "jsonrpsee",
  "jsonrpsee-core",
@@ -8270,6 +8236,7 @@ dependencies = [
  "bcs",
  "colored",
  "either",
+ "fastcrypto",
  "itertools",
  "move-binary-format",
  "move-bytecode-utils",
@@ -8277,7 +8244,7 @@ dependencies = [
  "schemars",
  "serde 1.0.147",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "sui-json",
  "sui-types",
  "tracing",
@@ -8365,6 +8332,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
+ "fastcrypto",
  "move-core-types",
  "pretty_assertions",
  "rand 0.8.5",
@@ -8411,7 +8379,7 @@ dependencies = [
  "rand 0.8.5",
  "serde 1.0.147",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "signature",
  "strum",
  "strum_macros",
@@ -8586,7 +8554,7 @@ dependencies = [
  "narwhal-executor",
  "rocksdb",
  "serde 1.0.147",
- "serde_with 1.14.0",
+ "serde_with",
  "strum",
  "strum_macros",
  "sui-config",
@@ -8649,7 +8617,6 @@ name = "sui-types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64ct",
  "bcs",
  "bincode",
  "byteorder",
@@ -8679,7 +8646,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "serde_with 1.14.0",
+ "serde_with",
  "sha2 0.9.9",
  "sha3 0.10.6",
  "signature",
@@ -8946,7 +8913,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "856bbca0314c328004691b9c0639fb198ca764d1ce0e20d4dd8b78f2697c2a6f"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "if_chain",
  "lazy_static 1.4.0",
  "proc-macro2 1.0.47",
@@ -10372,12 +10339,9 @@ dependencies = [
  "curve25519-dalek",
  "curve25519-dalek-fiat",
  "curve25519-dalek-ng",
- "darling 0.13.4",
- "darling 0.14.1",
- "darling_core 0.13.4",
- "darling_core 0.14.1",
- "darling_macro 0.13.4",
- "darling_macro 0.14.1",
+ "darling",
+ "darling_core",
+ "darling_macro",
  "dashmap",
  "data-encoding",
  "datatest-stable",
@@ -10807,10 +10771,8 @@ dependencies = [
  "serde_repr",
  "serde_test",
  "serde_urlencoded",
- "serde_with 1.14.0",
- "serde_with 2.0.1",
- "serde_with_macros 1.5.2",
- "serde_with_macros 2.0.1",
+ "serde_with",
+ "serde_with_macros",
  "serde_yaml",
  "sha-1 0.10.0",
  "sha-1 0.9.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,6 +2921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,7 +4771,6 @@ dependencies = [
 name = "narwhal-crypto"
 version = "0.1.0"
 dependencies = [
- "fastcrypto",
  "ark-bls12-377",
  "bincode",
  "criterion",
@@ -4785,8 +4790,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
->>>>>>> 85b52e588 (crypto: Use Base64 and Hex from fastcrypto instead of sui)
  "workspace-hack",
+ "zeroize",
 ]
 
 [[package]]
@@ -10450,6 +10455,7 @@ dependencies = [
  "heck 0.3.3",
  "heck 0.4.0",
  "hex",
+ "hex-literal",
  "hkdf",
  "hmac",
  "hmac-sha512",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ move-ir-types = { git = "https://github.com/move-language/move", rev = "1ffd0a3e
 move-prover = { git = "https://github.com/move-language/move", rev = "1ffd0a3e7bdc4bba7dafb8c814279e750113d030" }
 move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "1ffd0a3e7bdc4bba7dafb8c814279e750113d030" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "223ccb31da34823f6f7d940517872b37df08736a" }
 
 # anemo dependencies
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "f514987fa7f731058dd5a56e409e68600d84d909" }

--- a/crates/sui-benchmark/Cargo.toml
+++ b/crates/sui-benchmark/Cargo.toml
@@ -19,7 +19,7 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 num_cpus = "1.13.1"
 rocksdb = "0.19.0"
-serde_with = { version = "1.14.0", features = ["hex"] }
+serde_with = { version = "2.0.1", features = ["hex"] }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["time", "registry", "env-filter"] }
 telemetry-subscribers.workspace = true

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 bcs = "0.1.4"
 uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.2"
+fastcrypto = { workspace = true }
 
 sui-faucet = { path = "../sui-faucet" }
 sui-swarm = { path = "../sui-swarm" }

--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -3,8 +3,8 @@
 
 use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
+use fastcrypto::encoding::Base64;
 use jsonrpsee::rpc_params;
-use sui_types::sui_serde::Base64;
 use sui_types::{base_types::ObjectID, object::Owner};
 use test_utils::transaction::compile_basics_package;
 

--- a/crates/sui-config/Cargo.toml
+++ b/crates/sui-config/Cargo.toml
@@ -13,7 +13,7 @@ arc-swap = "1.5.1"
 camino = "1.1.1"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
 serde = { version = "1.0.144", features = ["derive", "rc"] }
-serde_with = "1.14.0"
+serde_with = "2.0.1"
 serde_yaml = "0.8.26"
 rand = "0.8.5"
 dirs = "4.0.0"

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -4,6 +4,7 @@
 use crate::ValidatorInfo;
 use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
+use fastcrypto::encoding::{Base64, Encoding};
 use move_binary_format::CompiledModule;
 use move_core_types::ident_str;
 use move_core_types::language_storage::ModuleId;
@@ -25,7 +26,6 @@ use sui_types::in_memory_storage::InMemoryStorage;
 use sui_types::messages::CallArg;
 use sui_types::messages::InputObjects;
 use sui_types::messages::Transaction;
-use sui_types::sui_serde::{Base64, Encoding};
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::temporary_store::{InnerTemporaryStore, TemporaryStore};
 use sui_types::MOVE_STDLIB_ADDRESS;

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3.23"
 bytes = "1.2.1"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.83"
-serde_with = "1.14.0"
+serde_with = "2.0.1"
 tokio = { version = "1.20.1", features = ["full", "tracing", "test-util"] }
 tokio-stream = { version = "0.1.8", features = ["sync", "net"] }
 parking_lot = "0.12.1"

--- a/crates/sui-framework-build/Cargo.toml
+++ b/crates/sui-framework-build/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }
+fastcrypto = { workspace = true }
 once_cell = "1.14.0"
 
 sui-types = { path = "../sui-types" }

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::HashSet, path::PathBuf};
 
+use fastcrypto::encoding::Base64;
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::{module_cache::GetModule, Modules};
 use move_compiler::compiled_unit::CompiledUnitEnum;
@@ -13,7 +14,6 @@ use move_package::{
 };
 use sui_types::{
     error::{SuiError, SuiResult},
-    sui_serde::Base64,
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::verifier as sui_bytecode_verifier;

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -9,10 +9,11 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.57"
 anyhow = "1.0.64"
+fastcrypto = { workspace = true }
 schemars = { version = "0.8.10", features = ["either"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.83"
-serde_with = { version = "1.14.0", features = ["hex"] }
+serde_with = { version = "2.0.1", features = ["hex"] }
 colored = "2.0.0"
 either = "1.7.0"
 itertools = "0.10.5"

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -29,6 +29,7 @@ use serde_json::Value;
 use serde_with::serde_as;
 use tracing::warn;
 
+use fastcrypto::encoding::{Base64, Encoding};
 use sui_json::SuiJsonValue;
 use sui_types::base_types::{
     ObjectDigest, ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
@@ -53,7 +54,6 @@ use sui_types::move_package::{disassemble_modules, MovePackage};
 use sui_types::object::{
     Data, MoveObject, Object, ObjectFormatOptions, ObjectRead, Owner, PastObjectRead,
 };
-use sui_types::sui_serde::{Base64, Encoding};
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag};
 
 #[cfg(test)]
@@ -2730,7 +2730,9 @@ impl TransactionBytes {
     }
 
     pub fn to_data(self) -> Result<TransactionData, anyhow::Error> {
-        TransactionData::from_signable_bytes(&self.tx_bytes.to_vec()?)
+        TransactionData::from_signable_bytes(
+            &self.tx_bytes.to_vec().map_err(|e| anyhow::anyhow!(e))?,
+        )
     }
 }
 

--- a/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
@@ -9,11 +9,11 @@ use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::{StructTag, TypeTag};
 use move_core_types::value::{MoveStruct, MoveValue};
 
+use fastcrypto::encoding::Base64;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::MoveObject;
-use sui_types::sui_serde::Base64;
 use sui_types::{MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
 
 use crate::{SuiMoveStruct, SuiMoveValue};

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+fastcrypto = { workspace = true }
 jsonrpsee = { version = "0.15.1", features = ["full"] }
 jsonrpsee-core = "0.15.1"
 jsonrpsee-proc-macros = "0.15.1"

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_proc_macros::rpc;
 
+use fastcrypto::encoding::Base64;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     GetObjectDataResponse, GetPastObjectDataResponse, GetRawObjectDataResponse,
@@ -23,7 +24,6 @@ use sui_types::messages::CommitteeInfoResponse;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
 use sui_types::query::{Ordering, TransactionQuery};
-use sui_types::sui_serde::Base64;
 
 /// Maximum number of events returned in an event query.
 /// This is equivalent to EVENT_STORE_QUERY_MAX_LIMIT in `sui-storage` crate.

--- a/crates/sui-json-rpc/src/estimator_api.rs
+++ b/crates/sui-json-rpc/src/estimator_api.rs
@@ -14,7 +14,7 @@ use sui_open_rpc::Module;
 use sui_types::crypto::SignableBytes;
 use sui_types::messages::TransactionData;
 
-use sui_types::sui_serde::Base64;
+use fastcrypto::encoding::Base64;
 
 pub struct EstimatorApi {
     pub state: Arc<AuthorityState>,
@@ -36,7 +36,9 @@ impl EstimatorApiServer for EstimatorApi {
         mutated_object_sizes_after: Option<usize>,
         storage_rebate: Option<u64>,
     ) -> RpcResult<SuiGasCostSummary> {
-        let data = TransactionData::from_signable_bytes(&tx_bytes.to_vec()?)?;
+        let data = TransactionData::from_signable_bytes(
+            &tx_bytes.to_vec().map_err(|e| anyhow::anyhow!(e))?,
+        )?;
 
         Ok(SuiGasCostSummary::from(
             estimate_transaction_computation_cost(

--- a/crates/sui-json-rpc/src/gateway_api.rs
+++ b/crates/sui-json-rpc/src/gateway_api.rs
@@ -7,6 +7,7 @@ use crate::api::{
 use crate::SuiRpcModule;
 use anyhow::anyhow;
 use async_trait::async_trait;
+use fastcrypto::encoding::Base64;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_core::server::rpc_module::RpcModule;
 use signature::Signature;
@@ -19,7 +20,6 @@ use sui_json_rpc_types::{
 use sui_open_rpc::Module;
 use sui_types::batch::TxSequenceNumber;
 use sui_types::crypto::SignatureScheme;
-use sui_types::sui_serde::Base64;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     crypto,
@@ -76,10 +76,16 @@ impl RpcGatewayApiServer for RpcGatewayImpl {
         signature: Base64,
         pub_key: Base64,
     ) -> RpcResult<SuiTransactionResponse> {
-        let data = TransactionData::from_signable_bytes(&tx_bytes.to_vec()?)?;
+        let data =
+            TransactionData::from_signable_bytes(&tx_bytes.to_vec().map_err(|e| anyhow!(e))?)?;
         let flag = vec![sig_scheme.flag()];
         let signature = crypto::Signature::from_bytes(
-            &[&*flag, &*signature.to_vec()?, &pub_key.to_vec()?].concat(),
+            &[
+                &*flag,
+                &*signature.to_vec().map_err(|e| anyhow!(e))?,
+                &pub_key.to_vec().map_err(|e| anyhow!(e))?,
+            ]
+            .concat(),
         )
         .map_err(|e| anyhow!(e))?;
         let result = self
@@ -257,7 +263,7 @@ impl RpcTransactionBuilderServer for TransactionBuilderImpl {
     ) -> RpcResult<TransactionBytes> {
         let compiled_modules = compiled_modules
             .into_iter()
-            .map(|data| data.to_vec())
+            .map(|data| data.to_vec().map_err(|e| anyhow!(e)))
             .collect::<Result<Vec<_>, _>>()?;
         let data = self
             .client

--- a/crates/sui-json-rpc/src/transaction_builder_api.rs
+++ b/crates/sui-json-rpc/src/transaction_builder_api.rs
@@ -14,7 +14,7 @@ use sui_transaction_builder::{DataReader, TransactionBuilder};
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::object::Owner;
 
-use sui_types::sui_serde::Base64;
+use fastcrypto::encoding::Base64;
 
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::RPCTransactionRequestParams;
@@ -150,7 +150,7 @@ impl RpcTransactionBuilderServer for FullNodeTransactionBuilderApi {
     ) -> RpcResult<TransactionBytes> {
         let compiled_modules = compiled_modules
             .into_iter()
-            .map(|data| data.to_vec())
+            .map(|data| data.to_vec().map_err(|e| anyhow::anyhow!(e)))
             .collect::<Result<Vec<_>, _>>()?;
         let data = self
             .builder

--- a/crates/sui-open-rpc/Cargo.toml
+++ b/crates/sui-open-rpc/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 clap = { version = "3.2.17", features = ["derive"] }
 pretty_assertions = "1.2.0"
 tokio = { version = "1.20.1", features = ["full"] }
-
+fastcrypto = { workspace = true }
 sui = { path = "../sui" }
 sui-core = { path = "../sui-core"}
 sui-json-rpc = { path = "../sui-json-rpc" }

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -10,6 +10,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use serde_json::json;
 
+use fastcrypto::encoding::Base64;
 use sui::client_commands::EXAMPLE_NFT_DESCRIPTION;
 use sui::client_commands::EXAMPLE_NFT_NAME;
 use sui::client_commands::EXAMPLE_NFT_URL;
@@ -36,7 +37,6 @@ use sui_types::messages::{
 use sui_types::object::Owner;
 use sui_types::query::Ordering;
 use sui_types::query::TransactionQuery;
-use sui_types::sui_serde::Base64;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 
 struct Examples {

--- a/crates/sui-rosetta/Cargo.toml
+++ b/crates/sui-rosetta/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 axum = "0.5.13"
 axum-core = "0.2.7"
-anyhow = { version = "1.0.58", features = ["backtrace"] }
+anyhow = { version = "1.0.64", features = ["backtrace"] }
 tracing = "0.1.36"
 serde = "1.0.143"
 serde_json = { version = "1.0.83", features = ["preserve_order"] }
@@ -17,7 +17,7 @@ tower = { version = "0.4.12", features = ["util", "timeout", "load-shed", "limit
 tower-http = { version = "0.3.4", features = ["cors"] }
 tokio = "1.20.1"
 once_cell = "1.13.1"
-serde_with = "1.14.0"
+serde_with = "2.0.1"
 signature = "1.6.0"
 bcs = "0.1.4"
 hyper = "0.14.20"

--- a/crates/sui-rosetta/src/network.rs
+++ b/crates/sui-rosetta/src/network.rs
@@ -7,8 +7,8 @@ use axum::{Extension, Json};
 use serde_json::json;
 use strum::IntoEnumIterator;
 
+use fastcrypto::encoding::Hex;
 use sui_types::base_types::ObjectID;
-use sui_types::sui_serde::Hex;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::SUI_SYSTEM_STATE_OBJECT_ID;
 

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -15,14 +15,13 @@ use serde_with::serde_as;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
 
+use fastcrypto::encoding::{Base64, Hex};
 use sui_types::base_types::{
     ObjectID, ObjectInfo, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
     TRANSACTION_DIGEST_LENGTH,
 };
 use sui_types::crypto::SignatureScheme;
 use sui_types::messages::ExecutionStatus;
-use sui_types::sui_serde::Base64;
-use sui_types::sui_serde::Hex;
 use sui_types::sui_serde::Readable;
 
 use crate::errors::Error;
@@ -361,7 +360,7 @@ impl TryInto<SuiAddress> for PublicKey {
     type Error = Error;
 
     fn try_into(self) -> Result<SuiAddress, Self::Error> {
-        let key_bytes = self.hex_bytes.to_vec()?;
+        let key_bytes = self.hex_bytes.to_vec().map_err(|e| anyhow::anyhow!(e))?;
         let pub_key =
             sui_types::crypto::PublicKey::try_from_bytes(self.curve_type.into(), &key_bytes)
                 .map_err(|e| Error::new_with_cause(ErrorType::ParsingError, e))?;

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -21,7 +21,7 @@ typed-store.workspace = true
 typed-store-derive.workspace = true
 tempfile = "3.3.0"
 narwhal-executor = { path = "../../narwhal/executor" }
-serde_with = { version = "1.14.0", features = ["hex"] }
+serde_with = { version = "2.0.1", features = ["hex"] }
 sui-storage = { path = "../sui-storage" }
 strum_macros = "^0.24"
 strum = "0.24.1"

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -23,12 +23,11 @@ tracing = "0.1"
 hex = "0.4.3"
 serde_bytes = "0.11.7"
 serde_json = "1.0.83"
-serde_with = "1.14.0"
+serde_with = "2.0.1"
 serde_repr = "0.1"
 signature = "1.6.0"
 static_assertions = "1.1.0"
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
-base64ct = { version = "1.5.2", features = ["std", "alloc"] }
 zeroize = "1.5.7"
 digest = "0.10.3"
 schemars ="0.8.10"

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -32,10 +32,9 @@ use crate::error::ExecutionError;
 use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
 use crate::object::{Object, Owner};
-use crate::sui_serde::Hex;
 use crate::sui_serde::Readable;
-use crate::sui_serde::{Base64, Encoding};
 use crate::waypoint::IntoPoint;
+use fastcrypto::encoding::{Base64, Encoding, Hex};
 
 #[cfg(test)]
 #[path = "unit_tests/base_types_tests.rs"]
@@ -981,7 +980,7 @@ impl FromStr for TransactionDigest {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut result = [0u8; TRANSACTION_DIGEST_LENGTH];
-        result.copy_from_slice(&Base64::decode(s)?);
+        result.copy_from_slice(&Base64::decode(s).map_err(|e| anyhow!(e))?);
         Ok(TransactionDigest(result))
     }
 }

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -33,7 +33,10 @@ use crate::base_types::{AuthorityName, SuiAddress};
 use crate::committee::{Committee, EpochId, StakeUnit};
 use crate::error::{SuiError, SuiResult};
 use crate::intent::{Intent, IntentMessage};
-use crate::sui_serde::{AggrAuthSignature, Base64, Encoding, Readable, SuiBitmap};
+use crate::sui_serde::{AggrAuthSignature, Readable, SuiBitmap};
+use fastcrypto::encoding::{Base64, Encoding};
+use std::fmt::Debug;
+
 pub use enum_dispatch::enum_dispatch;
 
 // Authority Objects

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -14,9 +14,9 @@ use crate::messages_checkpoint::{
 };
 use crate::object::{Object, ObjectFormatOptions, Owner, OBJECT_START_VERSION};
 use crate::storage::{DeleteKind, WriteKind};
-use crate::sui_serde::{Base64, Encoding};
 use crate::{SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION};
 use byteorder::{BigEndian, ReadBytesExt};
+use fastcrypto::encoding::{Base64, Encoding};
 use itertools::Either;
 use move_binary_format::access::ModuleAccess;
 use move_binary_format::file_format::LocalIndex;

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -13,7 +13,6 @@ use crate::crypto::{
     get_key_pair_from_bytes, AccountKeyPair, AuthorityKeyPair, AuthoritySignature,
     SuiAuthoritySignature, SuiSignature,
 };
-use crate::sui_serde::Encoding;
 use crate::{
     crypto::{get_key_pair, Signature},
     gas_coin::GasCoin,

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -14,7 +14,7 @@ signature = "1.6.0"
 camino = "1.1.1"
 tokio = { version = "1.20.1", features = ["full"] }
 async-trait = "0.1.57"
-serde_with = { version = "1.14.0", features = ["hex"] }
+serde_with = { version = "2.0.1", features = ["hex"] }
 tracing = "0.1.36"
 bcs = "0.1.4"
 clap = { version = "3.2.17", features = ["derive"] }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::anyhow;
 use bip32::{DerivationPath, Mnemonic};
 use clap::*;
+use fastcrypto::encoding::{Base64, Encoding};
 use fastcrypto::traits::{ToFromBytes, VerifyingKey};
 use signature::rand_core::OsRng;
 use sui_keys::key_derive::derive_key_pair_from_path;
@@ -20,8 +21,6 @@ use sui_types::crypto::{
     get_key_pair, AuthorityKeyPair, Ed25519SuiSignature, EncodeDecodeBase64, NetworkKeyPair,
     SignatureScheme, SuiKeyPair, SuiSignatureInner,
 };
-use sui_types::sui_serde::{Base64, Encoding};
-
 #[cfg(test)]
 #[path = "unit_tests/keytool_tests.rs"]
 mod keytool_tests;
@@ -230,7 +229,7 @@ pub fn read_network_keypair_from_file<P: AsRef<std::path::Path>>(
     path: P,
 ) -> anyhow::Result<NetworkKeyPair> {
     let value = std::fs::read_to_string(path)?;
-    let bytes = Base64::decode(value.as_str())?;
+    let bytes = Base64::decode(value.as_str()).map_err(|e| anyhow::anyhow!(e))?;
     if let Some(flag) = bytes.first() {
         if flag == &Ed25519SuiSignature::SCHEME.flag() {
             let sk = Ed25519PrivateKey::from_bytes(&bytes[1 + Ed25519PublicKey::LENGTH..])?;

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -53,7 +53,7 @@ backoff = { version = "0.4", features = ["futures", "futures-core", "pin-project
 backtrace = { version = "0.3", features = ["std"] }
 base16ct = { version = "0.1", default-features = false }
 base64 = { version = "0.13", features = ["alloc", "std"] }
-base64ct = { version = "1", default-features = false, features = ["alloc", "std"] }
+base64ct = { version = "1", default-features = false, features = ["alloc"] }
 bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde", "serde"] }
 better_any = { version = "0.1", default-features = false }
@@ -176,7 +176,7 @@ ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
 eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail = { version = "0.4", default-features = false }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d", features = ["copy_key", "secure"] }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "223ccb31da34823f6f7d940517872b37df08736a", features = ["copy_key", "secure"] }
 fastrand = { version = "1", default-features = false }
 fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
@@ -332,7 +332,7 @@ move-vm-types = { git = "https://github.com/move-language/move", rev = "1ffd0a3e
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 mysten-network = { version = "0.2", default-features = false }
-mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "2d031b1ba014b63a2680a1980d79fd808af3c3a0", features = ["estimate-heapsize", "hashbrown", "parking_lot", "smallvec", "std"] }
+mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2", features = ["estimate-heapsize", "hashbrown", "parking_lot", "smallvec", "std"] }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
 nexlint = { git = "https://github.com/nextest-rs/nexlint.git", rev = "5926141c20414814290bb1b04bd3b2238bbbc90e", default-features = false }
@@ -473,8 +473,7 @@ serde_cbor = { version = "0.11", features = ["std"] }
 serde_json = { version = "1", features = ["alloc", "indexmap", "preserve_order", "raw_value", "std", "unbounded_depth"] }
 serde_test = { version = "1", default-features = false }
 serde_urlencoded = { version = "0.7", default-features = false }
-serde_with-dff4ba8e3ae991db = { package = "serde_with", version = "1", features = ["hex", "macros", "serde_with_macros"] }
-serde_with-f595c2ba2a3f28df = { package = "serde_with", version = "2", features = ["alloc", "macros", "std"] }
+serde_with = { version = "2", features = ["alloc", "hex", "macros", "std"] }
 serde_yaml = { version = "0.8", default-features = false }
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10", features = ["std"] }
 sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features = false }
@@ -666,7 +665,7 @@ backoff = { version = "0.4", features = ["futures", "futures-core", "pin-project
 backtrace = { version = "0.3", features = ["std"] }
 base16ct = { version = "0.1", default-features = false }
 base64 = { version = "0.13", features = ["alloc", "std"] }
-base64ct = { version = "1", default-features = false, features = ["alloc", "std"] }
+base64ct = { version = "1", default-features = false, features = ["alloc"] }
 bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde", "serde"] }
 better_any = { version = "0.1", default-features = false }
@@ -758,12 +757,9 @@ ctr = { version = "0.9", default-features = false }
 curve25519-dalek = { version = "3", default-features = false, features = ["serde", "u64_backend"] }
 curve25519-dalek-fiat = { version = "0.1", default-features = false, features = ["alloc", "fiat-crypto", "fiat_u64_backend", "std"] }
 curve25519-dalek-ng = { version = "4", features = ["alloc", "serde", "std", "u64_backend"] }
-darling-594e8ee84c453af0 = { package = "darling", version = "0.13", features = ["suggestions"] }
-darling-582f2526e08bb6a0 = { package = "darling", version = "0.14", features = ["suggestions"] }
-darling_core-594e8ee84c453af0 = { package = "darling_core", version = "0.13", default-features = false, features = ["strsim", "suggestions"] }
-darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["strsim", "suggestions"] }
-darling_macro-594e8ee84c453af0 = { package = "darling_macro", version = "0.13", default-features = false }
-darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
+darling = { version = "0.14", features = ["suggestions"] }
+darling_core = { version = "0.14", default-features = false, features = ["strsim", "suggestions"] }
+darling_macro = { version = "0.14", default-features = false }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2", features = ["alloc", "std"] }
 datatest-stable = { version = "0.1", default-features = false }
@@ -809,8 +805,8 @@ ethnum = { version = "1", default-features = false }
 event-listener = { version = "2", default-features = false }
 eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
 fail = { version = "0.4", default-features = false }
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d", features = ["copy_key", "secure"] }
-fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "7766b1ef23f6bed6da9ff9e50dc2a0d1957d344d", default-features = false }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "223ccb31da34823f6f7d940517872b37df08736a", features = ["copy_key", "secure"] }
+fastcrypto-derive = { git = "https://github.com/MystenLabs/fastcrypto", rev = "223ccb31da34823f6f7d940517872b37df08736a", default-features = false }
 fastrand = { version = "1", default-features = false }
 fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
@@ -863,6 +859,7 @@ hdrhistogram = { version = "7", features = ["base64", "crossbeam-channel", "flat
 heck-468e82937335b1c9 = { package = "heck", version = "0.3", default-features = false }
 heck-9fbad63c4bcf4a8f = { package = "heck", version = "0.4", features = ["unicode", "unicode-segmentation"] }
 hex = { version = "0.4", features = ["alloc", "std"] }
+hex-literal = { version = "0.3", default-features = false }
 hkdf = { version = "0.12", default-features = false, features = ["std"] }
 hmac = { version = "0.12", default-features = false, features = ["reset", "std"] }
 hmac-sha512 = { version = "0.1", features = ["sha384"] }
@@ -980,8 +977,8 @@ multihash = { version = "0.16", default-features = false, features = ["alloc", "
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
 mysten-network = { version = "0.2", default-features = false }
-mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "2d031b1ba014b63a2680a1980d79fd808af3c3a0", features = ["estimate-heapsize", "hashbrown", "parking_lot", "smallvec", "std"] }
-mysten-util-mem-derive = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "2d031b1ba014b63a2680a1980d79fd808af3c3a0", default-features = false }
+mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2", features = ["estimate-heapsize", "hashbrown", "parking_lot", "smallvec", "std"] }
+mysten-util-mem-derive = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2", default-features = false }
 name-variant = { version = "0.1", default-features = false }
 named-lock = { version = "0.2", default-features = false }
 nested = { version = "0.1", default-features = false }
@@ -1156,10 +1153,8 @@ serde_json = { version = "1", features = ["alloc", "indexmap", "preserve_order",
 serde_repr = { version = "0.1", default-features = false }
 serde_test = { version = "1", default-features = false }
 serde_urlencoded = { version = "0.7", default-features = false }
-serde_with-dff4ba8e3ae991db = { package = "serde_with", version = "1", features = ["hex", "macros", "serde_with_macros"] }
-serde_with-f595c2ba2a3f28df = { package = "serde_with", version = "2", features = ["alloc", "macros", "std"] }
-serde_with_macros-dff4ba8e3ae991db = { package = "serde_with_macros", version = "1", default-features = false }
-serde_with_macros-f595c2ba2a3f28df = { package = "serde_with_macros", version = "2", default-features = false }
+serde_with = { version = "2", features = ["alloc", "hex", "macros", "std"] }
+serde_with_macros = { version = "2", default-features = false }
 serde_yaml = { version = "0.8", default-features = false }
 sha-1-93f6ce9d446188ac = { package = "sha-1", version = "0.10", features = ["std"] }
 sha-1-274715c4dabd11b0 = { package = "sha-1", version = "0.9", default-features = false }

--- a/narwhal/consensus/Cargo.toml
+++ b/narwhal/consensus/Cargo.toml
@@ -11,7 +11,7 @@ arc-swap = { version = "1.5.1", features = ["serde"] }
 bincode = "1.3.3"
 bytes = "1.2.1"
 match_opt = "0.1.2"
-mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "2d031b1ba014b63a2680a1980d79fd808af3c3a0" }
+mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2" }
 rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.144", features = ["derive"] }
 store.workspace = true

--- a/narwhal/crypto/Cargo.toml
+++ b/narwhal/crypto/Cargo.toml
@@ -9,3 +9,30 @@ publish = false
 [dependencies]
 fastcrypto.workspace = true
 workspace-hack.workspace = true
+ark-bls12-377 = { version = "0.3.0", features = ["std"], optional = true }
+eyre = "0.6.8"
+hex = "0.4.3"
+rand = { version = "0.8.5", features = ["std"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_bytes = "0.11.7"
+serde_with = "2.0.1"
+tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
+zeroize = "1.5.7"
+merlin = "3.0.0"
+once_cell = "1.14.0"
+readonly = "0.2.2"
+
+fastcrypto = { workspace = true, features = ["copy_key"] }
+
+workspace-hack.workspace = true
+
+[features]
+default = []
+[dev-dependencies]
+bincode = "1.3.3"
+criterion = "0.3.6"
+hex-literal = "0.3.4"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"
+serde_json = "1.0.85"
+serde-reflection = "0.3.6"

--- a/narwhal/crypto/Cargo.toml
+++ b/narwhal/crypto/Cargo.toml
@@ -22,10 +22,6 @@ merlin = "3.0.0"
 once_cell = "1.14.0"
 readonly = "0.2.2"
 
-fastcrypto = { workspace = true, features = ["copy_key"] }
-
-workspace-hack.workspace = true
-
 [features]
 default = []
 [dev-dependencies]

--- a/narwhal/types/Cargo.toml
+++ b/narwhal/types/Cargo.toml
@@ -16,7 +16,7 @@ derive_builder = "0.11.2"
 futures = "0.3.24"
 indexmap = { version = "1.9.1", features = ["serde"] }
 mockall = "0.11.2"
-mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "2d031b1ba014b63a2680a1980d79fd808af3c3a0" }
+mysten-util-mem = { git = "https://github.com/MystenLabs/mysten-infra/", rev = "d69adb7aa133b6306aea4ddfe3df5fbb5daa9cb2" }
 prometheus = "0.13.2"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"


### PR DESCRIPTION
unfortunately this PR has some trivial changes on map_err from eyre::Report to anyhow. There is an issue here that we want to prefer eyre over anyhow to get backtrace for free, https://github.com/MystenLabs/sui/issues/3895 it is a bit tedious and invasive, that I decide to leave it for a follow up PR after this. 