### PR TITLE
[checkpoints] Maintain reverse index consensus_position=>transaction

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1129,6 +1129,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             .contains_key(digest)?)
     }
 
+    /// Caller is responsible to call consensus_message_processed before this method
     pub async fn record_owned_object_cert_from_consensus(
         &self,
         certificate: &VerifiedCertificate,
@@ -1234,19 +1235,26 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     /// Tables updated:
     ///  * consensus_message_processed - indicate that this certificate was processed by consensus
     ///  * last_consensus_index - records last processed position in consensus stream
+    ///  * consensus_message_order - records at what position this transaction was first seen in consensus
     /// Self::consensus_message_processed returns true after this call for given certificate
     fn finish_consensus_message_process(
         &self,
-        mut batch: DBBatch,
+        batch: DBBatch,
         certificate: &VerifiedCertificate,
         consensus_index: ExecutionIndicesWithHash,
     ) -> SuiResult {
         let transaction_digest = *certificate.digest();
-        let index_to_write = iter::once((LAST_CONSENSUS_INDEX_ADDR, consensus_index));
-        batch = batch.insert_batch(&self.epoch_tables().last_consensus_index, index_to_write)?;
-        batch = batch.insert_batch(
+        let batch = batch.insert_batch(
+            &self.epoch_tables().consensus_message_order,
+            [(consensus_index.index.clone(), transaction_digest)],
+        )?;
+        let batch = batch.insert_batch(
+            &self.epoch_tables().last_consensus_index,
+            [(LAST_CONSENSUS_INDEX_ADDR, consensus_index)],
+        )?;
+        let batch = batch.insert_batch(
             &self.epoch_tables().consensus_message_processed,
-            iter::once((transaction_digest, true)),
+            [(transaction_digest, true)],
         )?;
         Ok(batch.write()?)
     }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -51,6 +51,13 @@ pub struct AuthorityEpochTables<S> {
     /// epoch change.
     pub(crate) consensus_message_processed: DBMap<TransactionDigest, bool>,
 
+    /// This is an inverse index for consensus_message_processed - it allows to select
+    /// all transactions at the specific consensus range
+    ///
+    /// The consensus position for the transaction is defined as first position at which valid
+    /// certificate for this transaction is seen in consensus
+    pub(crate) consensus_message_order: DBMap<ExecutionIndices, TransactionDigest>,
+
     /// The following table is used to store a single value (the corresponding key is a constant). The value
     /// represents the index of the latest consensus message this authority processed. This field is written
     /// by a single process acting as consensus (light) client. It is used to ensure the authority processes

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -915,7 +915,7 @@ async fn checkpoint_integration() {
 
 // Now check the connection between state / bacth and checkpoint mechanism
 
-#[sim_test]
+#[tokio::test]
 async fn test_batch_to_checkpointing() {
     // Create an authority
     // Make a test key pair


### PR DESCRIPTION
New `consensus_message_order` table is added that records the (first seen) consensus index for each transaction.

In combination with https://github.com/MystenLabs/sui/pull/5773 we will be able to query all the transactions in the range that are going to be basis for forming checkpoint(still need to add casual dependencies and sort them in a separate process).

https://github.com/MystenLabs/sui/issues/5763