### PR TITLE
[checkpoint] Support slicing large fragment into chunks

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@ fail-fast = false
 # Retry failing tests in order to not block builds on flaky tests
 retries = 5
 # Timeout tests after 4 minutes
-slow-timeout = { period = "60s", terminate-after = 4 }
+#slow-timeout = { period = "60s", terminate-after = 4 }
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@ fail-fast = false
 # Retry failing tests in order to not block builds on flaky tests
 retries = 5
 # Timeout tests after 4 minutes
-#slow-timeout = { period = "60s", terminate-after = 4 }
+slow-timeout = { period = "60s", terminate-after = 4 }
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2252,7 +2252,7 @@ impl AuthorityState {
                     })?;
             }
             ConsensusTransactionKind::Checkpoint(fragment) => {
-                fragment.verify_signatures(&committee).map_err(|err| {
+                fragment.verify().map_err(|err| {
                     warn!(
                         "Ignoring malformed fragment (failed to verify) from {}: {:?}",
                         transaction.consensus_output.certificate.header.author, err

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -58,8 +58,8 @@ use sui_storage::{
 use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair};
 use sui_types::messages_checkpoint::{
-    AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointRequest, CheckpointRequestType,
-    CheckpointResponse, CheckpointSequenceNumber, VerifiedCheckpointFragment,
+    AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointFragmentMessage,
+    CheckpointRequest, CheckpointRequestType, CheckpointResponse, CheckpointSequenceNumber,
 };
 use sui_types::object::{Owner, PastObjectRead};
 use sui_types::query::TransactionQuery;
@@ -2227,7 +2227,6 @@ impl AuthorityState {
             .metrics
             .verify_narwhal_transaction_duration_mcs
             .utilization_timer();
-        let committee = self.committee.load();
         match &transaction.transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
                 if self
@@ -2316,24 +2315,33 @@ impl AuthorityState {
                 Ok(())
             }
             ConsensusTransactionKind::Checkpoint(fragment) => {
-                // Safe because signatures are verified when VerifiedSequencedConsensusTransaction
-                // is constructed.
-                let fragment = VerifiedCheckpointFragment::new_unchecked(*fragment);
-
-                let cp_seq = fragment.proposer_sequence_number();
-                debug!(
-                    ?consensus_index,
-                    ?cp_seq,
-                    "handle_consensus_transaction Checkpoint. Proposer: {}, Other: {}",
-                    fragment.proposer.authority(),
-                    fragment.other.authority(),
-                );
+                match &fragment.message {
+                    CheckpointFragmentMessage::Header(header) => {
+                        debug!(
+                            ?consensus_index,
+                            cp_seq=?header.proposer.summary.sequence_number,
+                            proposer=?header.proposer.authority().concise(),
+                            other=?header.other.authority().concise(),
+                            chunk_count=?header.chunk_count,
+                            "handle_consensus_transaction Checkpoint header message",
+                        );
+                    }
+                    CheckpointFragmentMessage::Chunk(chunk) => {
+                        debug!(
+                            ?consensus_index,
+                            cp_seq=?chunk.sequence_number,
+                            proposer=?chunk.proposer.concise(),
+                            other=?chunk.other.concise(),
+                            chunk_id=?chunk.chunk_id,
+                            "handle_consensus_transaction Checkpoint chunk message",
+                        );
+                    }
+                }
 
                 let mut checkpoint = self.checkpoints.lock();
                 checkpoint.handle_internal_fragment(
                     consensus_index.index,
-                    fragment,
-                    self,
+                    fragment.message,
                     &self.committee.load(),
                 )?;
 

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -953,14 +953,14 @@ where
 {
     let mut diff_certs: BTreeMap<ExecutionDigests, CertifiedTransaction> = BTreeMap::new();
     debug!(
-        our_size = fragment.diff.second.items.len(),
-        other_size = fragment.diff.first.items.len(),
+        our_size = fragment.data.diff.second.items.len(),
+        other_size = fragment.data.diff.first.items.len(),
         "Augmenting fragment with diff transactions"
     );
 
     // These are the transactions that we have that the other validator does not
     // have, so we can read them from our local database.
-    for tx_digest in &fragment.diff.second.items {
+    for tx_digest in &fragment.data.diff.second.items {
         let cert = active_authority
             .state
             .read_certificate(&tx_digest.transaction)
@@ -978,6 +978,7 @@ where
         .database
         .multi_get_certified_transaction(
             &fragment
+                .data
                 .diff
                 .first
                 .items
@@ -986,6 +987,7 @@ where
                 .collect::<Vec<_>>(),
         )?;
     let (existing, missing): (Vec<_>, Vec<_>) = fragment
+        .data
         .diff
         .first
         .items
@@ -1031,7 +1033,7 @@ where
     }
 
     // Augment the fragment in place.
-    fragment.certs = diff_certs;
+    fragment.data.certs = diff_certs;
 
     Ok(fragment)
 }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -917,10 +917,10 @@ where
                 {
                     Ok(fragment) => {
                         // On success send the fragment to consensus
-                        if let Err(err) = checkpoint_db.lock().submit_local_fragment_to_consensus(
-                            &fragment,
-                            &active_authority.state.committee.load(),
-                        ) {
+                        if let Err(err) = checkpoint_db
+                            .lock()
+                            .submit_local_fragment_to_consensus(&fragment)
+                        {
                             warn!("Error submitting local fragment to consensus: {err:?}");
                         }
                     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -28,7 +28,7 @@ use sui_types::{
     messages_checkpoint::{
         AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents, CheckpointDigest,
         CheckpointFragment, CheckpointResponse, CheckpointSequenceNumber, CheckpointSummary,
-        SignedCheckpointSummary, VerifiedCheckpointFragment,
+        SignedCheckpointSummary,
     },
 };
 use tap::TapFallible;
@@ -555,10 +555,11 @@ impl CheckpointStore {
     pub fn submit_local_fragment_to_consensus(
         &mut self,
         fragment: &CheckpointFragment,
-        committee: &Committee,
     ) -> SuiResult {
-        // Check structure is correct and signatures verify
-        fragment.verify_signatures(committee)?;
+        fp_ensure!(
+            &self.name == fragment.proposer.authority(),
+            SuiError::from("Fragment can only be submitted by the proposer")
+        );
 
         // Does the fragment event suggest it is for the current round?
         let next_checkpoint_seq = self.next_checkpoint();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::{path::Path, sync::Arc};
 use sui_storage::default_db_options;
-use sui_types::messages_checkpoint::{CheckpointProposal, CheckpointProposalContents};
+use sui_types::messages_checkpoint::{
+    CheckpointFragmentMessage, CheckpointProposal, CheckpointProposalContents,
+    SignedCheckpointFragmentMessage,
+};
 use sui_types::{
     base_types::{AuthorityName, ExecutionDigests},
     batch::TxSequenceNumber,
@@ -40,12 +43,9 @@ use typed_store::{
 };
 use typed_store_derive::DBMapUtils;
 
+use crate::authority::StableSyncAuthoritySigner;
 use crate::checkpoints::causal_order_effects::{CausalOrder, EffectsStore};
 use crate::checkpoints::reconstruction::SpanGraph;
-use crate::{
-    authority::StableSyncAuthoritySigner,
-    authority_active::execution_driver::PendCertificateForExecution,
-};
 
 pub type DBLabel = usize;
 const LOCALS: DBLabel = 0;
@@ -103,7 +103,7 @@ pub struct CheckpointLocals {
 /// from real consensus.
 pub trait ConsensusSender: Send + Sync + 'static {
     // Send an item to the consensus
-    fn send_to_consensus(&self, fragment: CheckpointFragment) -> Result<(), SuiError>;
+    fn send_to_consensus(&self, fragment: SignedCheckpointFragmentMessage) -> Result<(), SuiError>;
 }
 
 /// DBMap tables for checkpoints
@@ -142,7 +142,7 @@ pub struct CheckpointStoreTables {
     /// to allow us to provide a list in order they were received. We only store
     /// the fragments that are relevant to the next checkpoints. Past checkpoints
     /// already contain all relevant information from previous checkpoints.
-    pub fragments: DBMap<ExecutionIndices, VerifiedCheckpointFragment>,
+    pub fragments: DBMap<ExecutionIndices, CheckpointFragmentMessage>,
 
     /// A single entry table to store locals.
     #[default_options_override_fn = "locals_table_default_config"]
@@ -188,21 +188,19 @@ impl CheckpointStoreTables {
             let next_checkpoint_fragments: Vec<_> = self
                 .fragments
                 .values()
-                .filter(|frag| {
-                    frag.proposer.summary.sequence_number == in_construction_checkpoint + 1
-                })
+                .filter(|frag| frag.proposer_sequence_number() == in_construction_checkpoint + 1)
                 .collect();
-            locals.in_construction_checkpoint = SpanGraph::mew(
+            locals.in_construction_checkpoint = SpanGraph::new(
                 committee,
                 in_construction_checkpoint + 1,
-                &next_checkpoint_fragments,
+                next_checkpoint_fragments,
             );
             locals.in_construction_checkpoint_seq += 1;
             batch = batch.delete_batch(
                 &self.fragments,
                 self.fragments.iter().filter_map(|(k, v)| {
                     // Delete all keys for checkpoints smaller than what we are committing now.
-                    if v.proposer.summary.sequence_number <= in_construction_checkpoint {
+                    if v.proposer_sequence_number() <= in_construction_checkpoint {
                         Some(k)
                     } else {
                         None
@@ -603,9 +601,18 @@ impl CheckpointStore {
 
         // Send to consensus for sequencing.
         if let Some(sender) = &self.sender {
+            let messages = fragment.to_signed_message_chunks(&*self.secret);
             let seq = fragment.proposer.summary.sequence_number;
-            debug!(cp_seq=?seq, "Sending fragment: {} -- {}", self.name, other_name);
-            sender.send_to_consensus(fragment.clone())?;
+            debug!(
+                cp_seq=?seq,
+                proposer=?self.name.concise(),
+                other=?other_name.concise(),
+                message_count=?messages.len(),
+                "Sending fragment to consensus"
+            );
+            for message in messages {
+                sender.send_to_consensus(message)?;
+            }
             debug!(cp_seq=?seq, "Fragment successfully sent: {} -- {}", self.name, other_name);
         } else {
             return Err(SuiError::from("No consensus sender configured"));
@@ -618,14 +625,29 @@ impl CheckpointStore {
         Ok(())
     }
 
+    /// For testing purpose only, split a fragment into chunks and call handle_internal_fragment
+    /// for each of them.
+    pub fn handle_fragment_for_testing(
+        &mut self,
+        seq: &mut ExecutionIndices,
+        fragment: CheckpointFragment,
+        committee: &Committee,
+    ) -> SuiResult {
+        let chunks = fragment.to_signed_message_chunks(&*self.secret);
+        for chunk in chunks {
+            self.handle_internal_fragment(seq.clone(), chunk.message, committee)?;
+            seq.next_transaction_index += 1;
+        }
+        Ok(())
+    }
+
     /// This function should be called by the consensus output, it is idempotent,
     /// and if called again with the same sequence number will do nothing. However,
     /// fragments should be provided in seq increasing order.
     pub fn handle_internal_fragment(
         &mut self,
         seq: ExecutionIndices,
-        fragment: VerifiedCheckpointFragment,
-        handle_pending_cert: impl PendCertificateForExecution,
+        fragment: CheckpointFragmentMessage,
         committee: &Committee,
     ) -> SuiResult {
         // Ensure we have not already processed this fragment.
@@ -636,37 +658,15 @@ impl CheckpointStore {
             }
         }
 
-        // Schedule for execution all the certificates that are included here.
-        // TODO: We should not schedule a cert if it has already been executed.
-        handle_pending_cert.add_pending_certificates(
-            fragment
-                .certs()
-                .map(|(digest, cert)| (digest.transaction, Some(cert)))
-                .collect(),
-        )?;
-
         // Save the new fragment in the DB
         self.tables.fragments.insert(&seq, &fragment)?;
-
-        // If the fragment contains us also save it in the list of local fragments
-        let fragment_seq = fragment.proposer.summary.sequence_number;
-        if fragment.proposer.authority() == &self.name {
-            self.tables
-                .local_fragments
-                .insert(&(fragment_seq, *fragment.other.authority()), &fragment)?;
-        }
-        if fragment.other.authority() == &self.name {
-            self.tables
-                .local_fragments
-                .insert(&(fragment_seq, *fragment.proposer.authority()), &fragment)?;
-        }
 
         let locals = self.get_locals();
         let mut new_locals = locals.as_ref().clone();
         new_locals.in_construction_checkpoint.add_fragment_to_span(
             committee,
             new_locals.in_construction_checkpoint_seq,
-            &fragment,
+            fragment,
         );
         self.tables
             .advance_checkpoint_construction_state(&mut new_locals, committee)?;

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -784,9 +784,9 @@ impl CheckpointStore {
 
             // Extract the diff
             let diff = if fragment.proposer.authority() == &self.name {
-                fragment.diff
+                fragment.data.diff
             } else {
-                fragment.diff.swap()
+                fragment.data.diff.swap()
             };
 
             if let Ok(contents) = reconstructed.global.checkpoint_items(

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -213,9 +213,9 @@ impl SpanGraph {
             let mut extra_transactions = BTreeMap::new();
             let mut active_links = span.active_links.clone();
             while let Some(link) = active_links.pop_front() {
-                match global.insert(link.diff.clone()) {
+                match global.insert(link.data.diff.clone()) {
                     Ok(_) | Err(WaypointError::NothingToDo) => {
-                        extra_transactions.extend(link.certs.clone());
+                        extra_transactions.extend(link.data.certs.clone());
                     }
                     Err(WaypointError::CannotConnect) => {
                         // Reinsert the fragment at the end

--- a/crates/sui-core/src/checkpoints/reconstruction.rs
+++ b/crates/sui-core/src/checkpoints/reconstruction.rs
@@ -9,15 +9,14 @@ use sui_types::base_types::ExecutionDigests;
 use sui_types::committee::StakeUnit;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages_checkpoint::{
-    CheckpointFragmentMessage, CheckpointProposalSummary, CheckpointSequenceNumber,
-    PartialCheckpointFragment,
+    CheckpointFragment, CheckpointFragmentMessage, CheckpointProposalSummary,
+    CheckpointSequenceNumber, PartialCheckpointFragment,
 };
 use sui_types::{
     base_types::AuthorityName,
     committee::Committee,
     fp_ensure,
     messages::CertifiedTransaction,
-    messages_checkpoint::VerifiedCheckpointFragment,
     waypoint::{GlobalCheckpoint, WaypointError},
 };
 
@@ -54,7 +53,7 @@ pub struct InProgressSpanGraph {
     next_checkpoint: CheckpointSequenceNumber,
 
     /// Fragments that have been used so far.
-    fragments_used: Vec<VerifiedCheckpointFragment>,
+    fragments_used: Vec<CheckpointFragment>,
 
     /// Proposals from each validator seen so far. This is needed to detect potential conflicting
     /// fragments.
@@ -160,7 +159,7 @@ impl InProgressSpanGraph {
 
 #[derive(Clone, Debug)]
 pub struct CompletedSpanGraph {
-    active_links: VecDeque<VerifiedCheckpointFragment>,
+    active_links: VecDeque<CheckpointFragment>,
 }
 
 impl SpanGraph {

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -345,18 +345,18 @@ async fn make_diffs() {
     let diff23 = p2.fragment_with(&p3);
 
     let mut global = GlobalCheckpoint::<AuthorityName, ExecutionDigests>::new();
-    global.insert(diff12.diff.clone()).unwrap();
-    global.insert(diff23.diff).unwrap();
+    global.insert(diff12.data.diff.clone()).unwrap();
+    global.insert(diff23.data.diff).unwrap();
 
     // P4 proposal not selected
     let diff41 = p4.fragment_with(&p1);
     let all_items4 = global
-        .checkpoint_items(&diff41.diff, p4.transactions().cloned().collect())
+        .checkpoint_items(&diff41.data.diff, p4.transactions().cloned().collect())
         .unwrap();
 
     // P1 proposal selected
     let all_items1 = global
-        .checkpoint_items(&diff12.diff, p1.transactions().cloned().collect())
+        .checkpoint_items(&diff12.data.diff, p1.transactions().cloned().collect())
         .unwrap();
 
     // All get the same set for the proposal
@@ -1188,7 +1188,7 @@ async fn set_fragment_external() {
         let mut certificate =
             CertifiedTransaction::new_with_auth_sign_infos(tx, sigs, &committee).unwrap();
         certificate.auth_sign_info.epoch = committee.epoch();
-        fragment12.certs.insert(digest, certificate);
+        fragment12.data.certs.insert(digest, certificate);
     }
     // let fragment13 = p1.diff_with(&p3);
 

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::test_utils::create_fake_cert_and_effect_digest;
 use crate::{
     authority::{AuthorityState, AuthorityStore},
-    authority_active::execution_driver::PendCertificateForExecutionNoop,
     authority_aggregator::{
         authority_aggregator_tests::transfer_coin_transaction, AuthorityAggregator,
     },
@@ -15,6 +15,7 @@ use crate::{
 };
 use rand::prelude::StdRng;
 use rand::SeedableRng;
+use std::collections::BTreeMap;
 use std::{collections::HashSet, env, fs, path::PathBuf, sync::Arc, time::Duration};
 use sui_types::{
     base_types::{AuthorityName, ObjectID},
@@ -1209,29 +1210,27 @@ async fn set_fragment_external() {
 #[tokio::test]
 async fn set_fragment_reconstruct() {
     telemetry_subscribers::init_for_testing();
-    let (committee, _keys, mut test_objects) = random_ckpoint_store();
-    let (_, mut cps1) = test_objects.pop().unwrap();
-    let (_, mut cps2) = test_objects.pop().unwrap();
-    let (_, mut cps3) = test_objects.pop().unwrap();
-    let (_, mut cps4) = test_objects.pop().unwrap();
 
-    let t1 = ExecutionDigests::random();
-    let t2 = ExecutionDigests::random();
-    let t3 = ExecutionDigests::random();
-    let t4 = ExecutionDigests::random();
-    let t5 = ExecutionDigests::random();
-    // let t6 = TransactionDigest::random();
+    let (committee, _keys, mut cp_stores) = random_ckpoint_store();
 
-    cps1.update_processed_transactions(&[(1, t2), (2, t3)])
+    let txs = create_random_tx_certs(cp_stores.iter(), &committee, 5);
+    let digests: Vec<_> = txs.keys().collect();
+
+    let (_, mut cps1) = cp_stores.pop().unwrap();
+    let (_, mut cps2) = cp_stores.pop().unwrap();
+    let (_, mut cps3) = cp_stores.pop().unwrap();
+    let (_, mut cps4) = cp_stores.pop().unwrap();
+
+    cps1.update_processed_transactions(&[(1, *digests[1]), (2, *digests[2])])
         .unwrap();
 
-    cps2.update_processed_transactions(&[(1, t1), (2, t2)])
+    cps2.update_processed_transactions(&[(1, *digests[1]), (2, *digests[2])])
         .unwrap();
 
-    cps3.update_processed_transactions(&[(1, t3), (2, t4)])
+    cps3.update_processed_transactions(&[(1, *digests[2]), (2, *digests[3])])
         .unwrap();
 
-    cps4.update_processed_transactions(&[(1, t4), (2, t5)])
+    cps4.update_processed_transactions(&[(1, *digests[3]), (2, *digests[4])])
         .unwrap();
 
     let p1 = cps1.set_proposal(committee.epoch).unwrap();
@@ -1239,34 +1238,32 @@ async fn set_fragment_reconstruct() {
     let p3 = cps3.set_proposal(committee.epoch).unwrap();
     let p4 = cps4.set_proposal(committee.epoch).unwrap();
 
-    // We use new_unchecked because the fragments don't have the actual certs, so verification is
-    // guaranteed to fail.
-    let fragment12 = VerifiedCheckpointFragment::new_unchecked(p1.fragment_with(&p2));
-    let fragment34 = VerifiedCheckpointFragment::new_unchecked(p3.fragment_with(&p4));
+    let fragment12 = make_fragment(&p1, &p2, &txs);
+    let fragment34 = make_fragment(&p3, &p4, &txs);
 
-    let span = SpanGraph::mew(&committee, 0, &[fragment12.clone(), fragment34.clone()]);
+    let span =
+        SpanGraph::new_for_testing(&committee, 0, vec![fragment12.clone(), fragment34.clone()]);
     assert!(!span.is_completed());
 
-    let fragment41 = VerifiedCheckpointFragment::new_unchecked(p4.fragment_with(&p1));
-    let span = SpanGraph::mew(&committee, 0, &[fragment12, fragment34, fragment41]);
+    let fragment41 = make_fragment(&p4, &p1, &txs);
+    let span = SpanGraph::new_for_testing(&committee, 0, vec![fragment12, fragment34, fragment41]);
     let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 4);
 }
 
 #[tokio::test]
 async fn set_fragment_reconstruct_two_components() {
-    let (committee, _keys, mut test_objects) = random_ckpoint_store_num(2 * 3 + 1);
+    let (committee, _keys, mut cp_stores) = random_ckpoint_store_num(2 * 3 + 1);
 
-    let t2 = ExecutionDigests::random();
-    let t3 = ExecutionDigests::random();
-    // let t6 = TransactionDigest::random();
+    let txs = create_random_tx_certs(cp_stores.iter(), &committee, 2);
+    let digests: Vec<_> = txs.keys().collect();
 
-    for (_, cps) in &mut test_objects {
-        cps.update_processed_transactions(&[(1, t2), (2, t3)])
+    for (_, cps) in &mut cp_stores {
+        cps.update_processed_transactions(&[(1, *digests[0]), (2, *digests[1])])
             .unwrap();
     }
 
-    let mut proposals: Vec<_> = test_objects
+    let mut proposals: Vec<_> = cp_stores
         .iter_mut()
         .map(|(_, cps)| cps.set_proposal(committee.epoch).unwrap())
         .collect();
@@ -1275,9 +1272,9 @@ async fn set_fragment_reconstruct_two_components() {
     let p_x = proposals.pop().unwrap();
     let p_y = proposals.pop().unwrap();
 
-    let fragment_xy = p_x.fragment_with(&p_y).verify(&committee).unwrap();
+    let fragment_xy = make_fragment(&p_x, &p_y, &txs);
 
-    let span = SpanGraph::mew(&committee, 0, &[fragment_xy.clone()]);
+    let span = SpanGraph::new_for_testing(&committee, 0, vec![fragment_xy.clone()]);
     assert!(!span.is_completed());
 
     // Make a daisy chain of the other proposals
@@ -1285,10 +1282,7 @@ async fn set_fragment_reconstruct_two_components() {
 
     while let Some(proposal) = proposals.pop() {
         if !proposals.is_empty() {
-            let fragment_xy = proposal
-                .fragment_with(&proposals[0])
-                .verify(&committee)
-                .unwrap();
+            let fragment_xy = make_fragment(&proposal, &proposals[0], &txs);
             fragments.push(fragment_xy);
         }
 
@@ -1296,12 +1290,12 @@ async fn set_fragment_reconstruct_two_components() {
             break;
         }
 
-        let span = SpanGraph::mew(&committee, 0, &fragments);
+        let span = SpanGraph::new_for_testing(&committee, 0, fragments.clone());
         // Incomplete until we have the full 5 others
         assert!(!span.is_completed());
     }
 
-    let span = SpanGraph::mew(&committee, 0, &fragments);
+    let span = SpanGraph::new_for_testing(&committee, 0, fragments);
 
     let reconstruction = span.construct_checkpoint().unwrap();
     assert_eq!(reconstruction.global.authority_waypoints.len(), 5);
@@ -1309,17 +1303,17 @@ async fn set_fragment_reconstruct_two_components() {
 
 #[tokio::test]
 async fn set_fragment_reconstruct_two_mutual() {
-    let (committee, _, mut test_objects) = random_ckpoint_store_num(4);
+    let (committee, _, mut test_stores) = random_ckpoint_store_num(4);
 
-    let t2 = ExecutionDigests::random();
-    let t3 = ExecutionDigests::random();
+    let txs = create_random_tx_certs(test_stores.iter(), &committee, 2);
+    let digests: Vec<_> = txs.keys().collect();
 
-    for (_, cps) in &mut test_objects {
-        cps.update_processed_transactions(&[(1, t2), (2, t3)])
+    for (_, cps) in &mut test_stores {
+        cps.update_processed_transactions(&[(1, *digests[0]), (2, *digests[1])])
             .unwrap();
     }
 
-    let mut proposals: Vec<_> = test_objects
+    let mut proposals: Vec<_> = test_stores
         .iter_mut()
         .map(|(_, cps)| cps.set_proposal(committee.epoch).unwrap())
         .collect();
@@ -1328,20 +1322,20 @@ async fn set_fragment_reconstruct_two_mutual() {
     let p_x = proposals.pop().unwrap();
     let p_y = proposals.pop().unwrap();
 
-    let fragment_xy = p_x.fragment_with(&p_y).verify(&committee).unwrap();
-    let fragment_yx = p_y.fragment_with(&p_x).verify(&committee).unwrap();
+    let fragment_xy = make_fragment(&p_x, &p_y, &txs);
+    let fragment_yx = make_fragment(&p_y, &p_x, &txs);
 
-    let span = SpanGraph::mew(&committee, 0, &[fragment_xy, fragment_yx]);
+    let span = SpanGraph::new_for_testing(&committee, 0, vec![fragment_xy, fragment_yx]);
     assert!(!span.is_completed());
 }
 
 #[derive(Clone)]
 struct TestConsensus {
-    sender: Arc<std::sync::Mutex<std::sync::mpsc::Sender<CheckpointFragment>>>,
+    sender: Arc<std::sync::Mutex<std::sync::mpsc::Sender<SignedCheckpointFragmentMessage>>>,
 }
 
 impl ConsensusSender for TestConsensus {
-    fn send_to_consensus(&self, fragment: CheckpointFragment) -> Result<(), SuiError> {
+    fn send_to_consensus(&self, fragment: SignedCheckpointFragmentMessage) -> Result<(), SuiError> {
         self.sender
             .lock()
             .expect("Locking failed")
@@ -1352,7 +1346,10 @@ impl ConsensusSender for TestConsensus {
 }
 
 impl TestConsensus {
-    pub fn new() -> (TestConsensus, std::sync::mpsc::Receiver<CheckpointFragment>) {
+    pub fn new() -> (
+        TestConsensus,
+        std::sync::mpsc::Receiver<SignedCheckpointFragmentMessage>,
+    ) {
         let (tx, rx) = std::sync::mpsc::channel();
         (
             TestConsensus {
@@ -1365,22 +1362,21 @@ impl TestConsensus {
 
 #[tokio::test]
 async fn test_fragment_full_flow() {
-    let (committee, _keys, mut test_objects) = random_ckpoint_store_num(2 * 3 + 1);
+    let (committee, _keys, mut test_stores) = random_ckpoint_store_num(2 * 3 + 1);
 
     let (test_tx, rx) = TestConsensus::new();
 
-    let t2 = ExecutionDigests::random();
-    let t3 = ExecutionDigests::random();
-    // let t6 = TransactionDigest::random();
+    let txs = create_random_tx_certs(test_stores.iter(), &committee, 2);
+    let digests: Vec<_> = txs.keys().collect();
 
-    for (_, cps) in &mut test_objects {
+    for (_, cps) in &mut test_stores {
         cps.set_consensus(Box::new(test_tx.clone()))
             .expect("No issues setting the consensus");
-        cps.update_processed_transactions(&[(1, t2), (2, t3)])
+        cps.update_processed_transactions(&[(1, *digests[0]), (2, *digests[1])])
             .unwrap();
     }
 
-    let mut proposals: Vec<_> = test_objects
+    let mut proposals: Vec<_> = test_stores
         .iter_mut()
         .map(|(_, cps)| cps.set_proposal(committee.epoch).unwrap())
         .collect();
@@ -1389,13 +1385,13 @@ async fn test_fragment_full_flow() {
     let p_x = proposals.pop().unwrap();
     let p_y = proposals.pop().unwrap();
 
-    let fragment_xy = p_x.fragment_with(&p_y);
+    let fragment_xy = make_fragment(&p_x, &p_y, &txs);
 
     // TEST 1 -- submitting a fragment not involving a validator gets rejected by the
     //           validator.
 
     // Validator 3 is not validator 5 or 6
-    assert!(test_objects[3]
+    assert!(test_stores[3]
         .1
         .submit_local_fragment_to_consensus(&fragment_xy, &committee)
         .is_err());
@@ -1403,25 +1399,25 @@ async fn test_fragment_full_flow() {
     assert!(rx.try_recv().is_err());
 
     // But accept it on both the 5 and 6
-    assert!(test_objects[5]
+    assert!(test_stores[5]
         .1
         .submit_local_fragment_to_consensus(&fragment_xy, &committee)
         .is_ok());
-    assert!(test_objects[6]
+    assert!(test_stores[6]
         .1
         .submit_local_fragment_to_consensus(&fragment_xy, &committee)
         .is_ok());
 
     // Check we registered one local fragment
-    assert_eq!(test_objects[5].1.tables.local_fragments.iter().count(), 1);
+    assert_eq!(test_stores[5].1.tables.local_fragments.iter().count(), 1);
 
     // Make a daisy chain of the other proposals
     let mut fragments = vec![fragment_xy];
 
     while let Some(proposal) = proposals.pop() {
         if !proposals.is_empty() {
-            let fragment_xy = proposal.fragment_with(&proposals[proposals.len() - 1]);
-            assert!(test_objects[proposals.len() - 1]
+            let fragment_xy = make_fragment(&proposal, &proposals[proposals.len() - 1], &txs);
+            assert!(test_stores[proposals.len() - 1]
                 .1
                 .submit_local_fragment_to_consensus(&fragment_xy, &committee)
                 .is_ok());
@@ -1436,18 +1432,13 @@ async fn test_fragment_full_flow() {
     // TEST 2 -- submit fragments to all validators, and construct checkpoint.
 
     let mut seq = ExecutionIndices::default();
-    let cps0 = &mut test_objects[0].1;
+    let cps0 = &mut test_stores[0].1;
     let mut all_fragments = Vec::new();
     while let Ok(fragment) = rx.try_recv() {
         let fragment = fragment.verify(&committee).unwrap();
         all_fragments.push(fragment.clone());
         assert!(cps0
-            .handle_internal_fragment(
-                seq.clone(),
-                fragment,
-                PendCertificateForExecutionNoop,
-                &committee
-            )
+            .handle_internal_fragment(seq.clone(), fragment.message, &committee)
             .is_ok());
         seq.next_transaction_index += 1;
     }
@@ -1456,7 +1447,8 @@ async fn test_fragment_full_flow() {
         .unwrap();
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
-    assert_eq!(seq.next_transaction_index, 6);
+    // Each fragment is then split to two messages.
+    assert_eq!(seq.next_transaction_index, 6 * 2);
     // We don't update next checkpoint yet until we get a cert.
     assert_eq!(cps0.next_checkpoint(), 0);
 
@@ -1474,19 +1466,14 @@ async fn test_fragment_full_flow() {
     // sequence of fragments.
 
     let mut seq = ExecutionIndices::default();
-    let cps6 = &mut test_objects[6].1;
+    let cps6 = &mut test_stores[6].1;
     for fragment in &all_fragments {
-        let _ = cps6.handle_internal_fragment(
-            seq.clone(),
-            fragment.clone(),
-            PendCertificateForExecutionNoop,
-            &committee,
-        );
-        seq.next_transaction_index += 100;
+        let _ = cps6.handle_internal_fragment(seq.clone(), fragment.message.clone(), &committee);
+        seq.next_transaction_index += 1;
     }
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
-    assert_eq!(cps6.tables.fragments.iter().count(), 6);
+    assert_eq!(cps6.tables.fragments.iter().count(), 6 * 2);
     // Cannot advance to next checkpoint
     assert!(cps6.latest_stored_checkpoint().is_none());
     // But recording of fragments is closed
@@ -1495,17 +1482,12 @@ async fn test_fragment_full_flow() {
     // and no more fragments are recorded.
 
     for fragment in &all_fragments {
-        let _ = cps6.handle_internal_fragment(
-            seq.clone(),
-            fragment.clone(),
-            PendCertificateForExecutionNoop,
-            &committee,
-        );
-        seq.next_transaction_index += 100;
+        let _ = cps6.handle_internal_fragment(seq.clone(), fragment.message.clone(), &committee);
+        seq.next_transaction_index += 1;
     }
 
     // Two fragments for 5-6, and then 0-1, 1-2, 2-3, 3-4
-    assert_eq!(cps6.tables.fragments.iter().count(), 12);
+    assert_eq!(cps6.tables.fragments.iter().count(), 12 * 2);
     // Cannot advance to next checkpoint
     assert_eq!(cps6.next_checkpoint(), 0);
     // But recording of fragments is closed
@@ -1524,22 +1506,10 @@ async fn test_slow_fragment() {
         VerifiedCheckpointFragment::new_unchecked(proposals[2].fragment_with(&proposals[3]));
     let mut index = ExecutionIndices::default();
     cp_stores.iter_mut().for_each(|(_, cp)| {
-        cp.handle_internal_fragment(
-            index.clone(),
-            fragment12.clone(),
-            PendCertificateForExecutionNoop,
-            &committee,
-        )
-        .unwrap();
-        index.next_transaction_index += 1;
-        cp.handle_internal_fragment(
-            index.clone(),
-            fragment23.clone(),
-            PendCertificateForExecutionNoop,
-            &committee,
-        )
-        .unwrap();
-        index.next_transaction_index += 1;
+        cp.handle_fragment_for_testing(&mut index, fragment12.clone(), &committee)
+            .unwrap();
+        cp.handle_fragment_for_testing(&mut index, fragment23.clone(), &committee)
+            .unwrap();
         assert!(cp.memory_locals.in_construction_checkpoint.is_completed());
     });
     // Missing link on validator 0, even though the span graph is complete.
@@ -1588,22 +1558,10 @@ async fn test_slow_fragment() {
     let fragment23 =
         VerifiedCheckpointFragment::new_unchecked(proposals[2].fragment_with(&proposals[3]));
     cp_stores.iter_mut().skip(1).for_each(|(_, cp)| {
-        cp.handle_internal_fragment(
-            index.clone(),
-            fragment12.clone(),
-            PendCertificateForExecutionNoop,
-            &committee,
-        )
-        .unwrap();
-        index.next_transaction_index += 1;
-        cp.handle_internal_fragment(
-            index.clone(),
-            fragment23.clone(),
-            PendCertificateForExecutionNoop,
-            &committee,
-        )
-        .unwrap();
-        index.next_transaction_index += 1;
+        cp.handle_fragment_for_testing(&mut index, fragment12.clone(), &committee)
+            .unwrap();
+        cp.handle_fragment_for_testing(&mut index, fragment23.clone(), &committee)
+            .unwrap();
         assert!(cp.memory_locals.in_construction_checkpoint.is_completed());
     });
     // Validator 0 is still at checkpoint 0, and haven't received any fragments for checkpoint 1.
@@ -1661,24 +1619,12 @@ async fn test_slow_fragment() {
     );
     cp_stores[0]
         .1
-        .handle_internal_fragment(
-            index.clone(),
-            fragment12,
-            PendCertificateForExecutionNoop,
-            &committee,
-        )
+        .handle_fragment_for_testing(&mut index, fragment12, &committee)
         .unwrap();
-    index.next_transaction_index += 1;
     cp_stores[0]
         .1
-        .handle_internal_fragment(
-            index.clone(),
-            fragment23,
-            PendCertificateForExecutionNoop,
-            &committee,
-        )
+        .handle_fragment_for_testing(&mut index, fragment23, &committee)
         .unwrap();
-    index.next_transaction_index += 1;
     // Validator 0 should have automatically advanced to be constructing checkpoint 2.
     assert_eq!(
         cp_stores[0].1.memory_locals.in_construction_checkpoint_seq,
@@ -1693,11 +1639,12 @@ async fn test_slow_fragment() {
 
 #[derive(Clone)]
 struct AsyncTestConsensus {
-    sender: Arc<std::sync::Mutex<tokio::sync::mpsc::UnboundedSender<CheckpointFragment>>>,
+    sender:
+        Arc<std::sync::Mutex<tokio::sync::mpsc::UnboundedSender<SignedCheckpointFragmentMessage>>>,
 }
 
 impl ConsensusSender for AsyncTestConsensus {
-    fn send_to_consensus(&self, fragment: CheckpointFragment) -> Result<(), SuiError> {
+    fn send_to_consensus(&self, fragment: SignedCheckpointFragmentMessage) -> Result<(), SuiError> {
         self.sender
             .lock()
             .expect("Locking failed")
@@ -1711,7 +1658,7 @@ impl ConsensusSender for AsyncTestConsensus {
 impl AsyncTestConsensus {
     pub fn new() -> (
         AsyncTestConsensus,
-        tokio::sync::mpsc::UnboundedReceiver<CheckpointFragment>,
+        tokio::sync::mpsc::UnboundedReceiver<SignedCheckpointFragmentMessage>,
     ) {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         (
@@ -1836,27 +1783,22 @@ pub async fn checkpoint_tests_setup(
     let _join = tokio::task::spawn(async move {
         let mut seq = ExecutionIndices::default();
         while let Some(msg) = _rx.recv().await {
-            let msg = msg.verify(&c).unwrap();
-            for (authority, cps) in &checkpoint_stores {
+            for (_, cps) in &checkpoint_stores {
                 if notify_noop {
-                    if let Err(err) = cps.lock().handle_internal_fragment(
-                        seq.clone(),
-                        msg.clone(),
-                        PendCertificateForExecutionNoop,
-                        &c,
-                    ) {
+                    if let Err(err) =
+                        cps.lock()
+                            .handle_internal_fragment(seq.clone(), msg.message.clone(), &c)
+                    {
                         println!("Error: {:?}", err);
                     }
-                } else if let Err(err) = cps.lock().handle_internal_fragment(
-                    seq.clone(),
-                    msg.clone(),
-                    authority.as_ref(),
-                    &c,
-                ) {
+                } else if let Err(err) =
+                    cps.lock()
+                        .handle_internal_fragment(seq.clone(), msg.message.clone(), &c)
+                {
                     println!("Error: {:?}", err);
                 }
+                seq.next_transaction_index += 1;
             }
-            seq.next_transaction_index += 100;
         }
         println!("CHANNEL EXIT.");
     });
@@ -2167,4 +2109,41 @@ async fn test_no_more_fragments() {
         .lock()
         .attempt_to_construct_checkpoint()
         .is_ok());
+}
+
+fn create_random_tx_certs<'a>(
+    cp_stores: impl Iterator<Item = &'a (PathBuf, CheckpointStore)> + Clone,
+    committee: &Committee,
+    count: u64,
+) -> BTreeMap<ExecutionDigests, CertifiedTransaction> {
+    let signers = cp_stores.map(|(_, cps)| (&cps.name, &*cps.secret));
+    (0..count)
+        .map(|_| create_fake_cert_and_effect_digest(signers.clone(), committee))
+        .collect()
+}
+
+fn make_fragment(
+    proposal1: &CheckpointProposal,
+    proposal2: &CheckpointProposal,
+    txs: &BTreeMap<ExecutionDigests, CertifiedTransaction>,
+) -> CheckpointFragment {
+    let mut fragment = proposal1.fragment_with(proposal2);
+    let certs = fragment
+        .data
+        .diff
+        .first
+        .items
+        .iter()
+        .map(|digest| (*digest, txs.get(digest).unwrap().clone()))
+        .chain(
+            fragment
+                .data
+                .diff
+                .second
+                .items
+                .iter()
+                .map(|digest| (*digest, txs.get(digest).unwrap().clone())),
+        );
+    fragment.data.certs.extend(certs);
+    fragment
 }

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -23,8 +23,8 @@ use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     hash::{Hash, Hasher},
 };
-use sui_types::messages_checkpoint::CheckpointFragment;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::messages_checkpoint::SignedCheckpointFragmentMessage;
 use sui_types::{
     error::{SuiError, SuiResult},
     messages::{ConsensusTransaction, VerifiedCertificate},
@@ -451,11 +451,11 @@ impl ConsensusListener {
 
 /// Send checkpoint fragments through consensus.
 pub struct CheckpointSender {
-    tx_checkpoint_consensus_adapter: Sender<CheckpointFragment>,
+    tx_checkpoint_consensus_adapter: Sender<SignedCheckpointFragmentMessage>,
 }
 
 impl CheckpointSender {
-    pub fn new(tx_checkpoint_consensus_adapter: Sender<CheckpointFragment>) -> Self {
+    pub fn new(tx_checkpoint_consensus_adapter: Sender<SignedCheckpointFragmentMessage>) -> Self {
         Self {
             tx_checkpoint_consensus_adapter,
         }
@@ -463,9 +463,9 @@ impl CheckpointSender {
 }
 
 impl ConsensusSender for CheckpointSender {
-    fn send_to_consensus(&self, fragment: CheckpointFragment) -> SuiResult {
+    fn send_to_consensus(&self, fragment_messages: SignedCheckpointFragmentMessage) -> SuiResult {
         self.tx_checkpoint_consensus_adapter
-            .try_send(fragment)
+            .try_send(fragment_messages)
             .map_err(|e| SuiError::from(&e.to_string()[..]))
     }
 }
@@ -481,7 +481,7 @@ pub struct CheckpointConsensusAdapter {
     /// Channel to request to be notified when a given consensus transaction is sequenced.
     tx_consensus_listener: Sender<ConsensusListenerMessage>,
     /// Receive new checkpoint fragments to sequence.
-    rx_checkpoint_consensus_adapter: Receiver<CheckpointFragment>,
+    rx_checkpoint_consensus_adapter: Receiver<SignedCheckpointFragmentMessage>,
     /// A pointer to the checkpoints local store.
     checkpoint_db: Arc<Mutex<CheckpointStore>>,
     /// The initial delay to wait before re-attempting a connection with consensus (in ms).
@@ -500,7 +500,7 @@ impl CheckpointConsensusAdapter {
     pub fn new(
         consensus_address: Multiaddr,
         tx_consensus_listener: Sender<ConsensusListenerMessage>,
-        rx_checkpoint_consensus_adapter: Receiver<CheckpointFragment>,
+        rx_checkpoint_consensus_adapter: Receiver<SignedCheckpointFragmentMessage>,
         checkpoint_db: Arc<Mutex<CheckpointStore>>,
         retry_delay: Duration,
         max_pending_transactions: usize,
@@ -613,7 +613,7 @@ impl CheckpointConsensusAdapter {
             tokio::select! {
                 // Listen to new checkpoint fragments.
                 Some(fragment) = self.rx_checkpoint_consensus_adapter.recv() => {
-                    let sequence_number = *fragment.proposer_sequence_number();
+                    let sequence_number = fragment.message.proposer_sequence_number();
 
                     // Cleanup the buffer.
                     if self.buffer.len() >= self.max_pending_transactions {
@@ -625,9 +625,7 @@ impl CheckpointConsensusAdapter {
                     }
 
                     // Add the fragment to the buffer.
-                    let cp_seq = *fragment.proposer_sequence_number();
-                    let proposer = fragment.proposer.auth_signature.authority;
-                    let other = fragment.other.auth_signature.authority;
+                    let (cp_seq, proposer, other) = fragment.message.message_key();
                     let transaction = ConsensusTransaction::new_checkpoint_message(fragment);
                     let tracking_id = transaction.get_tracking_id();
                     let serialized = bincode::serialize(&transaction).expect("Serialize consensus transaction cannot fail");

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -14,7 +14,6 @@ use sui_types::crypto::AuthoritySignInfo;
 use sui_types::messages::CertifiedTransaction;
 use sui_types::messages_checkpoint::{
     AuthenticatedCheckpoint, CertifiedCheckpointSummary, CheckpointContents,
-    VerifiedCheckpointFragment,
 };
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -258,10 +257,8 @@ async fn test_consensus_pause_after_last_fragment() {
             state.checkpoints.lock().set_proposal(0).unwrap()
         })
         .collect();
-    let fragment01 =
-        VerifiedCheckpointFragment::new_unchecked(proposals[0].fragment_with(&proposals[1]));
-    let fragment12 =
-        VerifiedCheckpointFragment::new_unchecked(proposals[1].fragment_with(&proposals[2]));
+    let fragment01 = proposals[0].fragment_with(&proposals[1]);
+    let fragment12 = proposals[1].fragment_with(&proposals[2]);
     let mut index = ExecutionIndices::default();
     states.iter().for_each(|state| {
         // Send the first fragment to every validator, and make sure ater this, none of them

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -26,7 +26,6 @@ use sui_types::{
 };
 
 use crate::authority::AuthorityState;
-use crate::authority_active::execution_driver::PendCertificateForExecutionNoop;
 use crate::checkpoints::causal_order_effects::TestEffectsStore;
 use crate::checkpoints::reconstruction::SpanGraph;
 use crate::{
@@ -63,10 +62,10 @@ async fn test_start_epoch_change() {
             next_transaction_sequence: 0,
             current_proposal: None,
             in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH,
-            in_construction_checkpoint: SpanGraph::mew(
+            in_construction_checkpoint: SpanGraph::new(
                 &genesis_committee,
                 CHECKPOINT_COUNT_PER_EPOCH,
-                &[],
+                vec![],
             ),
         })
         .unwrap();
@@ -169,10 +168,10 @@ async fn test_finish_epoch_change() {
                     next_transaction_sequence: 0,
                     current_proposal: None,
                     in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH,
-                    in_construction_checkpoint: SpanGraph::mew(
+                    in_construction_checkpoint: SpanGraph::new(
                         &genesis_committee,
                         CHECKPOINT_COUNT_PER_EPOCH,
-                        &[],
+                        vec![],
                     ),
                 };
                 state
@@ -241,10 +240,10 @@ async fn test_consensus_pause_after_last_fragment() {
                 next_transaction_sequence: 0,
                 current_proposal: None,
                 in_construction_checkpoint_seq: CHECKPOINT_COUNT_PER_EPOCH - 1,
-                in_construction_checkpoint: SpanGraph::mew(
+                in_construction_checkpoint: SpanGraph::new(
                     &genesis_committee,
                     CHECKPOINT_COUNT_PER_EPOCH - 1,
-                    &[],
+                    vec![],
                 ),
             };
             state
@@ -268,14 +267,8 @@ async fn test_consensus_pause_after_last_fragment() {
         // Send the first fragment to every validator, and make sure ater this, none of them
         // have a complete span graph, nor should they start rejecting consensus transactions.
         let mut cp = state.checkpoints.lock();
-        cp.handle_internal_fragment(
-            index.clone(),
-            fragment01.clone(),
-            PendCertificateForExecutionNoop,
-            &net.committee,
-        )
-        .unwrap();
-        index.next_transaction_index += 1;
+        cp.handle_fragment_for_testing(&mut index, fragment01.clone(), &net.committee)
+            .unwrap();
         assert!(!cp.get_locals().in_construction_checkpoint.is_completed());
         assert!(!cp.should_reject_consensus_transaction());
     });
@@ -287,14 +280,8 @@ async fn test_consensus_pause_after_last_fragment() {
         .skip(1)
         .map(|state| {
             let mut cp = state.checkpoints.lock();
-            cp.handle_internal_fragment(
-                index.clone(),
-                fragment12.clone(),
-                PendCertificateForExecutionNoop,
-                &net.committee,
-            )
-            .unwrap();
-            index.next_transaction_index += 1;
+            cp.handle_fragment_for_testing(&mut index, fragment12.clone(), &net.committee)
+                .unwrap();
             assert!(cp.get_locals().in_construction_checkpoint.is_completed());
             assert!(cp.should_reject_consensus_transaction());
             cp.sign_new_checkpoint(
@@ -336,13 +323,8 @@ async fn test_consensus_pause_after_last_fragment() {
     // Now send the second fragment to validator 0. It will complete the span graph, and since it's
     // already at a new checkpoint, it will automatically clear the graph. It will also start
     // rejecting consensus transactions.
-    cp0.handle_internal_fragment(
-        index,
-        fragment12,
-        PendCertificateForExecutionNoop,
-        &net.committee,
-    )
-    .unwrap();
+    cp0.handle_fragment_for_testing(&mut index, fragment12, &net.committee)
+        .unwrap();
     assert!(!cp0.get_locals().in_construction_checkpoint.is_completed());
     assert!(cp0.should_reject_consensus_transaction());
 }

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.64", features = ["backtrace"] }
+bincode = "1.3.3"
 bcs = "0.1.4"
 byteorder = "1.4.3"
 itertools = "0.10.5"

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -79,6 +79,14 @@ pub struct ObjectID(
 
 pub type ObjectRef = (ObjectID, SequenceNumber, ObjectDigest);
 
+pub fn random_object_ref() -> ObjectRef {
+    (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::new([0; 32]),
+    )
+}
+
 #[derive(Clone, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub struct ObjectInfo {
     pub object_id: ObjectID,

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -1332,6 +1332,10 @@ mod bcs_signable {
     impl BcsSignable for crate::messages_checkpoint::CheckpointContents {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointProposalContents {}
     impl BcsSignable for crate::messages_checkpoint::CheckpointProposalSummary {}
+    impl BcsSignable for crate::messages_checkpoint::CheckpointFragmentMessageHeader {}
+    impl BcsSignable for crate::messages_checkpoint::CheckpointFragmentMessageChunk {}
+    impl BcsSignable for crate::messages_checkpoint::CheckpointFragmentMessage {}
+
     impl BcsSignable for crate::messages::CommitteeInfoResponse {}
     impl BcsSignable for crate::messages::TransactionEffects {}
     impl BcsSignable for crate::messages::TransactionData {}

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1098,7 +1098,7 @@ pub type TxCertAndSignedEffects = (CertifiedTransaction, SignedTransactionEffect
 /// TrustedTransactionEnvelope is a serializable wrapper around TransactionEnvelope which is
 /// Into<VerifiedTransactionEnvelope> - in other words it models a verified object which has been
 /// written to the db (or some other trusted store), and may be read back from the db without
-/// futher signature verification.
+/// further signature verification.
 ///
 /// TrustedTransactionEnvelope should *only* appear in database interfaces.
 ///
@@ -2364,7 +2364,7 @@ impl ConsensusTransaction {
             ConsensusTransactionKind::UserTransaction(certificate) => {
                 certificate.verify_signatures(committee)
             }
-            ConsensusTransactionKind::Checkpoint(fragment) => fragment.verify_signatures(committee),
+            ConsensusTransactionKind::Checkpoint(fragment) => fragment.verify(),
         }
     }
 }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -14,7 +14,7 @@ use crate::crypto::{
 };
 use crate::error::SuiResult;
 use crate::gas::GasCostSummary;
-use crate::messages::{CertifiedTransaction, VerifiedCertificate};
+use crate::messages::CertifiedTransaction;
 use crate::waypoint::{Waypoint, WaypointDiff};
 use crate::{
     base_types::AuthorityName,
@@ -636,38 +636,8 @@ pub struct CheckpointFragment {
     pub data: CheckpointFragmentData,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VerifiedCheckpointFragment(CheckpointFragment);
-
-impl VerifiedCheckpointFragment {
-    /// Escape hatch for when it is too awkward / inefficient to use CheckpointFragment::verify().
-    /// Use carefully!
-    pub fn new_unchecked(fragment: CheckpointFragment) -> Self {
-        Self(fragment)
-    }
-
-    pub fn certs(&self) -> impl Iterator<Item = (&ExecutionDigests, VerifiedCertificate)> {
-        self.0
-            .certs
-            .iter()
-            .map(|(digests, cert)| (digests, VerifiedCertificate::new_unchecked(cert.clone())))
-    }
-}
-
-impl std::ops::Deref for VerifiedCheckpointFragment {
-    type Target = CheckpointFragment;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 impl CheckpointFragment {
-    pub fn verify(self, committee: &Committee) -> SuiResult<VerifiedCheckpointFragment> {
-        self.verify_signatures(committee)?;
-        Ok(VerifiedCheckpointFragment(self))
-    }
-
-    pub fn verify_signatures(&self, committee: &Committee) -> SuiResult {
+    pub fn verify(&self, committee: &Committee) -> SuiResult {
         fp_ensure!(
             self.proposer.summary.sequence_number == self.other.summary.sequence_number,
             SuiError::from("Proposer and other have inconsistent sequence number")

--- a/crates/sui/tests/checkpoints_tests.rs
+++ b/crates/sui/tests/checkpoints_tests.rs
@@ -178,7 +178,7 @@ async fn sequence_fragments() {
             node.state()
                 .checkpoints()
                 .lock()
-                .submit_local_fragment_to_consensus(&fragment, &committee)
+                .submit_local_fragment_to_consensus(&fragment)
         });
     }
 

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -10,8 +10,12 @@ use std::path::PathBuf;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_adapter::genesis;
+<<<<<<< HEAD
 use sui_core::test_utils::to_sender_signed_transaction;
 use sui_framework_build::compiled_package::BuildConfig;
+=======
+use sui_core::test_utils::{dummy_transaction_effects, to_sender_signed_transaction};
+>>>>>>> 7a9c50724 ([checkpoint] Support fragment chunks)
 use sui_json_rpc_types::SuiObjectInfo;
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;
@@ -23,27 +27,17 @@ use sui_types::crypto::{
     get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, AuthoritySignInfo,
     KeypairTraits,
 };
-use sui_types::gas::GasCostSummary;
 use sui_types::gas_coin::GasCoin;
+use sui_types::messages::CallArg;
 use sui_types::messages::SignedTransactionEffects;
-use sui_types::messages::{CallArg, ExecutionStatus, TransactionEffects};
 use sui_types::messages::{
     CertifiedTransaction, ObjectArg, TransactionData, VerifiedCertificate,
     VerifiedSignedTransaction, VerifiedTransaction,
 };
 use sui_types::object::Object;
-use sui_types::object::Owner;
 
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 100_000;
-
-pub fn random_object_ref() -> ObjectRef {
-    (
-        ObjectID::random(),
-        SequenceNumber::new(),
-        ObjectDigest::new([0; 32]),
-    )
-}
 
 /// A helper function to get all accounts and their owned GasCoin
 /// with a WalletContext
@@ -462,28 +456,4 @@ pub fn make_tx_certs_and_signed_effects_with_committee(
         }
     }
     (tx_certs, effect_sigs)
-}
-
-fn dummy_transaction_effects(tx: &VerifiedTransaction) -> TransactionEffects {
-    TransactionEffects {
-        status: ExecutionStatus::Success,
-        gas_used: GasCostSummary {
-            computation_cost: 0,
-            storage_cost: 0,
-            storage_rebate: 0,
-        },
-        shared_objects: Vec::new(),
-        transaction_digest: *tx.digest(),
-        created: Vec::new(),
-        mutated: Vec::new(),
-        unwrapped: Vec::new(),
-        deleted: Vec::new(),
-        wrapped: Vec::new(),
-        gas_object: (
-            random_object_ref(),
-            Owner::AddressOwner(tx.signed_data.data.signer()),
-        ),
-        events: Vec::new(),
-        dependencies: Vec::new(),
-    }
 }

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -10,12 +10,8 @@ use std::path::PathBuf;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_adapter::genesis;
-<<<<<<< HEAD
-use sui_core::test_utils::to_sender_signed_transaction;
-use sui_framework_build::compiled_package::BuildConfig;
-=======
 use sui_core::test_utils::{dummy_transaction_effects, to_sender_signed_transaction};
->>>>>>> 7a9c50724 ([checkpoint] Support fragment chunks)
+use sui_framework_build::compiled_package::BuildConfig;
 use sui_json_rpc_types::SuiObjectInfo;
 use sui_keys::keystore::AccountKeystore;
 use sui_keys::keystore::Keystore;


### PR DESCRIPTION
This PR adds support to slice a large fragment (current threshold is 3M) into smaller chunks before sending to consensus.
The way it works is that a fragment is now always a fragment header (which contains the proposer/other and number of chunks), followed by a list of individual fragment chunk, each contains a chunk_id. Each message is signed by the proposer of the fragment so we use that to verify each message is legit.
During span graph construction we remember each partial fragment and creates a complete fragment when we have seen all chunks.