### PR TITLE
wallet-ext: store the entropy to disk instead of  mnemonic

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -92,6 +92,7 @@
         "@mysten/core": "workspace:*",
         "@mysten/sui.js": "workspace:*",
         "@mysten/wallet-standard": "workspace:*",
+        "@noble/hashes": "^1.1.2",
         "@reduxjs/toolkit": "^1.8.3",
         "@scure/bip32": "^1.1.0",
         "@scure/bip39": "^1.1.0",

--- a/apps/wallet/src/background/connections/KeepAliveConnection.ts
+++ b/apps/wallet/src/background/connections/KeepAliveConnection.ts
@@ -3,7 +3,7 @@
 
 import { BehaviorSubject, filter, map, take } from 'rxjs';
 
-import Keyring from '_src/background/Keyring';
+import Keyring from '_src/background/keyring';
 import { MSG_DISABLE_AUTO_RECONNECT } from '_src/content-script/keep-bg-alive';
 
 import type { Runtime } from 'webextension-polyfill';

--- a/apps/wallet/src/background/connections/UiConnection.ts
+++ b/apps/wallet/src/background/connections/UiConnection.ts
@@ -13,10 +13,11 @@ import {
 import { isDisconnectApp } from '_payloads/permissions/DisconnectApp';
 import { isGetTransactionRequests } from '_payloads/transactions/ui/GetTransactionRequests';
 import { isTransactionRequestResponse } from '_payloads/transactions/ui/TransactionRequestResponse';
-import Keyring from '_src/background/Keyring';
 import Permissions from '_src/background/Permissions';
 import Tabs from '_src/background/Tabs';
 import Transactions from '_src/background/Transactions';
+import Keyring from '_src/background/keyring';
+import { entropyToSerialized } from '_src/shared/utils/bip39';
 
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
@@ -59,7 +60,9 @@ export class UiConnection extends Connection {
                 method: 'walletStatusUpdate',
                 return: {
                     isLocked,
-                    mnemonic: Keyring.mnemonic() || undefined,
+                    entropy: Keyring.entropy
+                        ? entropyToSerialized(Keyring.entropy)
+                        : undefined,
                     isInitialized: await Keyring.isWalletInitialized(),
                 },
             })

--- a/apps/wallet/src/background/index.ts
+++ b/apps/wallet/src/background/index.ts
@@ -5,9 +5,9 @@ import { lte } from 'semver';
 import Browser from 'webextension-polyfill';
 
 import { LOCK_ALARM_NAME } from './Alarms';
-import Keyring from './Keyring';
 import Permissions from './Permissions';
 import { Connections } from './connections';
+import Keyring from './keyring';
 import { openInNewTab } from '_shared/utils';
 import { MSG_CONNECT } from '_src/content-script/keep-bg-alive';
 

--- a/apps/wallet/src/background/keyring/Vault.ts
+++ b/apps/wallet/src/background/keyring/Vault.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { encrypt, decrypt } from '_shared/cryptography/keystore';
+import {
+    entropyToMnemonic,
+    entropyToSerialized,
+    mnemonicToEntropy,
+    toEntropy,
+    validateEntropy,
+} from '_shared/utils/bip39';
+
+export const LATEST_VAULT_VERSION = 1;
+
+export type StoredData = string | { v: number; data: string };
+
+/**
+ * Holds the mnemonic of the wallet and provides functionality to create/encrypt/decrypt it.
+ */
+export class Vault {
+    public readonly entropy: Uint8Array;
+
+    public static async from(
+        password: string,
+        data: StoredData,
+        onMigrateCallback?: (vault: Vault) => Promise<void>
+    ) {
+        let entropy: Uint8Array | null = null;
+        let doMigrate = false;
+        if (typeof data === 'string') {
+            entropy = mnemonicToEntropy(
+                Buffer.from(await decrypt<string>(password, data)).toString(
+                    'utf-8'
+                )
+            );
+            doMigrate = true;
+        } else if (data.v === 1) {
+            entropy = toEntropy(await decrypt<string>(password, data.data));
+        } else {
+            throw new Error(
+                "Unknown data, provided data can't be used to create a Vault"
+            );
+        }
+        if (!validateEntropy(entropy)) {
+            throw new Error("Can't restore Vault, entropy is invalid.");
+        }
+        const vault = new Vault(entropy);
+        if (doMigrate && typeof onMigrateCallback === 'function') {
+            await onMigrateCallback(vault);
+        }
+        return vault;
+    }
+
+    constructor(entropy: Uint8Array) {
+        this.entropy = entropy;
+    }
+
+    public async encrypt(password: string) {
+        return {
+            v: LATEST_VAULT_VERSION,
+            data: await encrypt(password, entropyToSerialized(this.entropy)),
+        };
+    }
+
+    public getMnemonic() {
+        return entropyToMnemonic(this.entropy);
+    }
+}

