### PR TITLE
[small] Use unified mechanism to verify whether certificate was sequenced

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2158,17 +2158,14 @@ impl AuthorityState {
         }
     }
 
-    /// Check whether a shared-object certificate has already been given shared-locks.
-    pub async fn transaction_shared_locks_exist(
+    /// Check whether certificate was processed by consensus.
+    /// For shared lock certificates, if this function returns true means shared locks for this certificate are set
+    pub fn consensus_message_processed(
         &self,
-        certificate: &VerifiedCertificate,
+        certificate: &CertifiedTransaction,
     ) -> SuiResult<bool> {
-        let digest = certificate.digest();
-        let shared_inputs = certificate.shared_input_objects().map(|(id, _)| id);
-        let shared_locks = self
-            .database
-            .get_assigned_object_versions(digest, shared_inputs)?;
-        Ok(shared_locks[0].is_some())
+        self.database
+            .consensus_message_processed(certificate.digest())
     }
 
     /// Get a read reference to an object/seq lock

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -488,6 +488,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Read a lock for a specific (transaction, shared object) pair.
+    #[cfg(test)] // Nothing wrong with this function, but it is not currently used outside of tests
     pub fn get_assigned_object_versions<'a>(
         &self,
         transaction_digest: &TransactionDigest,

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -417,7 +417,7 @@ impl ValidatorService {
 
         // 4) If it's a shared object transaction and requires consensus, we need to do so.
         // This will wait until either timeout or we have heard back from consensus.
-        if is_consensus_tx && !state.transaction_shared_locks_exist(&certificate).await? {
+        if is_consensus_tx && !state.consensus_message_processed(&certificate)? {
             // Note that num_inflight_transactions() only include user submitted transactions, and only user txns can be dropped here.
             // This backpressure should not affect system transactions, e.g. for checkpointing.
             if consensus_adapter.num_inflight_transactions() > MAX_PENDING_CONSENSUS_TRANSACTIONS {


### PR DESCRIPTION
In our code we sometimes need to understand whether certificate was sequenced in consensus.

Previously different code paths used two different approaches:

* `transaction_shared_locks_exist` would check if all shared locks are set on object by issuing multi-get to shared locks table
* `consensus_message_processed` would check a single entry in `consensus_message_processed` table

Two methods are essentially equivalent (both tables are atomically written when shared objects are set)

It seems to make sense to unify those approaches and use `consensus_message_processed` as more preferred one, as it only does one database read.

In the future `consensus_message_processed` will be used to verify if certificate was sent to the consensus for both shared and owned object certificate.

#5763