### PR TITLE
Qd retry transactions that locks objs

### DIFF
--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -21,6 +21,14 @@ pub struct QuorumDriverMetrics {
     pub(crate) latency_sec_wait_for_effects_cert: Histogram,
 
     pub(crate) current_requests_in_flight: IntGauge,
+
+    pub(crate) total_err_process_tx_responses_with_nonzero_conflicting_transactions: IntCounter,
+    pub(crate) total_attempts_retrying_conflicting_transaction: IntCounter,
+    pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
+    pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
+
+    pub(crate) total_times_could_not_get_conflicting_transaction_from_any_validators: IntCounter,
+    pub(crate) total_times_could_not_get_conflicting_transaction_from_a_validator: IntCounter,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -90,6 +98,42 @@ impl QuorumDriverMetrics {
             current_requests_in_flight: register_int_gauge_with_registry!(
                 "current_requests_in_flight",
                 "Current number of requests being processed in QuorumDriver",
+                registry,
+            )
+            .unwrap(),
+            total_err_process_tx_responses_with_nonzero_conflicting_transactions: register_int_counter_with_registry!(
+                "quorum_driver_total_err_process_tx_responses_with_nonzero_conflicting_transactions",
+                "Total number of err process_tx responses with non empty conflicting transactions",
+                registry,
+            )
+            .unwrap(),
+            total_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
+                "quorum_driver_total_attempts_trying_conflicting_transaction",
+                "Total number of attempts to retry a conflicting transaction",
+                registry,
+            )
+            .unwrap(),
+            total_successful_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
+                "quorum_driver_total_successful_attempts_trying_conflicting_transaction",
+                "Total number of successful attempts to retry a conflicting transaction",
+                registry,
+            )
+            .unwrap(),
+            total_times_conflicting_transaction_already_finalized_when_retrying: register_int_counter_with_registry!(
+                "quorum_driver_total_times_conflicting_transaction_already_finalized_when_retrying",
+                "Total number of times the conflicting transaction is already finalized when retrying",
+                registry,
+            )
+            .unwrap(),
+            total_times_could_not_get_conflicting_transaction_from_any_validators: register_int_counter_with_registry!(
+                "quorum_driver_total_times_could_not_get_conflicting_transaction_from_any_validators",
+                "Total number of times a validator could not return conflicting transaction info it is supposed to have",
+                registry,
+            )
+            .unwrap(),
+            total_times_could_not_get_conflicting_transaction_from_a_validator: register_int_counter_with_registry!(
+                "quorum_driver_total_times_could_not_get_conflicting_transaction_from_a_validator",
+                "Total number of times no validators could return conflicting transaction info they are supposed to have",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -27,8 +27,7 @@ pub struct QuorumDriverMetrics {
     pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
     pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
 
-    pub(crate) total_times_could_not_get_conflicting_transaction_from_any_validators: IntCounter,
-    pub(crate) total_times_could_not_get_conflicting_transaction_from_a_validator: IntCounter,
+    pub(crate) total_equivocation_detected: IntCounter,
 }
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
@@ -125,15 +124,9 @@ impl QuorumDriverMetrics {
                 registry,
             )
             .unwrap(),
-            total_times_could_not_get_conflicting_transaction_from_any_validators: register_int_counter_with_registry!(
-                "quorum_driver_total_times_could_not_get_conflicting_transaction_from_any_validators",
-                "Total number of times a validator could not return conflicting transaction info it is supposed to have",
-                registry,
-            )
-            .unwrap(),
-            total_times_could_not_get_conflicting_transaction_from_a_validator: register_int_counter_with_registry!(
-                "quorum_driver_total_times_could_not_get_conflicting_transaction_from_a_validator",
-                "Total number of times no validators could return conflicting transaction info they are supposed to have",
+            total_equivocation_detected: register_int_counter_with_registry!(
+                "quorum_driver_total_equivocation_detected",
+                "Total number of equivocations that are detected",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -9,11 +9,12 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use sui_types::base_types::{AuthorityName, ObjectRef, TransactionDigest};
 use sui_types::committee::{Committee, EpochId, StakeUnit};
+use tap::TapFallible;
 
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 use tracing::Instrument;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::authority_aggregator::AuthorityAggregator;
 use crate::authority_client::AuthorityAPI;
@@ -157,10 +158,7 @@ where
         &self,
         transaction: VerifiedTransaction,
     ) -> SuiResult<QuorumDriverResponse> {
-        let certificate = self
-            .process_transaction(transaction)
-            .instrument(tracing::debug_span!("process_tx"))
-            .await?;
+        let certificate = self.process_transaction(transaction).await?;
         self.task_sender
             .send(QuorumTask::ProcessCertificate(certificate.clone()))
             .await
@@ -174,14 +172,8 @@ where
         &self,
         transaction: VerifiedTransaction,
     ) -> SuiResult<QuorumDriverResponse> {
-        let certificate = self
-            .process_transaction(transaction)
-            .instrument(tracing::debug_span!("process_tx"))
-            .await?;
-        let response = self
-            .process_certificate(certificate)
-            .instrument(tracing::debug_span!("process_cert"))
-            .await?;
+        let certificate = self.process_transaction(transaction).await?;
+        let response = self.process_certificate(certificate).await?;
         Ok(QuorumDriverResponse::EffectsCert(Box::new(response)))
     }
 
@@ -200,19 +192,56 @@ where
 
         match &result {
             Err(SuiError::QuorumFailedToProcessTransaction {
+                good_stake,
                 errors: _errors,
                 conflicting_tx_digests,
             }) if !conflicting_tx_digests.is_empty() => {
-                // TODO metrics
+                self.metrics
+                    .total_err_process_tx_responses_with_nonzero_conflicting_transactions
+                    .inc();
                 debug!(
                     ?tx_digest,
-                    "Attempting to retry {} conflicting transactions: {:?}",
+                    ?good_stake,
+                    "Observed {} conflicting transactions: {:?}",
                     conflicting_tx_digests.len(),
                     conflicting_tx_digests
                 );
-                let _ = self
-                    .attempt_conflicting_transactions(conflicting_tx_digests)
+                let attempt_result = self
+                    .attempt_conflicting_transactions_maybe(
+                        *good_stake,
+                        conflicting_tx_digests,
+                        &tx_digest,
+                    )
                     .await;
+                match attempt_result {
+                    Err(err) => {
+                        debug!(
+                            ?tx_digest,
+                            "Encountered error in attempt_conflicting_transactions_maybe: {:?}",
+                            err
+                        );
+                    }
+                    Ok(None) => {
+                        debug!(?tx_digest, "Did not retry any conflicting transactions");
+                    }
+                    Ok(Some((retried_tx_digest, success))) => {
+                        self.metrics
+                            .total_attempts_retrying_conflicting_transaction
+                            .inc();
+                        debug!(
+                            ?tx_digest,
+                            ?retried_tx_digest,
+                            "Retried conflicting transaction success: {}",
+                            success
+                        );
+                        if success {
+                            self.metrics
+                                .total_successful_attempts_retrying_conflicting_transaction
+                                .inc();
+                        }
+                        return Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried { conflicting_tx_digest: retried_tx_digest, conflicting_tx_retry_success: success });
+                    }
+                }
             }
             _ => (),
         }
@@ -247,65 +276,76 @@ where
     }
 
     // TODO currently this function is not epoch-boundary-safe. We need to make it so.
