### PR TITLE
[RFC] Remove try/catch from TypeScript SDK

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -183,36 +183,24 @@ export class JsonRpcProvider extends Provider {
     moduleName: string,
     functionName: string
   ): Promise<SuiMoveFunctionArgTypes> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getMoveFunctionArgTypes',
-        [packageId, moduleName, functionName],
-        isSuiMoveFunctionArgTypes,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching Move function arg types with package object ID: ${packageId}, module name: ${moduleName}, function name: ${functionName}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getMoveFunctionArgTypes',
+      [packageId, moduleName, functionName],
+      isSuiMoveFunctionArgTypes,
+      this.options.skipDataValidation
+    );
   }
 
   async getNormalizedMoveModulesByPackage(
     packageId: string
   ): Promise<SuiMoveNormalizedModules> {
     // TODO: Add caching since package object does not change
-    try {
-      return await this.client.requestWithType(
-        'sui_getNormalizedMoveModulesByPackage',
-        [packageId],
-        isSuiMoveNormalizedModules,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching package: ${err} for package ${packageId}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getNormalizedMoveModulesByPackage',
+      [packageId],
+      isSuiMoveNormalizedModules,
+      this.options.skipDataValidation
+    );
   }
 
   async getNormalizedMoveModule(
@@ -220,18 +208,12 @@ export class JsonRpcProvider extends Provider {
     moduleName: string
   ): Promise<SuiMoveNormalizedModule> {
     // TODO: Add caching since package object does not change
-    try {
-      return await this.client.requestWithType(
-        'sui_getNormalizedMoveModule',
-        [packageId, moduleName],
-        isSuiMoveNormalizedModule,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching module: ${err} for package ${packageId}, module ${moduleName}}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getNormalizedMoveModule',
+      [packageId, moduleName],
+      isSuiMoveNormalizedModule,
+      this.options.skipDataValidation
+    );
   }
 
   async getNormalizedMoveFunction(
@@ -240,18 +222,12 @@ export class JsonRpcProvider extends Provider {
     functionName: string
   ): Promise<SuiMoveNormalizedFunction> {
     // TODO: Add caching since package object does not change
-    try {
-      return await this.client.requestWithType(
-        'sui_getNormalizedMoveFunction',
-        [packageId, moduleName, functionName],
-        isSuiMoveNormalizedFunction,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching function: ${err} for package ${packageId}, module ${moduleName} and function ${functionName}}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getNormalizedMoveFunction',
+      [packageId, moduleName, functionName],
+      isSuiMoveNormalizedFunction,
+      this.options.skipDataValidation
+    );
   }
 
   async getNormalizedMoveStruct(
@@ -259,34 +235,22 @@ export class JsonRpcProvider extends Provider {
     moduleName: string,
     structName: string
   ): Promise<SuiMoveNormalizedStruct> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getNormalizedMoveStruct',
-        [packageId, moduleName, structName],
-        isSuiMoveNormalizedStruct,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching struct: ${err} for package ${packageId}, module ${moduleName} and struct ${structName}}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getNormalizedMoveStruct',
+      [packageId, moduleName, structName],
+      isSuiMoveNormalizedStruct,
+      this.options.skipDataValidation
+    );
   }
 
   // Objects
   async getObjectsOwnedByAddress(address: string): Promise<SuiObjectInfo[]> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getObjectsOwnedByAddress',
-        [address],
-        isGetOwnedObjectsResponse,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching owned object: ${err} for address ${address}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getObjectsOwnedByAddress',
+      [address],
+      isGetOwnedObjectsResponse,
+      this.options.skipDataValidation
+    );
   }
 
   async getGasObjectsOwnedByAddress(address: string): Promise<SuiObjectInfo[]> {
@@ -298,7 +262,7 @@ export class JsonRpcProvider extends Provider {
     const [packageId, module, symbol] = coinType.split('::');
     if (
       normalizeSuiAddress(packageId) !== normalizeSuiAddress('0x2') ||
-      module != 'sui' ||
+      module !== 'sui' ||
       symbol !== 'SUI'
     ) {
       throw new Error(
@@ -358,31 +322,21 @@ export class JsonRpcProvider extends Provider {
   }
 
   async getObjectsOwnedByObject(objectId: string): Promise<SuiObjectInfo[]> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getObjectsOwnedByObject',
-        [objectId],
-        isGetOwnedObjectsResponse,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching owned object: ${err} for objectId ${objectId}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getObjectsOwnedByObject',
+      [objectId],
+      isGetOwnedObjectsResponse,
+      this.options.skipDataValidation
+    );
   }
 
   async getObject(objectId: string): Promise<GetObjectDataResponse> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getObject',
-        [objectId],
-        isGetObjectDataResponse,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(`Error fetching object info: ${err} for id ${objectId}`);
-    }
+    return await this.client.requestWithType(
+      'sui_getObject',
+      [objectId],
+      isGetObjectDataResponse,
+      this.options.skipDataValidation
+    );
   }
 
   async getObjectRef(objectId: string): Promise<SuiObjectRef | undefined> {
@@ -395,15 +349,12 @@ export class JsonRpcProvider extends Provider {
       method: 'sui_getObject',
       args: [id],
     }));
