### PR TITLE
Disable mem profile

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -24,11 +24,11 @@ struct Args {
 }
 
 // Memory profiling is now done automatically by the Ying profiler.
-use ying_profiler::utils::ProfilerRunner;
-use ying_profiler::YingProfiler;
+// use ying_profiler::utils::ProfilerRunner;
+// use ying_profiler::YingProfiler;
 
-#[global_allocator]
-static YING_ALLOC: YingProfiler = YingProfiler;
+// #[global_allocator]
+// static YING_ALLOC: YingProfiler = YingProfiler;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -54,8 +54,8 @@ async fn main() -> Result<()> {
 
     // Spins up a thread to check memory usage every minute, and dump out stack traces/profiles
     // if it has moved up or down more than 15%.  Also allow configuration of dump directory.
-    let profile_dump_dir = std::env::var("SUI_MEM_PROFILE_DIR").unwrap_or_default();
-    ProfilerRunner::new(60, 15, &profile_dump_dir).spawn();
+    // let profile_dump_dir = std::env::var("SUI_MEM_PROFILE_DIR").unwrap_or_default();
+    // ProfilerRunner::new(60, 15, &profile_dump_dir).spawn();
 
     let is_validator = config.consensus_config().is_some();
     task::spawn(async move {


### PR DESCRIPTION
Some of our workflows and users assume the `main` branch always works. Disable the mem profiler similar to https://github.com/MystenLabs/sui/commit/e2e4970a390d074b67d03932d9bbafa757b91cfe