### PR TITLE
Add `TransactionManager` to execute certified transactions based on input object availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,6 +8331,7 @@ dependencies = [
  "narwhal-executor",
  "narwhal-node",
  "narwhal-types",
+ "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
  "pretty_assertions",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -64,6 +64,7 @@ fastcrypto.workspace = true
 workspace-hack.workspace = true
 thiserror = "1.0.34"
 eyre = "0.6.8"
+num_cpus = "1.13.1"
 
 sui-simulator = { path = "../sui-simulator" }
 sui-macros = { path = "../sui-macros" }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -32,6 +32,7 @@ use prometheus::{
     register_int_gauge_with_registry, Histogram, IntCounter, IntGauge,
 };
 use tap::TapFallible;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::{
     broadcast::{self, error::RecvError},
     mpsc,
@@ -42,7 +43,7 @@ use typed_store::Map;
 
 pub use authority_notify_read::EffectsNotifyRead;
 pub use authority_store::{
-    AuthorityStore, GatewayStore, PendingDigest, ResolverWrapper, SuiDataStore, UpdateType,
+    AuthorityStore, GatewayStore, ResolverWrapper, SuiDataStore, UpdateType,
 };
 use narwhal_config::{
     Committee as ConsensusCommittee, WorkerCache as ConsensusWorkerCache,
@@ -104,8 +105,11 @@ use crate::{
     metrics::start_timer,
     query_helpers::QueryHelpers,
     transaction_input_checker,
+    transaction_manager::TransactionManager,
     transaction_streamer::TransactionStreamer,
 };
+
+use self::authority_store::ObjectKey;
 
 #[cfg(test)]
 #[path = "unit_tests/authority_tests.rs"]
@@ -127,7 +131,7 @@ pub mod authority_store_tables;
 
 pub mod authority_notifier;
 mod authority_notify_read;
-mod authority_store;
+pub(crate) mod authority_store;
 
 pub const MAX_ITEMS_LIMIT: u64 = 1_000;
 const BROADCAST_CAPACITY: usize = 10_000;
@@ -160,6 +164,11 @@ pub struct AuthorityMetrics {
     handle_transaction_latency: Histogram,
     handle_certificate_latency: Histogram,
     handle_node_sync_certificate_latency: Histogram,
+
+    pub(crate) transaction_manager_num_missing_objects: IntGauge,
+    pub(crate) transaction_manager_num_pending_certificates: IntGauge,
+    pub(crate) transaction_manager_objects_notified_via_scan: IntGauge,
+    pub(crate) transaction_manager_num_ready: IntGauge,
 
     total_consensus_txns: IntCounter,
     skipped_consensus_txns: IntCounter,
@@ -306,6 +315,30 @@ impl AuthorityMetrics {
                 "fullnode_handle_node_sync_certificate_latency",
                 "Latency of fullnode handling certificate from node sync",
                 LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_num_missing_objects: register_int_gauge_with_registry!(
+                "transaction_manager_num_missing_objects",
+                "Current number of missing objects in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_num_pending_certificates: register_int_gauge_with_registry!(
+                "transaction_manager_num_pending_certificates",
+                "Current number of pending certificates in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_objects_notified_via_scan: register_int_gauge_with_registry!(
+                "transaction_manager_objects_notified_via_scan",
+                "Current number of input objects found available via scanning in TransactionManager",
+                registry,
+            )
+            .unwrap(),
+            transaction_manager_num_ready: register_int_gauge_with_registry!(
+                "transaction_manager_num_ready",
+                "Current number of ready transactions in TransactionManager",
                 registry,
             )
             .unwrap(),
@@ -518,6 +551,16 @@ pub struct AuthorityState {
 
     committee_store: Arc<CommitteeStore>,
 
+    /// Manages pending certificates and their missing input objects.
+    pub(crate) transaction_manager: Arc<tokio::sync::Mutex<TransactionManager>>,
+
+    /// The contained receiver will stream out certificates that have all inputs available locally,
+    /// and are ready to be executed.
+    /// This member temporarily holds the receiver beginning from AuthorityState initialization,
+    /// until the receiver is extracted by execution driver. This a bit awkward because
+    /// AuthorityState is created before execution driver.
+    rx_ready_certificates: tokio::sync::Mutex<Option<UnboundedReceiver<VerifiedCertificate>>>,
+
     // Structures needed for handling batching and notifications.
     /// The sender to notify of new transactions
     /// and create batches for this authority.
@@ -700,7 +743,6 @@ impl AuthorityState {
         &self,
         certificate: &VerifiedCertificate,
     ) -> SuiResult<VerifiedTransactionInfoResponse> {
-        let _metrics_guard = start_timer(self.metrics.handle_certificate_latency.clone());
         self.handle_certificate_impl(certificate, false).await
     }
 
@@ -718,6 +760,7 @@ impl AuthorityState {
         certificate: &VerifiedCertificate,
         bypass_validator_halt: bool,
     ) -> SuiResult<VerifiedTransactionInfoResponse> {
+        let _metrics_guard = start_timer(self.metrics.handle_certificate_latency.clone());
         self.metrics.total_cert_attempts.inc();
         if self.is_fullnode() {
             return Err(SuiError::GenericStorageError(
@@ -845,7 +888,7 @@ impl AuthorityState {
         // this function occur before we have written anything to the db, so we commit the tx
         // guard and rely on the client to retry the tx (if it was transient).
         let (inner_temporary_store, signed_effects) =
-            match self.prepare_certificate(certificate, digest).await {
+            match self.prepare_certificate(certificate).await {
                 Err(e) => {
                     debug!(name = ?self.name, ?digest, "Error preparing transaction: {e}");
                     tx_guard.release();
@@ -861,6 +904,11 @@ impl AuthorityState {
         // will be persisted in the log for later recovery.
         let notifier_ticket = self.batch_notifier.ticket(bypass_validator_halt)?;
         let ticket_seq = notifier_ticket.seq();
+        let output_keys: Vec<_> = inner_temporary_store
+            .written
+            .iter()
+            .map(|(_, ((id, seq, _), _, _))| ObjectKey(*id, *seq))
+            .collect();
         let res = self
             .commit_certificate(
                 inner_temporary_store,
@@ -930,6 +978,14 @@ impl AuthorityState {
             }
         };
 
+        // Notifies transaction manager about available input objects. This allows the transaction
+        // manager to schedule ready transactions.
+        // TODO: investigate switching TransactionManager to use notify_read() on objects table.
+        {
+            let mut transaction_manager = self.transaction_manager.lock().await;
+            transaction_manager.objects_committed(output_keys);
+        }
+
         // commit_certificate finished, the tx is fully committed to the store.
         tx_guard.commit_tx();
 
@@ -977,7 +1033,6 @@ impl AuthorityState {
     async fn prepare_certificate(
         &self,
         certificate: &VerifiedCertificate,
-        transaction_digest: TransactionDigest,
     ) -> SuiResult<(InnerTemporaryStore, SignedTransactionEffects)> {
         let _metrics_guard = start_timer(self.metrics.prepare_certificate_latency.clone());
         let (gas_status, input_objects) =
@@ -993,7 +1048,7 @@ impl AuthorityState {
             // only be executed at a time when consensus is turned off.
             // TODO: Add some assert here to make sure consensus is indeed off with
             // is_change_epoch_tx.
-            self.check_shared_locks(&transaction_digest, &shared_object_refs)
+            self.check_shared_locks(certificate.digest(), &shared_object_refs)
                 .await?;
         }
 
@@ -1004,13 +1059,13 @@ impl AuthorityState {
 
         let transaction_dependencies = input_objects.transaction_dependencies();
         let temporary_store =
-            TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
+            TemporaryStore::new(self.database.clone(), input_objects, *certificate.digest());
         let (inner_temp_store, effects, _execution_error) =
             execution_engine::execute_transaction_to_effects(
                 shared_object_refs,
                 temporary_store,
                 certificate.data().data.clone(),
-                transaction_digest,
+                *certificate.digest(),
                 transaction_dependencies,
                 &self.move_vm,
                 &self._native_functions,
@@ -1432,6 +1487,7 @@ impl AuthorityState {
 
     // TODO: This function takes both committee and genesis as parameter.
     // Technically genesis already contains committee information. Could consider merging them.
+    #[allow(clippy::disallowed_methods)]
     pub async fn new(
         name: AuthorityName,
         secret: StableSyncAuthoritySigner,
@@ -1464,12 +1520,17 @@ impl AuthorityState {
                 .await
                 .expect("Cannot bulk insert genesis objects");
         }
-
         let committee = committee_store.get_latest_committee();
-
         let module_cache = Arc::new(SyncModuleCache::new(ResolverWrapper(store.clone())));
         let event_handler =
             event_store.map(|es| Arc::new(EventHandler::new(es, module_cache.clone())));
+        let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));
+        let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
+        let transaction_manager = Arc::new(tokio::sync::Mutex::new(TransactionManager::new(
+            store.clone(),
+            tx_ready_certificates,
+            metrics.clone(),
+        )));
 
         let mut state = AuthorityState {
             name,
@@ -1487,13 +1548,15 @@ impl AuthorityState {
             transaction_streamer,
             checkpoints,
             committee_store,
+            transaction_manager: transaction_manager.clone(),
+            rx_ready_certificates: tokio::sync::Mutex::new(Some(rx_ready_certificates)),
             batch_channels: tx,
             batch_notifier: Arc::new(
                 authority_notifier::TransactionNotifier::new(store.clone(), prometheus_registry)
                     .expect("Notifier cannot start."),
             ),
             consensus_guardrail: AtomicUsize::new(0),
-            metrics: Arc::new(AuthorityMetrics::new(prometheus_registry)),
+            metrics,
             tx_reconfigure_consensus,
             checkpoint_service,
         };
@@ -1626,36 +1689,14 @@ impl AuthorityState {
         .await
     }
 
-    pub fn add_pending_sequenced_certificate(&self, cert: VerifiedCertificate) -> SuiResult {
-        self.add_pending_impl(vec![(*cert.digest(), Some(cert))], true)
-    }
-
-    /// Add a number of certificates to the pending transactions as well as the
-    /// certificates structure if they are not already executed.
-    /// Certificates are optional, and if not provided, they will be eventually
-    /// downloaded in the execution driver.
-    pub fn add_pending_certificates(
-        &self,
-        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
-    ) -> SuiResult<()> {
-        self.add_pending_impl(certs, false)
-    }
-
-    fn add_pending_impl(
-        &self,
-        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
-        is_sequenced: bool,
-    ) -> SuiResult {
+    /// Adds certificates to the pending certificate store and transaction manager for ordered execution.
+    /// Currently, only used in tests and deprecated callsites.
+    pub async fn add_pending_certificates(&self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
         self.node_sync_store
-            .batch_store_certs(certs.iter().filter_map(|(_, cert_opt)| cert_opt.clone()))?;
-
-        self.database.add_pending_digests(
-            certs
-                .iter()
-                .map(|(seq_and_digest, _)| *seq_and_digest)
-                .collect(),
-            is_sequenced,
-        )
+            .batch_store_certs(certs.iter().cloned())?;
+        self.database.store_pending_certificates(&certs)?;
+        let mut transaction_manager = self.transaction_manager.lock().await;
+        transaction_manager.enqueue(certs)
     }
 
     // Continually pop in-progress txes from the WAL and try to drive them to completion.
@@ -1740,6 +1781,15 @@ impl AuthorityState {
         object_id: &ObjectID,
     ) -> Result<Option<Object>, SuiError> {
         self.database.get_object(object_id)
+    }
+
+    /// Extracts the stream of ready to execute certificates, published by the transaction manager.
+    /// Must only be called once, from execution driver only.
+    pub(crate) async fn ready_certificates_stream(
+        &self,
+    ) -> Option<UnboundedReceiver<VerifiedCertificate>> {
+        let mut rx_ready_certificates = self.rx_ready_certificates.lock().await;
+        rx_ready_certificates.take()
     }
 
     pub async fn get_framework_object_ref(&self) -> SuiResult<ObjectRef> {
@@ -2317,18 +2367,18 @@ impl AuthorityState {
                     "handle_consensus_transaction UserTransaction",
                 );
 
-                // Schedule the certificate for execution
-                self.add_pending_sequenced_certificate(certificate.clone())?;
-
                 if certificate.contains_shared_object() {
                     self.database
-                        .lock_shared_objects(&certificate, consensus_index)
-                        .await
+                        .record_shared_object_cert_from_consensus(&certificate, consensus_index)
+                        .await?;
                 } else {
                     self.database
                         .record_owned_object_cert_from_consensus(&certificate, consensus_index)
-                        .await
+                        .await?;
                 }
+
+                let mut transaction_manager = self.transaction_manager.lock().await;
+                transaction_manager.enqueue(vec![certificate])
             }
             ConsensusTransactionKind::Checkpoint(fragment) => {
                 match &fragment.message {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -15,7 +15,7 @@ use serde_with::serde_as;
 use std::collections::BTreeMap;
 use std::iter;
 use std::path::Path;
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::Arc;
 use std::{fmt::Debug, path::PathBuf};
 use sui_storage::{
     mutex_table::{LockGuard, MutexTable},
@@ -28,7 +28,6 @@ use sui_types::message_envelope::VerifiedEnvelope;
 use sui_types::object::Owner;
 use sui_types::storage::{ChildObjectResolver, SingleTxContext, WriteKind};
 use sui_types::{base_types::SequenceNumber, storage::ParentSync};
-use tokio::sync::Notify;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{debug, info, trace};
 use typed_store::rocks::DBBatch;
@@ -36,9 +35,6 @@ use typed_store::traits::Map;
 
 pub type AuthorityStore = SuiDataStore<AuthoritySignInfo>;
 pub type GatewayStore = SuiDataStore<EmptySignInfo>;
-
-pub type InternalSequenceNumber = u64;
-pub type PendingDigest = (bool /* is sequenced */, TransactionDigest);
 
 pub struct CertLockGuard(LockGuard);
 
@@ -65,11 +61,6 @@ pub struct SuiDataStore<S> {
 
     /// Internal vector of locks to manage concurrent writes to the database
     mutex_table: MutexTable<ObjectDigest>,
-
-    // The next sequence number.
-    next_pending_seq: AtomicU64,
-    // A notifier for new pending certificates
-    pending_notifier: Arc<Notify>,
 
     pub(crate) perpetual_tables: AuthorityPerpetualTables<S>,
     pub(crate) epoch_tables: ArcSwap<AuthorityEpochTables<S>>,
@@ -104,22 +95,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         let wal_path = path.join("recovery_log");
         let wal = Arc::new(DBWriteAheadLog::new(wal_path));
 
-        // Get the last sequence item
-        let pending_seq = epoch_tables
-            .pending_execution
-            .iter()
-            .skip_to_last()
-            .next()
-            .map(|(seq, _)| seq + 1)
-            .unwrap_or(0);
-        let next_pending_seq = AtomicU64::new(pending_seq);
-
         Ok(Self {
             wal,
             lock_service,
             mutex_table: MutexTable::new(NUM_SHARDS, SHARD_SIZE),
-            next_pending_seq,
-            pending_notifier: Arc::new(Notify::new()),
             perpetual_tables,
             epoch_tables: epoch_tables.into(),
             path: path.into(),
@@ -161,13 +140,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// Acquire the lock for a tx without writing to the WAL.
     pub async fn acquire_tx_lock(&self, digest: &TransactionDigest) -> CertLockGuard {
         CertLockGuard(self.wal.acquire_lock(digest).await)
-    }
-
-    // TODO: Async retry method, using tokio-retry crate.
-
-    /// Await a new pending certificate to be added
-    pub async fn wait_for_new_pending(&self) {
-        self.pending_notifier.notified().await
     }
 
     /// Returns the TransactionEffects if we have an effects structure for this transaction digest
@@ -221,57 +193,60 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         self.epoch_tables().next_object_versions.get(obj).unwrap()
     }
 
-    /// Add a number of certificates to the pending transactions as well as the
-    /// certificates structure if they are not already executed.
-    /// Certificates are optional, and if not provided, they will be eventually
-    /// downloaded in the execution driver.
-    ///
-    /// This function may be run concurrently: it increases atomically an internal index
-    /// by the number of certificates passed, and then records the certificates and their
-    /// index. If two instanced run concurrently, the indexes are guaranteed to not overlap
-    /// although some certificates may be included twice in the `pending_execution`, and
-    /// the same certificate may be written twice (but that is OK since it is valid.)
-    pub fn add_pending_digests(
+    /// Gets all pending certificates. Used during recovery.
+    pub fn all_pending_certificates(&self) -> SuiResult<Vec<VerifiedCertificate>> {
+        Ok(self
+            .epoch_tables()
+            .pending_certificates
+            .iter()
+            .map(|(_, cert)| cert.into())
+            .collect())
+    }
+
+    /// Stores a list of pending certificates to be executed.
+    pub fn store_pending_certificates(&self, certs: &[VerifiedCertificate]) -> SuiResult<()> {
+        let batch = self
+            .epoch_tables()
+            .pending_certificates
+            .batch()
+            .insert_batch(
+                &self.epoch_tables().pending_certificates,
+                certs
+                    .iter()
+                    .map(|cert| ((cert.epoch(), *cert.digest()), cert.clone().serializable())),
+            )?;
+        batch.write()?;
+        Ok(())
+    }
+
+    /// Gets one pending certificate.
+    pub fn get_pending_certificate(
         &self,
-        digests: Vec<TransactionDigest>,
-        is_sequenced: bool,
+        epoch_id: EpochId,
+        tx: &TransactionDigest,
+    ) -> SuiResult<Option<VerifiedCertificate>> {
+        Ok(self
+            .epoch_tables()
+            .pending_certificates
+            .get(&(epoch_id, *tx))?
+            .map(|c| c.into()))
+    }
+
+    /// Deletes one pending certificate.
+    pub fn remove_pending_certificate(
+        &self,
+        epoch_id: EpochId,
+        digest: &TransactionDigest,
     ) -> SuiResult<()> {
-        let first_index = self
-            .next_pending_seq
-            .fetch_add(digests.len() as u64, Ordering::Relaxed);
-
-        let batch = self.epoch_tables().pending_execution.batch();
-        let batch = batch.insert_batch(
-            &self.epoch_tables().pending_execution,
-            digests
-                .iter()
-                .enumerate()
-                .map(|(num, digest)| ((num as u64) + first_index, (is_sequenced, *digest))),
-        )?;
-        batch.write()?;
-
-        // now notify there is a pending certificate
-        self.pending_notifier.notify_one();
-
+        self.epoch_tables()
+            .pending_certificates
+            .remove(&(epoch_id, *digest))?;
         Ok(())
     }
 
-    /// Get all stored certificate digests
-    pub fn get_pending_digests(&self) -> SuiResult<Vec<(InternalSequenceNumber, PendingDigest)>> {
-        Ok(self.epoch_tables().pending_execution.iter().collect())
-    }
-
-    /// Remove entries from pending certificates
-    pub fn remove_pending_digests(&self, seqs: Vec<InternalSequenceNumber>) -> SuiResult<()> {
-        let batch = self.epoch_tables().pending_execution.batch();
-        let batch = batch.delete_batch(&self.epoch_tables().pending_execution, seqs.iter())?;
-        batch.write()?;
-        Ok(())
-    }
-
-    // Empty the pending_execution table.
-    pub fn remove_all_pending_certificates(&self) -> SuiResult {
-        self.epoch_tables().pending_execution.clear()?;
+    /// Deletes all pending certificates in the epoch.
+    pub fn cleanup_pending_certificates(&self) -> SuiResult<()> {
+        self.epoch_tables().pending_certificates.clear()?;
         Ok(())
     }
 
@@ -307,6 +282,17 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .get(&ObjectKey(*object_id, version))?)
     }
 
+    pub fn object_exists(
+        &self,
+        object_id: &ObjectID,
+        version: VersionNumber,
+    ) -> Result<bool, SuiError> {
+        Ok(self
+            .perpetual_tables
+            .objects
+            .contains_key(&ObjectKey(*object_id, version))?)
+    }
+
     /// Read an object and return it, or Err(ObjectNotFound) if the object was not found.
     pub fn get_object(&self, object_id: &ObjectID) -> Result<Option<Object>, SuiError> {
         self.perpetual_tables.get_object(object_id)
@@ -321,7 +307,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(result)
     }
 
-    pub fn get_input_objects(&self, objects: &[InputObjectKind]) -> Result<Vec<Object>, SuiError> {
+    pub fn check_input_objects(
+        &self,
+        objects: &[InputObjectKind],
+    ) -> Result<Vec<Object>, SuiError> {
         let mut result = Vec::new();
         let mut errors = Vec::new();
         for kind in objects {
@@ -345,7 +334,59 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         }
     }
 
-    pub fn get_sequenced_input_objects(
+    /// When making changes, please see if check_sequenced_input_objects() below needs
+    /// similiar changes as well.
+    pub fn get_missing_input_objects(
+        &self,
+        digest: &TransactionDigest,
+        objects: &[InputObjectKind],
+    ) -> Result<Vec<ObjectKey>, SuiError> {
+        let shared_locks_cell: OnceCell<HashMap<_, _>> = OnceCell::new();
+
+        let mut missing = Vec::new();
+        for kind in objects {
+            match kind {
+                InputObjectKind::SharedMoveObject { id, .. } => {
+                    let shared_locks = shared_locks_cell.get_or_try_init(|| {
+                        Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
+                            self.all_shared_locks(digest)?.into_iter().collect(),
+                        )
+                    })?;
+                    match shared_locks.get(id) {
+                        Some(version) => {
+                            if !self.object_exists(id, *version)? {
+                                // When this happens, other transactions that use smaller versions of
+                                // this shared object haven't finished execution.
+                                missing.push(ObjectKey(*id, *version));
+                            }
+                        }
+                        None => {
+                            // Abort the function because the lock should have been set.
+                            return Err(SuiError::SharedObjectLockNotSetError);
+                        }
+                    };
+                }
+                InputObjectKind::MovePackage(id) => {
+                    // Move package always uses version 1.
+                    let version = VersionNumber::from_u64(1);
+                    if !self.object_exists(id, version)? {
+                        missing.push(ObjectKey(*id, version));
+                    }
+                }
+                InputObjectKind::ImmOrOwnedMoveObject(objref) => {
+                    if !self.object_exists(&objref.0, objref.1)? {
+                        missing.push(ObjectKey::from(objref));
+                    }
+                }
+            };
+        }
+
+        Ok(missing)
+    }
+
+    /// When making changes, please see if get_missing_input_objects() above needs
+    /// similiar changes as well.
+    pub fn check_sequenced_input_objects(
         &self,
         digest: &TransactionDigest,
         objects: &[InputObjectKind],
@@ -695,11 +736,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         self.effects_notify_read
             .notify(transaction_digest, &effects.effects);
-
-        // Cleanup the lock of the shared objects. This must be done after we write effects, as
-        // effects_exists is used as the guard to avoid re-locking objects for a previously
-        // executed tx. remove_shared_objects_locks.
-        self.remove_shared_objects_locks(transaction_digest, certificate)?;
 
         Ok(seq)
     }
@@ -1093,33 +1129,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         self.perpetual_tables.get_latest_parent_entry(object_id)
     }
 
-    /// Remove the shared objects locks.
-    pub fn remove_shared_objects_locks(
-        &self,
-        transaction_digest: &TransactionDigest,
-        transaction: &VerifiedCertificate,
-    ) -> SuiResult {
-        let mut sequenced_to_delete = Vec::new();
-        let mut schedule_to_delete = Vec::new();
-        for (object_id, _) in transaction.shared_input_objects() {
-            sequenced_to_delete.push((*transaction_digest, *object_id));
-            if self.get_object(object_id)?.is_none() {
-                schedule_to_delete.push(*object_id);
-            }
-        }
-        let mut write_batch = self.epoch_tables().assigned_object_versions.batch();
-        write_batch = write_batch.delete_batch(
-            &self.epoch_tables().assigned_object_versions,
-            sequenced_to_delete,
-        )?;
-        write_batch = write_batch.delete_batch(
-            &self.epoch_tables().next_object_versions,
-            schedule_to_delete,
-        )?;
-        write_batch.write()?;
-        Ok(())
-    }
-
     /// Lock a sequence number for the shared objects of the input transaction based on the effects
     /// of that transaction. Used by the nodes, which don't listen to consensus.
     pub fn acquire_shared_locks_from_effects(
@@ -1183,12 +1192,12 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         self.finish_consensus_message_process(write_batch, certificate, consensus_index)
     }
 
-    /// Lock a sequence number for the shared objects of the input transaction. Also update the
-    /// last consensus index and consensus_message_processed table.
+    /// Locks a sequence number for the shared objects of the input transaction. Also updates the
+    /// last consensus index, consensus_message_processed and pending_certificates tables.
     /// This function must only be called from the consensus task (i.e. from handle_consensus_transaction).
     ///
     /// Caller is responsible to call consensus_message_processed before this method
-    pub async fn lock_shared_objects(
+    pub async fn record_shared_object_cert_from_consensus(
         &self,
         certificate: &VerifiedCertificate,
         consensus_index: ExecutionIndicesWithHash,
@@ -1245,29 +1254,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // Atomically store all elements.
         let mut write_batch = self.epoch_tables().assigned_object_versions.batch();
 
-        // If the tx has already been executed, we don't need to populate assigned_object_versions,
-        // and indeed we shouldn't because it will never be cleaned up.
-        //
-        // It may appear that this can cause assigned_object_versions to be inconsistent with
-        // next_object_versions - however there is no real inconsistency. assigned_object_versions
-        // effectively contains different snapshots of next_object_versions at different points in
-        // time.
-        //
-        // When we set assigned_object_versions from next_object_versions, we are taking a
-        // snapshot.
-        //
-        // When we set it from a TransactionEffects structure, we are instead copying the
-        // snapshot that was taken by another validator at the time at which the transaction was
-        // sequenced.
-        //
-        // (Both checkpoints and the node follower system ensure that at least one
-        // honest validator has vouched for the TransactionEffects that were used).
-        if !self.effects_exists(&transaction_digest)? {
-            write_batch = write_batch.insert_batch(
-                &self.epoch_tables().assigned_object_versions,
-                sequenced_to_write,
-            )?;
-        }
+        write_batch = write_batch.insert_batch(
+            &self.epoch_tables().assigned_object_versions,
+            sequenced_to_write,
+        )?;
 
         write_batch = write_batch
             .insert_batch(&self.epoch_tables().next_object_versions, schedule_to_write)?;
@@ -1299,6 +1289,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         let batch = batch.insert_batch(
             &self.epoch_tables().consensus_message_processed,
             [(transaction_digest, true)],
+        )?;
+        let batch = batch.insert_batch(
+            &self.epoch_tables().pending_certificates,
+            [(
+                (certificate.epoch(), *certificate.digest()),
+                certificate.clone().serializable(),
+            )],
         )?;
         batch.write()?;
         self.consensus_notify_read.notify(certificate.digest(), &());

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -37,7 +37,7 @@ use sui_types::{base_types::AuthorityName, error::SuiResult};
 use tokio::{
     sync::{oneshot, Mutex, MutexGuard},
     task::JoinHandle,
-    time::timeout,
+    time::{sleep, timeout},
 };
 use tracing::{debug, error, info, warn};
 
@@ -74,6 +74,7 @@ const MAX_RETRIES_RECORDED: u32 = 10;
 const DELAY_FOR_1_RETRY_MS: u64 = 2_000;
 const EXPONENTIAL_DELAY_BASIS: u64 = 2;
 pub const MAX_RETRY_DELAY_MS: u64 = 30_000;
+const TRANSACTION_MANAGER_SCAN_INTERNAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 pub struct AuthorityHealth {
@@ -379,14 +380,44 @@ where
         *lock_guard = Some(NodeSyncProcessHandle(join_handle, cancel_sender));
     }
 
-    /// Spawn pending certificate execution process
-    pub async fn spawn_execute_process(self: Arc<Self>) -> JoinHandle<()> {
-        spawn_monitored_task!(execution_process(self))
-    }
-
     pub async fn cancel_node_sync_process_for_tests(&self) {
         let mut lock_guard = self.node_sync_process.lock().await;
         Self::cancel_node_sync_process_impl(&mut lock_guard).await;
+    }
+
+    /// Start a periodic process to check transactions that are ready.
+    /// This is necessary even though we try to notify TransactionManager about each committed
+    /// object, because currently there is no transaction semantics for data store.
+    /// The following is possible:
+    /// 1. A certificate enters TransactionManager, and gathers its missing input objects.
+    /// 2. One of its missing input object is committed, and notifies TransactionManager. No action
+    ///    will be taken since the input object is not yet part of TransactionManager's data.
+    /// 3. TransactionManager saves the certificate's missing input into its data structure,
+    ///    including the object just committed.
+    /// TODO: investigate switching TransactionManager to use notify_read() on objects table.
+    pub fn spawn_transaction_manager_scanner(self: Arc<Self>) -> JoinHandle<()> {
+        let weak_transaction_manager = Arc::downgrade(&self.state.transaction_manager);
+        spawn_monitored_task!(async move {
+            loop {
+                sleep(TRANSACTION_MANAGER_SCAN_INTERNAL).await;
+                {
+                    let transaction_manager_arc_guard =
+                        if let Some(transaction_manager) = weak_transaction_manager.upgrade() {
+                            transaction_manager
+                        } else {
+                            // Shut down.
+                            return;
+                        };
+                    let mut transaction_manager = transaction_manager_arc_guard.lock().await;
+                    transaction_manager.scan_ready_transactions();
+                }
+            }
+        })
+    }
+
+    /// Spawn pending certificate execution process
+    pub async fn spawn_execute_process(self: Arc<Self>) -> JoinHandle<()> {
+        spawn_monitored_task!(execution_process(self))
     }
 }
 

--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -114,6 +114,7 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
             );
 
             println!("Start active execution process.");
+            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
 
             // Spin the checkpoint service.
@@ -205,6 +206,7 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
             );
 
             println!("Start active execution process.");
+            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
 
             // Spin the gossip service.
@@ -294,6 +296,7 @@ async fn test_empty_checkpoint() {
                 .unwrap(),
             );
 
+            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
 
             // Spawn the checkpointing service.

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -1,44 +1,52 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{sync::Arc, time::Duration};
+
 use prometheus::{
     register_int_counter_with_registry, register_int_gauge_with_registry, IntCounter, IntGauge,
     Registry,
 };
-use std::{collections::HashSet, sync::Arc};
-use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::VerifiedCertificate};
-use tracing::{debug, error, info};
-
-use crate::authority::{AuthorityState, PendingDigest};
-use crate::authority_client::AuthorityAPI;
-
-use futures::{stream, StreamExt};
+use sui_metrics::spawn_monitored_task;
+use tokio::{sync::Semaphore, time::sleep};
+use tracing::{debug, error, info, warn};
 
 use super::ActiveAuthority;
-
-use tap::TapFallible;
+use crate::authority_client::AuthorityAPI;
 
 #[cfg(test)]
 pub(crate) mod tests;
 
+// Execution should not encounter permanent failures, so any failure can and needs
+// to be retried.
+const EXECUTION_MAX_ATTEMPTS: usize = 10;
+const EXECUTION_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
 #[derive(Clone)]
 pub struct ExecutionDriverMetrics {
+    executing_transactions: IntGauge,
     executed_transactions: IntCounter,
-    pending_transactions: IntGauge,
+    execution_failures: IntCounter,
 }
 
 impl ExecutionDriverMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
+            executing_transactions: register_int_gauge_with_registry!(
+                "execution_driver_executing_transactions",
+                "Number of currently executing transactions in execution driver",
+                registry,
+            )
+            .unwrap(),
             executed_transactions: register_int_counter_with_registry!(
                 "execution_driver_executed_transactions",
                 "Cumulative number of transaction executed by execution driver",
                 registry,
             )
             .unwrap(),
-            pending_transactions: register_int_gauge_with_registry!(
-                "execution_driver_pending_transaction",
-                "Number of current pending transactions for execution driver",
+            execution_failures: register_int_counter_with_registry!(
+                "execution_driver_execution_failures",
+                "Cumulative number of transactions failed to be executed by execution driver",
                 registry,
             )
             .unwrap(),
@@ -51,250 +59,92 @@ impl ExecutionDriverMetrics {
     }
 }
 
-pub trait PendCertificateForExecution {
-    fn add_pending_certificates(
-        &self,
-        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
-    ) -> SuiResult<()>;
-}
-
-impl PendCertificateForExecution for &AuthorityState {
-    fn add_pending_certificates(
-        &self,
-        certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
-    ) -> SuiResult<()> {
-        AuthorityState::add_pending_certificates(self, certs)
-    }
-}
-
-/// A no-op PendCertificateForExecution that we use for testing, when
-/// we do not care about certificates actually being executed.
-pub struct PendCertificateForExecutionNoop;
-impl PendCertificateForExecution for PendCertificateForExecutionNoop {
-    fn add_pending_certificates(
-        &self,
-        _certs: Vec<(TransactionDigest, Option<VerifiedCertificate>)>,
-    ) -> SuiResult<()> {
-        Ok(())
-    }
-}
-
 /// When a notification that a new pending transaction is received we activate
 /// processing the transaction in a loop.
 pub async fn execution_process<A>(active_authority: Arc<ActiveAuthority<A>>)
 where
     A: AuthorityAPI + Send + Sync + 'static + Clone,
 {
-    info!("Start pending certificates execution process.");
+    info!("Starting pending certificates execution process.");
+
+    // Rate limit concurrent executions to # of cpus.
+    let limit = Arc::new(Semaphore::new(num_cpus::get()));
+
+    let mut ready_certificates_stream = active_authority
+        .state
+        .ready_certificates_stream()
+        .await
+        .expect(
+            "Initialization failed: only the executiion driver should receive ready certificates!",
+        );
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
-        // NOTE: nothing terrible happens if we fire more often than there are
-        //       transactions awaiting execution, or less often than once per transactions.
-        //       However, we need to be sure that if there is an awaiting trasnactions we
-        //       will eventually fire the notification and wake up here.
-        active_authority.state.database.wait_for_new_pending().await;
-
-        debug!("Pending certificate execution activated.");
+        let certificate = if let Some(cert) = ready_certificates_stream.recv().await {
+            cert
+        } else {
+            // Should not happen. Only possible if the AuthorityState has shut down.
+            warn!("Ready digest stream from authority state is broken. Retrying in 10s ...");
+            sleep(std::time::Duration::from_secs(10)).await;
+            continue;
+        };
+        let digest = *certificate.digest();
+        debug!(?digest, "Pending certificate execution activated.");
 
         // Process any tx that failed to commit.
         if let Err(err) = active_authority.state.process_tx_recovery_log(None).await {
             tracing::error!("Error processing tx recovery log: {:?}", err);
         }
 
-        match execute_pending(active_authority.clone()).await {
-            Err(err) => {
-                tracing::error!("Error in pending execution subsystem: {err}");
-                // The above should not return an error if the DB works, and we are connected to
-                // the network. However if it does, we should backoff a little.
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        let limit = limit.clone();
+        // hold semaphore permit until task completes. unwrap ok because we never close
+        // the semaphore in this context.
+        let permit = limit.acquire_owned().await.unwrap();
+        let authority = active_authority.clone();
+
+        authority
+            .execution_driver_metrics
+            .executing_transactions
+            .inc();
+
+        spawn_monitored_task!(async move {
+            let _guard = permit;
+            if let Ok(true) = authority.state.is_tx_already_executed(certificate.digest()) {
+                return;
             }
-            Ok(true) => {
-                // TODO: Move all of these timings into a control.
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let mut attempts = 0;
+            loop {
+                attempts += 1;
+                let res = authority.state.handle_certificate(&certificate).await;
+                if let Err(e) = res {
+                    if attempts == EXECUTION_MAX_ATTEMPTS {
+                        error!("Failed to execute certified transaction after {attempts} attempts! error={e} certificate={:?}", certificate);
+                        authority.execution_driver_metrics.execution_failures.inc();
+                        return;
+                    }
+                    // Assume only transient failure can happen. Permanent failure is probably
+                    // a bug. There would be nothing that can be done for permanent failures.
+                    warn!(tx_digest=?digest, "Failed to execute certified transaction! attempt {attempts}, {e}");
+                    sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
+                } else {
+                    break;
+                }
             }
-            Ok(false) => {
-                // Some execution failed. Wait a bit before we retry.
-                // TODO: We may want to make the retry delay per-transaction, instead of
-                // applying to the entire loop.
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-            }
-        }
+
+            // Remove the certificate that finished execution.
+            let _ = authority
+                .state
+                .database
+                .remove_pending_certificate(certificate.epoch(), &digest);
+
+            authority
+                .execution_driver_metrics
+                .executed_transactions
+                .inc();
+            authority
+                .execution_driver_metrics
+                .executing_transactions
+                .dec();
+        });
     }
-}
-
-type PendingVec = Vec<(u64, PendingDigest)>;
-
-fn sort_and_partition_pending_certs(
-    mut pending_transactions: PendingVec,
-) -> (
-    PendingVec, // sequenced
-    PendingVec, // unsequenced
-    Vec<u64>,   // duplicated indices, to be deleted
-) {
-    // sort sequenced digests before unsequenced so that the deduplication below favors
-    // sequenced digests.
-    pending_transactions.sort_by(|(idx_a, (is_seq_a, _)), (idx_b, (is_seq_b, _))| {
-        match is_seq_b.cmp(is_seq_a) {
-            // when both are sequenced or unsequenced, sort by idx.
-            std::cmp::Ordering::Equal => idx_a.cmp(idx_b),
-            // otherwise sort sequenced before unsequenced
-            res => res,
-        }
-    });
-
-    // Before executing de-duplicate the list of pending trasnactions
-    let mut seen = HashSet::new();
-    let mut indexes_to_delete = Vec::new();
-
-    let (pending_sequenced, pending_transactions): (Vec<_>, Vec<_>) = pending_transactions
-        .into_iter()
-        .filter(|(idx, (_, digest))| {
-            if seen.contains(digest) {
-                indexes_to_delete.push(*idx);
-                false
-            } else {
-                seen.insert(*digest);
-                true
-            }
-        })
-        .partition(|(_, (is_sequenced, _))| *is_sequenced);
-
-    debug!(
-        num_sequenced = ?pending_sequenced.len(),
-        num_unsequenced = ?pending_transactions.len()
-    );
-
-    (pending_sequenced, pending_transactions, indexes_to_delete)
-}
-
-#[test]
-fn test_sort_and_partition_pending_certs() {
-    let tx1 = TransactionDigest::random();
-    let tx2 = TransactionDigest::random();
-    let tx3 = TransactionDigest::random();
-    let tx4 = TransactionDigest::random();
-
-    // partitioning works correctly.
-    assert_eq!(
-        sort_and_partition_pending_certs(vec![(0, (false, tx1)), (1, (true, tx2))]),
-        (vec![(1, (true, tx2))], vec![(0, (false, tx1))], vec![],)
-    );
-
-    // if certs are duplicated, but some are sequenced, the sequenced certs take priority.
-    assert_eq!(
-        sort_and_partition_pending_certs(vec![(0, (false, tx1)), (1, (true, tx1))]),
-        (vec![(1, (true, tx1))], vec![], vec![0],)
-    );
-
-    // sorting works correctly for both sequenced and unsequenced.
-    assert_eq!(
-        sort_and_partition_pending_certs(vec![
-            (2, (false, tx3)),
-            (0, (false, tx2)),
-            (4, (true, tx4)),
-            (1, (true, tx1))
-        ]),
-        (
-            vec![(1, (true, tx1)), (4, (true, tx4))],
-            vec![(0, (false, tx2)), (2, (false, tx3))],
-            vec![],
-        )
-    );
-}
-
-/// Reads all pending transactions as a block and executes them.
-/// Returns whether all pending transactions succeeded.
-async fn execute_pending<A>(active_authority: Arc<ActiveAuthority<A>>) -> SuiResult<bool>
-where
-    A: AuthorityAPI + Send + Sync + 'static + Clone,
-{
-    // Get the pending transactions
-    let pending_transactions = active_authority.state.database.get_pending_digests()?;
-
-    active_authority
-        .execution_driver_metrics
-        .pending_transactions
-        .set(pending_transactions.len() as i64);
-
-    let (pending_sequenced, pending_transactions, indexes_to_delete) =
-        sort_and_partition_pending_certs(pending_transactions);
-
-    active_authority
-        .state
-        .database
-        .remove_pending_digests(indexes_to_delete)?;
-
-    // Send them for execution
-    let epoch = active_authority.state.committee.load().epoch;
-    let sync_handle = active_authority.clone().node_sync_handle();
-
-    // Execute certs that have a sequencing index associated with them serially.
-    for (seq, (_, digest)) in pending_sequenced.iter() {
-        let mut result_stream = sync_handle
-            .handle_execution_request(epoch, std::iter::once(*digest))
-            .await?;
-
-        match result_stream.next().await.unwrap() {
-            Ok(_) => {
-                debug!(?seq, ?digest, "serial certificate execution complete");
-                active_authority
-                    .execution_driver_metrics
-                    .executed_transactions
-                    .inc();
-                active_authority
-                    .state
-                    .database
-                    .remove_pending_digests(vec![*seq])
-                    .tap_err(|err| {
-                        error!(?seq, ?digest, "pending digest deletion failed: {}", err)
-                    })?;
-            }
-            Err(err) => {
-                info!(
-                    ?seq,
-                    ?digest,
-                    "serial certificate execution failed: {}",
-                    err
-                );
-            }
-        }
-    }
-
-    let executed: Vec<_> = sync_handle
-        // map to extract digest
-        .handle_execution_request(
-            epoch,
-            pending_transactions.iter().map(|(_, (_, digest))| *digest),
-        )
-        .await?
-        // zip results back together with seq
-        .zip(stream::iter(pending_transactions.iter()))
-        // filter out errors
-        .filter_map(|(result, (idx, tx_digest))| async move {
-            result
-                .tap_err(|e| info!(?idx, ?tx_digest, "certificate execution failed: {}", e))
-                .tap_ok(|_| debug!(?idx, ?tx_digest, "certificate execution complete"))
-                .ok()
-                .map(|_| idx)
-        })
-        .collect()
-        .await;
-
-    let pending_count = pending_transactions.len();
-    let executed_count = executed.len();
-    debug!(?pending_count, ?executed_count, "execute_pending completed");
-
-    active_authority
-        .execution_driver_metrics
-        .executed_transactions
-        .inc_by(executed_count as u64);
-
-    // Now update the pending store.
-    active_authority
-        .state
-        .database
-        .remove_pending_digests(executed)?;
-
-    Ok(pending_count == executed_count)
 }

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -1,27 +1,58 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{authority_active::ActiveAuthority, checkpoints::checkpoint_tests::TestSetup};
-
-use crate::authority_active::checkpoint_driver::CheckpointMetrics;
-use std::sync::Arc;
-use std::time::Duration;
-
-use sui_types::crypto::AccountKeyPair;
-use sui_types::{crypto::get_key_pair, messages::ExecutionStatus, object::Object};
-
-//use super::super::AuthorityState;
 use crate::authority_aggregator::authority_aggregator_tests::{
     crate_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     init_local_authorities, transfer_object_move_transaction,
 };
 use crate::checkpoints::checkpoint_tests::checkpoint_tests_setup;
 use crate::test_utils::wait_for_tx;
+use crate::{authority_active::ActiveAuthority, checkpoints::checkpoint_tests::TestSetup};
 
+use crate::authority_active::checkpoint_driver::CheckpointMetrics;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use itertools::Itertools;
+use sui_types::base_types::TransactionDigest;
+use sui_types::crypto::{get_key_pair, AccountKeyPair};
+use sui_types::messages::ExecutionStatus;
+use sui_types::messages::VerifiedCertificate;
+use sui_types::object::Object;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::time::timeout;
 use tracing::info;
 
+async fn wait_for_certs(
+    stream: &mut UnboundedReceiver<VerifiedCertificate>,
+    certs: &Vec<VerifiedCertificate>,
+) {
+    if certs.is_empty() {
+        if timeout(Duration::from_secs(30), stream.recv())
+            .await
+            .is_err()
+        {
+            return;
+        } else {
+            panic!("Should not receive certificate!");
+        }
+    }
+    let mut certs: BTreeSet<TransactionDigest> = certs.iter().map(|c| *c.digest()).collect();
+    while !certs.is_empty() {
+        match timeout(Duration::from_secs(5), stream.recv()).await {
+            Err(_) => panic!("Timed out waiting for next certificate!"),
+            Ok(None) => panic!("Next certificate channel closed!"),
+            Ok(Some(cert)) => {
+                println!("Found cert {:?}", cert.digest());
+                certs.remove(cert.digest())
+            }
+        };
+    }
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
-async fn pending_exec_storage_notify() {
+async fn pending_exec_notify_ready_certificates() {
     use telemetry_subscribers::init_for_testing;
     init_for_testing();
 
@@ -35,6 +66,7 @@ async fn pending_exec_storage_notify() {
     } = setup;
 
     let authority_state = authorities[0].authority.clone();
+    let mut ready_certificates_stream = authority_state.ready_certificates_stream().await.unwrap();
 
     // TODO: duplicated with checkpoint_driver/tests.rs
     // Start active part of authority.
@@ -81,32 +113,24 @@ async fn pending_exec_storage_notify() {
     let certs = _end_of_sending_join.await.expect("all ok");
 
     // Insert the certificates
-    let num_certs = certs.len();
     authority_state
-        .add_pending_certificates(
-            certs
-                .into_iter()
-                .map(|cert| (*cert.digest(), Some(cert)))
-                .collect(),
-        )
+        .add_pending_certificates(certs.clone())
+        .await
         .expect("Storage is ok");
 
     tokio::task::yield_now().await;
 
-    // Wait for a notification (must arrive)
-    authority_state.database.wait_for_new_pending().await;
-    // get back the certificates
-    let certs_back = authority_state
-        .database
-        .get_pending_digests()
-        .expect("DB should be there");
-    assert_eq!(num_certs, certs_back.len());
+    // Wait to get back the certificates
+    wait_for_certs(&mut ready_certificates_stream, &certs).await;
+
+    // Should have no certificate any more.
+    wait_for_certs(&mut ready_certificates_stream, &vec![]).await;
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn pending_exec_full() {
-    // use telemetry_subscribers::init_for_testing;
-    // init_for_testing();
+    use telemetry_subscribers::init_for_testing;
+    init_for_testing();
 
     let setup = checkpoint_tests_setup(20, Duration::from_millis(200), true).await;
 
@@ -130,7 +154,13 @@ async fn pending_exec_full() {
                 )
                 .unwrap(),
             );
-
+            let batch_state = inner_state.authority.clone();
+            tokio::task::spawn(async move {
+                batch_state
+                    .run_batch_service(1, Duration::from_secs(1))
+                    .await
+            });
+            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
             active_state
                 .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
@@ -167,56 +197,45 @@ async fn pending_exec_full() {
     let certs = _end_of_sending_join.await.expect("all ok");
 
     // Insert the certificates
-    let num_certs = certs.len();
     authority_state
-        .add_pending_certificates(
-            certs
-                .into_iter()
-                .map(|cert| (*cert.digest(), Some(cert)))
-                .collect(),
-        )
+        .add_pending_certificates(certs.clone())
+        .await
         .expect("Storage is ok");
-    let certs_back = authority_state
-        .database
-        .get_pending_digests()
-        .expect("DB should be there");
-    assert_eq!(num_certs, certs_back.len());
 
-    // In the time we are waiting the execution logic re-executes the
-    // transactions and therefore we have no certificate left pending at the end.
-    tokio::time::sleep(Duration::from_secs(5)).await;
-
-    // get back the certificates
-    let certs_back = authority_state
-        .database
-        .get_pending_digests()
-        .expect("DB should be there");
-    assert_eq!(0, certs_back.len());
+    // Wait for execution.
+    for cert in certs {
+        wait_for_tx(*cert.digest(), authority_state.clone()).await;
+    }
 }
 
-#[tokio::test]
-async fn test_parent_cert_exec() {
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_transaction_manager() {
     telemetry_subscribers::init_for_testing();
 
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
-    let gas_object1 = Object::with_owner_for_testing(addr1);
-    let gas_object2 = Object::with_owner_for_testing(addr1);
+    let gas_objects = vec![0..100]
+        .iter()
+        .map(|_| Object::with_owner_for_testing(addr1))
+        .collect_vec();
     let (aggregator, authorities, framework_obj_ref) =
-        init_local_authorities(4, vec![gas_object1.clone(), gas_object2.clone()]).await;
+        init_local_authorities(4, gas_objects.clone()).await;
     let authority_clients: Vec<_> = authorities
         .iter()
         .map(|a| &aggregator.authority_clients[&a.name])
         .collect();
 
     // Make a schedule of transactions
-    let gas_ref_1 = get_latest_ref(authority_clients[0], gas_object1.id()).await;
-    let tx1 = crate_object_move_transaction(addr1, &key1, addr1, 100, framework_obj_ref, gas_ref_1);
+    let gas_ref_0 = get_latest_ref(authority_clients[0], gas_objects[0].id()).await;
+    let tx1 = crate_object_move_transaction(addr1, &key1, addr1, 100, framework_obj_ref, gas_ref_0);
 
     // create an object and execute the cert on 3 authorities
     do_transaction(authority_clients[0], &tx1).await;
     do_transaction(authority_clients[1], &tx1).await;
     do_transaction(authority_clients[2], &tx1).await;
-    let cert1 = extract_cert(&authority_clients, &aggregator.committee, tx1.digest()).await;
+    let cert1 = extract_cert(&authority_clients, &aggregator.committee, tx1.digest())
+        .await
+        .verify(&aggregator.committee)
+        .unwrap();
 
     do_cert(authority_clients[0], &cert1).await;
     do_cert(authority_clients[1], &cert1).await;
@@ -239,12 +258,15 @@ async fn test_parent_cert_exec() {
     do_transaction(authority_clients[0], &tx2).await;
     do_transaction(authority_clients[1], &tx2).await;
     do_transaction(authority_clients[2], &tx2).await;
-    let cert2 = extract_cert(&authority_clients, &aggregator.committee, tx2.digest()).await;
+    let cert2 = extract_cert(&authority_clients, &aggregator.committee, tx2.digest())
+        .await
+        .verify(&aggregator.committee)
+        .unwrap();
     do_cert(authority_clients[0], &cert2).await;
     info!(digest = ?tx2.digest(), "cert2 finished");
 
     // the 4th authority has never heard of either of these transactions. Tell it to execute the
-    // cert and verify that it is able to fetch parents and apply.
+    // cert, sends it the missing dependency and verify that it is able to fetch parents and apply.
     let active_state = Arc::new(
         ActiveAuthority::new_with_ephemeral_storage_for_test(
             authorities[3].clone(),
@@ -252,26 +274,33 @@ async fn test_parent_cert_exec() {
         )
         .unwrap(),
     );
-
     let batch_state = authorities[3].clone();
     tokio::task::spawn(async move {
         batch_state
             .run_batch_service(1, Duration::from_secs(1))
             .await
     });
+    active_state.clone().spawn_transaction_manager_scanner();
     active_state.clone().spawn_execute_process().await;
 
+    // Basic test: add certs out of dependency order. They should still be executed.
     authorities[3]
-        .add_pending_certificates(vec![(*tx2.digest(), None)])
+        .add_pending_certificates(vec![cert2.clone()])
+        .await
+        .unwrap();
+    authorities[3]
+        .add_pending_certificates(vec![cert1.clone()])
+        .await
         .unwrap();
 
     wait_for_tx(*tx2.digest(), authorities[3].clone()).await;
-
-    // verify it has the cert.
+    // verify it has the effect.
     authority_clients[3]
         .handle_transaction_info_request((*tx2.digest()).into())
         .await
         .unwrap()
         .signed_effects
         .unwrap();
+
+    // TODO: more test cases.
 }

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -23,6 +23,7 @@ use sui_types::object::Object;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::timeout;
 use tracing::info;
+use typed_store::Map;
 
 async fn wait_for_certs(
     stream: &mut UnboundedReceiver<VerifiedCertificate>,
@@ -111,6 +112,14 @@ async fn pending_exec_notify_ready_certificates() {
 
     // Wait for all the sending to happen.
     let certs = _end_of_sending_join.await.expect("all ok");
+
+    // Clear effects so their executions will happen below.
+    authority_state
+        .database
+        .perpetual_tables
+        .effects
+        .clear()
+        .expect("Clearing effects failed!");
 
     // Insert the certificates
     authority_state

--- a/crates/sui-core/src/authority_active/gossip/mod.rs
+++ b/crates/sui-core/src/authority_active/gossip/mod.rs
@@ -332,7 +332,8 @@ impl GossipDigestHandler {
             }
             let digest = *certificate.digest();
             state
-                .add_pending_certificates(vec![(digest, Some(certificate))])
+                .add_pending_certificates(vec![certificate])
+                .await
                 .tap_err(|e| error!(?digest, "add_pending_certificates failed: {}", e))?;
 
             state.metrics.gossip_sync_count.inc();

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -148,6 +148,7 @@ async fn start_gossip_process(
                 ActiveAuthority::new_with_ephemeral_storage_for_test(state, inner_net).unwrap(),
             );
             active_state.clone().spawn_gossip_process(3).await;
+            active_state.clone().spawn_transaction_manager_scanner();
             active_state.spawn_execute_process().await;
         });
         active_authorities.push(handle);

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -40,7 +40,7 @@ use sui_types::messages_checkpoint::CheckpointRequest;
 use sui_types::messages_checkpoint::CheckpointResponse;
 
 use crate::consensus_handler::ConsensusHandler;
-use tracing::{debug, error, info, Instrument};
+use tracing::{debug, info, Instrument};
 
 #[cfg(test)]
 #[path = "unit_tests/server_tests.rs"]
@@ -471,10 +471,6 @@ impl ValidatorService {
                     retry_delay_ms *= 2;
                 }
                 Err(e) => {
-                    // Record the cert for later execution, including causal completion if necessary.
-                    let _ = state
-                        .add_pending_certificates(vec![(tx_digest, Some(certificate))])
-                        .tap_err(|e| error!(?tx_digest, "add_pending_certificates failed: {}", e));
                     return Err(tonic::Status::from(e));
                 }
                 Ok(response) => {

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -85,8 +85,11 @@ where
 
             // Delete any extra certificates now unprocessed.
             checkpoints.tables.extra_transactions.clear()?;
-
-            self.state.database.remove_all_pending_certificates()?;
+            // This is either unnecessary if the whole epoch database will be dropped, or
+            // in correct if the table can contain certificates from multiple epochs.
+            // TODO: fix this during reconfiguration work.
+            self.state.database.cleanup_pending_certificates()?;
+            // TODO: also clean up self.node_sync_store for epoch - 1.
 
             let (storage_charges, computation_charges, storage_rebates): (
                 Vec<u64>,

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -29,5 +29,6 @@ mod consensus_handler;
 mod histogram;
 mod node_sync;
 mod query_helpers;
+mod transaction_manager;
 
 pub const SUI_CORE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -66,7 +66,7 @@ where
     transaction.kind.validity_check()?;
     let gas_status = get_gas_status(store, transaction).await?;
     let input_objects = transaction.input_objects()?;
-    let objects = store.get_input_objects(&input_objects)?;
+    let objects = store.check_input_objects(&input_objects)?;
     let input_objects = check_objects(transaction, input_objects, objects).await?;
     Ok((gas_status, input_objects))
 }
@@ -79,17 +79,17 @@ where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
 {
     let gas_status = get_gas_status(store, &cert.data().data).await?;
-    let input_objects = cert.data().data.input_objects()?;
-
+    let input_object_kinds = cert.data().data.input_objects()?;
     let tx_data = &cert.data().data;
-    let objects = if tx_data.kind.is_change_epoch_tx() {
+    let input_object_data = if tx_data.kind.is_change_epoch_tx() {
         // When changing the epoch, we update a the system object, which is shared, without going
         // through sequencing, so we must bypass the sequence checks here.
-        store.get_input_objects(&input_objects)?
+        store.check_input_objects(&input_object_kinds)?
     } else {
-        store.get_sequenced_input_objects(cert.digest(), &input_objects)?
+        store.check_sequenced_input_objects(cert.digest(), &input_object_kinds)?
     };
-    let input_objects = check_objects(&cert.data().data, input_objects, objects).await?;
+    let input_objects =
+        check_objects(&cert.data().data, input_object_kinds, input_object_data).await?;
     Ok((gas_status, input_objects))
 }
 
@@ -120,7 +120,7 @@ where
             }],
         })?;
 
-        //TODO: cache this storage_gas_price in memory
+        // TODO: cache this storage_gas_price in memory
         let storage_gas_price = store
             .get_sui_system_state_object()?
             .parameters

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use sui_types::{
+    base_types::TransactionDigest, committee::EpochId, error::SuiResult,
+    messages::VerifiedCertificate,
+};
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::{error, warn};
+
+use crate::authority::{authority_store::ObjectKey, AuthorityMetrics, AuthorityStore};
+
+/// TransactionManager is responsible for managing pending certificates and publishes a stream
+/// of certificates ready to be executed. It works together with AuthorityState for receiving
+/// pending certificates, and getting notified about committed objects. Executing driver
+/// subscribes to the stream of ready certificates published by the TransactionManager, and can
+/// execute them in parallel.
+/// TODO: use TransactionManager for fullnode.
+pub(crate) struct TransactionManager {
+    authority_store: Arc<AuthorityStore>,
+    missing_inputs: BTreeMap<ObjectKey, (EpochId, TransactionDigest)>,
+    pending_certificates: BTreeMap<(EpochId, TransactionDigest), BTreeSet<ObjectKey>>,
+    tx_ready_certificates: UnboundedSender<VerifiedCertificate>,
+    metrics: Arc<AuthorityMetrics>,
+}
+
+impl TransactionManager {
+    /// If a node restarts, transaction manager recovers in-memory data from pending certificates and
+    /// other persistent data.
+    pub(crate) fn new(
+        authority_store: Arc<AuthorityStore>,
+        tx_ready_certificates: UnboundedSender<VerifiedCertificate>,
+        metrics: Arc<AuthorityMetrics>,
+    ) -> TransactionManager {
+        let mut transaction_manager = TransactionManager {
+            authority_store,
+            metrics,
+            missing_inputs: BTreeMap::new(),
+            pending_certificates: BTreeMap::new(),
+            tx_ready_certificates,
+        };
+        transaction_manager
+            .enqueue(
+                transaction_manager
+                    .authority_store
+                    .all_pending_certificates()
+                    .unwrap(),
+            )
+            .expect("Initialize TransactionManager with pending certificates failed.");
+        transaction_manager
+    }
+
+    /// Enqueues certificates into TransactionManager. Once all of the input objects are available
+    /// locally for a certificate, the certified transaction will be sent to execution driver.
+    ///
+    /// REQUIRED: Shared object locks must be taken before calling this function on shared object
+    /// transactions!
+    ///
+    /// TODO: it may be less error prone to take shared object locks inside this function, or
+    /// require shared object lock versions get passed in as input. But this function should not
+    /// have many callsites. Investigate the alternatives here.
+    pub(crate) fn enqueue(&mut self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
+        for cert in certs {
+            let missing = self
+                .authority_store
+                .get_missing_input_objects(cert.digest(), &cert.data().data.input_objects()?)
+                .expect("Are shared object locks set prior to enqueueing certificates?");
+            if missing.is_empty() {
+                self.certificate_ready(cert);
+                continue;
+            }
+            let cert_key = (cert.epoch(), *cert.digest());
+            for obj_key in missing {
+                // TODO: verify the key does not already exist.
+                self.missing_inputs.insert(obj_key, cert_key);
+                self.pending_certificates
+                    .entry(cert_key)
+                    .or_default()
+                    .insert(obj_key);
+            }
+        }
+        self.metrics
+            .transaction_manager_num_missing_objects
+            .set(self.missing_inputs.len() as i64);
+        self.metrics
+            .transaction_manager_num_pending_certificates
+            .set(self.pending_certificates.len() as i64);
+        Ok(())
+    }
+
+    /// Notifies TransactionManager that the given objects have been committed.
+    // TODO: investigate switching TransactionManager to use notify_read() on objects table.
+    pub(crate) fn objects_committed(&mut self, object_keys: Vec<ObjectKey>) {
+        for object_key in object_keys {
+            let cert_key = if let Some(key) = self.missing_inputs.remove(&object_key) {
+                key
+            } else {
+                continue;
+            };
+            let set = self.pending_certificates.entry(cert_key).or_default();
+            set.remove(&object_key);
+            // This certificate has no missing input. It is ready to execute.
+            if set.is_empty() {
+                self.pending_certificates.remove(&cert_key);
+                // NOTE: failing and ignoring the certificate is fine, if it will be retried at a higher level.
+                // Otherwise, this has to crash.
+                let cert = match self
+                    .authority_store
+                    .get_pending_certificate(cert_key.0, &cert_key.1)
+                {
+                    Ok(Some(cert)) => cert,
+                    Ok(None) => {
+                        error!(tx_digest = ?cert_key,
+                            "Ready certificate not found in the pending table",
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        error!(tx_digest = ?cert_key,
+                            "Failed to read pending table: {e}",
+                        );
+
+                        continue;
+                    }
+                };
+                self.certificate_ready(cert);
+            }
+        }
+        self.metrics
+            .transaction_manager_num_missing_objects
+            .set(self.missing_inputs.len() as i64);
+        self.metrics
+            .transaction_manager_num_pending_certificates
+            .set(self.pending_certificates.len() as i64);
+    }
+
+    /// Run a periodic scanning task that checks if any input object is in fact already committed.
+    /// This can discover more ready transactions.
+    /// TODO: rely on notify_read() for objects or the mutex on TransactionManager instead, and
+    /// remove this periodic scanner.
+    pub(crate) fn scan_ready_transactions(&mut self) {
+        let mut available_inputs = Vec::new();
+        for (object_key, _) in self.missing_inputs.iter() {
+            match self
+                .authority_store
+                .object_exists(&object_key.0, object_key.1)
+            {
+                Ok(true) => available_inputs.push(*object_key),
+                Err(e) => warn!("Failed to check if object exists: {e}"),
+                _ => {}
+            }
+        }
+        if available_inputs.is_empty() {
+            return;
+        }
+        self.metrics
+            .transaction_manager_objects_notified_via_scan
+            .add(available_inputs.len() as i64);
+        self.objects_committed(available_inputs);
+    }
+
+    /// Marks the given certificate as ready to be executed.
+    fn certificate_ready(&self, certificate: VerifiedCertificate) {
+        self.metrics.transaction_manager_num_ready.inc();
+        let _ = self.tx_ready_certificates.send(certificate);
+    }
+}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2365,14 +2365,8 @@ async fn shared_object() {
     assert_eq!(shared_object_version, OBJECT_START_VERSION);
 
     // Finally process the certificate and execute the contract. Ensure that the
-    // shared object lock is cleaned up and that its sequence number increased.
+    // shared object sequence number increased.
     authority.handle_certificate(&certificate).await.unwrap();
-
-    let shared_object_lock = authority
-        .db()
-        .get_assigned_object_versions(transaction_digest, [shared_object_id].iter())
-        .unwrap()[0];
-    assert!(shared_object_lock.is_none());
 
     let shared_object_version = authority
         .get_object(&shared_object_id)

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -76,6 +76,7 @@ pub struct SuiNode {
     _batch_subsystem_handle: tokio::task::JoinHandle<()>,
     _post_processing_subsystem_handle: Option<tokio::task::JoinHandle<Result<()>>>,
     _gossip_handle: Option<tokio::task::JoinHandle<()>>,
+    _transaction_manager_scanner_handle: Option<tokio::task::JoinHandle<()>>,
     _execute_driver_handle: tokio::task::JoinHandle<()>,
     _checkpoint_process_handle: Option<tokio::task::JoinHandle<()>>,
     state: Arc<AuthorityState>,
@@ -268,6 +269,8 @@ impl SuiNode {
         } else {
             None
         };
+        let transaction_manager_scanner_handle =
+            Some(active_authority.clone().spawn_transaction_manager_scanner());
         let execute_driver_handle = active_authority.clone().spawn_execute_process().await;
         let checkpoint_process_handle = if config.enable_checkpoint && is_validator {
             Some(
@@ -371,6 +374,7 @@ impl SuiNode {
             _json_rpc_service: json_rpc_service,
             _ws_subscription_service: ws_subscription_service,
             _gossip_handle: gossip_handle,
+            _transaction_manager_scanner_handle: transaction_manager_scanner_handle,
             _execute_driver_handle: execute_driver_handle,
             _checkpoint_process_handle: checkpoint_process_handle,
             _batch_subsystem_handle: batch_subsystem_handle,

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -363,7 +363,7 @@ impl LockServiceImpl {
     /// Loop to continuously process mutating commands in a single thread from async senders.
     /// It terminates when the sender drops, which usually is when the containing data store is dropped.
     fn run_command_loop(&self, mut receiver: Receiver<LockServiceCommands>) {
-        info!("LockService command processing loop started");
+        debug!("LockService command processing loop started");
         // NOTE: we use blocking_recv() as its faster than using regular async recv() with awaits in a loop
         while let Some(msg) = receiver.blocking_recv() {
             match msg {
@@ -412,7 +412,7 @@ impl LockServiceImpl {
 
     /// Loop to continuously process queries in a single thread
     fn run_queries_loop(&self, mut receiver: Receiver<LockServiceQueries>) {
-        info!("LockService queries processing loop started");
+        debug!("LockService queries processing loop started");
         while let Some(msg) = receiver.blocking_recv() {
             match msg {
                 LockServiceQueries::GetLock { object, resp } => {

--- a/crates/sui-swarm/src/memory/container-sim.rs
+++ b/crates/sui-swarm/src/memory/container-sim.rs
@@ -6,7 +6,7 @@ use prometheus::Registry;
 use std::net::{IpAddr, SocketAddr};
 use sui_config::NodeConfig;
 use sui_node::SuiNode;
-use tracing::{error, trace};
+use tracing::trace;
 
 use super::node::RuntimeType;
 
@@ -67,7 +67,7 @@ impl Container {
         let task_handle = node.spawn(async move {
             let _server = SuiNode::start(&config, Registry::new()).await.unwrap();
             // Notify that we've successfully started the node
-            error!("node started, sending oneshot");
+            trace!("node started, sending oneshot");
             let _ = startup_sender.send(());
             // run until canceled
             cancel_reciever.map(|_| ()).await;

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -885,6 +885,8 @@ impl WalletContext {
             .await?;
         #[cfg(msim)]
         let client = sui_sdk::embedded_gateway::SuiClient::new(&config_path.parent().unwrap())?;
+        #[cfg(msim)]
+        let _request_timeout = request_timeout; // silence linter.
 
         let config = config.persisted(config_path);
         let context = Self { config, client };


### PR DESCRIPTION
### Background

This change adds a `TransactionManager` component that manages dependencies between pending certified transactions and objects in their input. `TransactionManager` accepts certified transactions from various sources e.g. consensus output currently and checkpoint sync in future. It builds dependencies between objects and transactions, and publishes transactions that have all input available locally. The goal of the change is to avoid the inefficiency and instability in the existing execution logic, by guaranteeing availability of input objects before execution, and simplify execution logic.                      

### Transaction Manager

Here is a diagram for how `TransactionManager` communicates with other components.

![transaction_manager drawio](https://user-images.githubusercontent.com/81660174/200202495-b6ffb5c7-c085-43bc-867b-7326dbf5a879.svg)

Right now, `TransactionManager` is only activated in validators. The next step is to use `TransactionManager` in fullnode as well.

### Shared locks

Since `TransactionManager` requires input objects' versions, shared objects in a certificate must be locked before sending to `TransactionManager`. Currently, `SharedObjectLockNotSetError` is often observed in logs, so this is not yet guaranteed. Enforcing this invariant involves a few changes:
1. Drop the logic to remove shared object locks after a transaction commits. I'm unable to convince myself the existing logic of removing shared locks are correct. And even with 2 and 3 below, I still observed `SharedObjectLockNotSetError` in tests. Later after dust settles down with the new `TransactionManager`, we can implement the logic to clear shared locks table at epoch boundaries.
2. In `handle_consensus_transaction()`, take shared locks and add certificates to the `pending_certificates` table in one batch write, then send the certificate to `TransactionManager`. Otherwise if a certificate is added to the pending queue or TransactionManager first, it can get executed immediately, without taking the shared locks.
3. Certificates were sent to the pending queue (`add_pending_certificates()`) quite liberally before. Most of these corner cases are removed to avoid sending a certificate containing shared objects to `TransactionManager`, if no shared locks are taken for the certificate.

### Execution Driver and Node Sync

The new execution driver runs `AuthorityState::handle_certificate()` to process certificates directly, instead of sending digests to node sync. The driver shares similarities with the execution logic in node sync. Eventually we may want to merge the two. But right now, keeping the validator execution logic simple seems to be more beneficial.

There is no longer a retry path for certificates missing parents, since it is no longer possible. We will rely on other mechanisms (e.g. Narwhal) to catch up on missing certificates.

#4990 #5514 