### PR TITLE
Remove embedded gateway connection mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,9 +3087,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,9 +3087,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.22"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -221,7 +221,7 @@ pub struct FullNodeProxy {
 
 impl FullNodeProxy {
     pub async fn from_url(http_url: &str) -> Result<Self, anyhow::Error> {
-        let sui_client = SuiClient::new_rpc_client(http_url, None).await?;
+        let sui_client = SuiClient::new(http_url, None).await?;
 
         let resp = sui_client.read_api().get_committee_info(None).await?;
         let epoch = resp.epoch;

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -5,12 +5,11 @@ use async_trait::async_trait;
 use clap::*;
 use std::net::SocketAddr;
 use sui::client_commands::WalletContext;
-use sui::config::SuiClientConfig;
+use sui::config::{SuiClientConfig, SuiEnv};
 use sui_config::genesis_config::GenesisConfig;
 use sui_config::Config;
 use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
-use sui_sdk::ClientType;
 use sui_swarm::memory::Swarm;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
@@ -143,12 +142,6 @@ impl Cluster for LocalNewCluster {
         // Let the faucet account hold 1000 gas objects on genesis
         let genesis_config = GenesisConfig::custom_genesis(4, 1, 1000);
 
-        let gateway_port = options.gateway_address.as_ref().map(|addr| {
-            addr.parse::<SocketAddr>()
-                .expect("Unable to parse gateway address")
-                .port()
-        });
-
         // TODO: options should contain port instead of address
         let fullnode_port = options.fullnode_address.as_ref().map(|addr| {
             addr.parse::<SocketAddr>()
@@ -164,9 +157,6 @@ impl Cluster for LocalNewCluster {
 
         let mut cluster_builder = TestClusterBuilder::new().set_genesis_config(genesis_config);
 
-        if let Some(rpc_port) = gateway_port {
-            cluster_builder = cluster_builder.set_gateway_rpc_port(rpc_port);
-        }
         if let Some(rpc_port) = fullnode_port {
             cluster_builder = cluster_builder.set_fullnode_rpc_port(rpc_port);
         }
@@ -267,8 +257,13 @@ pub async fn new_wallet_context_from_cluster(
         .unwrap();
     SuiClientConfig {
         keystore,
-        client_type: ClientType::RPC(fullnode_url.into(), None),
+        envs: vec![SuiEnv {
+            alias: "localnet".to_string(),
+            rpc: fullnode_url.into(),
+            ws: None,
+        }],
         active_address: Some(address),
+        active_env: "localnet".to_string(),
     }
     .persisted(&wallet_config_path)
     .save()

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -263,7 +263,7 @@ pub async fn new_wallet_context_from_cluster(
             ws: None,
         }],
         active_address: Some(address),
-        active_env: "localnet".to_string(),
+        active_env: Some("localnet".to_string()),
     }
     .persisted(&wallet_config_path)
     .save()

--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -18,8 +18,6 @@ pub struct ClusterTestOpt {
     #[clap(arg_enum)]
     pub env: Env,
     #[clap(long)]
-    pub gateway_address: Option<String>,
-    #[clap(long)]
     pub faucet_address: Option<String>,
     #[clap(long)]
     pub fullnode_address: Option<String>,
@@ -31,7 +29,6 @@ impl ClusterTestOpt {
     pub fn new_local() -> Self {
         Self {
             env: Env::NewLocal,
-            gateway_address: None,
             faucet_address: None,
             fullnode_address: None,
             websocket_address: None,

--- a/crates/sui-cluster-test/src/wallet_client.rs
+++ b/crates/sui-cluster-test/src/wallet_client.rs
@@ -29,7 +29,7 @@ impl WalletClient {
 
         let rpc_url = String::from(cluster.fullnode_url());
         info!("Use fullnode rpc: {}", &rpc_url);
-        let fullnode_client = SuiClient::new_rpc_client(&rpc_url, None).await.unwrap();
+        let fullnode_client = SuiClient::new(&rpc_url, None).await.unwrap();
 
         Self {
             wallet_context,

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -10,7 +10,7 @@ use tap::tap::TapFallible;
 #[cfg(test)]
 use std::collections::HashSet;
 
-use sui::client_commands::{SuiClientCommands, WalletContext};
+use sui::client_commands::WalletContext;
 use sui_json_rpc_types::{
     SuiExecutionStatus, SuiObjectRead, SuiPaySui, SuiTransactionKind, SuiTransactionResponse,
 };
@@ -51,16 +51,6 @@ impl SimpleFaucet {
             .active_address()
             .map_err(|err| FaucetError::Wallet(err.to_string()))?;
         info!("SimpleFaucet::new with active address: {active_address}");
-
-        // Sync to have the latest status
-        if wallet.client.is_gateway() {
-            SuiClientCommands::SyncClientState {
-                address: Some(active_address),
-            }
-            .execute(&mut wallet)
-            .await
-            .map_err(|err| FaucetError::Wallet(format!("Fail to sync client state: {}", err)))?;
-        }
 
         let coins = wallet
             .gas_objects(active_address)

--- a/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
@@ -9,10 +9,11 @@ use sui_config::SUI_KEYSTORE_FILENAME;
 use sui_core::test_utils::to_sender_signed_transaction;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
-use sui_json_rpc::api::{
-    RpcGatewayApiClient, RpcReadApiClient, RpcTransactionBuilderClient, WalletSyncApiClient,
+use sui_json_rpc::api::TransactionExecutionApiClient;
+use sui_json_rpc::api::{RpcReadApiClient, RpcTransactionBuilderClient};
+use sui_json_rpc_types::{
+    GetObjectDataResponse, SuiExecuteTransactionResponse, SuiTransactionResponse, TransactionBytes,
 };
-use sui_json_rpc_types::{GetObjectDataResponse, SuiTransactionResponse, TransactionBytes};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::SuiClient;
 use sui_types::base_types::ObjectID;
@@ -27,14 +28,13 @@ use test_utils::network::TestClusterBuilder;
 async fn test_get_objects() -> Result<(), anyhow::Error> {
     let port = get_available_port();
     let cluster = TestClusterBuilder::new()
-        .set_gateway_rpc_port(port)
+        .set_fullnode_rpc_port(port)
         .build()
         .await?;
 
     let http_client = cluster.rpc_client().unwrap();
     let address = cluster.accounts.first().unwrap();
 
-    http_client.sync_account_state(*address).await?;
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     assert_eq!(5, objects.len());
     Ok(())
@@ -44,12 +44,12 @@ async fn test_get_objects() -> Result<(), anyhow::Error> {
 async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let port = get_available_port();
     let cluster = TestClusterBuilder::new()
-        .set_gateway_rpc_port(port)
+        .set_fullnode_rpc_port(port)
         .build()
         .await?;
     let http_client = cluster.rpc_client().unwrap();
     let address = cluster.accounts.first().unwrap();
-    http_client.sync_account_state(*address).await?;
+
     let objects = http_client.get_objects_owned_by_address(*address).await?;
 
     let transaction_bytes: TransactionBytes = http_client
@@ -67,12 +67,17 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
     let tx = to_sender_signed_transaction(transaction_bytes.to_data()?, keystore.get_key(address)?);
     let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
-    let tx_response = http_client
-        .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
+    let tx_response: SuiExecuteTransactionResponse = http_client
+        .execute_transaction(
+            tx_bytes,
+            sig_scheme,
+            signature_bytes,
+            pub_key,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
         .await?;
 
-    let effect = tx_response.effects;
-    assert_eq!(2, effect.mutated.len());
+    matches!(tx_response, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.mutated.len() == 2);
 
     Ok(())
 }
@@ -81,12 +86,12 @@ async fn test_public_transfer_object() -> Result<(), anyhow::Error> {
 async fn test_publish() -> Result<(), anyhow::Error> {
     let port = get_available_port();
     let cluster = TestClusterBuilder::new()
-        .set_gateway_rpc_port(port)
+        .set_fullnode_rpc_port(port)
         .build()
         .await?;
     let http_client = cluster.rpc_client().unwrap();
     let address = cluster.accounts.first().unwrap();
-    http_client.sync_account_state(*address).await?;
+
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     let gas = objects.first().unwrap();
 
@@ -104,9 +109,15 @@ async fn test_publish() -> Result<(), anyhow::Error> {
     let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
     let tx_response = http_client
-        .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
+        .execute_transaction(
+            tx_bytes,
+            sig_scheme,
+            signature_bytes,
+            pub_key,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
         .await?;
-    assert_eq!(6, tx_response.effects.created.len());
+    matches!(tx_response, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.created.len() == 6);
     Ok(())
 }
 
@@ -114,12 +125,12 @@ async fn test_publish() -> Result<(), anyhow::Error> {
 async fn test_move_call() -> Result<(), anyhow::Error> {
     let port = get_available_port();
     let cluster = TestClusterBuilder::new()
-        .set_gateway_rpc_port(port)
+        .set_fullnode_rpc_port(port)
         .build()
         .await?;
     let http_client = cluster.rpc_client().unwrap();
     let address = cluster.accounts.first().unwrap();
-    http_client.sync_account_state(*address).await?;
+
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     let gas = objects.first().unwrap();
     let coin = &objects[1];
@@ -154,10 +165,15 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
     let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
     let tx_response = http_client
-        .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
+        .execute_transaction(
+            tx_bytes,
+            sig_scheme,
+            signature_bytes,
+            pub_key,
+            ExecuteTransactionRequestType::WaitForLocalExecution,
+        )
         .await?;
-    let effect = tx_response.effects;
-    assert_eq!(1, effect.created.len());
+    matches!(tx_response, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.created.len() == 1);
     Ok(())
 }
 
@@ -165,12 +181,11 @@ async fn test_move_call() -> Result<(), anyhow::Error> {
 async fn test_get_object_info() -> Result<(), anyhow::Error> {
     let port = get_available_port();
     let cluster = TestClusterBuilder::new()
-        .set_gateway_rpc_port(port)
+        .set_fullnode_rpc_port(port)
         .build()
         .await?;
     let http_client = cluster.rpc_client().unwrap();
     let address = cluster.accounts.first().unwrap();
-    http_client.sync_account_state(*address).await?;
     let objects = http_client.get_objects_owned_by_address(*address).await?;
 
     for oref in objects {
@@ -186,19 +201,17 @@ async fn test_get_object_info() -> Result<(), anyhow::Error> {
 async fn test_get_transaction() -> Result<(), anyhow::Error> {
     let port = get_available_port();
     let cluster = TestClusterBuilder::new()
-        .set_gateway_rpc_port(port)
+        .set_fullnode_rpc_port(port)
         .build()
         .await?;
     let http_client = cluster.rpc_client().unwrap();
     let address = cluster.accounts.first().unwrap();
 
-    http_client.sync_account_state(*address).await?;
-
     let objects = http_client.get_objects_owned_by_address(*address).await?;
     let gas_id = objects.last().unwrap().object_id;
 
     // Make some transactions
-    let mut tx_responses = Vec::new();
+    let mut tx_responses: Vec<SuiExecuteTransactionResponse> = Vec::new();
     for oref in &objects[..objects.len() - 1] {
         let transaction_bytes: TransactionBytes = http_client
             .transfer_object(*address, oref.object_id, Some(gas_id), 1000, *address)
@@ -211,7 +224,13 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
         let (tx_bytes, sig_scheme, signature_bytes, pub_key) = tx.to_network_data_for_execution();
 
         let response = http_client
-            .execute_transaction(tx_bytes, sig_scheme, signature_bytes, pub_key)
+            .execute_transaction(
+                tx_bytes,
+                sig_scheme,
+                signature_bytes,
+                pub_key,
+                ExecuteTransactionRequestType::WaitForLocalExecution,
+            )
             .await?;
 
         tx_responses.push(response);
@@ -228,7 +247,7 @@ async fn test_get_transaction() -> Result<(), anyhow::Error> {
     for tx_digest in tx {
         let response: SuiTransactionResponse = http_client.get_transaction(tx_digest).await?;
         assert!(tx_responses.iter().any(
-            |effects| effects.effects.transaction_digest == response.effects.transaction_digest
+            |resp| matches!(resp, SuiExecuteTransactionResponse::EffectsCert {effects, ..} if effects.effects.transaction_digest == response.effects.transaction_digest)
         ))
     }
 

--- a/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-gateway/src/unit_tests/rpc_server_tests.rs
@@ -264,7 +264,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
         .unwrap();
 
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
-    let client = SuiClient::new_rpc_client(&format!("http://{}", addr), None).await?;
+    let client = SuiClient::new(&format!("http://{}", addr), None).await?;
     let keystore_path = cluster.swarm.dir().join(SUI_KEYSTORE_FILENAME);
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let mut tx_responses = Vec::new();
@@ -300,7 +300,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get_recent_transactions with smaller range
     let tx = client
-        .full_node_api()
+        .read_api()
         .get_transactions(TransactionQuery::All, None, Some(3), Ordering::Descending)
         .await
         .unwrap();
@@ -308,7 +308,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get all transactions paged
     let first_page = client
-        .full_node_api()
+        .read_api()
         .get_transactions(TransactionQuery::All, None, Some(5), Ordering::Ascending)
         .await
         .unwrap();
@@ -317,7 +317,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get all transactions in ascending order
     let second_page = client
-        .full_node_api()
+        .read_api()
         .get_transactions(
             TransactionQuery::All,
             first_page.next_cursor,
@@ -335,7 +335,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get 10 latest transactions paged
     let latest = client
-        .full_node_api()
+        .read_api()
         .get_transactions(TransactionQuery::All, None, Some(10), Ordering::Descending)
         .await
         .unwrap();
@@ -346,7 +346,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get from address txs in ascending order
     let address_txs_asc = client
-        .full_node_api()
+        .read_api()
         .get_transactions(
             TransactionQuery::FromAddress(cluster.accounts[0]),
             None,
@@ -359,7 +359,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get from address txs in descending order
     let address_txs_desc = client
-        .full_node_api()
+        .read_api()
         .get_transactions(
             TransactionQuery::FromAddress(cluster.accounts[0]),
             None,
@@ -377,7 +377,7 @@ async fn test_get_fullnode_transaction() -> Result<(), anyhow::Error> {
 
     // test get_recent_transactions
     let tx = client
-        .full_node_api()
+        .read_api()
         .get_transactions(TransactionQuery::All, None, Some(20), Ordering::Descending)
         .await
         .unwrap();

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -17,7 +17,7 @@ use sui_keys::keystore::Keystore;
 use sui_sdk::rpc_types::{
     OwnedObjectRef, SuiData, SuiEvent, SuiExecutionStatus, SuiTransactionEffects,
 };
-use sui_sdk::{SuiClient, TransactionExecutionResult};
+use sui_sdk::TransactionExecutionResult;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages::{
@@ -30,6 +30,11 @@ use test_utils::network::TestClusterBuilder;
 use crate::operations::Operation;
 use crate::state::extract_balance_changes_from_ops;
 use crate::types::SignedValue;
+
+#[cfg(msim)]
+use sui_sdk::embedded_gateway::SuiClient;
+#[cfg(not(msim))]
+use sui_sdk::SuiClient;
 
 #[tokio::test]
 async fn test_all_transaction_type() {

--- a/crates/sui-sdk/examples/event_subscription.rs
+++ b/crates/sui-sdk/examples/event_subscription.rs
@@ -7,8 +7,7 @@ use sui_sdk::SuiClient;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui =
-        SuiClient::new_rpc_client("http://127.0.0.1:5001", Some("ws://127.0.0.1:9001")).await?;
+    let sui = SuiClient::new("http://127.0.0.1:5001", Some("ws://127.0.0.1:9001")).await?;
     let mut subscribe_all = sui
         .event_api()
         .subscribe_event(SuiEventFilter::All(vec![]))

--- a/crates/sui-sdk/examples/get_owned_objects.rs
+++ b/crates/sui-sdk/examples/get_owned_objects.rs
@@ -7,7 +7,7 @@ use sui_sdk::SuiClient;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new_rpc_client("https://fullnode.devnet.sui.io:443", None).await?;
+    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None).await?;
     let address = SuiAddress::from_str("0xec11cad080d0496a53bafcea629fcbcfff2a9866")?;
     let objects = sui.read_api().get_objects_owned_by_address(address).await?;
     println!("{:?}", objects);

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let game = TicTacToe {
         game_package_id: opts.game_package_id,
-        client: SuiClient::new_rpc_client(&opts.rpc_server_url, None).await?,
+        client: SuiClient::new(&opts.rpc_server_url, None).await?,
         keystore,
     };
 

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -14,7 +14,7 @@ use sui_types::messages::ExecuteTransactionRequestType;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new_rpc_client("https://fullnode.devnet.sui.io:443", None).await?;
+    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None).await?;
     // Load keystore from ~/.sui/sui_config/sui.keystore
     let keystore_path = match dirs::home_dir() {
         Some(v) => v.join(".sui").join("sui_config").join("sui.keystore"),

--- a/crates/sui-sdk/src/embedded_gateway.rs
+++ b/crates/sui-sdk/src/embedded_gateway.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: Remove this file when sim test supports jsonrpc/ws
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 use std::path::Path;
 use sui_config::gateway::GatewayConfig;
@@ -66,13 +66,6 @@ impl SuiClient {
             wallet_sync_api,
         })
     }
-
-    /*    pub fn is_gateway(&self) -> bool {
-        match &*self.api {
-            SuiClientApi::Rpc(c) => c.is_gateway(),
-            SuiClientApi::Embedded(_) => true,
-        }
-    }*/
 
     pub fn available_rpc_methods(&self) -> Vec<String> {
         vec![]

--- a/crates/sui-sdk/src/embedded_gateway.rs
+++ b/crates/sui-sdk/src/embedded_gateway.rs
@@ -1,0 +1,203 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use std::path::Path;
+use sui_config::gateway::GatewayConfig;
+use sui_config::{NetworkConfig, PersistedConfig, SUI_NETWORK_CONFIG};
+use sui_core::gateway_state::{GatewayClient, GatewayState, TxSeqNumber};
+use sui_json_rpc_types::{
+    GetObjectDataResponse, GetRawObjectDataResponse, SuiObjectInfo, SuiTransactionResponse,
+};
+use sui_transaction_builder::{DataReader, TransactionBuilder};
+use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
+use sui_types::messages::{ExecuteTransactionRequestType, VerifiedTransaction};
+
+use crate::TransactionExecutionResult;
+
+#[derive(Clone)]
+pub struct SuiClient {
+    transaction_builder: TransactionBuilder,
+    read_api: Arc<ReadApi>,
+    quorum_driver: QuorumDriver,
+    wallet_sync_api: WalletSyncApi,
+}
+
+impl SuiClient {
+    pub fn transaction_builder(&self) -> &TransactionBuilder {
+        &self.transaction_builder
+    }
+    pub fn read_api(&self) -> &ReadApi {
+        &self.read_api
+    }
+    pub fn quorum_driver(&self) -> &QuorumDriver {
+        &self.quorum_driver
+    }
+
+    pub fn wallet_sync_api(&self) -> &WalletSyncApi {
+        &self.wallet_sync_api
+    }
+}
+
+impl SuiClient {
+    pub fn new(sui_config_dir: &Path) -> Result<Self, anyhow::Error> {
+        let network_path = sui_config_dir.join(SUI_NETWORK_CONFIG);
+        let network_conf: NetworkConfig = PersistedConfig::read(&network_path)?;
+        let db_folder_path = sui_config_dir.join("gateway_client_db");
+        let gateway_conf = GatewayConfig {
+            validator_set: network_conf.validator_set().to_owned(),
+            db_folder_path,
+            ..Default::default()
+        };
+        let api = GatewayState::create_client(&gateway_conf, None)?;
+        let read_api = Arc::new(ReadApi { api: api.clone() });
+        let quorum_driver = QuorumDriver { api: api.clone() };
+        let transaction_builder =
+            TransactionBuilder(Arc::new(GatewayClientDataReader::new(api.clone())));
+        let wallet_sync_api = WalletSyncApi(api);
+
+        Ok(Self {
+            transaction_builder,
+            read_api,
+            quorum_driver,
+            wallet_sync_api,
+        })
+    }
+
+    /*    pub fn is_gateway(&self) -> bool {
+        match &*self.api {
+            SuiClientApi::Rpc(c) => c.is_gateway(),
+            SuiClientApi::Embedded(_) => true,
+        }
+    }*/
+
+    pub fn available_rpc_methods(&self) -> Vec<String> {
+        vec![]
+    }
+
+    pub fn available_subscriptions(&self) -> Vec<String> {
+        vec![]
+    }
+
+    pub fn api_version(&self) -> &str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    pub fn check_api_version(&self) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+}
+
+pub struct ReadApi {
+    api: GatewayClient,
+}
+
+impl ReadApi {
+    pub async fn get_objects_owned_by_address(
+        &self,
+        address: SuiAddress,
+    ) -> anyhow::Result<Vec<SuiObjectInfo>> {
+        Ok(self.api.get_objects_owned_by_address(address).await?)
+    }
+
+    pub async fn get_objects_owned_by_object(
+        &self,
+        object_id: ObjectID,
+    ) -> anyhow::Result<Vec<SuiObjectInfo>> {
+        Ok(self.api.get_objects_owned_by_object(object_id).await?)
+    }
+
+    pub async fn get_parsed_object(
+        &self,
+        object_id: ObjectID,
+    ) -> anyhow::Result<GetObjectDataResponse> {
+        Ok(self.api.get_object(object_id).await?)
+    }
+
+    pub async fn get_object(
+        &self,
+        object_id: ObjectID,
+    ) -> anyhow::Result<GetRawObjectDataResponse> {
+        Ok(self.api.get_raw_object(object_id).await?)
+    }
+
+    pub async fn get_total_transaction_number(&self) -> anyhow::Result<u64> {
+        Ok(self.api.get_total_transaction_number()?)
+    }
+
+    pub async fn get_transactions_in_range(
+        &self,
+        start: TxSeqNumber,
+        end: TxSeqNumber,
+    ) -> anyhow::Result<Vec<TransactionDigest>> {
+        Ok(self.api.get_transactions_in_range(start, end)?)
+    }
+
+    pub async fn get_transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> anyhow::Result<SuiTransactionResponse> {
+        Ok(self.api.get_transaction(digest).await?)
+    }
+}
+
+#[derive(Clone)]
+pub struct QuorumDriver {
+    api: GatewayClient,
+}
+
+impl QuorumDriver {
+    pub async fn execute_transaction(
+        &self,
+        tx: VerifiedTransaction,
+        _request_type: Option<ExecuteTransactionRequestType>,
+    ) -> anyhow::Result<TransactionExecutionResult> {
+        let resp = self.api.execute_transaction(tx.into_inner()).await?;
+        Ok(TransactionExecutionResult {
+            tx_digest: resp.certificate.transaction_digest,
+            tx_cert: Some(resp.certificate),
+            effects: Some(resp.effects),
+            confirmed_local_execution: true,
+            timestamp_ms: resp.timestamp_ms,
+            parsed_data: resp.parsed_data,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct WalletSyncApi(GatewayClient);
+
+impl WalletSyncApi {
+    pub async fn sync_account_state(&self, address: SuiAddress) -> anyhow::Result<()> {
+        self.0.sync_account_state(address).await?;
+        Ok(())
+    }
+}
+
+pub struct GatewayClientDataReader(GatewayClient);
+
+impl GatewayClientDataReader {
+    pub fn new(state: GatewayClient) -> Self {
+        Self(state)
+    }
+}
+
+#[async_trait]
+impl DataReader for GatewayClientDataReader {
+    async fn get_objects_owned_by_address(
+        &self,
+        address: SuiAddress,
+    ) -> Result<Vec<SuiObjectInfo>, anyhow::Error> {
+        self.0.get_objects_owned_by_address(address).await
+    }
+
+    async fn get_object(
+        &self,
+        object_id: ObjectID,
+    ) -> Result<GetRawObjectDataResponse, anyhow::Error> {
+        self.0.get_raw_object(object_id).await
+    }
+}

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::{Debug, Write};
-use std::fmt::{Display, Formatter};
+use std::fmt::Debug;
+use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -13,8 +13,6 @@ use futures_core::Stream;
 use jsonrpsee::core::client::{ClientT, Subscription};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
-use serde::Deserialize;
-use serde::Serialize;
 use serde_json::Value;
 
 use rpc_types::{
@@ -562,7 +560,7 @@ impl SuiClient {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+/*#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ClientType {
     Embedded(GatewayConfig),
@@ -617,7 +615,7 @@ impl ClientType {
             }
         })
     }
-}
+}*/
 
 #[async_trait]
 impl DataReader for ReadApi {

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -20,8 +20,7 @@ use rpc_types::{
     SuiParsedTransactionResponse, SuiTransactionEffects,
 };
 pub use sui_config::gateway;
-use sui_config::gateway::GatewayConfig;
-use sui_core::gateway_state::{GatewayClient, GatewayState, TxSeqNumber};
+use sui_core::gateway_state::TxSeqNumber;
 pub use sui_json as json;
 use sui_json_rpc::api::EventStreamingApiClient;
 use sui_json_rpc::api::RpcBcsApiClient;
@@ -43,6 +42,9 @@ use types::committee::EpochId;
 use types::error::TRANSACTION_NOT_FOUND_MSG_PREFIX;
 use types::messages::{CommitteeInfoResponse, ExecuteTransactionRequestType};
 
+#[cfg(msim)]
+pub mod embedded_gateway;
+
 const WAIT_FOR_TX_TIMEOUT_SEC: u64 = 10;
 
 #[derive(Debug)]
@@ -57,38 +59,27 @@ pub struct TransactionExecutionResult {
 
 #[derive(Clone)]
 pub struct SuiClient {
-    api: Arc<SuiClientApi>,
+    api: Arc<RpcClient>,
     transaction_builder: TransactionBuilder,
     read_api: Arc<ReadApi>,
-    full_node_api: FullNodeApi,
     event_api: EventApi,
     quorum_driver: QuorumDriver,
-    wallet_sync_api: WalletSyncApi,
-}
-
-#[allow(clippy::large_enum_variant)]
-enum SuiClientApi {
-    Rpc(RpcClient),
-    Embedded(GatewayClient),
-}
-
-impl Debug for SuiClientApi {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SuiClientApi::Rpc(rpc_client) => write!(
-                f,
-                "RPC client. Http: {:?}, Websocket: {:?}",
-                rpc_client.http, rpc_client.ws
-            ),
-            SuiClientApi::Embedded(_) => write!(f, "Embedded Gateway client."),
-        }
-    }
 }
 
 struct RpcClient {
     http: HttpClient,
     ws: Option<WsClient>,
     info: ServerInfo,
+}
+
+impl Debug for RpcClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RPC client. Http: {:?}, Websocket: {:?}",
+            self.http, self.ws
+        )
+    }
 }
 
 struct ServerInfo {
@@ -153,75 +144,36 @@ impl RpcClient {
             .map(|s| s.into())
             .collect())
     }
-
-    fn is_gateway(&self) -> bool {
-        self.info
-            .rpc_methods
-            .contains(&"sui_syncAccountState".to_string())
-    }
 }
 
 impl SuiClient {
-    pub async fn new_rpc_client(
-        http_url: &str,
-        ws_url: Option<&str>,
-    ) -> Result<SuiClient, anyhow::Error> {
+    pub async fn new(http_url: &str, ws_url: Option<&str>) -> Result<Self, anyhow::Error> {
         let rpc = RpcClient::new(http_url, ws_url).await?;
-        Ok(SuiClient::new(SuiClientApi::Rpc(rpc)))
-    }
-
-    pub fn new_embedded_client(config: &GatewayConfig) -> Result<SuiClient, anyhow::Error> {
-        let state = GatewayState::create_client(config, None)?;
-        Ok(SuiClient::new(SuiClientApi::Embedded(state)))
-    }
-
-    fn new(api: SuiClientApi) -> Self {
-        let api = Arc::new(api);
+        let api = Arc::new(rpc);
         let read_api = Arc::new(ReadApi { api: api.clone() });
         let quorum_driver = QuorumDriver { api: api.clone() };
-
-        let full_node_api = FullNodeApi(api.clone());
         let event_api = EventApi(api.clone());
         let transaction_builder = TransactionBuilder(read_api.clone());
-        let wallet_sync_api = WalletSyncApi(api.clone());
 
-        SuiClient {
+        Ok(SuiClient {
             api,
             transaction_builder,
             read_api,
-            full_node_api,
             event_api,
             quorum_driver,
-            wallet_sync_api,
-        }
+        })
     }
 
-    pub fn is_gateway(&self) -> bool {
-        match &*self.api {
-            SuiClientApi::Rpc(c) => c.is_gateway(),
-            SuiClientApi::Embedded(_) => true,
-        }
+    pub fn available_rpc_methods(&self) -> &Vec<String> {
+        &self.api.info.rpc_methods
     }
 
-    pub fn available_rpc_methods(&self) -> Vec<String> {
-        match &*self.api {
-            SuiClientApi::Rpc(c) => c.info.rpc_methods.clone(),
-            SuiClientApi::Embedded(_) => vec![],
-        }
-    }
-
-    pub fn available_subscriptions(&self) -> Vec<String> {
-        match &*self.api {
-            SuiClientApi::Rpc(c) => c.info.subscriptions.clone(),
-            SuiClientApi::Embedded(_) => vec![],
-        }
+    pub fn available_subscriptions(&self) -> &Vec<String> {
+        &self.api.info.subscriptions
     }
 
     pub fn api_version(&self) -> &str {
-        match &*self.api {
-            SuiClientApi::Rpc(c) => &c.info.version,
-            SuiClientApi::Embedded(_) => env!("CARGO_PKG_VERSION"),
-        }
+        &self.api.info.version
     }
 
     pub fn check_api_version(&self) -> Result<(), anyhow::Error> {
@@ -236,7 +188,7 @@ impl SuiClient {
 
 #[derive(Debug)]
 pub struct ReadApi {
-    api: Arc<SuiClientApi>,
+    api: Arc<RpcClient>,
 }
 
 impl ReadApi {
@@ -244,30 +196,21 @@ impl ReadApi {
         &self,
         address: SuiAddress,
     ) -> anyhow::Result<Vec<SuiObjectInfo>> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_objects_owned_by_address(address).await?,
-            SuiClientApi::Embedded(c) => c.get_objects_owned_by_address(address).await?,
-        })
+        Ok(self.api.http.get_objects_owned_by_address(address).await?)
     }
 
     pub async fn get_objects_owned_by_object(
         &self,
         object_id: ObjectID,
     ) -> anyhow::Result<Vec<SuiObjectInfo>> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_objects_owned_by_object(object_id).await?,
-            SuiClientApi::Embedded(c) => c.get_objects_owned_by_object(object_id).await?,
-        })
+        Ok(self.api.http.get_objects_owned_by_object(object_id).await?)
     }
 
     pub async fn get_parsed_object(
         &self,
         object_id: ObjectID,
     ) -> anyhow::Result<GetObjectDataResponse> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_object(object_id).await?,
-            SuiClientApi::Embedded(c) => c.get_object(object_id).await?,
-        })
+        Ok(self.api.http.get_object(object_id).await?)
     }
 
     pub async fn try_get_parsed_past_object(
@@ -275,30 +218,22 @@ impl ReadApi {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> anyhow::Result<GetPastObjectDataResponse> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.try_get_past_object(object_id, version).await?,
-            // Gateway does not support get past object
-            SuiClientApi::Embedded(_) => {
-                unimplemented!("Gateway/embedded client does not support get past object")
-            }
-        })
+        Ok(self
+            .api
+            .http
+            .try_get_past_object(object_id, version)
+            .await?)
     }
 
     pub async fn get_object(
         &self,
         object_id: ObjectID,
     ) -> anyhow::Result<GetRawObjectDataResponse> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_raw_object(object_id).await?,
-            SuiClientApi::Embedded(c) => c.get_raw_object(object_id).await?,
-        })
+        Ok(self.api.http.get_raw_object(object_id).await?)
     }
 
     pub async fn get_total_transaction_number(&self) -> anyhow::Result<u64> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_total_transaction_number().await?,
-            SuiClientApi::Embedded(c) => c.get_total_transaction_number()?,
-        })
+        Ok(self.api.http.get_total_transaction_number().await?)
     }
 
     pub async fn get_transactions_in_range(
@@ -306,39 +241,23 @@ impl ReadApi {
         start: TxSeqNumber,
         end: TxSeqNumber,
     ) -> anyhow::Result<Vec<TransactionDigest>> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_transactions_in_range(start, end).await?,
-            SuiClientApi::Embedded(c) => c.get_transactions_in_range(start, end)?,
-        })
+        Ok(self.api.http.get_transactions_in_range(start, end).await?)
     }
 
     pub async fn get_transaction(
         &self,
         digest: TransactionDigest,
     ) -> anyhow::Result<SuiTransactionResponse> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_transaction(digest).await?,
-            SuiClientApi::Embedded(c) => c.get_transaction(digest).await?,
-        })
+        Ok(self.api.http.get_transaction(digest).await?)
     }
 
     pub async fn get_committee_info(
         &self,
         epoch: Option<EpochId>,
     ) -> anyhow::Result<CommitteeInfoResponse> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => c.http.get_committee_info(epoch).await?,
-            SuiClientApi::Embedded(_c) => {
-                unimplemented!("Gateway/embedded client does not support get committee info")
-            }
-        })
+        Ok(self.api.http.get_committee_info(epoch).await?)
     }
-}
 
-#[derive(Clone)]
-pub struct FullNodeApi(Arc<SuiClientApi>);
-
-impl FullNodeApi {
     pub async fn get_transactions(
         &self,
         query: TransactionQuery,
@@ -346,25 +265,24 @@ impl FullNodeApi {
         limit: Option<usize>,
         order: Ordering,
     ) -> anyhow::Result<TransactionsPage> {
-        Ok(match &*self.0 {
-            SuiClientApi::Rpc(c) => c.http.get_transactions(query, cursor, limit, order).await?,
-            SuiClientApi::Embedded(_) => {
-                return Err(anyhow!("Method not supported by embedded gateway client."))
-            }
-        })
+        Ok(self
+            .api
+            .http
+            .get_transactions(query, cursor, limit, order)
+            .await?)
     }
 }
 
 #[derive(Clone)]
-pub struct EventApi(Arc<SuiClientApi>);
+pub struct EventApi(Arc<RpcClient>);
 
 impl EventApi {
     pub async fn subscribe_event(
         &self,
         filter: SuiEventFilter,
     ) -> anyhow::Result<impl Stream<Item = Result<SuiEventEnvelope, anyhow::Error>>> {
-        match &*self.0 {
-            SuiClientApi::Rpc(RpcClient { ws: Some(c), .. }) => {
+        match &self.0.ws {
+            Some(c) => {
                 let subscription: Subscription<SuiEventEnvelope> =
                     c.subscribe_event(filter).await?;
                 Ok(subscription.map(|item| Ok(item?)))
@@ -376,7 +294,7 @@ impl EventApi {
 
 #[derive(Clone)]
 pub struct QuorumDriver {
-    api: Arc<SuiClientApi>,
+    api: Arc<RpcClient>,
 }
 
 impl QuorumDriver {
@@ -394,100 +312,83 @@ impl QuorumDriver {
         tx: VerifiedTransaction,
         request_type: Option<ExecuteTransactionRequestType>,
     ) -> anyhow::Result<TransactionExecutionResult> {
-        Ok(match &*self.api {
-            SuiClientApi::Rpc(c) => {
-                let (tx_bytes, flag, signature, pub_key) = tx.to_network_data_for_execution();
-                let request_type =
-                    request_type.unwrap_or(ExecuteTransactionRequestType::WaitForLocalExecution);
-                let resp = TransactionExecutionApiClient::execute_transaction(
-                    &c.http,
-                    tx_bytes,
-                    flag,
-                    signature,
-                    pub_key,
-                    request_type.clone(),
-                )
-                .await?;
+        use ExecuteTransactionRequestType::*;
 
-                match (request_type, resp) {
-                    (
-                        ExecuteTransactionRequestType::ImmediateReturn,
-                        SuiExecuteTransactionResponse::ImmediateReturn { tx_digest },
-                    ) => TransactionExecutionResult {
-                        tx_digest,
-                        tx_cert: None,
-                        effects: None,
-                        confirmed_local_execution: false,
-                        timestamp_ms: None,
-                        parsed_data: None,
-                    },
-                    (
-                        ExecuteTransactionRequestType::WaitForTxCert,
-                        SuiExecuteTransactionResponse::TxCert { certificate },
-                    ) => TransactionExecutionResult {
-                        tx_digest: certificate.transaction_digest,
-                        tx_cert: Some(certificate),
-                        effects: None,
-                        confirmed_local_execution: false,
-                        timestamp_ms: None,
-                        parsed_data: None,
-                    },
-                    (
-                        ExecuteTransactionRequestType::WaitForEffectsCert,
-                        SuiExecuteTransactionResponse::EffectsCert {
-                            certificate,
-                            effects,
-                            confirmed_local_execution,
-                        },
-                    ) => TransactionExecutionResult {
-                        tx_digest: certificate.transaction_digest,
-                        tx_cert: Some(certificate),
-                        effects: Some(effects.effects),
-                        confirmed_local_execution,
-                        timestamp_ms: None,
-                        parsed_data: None,
-                    },
-                    (
-                        ExecuteTransactionRequestType::WaitForLocalExecution,
-                        SuiExecuteTransactionResponse::EffectsCert {
-                            certificate,
-                            effects,
-                            confirmed_local_execution,
-                        },
-                    ) => {
-                        if !confirmed_local_execution {
-                            Self::wait_until_fullnode_sees_tx(c, certificate.transaction_digest)
-                                .await?;
-                        }
-                        TransactionExecutionResult {
-                            tx_digest: certificate.transaction_digest,
-                            tx_cert: Some(certificate),
-                            effects: Some(effects.effects),
-                            confirmed_local_execution,
-                            timestamp_ms: None,
-                            parsed_data: None,
-                        }
-                    }
-                    (other_request_type, other_resp) => {
-                        bail!(
-                            "Invalid response type {:?} for request type: {:?}",
-                            other_resp,
-                            other_request_type
-                        );
-                    }
+        let (tx_bytes, flag, signature, pub_key) = tx.to_network_data_for_execution();
+        let request_type = request_type.unwrap_or(WaitForLocalExecution);
+        let resp = TransactionExecutionApiClient::execute_transaction(
+            &self.api.http,
+            tx_bytes,
+            flag,
+            signature,
+            pub_key,
+            request_type.clone(),
+        )
+        .await?;
+
+        Ok(match (request_type, resp) {
+            (ImmediateReturn, SuiExecuteTransactionResponse::ImmediateReturn { tx_digest }) => {
+                TransactionExecutionResult {
+                    tx_digest,
+                    tx_cert: None,
+                    effects: None,
+                    confirmed_local_execution: false,
+                    timestamp_ms: None,
+                    parsed_data: None,
                 }
             }
-            // TODO do we want to support an embedded quorum driver?
-            SuiClientApi::Embedded(c) => {
-                let resp = c.execute_transaction(tx.into_inner()).await?;
+            (WaitForTxCert, SuiExecuteTransactionResponse::TxCert { certificate }) => {
                 TransactionExecutionResult {
-                    tx_digest: resp.certificate.transaction_digest,
-                    tx_cert: Some(resp.certificate),
-                    effects: Some(resp.effects),
-                    confirmed_local_execution: true,
-                    timestamp_ms: resp.timestamp_ms,
-                    parsed_data: resp.parsed_data,
+                    tx_digest: certificate.transaction_digest,
+                    tx_cert: Some(certificate),
+                    effects: None,
+                    confirmed_local_execution: false,
+                    timestamp_ms: None,
+                    parsed_data: None,
                 }
+            }
+            (
+                WaitForEffectsCert,
+                SuiExecuteTransactionResponse::EffectsCert {
+                    certificate,
+                    effects,
+                    confirmed_local_execution,
+                },
+            ) => TransactionExecutionResult {
+                tx_digest: certificate.transaction_digest,
+                tx_cert: Some(certificate),
+                effects: Some(effects.effects),
+                confirmed_local_execution,
+                timestamp_ms: None,
+                parsed_data: None,
+            },
+            (
+                WaitForLocalExecution,
+                SuiExecuteTransactionResponse::EffectsCert {
+                    certificate,
+                    effects,
+                    confirmed_local_execution,
+                },
+            ) => {
+                if !confirmed_local_execution {
+                    Self::wait_until_fullnode_sees_tx(&self.api, certificate.transaction_digest)
+                        .await?;
+                }
+                TransactionExecutionResult {
+                    tx_digest: certificate.transaction_digest,
+                    tx_cert: Some(certificate),
+                    effects: Some(effects.effects),
+                    confirmed_local_execution,
+                    timestamp_ms: None,
+                    parsed_data: None,
+                }
+            }
+            (other_request_type, other_resp) => {
+                bail!(
+                    "Invalid response type {:?} for request type: {:?}",
+                    other_resp,
+                    other_request_type
+                );
             }
         })
     }
@@ -524,21 +425,6 @@ impl QuorumDriver {
     }
 }
 
-#[derive(Clone)]
-pub struct WalletSyncApi(Arc<SuiClientApi>);
-
-impl WalletSyncApi {
-    pub async fn sync_account_state(&self, address: SuiAddress) -> anyhow::Result<()> {
-        match &*self.0 {
-            SuiClientApi::Rpc(_) => {
-                unimplemented!("Rpc SuiClient does not support WalletSyncApi");
-            }
-            SuiClientApi::Embedded(c) => c.sync_account_state(address).await?,
-        }
-        Ok(())
-    }
-}
-
 impl SuiClient {
     pub fn transaction_builder(&self) -> &TransactionBuilder {
         &self.transaction_builder
@@ -546,17 +432,11 @@ impl SuiClient {
     pub fn read_api(&self) -> &ReadApi {
         &self.read_api
     }
-    pub fn full_node_api(&self) -> &FullNodeApi {
-        &self.full_node_api
-    }
     pub fn event_api(&self) -> &EventApi {
         &self.event_api
     }
     pub fn quorum_driver(&self) -> &QuorumDriver {
         &self.quorum_driver
-    }
-    pub fn wallet_sync_api(&self) -> &WalletSyncApi {
-        &self.wallet_sync_api
     }
 }
 

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -440,63 +440,6 @@ impl SuiClient {
     }
 }
 
-/*#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ClientType {
-    Embedded(GatewayConfig),
-    RPC(
-        String,
-        #[serde(default, skip_serializing_if = "Option::is_none")] Option<String>,
-    ),
-}
-
-impl Display for ClientType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut writer = String::new();
-
-        match self {
-            ClientType::Embedded(config) => {
-                writeln!(writer, "Client Type : Embedded Gateway")?;
-                writeln!(
-                    writer,
-                    "Gateway state DB folder path : {:?}",
-                    config.db_folder_path
-                )?;
-                let authorities = config
-                    .validator_set
-                    .iter()
-                    .map(|info| info.network_address());
-                write!(
-                    writer,
-                    "Authorities : {:?}",
-                    authorities.collect::<Vec<_>>()
-                )?;
-            }
-            ClientType::RPC(url, ws_url) => {
-                writeln!(writer, "Client Type : JSON-RPC")?;
-                writeln!(writer, "HTTP RPC URL : {}", url)?;
-                write!(
-                    writer,
-                    "WS RPC URL : {}",
-                    ws_url.clone().unwrap_or_else(|| "None".to_string())
-                )?;
-            }
-        }
-        write!(f, "{}", writer)
-    }
-}
-
-impl ClientType {
-    pub async fn init(&self) -> Result<SuiClient, anyhow::Error> {
-        Ok(match self {
-            ClientType::Embedded(config) => SuiClient::new_embedded_client(config)?,
-            ClientType::RPC(url, ws_url) => {
-                SuiClient::new_rpc_client(url, ws_url.as_deref()).await?
-            }
-        })
-    }
-}*/
-
 #[async_trait]
 impl DataReader for ReadApi {
     async fn get_objects_owned_by_address(

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -158,11 +158,21 @@ impl<R: rand::RngCore + rand::CryptoRng> SwarmBuilder<R> {
             .map(|config| (config.sui_address(), Node::new(config.to_owned())))
             .collect();
 
+        let fullnodes = if let Some(fullnode_rpc_addr) = self.fullnode_rpc_addr {
+            let mut config =
+                network_config.generate_fullnode_config_with_random_dir_name(true, true);
+            config.websocket_address = self.websocket_rpc_addr;
+            config.json_rpc_address = fullnode_rpc_addr;
+            HashMap::from([(config.sui_address(), Node::new(config))])
+        } else {
+            Default::default()
+        };
+
         Swarm {
             dir,
             network_config,
             validators,
-            fullnodes: HashMap::new(),
+            fullnodes,
         }
     }
 }

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -55,7 +55,6 @@ async fn main() -> Result<()> {
 
     let cluster = LocalNewCluster::start(&ClusterTestOpt {
         env: Env::NewLocal,
-        gateway_address: Some(format!("127.0.0.1:{}", args.gateway_rpc_port)),
         fullnode_address: Some(format!("127.0.0.1:{}", args.fullnode_rpc_port)),
         websocket_address: Some(format!("127.0.0.1:{}", args.websocket_rpc_port)),
         faucet_address: None,

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -23,7 +23,6 @@ use serde::Serialize;
 use serde_json::json;
 use tracing::info;
 
-use crate::config::{Config, PersistedConfig, SuiClientConfig};
 use sui_framework::build_move_package;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
@@ -33,8 +32,8 @@ use sui_json_rpc_types::{
 use sui_json_rpc_types::{GetRawObjectDataResponse, SuiData};
 use sui_json_rpc_types::{SuiCertifiedTransaction, SuiExecutionStatus, SuiTransactionEffects};
 use sui_keys::keystore::AccountKeystore;
+use sui_sdk::SuiClient;
 use sui_sdk::TransactionExecutionResult;
-use sui_sdk::{ClientType, SuiClient};
 use sui_types::crypto::SignableBytes;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -47,6 +46,8 @@ use sui_types::{
     crypto::{Signature, SignatureScheme},
     messages::TransactionData,
 };
+
+use crate::config::{Config, PersistedConfig, SuiClientConfig, SuiEnv};
 
 pub const EXAMPLE_NFT_NAME: &str = "Example NFT";
 pub const EXAMPLE_NFT_DESCRIPTION: &str = "An NFT created by the Sui Command Line Tool";
@@ -65,16 +66,29 @@ pub enum SuiClientCommands {
         address: Option<SuiAddress>,
         /// The RPC server URL (e.g., local rpc server, devnet rpc server, etc) to be
         /// used for subsequent commands.
+        #[clap(long)]
+        env: Option<String>,
+    },
+    /// Add new Sui environment.
+    #[clap(name = "new-env")]
+    NewEnv {
+        #[clap(long)]
+        alias: String,
         #[clap(long, value_hint = ValueHint::Url)]
-        rpc: Option<String>,
-        /// The pubsub Websocket server URL
+        rpc: String,
         #[clap(long, value_hint = ValueHint::Url)]
         ws: Option<String>,
     },
+    /// List all Sui environments
+    Envs,
 
     /// Default address used for commands when none specified
     #[clap(name = "active-address")]
     ActiveAddress,
+
+    /// Default environment used for commands when none specified
+    #[clap(name = "active-env")]
+    ActiveEnv,
 
     /// Get object info
     #[clap(name = "object")]
@@ -728,23 +742,21 @@ impl SuiClientCommands {
 
                 SuiClientCommandResult::MergeCoin(response)
             }
-            SuiClientCommands::Switch { address, rpc, ws } => {
-                if let Some(addr) = address {
-                    if !context.config.keystore.addresses().contains(&addr) {
-                        return Err(anyhow!("Address {} not managed by wallet", addr));
+            SuiClientCommands::Switch { address, env } => {
+                match (address, &env) {
+                    (None, Some(env)) => {
+                        Self::switch_env(&mut context.config, env)?;
                     }
-                    context.config.active_address = Some(addr);
-                }
-
-                Self::switch_server(&mut context.config, &rpc, &ws)?;
-
-                if Option::is_none(&address) && Option::is_none(&rpc) && Option::is_none(&ws) {
-                    return Err(anyhow!(
-                        "No address or RPC url specified. Please Specify one."
-                    ));
+                    (Some(addr), None) => {
+                        if !context.config.keystore.addresses().contains(&addr) {
+                            return Err(anyhow!("Address {} not managed by wallet", addr));
+                        }
+                        context.config.active_address = Some(addr);
+                    }
+                    _ => return Err(anyhow!("No address or env specified. Please Specify one.")),
                 }
                 context.config.save()?;
-                SuiClientCommandResult::Switch(SwitchResponse { address, rpc, ws })
+                SuiClientCommandResult::Switch(SwitchResponse { address, env })
             }
             SuiClientCommands::ActiveAddress => {
                 SuiClientCommandResult::ActiveAddress(context.active_address().ok())
@@ -830,30 +842,37 @@ impl SuiClientCommands {
                 let response = context.execute_transaction(signed_tx).await?;
                 SuiClientCommandResult::ExecuteSignedTx(response)
             }
+            SuiClientCommands::NewEnv { alias, rpc, ws } => {
+                if context
+                    .config
+                    .envs
+                    .iter()
+                    .find(|env| env.alias == alias)
+                    .is_some()
+                {
+                    return Err(anyhow!(
+                        "Environment config with name [{alias}] already exists."
+                    ));
+                }
+                let env = SuiEnv { alias, rpc, ws };
+
+                // Check urls are valid and server is reachable
+                env.init().await?;
+                context.config.envs.push(env.clone());
+                context.config.save()?;
+                SuiClientCommandResult::NewEnv(env)
+            }
+            SuiClientCommands::ActiveEnv => {
+                SuiClientCommandResult::ActiveEnv(context.config.active_env.clone())
+            }
+            SuiClientCommands::Envs => SuiClientCommandResult::Envs(context.config.envs.clone()),
         });
         ret
     }
 
-    pub fn switch_server(
-        config: &mut SuiClientConfig,
-        rpc: &Option<String>,
-        ws: &Option<String>,
-    ) -> Result<(), anyhow::Error> {
-        if let Some(rpc) = rpc {
-            let ws = match &config.client_type {
-                ClientType::RPC(_, Some(ws)) => Some(ws.clone()),
-                _ => None,
-            };
-            config.client_type = ClientType::RPC(rpc.clone(), ws);
-        }
-
-        if let Some(ws) = ws {
-            let rpc = match &config.client_type {
-                ClientType::RPC(rpc, _) => rpc.clone(),
-                _ => return Err(anyhow!("RPC server address must be defined")),
-            };
-            config.client_type = ClientType::RPC(rpc, Some(ws.clone()));
-        }
+    pub fn switch_env(config: &mut SuiClientConfig, env: &str) -> Result<(), anyhow::Error> {
+        ensure!(config.get_env(env).is_some(), "Environment config not found for [{env}], add new environment config using the `sui client new-env` command.");
+        config.active_env = env.into();
         Ok(())
     }
 }
@@ -872,7 +891,8 @@ impl WalletContext {
             ))
         })?;
 
-        let client = config.client_type.init().await?;
+        let env = config.get_active_env();
+        let client = env.init().await?;
         let config = config.persisted(config_path);
         let context = Self { config, client };
         Ok(context)
@@ -1155,6 +1175,17 @@ impl Display for SuiClientCommandResult {
             SuiClientCommandResult::SerializeTransferSui(res) => {
                 write!(writer, "{}", res)?;
             }
+            SuiClientCommandResult::ActiveEnv(env) => {
+                write!(writer, "{}", env)?;
+            }
+            SuiClientCommandResult::NewEnv(env) => {
+                writeln!(writer, "Added new Sui env [{}] to config.", env.alias)?;
+            }
+            SuiClientCommandResult::Envs(envs) => {
+                for env in envs {
+                    writeln!(writer, "{} => {}", env.alias, env.rpc)?;
+                }
+            }
         }
         write!(f, "{}", writer.trim_end_matches('\n'))
     }
@@ -1283,31 +1314,29 @@ pub enum SuiClientCommandResult {
     MergeCoin(SuiTransactionResponse),
     Switch(SwitchResponse),
     ActiveAddress(Option<SuiAddress>),
+    ActiveEnv(String),
+    Envs(Vec<SuiEnv>),
     CreateExampleNFT(GetObjectDataResponse),
     SerializeTransferSui(String),
     ExecuteSignedTx(SuiTransactionResponse),
+    NewEnv(SuiEnv),
 }
 
 #[derive(Serialize, Clone, Debug)]
 pub struct SwitchResponse {
     /// Active address
     pub address: Option<SuiAddress>,
-    pub rpc: Option<String>,
-    pub ws: Option<String>,
+    pub env: Option<String>,
 }
 
 impl Display for SwitchResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut writer = String::new();
         if let Some(addr) = self.address {
-            writeln!(writer, "Active address switched to {}", addr)?;
+            writeln!(writer, "Active address switched to {addr}")?;
         }
-        if let Some(rpc) = &self.rpc {
-            writeln!(writer, "Active RPC server switched to {}", rpc)?;
-        }
-
-        if let Some(ws) = &self.ws {
-            writeln!(writer, "Active Websocket server switched to {}", ws)?;
+        if let Some(env) = &self.env {
+            writeln!(writer, "Active environment switched to [{env}]")?;
         }
         write!(f, "{}", writer)
     }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -843,13 +843,7 @@ impl SuiClientCommands {
                 SuiClientCommandResult::ExecuteSignedTx(response)
             }
             SuiClientCommands::NewEnv { alias, rpc, ws } => {
-                if context
-                    .config
-                    .envs
-                    .iter()
-                    .find(|env| env.alias == alias)
-                    .is_some()
-                {
+                if context.config.envs.iter().any(|env| env.alias == alias) {
                     return Err(anyhow!(
                         "Environment config with name [{alias}] already exists."
                     ));
@@ -891,7 +885,7 @@ impl WalletContext {
             ))
         })?;
 
-        let env = config.get_active_env();
+        let env = config.get_active_env()?;
         let client = env.init().await?;
         let config = config.persisted(config_path);
         let context = Self { config, client };

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -46,6 +46,11 @@ use sui_types::{
     messages::TransactionData,
 };
 
+#[cfg(msim)]
+use sui_sdk::embedded_gateway::SuiClient;
+#[cfg(not(msim))]
+use sui_sdk::SuiClient;
+
 use crate::config::{Config, PersistedConfig, SuiClientConfig, SuiEnv};
 
 pub const EXAMPLE_NFT_NAME: &str = "Example NFT";
@@ -855,10 +860,7 @@ impl SuiClientCommands {
 
 pub struct WalletContext {
     pub config: PersistedConfig<SuiClientConfig>,
-    #[cfg(msim)]
-    pub client: sui_sdk::embedded_gateway::SuiClient,
-    #[cfg(not(msim))]
-    pub client: sui_sdk::SuiClient,
+    pub client: SuiClient,
 }
 
 impl WalletContext {
@@ -1011,10 +1013,6 @@ impl WalletContext {
             )),
         }
     }
-
-    /*    pub fn switch_client(&mut self, new_client: SuiClient) {
-        self.client = new_client;
-    }*/
 }
 
 impl Display for SuiClientCommandResult {

--- a/crates/sui/src/config/mod.rs
+++ b/crates/sui/src/config/mod.rs
@@ -49,8 +49,8 @@ pub struct SuiEnv {
 }
 
 impl SuiEnv {
-    pub async fn init(&self) -> Result<SuiClient, anyhow::Error> {
-        SuiClient::new_rpc_client(&self.rpc, self.ws.as_deref()).await
+    pub async fn create_rpc_client(&self) -> Result<SuiClient, anyhow::Error> {
+        SuiClient::new(&self.rpc, self.ws.as_deref()).await
     }
 
     pub fn devnet() -> Self {

--- a/crates/sui/src/console.rs
+++ b/crates/sui/src/console.rs
@@ -11,8 +11,6 @@ use clap::FromArgMatches;
 use clap::Parser;
 use colored::Colorize;
 
-use sui_sdk::ClientType;
-
 use crate::client_commands::SwitchResponse;
 use crate::client_commands::{SuiClientCommandResult, SuiClientCommands, WalletContext};
 use crate::shell::{
@@ -51,22 +49,11 @@ pub async fn start_console(
     writeln!(out)?;
     writeln!(out, "{}", context.config.deref())?;
 
-    if let ClientType::RPC { .. } = context.config.client_type {
-        writeln!(out)?;
-        if context.client.is_gateway() {
-            writeln!(
-                out,
-                "Connecting to Sui Embedded Gateway. API version {}",
-                context.client.api_version()
-            )?;
-        } else {
-            writeln!(
-                out,
-                "Connecting to Sui Fullnode. API version {}",
-                context.client.api_version()
-            )?;
-        }
-    }
+    writeln!(
+        out,
+        "Connecting to Sui full node. API version {}",
+        context.client.api_version()
+    )?;
 
     if !context.client.available_rpc_methods().is_empty() {
         writeln!(out)?;
@@ -168,9 +155,9 @@ async fn handle_command(
     // Quit shell after RPC switch
     if matches!(
         result,
-        SuiClientCommandResult::Switch(SwitchResponse { rpc: Some(_), .. })
+        SuiClientCommandResult::Switch(SwitchResponse { env: Some(_), .. })
     ) {
-        println!("RPC server switch completed, please restart Sui console.");
+        println!("Sui environment switch completed, please restart Sui console.");
         return Ok(true);
     }
     Ok(false)

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -13,20 +13,18 @@ use fastcrypto::traits::KeyPair;
 use move_package::BuildConfig;
 use tracing::{info, warn};
 
-use sui_config::gateway::GatewayConfig;
-use sui_config::{builder::ConfigBuilder, NetworkConfig, SUI_DEV_NET_URL, SUI_KEYSTORE_FILENAME};
+use sui_config::{builder::ConfigBuilder, NetworkConfig, SUI_KEYSTORE_FILENAME};
 use sui_config::{genesis_config::GenesisConfig, SUI_GENESIS_FILENAME};
 use sui_config::{
     sui_config_dir, Config, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
-    SUI_GATEWAY_CONFIG, SUI_NETWORK_CONFIG,
+    SUI_NETWORK_CONFIG,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
-use sui_sdk::ClientType;
 use sui_swarm::memory::Swarm;
 use sui_types::crypto::{SignatureScheme, SuiKeyPair};
 
 use crate::client_commands::{SuiClientCommands, WalletContext};
-use crate::config::SuiClientConfig;
+use crate::config::{SuiClientConfig, SuiEnv};
 use crate::console::start_console;
 use crate::genesis_ceremony::{run, Ceremony};
 use crate::keytool::KeyToolCommand;
@@ -119,6 +117,11 @@ impl SuiCommand {
     pub async fn execute(self) -> Result<(), anyhow::Error> {
         match self {
             SuiCommand::Start { config } => {
+                // Auto genesis if path is none and sui directory doesn't exists.
+                if config.is_none() && !sui_config_dir()?.join(SUI_NETWORK_CONFIG).exists() {
+                    genesis(None, None, None, false).await?;
+                }
+
                 // Load the config of the Sui authority.
                 let network_config_path = config
                     .clone()
@@ -131,8 +134,9 @@ impl SuiCommand {
                         ))
                     })?;
 
-                let mut swarm =
-                    Swarm::builder().from_network_config(sui_config_dir()?, network_config);
+                let mut swarm = Swarm::builder()
+                    .with_fullnode_rpc_addr(sui_config::node::default_json_rpc_address())
+                    .from_network_config(sui_config_dir()?, network_config);
                 swarm.launch().await?;
 
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
@@ -172,142 +176,7 @@ impl SuiCommand {
                 force,
                 from_config,
                 write_config,
-            } => {
-                let sui_config_dir = &match working_dir {
-                    // if a directory is specified, it must exist (it
-                    // will not be created)
-                    Some(v) => v,
-                    // create default Sui config dir if not specified
-                    // on the command line and if it does not exist
-                    // yet
-                    None => {
-                        let config_path = sui_config_dir()?;
-                        fs::create_dir_all(&config_path)?;
-                        config_path
-                    }
-                };
-
-                // if Sui config dir is not empty then either clean it
-                // up (if --force/-f option was specified or report an
-                // error
-                if write_config.is_none()
-                    && sui_config_dir
-                        .read_dir()
-                        .map_err(|err| {
-                            anyhow!(err)
-                                .context(format!("Cannot open Sui config dir {:?}", sui_config_dir))
-                        })?
-                        .next()
-                        .is_some()
-                {
-                    if force {
-                        fs::remove_dir_all(sui_config_dir).map_err(|err| {
-                            anyhow!(err).context(format!(
-                                "Cannot remove Sui config dir {:?}",
-                                sui_config_dir
-                            ))
-                        })?;
-                        fs::create_dir(sui_config_dir).map_err(|err| {
-                            anyhow!(err).context(format!(
-                                "Cannot create Sui config dir {:?}",
-                                sui_config_dir
-                            ))
-                        })?;
-                    } else {
-                        bail!("Cannot run genesis with non-empty Sui config directory {}, please use --force/-f option to remove existing configuration", sui_config_dir.to_str().unwrap());
-                    }
-                }
-
-                let network_path = sui_config_dir.join(SUI_NETWORK_CONFIG);
-                let genesis_path = sui_config_dir.join(SUI_GENESIS_FILENAME);
-                let client_path = sui_config_dir.join(SUI_CLIENT_CONFIG);
-                let gateway_path = sui_config_dir.join(SUI_GATEWAY_CONFIG);
-                let keystore_path = sui_config_dir.join(SUI_KEYSTORE_FILENAME);
-                let db_folder_path = sui_config_dir.join("client_db");
-                let gateway_db_folder_path = sui_config_dir.join("gateway_client_db");
-
-                let mut genesis_conf = match from_config {
-                    Some(path) => PersistedConfig::read(&path)?,
-                    None => GenesisConfig::for_local_testing(),
-                };
-
-                if let Some(path) = write_config {
-                    let persisted = genesis_conf.persisted(&path);
-                    persisted.save()?;
-                    return Ok(());
-                }
-
-                let validator_info = genesis_conf.validator_genesis_info.take();
-                let mut network_config = if let Some(validators) = validator_info {
-                    ConfigBuilder::new(sui_config_dir)
-                        .initial_accounts_config(genesis_conf)
-                        .with_validators(validators)
-                        .build()
-                } else {
-                    ConfigBuilder::new(sui_config_dir)
-                        .committee_size(NonZeroUsize::new(genesis_conf.committee_size).unwrap())
-                        .initial_accounts_config(genesis_conf)
-                        .build()
-                };
-
-                let mut keystore = FileBasedKeystore::new(&keystore_path)?;
-                for key in &network_config.account_keys {
-                    keystore.add_key(SuiKeyPair::Ed25519SuiKeyPair(key.copy()))?;
-                }
-                let active_address = keystore.addresses().pop();
-
-                network_config.genesis.save(&genesis_path)?;
-                for validator in &mut network_config.validator_configs {
-                    validator.genesis = sui_config::node::Genesis::new_from_file(&genesis_path);
-                }
-
-                info!("Network genesis completed.");
-                network_config.save(&network_path)?;
-                info!("Network config file is stored in {:?}.", network_path);
-
-                info!("Client keystore is stored in {:?}.", keystore_path);
-
-                let validator_set = network_config.validator_set();
-
-                GatewayConfig {
-                    db_folder_path: gateway_db_folder_path,
-                    validator_set: validator_set.to_owned(),
-                    ..Default::default()
-                }
-                .save(&gateway_path)?;
-                info!("Gateway config file is stored in {:?}.", gateway_path);
-
-                let wallet_gateway_config = GatewayConfig {
-                    db_folder_path,
-                    validator_set: validator_set.to_owned(),
-                    ..Default::default()
-                };
-
-                let wallet_config = SuiClientConfig {
-                    keystore: Keystore::from(keystore),
-                    client_type: ClientType::Embedded(wallet_gateway_config),
-                    active_address,
-                };
-
-                wallet_config.save(&client_path)?;
-                info!("Client config file is stored in {:?}.", client_path);
-
-                let mut fullnode_config = network_config.generate_fullnode_config();
-                fullnode_config.json_rpc_address = sui_config::node::default_json_rpc_address();
-                fullnode_config.websocket_address = sui_config::node::default_websocket_address();
-                fullnode_config.save(sui_config_dir.join(SUI_FULLNODE_CONFIG))?;
-
-                for (i, validator) in network_config
-                    .into_validator_configs()
-                    .into_iter()
-                    .enumerate()
-                {
-                    let path = sui_config_dir.join(format!("validator-config-{}.yaml", i));
-                    validator.save(path)?;
-                }
-
-                Ok(())
-            }
+            } => genesis(from_config, write_config, working_dir, force).await,
             SuiCommand::GenesisCeremony(cmd) => run(cmd),
             SuiCommand::KeyTool { keystore_path, cmd } => {
                 let keystore_path =
@@ -318,8 +187,7 @@ impl SuiCommand {
             SuiCommand::Console { config } => {
                 let config = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config).await?;
-                let mut context = WalletContext::new(&config).await?;
-                sync_accounts(&mut context).await?;
+                let context = WalletContext::new(&config).await?;
                 start_console(context, &mut stdout(), &mut stderr()).await
             }
             SuiCommand::Client { config, cmd, json } => {
@@ -327,22 +195,18 @@ impl SuiCommand {
                 prompt_if_no_config(&config_path).await?;
 
                 // Server switch need to happen before context creation, or else it might fail due to previously misconfigured url.
-                if let Some(SuiClientCommands::Switch { rpc, ws, .. }) = &cmd {
+                if let Some(SuiClientCommands::Switch { env: Some(env), .. }) = &cmd {
                     let config: SuiClientConfig = PersistedConfig::read(&config_path)?;
                     let mut config = config.persisted(&config_path);
-                    SuiClientCommands::switch_server(&mut config, rpc, ws)?;
+                    SuiClientCommands::switch_env(&mut config, env)?;
                     // This will init the client to check if the urls are correct and reachable
-                    config.client_type.init().await?;
+                    config.get_active_env().init().await?;
                     config.save()?;
                 }
 
                 let mut context = WalletContext::new(&config_path).await?;
 
                 if let Some(cmd) = cmd {
-                    // Do not sync if command is a gateway switch, as the current gateway might be unreachable and causes sync to panic.
-                    if !matches!(cmd, SuiClientCommands::Switch { rpc: Some(_), .. }) {
-                        sync_accounts(&mut context).await?;
-                    }
                     if let Err(e) = context.client.check_api_version() {
                         warn!("{e}");
                         println!("{}", format!("[warn] {e}").yellow().bold());
@@ -365,25 +229,139 @@ impl SuiCommand {
     }
 }
 
-// Sync all accounts on start up.
-async fn sync_accounts(context: &mut WalletContext) -> Result<(), anyhow::Error> {
-    if context.client.is_gateway() {
-        for address in context.config.keystore.addresses().clone() {
-            SuiClientCommands::SyncClientState {
-                address: Some(address),
-            }
-            .execute(context)
-            .await?;
+async fn genesis(
+    from_config: Option<PathBuf>,
+    write_config: Option<PathBuf>,
+    working_dir: Option<PathBuf>,
+    force: bool,
+) -> Result<(), anyhow::Error> {
+    let sui_config_dir = &match working_dir {
+        // if a directory is specified, it must exist (it
+        // will not be created)
+        Some(v) => v,
+        // create default Sui config dir if not specified
+        // on the command line and if it does not exist
+        // yet
+        None => {
+            let config_path = sui_config_dir()?;
+            fs::create_dir_all(&config_path)?;
+            config_path
+        }
+    };
+
+    // if Sui config dir is not empty then either clean it
+    // up (if --force/-f option was specified or report an
+    // error
+    if write_config.is_none()
+        && sui_config_dir
+            .read_dir()
+            .map_err(|err| {
+                anyhow!(err).context(format!("Cannot open Sui config dir {:?}", sui_config_dir))
+            })?
+            .next()
+            .is_some()
+    {
+        if force {
+            fs::remove_dir_all(sui_config_dir).map_err(|err| {
+                anyhow!(err).context(format!("Cannot remove Sui config dir {:?}", sui_config_dir))
+            })?;
+            fs::create_dir(sui_config_dir).map_err(|err| {
+                anyhow!(err).context(format!("Cannot create Sui config dir {:?}", sui_config_dir))
+            })?;
+        } else {
+            bail!("Cannot run genesis with non-empty Sui config directory {}, please use --force/-f option to remove existing configuration", sui_config_dir.to_str().unwrap());
         }
     }
+
+    let network_path = sui_config_dir.join(SUI_NETWORK_CONFIG);
+    let genesis_path = sui_config_dir.join(SUI_GENESIS_FILENAME);
+    let client_path = sui_config_dir.join(SUI_CLIENT_CONFIG);
+    let keystore_path = sui_config_dir.join(SUI_KEYSTORE_FILENAME);
+
+    let mut genesis_conf = match from_config {
+        Some(path) => PersistedConfig::read(&path)?,
+        None => GenesisConfig::for_local_testing(),
+    };
+
+    if let Some(path) = write_config {
+        let persisted = genesis_conf.persisted(&path);
+        persisted.save()?;
+        return Ok(());
+    }
+
+    let validator_info = genesis_conf.validator_genesis_info.take();
+    let mut network_config = if let Some(validators) = validator_info {
+        ConfigBuilder::new(sui_config_dir)
+            .initial_accounts_config(genesis_conf)
+            .with_validators(validators)
+            .build()
+    } else {
+        ConfigBuilder::new(sui_config_dir)
+            .committee_size(NonZeroUsize::new(genesis_conf.committee_size).unwrap())
+            .initial_accounts_config(genesis_conf)
+            .build()
+    };
+
+    let mut keystore = FileBasedKeystore::new(&keystore_path)?;
+    for key in &network_config.account_keys {
+        keystore.add_key(SuiKeyPair::Ed25519SuiKeyPair(key.copy()))?;
+    }
+    let active_address = keystore.addresses().pop();
+
+    network_config.genesis.save(&genesis_path)?;
+    for validator in &mut network_config.validator_configs {
+        validator.genesis = sui_config::node::Genesis::new_from_file(&genesis_path);
+    }
+
+    info!("Network genesis completed.");
+    network_config.save(&network_path)?;
+    info!("Network config file is stored in {:?}.", network_path);
+
+    info!("Client keystore is stored in {:?}.", keystore_path);
+
+    let mut fullnode_config = network_config.generate_fullnode_config();
+    fullnode_config.json_rpc_address = sui_config::node::default_json_rpc_address();
+    fullnode_config.websocket_address = sui_config::node::default_websocket_address();
+    fullnode_config.save(sui_config_dir.join(SUI_FULLNODE_CONFIG))?;
+
+    for (i, validator) in network_config
+        .into_validator_configs()
+        .into_iter()
+        .enumerate()
+    {
+        let path = sui_config_dir.join(format!("validator-config-{}.yaml", i));
+        validator.save(path)?;
+    }
+
+    let client_config = SuiClientConfig {
+        keystore: Keystore::from(keystore),
+        envs: vec![
+            SuiEnv {
+                alias: "localnet".to_string(),
+                rpc: format!("http://{}", fullnode_config.json_rpc_address),
+                ws: None,
+            },
+            SuiEnv::devnet(),
+        ],
+        active_env: "localnet".into(),
+        active_address,
+    };
+
+    client_config.save(&client_path)?;
+    info!("Client config file is stored in {:?}.", client_path);
+
     Ok(())
 }
 
 async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Error> {
     // Prompt user for connect to devnet fullnode if config does not exist.
     if !wallet_conf_path.exists() {
-        let url = match std::env::var_os("SUI_CONFIG_WITH_RPC_URL") {
-            Some(v) => Some(v.into_string().unwrap()),
+        let env = match std::env::var_os("SUI_CONFIG_WITH_RPC_URL") {
+            Some(v) => Some(SuiEnv {
+                alias: "custom".to_string(),
+                rpc: v.into_string().unwrap(),
+                ws: None,
+            }),
             None => {
                 print!(
                     "Config file [{:?}] doesn't exist, do you want to connect to a Sui full node server [yN]?",
@@ -392,22 +370,29 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
                 if matches!(read_line(), Ok(line) if line.trim().to_lowercase() == "y") {
                     print!("Sui full node server url (Default to Sui DevNet if not specified) : ");
                     let url = read_line()?;
-                    let url = if url.trim().is_empty() {
-                        SUI_DEV_NET_URL
+                    Some(if url.trim().is_empty() {
+                        SuiEnv::devnet()
                     } else {
-                        &url
-                    };
-                    Some(String::from(url))
+                        print!("Environment alias for [{url}] : ");
+                        let alias = read_line()?;
+                        let alias = if alias.trim().is_empty() {
+                            "custom".to_string()
+                        } else {
+                            alias
+                        };
+                        SuiEnv {
+                            alias,
+                            rpc: url,
+                            ws: None,
+                        }
+                    })
                 } else {
                     None
                 }
             }
         };
 
-        if let Some(url) = url {
-            let client = ClientType::RPC(url, None);
-            // Check url is valid
-            client.init().await?;
+        if let Some(env) = env {
             let keystore_path = wallet_conf_path
                 .parent()
                 .unwrap_or(&sui_config_dir()?)
@@ -424,10 +409,12 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
                 scheme.to_string()
             );
             println!("Secret Recovery Phrase : [{phrase}]");
+            let alias = env.alias.clone();
             SuiClientConfig {
                 keystore,
-                client_type: client,
+                envs: vec![env],
                 active_address: Some(new_address),
+                active_env: alias,
             }
             .persisted(wallet_conf_path)
             .save()?;

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -200,7 +200,7 @@ impl SuiCommand {
                     let mut config = config.persisted(&config_path);
                     SuiClientCommands::switch_env(&mut config, env)?;
                     // This will init the client to check if the urls are correct and reachable
-                    config.get_active_env()?.init().await?;
+                    config.get_active_env()?.create_rpc_client().await?;
                     config.save()?;
                 }
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -260,11 +260,12 @@ async fn genesis(
     let client_path = sui_config_dir.join(SUI_CLIENT_CONFIG);
     let keystore_path = sui_config_dir.join(SUI_KEYSTORE_FILENAME);
 
-    if write_config.is_none() && files.len() > 0 {
+    if write_config.is_none() && !files.is_empty() {
         if force {
             // check old keystore and client.yaml is compatible
             let is_compatible = FileBasedKeystore::new(&keystore_path).is_ok()
                 && PersistedConfig::<SuiClientConfig>::read(&client_path).is_ok();
+            // Keep keystore and client.yaml if they are compatible
             if is_compatible {
                 for file in files {
                     let path = file.path();

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -200,7 +200,7 @@ impl SuiCommand {
                     let mut config = config.persisted(&config_path);
                     SuiClientCommands::switch_env(&mut config, env)?;
                     // This will init the client to check if the urls are correct and reachable
-                    config.get_active_env().init().await?;
+                    config.get_active_env()?.init().await?;
                     config.save()?;
                 }
 

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -4,7 +4,6 @@
 use std::{fmt::Write, fs::read_dir, path::PathBuf, str, time::Duration};
 
 use anyhow::anyhow;
-use fastcrypto::traits::KeyPair;
 use move_package::BuildConfig;
 use serde_json::json;
 
@@ -14,11 +13,10 @@ use sui::{
     config::SuiClientConfig,
     sui_commands::SuiCommand,
 };
-use sui_config::gateway::GatewayConfig;
 use sui_config::genesis_config::{AccountConfig, GenesisConfig, ObjectConfig};
 use sui_config::{
-    Config, NetworkConfig, PersistedConfig, ValidatorInfo, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
-    SUI_GATEWAY_CONFIG, SUI_GENESIS_FILENAME, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
+    Config, NetworkConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
+    SUI_GENESIS_FILENAME, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -26,17 +24,15 @@ use sui_json_rpc_types::{
     SuiTransactionEffects,
 };
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
+use sui_macros::sim_test;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
-    AccountKeyPair, AuthorityKeyPair, Ed25519SuiSignature, NetworkKeyPair, Secp256k1SuiSignature,
-    SignatureScheme, SuiKeyPair, SuiSignatureInner,
+    Ed25519SuiSignature, Secp256k1SuiSignature, SignatureScheme, SuiKeyPair, SuiSignatureInner,
 };
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
 use sui_types::{sui_framework_address_concat_string, SUI_FRAMEWORK_ADDRESS};
 use test_utils::messages::make_transactions_with_wallet_context;
 use test_utils::network::init_cluster_builder_env_aware;
-
-use sui_macros::sim_test;
 
 const TEST_DATA_DIR: &str = "src/unit_tests/data/";
 
@@ -104,14 +100,10 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[sim_test]
+#[tokio::test]
 async fn test_addresses_command() -> Result<(), anyhow::Error> {
     let temp_dir = tempfile::tempdir().unwrap();
     let working_dir = temp_dir.path();
-    let keypair: AuthorityKeyPair = get_key_pair().1;
-    let worker_keypair: NetworkKeyPair = get_key_pair().1;
-    let network_keypair: NetworkKeyPair = get_key_pair().1;
-    let account_keypair: SuiKeyPair = get_key_pair::<AccountKeyPair>().1.into();
 
     let wallet_config = SuiClientConfig {
         keystore: Keystore::from(FileBasedKeystore::new(
@@ -122,31 +114,10 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
         active_env: "".to_string(),
     };
 
-    let gateway_config = GatewayConfig {
-        db_folder_path: working_dir.join("client_db"),
-        validator_set: vec![ValidatorInfo {
-            name: "0".into(),
-            protocol_key: keypair.public().into(),
-            worker_key: worker_keypair.public().clone(),
-            account_key: account_keypair.public(),
-            network_key: network_keypair.public().clone(),
-            stake: 1,
-            delegation: 1,
-            gas_price: 1,
-            network_address: sui_config::utils::new_network_address(),
-            narwhal_primary_address: sui_config::utils::new_network_address(),
-            narwhal_worker_address: sui_config::utils::new_network_address(),
-            narwhal_consensus_address: sui_config::utils::new_network_address(),
-        }],
-        ..Default::default()
-    };
-
     let wallet_conf_path = working_dir.join(SUI_CLIENT_CONFIG);
     let wallet_config = wallet_config.persisted(&wallet_conf_path);
     wallet_config.save().unwrap();
-    let mut context = WalletContext::new_with_embedded_gateway(&wallet_conf_path, &gateway_config)
-        .await
-        .unwrap();
+    let mut context = WalletContext::new(&wallet_conf_path).await.unwrap();
 
     // Add 3 accounts
     for _ in 0..3 {
@@ -356,12 +327,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
     .await?;
 
     let package = if let SuiClientCommandResult::Publish(response) = resp {
-        if context.client.is_gateway() {
-            let publish_resp = response.parsed_data.unwrap().to_publish_response().unwrap();
-            publish_resp.package.object_id
-        } else {
-            response.effects.created[0].reference.object_id
-        }
+        response.effects.created[0].reference.object_id
     } else {
         unreachable!("Invalid response");
     };
@@ -532,20 +498,12 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     resp.print(true);
 
     let obj_ids = if let SuiClientCommandResult::Publish(response) = resp {
-        if context.client.is_gateway() {
-            let publish_resp = response.parsed_data.unwrap().to_publish_response().unwrap();
-            vec![
-                publish_resp.package.object_id,
-                publish_resp.created_objects[0].reference.object_id,
-            ]
-        } else {
-            response
-                .effects
-                .created
-                .iter()
-                .map(|refe| refe.reference.object_id)
-                .collect::<Vec<_>>()
-        }
+        response
+            .effects
+            .created
+            .iter()
+            .map(|refe| refe.reference.object_id)
+            .collect::<Vec<_>>()
     } else {
         unreachable!("Invalid response");
     };
@@ -909,22 +867,14 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
     .execute(context)
     .await?;
     let g = if let SuiClientCommandResult::MergeCoin(r) = resp {
-        if context.client.is_gateway() {
-            r.parsed_data
-                .unwrap()
-                .to_merge_coin_response()
-                .unwrap()
-                .updated_coin
-        } else {
-            let object_id = r
-                .effects
-                .mutated_excluding_gas()
-                .next()
-                .unwrap()
-                .reference
-                .object_id;
-            get_parsed_object_assert_existence(object_id, context).await
-        }
+        let object_id = r
+            .effects
+            .mutated_excluding_gas()
+            .next()
+            .unwrap()
+            .reference
+            .object_id;
+        get_parsed_object_assert_existence(object_id, context).await
     } else {
         panic!("Command failed")
     };
@@ -958,22 +908,14 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
     .await?;
 
     let g = if let SuiClientCommandResult::MergeCoin(r) = resp {
-        if context.client.is_gateway() {
-            r.parsed_data
-                .unwrap()
-                .to_merge_coin_response()
-                .unwrap()
-                .updated_coin
-        } else {
-            let object_id = r
-                .effects
-                .mutated_excluding_gas()
-                .next()
-                .unwrap()
-                .reference
-                .object_id;
-            get_parsed_object_assert_existence(object_id, context).await
-        }
+        let object_id = r
+            .effects
+            .mutated_excluding_gas()
+            .next()
+            .unwrap()
+            .reference
+            .object_id;
+        get_parsed_object_assert_existence(object_id, context).await
     } else {
         panic!("Command failed")
     };
@@ -1018,27 +960,22 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     .await?;
 
     let (updated_coin, new_coins) = if let SuiClientCommandResult::SplitCoin(r) = resp {
-        if context.client.is_gateway() {
-            let resp = r.parsed_data.unwrap().to_split_coin_response().unwrap();
-            (resp.updated_coin, resp.new_coins)
-        } else {
-            let updated_object_id = r
-                .effects
-                .mutated_excluding_gas()
-                .next()
-                .unwrap()
-                .reference
-                .object_id;
-            let updated_obj = get_parsed_object_assert_existence(updated_object_id, context).await;
-            let new_object_refs = r.effects.created;
-            let mut new_objects = Vec::with_capacity(new_object_refs.len());
-            for obj_ref in new_object_refs {
-                new_objects.push(
-                    get_parsed_object_assert_existence(obj_ref.reference.object_id, context).await,
-                );
-            }
-            (updated_obj, new_objects)
+        let updated_object_id = r
+            .effects
+            .mutated_excluding_gas()
+            .next()
+            .unwrap()
+            .reference
+            .object_id;
+        let updated_obj = get_parsed_object_assert_existence(updated_object_id, context).await;
+        let new_object_refs = r.effects.created;
+        let mut new_objects = Vec::with_capacity(new_object_refs.len());
+        for obj_ref in new_object_refs {
+            new_objects.push(
+                get_parsed_object_assert_existence(obj_ref.reference.object_id, context).await,
+            );
         }
+        (updated_obj, new_objects)
     } else {
         panic!("Command failed")
     };
@@ -1074,27 +1011,22 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     .await?;
 
     let (updated_coin, new_coins) = if let SuiClientCommandResult::SplitCoin(r) = resp {
-        if context.client.is_gateway() {
-            let resp = r.parsed_data.unwrap().to_split_coin_response().unwrap();
-            (resp.updated_coin, resp.new_coins)
-        } else {
-            let updated_object_id = r
-                .effects
-                .mutated_excluding_gas()
-                .next()
-                .unwrap()
-                .reference
-                .object_id;
-            let updated_obj = get_parsed_object_assert_existence(updated_object_id, context).await;
-            let new_object_refs = r.effects.created;
-            let mut new_objects = Vec::with_capacity(new_object_refs.len());
-            for obj_ref in new_object_refs {
-                new_objects.push(
-                    get_parsed_object_assert_existence(obj_ref.reference.object_id, context).await,
-                );
-            }
-            (updated_obj, new_objects)
+        let updated_object_id = r
+            .effects
+            .mutated_excluding_gas()
+            .next()
+            .unwrap()
+            .reference
+            .object_id;
+        let updated_obj = get_parsed_object_assert_existence(updated_object_id, context).await;
+        let new_object_refs = r.effects.created;
+        let mut new_objects = Vec::with_capacity(new_object_refs.len());
+        for obj_ref in new_object_refs {
+            new_objects.push(
+                get_parsed_object_assert_existence(obj_ref.reference.object_id, context).await,
+            );
         }
+        (updated_obj, new_objects)
     } else {
         panic!("Command failed")
     };
@@ -1133,27 +1065,22 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
     .await?;
 
     let (updated_coin, new_coins) = if let SuiClientCommandResult::SplitCoin(r) = resp {
-        if context.client.is_gateway() {
-            let resp = r.parsed_data.unwrap().to_split_coin_response().unwrap();
-            (resp.updated_coin, resp.new_coins)
-        } else {
-            let updated_object_id = r
-                .effects
-                .mutated_excluding_gas()
-                .next()
-                .unwrap()
-                .reference
-                .object_id;
-            let updated_obj = get_parsed_object_assert_existence(updated_object_id, context).await;
-            let new_object_refs = r.effects.created;
-            let mut new_objects = Vec::with_capacity(new_object_refs.len());
-            for obj_ref in new_object_refs {
-                new_objects.push(
-                    get_parsed_object_assert_existence(obj_ref.reference.object_id, context).await,
-                );
-            }
-            (updated_obj, new_objects)
+        let updated_object_id = r
+            .effects
+            .mutated_excluding_gas()
+            .next()
+            .unwrap()
+            .reference
+            .object_id;
+        let updated_obj = get_parsed_object_assert_existence(updated_object_id, context).await;
+        let new_object_refs = r.effects.created;
+        let mut new_objects = Vec::with_capacity(new_object_refs.len());
+        for obj_ref in new_object_refs {
+            new_objects.push(
+                get_parsed_object_assert_existence(obj_ref.reference.object_id, context).await,
+            );
         }
+        (updated_obj, new_objects)
     } else {
         panic!("Command failed")
     };

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -4,6 +4,7 @@
 use std::{fmt::Write, fs::read_dir, path::PathBuf, str, time::Duration};
 
 use anyhow::anyhow;
+use fastcrypto::traits::KeyPair;
 use move_package::BuildConfig;
 use serde_json::json;
 
@@ -27,7 +28,8 @@ use sui_json_rpc_types::{
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
-    Ed25519SuiSignature, Secp256k1SuiSignature, SignatureScheme, SuiKeyPair, SuiSignatureInner,
+    AccountKeyPair, AuthorityKeyPair, Ed25519SuiSignature, NetworkKeyPair, Secp256k1SuiSignature,
+    SignatureScheme, SuiKeyPair, SuiSignatureInner,
 };
 use sui_types::{base_types::ObjectID, crypto::get_key_pair, gas_coin::GasCoin};
 use sui_types::{sui_framework_address_concat_string, SUI_FRAMEWORK_ADDRESS};
@@ -107,6 +109,10 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 async fn test_addresses_command() -> Result<(), anyhow::Error> {
     let temp_dir = tempfile::tempdir().unwrap();
     let working_dir = temp_dir.path();
+    let keypair: AuthorityKeyPair = get_key_pair().1;
+    let worker_keypair: NetworkKeyPair = get_key_pair().1;
+    let network_keypair: NetworkKeyPair = get_key_pair().1;
+    let account_keypair: SuiKeyPair = get_key_pair::<AccountKeyPair>().1.into();
 
     let wallet_config = SuiClientConfig {
         keystore: Keystore::from(FileBasedKeystore::new(

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -70,7 +70,6 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 
     assert_eq!(9, files.len());
     assert!(files.contains(&SUI_CLIENT_CONFIG.to_string()));
-    assert!(files.contains(&SUI_GATEWAY_CONFIG.to_string()));
     assert!(files.contains(&SUI_NETWORK_CONFIG.to_string()));
     assert!(files.contains(&SUI_FULLNODE_CONFIG.to_string()));
     assert!(files.contains(&SUI_GENESIS_FILENAME.to_string()));

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -15,15 +15,15 @@ use sui::{
 };
 use sui_config::genesis_config::{AccountConfig, GenesisConfig, ObjectConfig};
 use sui_config::{
-    Config, NetworkConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG,
-    SUI_GENESIS_FILENAME, SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
+    NetworkConfig, PersistedConfig, SUI_CLIENT_CONFIG, SUI_FULLNODE_CONFIG, SUI_GENESIS_FILENAME,
+    SUI_KEYSTORE_FILENAME, SUI_NETWORK_CONFIG,
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     GetObjectDataResponse, SuiData, SuiObject, SuiParsedData, SuiParsedObject,
     SuiTransactionEffects,
 };
-use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
+use sui_keys::keystore::AccountKeystore;
 use sui_macros::sim_test;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{
@@ -102,22 +102,8 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_addresses_command() -> Result<(), anyhow::Error> {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let working_dir = temp_dir.path();
-
-    let wallet_config = SuiClientConfig {
-        keystore: Keystore::from(FileBasedKeystore::new(
-            &working_dir.join(SUI_KEYSTORE_FILENAME),
-        )?),
-        envs: vec![],
-        active_address: None,
-        active_env: "".to_string(),
-    };
-
-    let wallet_conf_path = working_dir.join(SUI_CLIENT_CONFIG);
-    let wallet_config = wallet_config.persisted(&wallet_conf_path);
-    wallet_config.save().unwrap();
-    let mut context = WalletContext::new(&wallet_conf_path).await.unwrap();
+    let test_cluster = init_cluster_builder_env_aware().build().await?;
+    let mut context = test_cluster.wallet;
 
     // Add 3 accounts
     for _ in 0..3 {

--- a/crates/sui/tests/shared_objects_tests.rs
+++ b/crates/sui/tests/shared_objects_tests.rs
@@ -1,11 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-use sui_core::authority::GatewayStore;
-use sui_core::authority_aggregator::AuthorityAggregatorBuilder;
 use sui_core::authority_client::AuthorityAPI;
-use sui_core::gateway_state::{GatewayAPI, GatewayMetrics, GatewayState};
 use sui_types::messages::{
     CallArg, ExecutionStatus, ObjectArg, ObjectInfoRequest, ObjectInfoRequestKind,
 };
@@ -351,122 +347,5 @@ async fn replay_shared_object_transaction() {
         // Ensure the sequence number of the shared object did not change.
         let ((_, seq, _), _) = effects.created[0];
         assert_eq!(seq, OBJECT_START_VERSION);
-    }
-}
-
-// TODO [gateway-deprecation] remove test case
-#[sim_test]
-async fn shared_object_on_gateway() {
-    let mut gas_objects = test_gas_objects();
-
-    // Get the authority configs and spawn them. Note that it is important to not drop
-    // the handles (or the authorities will stop).
-    let configs = test_authority_configs();
-    let handles = spawn_test_authorities(gas_objects.clone(), &configs).await;
-    let committee_store = handles[0].with(|h| h.state().committee_store().clone());
-    let (aggregator, _) = AuthorityAggregatorBuilder::from_network_config(&configs)
-        .with_committee_store(committee_store)
-        .build()
-        .unwrap();
-    let path = tempfile::tempdir().unwrap().into_path();
-    let gateway_store = Arc::new(GatewayStore::open(&path.join("store"), None).unwrap());
-    let gateway = Arc::new(
-        GatewayState::new_with_authorities(
-            gateway_store,
-            aggregator,
-            GatewayMetrics::new_for_tests(),
-        )
-        .unwrap(),
-    );
-
-    // Publish the move package to all authorities and get the new package ref.
-    let package_ref =
-        publish_counter_package(gas_objects.pop().unwrap(), configs.validator_set()).await;
-
-    // Send a transaction to create a counter.
-    let create_counter_transaction = move_transaction(
-        gas_objects.pop().unwrap(),
-        "counter",
-        "create",
-        package_ref,
-        /* arguments */ Vec::default(),
-    );
-    let resp = gateway
-        .execute_transaction(create_counter_transaction.into_inner())
-        .await
-        .unwrap();
-    let effects = resp.effects;
-    let shared_object_ref = &effects.created[0].reference;
-    let shared_object_arg = ObjectArg::SharedObject {
-        id: shared_object_ref.object_id,
-        initial_shared_version: shared_object_ref.version,
-    };
-    // We need to have one gas object left for the final value check.
-    let last_gas_object = gas_objects.pop().unwrap();
-    let increment_amount = gas_objects.len();
-
-    // It may happen that no authorities manage to get their transaction sequenced by consensus
-    // (we may be unlucky and consensus may drop all our transactions). It would have been nice
-    // to only filter "timeout" errors, but the game way simply returns `anyhow::Error`, this
-    // will be fixed by issue #1717. Note that the gateway has an internal retry mechanism but
-    // it is not an infinite loop.
-    let mut retry = 10;
-    loop {
-        let futures: Vec<_> = gas_objects
-            .iter()
-            .cloned()
-            .map(|gas_object| {
-                let g = gateway.clone();
-                let increment_counter_transaction = move_transaction(
-                    gas_object,
-                    "counter",
-                    "increment",
-                    package_ref,
-                    /* arguments */
-                    vec![CallArg::Object(shared_object_arg)],
-                );
-                async move {
-                    g.execute_transaction(increment_counter_transaction.into_inner())
-                        .await
-                }
-            })
-            .collect();
-
-        let replies: Vec<_> = futures::future::join_all(futures)
-            .await
-            .into_iter()
-            .collect();
-        assert_eq!(replies.len(), increment_amount);
-        if replies.iter().all(|result| result.is_ok()) {
-            break;
-        }
-        if retry == 0 {
-            unreachable!("Failed after 10 retries. Latest replies: {:?}", replies);
-        }
-        retry -= 1;
-    }
-
-    let assert_value_transaction = move_transaction(
-        last_gas_object,
-        "counter",
-        "assert_value",
-        package_ref,
-        vec![
-            CallArg::Object(shared_object_arg),
-            CallArg::Pure((increment_amount as u64).to_le_bytes().to_vec()),
-        ],
-    );
-
-    // Same problem may happen here (consensus may drop transactions).
-    loop {
-        let result = gateway
-            .clone()
-            .execute_transaction(assert_value_transaction.clone().into_inner())
-            .await;
-        if let Ok(response) = result {
-            let effects = response.effects;
-            assert!(effects.status.is_ok());
-            break;
-        }
     }
 }

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -172,7 +172,7 @@ impl TestClusterBuilder {
                 rpc: handle.rpc_url.clone(),
                 ws: handle.ws_url.clone(),
             });
-            wallet_conf.active_env = "localnet".to_string();
+            wallet_conf.active_env = Some("localnet".to_string());
 
             Some(handle)
         };

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -1,36 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+
+use jsonrpsee::ws_client::WsClient;
 use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
 use prometheus::Registry;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::num::NonZeroUsize;
-use std::path::Path;
-use sui::{
-    client_commands::{SuiClientCommands, WalletContext},
-    config::SuiClientConfig,
-};
-use sui_config::gateway::GatewayConfig;
+
+use sui::config::SuiEnv;
+use sui::{client_commands::WalletContext, config::SuiClientConfig};
 use sui_config::genesis_config::GenesisConfig;
 use sui_config::utils::get_available_port;
-use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_GATEWAY_CONFIG, SUI_NETWORK_CONFIG};
+use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{PersistedConfig, SUI_KEYSTORE_FILENAME};
-use sui_core::gateway_state::GatewayState;
-use sui_node::SuiNode;
 
-use jsonrpsee::ws_client::WsClient;
-use sui_json_rpc::bcs_api::BcsApiImpl;
-use sui_json_rpc::gateway_api::{
-    GatewayReadApiImpl, GatewayWalletSyncApiImpl, RpcGatewayImpl, TransactionBuilderImpl,
-};
-use sui_json_rpc::{JsonRpcServerBuilder, ServerHandle};
+use sui_json_rpc::ServerHandle;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
-use sui_sdk::{ClientType, SuiClient};
+use sui_node::SuiNode;
+use sui_sdk::SuiClient;
 use sui_swarm::memory::{Swarm, SwarmBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::SuiKeyPair::Ed25519SuiKeyPair;
+
 const NUM_VALIDAOTR: usize = 4;
 
 pub struct FullNodeHandle {
@@ -50,7 +44,6 @@ pub struct GatewayHandle {
 
 pub struct TestCluster {
     pub swarm: Swarm,
-    pub gateway_handle: Option<GatewayHandle>,
     pub fullnode_handle: Option<FullNodeHandle>,
     pub accounts: Vec<SuiAddress>,
     pub wallet: WalletContext,
@@ -58,9 +51,7 @@ pub struct TestCluster {
 
 impl TestCluster {
     pub fn rpc_client(&self) -> Option<&HttpClient> {
-        if let Some(gateway_handle) = &self.gateway_handle {
-            Some(&gateway_handle.http_client)
-        } else if let Some(fullnode_handle) = &self.fullnode_handle {
+        if let Some(fullnode_handle) = &self.fullnode_handle {
             Some(&fullnode_handle.rpc_client)
         } else {
             None
@@ -68,9 +59,7 @@ impl TestCluster {
     }
 
     pub fn rpc_url(&self) -> Option<&str> {
-        if let Some(gateway_handle) = &self.gateway_handle {
-            Some(&gateway_handle.url)
-        } else if let Some(fullnode_handle) = &self.fullnode_handle {
+        if let Some(fullnode_handle) = &self.fullnode_handle {
             Some(&fullnode_handle.rpc_url)
         } else {
             None
@@ -106,10 +95,8 @@ impl TestCluster {
 
 pub struct TestClusterBuilder {
     genesis_config: Option<GenesisConfig>,
-    use_embedded_gateway: bool,
     fullnode_rpc_port: Option<u16>,
     fullnode_ws_port: Option<u16>,
-    gateway_rpc_port: Option<u16>,
     do_not_build_fullnode: bool,
 }
 
@@ -117,10 +104,8 @@ impl TestClusterBuilder {
     pub fn new() -> Self {
         TestClusterBuilder {
             genesis_config: None,
-            use_embedded_gateway: false,
             fullnode_rpc_port: None,
             fullnode_ws_port: None,
-            gateway_rpc_port: None,
             do_not_build_fullnode: false,
         }
     }
@@ -135,13 +120,6 @@ impl TestClusterBuilder {
         self
     }
 
-    // Only start a Gateway Server when this field is set.
-    // This Gateway Server exposes RPC endpoints.
-    pub fn set_gateway_rpc_port(mut self, rpc_port: u16) -> Self {
-        self.gateway_rpc_port = Some(rpc_port);
-        self
-    }
-
     pub fn set_genesis_config(mut self, genesis_config: GenesisConfig) -> Self {
         self.genesis_config = Some(genesis_config);
         self
@@ -152,28 +130,8 @@ impl TestClusterBuilder {
         self
     }
 
-    // Let WalltContext to use an embedded Gateway
-    // If set to false (default), WalletContext connects to an RPC endpoint,
-    // which will be Gateway if `set_gateway_rpc_port` is set, otherwise
-    // FullNode.
-    pub fn use_embedded_gateway(mut self) -> Self {
-        self.use_embedded_gateway = true;
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<TestCluster> {
-        let use_embedded_gateway = self.use_embedded_gateway;
-        let mut cluster = self.start_test_network_with_customized_ports().await?;
-
-        if use_embedded_gateway {
-            SuiClientCommands::SyncClientState {
-                address: Some(cluster.get_address_0()),
-            }
-            .execute(cluster.wallet_mut())
-            .await?;
-        };
-
-        Ok(cluster)
+        Ok(self.start_test_network_with_customized_ports().await?)
     }
 
     async fn start_test_network_with_customized_ports(self) -> Result<TestCluster, anyhow::Error> {
@@ -202,29 +160,14 @@ impl TestClusterBuilder {
                 false,
             )
             .await?;
-            if !self.use_embedded_gateway {
-                wallet_conf.client_type =
-                    ClientType::RPC(handle.rpc_url.clone(), handle.ws_url.clone());
-            }
-            Some(handle)
-        };
+            wallet_conf.envs.push(SuiEnv {
+                alias: "localnet".to_string(),
+                rpc: handle.rpc_url.clone(),
+                ws: handle.ws_url.clone(),
+            });
+            wallet_conf.active_env = "localnet".to_string();
 
-        let gateway_handle = if let Some(gateway_port) = self.gateway_rpc_port {
-            let handle =
-                Self::start_rpc_gateway(&working_dir.join(SUI_GATEWAY_CONFIG), Some(gateway_port))
-                    .await?;
-            let url = format!("http://{}", handle.local_addr());
-            let http_client = HttpClientBuilder::default().build(url.clone())?;
-            if !self.use_embedded_gateway {
-                wallet_conf.client_type = ClientType::RPC(url.clone(), None);
-            }
-            Some(GatewayHandle {
-                handle,
-                http_client,
-                url,
-            })
-        } else {
-            None
+            Some(handle)
         };
 
         let accounts = wallet_conf.keystore.addresses();
@@ -238,7 +181,6 @@ impl TestClusterBuilder {
 
         Ok(TestCluster {
             swarm,
-            gateway_handle,
             fullnode_handle,
             accounts,
             wallet,
@@ -249,8 +191,9 @@ impl TestClusterBuilder {
     async fn start_test_swarm_with_fullnodes(
         genesis_config: Option<GenesisConfig>,
     ) -> Result<Swarm, anyhow::Error> {
-        let mut builder: SwarmBuilder =
-            Swarm::builder().committee_size(NonZeroUsize::new(NUM_VALIDAOTR).unwrap());
+        let mut builder: SwarmBuilder = Swarm::builder()
+            .committee_size(NonZeroUsize::new(NUM_VALIDAOTR).unwrap())
+            .with_fullnode_count(1);
 
         if let Some(genesis_config) = genesis_config {
             builder = builder.initial_accounts_config(genesis_config);
@@ -264,8 +207,6 @@ impl TestClusterBuilder {
         let network_path = dir.join(SUI_NETWORK_CONFIG);
         let wallet_path = dir.join(SUI_CLIENT_CONFIG);
         let keystore_path = dir.join(SUI_KEYSTORE_FILENAME);
-        let db_folder_path = dir.join("client_db");
-        let gateway_path = dir.join(SUI_GATEWAY_CONFIG);
 
         swarm.config().save(&network_path)?;
         let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
@@ -273,48 +214,30 @@ impl TestClusterBuilder {
             keystore.add_key(Ed25519SuiKeyPair(key.copy()))?;
         }
 
-        let validators = swarm.config().validator_set().to_owned();
         let active_address = keystore.addresses().first().cloned();
 
-        GatewayConfig {
-            db_folder_path: db_folder_path.clone(),
-            validator_set: validators.clone(),
-            ..Default::default()
-        }
-        .save(gateway_path)?;
+        let envs = swarm
+            .fullnodes()
+            .map(|fullnode| SuiEnv {
+                alias: fullnode.name().to_string(),
+                rpc: fullnode.json_rpc_address().to_string(),
+                ws: None,
+            })
+            .collect::<Vec<_>>();
+
+        let active_env = envs.first().unwrap().alias.clone();
 
         // Create wallet config with stated authorities port
         SuiClientConfig {
             keystore: Keystore::from(FileBasedKeystore::new(&keystore_path)?),
-            client_type: ClientType::Embedded(GatewayConfig {
-                db_folder_path,
-                validator_set: validators,
-                ..Default::default()
-            }),
+            envs,
             active_address,
+            active_env,
         }
         .save(&wallet_path)?;
 
         // Return network handle
         Ok(swarm)
-    }
-
-    async fn start_rpc_gateway(
-        config_path: &Path,
-        port: Option<u16>,
-    ) -> Result<ServerHandle, anyhow::Error> {
-        let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port.unwrap_or(0));
-        let mut server = JsonRpcServerBuilder::new_without_metrics_for_testing(false)?;
-
-        let config = PersistedConfig::read(config_path)?;
-        let client = GatewayState::create_client(&config, None)?;
-        server.register_module(RpcGatewayImpl::new(client.clone()))?;
-        server.register_module(GatewayReadApiImpl::new(client.clone()))?;
-        server.register_module(TransactionBuilderImpl::new(client.clone()))?;
-        server.register_module(GatewayWalletSyncApiImpl::new(client.clone()))?;
-        server.register_module(BcsApiImpl::new_with_gateway(client.clone()))?;
-
-        server.start(server_addr).await
     }
 }
 
@@ -375,7 +298,7 @@ pub async fn start_a_fullnode_with_handle(
 
     let rpc_url = format!("http://{}", jsonrpc_server_url);
     let rpc_client = HttpClientBuilder::default().build(&rpc_url)?;
-    let sui_client = ClientType::RPC(rpc_url.clone(), ws_url.clone());
+    let sui_client = SuiClient::new_rpc_client(&rpc_url, ws_url.as_deref()).await?;
 
     let ws_client = if let Some(ws_url) = &ws_url {
         Some(WsClientBuilder::default().build(ws_url).await?)
@@ -383,8 +306,6 @@ pub async fn start_a_fullnode_with_handle(
         None
     };
 
-    // Check url is valid
-    let sui_client = sui_client.init().await?;
     Ok(FullNodeHandle {
         sui_node,
         sui_client,
@@ -399,9 +320,5 @@ pub async fn start_a_fullnode_with_handle(
 /// test runs. Before simtest supports jsonrpc/ws, we use an embedded
 /// Gateway.
 pub fn init_cluster_builder_env_aware() -> TestClusterBuilder {
-    let mut builder = TestClusterBuilder::new();
-    if cfg!(msim) {
-        builder = builder.use_embedded_gateway().do_not_build_fullnode();
-    }
-    builder
+    TestClusterBuilder::new()
 }

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -9,10 +9,8 @@ use jsonrpsee::ws_client::WsClientBuilder;
 use jsonrpsee_http_client::{HttpClient, HttpClientBuilder};
 use prometheus::Registry;
 
-use sui::client_commands::SuiClientCommands;
 use sui::config::SuiEnv;
 use sui::{client_commands::WalletContext, config::SuiClientConfig};
-use sui_config::gateway::GatewayConfig;
 use sui_config::genesis_config::GenesisConfig;
 use sui_config::utils::get_available_port;
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
@@ -96,7 +94,6 @@ impl TestCluster {
 
 pub struct TestClusterBuilder {
     genesis_config: Option<GenesisConfig>,
-    use_embedded_gateway: bool,
     fullnode_rpc_port: Option<u16>,
     fullnode_ws_port: Option<u16>,
     do_not_build_fullnode: bool,
@@ -106,7 +103,6 @@ impl TestClusterBuilder {
     pub fn new() -> Self {
         TestClusterBuilder {
             genesis_config: None,
-            use_embedded_gateway: false,
             fullnode_rpc_port: None,
             fullnode_ws_port: None,
             do_not_build_fullnode: false,
@@ -133,26 +129,15 @@ impl TestClusterBuilder {
         self
     }
 
-    // Let WalltContext to use an embedded Gateway
-    // If set to false (default), WalletContext connects to an RPC endpoint,
-    // which will be Gateway if `set_gateway_rpc_port` is set, otherwise
-    // FullNode.
-    pub fn use_embedded_gateway(mut self) -> Self {
-        self.use_embedded_gateway = true;
-        self
-    }
-
     pub async fn build(self) -> anyhow::Result<TestCluster> {
-        let use_embedded_gateway = self.use_embedded_gateway;
-        let mut cluster = self.start_test_network_with_customized_ports().await?;
-
-        if use_embedded_gateway {
-            SuiClientCommands::SyncClientState {
-                address: Some(cluster.get_address_0()),
-            }
-            .execute(cluster.wallet_mut())
+        let cluster = self.start_test_network_with_customized_ports().await?;
+        #[cfg(msim)]
+        cluster
+            .wallet
+            .client
+            .wallet_sync_api()
+            .sync_account_state(cluster.get_address_0())
             .await?;
-        };
 
         Ok(cluster)
     }
@@ -200,25 +185,12 @@ impl TestClusterBuilder {
             .save()?;
 
         let wallet_conf = swarm.dir().join(SUI_CLIENT_CONFIG);
-        let wallet = if self.use_embedded_gateway {
-            let dir = swarm.dir();
-            let db_folder_path = dir.join("client_db");
-            let validators = swarm.config().validator_set().to_owned();
-            let conf = GatewayConfig {
-                db_folder_path: db_folder_path.clone(),
-                validator_set: validators.clone(),
-                ..Default::default()
-            };
-            WalletContext::new_with_embedded_gateway(&wallet_conf, &conf).await?
-        } else {
-            WalletContext::new(&wallet_conf).await?
-        };
 
         Ok(TestCluster {
             swarm,
             fullnode_handle,
             accounts,
-            wallet,
+            wallet: WalletContext::new(&wallet_conf).await?,
         })
     }
 
@@ -333,7 +305,7 @@ pub async fn start_a_fullnode_with_handle(
 
     let rpc_url = format!("http://{}", jsonrpc_server_url);
     let rpc_client = HttpClientBuilder::default().build(&rpc_url)?;
-    let sui_client = SuiClient::new_rpc_client(&rpc_url, ws_url.as_deref()).await?;
+    let sui_client = SuiClient::new(&rpc_url, ws_url.as_deref()).await?;
 
     let ws_client = if let Some(ws_url) = &ws_url {
         Some(WsClientBuilder::default().build(ws_url).await?)
@@ -357,7 +329,7 @@ pub async fn start_a_fullnode_with_handle(
 pub fn init_cluster_builder_env_aware() -> TestClusterBuilder {
     let mut builder = TestClusterBuilder::new();
     if cfg!(msim) {
-        builder = builder.use_embedded_gateway().do_not_build_fullnode();
+        builder = builder.do_not_build_fullnode();
     }
     builder
 }

--- a/doc/src/build/install.md
+++ b/doc/src/build/install.md
@@ -209,12 +209,11 @@ Sui requires the following additional tools on computers running Windows.
 After you install Cargo, use the following command to install Sui binaries:
 
 ```shell
-$ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch devnet sui sui-node
+$ cargo install --locked --git https://github.com/MystenLabs/sui.git --branch devnet sui
 ```
 
 The command installs the following Sui components in `~/.cargo/bin`:
 * [`sui`](cli-client.md) - The Sui CLI tool contains subcommands for enabling `genesis` of validators and accounts, starting the Sui network, and [building and testing Move packages](move/index.md), as well as a [client](cli-client.md) for interacting with the Sui network.
-* `Sui node` - installs the Sui node binary.
 
 Trouble shooting:
 If the previous command fails, make sure you have the latest version of Rust installed:


### PR DESCRIPTION
* Remove embedded gateway connection mode
* capability to store multiple Sui environment configuration for sui cli using the new `new-env` command
* auto genesis if the sui_config/network.yaml does not exists when running `sui start`
* Separated out embedded gateway from SuiClient to sui_sdk::embedded_gateway, this is now only used by the sim test 
* start fullnode with `sui start`
* `sui genesis` will try to preserve keystore and existing sui environnent configuration if the old configuration is compatible.

**Screenshots:**
RPC Environment switching:
<img width="927" alt="image" src="https://user-images.githubusercontent.com/1888654/199620811-b11394f0-96f4-498b-a0ef-03c1083d1e4a.png">

Fullnode started with `sui start`:
<img width="1319" alt="Screenshot 2022-11-02 at 11 26 32 pm" src="https://user-images.githubusercontent.com/1888654/199621092-d72c90e8-c83a-4b74-8201-7c77865f9e68.png">
