### PR TITLE
fix: test & fix crypto functions accepting bytes

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -9,4 +9,6 @@ disallowed-methods = [
     { path = "tokio::sync::mpsc::unbounded_channel", reason = "use a bounded channel instead" },
     { path = "futures::channel::mpsc::unbounded", reason = "use a bounded channel instead" },
     { path = "futures_channel::mpsc::unbounded", reason = "use a bounded channel instead" },
+    # bincode::deserialize_from is easy to shoot your foot with
+    { path = "bincode::deserialize_from", reason = "use bincode::deserialize instead" },
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8691,6 +8691,7 @@ dependencies = [
  "narwhal-executor",
  "once_cell",
  "opentelemetry 0.17.0",
+ "proptest",
  "rand 0.8.5",
  "roaring",
  "schemars",

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -56,6 +56,7 @@ fastcrypto = { workspace = true, features = ["copy_key"] }
 
 sui-cost-tables = { path = "../sui-cost-tables"}
 workspace-hack.workspace = true
+proptest = "1.0.0"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/crates/sui-types/src/unit_tests/crypto_tests.rs
+++ b/crates/sui-types/src/unit_tests/crypto_tests.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use super::*;
+use crate::crypto::bcs_signable_test::Foo;
+use proptest::collection;
+use proptest::prelude::*;
+
+proptest! {
+    // Check those functions do not panic
+    #[test]
+    fn test_get_key_pair_from_bytes(
+        bytes in collection::vec(any::<u8>(), 0..1024)
+    ){
+        let _key_pair = get_key_pair_from_bytes::<AuthorityKeyPair>(&bytes);
+        let _key_pair = get_key_pair_from_bytes::<NetworkKeyPair>(&bytes);
+        let _key_pair = get_key_pair_from_bytes::<AccountKeyPair>(&bytes);
+    }
+
+    #[test]
+    fn test_from_signable_bytes(
+        bytes in collection::vec(any::<u8>(), 0..1024)
+    ){
+        let _foo = Foo::from_signable_bytes(&bytes);
+    }
+
+    #[test]
+    fn test_authority_pk_bytes(
+        bytes in collection::vec(any::<u8>(), 0..1024)
+    ){
+        let _apkb = AuthorityPublicKeyBytes::from_bytes(&bytes);
+        let _suisig = Ed25519SuiSignature::from_bytes(&bytes);
+        let _suisig = Secp256k1SuiSignature::from_bytes(&bytes);
+        let _pk = PublicKey::try_from_bytes(SignatureScheme::BLS12381, &bytes);
+        let _pk = PublicKey::try_from_bytes(SignatureScheme::ED25519, &bytes);
+        let _pk = PublicKey::try_from_bytes(SignatureScheme::Secp256k1, &bytes);
+        let _sig = Signature::from_bytes(&bytes);
+    }
+
+    #[test]
+    fn test_deserialize_keypair(
+        bytes in collection::vec(any::<u8>(), 0..1024)
+    ){
+        let _skp: Result<SuiKeyPair, _> = bincode::deserialize(&bytes);
+        let _pk: Result<PublicKey, _> = bincode::deserialize(&bytes);
+    }
+
+
+}


### PR DESCRIPTION
This is a small follow-up to #5678 getting the ball rolling on adding tests for arbitrary byte inputs.
