### PR TITLE
[ts-sdk] Remove "withRequestType" from API names

### DIFF
--- a/apps/explorer/cypress/localnet.ts
+++ b/apps/explorer/cypress/localnet.ts
@@ -35,7 +35,7 @@ export async function createLocalnetTasks() {
                 keypair.getPublicKey().toSuiAddress()
             );
 
-            const tx = await signer.executeMoveCallWithRequestType({
+            const tx = await signer.executeMoveCall({
                 packageObjectId: '0x2',
                 module: 'devnet_nft',
                 function: 'mint',

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -100,7 +100,7 @@ export class Coin {
                 BigInt(gasBudget)
             ),
         };
-        return await signer.payWithRequestType(payTxn);
+        return await signer.pay(payTxn);
     }
 
     private static computeGasCostForPay(numInputCoins: number): number {
@@ -158,7 +158,7 @@ export class Coin {
                 recipient: recipient,
                 amount: Number(amount),
             };
-            return await signer.transferSuiWithRequestType(txn);
+            return await signer.transferSui(txn);
         }
 
         // TODO: use PaySui Transaction when it is ready
@@ -202,7 +202,7 @@ export class Coin {
                 recipient: await signer.getAddress(),
                 amount: gasCostForPay,
             };
-            await signer.transferSuiWithRequestType(txn);
+            await signer.transferSui(txn);
 
             inputCoins =
                 await signer.provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
@@ -218,7 +218,7 @@ export class Coin {
             amounts: [Number(amount)],
             gasBudget: gasCostForPay,
         };
-        return await signer.payWithRequestType(txn);
+        return await signer.pay(txn);
     }
 
     private static async assertAndGetCoinsWithBalanceGte(
@@ -272,7 +272,7 @@ export class Coin {
             arguments: [SUI_SYSTEM_STATE_OBJECT_ID, coin, validator],
             gasBudget: DEFAULT_GAS_BUDGET_FOR_STAKE,
         };
-        return await signer.executeMoveCallWithRequestType(txn);
+        return await signer.executeMoveCall(txn);
     }
 
     private static async requestSuiCoinWithExactAmount(

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -19,7 +19,7 @@ export class ExampleNFT {
         description?: string,
         imageUrl?: string
     ): Promise<SuiExecuteTransactionResponse> {
-        return await signer.executeMoveCallWithRequestType({
+        return await signer.executeMoveCall({
             packageObjectId: '0x2',
             module: 'devnet_nft',
             function: 'mint',
@@ -39,7 +39,7 @@ export class ExampleNFT {
         recipientID: string,
         transferCost: number
     ): Promise<SuiExecuteTransactionResponse> {
-        return await signer.transferObjectWithRequestType({
+        return await signer.transferObject({
             objectId: nftId,
             gasBudget: transferCost,
             recipient: recipientID,

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -153,16 +153,10 @@ export const respondToTransactionRequest = createAsyncThunk<
                               }
                             : txRequest.tx.data;
 
-                    response =
-                        await signer.signAndExecuteTransactionWithRequestType(
-                            txn
-                        );
+                    response = await signer.signAndExecuteTransaction(txn);
                 } else if (txRequest.tx.type === 'serialized-move-call') {
                     const txBytes = new Base64DataBuffer(txRequest.tx.data);
-                    response =
-                        await signer.signAndExecuteTransactionWithRequestType(
-                            txBytes
-                        );
+                    response = await signer.signAndExecuteTransaction(txBytes);
                 } else {
                     throw new Error(
                         `Either tx or txBytes needs to be defined.`

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -181,7 +181,7 @@ import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const transferTxn = await signer.transferObjectWithRequestType({
+const transferTxn = await signer.transferObject({
   objectId: '0x5015b016ab570df14c87649eda918e09e5cc61e0',
   gasBudget: 1000,
   recipient: '0xd84058cb73bdeabe123b56632713dcd65e1a6c92',
@@ -197,7 +197,7 @@ import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const splitTxn = await signer.splitCoinWithRequestType({
+const splitTxn = await signer.splitCoin({
   coinObjectId: '0x5015b016ab570df14c87649eda918e09e5cc61e0',
   // Say if the original coin has a balance of 100,
   // This function will create three new coins of amount 10, 20, 30,
@@ -216,7 +216,7 @@ import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const mergeTxn = await signer.mergeCoinWithRequestType({
+const mergeTxn = await signer.mergeCoin({
   primaryCoin: '0x5015b016ab570df14c87649eda918e09e5cc61e0',
   coinToMerge: '0xcc460051569bfb888dedaf5182e76f473ee351af',
   gasBudget: 1000,
@@ -232,7 +232,7 @@ import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 const keypair = new Ed25519Keypair();
 const provider = new JsonRpcProvider();
 const signer = new RawSigner(keypair, provider);
-const moveCallTxn = await signer.executeMoveCallWithRequestType({
+const moveCallTxn = await signer.executeMoveCall({
   packageObjectId: '0x2',
   module: 'devnet_nft',
   function: 'mint',
@@ -306,7 +306,7 @@ const compiledModules = JSON.parse(
 const modulesInBytes = compiledModules.map((m) =>
   Array.from(new Base64DataBuffer(m).getData())
 );
-const publishTxn = await signer.publishWithRequestType({
+const publishTxn = await signer.publish({
   compiledModules: modulesInBytes,
   gasBudget: 10000,
 });

--- a/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider-with-cache.ts
@@ -66,7 +66,7 @@ export class JsonRpcProviderWithCache extends JsonRpcProvider {
 
   // Transactions
 
-  async executeTransactionWithRequestType(
+  async executeTransaction(
     txnBytes: string,
     signatureScheme: SignatureScheme,
     signature: string,
@@ -76,11 +76,11 @@ export class JsonRpcProviderWithCache extends JsonRpcProvider {
     if (requestType !== 'WaitForEffectsCert') {
       console.warn(
         `It's not recommended to use JsonRpcProviderWithCache with the request ` +
-          `type other than 'WaitForEffectsCert' for executeTransactionWithRequestType. Using ` +
+          `type other than 'WaitForEffectsCert' for executeTransaction. Using ` +
           `the '${requestType}' may result in stale cache and a failure in subsequent transactions.`
       );
     }
-    const resp = await super.executeTransactionWithRequestType(
+    const resp = await super.executeTransaction(
       txnBytes,
       signatureScheme,
       signature,

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -527,7 +527,7 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
-  async executeTransactionWithRequestType(
+  async executeTransaction(
     txnBytes: string,
     signatureScheme: SignatureScheme,
     signature: string,

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -176,7 +176,7 @@ export abstract class Provider {
    * replace the other `executeTransaction` that's only available on the
    * Gateway
    */
-  abstract executeTransactionWithRequestType(
+  abstract executeTransaction(
     txnBytes: string,
     signatureScheme: SignatureScheme,
     signature: string,

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -106,7 +106,7 @@ export class VoidProvider extends Provider {
     throw this.newError('getTransaction');
   }
 
-  async executeTransactionWithRequestType(
+  async executeTransaction(
     _txnBytes: string,
     _signatureScheme: SignatureScheme,
     _signature: string,

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -82,7 +82,7 @@ export abstract class SignerWithProvider implements Signer {
    * Sign a transaction and submit to the Fullnode for execution. Only exists
    * on Fullnode
    */
-  async signAndExecuteTransactionWithRequestType(
+  async signAndExecuteTransaction(
     transaction: Base64DataBuffer | SignableTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -97,7 +97,7 @@ export abstract class SignerWithProvider implements Signer {
           : new Base64DataBuffer(transaction.data);
 
       const sig = await this.signData(txBytes);
-      return await this.provider.executeTransactionWithRequestType(
+      return await this.provider.executeTransaction(
         txBytes.toString(),
         sig.signatureScheme,
         sig.signature.toString(),
@@ -108,29 +108,23 @@ export abstract class SignerWithProvider implements Signer {
 
     switch (transaction.kind) {
       case 'moveCall':
-        return this.executeMoveCallWithRequestType(
-          transaction.data,
-          requestType
-        );
+        return this.executeMoveCall(transaction.data, requestType);
       case 'transferSui':
-        return this.transferSuiWithRequestType(transaction.data, requestType);
+        return this.transferSui(transaction.data, requestType);
       case 'transferObject':
-        return this.transferObjectWithRequestType(
-          transaction.data,
-          requestType
-        );
+        return this.transferObject(transaction.data, requestType);
       case 'mergeCoin':
-        return this.mergeCoinWithRequestType(transaction.data, requestType);
+        return this.mergeCoin(transaction.data, requestType);
       case 'splitCoin':
-        return this.splitCoinWithRequestType(transaction.data, requestType);
+        return this.splitCoin(transaction.data, requestType);
       case 'pay':
-        return this.payWithRequestType(transaction.data, requestType);
+        return this.pay(transaction.data, requestType);
       case 'paySui':
-        return this.paySuiWithRequestType(transaction.data, requestType);
+        return this.paySui(transaction.data, requestType);
       case 'payAllSui':
-        return this.payAllSuiWithRequestType(transaction.data, requestType);
+        return this.payAllSui(transaction.data, requestType);
       case 'publish':
-        return this.publishWithRequestType(transaction.data, requestType);
+        return this.publish(transaction.data, requestType);
       default:
         throw new Error(
           `Unknown transaction kind: "${(transaction as any).kind}"`
@@ -143,7 +137,7 @@ export abstract class SignerWithProvider implements Signer {
    * Serialize and sign a `TransferObject` transaction and submit to the Fullnode
    * for execution
    */
-  async transferObjectWithRequestType(
+  async transferObject(
     transaction: TransferObjectTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -152,10 +146,7 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
@@ -163,7 +154,7 @@ export abstract class SignerWithProvider implements Signer {
    * Serialize and sign a `TransferSui` transaction and submit to the Fullnode
    * for execution
    */
-  async transferSuiWithRequestType(
+  async transferSui(
     transaction: TransferSuiTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -172,47 +163,38 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
    *
    * Serialize and Sign a `Pay` transaction and submit to the fullnode for execution
    */
-  async payWithRequestType(
+  async pay(
     transaction: PayTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newPay(signerAddress, transaction);
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
    * Serialize and Sign a `PaySui` transaction and submit to the fullnode for execution
    */
-  async paySuiWithRequestType(
+  async paySui(
     transaction: PaySuiTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
     const signerAddress = await this.getAddress();
     const txBytes = await this.serializer.newPaySui(signerAddress, transaction);
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
    * Serialize and Sign a `PayAllSui` transaction and submit to the fullnode for execution
    */
-  async payAllSuiWithRequestType(
+  async payAllSui(
     transaction: PayAllSuiTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -221,10 +203,7 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
@@ -232,7 +211,7 @@ export abstract class SignerWithProvider implements Signer {
    * Serialize and sign a `MergeCoin` transaction and submit to the Fullnode
    * for execution
    */
-  async mergeCoinWithRequestType(
+  async mergeCoin(
     transaction: MergeCoinTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -241,10 +220,7 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
@@ -252,7 +228,7 @@ export abstract class SignerWithProvider implements Signer {
    * Serialize and sign a `SplitCoin` transaction and submit to the Fullnode
    * for execution
    */
-  async splitCoinWithRequestType(
+  async splitCoin(
     transaction: SplitCoinTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -261,17 +237,14 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
    * Serialize and sign a `MoveCall` transaction and submit to the Fullnode
    * for execution
    */
-  async executeMoveCallWithRequestType(
+  async executeMoveCall(
     transaction: MoveCallTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -280,10 +253,7 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 
   /**
@@ -291,7 +261,7 @@ export abstract class SignerWithProvider implements Signer {
    * Serialize and sign a `Publish` transaction and submit to the Fullnode
    * for execution
    */
-  async publishWithRequestType(
+  async publish(
     transaction: PublishTransaction,
     requestType: ExecuteTransactionRequestType = 'WaitForLocalExecution'
   ): Promise<SuiExecuteTransactionResponse> {
@@ -300,9 +270,6 @@ export abstract class SignerWithProvider implements Signer {
       signerAddress,
       transaction
     );
-    return await this.signAndExecuteTransactionWithRequestType(
-      txBytes,
-      requestType
-    );
+    return await this.signAndExecuteTransaction(txBytes, requestType);
   }
 }

--- a/sdk/typescript/test/e2e/coin.test.ts
+++ b/sdk/typescript/test/e2e/coin.test.ts
@@ -34,7 +34,7 @@ describe('Coin related API', () => {
     );
     coinToSplit = coins[0].objectId;
     // split coins into desired amount
-    await signer.splitCoinWithRequestType({
+    await signer.splitCoin({
       coinObjectId: coinToSplit,
       splitAmounts: SPLIT_AMOUNTS.map((s) => Number(s)),
       gasBudget: DEFAULT_GAS_BUDGET,

--- a/sdk/typescript/test/e2e/entry-point-string.test.ts
+++ b/sdk/typescript/test/e2e/entry-point-string.test.ts
@@ -23,7 +23,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
     let packageId: ObjectId;
 
     async function callWithString(str: string | string[], funcName: string) {
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: packageId,
         module: 'entry_point_string',
         function: funcName,

--- a/sdk/typescript/test/e2e/id-entry-args.test.ts
+++ b/sdk/typescript/test/e2e/id-entry-args.test.ts
@@ -31,7 +31,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
     });
 
     it('Test ID as arg to entry functions', async () => {
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: packageId,
         module: 'test',
         function: 'test_id',

--- a/sdk/typescript/test/e2e/object-vector.test.ts
+++ b/sdk/typescript/test/e2e/object-vector.test.ts
@@ -26,7 +26,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
     let packageId: ObjectId;
 
     async function mintObject(val: number) {
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: packageId,
         module: 'entry_point_vector',
         function: 'mint',
@@ -39,7 +39,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
     }
 
     async function destroyObjects(objects: ObjectId[]) {
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: packageId,
         module: 'entry_point_vector',
         function: 'two_obj_vec_destroy',
@@ -74,7 +74,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
         toolbox.address()
       );
       const coinIDs = coins.map((coin) => Coin.getID(coin));
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: SUI_FRAMEWORK_ADDRESS,
         module: 'pay',
         function: 'join_vec',

--- a/sdk/typescript/test/e2e/txn-builder.test.ts
+++ b/sdk/typescript/test/e2e/txn-builder.test.ts
@@ -39,7 +39,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address()
       );
-      const txn = await signer.splitCoinWithRequestType({
+      const txn = await signer.splitCoin({
         coinObjectId: coins[0].objectId,
         splitAmounts: [DEFAULT_GAS_BUDGET * 2],
         gasBudget: DEFAULT_GAS_BUDGET,
@@ -51,7 +51,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address()
       );
-      const txn = await signer.mergeCoinWithRequestType({
+      const txn = await signer.mergeCoin({
         primaryCoin: coins[0].objectId,
         coinToMerge: coins[1].objectId,
         gasBudget: DEFAULT_GAS_BUDGET,
@@ -63,7 +63,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address()
       );
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: '0x2',
         module: 'devnet_nft',
         function: 'mint',
@@ -90,7 +90,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const validator_address = (validator_metadata as SuiMoveObject).fields
         .sui_address;
 
-      const txn = await signer.executeMoveCallWithRequestType({
+      const txn = await signer.executeMoveCall({
         packageObjectId: '0x2',
         module: 'sui_system',
         function: 'request_add_delegation',
@@ -111,7 +111,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address()
       );
-      const txn = await signer.transferSuiWithRequestType({
+      const txn = await signer.transferSui({
         suiObjectId: coins[0].objectId,
         gasBudget: DEFAULT_GAS_BUDGET,
         recipient: DEFAULT_RECIPIENT,
@@ -124,7 +124,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       const coins = await toolbox.provider.getGasObjectsOwnedByAddress(
         toolbox.address()
       );
-      const txn = await signer.transferObjectWithRequestType({
+      const txn = await signer.transferObject({
         objectId: coins[0].objectId,
         gasBudget: DEFAULT_GAS_BUDGET,
         recipient: DEFAULT_RECIPIENT,
@@ -141,7 +141,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
         );
 
       // get some new coins with small amount
-      const splitTxn = await signer.splitCoinWithRequestType({
+      const splitTxn = await signer.splitCoin({
         coinObjectId: getObjectId(coins[0]),
         splitAmounts: [1, 2, 3],
         gasBudget: DEFAULT_GAS_BUDGET,
@@ -152,7 +152,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
       );
 
       // use the newly created coins as the input coins for the pay transaction
-      const txn = await signer.payWithRequestType({
+      const txn = await signer.pay({
         inputCoins: splitCoins,
         gasBudget: DEFAULT_GAS_BUDGET,
         recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
@@ -170,7 +170,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
           BigInt(DEFAULT_GAS_BUDGET)
         );
 
-      const splitTxn = await signer.splitCoinWithRequestType({
+      const splitTxn = await signer.splitCoin({
         coinObjectId: getObjectId(coins[0]),
         splitAmounts: [2000, 2000, 2000],
         gasBudget: gasBudget,
@@ -180,7 +180,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
         getObjectId(c)
       );
 
-      const txn = await signer.paySuiWithRequestType({
+      const txn = await signer.paySui({
         inputCoins: splitCoins,
         recipients: [DEFAULT_RECIPIENT, DEFAULT_RECIPIENT_2],
         amounts: [1000, 1000],
@@ -197,7 +197,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
           BigInt(DEFAULT_GAS_BUDGET)
         );
 
-      const splitTxn = await signer.splitCoinWithRequestType({
+      const splitTxn = await signer.splitCoin({
         coinObjectId: getObjectId(coins[0]),
         splitAmounts: [2000, 2000, 2000],
         gasBudget: gasBudget,
@@ -207,7 +207,7 @@ describe.each([{ useLocalTxnBuilder: true }, { useLocalTxnBuilder: false }])(
         getObjectId(c)
       );
 
-      const txn = await signer.payAllSuiWithRequestType({
+      const txn = await signer.payAllSui({
         inputCoins: splitCoins,
         recipient: DEFAULT_RECIPIENT,
         gasBudget: gasBudget,

--- a/sdk/typescript/test/e2e/utils/setup.ts
+++ b/sdk/typescript/test/e2e/utils/setup.ts
@@ -83,7 +83,7 @@ export async function publishPackage(
       { encoding: 'utf-8' }
     )
   );
-  const publishTxn = await signer.publishWithRequestType({
+  const publishTxn = await signer.publish({
     compiledModules: useLocalTxnBuilder
       ? compiledModules.map((m: any) =>
           Array.from(new Base64DataBuffer(m).getData())

--- a/sdk/wallet-adapter/packages/adapters/unsafe-burner/src/index.ts
+++ b/sdk/wallet-adapter/packages/adapters/unsafe-burner/src/index.ts
@@ -44,8 +44,7 @@ export class UnsafeBurnerWalletAdapter implements WalletAdapter {
   }
 
   async signAndExecuteTransaction(transaction: SignableTransaction) {
-    const response =
-      await this.#signer.signAndExecuteTransactionWithRequestType(transaction);
+    const response = await this.#signer.signAndExecuteTransaction(transaction);
 
     return {
       certificate: getCertifiedTransaction(response)!,


### PR DESCRIPTION
We added the new `${api}WithRequestType` APIs to separate out calls to fullnode and gateway, but now that gateway has been fully removed, we can clean up function naming here and move back to the simpler API names.