### PR TITLE
rename/polish some execution errors

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -626,7 +626,7 @@ impl AuthorityState {
         debug!(?digest, "handle_certificate_with_effects");
         fp_ensure!(
             effects.effects.transaction_digest == digest,
-            SuiError::ErrorWhileProcessingConfirmationTransaction {
+            SuiError::ErrorWhileProcessingCertificate {
                 err: "effects/tx digest mismatch".to_string()
             }
         );

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -144,7 +144,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             // prevent the client from continually retrying it.
             let err = "tx has exceeded the maximum retry limit for transient errors".to_owned();
             debug!(?digest, "{}", err);
-            return Err(SuiError::ErrorWhileProcessingConfirmationTransaction { err });
+            return Err(SuiError::ErrorWhileProcessingCertificate { err });
         }
 
         Ok(guard)

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1655,8 +1655,8 @@ where
                                     );
                                 }
                                 state.errors.push(
-                                    SuiError::ErrorWhileProcessingTransactionTransaction {
-                                        err: format!("Unexpected: {:?}", ret),
+                                    SuiError::UnexectedResultFromValidatorHandleTransaction {
+                                        err: format!("{:?}", ret),
                                     },
                                 );
                                 state.bad_stake += weight; // This is the bad stake counter
@@ -1719,8 +1719,8 @@ where
         // If we have some certificate return it, or return an error.
         state
             .certificate
-            .ok_or_else(|| SuiError::ErrorWhileProcessingTransactionTransaction {
-                err: format!("No certificate: {:?}", state.errors),
+            .ok_or(SuiError::QuorumFailedToProcessTransaction {
+                errors: state.errors,
             })
     }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -113,12 +113,17 @@ pub enum SuiError {
     },
     #[error("Invalid Authority Bitmap: {}", error)]
     InvalidAuthorityBitmap { error: String },
-    #[error("Transaction processing failed: {err}")]
-    ErrorWhileProcessingTransactionTransaction { err: String },
-    #[error("Confirmation transaction processing failed: {err}")]
-    ErrorWhileProcessingConfirmationTransaction { err: String },
+    #[error("Unexpected validator response from handle_transaction: {err}")]
+    UnexectedResultFromValidatorHandleTransaction { err: String },
+    #[error("Transaction certificate processing failed: {err}")]
+    ErrorWhileProcessingCertificate { err: String },
     #[error(
-    "Failed to execute certificate on a quorum of validators, cause by : {:#?}",
+        "Failed to process transaction on a quorum of validators to form a transaction certificate, caused by : {:#?}",
+        errors.iter().map(| e | ToString::to_string(&e)).collect::<Vec<String>>()
+        )]
+    QuorumFailedToProcessTransaction { errors: Vec<SuiError> },
+    #[error(
+    "Failed to execute certificate on a quorum of validators, caused by : {:#?}",
     errors.iter().map(| e | ToString::to_string(&e)).collect::<Vec<String>>()
     )]
     QuorumFailedToExecuteCertificate { errors: Vec<SuiError> },


### PR DESCRIPTION
1. rename `ErrorWhileProcessingConfirmationTransaction` -> `ErrorWhileProcessingCertificate` as we moved away calling it `confirmation transaction`
2. add `UnexectedResultFromValidatorHandleTransaction` in authority aggregator when getting a mismatched response (e.g.wrong epoch). 
3. add `QuorumFailedToProcessTransaction` which has a vector of `SuiError` to convoy a list of errors from validators, similar to `QuorumFailedToExecuteCertificate`.
4. 2 and 3 together make `ErrorWhileProcessingTransactionTransaction` a pure server side error.
5. remove `ErrorWhileProcessingTransactionTransaction`