### PR TITLE
[error] Properly detect epoch change error in auth aggregator

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -570,8 +570,17 @@ impl From<&str> for SuiError {
 
 impl SuiError {
     pub fn indicates_epoch_change(&self) -> bool {
-        matches!(self, SuiError::ValidatorHaltedAtEpochEnd)
-            || matches!(self, SuiError::MissingCommitteeAtEpoch(_))
+        match self {
+            SuiError::QuorumFailedToProcessTransaction { errors, .. }
+            | SuiError::QuorumFailedToExecuteCertificate { errors, .. } => {
+                errors.iter().any(|err| {
+                    matches!(err, SuiError::ValidatorHaltedAtEpochEnd)
+                        || matches!(self, SuiError::MissingCommitteeAtEpoch(_))
+                })
+            }
+            SuiError::ValidatorHaltedAtEpochEnd | SuiError::MissingCommitteeAtEpoch(_) => true,
+            _ => false,
+        }
     }
 }
 


### PR DESCRIPTION
Address the feedback from previous PR. The epoch change related errors are all nested inside the quorum errors.