### PR TITLE
[error] Allow conversion between tonic error and sui error

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -492,7 +492,7 @@ where
                         if state.bad_weight > validity {
                             return Err(SuiError::TooManyIncorrectAuthorities {
                                 errors: state.errors,
-                                action: "get_latest_checkpoint_from_all",
+                                action: "get_latest_checkpoint_from_all".to_string(),
                             });
                         }
                     }

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -927,7 +927,7 @@ where
         // When to give up on the attempt entirely.
         timeout_total: Option<Duration>,
         // The behavior that authorities expect to perform, used for logging and error
-        description: &'static str,
+        description: String,
     ) -> Result<S, SuiError>
     where
         FMap: Fn(AuthorityName, SafeClient<A>) -> AsyncResult<'a, S, SuiError> + Send + Clone + 'a,
@@ -1022,7 +1022,7 @@ where
                         if state.bad_weight > validity {
                             return Err(SuiError::TooManyIncorrectAuthorities {
                                 errors: state.errors,
-                                action: "get_committee_info",
+                                action: "get_committee_info".to_string(),
                             });
                         }
                         Ok(ReduceOutput::Continue(state))
@@ -1038,7 +1038,7 @@ where
         } else {
             Err(SuiError::TooManyIncorrectAuthorities {
                 errors: final_state.errors,
-                action: "get_committee_info",
+                action: "get_committee_info".to_string(),
             })
         }
     }
@@ -1201,7 +1201,7 @@ where
                                             response.err().map(|err| (name, err))
                                         })
                                         .collect(),
-                                    action: "get_object_by_id",
+                                    action: "get_object_by_id".to_string(),
                                 });
                             }
                         }
@@ -1362,7 +1362,7 @@ where
                                 if state.bad_weight > validity {
                                     return Err(SuiError::TooManyIncorrectAuthorities {
                                         errors: state.errors,
-                                        action: "get_all_owned_objects",
+                                        action: "get_all_owned_objects".to_string(),
                                     });
                                 }
                             }
@@ -2041,7 +2041,7 @@ where
             |_, client| Box::pin(async move { client.handle_checkpoint(request.clone()).await }),
             self.timeouts.serial_authority_request_timeout,
             timeout_total,
-            "handle_checkpoint_request",
+            "handle_checkpoint_request".to_string(),
         )
         .await
     }
@@ -2078,7 +2078,7 @@ where
             },
             self.timeouts.serial_authority_request_timeout,
             timeout_total,
-            "get_certified_checkpoint",
+            "get_certified_checkpoint".to_string(),
         )
         .await
     }
@@ -2113,7 +2113,7 @@ where
             },
             self.timeouts.serial_authority_request_timeout,
             timeout_total,
-            "handle_cert_info_request",
+            "handle_cert_info_request".to_string(),
         )
         .await
     }
@@ -2158,7 +2158,7 @@ where
             },
             self.timeouts.serial_authority_request_timeout,
             timeout_total,
-            "handle_transaction_and_effects_info_request",
+            "handle_transaction_and_effects_info_request".to_string(),
         )
         .await
     }
@@ -2268,7 +2268,7 @@ where
             .true_effects
             .ok_or(SuiError::TooManyIncorrectAuthorities {
                 errors: final_state.errors,
-                action: "execute_cert_to_true_effects",
+                action: "execute_cert_to_true_effects".to_string(),
             })
             .tap_err(|e| info!(?digest, "execute_cert_to_true_effects failed: {}", e))
     }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -496,7 +496,7 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     Err(SuiError::TooManyIncorrectAuthorities {
                         errors: vec![],
-                        action: "",
+                        action: "".to_string(),
                     })
                 })
             },
@@ -516,7 +516,7 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     let res: Result<usize, SuiError> = Err(SuiError::TooManyIncorrectAuthorities {
                         errors: vec![],
-                        action: "",
+                        action: "".to_string(),
                     });
                     res
                 })
@@ -571,7 +571,7 @@ async fn test_map_reducer() {
                 Box::pin(async move {
                     Err(SuiError::TooManyIncorrectAuthorities {
                         errors: vec![],
-                        action: "",
+                        action: "".to_string(),
                     })
                 })
             },
@@ -1044,7 +1044,7 @@ async fn test_quorum_once_with_timeout() {
             },
             Duration::from_millis(authority_request_timeout),
             Some(Duration::from_millis(30 * 50)),
-            "test",
+            "test".to_string(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
Serialize SuiError into bytes inside tonic status, which will allow us recover the sui error on the client. We can then inspect such error and react accordingly.