-    try {
-      return await this.client.batchRequestWithType(
-        requests,
-        isGetObjectDataResponse,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(`Error fetching object info: ${err} for id ${objectIds}`);
-    }
+
+    return await this.client.batchRequestWithType(
+      requests,
+      isGetObjectDataResponse,
+      this.options.skipDataValidation
+    );
   }
 
   // Transactions
@@ -413,18 +364,12 @@ export class JsonRpcProvider extends Provider {
     limit: number | null = null,
     order: Ordering = 'Descending'
   ): Promise<PaginatedTransactionDigests> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getTransactions',
-        [query, cursor, limit, order],
-        isPaginatedTransactionDigests,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting transactions for query: ${err} for query ${query}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getTransactions',
+      [query, cursor, limit, order],
+      isPaginatedTransactionDigests,
+      this.options.skipDataValidation
+    );
   }
 
   async getTransactionsForObject(
@@ -442,18 +387,12 @@ export class JsonRpcProvider extends Provider {
       },
     ];
 
-    try {
-      const results = await this.client.batchRequestWithType(
-        requests,
-        isPaginatedTransactionDigests,
-        this.options.skipDataValidation
-      );
-      return [...results[0].data, ...results[1].data];
-    } catch (err) {
-      throw new Error(
-        `Error getting transactions for object: ${err} for id ${objectID}`
-      );
-    }
+    const results = await this.client.batchRequestWithType(
+      requests,
+      isPaginatedTransactionDigests,
+      this.options.skipDataValidation
+    );
+    return [...results[0].data, ...results[1].data];
   }
 
   async getTransactionsForAddress(
@@ -470,36 +409,25 @@ export class JsonRpcProvider extends Provider {
         args: [{ FromAddress: addressID }, null, null, ordering],
       },
     ];
-    try {
-      const results = await this.client.batchRequestWithType(
-        requests,
-        isPaginatedTransactionDigests,
-        this.options.skipDataValidation
-      );
-      return [...results[0].data, ...results[1].data];
-    } catch (err) {
-      throw new Error(
-        `Error getting transactions for address: ${err} for id ${addressID}`
-      );
-    }
+
+    const results = await this.client.batchRequestWithType(
+      requests,
+      isPaginatedTransactionDigests,
+      this.options.skipDataValidation
+    );
+    return [...results[0].data, ...results[1].data];
   }
 
   async getTransactionWithEffects(
     digest: TransactionDigest
   ): Promise<SuiTransactionResponse> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getTransaction',
