### PR TITLE
[explorer] Add balance formatting for owned objects

### DIFF
--- a/apps/explorer/cypress/e2e/static/e2e.cy.ts
+++ b/apps/explorer/cypress/e2e/static/e2e.cy.ts
@@ -155,15 +155,15 @@ describe('End-to-end Tests', () => {
 
             cy.visit(`/addresses/${address}`);
 
-            cy.get(`${rowCSSSelector(1)} ${label}`).contains('0x2::USD::USD');
+            cy.get(`${rowCSSSelector(1)} ${label}`).contains('USD');
             cy.get(`${rowCSSSelector(1)} ${count}`).contains('2');
             cy.get(`${rowCSSSelector(1)} ${balance}`).contains(
-                '9007199254740993'
+                '9,007,199,254,740,993'
             );
 
             cy.get(`${rowCSSSelector(2)} ${label}`).contains('SUI');
             cy.get(`${rowCSSSelector(2)} ${count}`).contains('2');
-            cy.get(`${rowCSSSelector(2)} ${balance}`).contains('200');
+            cy.get(`${rowCSSSelector(2)} ${balance}`).contains('0.0000002');
         });
     });
 

--- a/apps/explorer/src/pages/transaction-result/SendReceiveView.tsx
+++ b/apps/explorer/src/pages/transaction-result/SendReceiveView.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { COIN_TYPE_ARG_REGEX } from '@mysten/sui.js';
+import { Coin } from '@mysten/sui.js';
 import { useQuery } from '@tanstack/react-query';
 import cl from 'clsx';
 
@@ -22,9 +22,6 @@ type TxAddress = {
     amount?: bigint[];
     objects?: string[];
 };
-
-const getCoinLabelFromObjType = (objType: string) =>
-    COIN_TYPE_ARG_REGEX.exec(objType)?.[1];
 
 function MultipleRecipients({ sender, recipient, amount, objects }: TxAddress) {
     const rpc = useRpc();
@@ -116,10 +113,10 @@ function MultipleRecipients({ sender, recipient, amount, objects }: TxAddress) {
 }
 
 function Amount({ amount, label }: { amount: bigint; label: string }) {
-    const coinBoilerPlateRemoved = getCoinLabelFromObjType(label);
+    const coinType = Coin.getCoinType(label);
     const [formattedAmount, suffix] = useFormatCoin(
         amount,
-        coinBoilerPlateRemoved,
+        coinType,
         CoinFormat.FULL
     );
     return (
@@ -144,7 +141,7 @@ function SingleAmount({
         async () => {
             const obj = await rpc.getObject(objectId);
 
-            return getCoinLabelFromObjType(parseObjectType(obj));
+            return Coin.getCoinType(parseObjectType(obj));
         }
     );
 

--- a/apps/explorer/src/utils/stringUtils.ts
+++ b/apps/explorer/src/utils/stringUtils.ts
@@ -20,11 +20,6 @@ export function hexToAscii(hex: string) {
 export const trimStdLibPrefix = (str: string): string =>
     str.replace(/^0x2::/, '');
 
-export const handleCoinType = (str: string): string =>
-    str === '0x2::coin::Coin<0x2::sui::SUI>'
-        ? 'SUI'
-        : str.match(/^([a-zA-Z0-9:]*)<([a-zA-Z0-9:]*)>$/)?.[2] || str;
-
 export const findIPFSvalue = (url: string): string | undefined =>
     url.match(/^ipfs:\/\/(.*)/)?.[1];
 

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -45,9 +45,14 @@ export class Coin {
     return Coin.getType(data)?.startsWith(COIN_TYPE) ?? false;
   }
 
+  static getCoinType(type: string) {
+    const [, res] = type.match(COIN_TYPE_ARG_REGEX) ?? [];
+    return res || null;
+  }
+
   static getCoinTypeArg(obj: ObjectData) {
-    const res = Coin.getType(obj)?.match(COIN_TYPE_ARG_REGEX);
-    return res ? res[1] : null;
+    const type = Coin.getType(obj);
+    return type ? Coin.getCoinType(type) : null;
   }
 
   static isSUI(obj: ObjectData) {


### PR DESCRIPTION
This was missed during adding denomination. There's more redesign work that's planned on this screen but we'll do that as part of further design alignment later.

<img width="688" alt="Screen Shot 2022-11-03 at 2 05 50 PM" src="https://user-images.githubusercontent.com/109986297/199742148-a68569dc-ef35-48e6-bde5-d22712a74e00.png">
<img width="651" alt="Screen Shot 2022-11-03 at 2 05 39 PM" src="https://user-images.githubusercontent.com/109986297/199742161-1bda6282-2950-4d2b-b66d-29543aecc8b5.png">