-    async fn attempt_conflicting_transactions(
+    /// Returns Ok(None) if the no conflicting transaction was retried.
+    /// Returns Ok(Some((tx_digest, true))) if one conflicting transaction was retried and succeeded,
+    /// Some((tx_digest, false)) otherwise.
+    /// Returns Error on unexpected errors.
+    #[allow(clippy::type_complexity)]
+    async fn attempt_conflicting_transactions_maybe(
         &self,
+        good_stake: StakeUnit,
         conflicting_tx_digests: &BTreeMap<
-            ObjectRef,
-            BTreeMap<TransactionDigest, (Vec<AuthorityName>, StakeUnit)>,
+            TransactionDigest,
+            (Vec<(AuthorityName, ObjectRef)>, StakeUnit),
         >,
-    ) -> SuiResult<()> {
+        original_tx_digest: &TransactionDigest,
+    ) -> SuiResult<Option<(TransactionDigest, bool)>> {
         let validity = self.validators.load().committee.validity_threshold();
-
-        let mut futs = Vec::new();
-        for (obj_ref, tx_digests) in conflicting_tx_digests {
-            futs.push(self.attempt_one_conflicting_transaction(obj_ref, tx_digests, validity));
+        // if we have >= f+1 good stake on the current transaction, no point in retrying conflicting ones
+        if good_stake >= validity {
+            return Ok(None);
         }
 
-        futures::future::join_all(futs).await;
-        Ok(())
-    }
-
-    async fn attempt_one_conflicting_transaction(
-        &self,
-        obj_ref: &ObjectRef,
-        conflicting_tx_digests: &BTreeMap<TransactionDigest, (Vec<AuthorityName>, StakeUnit)>,
-        validity: u64,
-    ) -> SuiResult<()> {
-        if conflicting_tx_digests.is_empty() {
-            // TODO log error
-            return Ok(());
-        }
         let mut conflicting_tx_digests = Vec::from_iter(conflicting_tx_digests.iter());
-        // sort by weights
         conflicting_tx_digests.sort_by(|lhs, rhs| rhs.1 .1.cmp(&lhs.1 .1));
+        if conflicting_tx_digests.is_empty() {
+            error!("This path in unreachable with an emtpy conflicting_tx_digests.");
+            return Ok(None);
+        }
 
         // we checked emptiness above, safe to unwrap.
         let (tx_digest, (validators, total_stake)) = conflicting_tx_digests.get(0).unwrap();
-        if let Some((tx_digest_2, (validators_2, total_stake_2))) = conflicting_tx_digests.get(1) {
-            // If the 2nd digest's total stake also surpasses f+1, the object is fully equivocated.
-            if *total_stake_2 >= validity {
-                // TODO add metric here
-                info!(
-                    ?obj_ref,
-                    tx_digest_1=?tx_digest,
-                    validators_1=?validators,
-                    total_stake_1=?total_stake,
-                    tx_digest_2=?tx_digest_2,
-                    validators_2=?validators_2,
-                    total_stake_2=?total_stake_2,
-                    "Object is now fully equivocated on validators"
-                );
-                return Ok(());
-            }
-        }
 
-        // Now, we optimistically assume the object is not fully equivocated yet, and try to execute the tx.
+        // To be more conservative and try not to actually cause full equivocation,
+        // we only retry a transaction when at least f+1 validators claims this tx locks objects
+        if *total_stake < validity {
+            return Ok(None);
+        }
+        info!(
+            ?tx_digest,
+            ?total_stake,
+            ?original_tx_digest,
+            "retrying conflicting tx."
+        );
+        let is_tx_executed = self
+            .attempt_one_conflicting_transaction(
+                tx_digest,
+                original_tx_digest,
+                validators
+                    .iter()
+                    .map(|(name, _obj_ref)| name)
+                    .collect::<Vec<_>>(),
+            )
+            .await?;
+
+        Ok(Some((**tx_digest, is_tx_executed)))
+    }
+
+    /// Returns Some(true) if the conflicting transaction is executed successfully
+    /// (or already executed), or Some(false) if it did not.
+    async fn attempt_one_conflicting_transaction(
+        &self,
+        tx_digest: &&TransactionDigest,
+        original_tx_digest: &TransactionDigest,
+        validators: Vec<&AuthorityName>,
+    ) -> SuiResult<bool> {
         let clients = self.validators.load();
         for validator_name in validators {
             // If we cannot find the client, it indicates an epoch change. Then we stop all attempts.
-            let client = clients.get_client(validator_name).ok_or_else( ||
+            let client = clients.get_client(validator_name).ok_or_else( || {
+                info!(?tx_digest, "It looks like we have an epoch change when doing attempt_one_conflicting_transaction.");
                 SuiError::InconsistentEpochState { error: format!("Epoch advance caused validator {:?} missing in AuthorityAggreagtor, giving up all attempts.", validator_name) }
-            )?;
+            })?;
             if let Ok(TransactionInfoResponse {
                 signed_transaction,
                 certified_transaction,
@@ -316,9 +356,35 @@ where
                 })
                 .await
             {
-                // If we happen to find that a validator returns TransactionCertificate, this transaction is finalized.
-                if certified_transaction.is_some() {
-                    return Ok(());
+                // If we happen to find that a validator returns TransactionCertificate:
+                if let Some(certified_transaction) = certified_transaction {
+                    self.metrics
+                        .total_times_conflicting_transaction_already_finalized_when_retrying
+                        .inc();
+                    // We still want to ask validators to execute this certificate in case this certificate is not
+                    // known to the rest of them (e.g. when *this* validator is bad).
+                    let result = self
+                        .validators
+                        .load()
+                        .process_certificate(certified_transaction.into_inner())
+                        .await
+                        .tap_ok(|_resp| {
+                            debug!(
+                                ?tx_digest,
+                                ?original_tx_digest,
+                                "Retry conflicting transaction certificate succeeded."
+                            );
+                        })
+                        .tap_err(|err| {
+                            debug!(
+                                ?tx_digest,
+                                ?original_tx_digest,
+                                "Retry conflicting transaction certificate got an error: {:?}",
+                                err
+                            );
+                        });
+                    // We only retry once.
+                    return Ok(result.is_ok());
                 }
                 if let Some(verified_transaction) = signed_transaction {
                     let transaction =
@@ -326,24 +392,44 @@ where
                     // SafeClient checked the transaction is legit in `handle_transaction_info_request`
                     let verified_transaction =
                         VerifiedTransactionEnvelope::new_unchecked(transaction);
-                    let _ = self
+                    // Now ask validators to execute this transaction.
+                    let result = self
                         .validators
                         .load()
                         .execute_transaction(&verified_transaction)
-                        .await;
-                    // TODO log & metrics
-                    // Now for each digest, we only give it one shot.
-                    return Ok(());
+                        .await
+                        .tap_ok(|_resp| {
+                            debug!(
+                                ?tx_digest,
+                                ?original_tx_digest,
+                                "Retry conflicting transaction succeeded."
+                            );
+                        })
+                        .tap_err(|err| {
+                            debug!(
+                                ?tx_digest,
+                                ?original_tx_digest,
+                                "Retry conflicting transaction got an error: {:?}",
+                                err
+                            );
+                        });
+                    // We only retry once.
+                    return Ok(result.is_ok());
                 } else {
-                    // TODO log byzantinue behavior
+                    self.metrics
+                        .total_times_could_not_get_conflicting_transaction_from_a_validator
+                        .inc();
+                    warn!(name=?validator_name, ?tx_digest, ?original_tx_digest, "Suspicious Byzantine behavior - valdiator couldn't give transaction info that it is supposed to know about");
                     // try the next validator
                 }
             }
         }
-        // if we reach here, it means none of the validators gives us the transaction.
-        // TODO metrics
-        warn!(?obj_ref, "No one validator gives us the transaction info. They either just experienced an epoch change, or are byzantine.");
-        Ok(())
+        // if we reach here, it means none of the validators returned the transaction info.
+        self.metrics
+            .total_times_could_not_get_conflicting_transaction_from_any_validators
+            .inc();
+        warn!(?tx_digest, ?original_tx_digest, "No one validator could give the transaction info. They either just experienced an epoch change, or are byzantine");
+        Ok(false)
     }
 }
 
@@ -454,5 +540,69 @@ where
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority_aggregator::authority_aggregator_tests::init_local_authorities;
+
+    #[tokio::test]
+    async fn test_not_retry_on_object_locked() -> Result<(), anyhow::Error> {
+        let (auth_agg, _, _) = init_local_authorities(4, vec![]).await;
+
+        let quorum_driver_handler = QuorumDriverHandler::new(
+            Arc::new(auth_agg.clone()),
+            QuorumDriverMetrics::new_for_tests(),
+        );
+        let quorum_driver = quorum_driver_handler.clone_quorum_driver();
+        let validity = quorum_driver
+            .authority_aggregator()
+            .load()
+            .committee
+            .validity_threshold();
+
+        assert_eq!(auth_agg.clone_inner_clients().keys().cloned().count(), 4);
+
+        // good stake >= validity, no transaction will be retried, expect Ok(None)
+        assert_eq!(
+            quorum_driver
+                .attempt_conflicting_transactions_maybe(
+                    validity,
+                    &BTreeMap::new(),
+                    &TransactionDigest::random()
+                )
+                .await,
+            Ok(None)
+        );
+        assert_eq!(
+            quorum_driver
+                .attempt_conflicting_transactions_maybe(
+                    validity + 1,
+                    &BTreeMap::new(),
+                    &TransactionDigest::random()
+                )
+                .await,
+            Ok(None)
+        );
+
+        // good stake < validity, but the top transaction total stake < validaty too, no transaction will be retried, expect Ok(None)
+        let conflicting_tx_digests = BTreeMap::from([
+            (TransactionDigest::random(), (vec![], validity - 1)),
+            (TransactionDigest::random(), (vec![], 1)),
+        ]);
+        assert_eq!(
+            quorum_driver
+                .attempt_conflicting_transactions_maybe(
+                    validity - 1,
+                    &conflicting_tx_digests,
+                    &TransactionDigest::random()
+                )
+                .await,
+            Ok(None)
+        );
+
+        Ok(())
     }
 }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -128,9 +128,19 @@ pub enum SuiError {
         errors.iter().map(| e | ToString::to_string(&e)).collect::<Vec<String>>()
     )]
     QuorumFailedToProcessTransaction {
+        good_stake: StakeUnit,
         errors: Vec<SuiError>,
         conflicting_tx_digests:
-            BTreeMap<ObjectRef, BTreeMap<TransactionDigest, (Vec<AuthorityName>, StakeUnit)>>,
+            BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
+    },
+    #[error(
+        "Failed to process transaction on a quorum of validators to form a transaction certificate because of locked objects, but retried a conflicting transaction {:?}, success: {}",
+        conflicting_tx_digest,
+        conflicting_tx_retry_success
+    )]
+    QuorumFailedToProcessTransactionWithConflictingTransactionRetried {
+        conflicting_tx_digest: TransactionDigest,
+        conflicting_tx_retry_success: bool,
     },
     #[error(
     "Failed to execute certificate on a quorum of validators. Validator errors: {:#?}",

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -899,14 +899,6 @@ impl<S> TransactionEnvelope<S> {
     pub fn is_system_tx(&self) -> bool {
         self.signed_data.data.kind.is_system_tx()
     }
-
-    pub fn remove_auth_sig_info(self) -> Transaction {
-        Transaction {
-            transaction_digest: self.transaction_digest,
-            signed_data: self.signed_data,
-            auth_sign_info: EmptySignInfo {},
-        }
-    }
 }
 
 // In combination with #[serde(remote = "TransactionEnvelope")].

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -899,6 +899,14 @@ impl<S> TransactionEnvelope<S> {
     pub fn is_system_tx(&self) -> bool {
         self.signed_data.data.kind.is_system_tx()
     }
+
+    pub fn remove_auth_sig_info(self) -> Transaction {
+        Transaction {
+            transaction_digest: self.transaction_digest,
+            signed_data: self.signed_data,
+            auth_sign_info: EmptySignInfo {},
+        }
+    }
 }
 
 // In combination with #[serde(remote = "TransactionEnvelope")].

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -8,10 +8,15 @@ use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::quorum_driver::{QuorumDriverHandler, QuorumDriverMetrics};
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::SuiAddress;
+use sui_types::crypto::AccountKeyPair;
+use sui_types::error::SuiError;
 use sui_types::messages::{
     QuorumDriverRequest, QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
 };
