### PR TITLE
[Rosetta] - Use PaySui instead of TransferSui in Rosetta API

### DIFF
--- a/crates/sui-rosetta/docker/sui-rosetta-devnet/Dockerfile
+++ b/crates/sui-rosetta/docker/sui-rosetta-devnet/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 FROM chef AS builder
 RUN git clone https://github.com/MystenLabs/sui .
 # We can change this to `git checkout -b devnet` after next devnet update
-RUN git checkout 65aa6883aebbe7e429a1d95c82b4b5b2fc2d73bc
+RUN git checkout devnet
 
 RUN curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s
 RUN curl -fLJO https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob

--- a/crates/sui-rosetta/docker/sui-rosetta-devnet/Dockerfile
+++ b/crates/sui-rosetta/docker/sui-rosetta-devnet/Dockerfile
@@ -8,7 +8,6 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 FROM chef AS builder
 RUN git clone https://github.com/MystenLabs/sui .
-# We can change this to `git checkout -b devnet` after next devnet update
 RUN git checkout devnet
 
 RUN curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s

--- a/crates/sui-rosetta/resources/rosetta_cli.json
+++ b/crates/sui-rosetta/resources/rosetta_cli.json
@@ -16,7 +16,7 @@
   "compression_disabled": false,
   "all_in_memory_enabled": false,
   "error_stack_trace_disabled": false,
-  "coin_supported": true,
+  "coin_supported": false,
   "construction": {
     "offline_url": "http://rosetta-offline:9003",
     "constructor_dsl_file": "sui.ros",

--- a/crates/sui-rosetta/resources/sui.ros
+++ b/crates/sui-rosetta/resources/sui.ros
@@ -6,8 +6,7 @@ transfer(10){
       "minimum_balance":{
         "value": "100000",
         "currency": {{currency}}
-      },
-      "require_coin": true
+      }
     });
     recipient_amount = random_number({"minimum": "1", "maximum": "100000"});
     print_message({"recipient_amount":{{recipient_amount}}});
