### PR TITLE
[checkpoint] Run syncing in active process for fullnodes

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -5,8 +5,8 @@ use crate::{
     genesis,
     genesis_config::{GenesisConfig, ValidatorGenesisInfo},
     p2p::P2pConfig,
-    utils, ConsensusConfig, NetworkConfig, NodeConfig, ValidatorInfo, AUTHORITIES_DB_NAME,
-    CONSENSUS_DB_NAME,
+    utils, CheckpointProcessControl, ConsensusConfig, NetworkConfig, NodeConfig, ValidatorInfo,
+    AUTHORITIES_DB_NAME, CONSENSUS_DB_NAME,
 };
 use rand::rngs::OsRng;
 use std::{
@@ -41,6 +41,7 @@ pub struct ConfigBuilder<R = OsRng> {
     initial_accounts_config: Option<GenesisConfig>,
     with_swarm: bool,
     validator_ip_sel: ValidatorIpSelection,
+    checkpoint_config: CheckpointProcessControl,
 }
 
 impl ConfigBuilder {
@@ -59,6 +60,7 @@ impl ConfigBuilder {
             } else {
                 ValidatorIpSelection::Localhost
             },
+            checkpoint_config: CheckpointProcessControl::default(),
         }
     }
 }
@@ -89,6 +91,11 @@ impl<R> ConfigBuilder<R> {
         self
     }
 
+    pub fn with_checkpoint_config(mut self, checkpoint_config: CheckpointProcessControl) -> Self {
+        self.checkpoint_config = checkpoint_config;
+        self
+    }
+
     pub fn initial_accounts_config(mut self, initial_accounts_config: GenesisConfig) -> Self {
         self.initial_accounts_config = Some(initial_accounts_config);
         self
@@ -103,6 +110,7 @@ impl<R> ConfigBuilder<R> {
             initial_accounts_config: self.initial_accounts_config,
             with_swarm: self.with_swarm,
             validator_ip_sel: self.validator_ip_sel,
+            checkpoint_config: self.checkpoint_config,
         }
     }
 }
@@ -287,6 +295,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                     grpc_load_shed: initial_accounts_config.grpc_load_shed,
                     grpc_concurrency_limit: initial_accounts_config.grpc_concurrency_limit,
                     p2p_config,
+                    checkpoint_config: self.checkpoint_config.clone(),
                 }
             })
             .collect();