--- a/apps/wallet/src/shared/cryptography/keystore.test.ts
+++ b/apps/wallet/src/shared/cryptography/keystore.test.ts
@@ -9,21 +9,15 @@ describe('keystore', () => {
     it('encrypt and decrypt success', async () => {
         const password = 'password';
         const plaintext = JSON.stringify('hello world');
-        const ciphertext = await encrypt(
-            password,
-            Buffer.from(plaintext, 'utf8')
-        );
-        const result = await decrypt(password, ciphertext);
-        expect(Buffer.from(result).toString('utf8')).toEqual(plaintext);
+        const ciphertext = await encrypt(password, plaintext);
+        const result = await decrypt<string>(password, ciphertext);
+        expect(result).toBe(plaintext);
     });
 
     it('encrypt and decrypt failed with wrong password', async () => {
         const password = 'password';
         const plaintext = JSON.stringify('hello world');
-        const ciphertext = await encrypt(
-            password,
-            Buffer.from(plaintext, 'utf8')
-        );
+        const ciphertext = await encrypt(password, plaintext);
         await expect(decrypt('random', ciphertext)).rejects.toThrow(
             'Incorrect password'
         );

--- a/apps/wallet/src/shared/cryptography/keystore.ts
+++ b/apps/wallet/src/shared/cryptography/keystore.ts
@@ -2,16 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import passworder from '@metamask/browser-passworder';
+
+type Serializable =
+    | string
+    | number
+    | boolean
+    | { [index: string]: Serializable };
+
 export async function encrypt(
     password: string,
-    secrets: Buffer
+    secrets: Serializable
 ): Promise<string> {
     return passworder.encrypt(password, secrets);
 }
 
-export async function decrypt(
+export async function decrypt<T extends Serializable>(
     password: string,
     ciphertext: string
-): Promise<Buffer> {
-    return passworder.decrypt(password, ciphertext);
+): Promise<T> {
+    return await passworder.decrypt(password, ciphertext);
 }

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -6,11 +6,11 @@ import { isBasePayload } from '_payloads';
 import type { BasePayload, Payload } from '_payloads';
 
 type MethodToPayloads = {
-    createMnemonic: {
-        args: { password: string; importedMnemonic?: string };
-        return: { mnemonic: string };
+    create: {
+        args: { password: string; importedEntropy?: string };
+        return: { entropy: string };
     };
-    getMnemonic: {
+    getEntropy: {
         args: string | undefined;
         return: string;
     };
@@ -23,7 +23,7 @@ type MethodToPayloads = {
         return: Partial<{
             isLocked: boolean;
             isInitialized: boolean;
-            mnemonic: string;
+            entropy: string;
         }>;
     };
     lock: {

--- a/apps/wallet/src/shared/utils/bip39.ts
+++ b/apps/wallet/src/shared/utils/bip39.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import {
-    generateMnemonic as bip39GenerateMnemonic,
-    validateMnemonic as bip39ValidateMnemonic,
-} from '@scure/bip39';
+import { bytesToHex, hexToBytes, randomBytes } from '@noble/hashes/utils';
+import * as bip39 from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
 /**
@@ -12,7 +10,49 @@ import { wordlist } from '@scure/bip39/wordlists/english';
  * @returns a 12 words string separated by spaces.
  */
 export function generateMnemonic(): string {
-    return bip39GenerateMnemonic(wordlist);
+    return bip39.generateMnemonic(wordlist);
+}
+
+/**
+ * Converts mnemonic to entropy (byte array) using the english wordlist.
+ *
+ * @param mnemonic 12-24 words
+ *
+ * @return the entropy of the mnemonic (Uint8Array)
+ */
+export function mnemonicToEntropy(mnemonic: string): Uint8Array {
+    return bip39.mnemonicToEntropy(mnemonic, wordlist);
+}
+
+/**
+ * Converts entropy (byte array) to mnemonic using the english wordlist.
+ *
+ * @param entropy Uint8Array
+ *
+ * @return the mnemonic as string
+ */
+export function entropyToMnemonic(entropy: Uint8Array): string {
+    return bip39.entropyToMnemonic(entropy, wordlist);
+}
+
+/**
+ * Generate random byte to be used as entropy for the mnemonic
+ * @param strength defaults to 128 to generate 12-word mnemonic that now is the default for the wallet
+ * @returns
+ */
+export function getRandomEntropy(strength: 128 | 256 = 128) {
+    return randomBytes(strength / 8);
+}
+
+/**
+ * Validates entropy see https://github.com/paulmillr/scure-bip39/blob/4b4a17f13862da0b7ff3db1ef9d1bb3c2fc05e14/src/index.ts#L27
+ * @param entropy
+ * @returns {boolean} true
+ * @throws if entropy is invalid
+ */
+export function validateEntropy(entropy: Uint8Array) {
+    assertBytes(entropy, 16, 20, 24, 28, 32);
+    return true;
 }
 
 /**
@@ -23,7 +63,7 @@ export function generateMnemonic(): string {
  * @returns true if the mnemonic is valid, false otherwise.
  */
 export function validateMnemonics(mnemonics: string): boolean {
-    return bip39ValidateMnemonic(mnemonics, wordlist);
+    return bip39.validateMnemonic(mnemonics, wordlist);
 }
 
 /**
@@ -40,4 +80,31 @@ export function normalizeMnemonics(mnemonics: string): string {
         .split(/\s+/)
         .map((part) => part.toLowerCase())
         .join(' ');
+}
+
+/**
+ * Serializes entropy
+ * @param entropy
+ * @returns {string} the serialized value
+ */
+export function entropyToSerialized(entropy: Uint8Array) {
+    return bytesToHex(entropy);
+}
+
+/**
+ *
+ * @param serializedEntropy the serialized value of entropy (produced by {@link entropyToSerialized})
+ * @returns the entropy bytes
+ */
+export function toEntropy(serializedEntropy: string) {
+    return hexToBytes(serializedEntropy);
+}
+
+// ported from https://github.com/paulmillr/noble-hashes/blob/main/src/_assert.ts#L9
+export function assertBytes(b: Uint8Array | undefined, ...lengths: number[]) {
+    if (!(b instanceof Uint8Array)) throw new TypeError('Expected Uint8Array');
+    if (lengths.length > 0 && !lengths.includes(b.length))
+        throw new TypeError(
+            `Expected Uint8Array of length ${lengths}, not of length=${b.length}`
+        );
 }

--- a/apps/wallet/src/ui/app/KeypairVault.ts
+++ b/apps/wallet/src/ui/app/KeypairVault.ts
@@ -3,13 +3,17 @@
 
 import { Ed25519Keypair } from '@mysten/sui.js';
 
+import { toEntropy, entropyToMnemonic } from '_shared/utils/bip39';
+
 import type { Keypair } from '@mysten/sui.js';
 
 export default class KeypairVault {
     private _keypair: Keypair | null = null;
 
-    public set mnemonic(mnemonic: string) {
-        this._keypair = Ed25519Keypair.deriveKeypair(mnemonic);
+    public set entropy(entropy: string) {
+        this._keypair = Ed25519Keypair.deriveKeypair(
+            entropyToMnemonic(toEntropy(entropy))
+        );
     }
 
     public getAccount(): string | null {

--- a/apps/wallet/src/ui/app/background-client/index.ts
+++ b/apps/wallet/src/ui/app/background-client/index.ts
@@ -115,13 +115,13 @@ export class BackgroundClient {
         );
     }
 
-    public async createMnemonic(password: string, importedMnemonic?: string) {
+    public async createVault(password: string, importedEntropy?: string) {
         return await lastValueFrom(
             this.sendMessage(
-                createMessage<KeyringPayload<'createMnemonic'>>({
+                createMessage<KeyringPayload<'create'>>({
                     type: 'keyring',
-                    method: 'createMnemonic',
-                    args: { password, importedMnemonic },
+                    method: 'create',
+                    args: { password, importedEntropy },
                     return: undefined,
                 })
             ).pipe(take(1))
@@ -163,12 +163,12 @@ export class BackgroundClient {
         );
     }
 
-    public async getMnemonic(password?: string) {
+    public async getEntropy(password?: string) {
         return await lastValueFrom(
             this.sendMessage(
-                createMessage<KeyringPayload<'getMnemonic'>>({
+                createMessage<KeyringPayload<'getEntropy'>>({
                     type: 'keyring',
-                    method: 'getMnemonic',
+                    method: 'getEntropy',
                     args: password,
                     return: undefined,
                 })
@@ -176,10 +176,7 @@ export class BackgroundClient {
                 take(1),
                 map(({ payload }) => {
                     if (
-                        isKeyringPayload<'getMnemonic'>(
-                            payload,
-                            'getMnemonic'
-                        ) &&
+                        isKeyringPayload(payload, 'getEntropy') &&
                         payload.return
                     ) {
                         return payload.return;

--- a/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/backup/index.tsx
@@ -12,7 +12,8 @@ import CopyToClipboard from '_components/copy-to-clipboard';
 import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppDispatch } from '_hooks';
-import { loadMnemonicFromKeyring } from '_redux/slices/account';
+import { loadEntropyFromKeyring } from '_redux/slices/account';
+import { entropyToMnemonic, toEntropy } from '_shared/utils/bip39';
 
 import st from './Backup.module.scss';
 
@@ -35,7 +36,11 @@ const BackupPage = ({ mode = 'created' }: BackupPageProps) => {
             setLoading(true);
             try {
                 setLocalMnemonic(
-                    await dispatch(loadMnemonicFromKeyring({})).unwrap()
+                    entropyToMnemonic(
+                        toEntropy(
+                            await dispatch(loadEntropyFromKeyring({})).unwrap()
+                        )
+                    )
                 );
             } catch (e) {
                 setError(

--- a/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/create/index.tsx
@@ -12,7 +12,7 @@ import Icon, { SuiIcons } from '_components/icon';
 import Loading from '_components/loading';
 import { useAppDispatch } from '_hooks';
 import PasswordFields from '_pages/initialize/shared/password-fields';
-import { createMnemonic } from '_redux/slices/account';
+import { createVault } from '_redux/slices/account';
 import { PRIVACY_POLICY_LINK, ToS_LINK } from '_shared/constants';
 
 import st from './Create.module.scss';
@@ -36,7 +36,7 @@ const CreatePage = () => {
                 onSubmit={async (values) => {
                     try {
                         await dispatch(
-                            createMnemonic({ password: values.password })
+                            createVault({ password: values.password })
                         ).unwrap();
                         navigate('../backup');
                     } catch (e) {

--- a/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
+++ b/apps/wallet/src/ui/app/pages/initialize/import/index.tsx
@@ -8,8 +8,9 @@ import StepOne from './steps/StepOne';
 import StepTwo from './steps/StepTwo';
 import CardLayout from '_app/shared/card-layout';
 import { useAppDispatch } from '_hooks';
-import { createMnemonic, logout } from '_redux/slices/account';
-import { MAIN_UI_URL } from '_src/shared/utils';
+import { createVault, logout } from '_redux/slices/account';
+import { MAIN_UI_URL } from '_shared/utils';
+import { entropyToSerialized, mnemonicToEntropy } from '_shared/utils/bip39';
 
 const initialValues = {
     mnemonic: '',
@@ -36,7 +37,12 @@ const ImportPage = ({ mode = 'import' }: ImportPageProps) => {
                     await dispatch(logout());
                 }
                 await dispatch(
-                    createMnemonic({ importedMnemonic: mnemonic, password })
+                    createVault({
+                        importedEntropy: entropyToSerialized(
+                            mnemonicToEntropy(mnemonic)
+                        ),
+                        password,
+                    })
                 ).unwrap();
                 if (mode === 'import') {
                     navigate('../backup-imported');

--- a/apps/wallet/src/ui/app/redux/slices/account/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/account/index.ts
@@ -18,39 +18,39 @@ import type { KeyringPayload } from '_payloads/keyring';
 import type { RootState } from '_redux/RootReducer';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
-export const createMnemonic = createAsyncThunk<
+export const createVault = createAsyncThunk<
     string,
     {
-        importedMnemonic?: string;
+        importedEntropy?: string;
         password: string;
     },
     AppThunkConfig
 >(
-    'account/createMnemonic',
-    async ({ importedMnemonic, password }, { extra: { background } }) => {
-        const { payload } = await background.createMnemonic(
+    'account/createVault',
+    async ({ importedEntropy, password }, { extra: { background } }) => {
+        const { payload } = await background.createVault(
             password,
-            importedMnemonic
+            importedEntropy
         );
         await background.unlockWallet(password);
-        if (!isKeyringPayload<'createMnemonic'>(payload, 'createMnemonic')) {
+        if (!isKeyringPayload(payload, 'create')) {
             throw new Error('Unknown payload');
         }
-        if (!payload.return?.mnemonic) {
-            throw new Error('Empty mnemonic in payload');
+        if (!payload.return?.entropy) {
+            throw new Error('Empty entropy in payload');
         }
-        return payload.return.mnemonic;
+        return payload.return.entropy;
     }
 );
 
-export const loadMnemonicFromKeyring = createAsyncThunk<
+export const loadEntropyFromKeyring = createAsyncThunk<
     string,
     { password?: string }, // can be undefined when we know Keyring is unlocked
     AppThunkConfig
 >(
-    'account/loadMnemonicFromKeyring',
+    'account/loadEntropyFromKeyring',
     async ({ password }, { extra: { background } }) =>
-        await background.getMnemonic(password)
+        await background.getEntropy(password)
 );
 
 export const logout = createAsyncThunk<void, void, AppThunkConfig>(
@@ -98,14 +98,14 @@ const accountSlice = createSlice({
     },
     extraReducers: (builder) =>
         builder
-            .addCase(createMnemonic.pending, (state) => {
+            .addCase(createVault.pending, (state) => {
                 state.creating = true;
             })
-            .addCase(createMnemonic.fulfilled, (state, action) => {
+            .addCase(createVault.fulfilled, (state) => {
                 state.creating = false;
                 state.isInitialized = true;
             })
-            .addCase(createMnemonic.rejected, (state) => {
+            .addCase(createVault.rejected, (state) => {
                 state.creating = false;
             }),
 });

--- a/apps/wallet/src/ui/app/redux/store/middlewares/KeypairVaultMiddleware.ts
+++ b/apps/wallet/src/ui/app/redux/store/middlewares/KeypairVaultMiddleware.ts
@@ -4,9 +4,9 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
 import {
-    loadMnemonicFromKeyring,
+    loadEntropyFromKeyring,
     setAddress,
-    createMnemonic,
+    createVault,
     setKeyringStatus,
 } from '_redux/slices/account';
 import { thunkExtras } from '_store/thunk-extras';
@@ -14,9 +14,9 @@ import { thunkExtras } from '_store/thunk-extras';
 import type { Middleware } from '@reduxjs/toolkit';
 
 const keypairVault = thunkExtras.keypairVault;
-const matchUpdateMnemonic = isAnyOf(
-    loadMnemonicFromKeyring.fulfilled,
-    createMnemonic.fulfilled,
+const matchUpdateKeypairVault = isAnyOf(
+    loadEntropyFromKeyring.fulfilled,
+    createVault.fulfilled,
     setKeyringStatus
 );
 
@@ -24,18 +24,18 @@ export const KeypairVaultMiddleware: Middleware =
     ({ dispatch }) =>
     (next) =>
     (action) => {
-        if (matchUpdateMnemonic(action)) {
-            let mnemonic;
+        if (matchUpdateKeypairVault(action)) {
+            let entropy;
             if (typeof action.payload === 'string') {
-                mnemonic = action.payload;
+                entropy = action.payload;
             } else {
-                mnemonic = action.payload?.mnemonic;
+                entropy = action.payload?.entropy;
             }
-            if (mnemonic) {
-                keypairVault.mnemonic = mnemonic;
+            if (entropy) {
+                keypairVault.entropy = entropy;
                 dispatch(setAddress(keypairVault.getAccount()));
             }
-            mnemonic = null;
+            entropy = null;
         }
         return next(action);
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,7 @@ importers:
       '@mysten/core': workspace:*
       '@mysten/sui.js': workspace:*
       '@mysten/wallet-standard': workspace:*
+      '@noble/hashes': ^1.1.2
       '@reduxjs/toolkit': ^1.8.3
       '@scure/bip32': ^1.1.0
       '@scure/bip39': ^1.1.0
@@ -259,6 +260,7 @@ importers:
       '@mysten/core': link:../core
       '@mysten/sui.js': link:../../sdk/typescript
       '@mysten/wallet-standard': link:../../sdk/wallet-adapter/packages/wallet-standard
+      '@noble/hashes': 1.1.2
       '@reduxjs/toolkit': 1.8.5_kkwg4cbsojnjnupd3btipussee
       '@scure/bip32': 1.1.0
       '@scure/bip39': 1.1.0
@@ -15369,6 +15371,17 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
+  /postcss-import/14.1.0:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
+
   /postcss-import/14.1.0_postcss@8.4.16:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
     engines: {node: '>=10.0.0'}
@@ -15386,6 +15399,15 @@ packages:
       postcss: ^8.0.0
     dependencies:
       postcss: 8.4.16
+    dev: true
+
+  /postcss-js/4.0.0:
+    resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
     dev: true
 
   /postcss-js/4.0.0_postcss@8.4.16:
@@ -15551,6 +15573,15 @@ packages:
     dependencies:
       icss-utils: 5.1.0_postcss@8.4.16
       postcss: 8.4.16
+    dev: true
+
+  /postcss-nested/5.0.6:
+    resolution: {integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss-selector-parser: 6.0.10
     dev: true
 
   /postcss-nested/5.0.6_postcss@8.4.16:
@@ -18232,6 +18263,8 @@ packages:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -18247,10 +18280,10 @@ packages:
       object-hash: 3.0.0
       picocolors: 1.0.0
       postcss: 8.4.16
-      postcss-import: 14.1.0_postcss@8.4.16
-      postcss-js: 4.0.0_postcss@8.4.16
-      postcss-load-config: 3.1.4_postcss@8.4.16
-      postcss-nested: 5.0.6_postcss@8.4.16
+      postcss-import: 14.1.0
+      postcss-js: 4.0.0
+      postcss-load-config: 3.1.4
+      postcss-nested: 5.0.6
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1


### PR DESCRIPTION
* bip39 utils to help working with entropy
* change encrypt/decrypt functions to accept serializable data
  * passworder uses JSON.stringify() to convert the secret to text
  * to avoid serializing the Buffer as json allow only Serializable data for encrypt/decrypt
* keep entropy in memory instead of mnemonic (when unlocked)
  * avoid having the plain mnemonic in memory where possible
  * use entropy to serialized to hex for messages between ui and bg

closes APPS-104