### PR TITLE
[wallet-ext] Automate wallet versioning process

### DIFF
--- a/.github/workflows/wallet-version.yml
+++ b/.github/workflows/wallet-version.yml
@@ -1,0 +1,40 @@
+name: Wallet Extension PR Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    # This cron runs every Tuesday at 17:00 UTC.
+    - cron: "0 17 * * 2"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v3
+      - name: Increment patch version
+        working-directory: ./app
+        run: |
+          pnpm version patch
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "[wallet-ext] Auto-version Extension Wallet"
+          body: |
+            This is an automated pull request that increments the wallet version.
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: Enable auto-merge for PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a job that creates a PR to bump the patch version of the wallet, and enables auto-merge for the PR. This runs automatically every Tuesday.