--- a/crates/sui-config/src/checkpoint.rs
+++ b/crates/sui-config/src/checkpoint.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CheckpointProcessControl {
     /// The time to allow upon quorum failure for sufficient
     /// authorities to come online, to proceed with the checkpointing
@@ -62,7 +63,7 @@ impl Default for CheckpointProcessControl {
 impl CheckpointProcessControl {
     pub fn default_for_test() -> Self {
         CheckpointProcessControl {
-            long_pause_between_checkpoints: Duration::from_secs(3),
+            long_pause_between_checkpoints: Duration::from_secs(5),
             ..CheckpointProcessControl::default()
         }
     }

--- a/crates/sui-config/src/checkpoint.rs
+++ b/crates/sui-config/src/checkpoint.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CheckpointProcessControl {
+    /// The time to allow upon quorum failure for sufficient
+    /// authorities to come online, to proceed with the checkpointing
+    /// main loop.
+    pub delay_on_quorum_failure: Duration,
+
+    /// The delay before we retry the process, when there is a local error
+    /// that prevented us from making progress, e.g. failed to create
+    /// a new proposal, or not ready to set a new checkpoint due to unexecuted transactions.
+    pub delay_on_local_failure: Duration,
+
+    /// The time between full iterations of the checkpointing
+    /// logic loop.
+    pub long_pause_between_checkpoints: Duration,
+
+    /// The time we allow until a quorum of responses
+    /// is received.
+    pub timeout_until_quorum: Duration,
+
+    /// The time we allow after a quorum is received for
+    /// additional responses to arrive.
+    pub extra_time_after_quorum: Duration,
+
+    /// The estimate of the consensus delay.
+    pub consensus_delay_estimate: Duration,
+
+    /// The amount of time we wait on any specific authority
+    /// per request (it could be byzantine)
+    pub per_other_authority_delay: Duration,
+
+    /// The amount if time we wait before retrying anything
+    /// during an epoch change. We want this duration to be very small
+    /// to minimize the amount of time to finish epoch change.
+    pub epoch_change_retry_delay: Duration,
+}
+
+impl Default for CheckpointProcessControl {
+    /// Standard parameters (currently set heuristically).
+    fn default() -> Self {
+        CheckpointProcessControl {
+            delay_on_quorum_failure: Duration::from_secs(10),
+            delay_on_local_failure: Duration::from_secs(3),
+            long_pause_between_checkpoints: Duration::from_secs(120),
+            timeout_until_quorum: Duration::from_secs(60),
+            extra_time_after_quorum: Duration::from_millis(200),
+            // TODO: Optimize this.
+            // https://github.com/MystenLabs/sui/issues/3619.
+            consensus_delay_estimate: Duration::from_secs(3),
+            per_other_authority_delay: Duration::from_secs(30),
+            epoch_change_retry_delay: Duration::from_millis(100),
+        }
+    }
+}
+
+impl CheckpointProcessControl {
+    pub fn default_for_test() -> Self {
+        CheckpointProcessControl {
+            long_pause_between_checkpoints: Duration::from_secs(3),
+            ..Default::default()
+        }
+    }
+}

--- a/crates/sui-config/src/checkpoint.rs
+++ b/crates/sui-config/src/checkpoint.rs
@@ -63,7 +63,7 @@ impl CheckpointProcessControl {
     pub fn default_for_test() -> Self {
         CheckpointProcessControl {
             long_pause_between_checkpoints: Duration::from_secs(3),
-            ..Default::default()
+            ..CheckpointProcessControl::default()
         }
     }
 }

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -11,6 +11,7 @@ use sui_types::committee::StakeUnit;
 use tracing::trace;
 
 pub mod builder;
+pub mod checkpoint;
 pub mod gateway;
 pub mod genesis;
 pub mod genesis_config;
@@ -19,6 +20,7 @@ pub mod p2p;
 mod swarm;
 pub mod utils;
 
+pub use checkpoint::CheckpointProcessControl;
 pub use node::{ConsensusConfig, NodeConfig, ValidatorInfo};
 pub use swarm::NetworkConfig;
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -83,6 +83,7 @@ pub struct NodeConfig {
 
     pub genesis: Genesis,
 
+    #[serde(default = "default_checkpoint_config")]
     pub checkpoint_config: CheckpointProcessControl,
 }
 
@@ -124,6 +125,10 @@ pub fn default_websocket_address() -> Option<SocketAddr> {
 
 pub fn default_concurrency_limit() -> Option<usize> {
     Some(DEFAULT_GRPC_CONCURRENCY_LIMIT)
+}
+
+pub fn default_checkpoint_config() -> CheckpointProcessControl {
+    CheckpointProcessControl::default()
 }
 
 pub fn bool_true() -> bool {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::checkpoint::CheckpointProcessControl;
 use crate::genesis;
 use crate::p2p::P2pConfig;
 use crate::Config;
@@ -81,6 +82,8 @@ pub struct NodeConfig {
     pub p2p_config: P2pConfig,
 
     pub genesis: Genesis,
+
+    pub checkpoint_config: CheckpointProcessControl,
 }
 
 fn default_key_pair() -> Arc<AuthorityKeyPair> {

--- a/crates/sui-config/src/swarm.rs
+++ b/crates/sui-config/src/swarm.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::p2p::P2pConfig;
+use crate::CheckpointProcessControl;
 use crate::{builder, genesis, utils, Config, NodeConfig, ValidatorInfo, FULL_NODE_DB_PATH};
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -126,6 +127,7 @@ impl NetworkConfig {
             grpc_load_shed: None,
             grpc_concurrency_limit: None,
             p2p_config,
+            checkpoint_config: CheckpointProcessControl::default(),
         }
     }
 }

--- a/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -51,6 +51,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
   - protocol-key-pair: LqPR5IijTDFVFUq2rCvOsiIO8dIRuXSAldAP+DYC1me2tykqD8b9TR5r1KXG1tk5NzsUp1pV97mzqOf4RZiHOuHRbC/7MTIsXXZZqIJo6WQCoJQf//aqfEwxf5hNpYWpnuGovtGTaPGU7tq29e9O7GmsMIAVjtZZHy3ribwbBb8=
     worker-key-pair: 9Z/d0Lf1LcwMYKRIy/lRFhCwp0Lx5NI4p6RcrgVOwhydR2FqGN8gOTB/BkIiYCWItSpqrqp7b+jGtNnrqKeHsQ==
     account-key-pair: AOo/znbuELOmRfswQFEd+rTJzWBY9BkpAU0WRm9eOywq4BB+FmG6xjjQpGNs/bv21foY4nMY2jMCltCjhxgNbIw=
@@ -99,6 +124,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
   - protocol-key-pair: Hiq/0Ct6fmLhv1nBMiPqovOB6sOCfo5729qmN08q5xqmoXf1i/SZl1hJgzwzhR0tHh1rEBWcoC23JZIvZTv5l61M6Do8FX6cWWirPwYkXz0JpmyKSWt+uTVCq3nJc6q7GWTWC0H8eafBj9shurYTrgUf8CSXw6dc8Pwr8R2ywIw=
     worker-key-pair: kYP0d2s+pZoXgeVko+rpZ2k5e4q0NbJd2kGJ4QPQMc9cR/734xE9wBxW701He/5RV6/DOWmgFPi7VTfhjM7GTA==
     account-key-pair: AIM52ZwzO7Oid/63gLjUbKwwzc2QUNviNfuMxnuRwbBqnZTXHAccZRpZcVXhUvvQe7WAB32Ak1vyNmNCX/Kl8ak=
@@ -147,6 +197,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
   - protocol-key-pair: GzzrEigjxChf2XnG0nSJuAfP6tSQo4A7/63k4hAOjOeL0OmML+RlsN3ntyxKDupYUwXe5MQI7aMEPczkE5dTxPsB5tOsw770PkhudQjw3uUWGaMSIoWHBQ6UUZvHWOR0/bXY9H9e+drIfENom4yTK3EAIGeyGL1OttmJk/XS2os=
     worker-key-pair: EQwhVD8hX7efjIVAYfuALmRyfmPqQ4ebKA5PameIh5D6gqrtUVPSkBC+OW8S2LZhTDl8dcRhP9uzbU/3BOUAqw==
     account-key-pair: ABbIisgBp4THAoTQX/i9gfBB1+pjLqfKKifGyv/WUZMM+K6cRt6kc+jMcFpq8yJS6MNJtJTF3O/XGG0atPFaJY0=
@@ -195,6 +270,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
   - protocol-key-pair: NsLWImHeTmGIB9KvW1EAu3X+tW7Q/KkI5gk3COXONCmm1yzKunhYP2XGQ4HKxwLtN5RUod5uTWXZX7P1wdIn2g5MbKFtB3Rj74n7dbqnia8Oqz14vEoSNUoxrh+6xLgU9IDbBhMKOlyOcHFrDQVkXoV75fge2er7vrS7f8/5wCw=
     worker-key-pair: Neqo634LMrcrpZYZ2dT5jOG8wyg5tK6nYrRGYFGa4WGWuKxioRp0flyAuGxPURbmrq5UrHAJctMlA7eSVqFTLw==
     account-key-pair: AFWsiGMz7Iq6Fa2OHopRFFSgjPy3zXDFjdhCyqBwjRq/a7tE8gojj/hBeXcgQGHOCDL2HfJ2KPJ4Q1ggrXvO/+Y=
@@ -243,6 +343,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
   - protocol-key-pair: CsRQrECMM8bjsounq/lp4HpZ78DfTEQ+8JZ8ep9Uwd2oUEn0LWkMFMIY2sZlOweOIHI1PV/hKGf74V8tdqFj1X3vaDCy7xCKXUrHW4MK4I8CQSs29yb3X//ssrVtkq3DHEUgHSiJu9bxRDABWZt1BPRnAJom/Ta3blmSnDSP0rE=
     worker-key-pair: SmwxHcV2gQzxKoBcs5t39VDlpi6qn4CTFlvWdcQ2bo98EQEujhdX27EEV3Z86OoMCQvPAkniwEgO0RrLK3A7sA==
     account-key-pair: AIuFbz7FC0IUpvvkfoabM2nORDi5yW4dNjQDEnD/+Pi9LskdaKDI6rfXAXjiEd/Ot3tQDPgwFi2lyCfU68jIPj8=
@@ -291,6 +416,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
   - protocol-key-pair: ATtFYSC+WduPcjkDb5W/0qmeY8rJakh27PTldLq+nuaoaYghGPn/1BWEWXhXazXPUQf8cN4uOBzwlLo6iPuLQNcbp2Pg5RHFiVKZxrNDM6wNbuWCIMktDH6wzEJFDLBAb6alikZSqgMsGoi5ZpmIdqI0p+jHsU8TyXZ5wHORhWA=
     worker-key-pair: zqXFxYQpWyrIZx3ICuKRy6ie+Wm8m95nm9W63uaig36qOKjHsxwR6y1zCu5mSIno9fisAX34MT7/Vna0Cbrs4A==
     account-key-pair: AN0bN3jLSY/+7Ujz2rArJBe/aA5PpUqd4MeiL6JNiqBkTuESCA04r/Za9cqm5666CpZ6hHuIcdT0QtKnD3S1qNE=
@@ -339,6 +489,31 @@ validator_configs:
       listen-address: "0.0.0.0:1"
     genesis:
       genesis: "[fake genesis]"
+    checkpoint-config:
+      delay-on-quorum-failure:
+        secs: 10
+        nanos: 0
+      delay-on-local-failure:
+        secs: 3
+        nanos: 0
+      long-pause-between-checkpoints:
+        secs: 120
+        nanos: 0
+      timeout-until-quorum:
+        secs: 60
+        nanos: 0
+      extra-time-after-quorum:
+        secs: 0
+        nanos: 200000000
+      consensus-delay-estimate:
+        secs: 3
+        nanos: 0
+      per-other-authority-delay:
+        secs: 30
+        nanos: 0
+      epoch-change-retry-delay:
+        secs: 0
+        nanos: 100000000
 account_keys:
   - yIbne+wwgP4d/FJwW9ew24THp3ndohgNYuCyjolSB7FkenjWSH2tsGuc37yf7VtGcAsiwgbeT4MmrSfWJkv72A==
   - 4SbmUpOLhdu5hStv+P9N7Y0PaQjksjQ4qZ6N65TG3fYH8hVkxLer32Jowa3ene0Lod8xIpaJ/1ai/5vkqnMAYA==

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -59,7 +59,7 @@ pub mod checkpoint_driver;
 use crate::authority_active::checkpoint_driver::CheckpointMetrics;
 use crate::authority_client::NetworkAuthorityClientMetrics;
 use crate::epoch::reconfiguration::Reconfigurable;
-use checkpoint_driver::{checkpoint_process, get_latest_checkpoint_from_all, sync_to_checkpoint};
+use checkpoint_driver::{checkpoint_drive_process, checkpoint_sync_process};
 
 pub mod execution_driver;
 
@@ -261,38 +261,6 @@ where
             .clone()
     }
 
-    pub async fn sync_to_latest_checkpoint(self: Arc<Self>) -> SuiResult {
-        self.sync_to_latest_checkpoint_with_config(Default::default())
-            .await
-    }
-
-    pub async fn sync_to_latest_checkpoint_with_config(
-        self: Arc<Self>,
-        checkpoint_process_control: CheckpointProcessControl,
-    ) -> SuiResult {
-        let checkpoint_store = self.state.checkpoints.clone();
-
-        // TODO: fullnode should not get proposals
-        // TODO: potentially move get_latest_proposal_and_checkpoint_from_all and
-        // sync_to_checkpoint out of checkpoint_driver
-        let checkpoint_summary = get_latest_checkpoint_from_all(
-            self.agg_aggregator(),
-            checkpoint_process_control.extra_time_after_quorum,
-            checkpoint_process_control.timeout_until_quorum,
-        )
-        .await?;
-
-        let checkpoint_summary = match checkpoint_summary {
-            Some(c) => c,
-            None => {
-                info!(name = ?self.state.name, "no checkpoints found");
-                return Ok(());
-            }
-        };
-
-        sync_to_checkpoint(self, checkpoint_store, checkpoint_summary).await
-    }
-
     /// Spawn gossip process
     pub async fn spawn_gossip_process(self: Arc<Self>, degree: usize) -> JoinHandle<()> {
         // Number of tasks at most "degree" and no more than committee - 1
@@ -399,11 +367,20 @@ where
         checkpoint_process_control: CheckpointProcessControl,
         metrics: CheckpointMetrics,
     ) -> JoinHandle<()> {
-        // Spawn task to take care of checkpointing
-        spawn_monitored_task!(checkpoint_process(
-            self,
-            &checkpoint_process_control,
-            metrics
-        ))
+        if !self.state.is_fullnode() {
+            // Spawn task to take care of checkpointing driving
+            spawn_monitored_task!(checkpoint_drive_process(
+                self,
+                &checkpoint_process_control,
+                metrics
+            ));
+        } else {
+            // Spawn task to take care of checkpointing syncing
+            spawn_monitored_task!(checkpoint_sync_process(
+                self,
+                &checkpoint_process_control,
+                metrics
+            ));
+        }
     }
 }

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -40,6 +40,8 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
+use sui_config::checkpoint::CheckpointProcessControl;
+
 use crate::{
     authority::AuthorityState,
     authority_aggregator::AuthorityAggregator,
@@ -63,7 +65,7 @@ use checkpoint_driver::{checkpoint_drive_process, checkpoint_sync_process};
 
 pub mod execution_driver;
 
-use self::{checkpoint_driver::CheckpointProcessControl, execution_driver::execution_process};
+use self::execution_driver::execution_process;
 
 // TODO: Make these into a proper config
 const MAX_RETRIES_RECORDED: u32 = 10;

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -369,20 +369,20 @@ where
         checkpoint_process_control: CheckpointProcessControl,
         metrics: CheckpointMetrics,
     ) -> JoinHandle<()> {
-        if !self.state.is_fullnode() {
-            // Spawn task to take care of checkpointing driving
-            spawn_monitored_task!(checkpoint_drive_process(
-                self,
-                &checkpoint_process_control,
-                metrics
-            ));
-        } else {
+        if self.state.is_fullnode() {
             // Spawn task to take care of checkpointing syncing
             spawn_monitored_task!(checkpoint_sync_process(
                 self,
                 &checkpoint_process_control,
                 metrics
-            ));
+            ))
+        } else {
+            // Spawn task to take care of checkpointing driving
+            spawn_monitored_task!(checkpoint_drive_process(
+                self,
+                &checkpoint_process_control,
+                metrics
+            ))
         }
     }
 }

