### PR TITLE
[ts-sdk] increase hook timeout of vitest

### DIFF
--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     minThreads: 1,
     maxThreads: 8,
+    hookTimeout: 100000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
The e2e will timeout sometimes:

```
 FAIL  test/e2e/object-vector.test.ts > Test Move call with a vector of objects as input
 FAIL  test/e2e/entry-point-string.test.ts > Test Move call with strings
Error: Hook timed out in 10000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "hookTimeout".
```

This PR increases the default timeout value as a short-term fix. Meanwhile I am hoping https://github.com/MystenLabs/sui/issues/5755 will increase the test performance.