### PR TITLE
wallet-ext: keep service worker alive in bg for longer

### DIFF
--- a/apps/wallet/src/background/connections/Connection.ts
+++ b/apps/wallet/src/background/connections/Connection.ts
@@ -18,7 +18,7 @@ export abstract class Connection {
 
     public get onDisconnect() {
         return this._portStream.onDisconnect.pipe(
-            map((port) => ({ port, connection: this })),
+            map((port) => ({ port })),
             take(1)
         );
     }

--- a/apps/wallet/src/background/connections/KeepAliveConnection.ts
+++ b/apps/wallet/src/background/connections/KeepAliveConnection.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BehaviorSubject, filter, map, take } from 'rxjs';
+
+import Keyring from '_src/background/Keyring';
+import { MSG_DISABLE_AUTO_RECONNECT } from '_src/content-script/keep-bg-alive';
+
+import type { Runtime } from 'webextension-polyfill';
+
+const MIN_DISCONNECT_TIMEOUT = 1000 * 30;
+const MAX_DISCONNECT_TIMEOUT = 1000 * 60 * 3;
+
+export class KeepAliveConnection {
+    private onDisconnectSubject = new BehaviorSubject<Runtime.Port | null>(
+        null
+    );
+    private autoDisconnectTimeout: number | null = null;
+
+    constructor(private port: Runtime.Port) {
+        Keyring.on('lockedStatusUpdate', this.onKeyringLockedStatusUpdate);
+        this.port.onDisconnect.addListener(this.onPortDisconnected);
+        this.onKeyringLockedStatusUpdate(Keyring.isLocked);
+    }
+
+    public get onDisconnect() {
+        return this.onDisconnectSubject.asObservable().pipe(
+            filter((aPort) => !!aPort),
+            map((port) => ({
+                port,
+            })),
+            take(1)
+        );
+    }
+
+    private getRandomDisconnectTimeout() {
+        return Math.floor(
+            Math.random() *
+                (MAX_DISCONNECT_TIMEOUT - MIN_DISCONNECT_TIMEOUT + 1) +
+                MIN_DISCONNECT_TIMEOUT
+        );
+    }
+
+    private onPortDisconnected = (aPort: Runtime.Port) => {
+        this.clearAutoDisconnectTimeout();
+        Keyring.off('lockedStatusUpdate', this.onKeyringLockedStatusUpdate);
+        this.onDisconnectSubject.next(aPort);
+    };
+
+    private onKeyringLockedStatusUpdate = (isLocked: boolean) => {
+        if (isLocked) {
+            this.forcePortDisconnect(false);
+        } else {
+            this.autoDisconnectTimeout = setTimeout(() => {
+                this.forcePortDisconnect(true);
+                this.autoDisconnectTimeout = null;
+            }, this.getRandomDisconnectTimeout()) as unknown as number;
+        }
+    };
+
+    private clearAutoDisconnectTimeout() {
+        if (this.autoDisconnectTimeout) {
+            clearTimeout(this.autoDisconnectTimeout);
+            this.autoDisconnectTimeout = null;
+        }
+    }
+
+    private forcePortDisconnect(allowReconnect: boolean) {
+        if (!allowReconnect) {
+            try {
+                this.port.postMessage(MSG_DISABLE_AUTO_RECONNECT);
+            } catch (e) {
+                // in case port is already closed
+            }
+        }
+        this.port.disconnect();
+        // calling disconnect triggers onDisconnect only on the other side of the port
+        // so we are calling it ourselves to clean-up
+        this.onPortDisconnected(this.port);
+    }
+}

--- a/apps/wallet/src/background/connections/index.ts
+++ b/apps/wallet/src/background/connections/index.ts
@@ -4,24 +4,29 @@
 import Browser from 'webextension-polyfill';
 
 import { ContentScriptConnection } from './ContentScriptConnection';
+import { KeepAliveConnection } from './KeepAliveConnection';
 import { UiConnection } from './UiConnection';
+import { KEEP_ALIVE_BG_PORT_NAME } from '_src/content-script/keep-bg-alive';
 
 import type { Connection } from './Connection';
 import type { Permission } from '_payloads/permissions';
 
 export class Connections {
-    #connections: Connection[] = [];
+    #connections: (Connection | KeepAliveConnection)[] = [];
 
     constructor() {
         Browser.runtime.onConnect.addListener((port) => {
             try {
-                let connection: Connection;
+                let connection: Connection | KeepAliveConnection;
                 switch (port.name) {
                     case ContentScriptConnection.CHANNEL:
                         connection = new ContentScriptConnection(port);
                         break;
                     case UiConnection.CHANNEL:
                         connection = new UiConnection(port);
+                        break;
+                    case KEEP_ALIVE_BG_PORT_NAME:
+                        connection = new KeepAliveConnection(port);
                         break;
                     default:
                         throw new Error(

--- a/apps/wallet/src/content-script/index.ts
+++ b/apps/wallet/src/content-script/index.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { injectDappInterface } from './interface-inject';
+import { init as keepAliveInit } from './keep-bg-alive';
 import { setupMessagesProxy } from './messages-proxy';
 
 injectDappInterface();
 setupMessagesProxy();
+keepAliveInit();

--- a/apps/wallet/src/content-script/keep-bg-alive.ts
+++ b/apps/wallet/src/content-script/keep-bg-alive.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import Browser from 'webextension-polyfill';
+
+import type { Runtime } from 'webextension-polyfill';
+
+export const KEEP_ALIVE_BG_PORT_NAME = 'content-script<->background-script';
+export const MSG_CONNECT = 'connect';
+export const MSG_DISABLE_AUTO_RECONNECT = 'disable-auto-reconnect';
+
+let bgPort: Runtime.Port | null = null;
+let autoReConnect = true;
+
+function doConnect() {
+    if (autoReConnect) {
+        try {
+            bgPort = Browser.runtime.connect({ name: KEEP_ALIVE_BG_PORT_NAME });
+        } catch (e) {
+            // usually fails when extension gets updated and context is invalidated
+        }
+    }
+    if (bgPort) {
+        bgPort.onMessage.addListener((msg) => {
+            if (msg === MSG_DISABLE_AUTO_RECONNECT) {
+                autoReConnect = false;
+            }
+        });
+        bgPort.onDisconnect.addListener(() => {
+            bgPort = null;
+            doConnect();
+        });
+    }
+}
+
+export function init() {
+    Browser.runtime.onMessage.addListener((msg) => {
+        if (msg === MSG_CONNECT) {
+            autoReConnect = true;
+            if (!bgPort) {
+                doConnect();
+            }
+        }
+    });
+    doConnect();
+}


### PR DESCRIPTION
* this is used to keep the bg service alive for longer when the wallet is unlocked
* every cs connects to bg and while the wallet is unlocked randomly disconnects each connection in a range of 30 to 180 seconds (from the time of the connection) and automatically reconnects the cs
* when wallet is locked disconnect all ports and stop reconnecting to allow bg to suspend
* this is a temporary solution to improve the wallet locking experience
* this only improves the locking only when there are tab open with the cs loaded

closes: APPS-69