-use test_utils::authority::{spawn_test_authorities, test_authority_configs};
+use sui_types::object::Object;
+use test_utils::authority::{
+    spawn_test_authorities, test_and_configure_authority_configs, test_authority_configs,
+};
 use test_utils::messages::make_transfer_sui_transaction;
 use test_utils::objects::test_gas_objects;
 use test_utils::test_account_keys;
@@ -161,4 +166,202 @@ async fn test_update_validators() {
     );
 
     handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_retry_on_object_locked() -> Result<(), anyhow::Error> {
+    let mut gas_objects = test_gas_objects();
+    let configs = test_and_configure_authority_configs(4);
+    let handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
+    let committee_store = handles[0].with(|h| h.state().committee_store().clone());
+    let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(&configs)
+        .with_committee_store(committee_store)
+        .build()
+        .unwrap();
+    let aggregator = Arc::new(aggregator);
+    let quorum_driver_handler =
+        QuorumDriverHandler::new(aggregator.clone(), QuorumDriverMetrics::new_for_tests());
+    let quorum_driver = quorum_driver_handler.clone_quorum_driver();
+
+    let (sender, keypair) = test_account_keys().pop().unwrap();
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+    let names: Vec<_> = aggregator.authority_clients.keys().clone().collect();
+    assert_eq!(names.len(), 4);
+    let client0 = aggregator.clone_client(names[0]);
+    let client1 = aggregator.clone_client(names[1]);
+    let client2 = aggregator.clone_client(names[2]);
+
+    // Case 1 - two validators lock the object with the same tx
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client1.handle_transaction(tx.clone()).await.is_ok());
+
+    let tx2 = make_tx(&gas, sender, &keypair);
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx2,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    match res {
+        // If aggregator gets two bad responses from 0 and 1 before getting two good responses from 2 and 3,
+        // it will retry tx, but it will fail due to equivocaiton.
+        Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried {conflicting_tx_digest, conflicting_tx_retry_success}) => {
+            assert_eq!(conflicting_tx_digest, *tx.digest());
+            assert!(!conflicting_tx_retry_success);
+        },
+        // If aggregator gets two good responses from client 2 and 3 before two bad responses from 0 and 1, 
+        // tx will not be retried.
+        Err(SuiError::QuorumFailedToProcessTransaction {..}) => (),
+        _ => panic!("expect Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried) or QuorumFailedToProcessTransaction but got {:?}", res),
+    }
+
+    // Case 2 - three validators lock the object with the same tx
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client1.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client2.handle_transaction(tx.clone()).await.is_ok());
+
+    let tx2 = make_tx(&gas, sender, &keypair);
+
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx2,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    // Aggregator gets three bad responses, and tries tx, which should succeed.
+    if let Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried {
+        conflicting_tx_digest,
+        conflicting_tx_retry_success,
+    }) = res
+    {
+        assert_eq!(conflicting_tx_digest, *tx.digest());
+        assert!(conflicting_tx_retry_success);
+    } else {
+        panic!("expect Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried) but got {:?}", res)
+    }
+
+    // Case 3 - one validator locks the object
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+
+    let tx2 = make_tx(&gas, sender, &keypair);
+
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx2,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    // Aggregator gets three good responses and execution succeeds.
+    assert!(res.is_ok());
+
+    // Case 4 - object is locked by 2 txes with weight 2 and 1 respectivefully. Then try to execute the third txn
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+    let tx2 = make_tx(&gas, sender, &keypair);
+
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client1.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client2.handle_transaction(tx2.clone()).await.is_ok());
+
+    let tx3 = make_tx(&gas, sender, &keypair);
+
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx3,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    match res {
+        // If aggregator gets two bad responses from 0 and 1, it will retry tx, but it will fail due to equivocaiton.
+        Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried {conflicting_tx_digest, conflicting_tx_retry_success}) => {
+            assert_eq!(conflicting_tx_digest, *tx.digest());
+            assert!(!conflicting_tx_retry_success);
+        },
+        // If aggregator gets two bad responses of which one from 2, then no tx will be retried.
+        Err(SuiError::QuorumFailedToProcessTransaction {..}) => (),
+        _ => panic!("expect Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried) or QuorumFailedToProcessTransaction but got {:?}", res),
+    }
+
+    // Case 5 - object is locked by 2 txes with weight 2 and 1, try to execute the lighter stake tx
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+    let tx2 = make_tx(&gas, sender, &keypair);
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client1.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client2.handle_transaction(tx2.clone()).await.is_ok());
+    println!("tx2: {:?}", tx2.digest());
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx2,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    match res {
+        // if aggregator gets two bad responses from 0 and 1 first, it will try to retry tx (stake = 2), but that will fail
+        Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried {conflicting_tx_digest, conflicting_tx_retry_success}) => {
+            assert_eq!(conflicting_tx_digest, *tx.digest());
+            assert!(!conflicting_tx_retry_success);
+        },
+        // If aggregator gets two bad responses of which one from 2, then no tx will be retried.
+        Err(SuiError::QuorumFailedToProcessTransaction {..}) => (),
+        _ => panic!("expect Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried) or QuorumFailedToProcessTransaction but got {:?}", res),
+    }
+
+    // Case 6 - object is locked by 2 txes with weight 2 and 1, try to execute the heavier stake tx
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+    let tx2 = make_tx(&gas, sender, &keypair);
+
+    assert!(client0.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client1.handle_transaction(tx.clone()).await.is_ok());
+    assert!(client2.handle_transaction(tx2).await.is_ok());
+
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    assert!(res.is_ok());
+
+    // Case 7 - three validators lock the object, by different txes
+    let gas = gas_objects.pop().unwrap();
+    let tx = make_tx(&gas, sender, &keypair);
+    let tx2 = make_tx(&gas, sender, &keypair);
+    let tx3 = make_tx(&gas, sender, &keypair);
+    assert!(client0.handle_transaction(tx).await.is_ok());
+    assert!(client1.handle_transaction(tx2).await.is_ok());
+    assert!(client2.handle_transaction(tx3).await.is_ok());
+
+    let tx4 = make_tx(&gas, sender, &keypair);
+    let res = quorum_driver
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx4,
+            request_type: QuorumDriverRequestType::WaitForEffectsCert,
+        })
+        .await;
+    if !matches!(res, Err(SuiError::QuorumFailedToProcessTransaction { .. })) {
+        panic!(
+            "expect Err(SuiError::QuorumFailedToProcessTransaction) but got {:?}",
+            res
+        )
+    }
+
+    Ok(())
+}
+
+fn make_tx(gas: &Object, sender: SuiAddress, keypair: &AccountKeyPair) -> VerifiedTransaction {
+    make_transfer_sui_transaction(
+        gas.compute_object_reference(),
+        SuiAddress::random_for_testing_only(),
+        None,
+        sender,
+        keypair,
+    )
 }


