### PR TITLE
check that JS `Number` types in vectors are all integers

### DIFF
--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -294,7 +294,7 @@ fn is_homogeneous_rec(curr_q: &mut VecDeque<&JsonValue>) -> bool {
         // Okay to unwrap since we know values exist
         let curr = match curr_q.pop_front().unwrap() {
             JsonValue::Bool(_) => ValidJsonType::Bool,
-            JsonValue::Number(_) => ValidJsonType::Number,
+            JsonValue::Number(x) => if x.is_u64() { ValidJsonType::Number } else { return false },
             JsonValue::String(_) => ValidJsonType::String,
             JsonValue::Array(w) => {
                 // Add to the next level

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -294,7 +294,13 @@ fn is_homogeneous_rec(curr_q: &mut VecDeque<&JsonValue>) -> bool {
         // Okay to unwrap since we know values exist
         let curr = match curr_q.pop_front().unwrap() {
             JsonValue::Bool(_) => ValidJsonType::Bool,
-            JsonValue::Number(x) => if x.is_u64() { ValidJsonType::Number } else { return false },
+            JsonValue::Number(x) => {
+                if x.is_u64() {
+                    ValidJsonType::Number
+                } else {
+                    return false;
+                }
+            }
             JsonValue::String(_) => ValidJsonType::String,
             JsonValue::Array(w) => {
                 // Add to the next level


### PR DESCRIPTION
should fix the crash bug recently reported in the json parser.

The issue is that we weren't type-checking JS `Number` types that came inside vectors to ensure they were integers.  This adds that safety check that we usually do on non-vectored `Number` input.