### PR TITLE
[explorer] Add denominated gas fees

### DIFF
--- a/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
@@ -6,9 +6,11 @@ import type {
     ExecutionStatusType,
     SuiObjectRef,
     SuiEvent,
+    SuiTransactionResponse,
 } from '@mysten/sui.js';
 
 export type DataType = CertifiedTransaction & {
+    transaction: SuiTransactionResponse | null
     loadState: string;
     txId: string;
     status: ExecutionStatusType;

--- a/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@mysten/sui.js';
 
 export type DataType = CertifiedTransaction & {
-    transaction: SuiTransactionResponse | null
+    transaction: SuiTransactionResponse | null;
     loadState: string;
     txId: string;
     status: ExecutionStatusType;

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -12,6 +12,8 @@ import {
     getObjectId,
     getTransferSuiTransaction,
     getTransferSuiAmount,
+    getExecutionStatusGasSummary,
+    SUI_TYPE_ARG,
 } from '@mysten/sui.js';
 import cl from 'clsx';
 import { Link } from 'react-router-dom';
@@ -43,9 +45,11 @@ import type {
 
 import styles from './TransactionResult.module.css';
 
+import { CoinFormat, useFormatCoin } from '~/hooks/useFormatCoin';
 import { Banner } from '~/ui/Banner';
 import { PageHeader } from '~/ui/PageHeader';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { Text } from '~/ui/Text';
 
 type TxDataProps = CertifiedTransaction & {
     status: ExecutionStatusType;
@@ -245,6 +249,34 @@ const isPayType = (
     return 'Pay' in txdetails;
 };
 
+function GasAmount({ amount }: { amount: bigint | number }) {
+    const [formattedAmount, symbol] = useFormatCoin(
+        amount,
+        SUI_TYPE_ARG,
+        CoinFormat.FULL
+    );
+
+    return (
+        <div className="flex items-baseline gap-1">
+            <div className="text-sui-grey-90">
+                <Text variant="body" weight="medium">
+                    {formattedAmount}
+                </Text>
+            </div>
+            <div className="text-sui-grey-65">
+                <Text variant="subtitleSmall" weight="medium">
+                    {symbol}
+                </Text>
+            </div>
+            <div className="text-sui-grey-65">
+                <Text variant="bodySmall">
+                    ({amount.toLocaleString()} MIST)
+                </Text>
+            </div>
+        </div>
+    );
+}
+
 const convertAmounts = (
     amounts: (number | bigint | null)[]
 ): bigint[] | undefined =>
@@ -347,12 +379,12 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                 link: true,
             },
             {
-                label: 'Gas Fees',
-                value: txdata.gasFee,
+                label: 'Gas Budget',
+                value: <GasAmount amount={txdata.data.gasBudget} />,
             },
             {
-                label: 'Gas Budget',
-                value: txdata.data.gasBudget,
+                label: 'Total Gas Fee',
+                value: <GasAmount amount={txdata.gasFee} />,
             },
             //TODO: Add Storage Fees
         ],

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -12,7 +12,6 @@ import {
     getObjectId,
     getTransferSuiTransaction,
     getTransferSuiAmount,
-    getExecutionStatusGasSummary,
     SUI_TYPE_ARG,
 } from '@mysten/sui.js';
 import cl from 'clsx';
@@ -257,20 +256,19 @@ function GasAmount({ amount }: { amount: bigint | number }) {
     );
 
     return (
-        <div className="flex items-baseline gap-1">
-            <div className="text-sui-grey-90">
+        <div className="flex items-center gap-1">
+            <div className="text-sui-grey-90 flex items-baseline gap-0.5">
                 <Text variant="body" weight="medium">
                     {formattedAmount}
                 </Text>
-            </div>
-            <div className="text-sui-grey-65">
                 <Text variant="subtitleSmall" weight="medium">
                     {symbol}
                 </Text>
             </div>
-            <div className="text-sui-grey-65">
-                <Text variant="bodySmall">
-                    ({amount.toLocaleString()} MIST)
+            <div className="text-sui-grey-65 flex items-baseline gap-0.5">
+                <Text variant="bodySmall">({amount.toLocaleString()}</Text>
+                <Text variant="subtitleSmall" weight="medium">
+                    MIST)
                 </Text>
             </div>
         </div>

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -41,6 +41,7 @@ import type {
     SuiObjectRef,
     SuiEvent,
 } from '@mysten/sui.js';
+import type { ReactNode } from 'react';
 
 import styles from './TransactionResult.module.css';
 
@@ -164,7 +165,7 @@ type TxItemView = {
     titleStyle?: string;
     content: {
         label?: string | number | any;
-        value: string | number;
+        value: ReactNode;
         link?: boolean;
         category?: string;
         monotypeClass?: boolean;

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -259,19 +259,19 @@ function GasAmount({ amount }: { amount: bigint | number }) {
     return (
         <div className="flex items-center gap-1">
             <div className="text-sui-grey-90 flex items-baseline gap-0.5">
-                <Text variant="body" weight="medium">
-                    {formattedAmount}
-                </Text>
-                <Text variant="subtitleSmall" weight="medium">
-                    {symbol}
-                </Text>
+                <Text variant="body">{formattedAmount}</Text>
+                <Text variant="subtitleSmall">{symbol}</Text>
             </div>
-            <div className="text-sui-grey-65 flex items-baseline gap-0.5">
-                <Text variant="bodySmall">({amount.toLocaleString()}</Text>
-                <Text variant="subtitleSmall" weight="medium">
-                    MIST)
-                </Text>
-            </div>
+            <Text variant="bodySmall">
+                <div className="text-sui-grey-65 flex items-center">
+                    (
+                    <div className="flex items-baseline gap-0.5">
+                        <div>{amount.toLocaleString()}</div>
+                        <Text variant="subtitleSmall">MIST</Text>
+                    </div>
+                    )
+                </div>
+            </Text>
         </div>
     );
 }

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -257,7 +257,7 @@ function GasAmount({ amount }: { amount: bigint | number }) {
     );
 
     return (
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 h-full">
             <div className="text-sui-grey-90 flex items-baseline gap-0.5">
                 <Text variant="body">{formattedAmount}</Text>
                 <Text variant="subtitleSmall">{symbol}</Text>


### PR DESCRIPTION
This updates the gas fees to be properly denominated. We'll at some point need to rework this a bit to match the new UI with detailed gas breakdowns, I'll create a separate task for that.

<img width="629" alt="Screen Shot 2022-11-03 at 7 43 43 PM" src="https://user-images.githubusercontent.com/109986297/199819232-dba935c2-4218-4dd4-ad2b-5a78bbd1819a.png">


This needs a UI pass since the MIST part is not in design yet. Will hold off on merging until I have clarity there.