--- a/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/mod.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use sui_config::CheckpointProcessControl;
 
 use parking_lot::Mutex;
 use prometheus::{
@@ -42,61 +43,6 @@ use tracing::{debug, error, info, warn};
 pub(crate) mod tests;
 
 use super::ActiveAuthority;
-
-#[derive(Clone, Debug)]
-pub struct CheckpointProcessControl {
-    /// The time to allow upon quorum failure for sufficient
-    /// authorities to come online, to proceed with the checkpointing
-    /// main loop.
-    pub delay_on_quorum_failure: Duration,
-
-    /// The delay before we retry the process, when there is a local error
-    /// that prevented us from making progress, e.g. failed to create
-    /// a new proposal, or not ready to set a new checkpoint due to unexecuted transactions.
-    pub delay_on_local_failure: Duration,
-
-    /// The time between full iterations of the checkpointing
-    /// logic loop.
-    pub long_pause_between_checkpoints: Duration,
-
-    /// The time we allow until a quorum of responses
-    /// is received.
-    pub timeout_until_quorum: Duration,
-
-    /// The time we allow after a quorum is received for
-    /// additional responses to arrive.
-    pub extra_time_after_quorum: Duration,
-
-    /// The estimate of the consensus delay.
-    pub consensus_delay_estimate: Duration,
-
-    /// The amount of time we wait on any specific authority
-    /// per request (it could be byzantine)
-    pub per_other_authority_delay: Duration,
-
-    /// The amount if time we wait before retrying anything
-    /// during an epoch change. We want this duration to be very small
-    /// to minimize the amount of time to finish epoch change.
-    pub epoch_change_retry_delay: Duration,
-}
-
-impl Default for CheckpointProcessControl {
-    /// Standard parameters (currently set heuristically).
-    fn default() -> CheckpointProcessControl {
-        CheckpointProcessControl {
-            delay_on_quorum_failure: Duration::from_secs(10),
-            delay_on_local_failure: Duration::from_secs(3),
-            long_pause_between_checkpoints: Duration::from_secs(120),
-            timeout_until_quorum: Duration::from_secs(60),
-            extra_time_after_quorum: Duration::from_millis(200),
-            // TODO: Optimize this.
-            // https://github.com/MystenLabs/sui/issues/3619.
-            consensus_delay_estimate: Duration::from_secs(3),
-            per_other_authority_delay: Duration::from_secs(30),
-            epoch_change_retry_delay: Duration::from_millis(100),
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct CheckpointMetrics {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -250,7 +250,10 @@ impl SuiNode {
             Some(
                 active_authority
                     .clone()
-                    .spawn_checkpoint_process(CheckpointMetrics::new(&prometheus_registry))
+                    .spawn_checkpoint_process_with_config(
+                        config.checkpoint_config.clone(),
+                        CheckpointMetrics::new(&prometheus_registry),
+                    )
                     .await,
             )
         } else {

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -97,7 +97,8 @@ async fn test_full_node_syncs_checkpoints() -> Result<(), anyhow::Error> {
     };
 
     // Wait for long enough to have generated some checkpoint.
-    tokio::time::sleep(Duration::from_secs(5 * 60)).await;
+    // Note that in test, pause between checkpoints is made much smaller
+    tokio::time::sleep(Duration::from_secs(20)).await;
 
     let active = node.active();
     let next_checkpoint_sequence = active.state.checkpoints.lock().next_checkpoint();

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -98,7 +98,7 @@ async fn test_full_node_syncs_checkpoints() -> Result<(), anyhow::Error> {
 
     // Wait for long enough to have generated some checkpoint.
     // Note that in test, pause between checkpoints is made much smaller
-    tokio::time::sleep(Duration::from_secs(20)).await;
+    tokio::time::sleep(Duration::from_secs(30)).await;
 
     let active = node.active();
     let next_checkpoint_sequence = active.state.checkpoints.lock().next_checkpoint();

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{NetworkConfig, ValidatorInfo};
 use sui_core::authority_active::checkpoint_driver::{
-    checkpoint_process_step, CheckpointProcessControl,
+    checkpoint_drive_process_step, CheckpointProcessControl,
 };
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
@@ -295,9 +295,11 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {
-                let _ =
-                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
-                        .await;
+                let _ = checkpoint_drive_process_step(
+                    active.clone(),
+                    &CheckpointProcessControl::default(),
+                )
+                .await;
             }
         })
     });
@@ -316,7 +318,7 @@ async fn reconfig_last_checkpoint_sync_missing_tx() {
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {
-                let _ = checkpoint_process_step(
+                let _ = checkpoint_drive_process_step(
                     node.active().clone(),
                     &CheckpointProcessControl::default(),
                 )
@@ -429,9 +431,11 @@ async fn fast_forward_to_ready_for_reconfig_start(handles: &[SuiNodeHandle]) {
                 .lock()
                 .is_ready_to_start_epoch_change()
             {
-                let _ =
-                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
-                        .await;
+                let _ = checkpoint_drive_process_step(
+                    active.clone(),
+                    &CheckpointProcessControl::default(),
+                )
+                .await;
             }
         })
     });
@@ -449,9 +453,11 @@ async fn fast_forward_to_ready_for_reconfig_finish(handles: &[SuiNodeHandle]) {
                 .lock()
                 .is_ready_to_finish_epoch_change()
             {
-                let _ =
-                    checkpoint_process_step(active.clone(), &CheckpointProcessControl::default())
-                        .await;
+                let _ = checkpoint_drive_process_step(
+                    active.clone(),
+                    &CheckpointProcessControl::default(),
+                )
+                .await;
             }
         })
     });

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -6,10 +6,8 @@ use multiaddr::Multiaddr;
 use prometheus::Registry;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_config::{NetworkConfig, ValidatorInfo};