-        [digest],
-        isSuiTransactionResponse,
-        this.options.skipDataValidation
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(
-        `Error getting transaction with effects: ${err} for digest ${digest}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_getTransaction',
+      [digest],
+      isSuiTransactionResponse,
+      this.options.skipDataValidation
+    );
+    return resp;
   }
 
   async getTransactionWithEffectsBatch(
@@ -509,18 +437,11 @@ export class JsonRpcProvider extends Provider {
       method: 'sui_getTransaction',
       args: [d],
     }));
-    try {
-      return await this.client.batchRequestWithType(
-        requests,
-        isSuiTransactionResponse,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      const list = digests.join(', ').substring(0, -2);
-      throw new Error(
-        `Error getting transaction effects: ${err} for digests [${list}]`
-      );
-    }
+    return await this.client.batchRequestWithType(
+      requests,
+      isSuiTransactionResponse,
+      this.options.skipDataValidation
+    );
   }
 
   async executeTransactionWithRequestType(
@@ -530,49 +451,35 @@ export class JsonRpcProvider extends Provider {
     pubkey: string,
     requestType: ExecuteTransactionRequestType = 'WaitForEffectsCert'
   ): Promise<SuiExecuteTransactionResponse> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_executeTransaction',
-        [txnBytes, signatureScheme, signature, pubkey, requestType],
-        isSuiExecuteTransactionResponse,
-        this.options.skipDataValidation
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(`Error executing transaction with request type: ${err}}`);
-    }
+    const resp = await this.client.requestWithType(
+      'sui_executeTransaction',
+      [txnBytes, signatureScheme, signature, pubkey, requestType],
+      isSuiExecuteTransactionResponse,
+      this.options.skipDataValidation
+    );
+    return resp;
   }
 
   async getTotalTransactionNumber(): Promise<number> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_getTotalTransactionNumber',
-        [],
-        isNumber,
-        this.options.skipDataValidation
-      );
-      return resp;
-    } catch (err) {
-      throw new Error(`Error fetching total transaction number: ${err}`);
-    }
+    const resp = await this.client.requestWithType(
+      'sui_getTotalTransactionNumber',
+      [],
+      isNumber,
+      this.options.skipDataValidation
+    );
+    return resp;
   }
 
   async getTransactionDigestsInRange(
     start: GatewayTxSeqNumber,
     end: GatewayTxSeqNumber
   ): Promise<GetTxnDigestsResponse> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getTransactionsInRange',
-        [start, end],
-        isGetTxnDigestsResponse,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error fetching transaction digests in range: ${err} for range ${start}-${end}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getTransactionsInRange',
+      [start, end],
+      isGetTxnDigestsResponse,
+      this.options.skipDataValidation
+    );
   }
 
   // Events
@@ -581,39 +488,27 @@ export class JsonRpcProvider extends Provider {
     digest: TransactionDigest,
     count: number = EVENT_QUERY_MAX_LIMIT
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsByTransaction',
-        [digest, count],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by transaction: ${digest}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsByTransaction',
+      [digest, count],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async getEventsByModule(
-    package_: string,
+    packageId: string,
     module: string,
     count: number = EVENT_QUERY_MAX_LIMIT,
     startTime: number = DEFAULT_START_TIME,
     endTime: number = DEFAULT_END_TIME
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsByModule',
-        [package_, module, count, startTime, endTime],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by transaction module: ${package_}::${module}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsByModule',
+      [packageId, module, count, startTime, endTime],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async getEventsByMoveEventStructName(
@@ -622,18 +517,12 @@ export class JsonRpcProvider extends Provider {
     startTime: number = DEFAULT_START_TIME,
     endTime: number = DEFAULT_END_TIME
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsByMoveEventStructName',
-        [moveEventStructName, count, startTime, endTime],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by move event struct name: ${moveEventStructName}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsByMoveEventStructName',
+      [moveEventStructName, count, startTime, endTime],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async getEventsBySender(
@@ -642,18 +531,12 @@ export class JsonRpcProvider extends Provider {
     startTime: number = DEFAULT_START_TIME,
     endTime: number = DEFAULT_END_TIME
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsBySender',
-        [sender, count, startTime, endTime],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by sender: ${sender}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsBySender',
+      [sender, count, startTime, endTime],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async getEventsByRecipient(
@@ -662,18 +545,12 @@ export class JsonRpcProvider extends Provider {
     startTime: number = DEFAULT_START_TIME,
     endTime: number = DEFAULT_END_TIME
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsByRecipient',
-        [recipient, count, startTime, endTime],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by receipient: ${recipient}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsByRecipient',
+      [recipient, count, startTime, endTime],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async getEventsByObject(
@@ -682,18 +559,12 @@ export class JsonRpcProvider extends Provider {
     startTime: number = DEFAULT_START_TIME,
     endTime: number = DEFAULT_END_TIME
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsByObject',
-        [object, count, startTime, endTime],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by object: ${object}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsByObject',
+      [object, count, startTime, endTime],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async getEventsByTimeRange(
@@ -701,18 +572,12 @@ export class JsonRpcProvider extends Provider {
     startTime: number = DEFAULT_START_TIME,
     endTime: number = DEFAULT_END_TIME
   ): Promise<SuiEvents> {
-    try {
-      return await this.client.requestWithType(
-        'sui_getEventsByTimeRange',
-        [count, startTime, endTime],
-        isSuiEvents,
-        this.options.skipDataValidation
-      );
-    } catch (err) {
-      throw new Error(
-        `Error getting events by time range: ${startTime} thru ${endTime}, with error: ${err}`
-      );
-    }
+    return await this.client.requestWithType(
+      'sui_getEventsByTimeRange',
+      [count, startTime, endTime],
+      isSuiEvents,
+      this.options.skipDataValidation
+    );
   }
 
   async subscribeEvent(

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -49,254 +49,186 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
     signerAddress: SuiAddress,
     t: TransferObjectTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const objectRef = await this.provider.getObjectRef(t.objectId);
-      const tx = {
-        TransferObject: {
-          recipient: t.recipient,
-          object_ref: objectRef!,
-        },
-      };
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'transferObject', data: t },
-        t.gasPayment,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a TransferObject transaction: ${err} args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const objectRef = await this.provider.getObjectRef(t.objectId);
+    const tx = {
+      TransferObject: {
+        recipient: t.recipient,
+        object_ref: objectRef!,
+      },
+    };
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'transferObject', data: t },
+      t.gasPayment,
+      signerAddress
+    );
   }
 
   async newTransferSui(
     signerAddress: SuiAddress,
     t: TransferSuiTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const tx = {
-        TransferSui: {
-          recipient: t.recipient,
-          amount: t.amount == null ? { None: null } : { Some: t.amount },
-        },
-      };
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'transferSui', data: t },
-        t.suiObjectId,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a TransferSui transaction: ${err} args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const tx = {
+      TransferSui: {
+        recipient: t.recipient,
+        amount: t.amount == null ? { None: null } : { Some: t.amount },
+      },
+    };
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'transferSui', data: t },
+      t.suiObjectId,
+      signerAddress
+    );
   }
 
   async newPay(
     signerAddress: SuiAddress,
     t: PayTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const inputCoinRefs = (
-        await Promise.all(
-          t.inputCoins.map((coin) => this.provider.getObjectRef(coin))
-        )
-      ).map((ref) => ref!);
-      const tx = {
-        Pay: {
-          coins: inputCoinRefs,
-          recipients: t.recipients,
-          amounts: t.amounts,
-        },
-      };
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'pay', data: t },
-        t.gasPayment,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a Pay transaction: ${err} args ${JSON.stringify(t)}`
-      );
-    }
+    const inputCoinRefs = (
+      await Promise.all(
+        t.inputCoins.map((coin) => this.provider.getObjectRef(coin))
+      )
+    ).map((ref) => ref!);
+    const tx = {
+      Pay: {
+        coins: inputCoinRefs,
+        recipients: t.recipients,
+        amounts: t.amounts,
+      },
+    };
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'pay', data: t },
+      t.gasPayment,
+      signerAddress
+    );
   }
 
   async newPaySui(
     signerAddress: SuiAddress,
     t: PaySuiTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const inputCoinRefs = (
-        await Promise.all(
-          t.inputCoins.map((coin) => this.provider.getObjectRef(coin))
-        )
-      ).map((ref) => ref!);
-      const tx = {
-        PaySui: {
-          coins: inputCoinRefs,
-          recipients: t.recipients,
-          amounts: t.amounts,
-        },
-      };
-      const gas_coin_obj = t.inputCoins[0];
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'paySui', data: t },
-        gas_coin_obj,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a PaySui transaction: ${err} args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const inputCoinRefs = (
+      await Promise.all(
+        t.inputCoins.map((coin) => this.provider.getObjectRef(coin))
+      )
+    ).map((ref) => ref!);
+    const tx = {
+      PaySui: {
+        coins: inputCoinRefs,
+        recipients: t.recipients,
+        amounts: t.amounts,
+      },
+    };
+    const gas_coin_obj = t.inputCoins[0];
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'paySui', data: t },
+      gas_coin_obj,
+      signerAddress
+    );
   }
 
   async newPayAllSui(
     signerAddress: SuiAddress,
     t: PayAllSuiTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const inputCoinRefs = (
-        await Promise.all(
-          t.inputCoins.map((coin) => this.provider.getObjectRef(coin))
-        )
-      ).map((ref) => ref!);
-      const tx = {
-        PayAllSui: {
-          coins: inputCoinRefs,
-          recipient: t.recipient,
-        },
-      };
-      const gas_coin_obj = t.inputCoins[0];
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'payAllSui', data: t },
-        gas_coin_obj,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a PayAllSui transaction: ${err} args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const inputCoinRefs = (
+      await Promise.all(
+        t.inputCoins.map((coin) => this.provider.getObjectRef(coin))
+      )
+    ).map((ref) => ref!);
+    const tx = {
+      PayAllSui: {
+        coins: inputCoinRefs,
+        recipient: t.recipient,
+      },
+    };
+    const gas_coin_obj = t.inputCoins[0];
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'payAllSui', data: t },
+      gas_coin_obj,
+      signerAddress
+    );
   }
 
   async newMoveCall(
     signerAddress: SuiAddress,
     t: MoveCallTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const pkg = await this.provider.getObjectRef(t.packageObjectId);
-      const tx = {
-        Call: {
-          package: pkg!,
-          module: t.module,
-          function: t.function,
-          typeArguments: t.typeArguments.map((a) =>
-            typeof a === 'string'
-              ? new TypeTagSerializer().parseFromStr(a)
-              : (a as TypeTag)
-          ),
-          arguments: await new CallArgSerializer(
-            this.provider
-          ).serializeMoveCallArguments(t),
-        },
-      };
+    const pkg = await this.provider.getObjectRef(t.packageObjectId);
+    const tx = {
+      Call: {
+        package: pkg!,
+        module: t.module,
+        function: t.function,
+        typeArguments: t.typeArguments.map((a) =>
+          typeof a === 'string'
+            ? new TypeTagSerializer().parseFromStr(a)
+            : (a as TypeTag)
+        ),
+        arguments: await new CallArgSerializer(
+          this.provider
+        ).serializeMoveCallArguments(t),
+      },
+    };
 
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'moveCall', data: t },
-        t.gasPayment,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a move call: ${err} args ${JSON.stringify(t)}`
-      );
-    }
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'moveCall', data: t },
+      t.gasPayment,
+      signerAddress
+    );
   }
 
   async newMergeCoin(
     signerAddress: SuiAddress,
     t: MergeCoinTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      return await this.newMoveCall(signerAddress, {
-        packageObjectId: SUI_FRAMEWORK_ADDRESS,
-        module: PAY_MODULE_NAME,
-        function: PAY_JOIN_COIN_FUNC_NAME,
-        typeArguments: [await this.getCoinStructTag(t.coinToMerge)],
-        arguments: [t.primaryCoin, t.coinToMerge],
-        gasPayment: t.gasPayment,
-        gasBudget: t.gasBudget,
-      });
-    } catch (err) {
-      throw new Error(
-        `Error constructing a MergeCoin Transaction: ${err} args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    return await this.newMoveCall(signerAddress, {
+      packageObjectId: SUI_FRAMEWORK_ADDRESS,
+      module: PAY_MODULE_NAME,
+      function: PAY_JOIN_COIN_FUNC_NAME,
+      typeArguments: [await this.getCoinStructTag(t.coinToMerge)],
+      arguments: [t.primaryCoin, t.coinToMerge],
+      gasPayment: t.gasPayment,
+      gasBudget: t.gasBudget,
+    });
   }
 
   async newSplitCoin(
     signerAddress: SuiAddress,
     t: SplitCoinTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      return await this.newMoveCall(signerAddress, {
-        packageObjectId: SUI_FRAMEWORK_ADDRESS,
-        module: PAY_MODULE_NAME,
-        function: PAY_SPLIT_COIN_VEC_FUNC_NAME,
-        typeArguments: [await this.getCoinStructTag(t.coinObjectId)],
-        arguments: [t.coinObjectId, t.splitAmounts],
-        gasPayment: t.gasPayment,
-        gasBudget: t.gasBudget,
-      });
-    } catch (err) {
-      throw new Error(
-        `Error constructing a SplitCoin Transaction: ${err} args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    return await this.newMoveCall(signerAddress, {
+      packageObjectId: SUI_FRAMEWORK_ADDRESS,
+      module: PAY_MODULE_NAME,
+      function: PAY_SPLIT_COIN_VEC_FUNC_NAME,
+      typeArguments: [await this.getCoinStructTag(t.coinObjectId)],
+      arguments: [t.coinObjectId, t.splitAmounts],
+      gasPayment: t.gasPayment,
+      gasBudget: t.gasBudget,
+    });
   }
 
   async newPublish(
     signerAddress: SuiAddress,
     t: PublishTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const tx = {
-        Publish: {
-          modules: t.compiledModules as ArrayLike<ArrayLike<number>>,
-        },
-      };
-      return await this.constructTransactionData(
-        tx,
-        { kind: 'publish', data: t },
-        t.gasPayment,
-        signerAddress
-      );
-    } catch (err) {
-      throw new Error(
-        `Error constructing a newPublish transaction: ${err} with args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const tx = {
+      Publish: {
+        modules: t.compiledModules as ArrayLike<ArrayLike<number>>,
+      },
+    };
+    return await this.constructTransactionData(
+      tx,
+      { kind: 'publish', data: t },
+      t.gasPayment,
+      signerAddress
+    );
   }
 
   /**

--- a/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/rpc-txn-data-serializer.ts
@@ -50,196 +50,138 @@ export class RpcTxnDataSerializer implements TxnDataSerializer {
     signerAddress: SuiAddress,
     t: TransferObjectTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_transferObject',
-        [signerAddress, t.objectId, t.gasPayment, t.gasBudget, t.recipient],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(
-        `Error transferring object: ${err} with args ${JSON.stringify(t)}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_transferObject',
+      [signerAddress, t.objectId, t.gasPayment, t.gasBudget, t.recipient],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newTransferSui(
     signerAddress: SuiAddress,
     t: TransferSuiTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_transferSui',
-        [signerAddress, t.suiObjectId, t.gasBudget, t.recipient, t.amount],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(
-        `Error transferring Sui coin: ${err} with args ${JSON.stringify(t)}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_transferSui',
+      [signerAddress, t.suiObjectId, t.gasBudget, t.recipient, t.amount],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newPay(
     signerAddress: SuiAddress,
     t: PayTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_pay',
-        [
-          signerAddress,
-          t.inputCoins,
-          t.recipients,
-          t.amounts,
-          t.gasPayment,
-          t.gasBudget,
-        ],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(
-        `Error executing Pay transaction: ${err} with args ${JSON.stringify(t)}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_pay',
+      [
+        signerAddress,
+        t.inputCoins,
+        t.recipients,
+        t.amounts,
+        t.gasPayment,
+        t.gasBudget,
+      ],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newPaySui(
     signerAddress: SuiAddress,
     t: PaySuiTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_paySui',
-        [signerAddress, t.inputCoins, t.recipients, t.amounts, t.gasBudget],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(
-        `Error executing PaySui transaction: ${err} with args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_paySui',
+      [signerAddress, t.inputCoins, t.recipients, t.amounts, t.gasBudget],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newPayAllSui(
     signerAddress: SuiAddress,
     t: PayAllSuiTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_payAllSui',
-        [signerAddress, t.inputCoins, t.recipient, t.gasBudget],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(
-        `Error executing PayAllSui transaction: ${err} with args ${JSON.stringify(
-          t
-        )}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_payAllSui',
+      [signerAddress, t.inputCoins, t.recipient, t.gasBudget],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newMoveCall(
     signerAddress: SuiAddress,
     t: MoveCallTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_moveCall',
-        [
-          signerAddress,
-          t.packageObjectId,
-          t.module,
-          t.function,
-          t.typeArguments,
-          t.arguments,
-          t.gasPayment,
-          t.gasBudget,
-        ],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(
-        `Error executing a move call: ${err} with args ${JSON.stringify(t)}`
-      );
-    }
+    const resp = await this.client.requestWithType(
+      'sui_moveCall',
+      [
+        signerAddress,
+        t.packageObjectId,
+        t.module,
+        t.function,
+        t.typeArguments,
+        t.arguments,
+        t.gasPayment,
+        t.gasBudget,
+      ],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newMergeCoin(
     signerAddress: SuiAddress,
     t: MergeCoinTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_mergeCoins',
-        [
-          signerAddress,
-          t.primaryCoin,
-          t.coinToMerge,
-          t.gasPayment,
-          t.gasBudget,
-        ],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(`Error merging coin: ${err}`);
-    }
+    const resp = await this.client.requestWithType(
+      'sui_mergeCoins',
+      [signerAddress, t.primaryCoin, t.coinToMerge, t.gasPayment, t.gasBudget],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newSplitCoin(
     signerAddress: SuiAddress,
     t: SplitCoinTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_splitCoin',
-        [
-          signerAddress,
-          t.coinObjectId,
-          t.splitAmounts,
-          t.gasPayment,
-          t.gasBudget,
-        ],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(`Error splitting coin: ${err}`);
-    }
+    const resp = await this.client.requestWithType(
+      'sui_splitCoin',
+      [
+        signerAddress,
+        t.coinObjectId,
+        t.splitAmounts,
+        t.gasPayment,
+        t.gasBudget,
+      ],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 
   async newPublish(
     signerAddress: SuiAddress,
     t: PublishTransaction
   ): Promise<Base64DataBuffer> {
-    try {
-      const resp = await this.client.requestWithType(
-        'sui_publish',
-        [signerAddress, t.compiledModules, t.gasPayment, t.gasBudget],
-        isTransactionBytes,
-        this.skipDataValidation
-      );
-      return new Base64DataBuffer(resp.txBytes);
-    } catch (err) {
-      throw new Error(`Error publishing package ${err}`);
-    }
+    const resp = await this.client.requestWithType(
+      'sui_publish',
+      [signerAddress, t.compiledModules, t.gasPayment, t.gasBudget],
+      isTransactionBytes,
+      this.skipDataValidation
+    );
+    return new Base64DataBuffer(resp.txBytes);
   }
 }


### PR DESCRIPTION
This is an RFC to remove all of the try/catch error handling from the TypeScript SDK. This error handles generally does the following: Catch the error, construct a new error using the caught error message, and some argument information, and throw the new error. Given debugging arguments is very simple (either through devtools or trivial logs), and the throwing function should provide you with plenty of functional context, this error handling doesn't add any real value. Instead, it actually makes it harder to get to the underlying error that was thrown in the first place.

Removing these shouldn't have any end-user impact outside of different error messages.