### PR TITLE
[explorer] Fix mis-alignment of signatures and events tabs

### DIFF
--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -480,16 +480,18 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                             <ItemView data={GasStorageFees} />
                         </div>
                     </TabPanel>
-                    <TabPanel>
-                        <div className={styles.txevents}>
-                            <div className={styles.txeventsleft}>
-                                {eventTitlesDisplay}
+                    {hasEvents && (
+                        <TabPanel>
+                            <div className={styles.txevents}>
+                                <div className={styles.txeventsleft}>
+                                    {eventTitlesDisplay}
+                                </div>
+                                <div className={styles.txeventsright}>
+                                    {txEventDisplay}
+                                </div>
                             </div>
-                            <div className={styles.txeventsright}>
-                                {txEventDisplay}
-                            </div>
-                        </div>
-                    </TabPanel>
+                        </TabPanel>
+                    )}
                     <TabPanel>
                         <div className={styles.txgridcomponent}>
                             <ItemView data={transactionSignatureData} />


### PR DESCRIPTION
The previous behavior had the "Signatures" tab actually index into the events page.