-use sui_core::authority_active::checkpoint_driver::{
-    checkpoint_drive_process_step, CheckpointProcessControl,
-};
+use sui_config::{CheckpointProcessControl, NetworkConfig, ValidatorInfo};
+use sui_core::authority_active::checkpoint_driver::checkpoint_drive_process_step;
 use sui_node::SuiNodeHandle;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::committee::Committee;

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -5,13 +5,11 @@ use prometheus::Registry;
 use rand::{prelude::StdRng, SeedableRng};
 use std::sync::Arc;
 use std::time::Duration;
+use sui_config::CheckpointProcessControl;
 use sui_config::{NetworkConfig, NodeConfig, ValidatorInfo};
 use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClientMetrics};
 use sui_core::{
-    authority_active::{
-        checkpoint_driver::{CheckpointMetrics, CheckpointProcessControl},
-        ActiveAuthority,
-    },
+    authority_active::{checkpoint_driver::CheckpointMetrics, ActiveAuthority},
     authority_aggregator::AuthorityAggregatorBuilder,
     authority_client::NetworkAuthorityClient,
 };

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -13,6 +13,7 @@ use sui::config::SuiEnv;
 use sui::{client_commands::WalletContext, config::SuiClientConfig};
 use sui_config::genesis_config::GenesisConfig;
 use sui_config::utils::get_available_port;
