### PR TITLE
[explorer] Add useRpc hook

### DIFF
--- a/apps/explorer/src/components/module/ModuleView.tsx
+++ b/apps/explorer/src/components/module/ModuleView.tsx
@@ -4,18 +4,17 @@ import { useQuery } from '@tanstack/react-query';
 import cl from 'clsx';
 import Highlight, { defaultProps, Prism } from 'prism-react-renderer';
 import 'prism-themes/themes/prism-one-light.css';
-import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 
-import { NetworkContext } from '../../context';
 import codestyle from '../../styles/bytecode.module.css';
-import { DefaultRpcClient as rpc } from '../../utils/api/DefaultRpcClient';
 import { normalizeSuiAddress } from '../../utils/stringUtils';
 
 import type { SuiMoveNormalizedType } from '@mysten/sui.js';
 import type { Language } from 'prism-react-renderer';
 
 import styles from './ModuleView.module.css';
+
+import { useRpc } from '~/hooks/useRpc';
 
 // Include Rust language support.
 // TODO: Write a custom prismjs syntax for Move Bytecode.
@@ -59,11 +58,12 @@ function unwrapTypeReference(
 }
 
 function ModuleView({ id, name, code }: Props) {
-    const [network] = useContext(NetworkContext);
+    const rpc = useRpc();
+
     const { data: normalizedModuleReferences } = useQuery(
         ['normalized-module', id, name],
         async () => {
-            const normalizedModule = await rpc(network).getNormalizedMoveModule(
+            const normalizedModule = await rpc.getNormalizedMoveModule(
                 id!,
                 name
             );

--- a/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
+++ b/apps/explorer/src/components/top-validators-card/TopValidatorsCard.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Longtext from '../../components/longtext/Longtext';
-import { NetworkContext } from '../../context';
 import {
     getValidatorState,
     processValidators,
@@ -14,6 +13,7 @@ import {
 import { mockState } from '../../pages/validators/mockData';
 import { truncate } from '../../utils/stringUtils';
 
+import { useRpc } from '~/hooks/useRpc';
 import { PlaceholderTable } from '~/ui/PlaceholderTable';
 import { TableCard } from '~/ui/TableCard';
 import { TabGroup, TabList, Tab, TabPanels, TabPanel } from '~/ui/Tabs';
@@ -55,9 +55,9 @@ export function TopValidatorsCardStatic() {
 export function TopValidatorsCardAPI() {
     const [showObjectState, setObjectState] = useState(STATE_DEFAULT);
     const [loadState, setLoadState] = useState('pending');
-    const [network] = useContext(NetworkContext);
+    const rpc = useRpc();
     useEffect(() => {
-        getValidatorState(network)
+        getValidatorState(rpc)
             .then((objState: ValidatorState) => {
                 setObjectState(objState);
                 setLoadState('loaded');
@@ -66,7 +66,7 @@ export function TopValidatorsCardAPI() {
                 console.log(error);
                 setLoadState('fail');
             });
-    }, [network]);
+    }, [rpc]);
 
     if (loadState === 'loaded') {
         return <TopValidatorsCard state={showObjectState as ValidatorState} />;

--- a/apps/explorer/src/hooks/useFormatCoin.ts
+++ b/apps/explorer/src/hooks/useFormatCoin.ts
@@ -4,10 +4,9 @@
 import { Coin } from '@mysten/sui.js';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
-import { useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import { NetworkContext } from '~/context';
-import { DefaultRpcClient as rpc } from '~/utils/api/DefaultRpcClient';
+import { useRpc } from './useRpc';
 
 type FormattedCoin = [
     formattedBalance: string,
@@ -56,7 +55,7 @@ export function formatBalance(
 }
 
 export function useCoinDecimals(coinType?: string | null) {
-    const [network] = useContext(NetworkContext);
+    const rpc = useRpc();
 
     const queryResult = useQuery(
         ['denomination', coinType],
@@ -67,7 +66,7 @@ export function useCoinDecimals(coinType?: string | null) {
                 );
             }
 
-            return rpc(network).getCoinDenominationInfo(coinType);
+            return rpc.getCoinDenominationInfo(coinType);
         },
         {
             // This is currently expected to fail for non-SUI tokens, so disable retries:

--- a/apps/explorer/src/hooks/useRpc.ts
+++ b/apps/explorer/src/hooks/useRpc.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useContext, useMemo } from 'react';
+
+import { NetworkContext } from '~/context';
+import { DefaultRpcClient as rpc } from '~/utils/api/DefaultRpcClient';
+
+// NOTE: This is intended to create a standard RPC interface to insulate consumers
+// from internal implementation changes. We will refactor the RPC client to use a different
+// approach at some point in the future, but this API should be constant through that.
+export function useRpc() {
+    const [network] = useContext(NetworkContext);
+    return useMemo(() => rpc(network), [network]);
+}

--- a/apps/explorer/src/pages/validators/Validators.tsx
+++ b/apps/explorer/src/pages/validators/Validators.tsx
@@ -3,24 +3,24 @@
 
 import {
     Base64DataBuffer,
-    type GetObjectDataResponse,
     isSuiMoveObject,
     isSuiObject,
+    type JsonRpcProvider,
+    type GetObjectDataResponse,
 } from '@mysten/sui.js';
-import { useState, useContext, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import ErrorResult from '../../components/error-result/ErrorResult';
 import Longtext from '../../components/longtext/Longtext';
 import TabFooter from '../../components/tabs/TabFooter';
 import { STATE_DEFAULT } from '../../components/top-validators-card/TopValidatorsCard';
-import { NetworkContext } from '../../context';
 import theme from '../../styles/theme.module.css';
-import { DefaultRpcClient as rpc } from '../../utils/api/DefaultRpcClient';
 import { IS_STATIC_ENV } from '../../utils/envUtil';
 import { truncate } from '../../utils/stringUtils';
 import { mockState } from './mockData';
 
+import { useRpc } from '~/hooks/useRpc';
 import { Heading } from '~/ui/Heading';
 import { TableCard } from '~/ui/TableCard';
 
@@ -106,8 +106,10 @@ function instanceOfValidatorState(object: any): object is ValidatorState {
 
 const VALIDATORS_OBJECT_ID = '0x05';
 
-export function getValidatorState(network: string): Promise<ValidatorState> {
-    return rpc(network)
+export function getValidatorState(
+    rpc: JsonRpcProvider
+): Promise<ValidatorState> {
+    return rpc
         .getObject(VALIDATORS_OBJECT_ID)
         .then((objState: GetObjectDataResponse) => {
             if (
@@ -236,9 +238,9 @@ export function ValidatorLoadFail() {
 export function ValidatorPageAPI() {
     const [showObjectState, setObjectState] = useState(STATE_DEFAULT);
     const [loadState, setLoadState] = useState('pending');
-    const [network] = useContext(NetworkContext);
+    const rpc = useRpc();
     useEffect(() => {
-        getValidatorState(network)
+        getValidatorState(rpc)
             .then((objState: ValidatorState) => {
                 setObjectState(objState);
                 setLoadState('loaded');
@@ -247,7 +249,7 @@ export function ValidatorPageAPI() {
                 console.error(error);
                 setLoadState('fail');
             });
-    }, [network]);
+    }, [rpc]);
 
     if (loadState === 'loaded') {
         return <ValidatorsPage state={showObjectState as ValidatorState} />;


### PR DESCRIPTION
This adds a new `useRpc` hook that takes some of the ceremony out of retrieving a JSON RPC Provider. I refactored the easy-to-do surface areas, and will tackle the rest later. I'm going to do a rework of most of the JSON RPC provider setup, and this should be able to fully insulate RPC users of the changes. It also better signals to users that they do not need to use `network` in their cache keys.