### PR TITLE
Add ctx argument to sui::table::new example

### DIFF
--- a/doc/src/build/programming-with-objects/ch6-collections.md
+++ b/doc/src/build/programming-with-objects/ch6-collections.md
@@ -179,8 +179,8 @@ that can only be called for tables where the value type also has `drop`, which a
 Equality on collections is based on identity, i.e. an instance of a collection type is only considered equal to itself and not to all collections that hold the same entries:
 
 ```rust
-let t1 = sui::table::new<u64, u64>();
-let t2 = sui::table::new<u64, u64>();
+let t1 = sui::table::new<u64, u64>(ctx);
+let t2 = sui::table::new<u64, u64>(ctx);
 
 assert!(&t1 == &t1, 0);
 assert!(&t1 != &t2, 1);


### PR DESCRIPTION
`sui::table::new` takes a TxContext as an argument. I got a little confused by the documentation here and had to look up the table definition in the source. The `ctx` is a little out-of-context (pun intended) here but it is a commonly used abbreviation for `TxContext`, so hopefully helps communicate that the `TxContext` argument is required.