@@ -24,16 +23,14 @@ transfer(10){
     transfer.operations = [
       {
         "operation_identifier":{"index":0},
-        "type":"TransferSUI",
+        "type":"PaySui",
         "account":{{sender.account_identifier}},
-        "coin_change":{"coin_action":"coin_spent", "coin_identifier":{{sender.coin}}},
-        "metadata":{"recipient":{{recipient.account_identifier.address}}, "amount": {{recipient_amount}}}
+        "metadata":{"recipients":[{{recipient.account_identifier.address}}], "amounts": [{{recipient_amount}}]}
       },
       {
         "operation_identifier":{"index":1},
         "type":"GasBudget",
         "account":{{sender.account_identifier}},
-        "coin_change":{"coin_action":"coin_spent", "coin_identifier":{{sender.coin}}},
         "metadata":{
           "budget": "1000"
         }

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -9,23 +9,17 @@ use serde_json::{json, Value};
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
 
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
-use sui_types::coin::{PAY_JOIN_FUNC_NAME, PAY_MODULE_NAME, PAY_SPLIT_VEC_FUNC_NAME};
+use sui_types::base_types::{ObjectRef, SuiAddress};
 use sui_types::event::Event;
 use sui_types::gas_coin::GAS;
-use sui_types::messages::{
-    CallArg, ExecutionStatus, MoveCall, ObjectArg, Pay, PayAllSui, PaySui, SingleTransactionKind,
-    TransactionData, TransferObject,
-};
+use sui_types::messages::{ExecutionStatus, SingleTransactionKind, TransactionData};
 use sui_types::move_package::disassemble_modules;
 use sui_types::object::Owner;
-use sui_types::{parse_sui_struct_tag, SUI_FRAMEWORK_OBJECT_ID};
 
 use crate::types::{
     AccountIdentifier, Amount, CoinAction, CoinChange, CoinIdentifier, ConstructionMetadata,
     IndexCounter, OperationIdentifier, OperationStatus, OperationType,
 };
-use crate::ErrorType::UnsupportedOperation;
 use crate::{Error, ErrorType, SUI};
 
 #[cfg(test)]
@@ -53,25 +47,17 @@ pub struct Operation {
 
 impl Operation {
     pub fn from_data(data: &TransactionData) -> Result<Vec<Operation>, anyhow::Error> {
-        let budget = data.gas_budget;
-        let gas = data.gas();
         let sender = data.signer();
-        Ok(data
+        let mut counter = IndexCounter::default();
+        let mut ops = data
             .kind
             .single_transactions()
-            .flat_map(|tx| {
-                parse_operations(
-                    tx,
-                    budget,
-                    gas,
-                    sender,
-                    &mut IndexCounter::default(),
-                    None,
-                    None,
-                )
-            })
+            .flat_map(|tx| parse_operations(tx, sender, &mut counter, None, None))
             .flatten()
-            .collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        let gas = Operation::gas_budget(&mut counter, None, data.gas(), data.gas_budget, sender);
+        ops.push(gas);
+        Ok(ops)
     }
 
     pub fn from_data_and_events(
@@ -79,19 +65,18 @@ impl Operation {
         status: &ExecutionStatus,
         events: &Vec<Event>,
     ) -> Result<Vec<Operation>, anyhow::Error> {
-        let budget = data.gas_budget;
-        let gas = data.gas();
         let sender = data.signer();
         let mut counter = IndexCounter::default();
         let status = Some((status).into());
-        Ok(data
+        let mut ops = data
             .kind
             .single_transactions()
-            .flat_map(|tx| {
-                parse_operations(tx, budget, gas, sender, &mut counter, status, Some(events))
-            })
+            .flat_map(|tx| parse_operations(tx, sender, &mut counter, status, Some(events)))
             .flatten()
-            .collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        let gas = Operation::gas_budget(&mut counter, status, data.gas(), data.gas_budget, sender);
+        ops.push(gas);
+        Ok(ops)
     }
 
     fn get_coin_operation_from_events(
@@ -138,12 +123,57 @@ impl Operation {
         operations
     }
 
-    pub async fn parse_transaction_data(
+    /// Parse operation input from rosetta to Sui transaction
+    pub async fn create_data(
         operations: Vec<Operation>,
         metadata: ConstructionMetadata,
     ) -> Result<TransactionData, Error> {
-        let action: SuiAction = operations.try_into()?;
-        action.try_into_data(metadata).await
+        // Currently only PaySui is support,
+        // first operation is PaySui operation and second operation is the budget operation.
+        if operations.len() != 2 || operations[0].type_ != OperationType::PaySui {
+            return Err(Error::new_with_msg(
+                ErrorType::InvalidInput,
+                "Malformed operation.",
+            ));
+        }
+        let pay_sui_op = &operations[0];
+        let budget_op = &operations[1];
+
+        let account = pay_sui_op
+            .account
+            .as_ref()
+            .ok_or_else(|| Error::missing_input("operation.account"))?;
+        let address = account.address;
+        let pay_sui = pay_sui_op
+            .metadata
+            .clone()
+            .ok_or_else(|| Error::missing_input("operation.metadata"))?;
+        let pay_sui: PaySuiMetadata = serde_json::from_value(pay_sui)
+            .map_err(|e| Error::new_with_cause(ErrorType::MalformedOperationError, e))?;
+        let gas = metadata.sender_coins[0];
+        let budget_value = budget_op
+            .metadata
+            .clone()
+            .and_then(|v| v.pointer("/budget").cloned())
+            .ok_or_else(|| Error::missing_input("gas budget"))?;
+        let budget = budget_value
+            .as_u64()
+            .or_else(|| budget_value.as_str().and_then(|s| u64::from_str(s).ok()))
+            .ok_or_else(|| {
+                Error::new_with_msg(
+                    ErrorType::InvalidInput,
+                    format!("Cannot parse gas budget : [{budget_value}]").as_str(),
+                )
+            })?;
+
+        Ok(TransactionData::new_pay_sui(
+            address,
+            metadata.sender_coins,
+            pay_sui.recipients,
+            pay_sui.amounts,
+            gas,
+            budget,
+        ))
     }
 
     pub fn gas_budget(
@@ -173,66 +203,43 @@ impl Operation {
 
 fn parse_operations(
     tx: &SingleTransactionKind,
-    budget: u64,
-    gas: ObjectRef,
     sender: SuiAddress,
     counter: &mut IndexCounter,
     status: Option<OperationStatus>,
     events: Option<&Vec<Event>>,
 ) -> Result<Vec<Operation>, anyhow::Error> {
-    let mut operations = match tx {
-        SingleTransactionKind::TransferSui(tx) => transfer_sui_operations(
-            budget,
-            gas,
-            sender,
-            tx.recipient,
-            tx.amount,
-            counter,
-            status,
-        ),
-        SingleTransactionKind::TransferObject(tx) => transfer_object_operations(
-            budget,
-            tx.object_ref,
-            gas,
-            sender,
-            tx.recipient,
-            counter,
-            status,
-        ),
-        SingleTransactionKind::Call(c) => {
-            move_call_operations(sender, gas, budget, c, counter, status)
+    let (type_, metadata) = match tx {
+        SingleTransactionKind::TransferObject(tx) => (OperationType::TransferObject, json!(tx)),
+        SingleTransactionKind::Publish(tx) => {
+            let disassembled = disassemble_modules(tx.modules.iter())?;
+            (OperationType::Publish, json!(disassembled))
         }
-        SingleTransactionKind::Publish(p) => {
-            let disassembled = disassemble_modules(p.modules.iter())?;
-            vec![Operation {
-                operation_identifier: counter.next_idx().into(),
-                related_operations: vec![],
-                type_: OperationType::Publish,
-                status,
-                account: Some(AccountIdentifier { address: sender }),
-                amount: None,
-                coin_change: None,
-                metadata: Some(json!(disassembled)),
-            }]
+        SingleTransactionKind::Call(tx) => (OperationType::MoveCall, json!(tx)),
+        SingleTransactionKind::TransferSui(tx) => (OperationType::TransferSUI, json!(tx)),
+        SingleTransactionKind::Pay(tx) => (OperationType::Pay, json!(tx)),
+        SingleTransactionKind::PaySui(tx) => {
+            let pay_sui = PaySuiMetadata {
+                recipients: tx.recipients.clone(),
+                amounts: tx.amounts.clone(),
+            };
+            (OperationType::PaySui, json!(pay_sui))
         }
-        SingleTransactionKind::ChangeEpoch(change) => vec![Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::EpochChange,
-            status,
-            account: None,
-            amount: None,
-            coin_change: None,
-            metadata: Some(json!(change)),
-        }],
-        SingleTransactionKind::Pay(pay) => parse_pay(sender, gas, budget, pay, counter, status),
-        SingleTransactionKind::PaySui(pay_sui) => {
-            parse_pay_sui(sender, gas, budget, pay_sui, counter, status)
-        }
-        SingleTransactionKind::PayAllSui(pay_all_sui) => {
-            parse_pay_all_sui(sender, gas, budget, pay_all_sui, counter, status)
-        }
+        SingleTransactionKind::PayAllSui(tx) => (OperationType::PayAllSui, json!(tx)),
+        SingleTransactionKind::ChangeEpoch(tx) => (OperationType::EpochChange, json!(tx)),
     };
+
+    let mut operations = vec![Operation {
+        operation_identifier: counter.next_idx().into(),
+        related_operations: vec![],
+        type_,
+        status,
+        account: Some(AccountIdentifier { address: sender }),
+        amount: None,
+        coin_change: None,
+        metadata: Some(metadata),
+    }];
+
+    // Extract coin change operations from events
     if let Some(events) = events {
         let coin_change_operations =
             Operation::get_coin_operation_from_events(events, status, counter);
@@ -241,409 +248,10 @@ fn parse_operations(
     Ok(operations)
 }
 
-fn transfer_sui_operations(
-    budget: u64,
-    coin: ObjectRef,
-    sender: SuiAddress,
-    recipient: SuiAddress,
-    amount: Option<u64>,
-    counter: &mut IndexCounter,
-    status: Option<OperationStatus>,
-) -> Vec<Operation> {
-    let transfer_sui = TransferSuiMetadata { recipient, amount };
-    vec![
-        Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::TransferSUI,
-            status,
-            account: Some(AccountIdentifier { address: sender }),
-            amount: None,
-            coin_change: Some(CoinChange {
-                coin_identifier: CoinIdentifier {
-                    identifier: coin.into(),
-                },
-                coin_action: CoinAction::CoinSpent,
-            }),
-            metadata: Some(json!(transfer_sui)),
-        },
-        Operation::gas_budget(counter, status, coin, budget, sender),
-    ]
-}
-
 #[serde_as]
 #[derive(Serialize, Deserialize)]
-struct TransferSuiMetadata {
-    pub recipient: SuiAddress,
-    #[serde_as(as = "Option<DisplayFromStr>")]
-    pub amount: Option<u64>,
-}
-
-fn transfer_object_operations(
-    budget: u64,
-    object_ref: ObjectRef,
-    gas: ObjectRef,
-    sender: SuiAddress,
-    recipient: SuiAddress,
-    counter: &mut IndexCounter,
-    status: Option<OperationStatus>,
-) -> Vec<Operation> {
-    let transfer_object = TransferObject {
-        recipient,
-        object_ref,
-    };
-    vec![
-        Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::TransferObject,
-            status,
-            account: Some(AccountIdentifier { address: sender }),
-            amount: None,
-            coin_change: None,
-            metadata: Some(json!(transfer_object)),
-        },
-        Operation::gas_budget(counter, status, gas, budget, sender),
-    ]
-}
-
-fn move_call_operations(
-    sender: SuiAddress,
-    gas: ObjectRef,
-    budget: u64,
-    call: &MoveCall,
-    counter: &mut IndexCounter,
-    status: Option<OperationStatus>,
-) -> Vec<Operation> {
-    vec![
-        Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::MoveCall,
-            status,
-            account: Some(AccountIdentifier { address: sender }),
-            amount: None,
-            coin_change: None,
-            metadata: Some(json!(call)),
-        },
-        Operation::gas_budget(counter, status, gas, budget, sender),
-    ]
-}
-
-fn parse_pay(
-    sender: SuiAddress,
-    gas: ObjectRef,
-    budget: u64,
-    pay: &Pay,
-    counter: &mut IndexCounter,
-    status: Option<OperationStatus>,
-) -> Vec<Operation> {
-    vec![
-        Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::Pay,
-            status,
-            account: Some(AccountIdentifier { address: sender }),
-            amount: None,
-            coin_change: None,
-            metadata: Some(json!(pay)),
-        },
-        Operation::gas_budget(counter, status, gas, budget, sender),
-    ]
-}
-
-fn parse_pay_sui(
-    sender: SuiAddress,
-    gas: ObjectRef,
-    budget: u64,
-    pay_sui: &PaySui,
-    counter: &mut IndexCounter,
-    status: Option<OperationStatus>,
-) -> Vec<Operation> {
-    vec![
-        Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::PaySui,
-            status,
-            account: Some(AccountIdentifier { address: sender }),
-            amount: None,
-            coin_change: None,
-            metadata: Some(json!(pay_sui)),
-        },
-        Operation::gas_budget(counter, status, gas, budget, sender),
-    ]
-}
-
-fn parse_pay_all_sui(
-    sender: SuiAddress,
-    gas: ObjectRef,
-    budget: u64,
-    pay_all_sui: &PayAllSui,
-    counter: &mut IndexCounter,
-    status: Option<OperationStatus>,
-) -> Vec<Operation> {
-    vec![
-        Operation {
-            operation_identifier: counter.next_idx().into(),
-            related_operations: vec![],
-            type_: OperationType::PayAllSui,
-            status,
-            account: Some(AccountIdentifier { address: sender }),
-            amount: None,
-            coin_change: None,
-            metadata: Some(json!(pay_all_sui)),
-        },
-        Operation::gas_budget(counter, status, gas, budget, sender),
-    ]
-}
-
-#[derive(Debug)]
-pub enum SuiAction {
-    TransferSui {
-        budget: u64,
-        coin: ObjectID,
-        sender: SuiAddress,
-        recipient: SuiAddress,
-        amount: Option<u64>,
-    },
-
-    Transfer {
-        budget: u64,
-        coin: ObjectID,
-        gas: ObjectID,
-        sender: SuiAddress,
-        recipient: SuiAddress,
-    },
-
-    MergeCoin {
-        budget: u64,
-        primary_coin: ObjectID,
-        coin_to_merge: ObjectID,
-        gas: ObjectID,
-        sender: SuiAddress,
-    },
-    SplitCoin {
-        budget: u64,
-        coin_to_split: ObjectID,
-        split_amounts: Vec<u64>,
-        gas: ObjectID,
-        sender: SuiAddress,
-    },
-}
-
-impl SuiAction {
-    pub async fn try_into_data(
-        self,
-        metadata: ConstructionMetadata,
-    ) -> Result<TransactionData, Error> {
-        Ok(match self {
-            SuiAction::TransferSui {
-                budget,
-                coin,
-                sender,
-                recipient,
-                amount,
-            } => {
-                let gas = metadata.try_get_info(&coin)?;
-                TransactionData::new_transfer_sui(recipient, sender, amount, gas.into(), budget)
-            }
-            SuiAction::Transfer {
-                budget,
-                coin,
-                gas,
-                sender,
-                recipient,
-            } => {
-                let gas = metadata.try_get_info(&gas)?;
-                let coin = metadata.try_get_info(&coin)?;
-                TransactionData::new_transfer(recipient, coin.into(), sender, gas.into(), budget)
-            }
-            SuiAction::MergeCoin {
-                budget,
-                primary_coin,
-                coin_to_merge,
-                gas,
-                sender,
-            } => {
-                let gas = metadata.try_get_info(&gas)?;
-                let primary_coin = metadata.try_get_info(&primary_coin)?;
-                let coin_to_merge = metadata.try_get_info(&coin_to_merge)?;
-                let type_args = parse_sui_struct_tag(&primary_coin.type_)?.type_params;
-
-                TransactionData::new_move_call(
-                    sender,
-                    metadata.try_get_info(&SUI_FRAMEWORK_OBJECT_ID)?.into(),
-                    PAY_MODULE_NAME.to_owned(),
-                    PAY_JOIN_FUNC_NAME.to_owned(),
-                    type_args,
-                    gas.into(),
-                    vec![
-                        CallArg::Object(ObjectArg::ImmOrOwnedObject(primary_coin.into())),
-                        CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_to_merge.into())),
-                    ],
-                    budget,
-                )
-            }
-            SuiAction::SplitCoin {
-                budget,
-                coin_to_split,
-                split_amounts,
-                gas,
-                sender,
-            } => {
-                let gas = metadata.try_get_info(&gas)?;
-                let coin_to_split = metadata.try_get_info(&coin_to_split)?;
-                let type_args = parse_sui_struct_tag(&coin_to_split.type_)?.type_params;
-                TransactionData::new_move_call(
-                    sender,
-                    metadata.try_get_info(&SUI_FRAMEWORK_OBJECT_ID)?.into(),
-                    PAY_MODULE_NAME.to_owned(),
-                    PAY_SPLIT_VEC_FUNC_NAME.to_owned(),
-                    type_args,
-                    gas.into(),
-                    vec![
-                        CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_to_split.into())),
-                        CallArg::Pure(bcs::to_bytes(&split_amounts)?),
-                    ],
-                    budget,
-                )
-            }
-        })
-    }
-
-    pub fn input_objects(&self) -> Vec<ObjectID> {
-        match self {
-            SuiAction::TransferSui { coin, .. } => {
-                vec![*coin]
-            }
-            SuiAction::Transfer { coin, gas, .. } => vec![*coin, *gas],
-            SuiAction::MergeCoin {
-                primary_coin,
-                coin_to_merge,
-                gas,
-                ..
-            } => vec![SUI_FRAMEWORK_OBJECT_ID, *primary_coin, *coin_to_merge, *gas],
-            SuiAction::SplitCoin {
-                coin_to_split, gas, ..
-            } => vec![SUI_FRAMEWORK_OBJECT_ID, *coin_to_split, *gas],
-        }
-    }
-
-    pub fn signer(&self) -> SuiAddress {
-        *match self {
-            SuiAction::TransferSui { sender, .. }
-            | SuiAction::Transfer { sender, .. }
-            | SuiAction::MergeCoin { sender, .. }
-            | SuiAction::SplitCoin { sender, .. } => sender,
-        }
-    }
-}
-
-impl TryInto<SuiAction> for Vec<Operation> {
-    type Error = Error;
-
-    fn try_into(self) -> Result<SuiAction, Self::Error> {
-        let mut builder = SuiActionBuilder::default();
-
-        for op in self {
-            match op.type_ {
-                OperationType::TransferSUI => {
-                    let account = op
-                        .account
-                        .as_ref()
-                        .ok_or_else(|| Error::missing_input("operation.account"))?;
-                    let address = account.address;
-                    builder.operation_type = Some(op.type_);
-                    let transfer_sui = op
-                        .metadata
-                        .ok_or_else(|| Error::missing_input("operation.metadata"))?;
-                    let transfer_sui: TransferSuiMetadata = serde_json::from_value(transfer_sui)
-                        .map_err(|e| {
-                            Error::new_with_cause(ErrorType::MalformedOperationError, e)
-                        })?;
-                    builder.coin = op
-                        .coin_change
-                        .map(|coin| coin.coin_identifier.identifier.id);
-                    builder.sender = Some(address);
-                    builder.recipient = Some(transfer_sui.recipient);
-                    builder.send_amount = transfer_sui.amount;
-                }
-                OperationType::GasBudget => {
-                    if let Some(coin) = op.coin_change.as_ref() {
-                        builder.gas = Some(coin.coin_identifier.identifier.id);
-                    }
-                    let budget_value = op
-                        .metadata
-                        .and_then(|v| v.pointer("/budget").cloned())
-                        .ok_or_else(|| Error::missing_input("gas budget"))?;
-
-                    let budget = budget_value
-                        .as_u64()
-                        .or_else(|| budget_value.as_str().and_then(|s| u64::from_str(s).ok()))
-                        .ok_or_else(|| {
-                            Error::new_with_msg(
-                                ErrorType::InvalidInput,
-                                format!("Cannot parse gas budget : [{budget_value}]").as_str(),
-                            )
-                        })?;
-                    builder.gas_budget = Some(budget);
-                }
-                OperationType::TransferObject
-                | OperationType::SuiBalanceChange
-                | OperationType::Pay
-                | OperationType::PaySui
-                | OperationType::PayAllSui
-                | OperationType::GasSpent
-                | OperationType::Genesis
-                | OperationType::MoveCall
-                | OperationType::Publish
-                | OperationType::EpochChange => return Err(Error::unsupported_operation(op.type_)),
-            }
-        }
-        builder.build()
-    }
-}
-
-#[derive(Default)]
-struct SuiActionBuilder {
-    sender: Option<SuiAddress>,
-    recipient: Option<SuiAddress>,
-    gas: Option<ObjectID>,
-    coin: Option<ObjectID>,
-    send_amount: Option<u64>,
-    gas_budget: Option<u64>,
-    operation_type: Option<OperationType>,
-}
-
-impl SuiActionBuilder {
-    fn build(self) -> Result<SuiAction, Error> {
-        let type_ = self
-            .operation_type
-            .ok_or_else(|| Error::missing_input("operation_type"))?;
-        match type_ {
-            OperationType::TransferSUI => {
-                let sender = self.sender.ok_or_else(|| Error::missing_input("sender"))?;
-                let recipient = self
-                    .recipient
-                    .ok_or_else(|| Error::missing_input("recipient"))?;
-                let gas = self.gas.ok_or_else(|| Error::missing_input("gas"))?;
-                let budget = self
-                    .gas_budget
-                    .ok_or_else(|| Error::missing_input("gas_budget"))?;
-                Ok(SuiAction::TransferSui {
-                    budget,
-                    coin: gas,
-                    sender,
-                    recipient,
-                    amount: self.send_amount,
-                })
-            }
-            _ => Err(Error::new_with_msg(
-                UnsupportedOperation,
-                format!("Unsupported operation [{type_:?}]").as_str(),
-            )),
-        }
-    }
+struct PaySuiMetadata {
+    pub recipients: Vec<SuiAddress>,
+    #[serde_as(as = "Vec<DisplayFromStr>")]
+    pub amounts: Vec<u64>,
 }

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -287,8 +287,6 @@ async fn test_transaction(
         .map_err(|e| anyhow!("TX execution failed for {data:#?}, error : {e}"))
         .unwrap();
 
-    println!("{:#?}", response.effects);
-
     let effect = response.effects.clone().unwrap();
 
     assert_eq!(

--- a/crates/sui-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/operations_tests.rs
@@ -1,14 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
-use sui_types::base_types::{
-    ObjectDigest, ObjectID, ObjectInfo, SequenceNumber, SuiAddress, TransactionDigest,
-};
-use sui_types::gas_coin::GasCoin;
+use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
 use sui_types::messages::TransactionData;
-use sui_types::object::Owner;
 
 use crate::operations::Operation;
 use crate::types::ConstructionMetadata;
@@ -23,35 +17,21 @@ async fn test_operation_data_parsing() -> Result<(), anyhow::Error> {
 
     let sender = SuiAddress::random_for_testing_only();
 
-    let data = TransactionData::new_transfer_sui(
-        SuiAddress::random_for_testing_only(),
+    let data = TransactionData::new_pay_sui(
         sender,
-        Some(10000),
+        vec![gas],
+        vec![SuiAddress::random_for_testing_only()],
+        vec![10000],
         gas,
         1000,
     );
 
     let ops = Operation::from_data(&data)?;
-
     let metadata = ConstructionMetadata {
-        input_objects: BTreeMap::from([gas].map(|obj| {
-            (
-                obj.0,
-                ObjectInfo {
-                    object_id: obj.0,
-                    version: obj.1,
-                    digest: obj.2,
-                    type_: GasCoin::type_().to_string(),
-                    owner: Owner::AddressOwner(sender),
-                    previous_transaction: TransactionDigest::random(),
-                },
-            )
-        })),
+        sender_coins: vec![gas],
     };
 
-    let parsed_data = Operation::parse_transaction_data(ops, metadata)
-        .await
-        .unwrap();
+    let parsed_data = Operation::create_data(ops, metadata).await.unwrap();
     assert_eq!(data, parsed_data);
 
     Ok(())


### PR DESCRIPTION
*  Use paysui instead of transferSui
*  Simplified rosetta operations as we don't need to support split coin/ merge coin anymore