### PR TITLE
[checkpoints] Record checkpoint boundaries

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -47,6 +47,7 @@ use narwhal_config::{
     Committee as ConsensusCommittee, WorkerCache as ConsensusWorkerCache,
     WorkerId as ConsensusWorkerId,
 };
+use narwhal_consensus::ConsensusOutput;
 use sui_adapter::adapter;
 use sui_config::genesis::Genesis;
 use sui_json_rpc_types::{
@@ -2359,5 +2360,13 @@ impl AuthorityState {
                 Ok(())
             }
         }
+    }
+
+    pub(crate) fn handle_commit_boundary(
+        &self,
+        consensus_output: &Arc<ConsensusOutput>,
+    ) -> SuiResult {
+        self.database
+            .record_checkpoint_boundary(consensus_output.consensus_index)
     }
 }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -63,6 +63,12 @@ pub struct AuthorityEpochTables<S> {
     /// by a single process acting as consensus (light) client. It is used to ensure the authority processes
     /// every message output by consensus (and in the right order).
     pub(crate) last_consensus_index: DBMap<u64, ExecutionIndicesWithHash>,
+
+    /// This table lists all checkpoint boundaries in the consensus sequence
+    ///
+    /// The key in this table is incremental index and value is corresponding narwhal
+    /// consensus output index
+    pub(crate) checkpoint_boundary: DBMap<u64, u64>,
 }
 
 impl<S> AuthorityEpochTables<S>


### PR DESCRIPTION
This PR adds checkpoint_boundary table to authority store. In combination with `consensus_message_order` table this will define set of "root" transaction to form a checkpoint.