+use sui_config::CheckpointProcessControl;
 use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_NETWORK_CONFIG};
 use sui_config::{PersistedConfig, SUI_KEYSTORE_FILENAME};
 use sui_json_rpc::ServerHandle;
@@ -198,8 +199,9 @@ impl TestClusterBuilder {
     async fn start_test_swarm_with_fullnodes(
         genesis_config: Option<GenesisConfig>,
     ) -> Result<Swarm, anyhow::Error> {
-        let mut builder: SwarmBuilder =
-            Swarm::builder().committee_size(NonZeroUsize::new(NUM_VALIDATOR).unwrap());
+        let mut builder: SwarmBuilder = Swarm::builder()
+            .committee_size(NonZeroUsize::new(NUM_VALIDATOR).unwrap())
+            .with_checkpoint_config(CheckpointProcessControl::default_for_test());
 
         if let Some(genesis_config) = genesis_config {
             builder = builder.initial_accounts_config(genesis_config);
@@ -254,6 +256,7 @@ pub async fn start_a_fullnode(swarm: &Swarm, disable_ws: bool) -> Result<SuiNode
         .config()
         .generate_fullnode_config_with_random_dir_name(true, false);
     config.json_rpc_address = jsonrpc_addr;
+    config.checkpoint_config = CheckpointProcessControl::default_for_test();
 
     if !disable_ws {
         let ws_server_url = format!("127.0.0.1:{}", get_available_port());
@@ -279,6 +282,7 @@ pub async fn start_a_fullnode_with_handle(
         .config()
         .generate_fullnode_config_with_random_dir_name(true, false);
     config.json_rpc_address = jsonrpc_addr;
+    config.checkpoint_config = CheckpointProcessControl::default_for_test();
 
     let ws_url = if !disable_ws {
         let ws_server_url = format!("127.0.0.1:{}", ws_port.unwrap_or_else(get_available_port));

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -24,7 +24,7 @@ use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::SuiKeyPair::Ed25519SuiKeyPair;
 
-const NUM_VALIDAOTR: usize = 4;
+const NUM_VALIDATOR: usize = 4;
 
 pub struct FullNodeHandle {
     pub sui_node: SuiNode,
@@ -199,7 +199,7 @@ impl TestClusterBuilder {
         genesis_config: Option<GenesisConfig>,
     ) -> Result<Swarm, anyhow::Error> {
         let mut builder: SwarmBuilder =
-            Swarm::builder().committee_size(NonZeroUsize::new(NUM_VALIDAOTR).unwrap());
+            Swarm::builder().committee_size(NonZeroUsize::new(NUM_VALIDATOR).unwrap());
 
         if let Some(genesis_config) = genesis_config {
             builder = builder.initial_accounts_config(genesis_config);
@@ -242,7 +242,7 @@ impl Default for TestClusterBuilder {
     }
 }
 
-/// Note: the initial purpose of thi function is to make tests compatible with
+/// Note: the initial purpose of this function is to make tests compatible with
 /// simtest before it supports jsonrpc/ws. We should use `start_a_fullnode_with_handle`
 /// once the support is added.
 /// Start a fullnode for an existing Swarm and return FullNodeHandle


### PR DESCRIPTION
This adopts a similar pattern to the handling of the `sui-node` gossip process handle (which, for full nodes is a process to sync state from a quorum of validators, and for validators, is an active gossip process for txes, etc.), but for the checkpoint process.

Before: 
* Full nodes do a full checkpoint sync once before spawning an active process for syncing state with validators
* Validator nodes spawn an active process for syncing and driving checkpoints

After:
* Both full nodes and validators spawn an active checkpoint process. 
* For validators, this is the same checkpoint driving process as before
* For full nodes, this is an active checkpoint syncing process that runs periodically

Other notes on this change:
* In order to facilitate testing checkpoints on a simtest swarm, it was necessary to make `CheckpointProcessControl` configurable so as to avoid waiting 2+ minutes for the pause between checkpoint times. `CheckpointProcessControl` is now configured by setting a member of the `Node`, and for simtests that call `start_a_fullnode*`, is configured to wait on the order of seconds between checkpoints.
* As such, we can also now configure CheckpointProcessControl from the `NetworkConfig` yaml