### PR DESCRIPTION
This PR let Quorum Driver auto retry conflicting transactions in some conditions.
## Main Logic
1. in `authority_aggregator::process_transaction`, if it see `ObjectLockConflict`, note that down in `state.conflicting_tx_digests` for later processing.
2. `authority_aggregator::process_transaction` return `QuorumFailedToProcessTransaction` when it fails, which contains `good_stake` and `conflicting_tx_digests`.
3. When seeing `QuorumFailedToProcessTransaction`, Quorum Driver examine whether a retry is desirable based on a few rules: 
a. if `good_stake` >= validity, do not retry any conflicting transactions because that will either cause equivocation or is purely in vain. (An optimization is we examine the error types and see if we want to retry the current transaction. But that's not in this PR's scope)
b. if the transaction with the highest stake in `conflicting_tx_digests` has stake < validity, we do not try. This is because authority aggregator returns as soon as it has error-stake >= validity. Based on the limited information it does not know whether it's safe to retry when the stake of the conflicting tx < validity. We want to be conservative and not cause equivocation. If its stake >= validity, it's safe to retry because either the retry succeeds, or fails when there is another transaction (that is not in the returned conflicting info) also with stake >= validity. In the latter case, the object is already fully equivocated so that's an op. (An optimization is we query all validators to get a full picture, but let's see if PR can solve most of the problems first)
c. if there's a transaction with >= validity stake, we try to query validators who said they know about the transaction info. If we happen to find there's a `CertifiedTransaction` returned from a validator, we can directly ask validators to execute the cert. This is to make sure other validators know about it. If we get a `SignedTransaction`, we also pass that to validators for execution. If any validator couldn't give `SignedTransaction`, they are likely byzantine (or just experienced an epoch change)
4. If we decide to retry a conflicting transaction, QuorumDriver returns `QuorumFailedToProcessTransactionWithConflictingTransactionRetried` with the retried tx and result. If not, we return the original `QuorumFailedToProcessTransaction` error.

## Other Stuff
1. add various test cases
2. get rid of `QuorumNotReached` error and make `QuorumFailedToProcessTransaction` the only error returned from `authority_aggregator::process_transaction`
3. remove two duplicate spans that cause double-counted metrics
