### PR TITLE
Update index.md

### DIFF
--- a/doc/src/build/programming-with-objects/index.md
+++ b/doc/src/build/programming-with-objects/index.md
@@ -2,7 +2,7 @@
 title: Programming Objects Tutorial Series
 ---
 
-Sui is a blockchain centered on [objects](../../build/objects.md). Once you start programming non-trivial [smart contracts](../../build/move/index.md) on Sui, you will start dealing with Sui objects in the code. Sui includes a rich, comprehensive library and testing framework to allow you interact with objects in a safe and yet flexible way.
+Sui is a blockchain centered on [objects](../../learn/objects.md). Once you start programming non-trivial [smart contracts](../../build/move/index.md) on Sui, you will start dealing with Sui objects in the code. Sui includes a rich, comprehensive library and testing framework to allow you interact with objects in a safe and yet flexible way.
 
 In this tutorial series, we will walk through all the powerful ways to interact with objects in [Sui Move](../../learn/sui-move-diffs.md). At the end, we will also explore the designs of a few (close-to-)real-world examples to demonstrate the tradeoffs of using different object types and ownership relationships.
 


### PR DESCRIPTION
Fixing link to objects.md (moved from /build to /learn)

Thanks for pointing this out. We moved some stuff around and I missed updating this link (I thought a redirect would catch it).