### PR TITLE
[narwhal] Make the primary re-transmit batch digests in non-committed headers

### DIFF
--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -221,7 +221,7 @@ pub struct Consensus<ConsensusProtocol> {
     /// if it already sent us its whole history.
     rx_new_certificates: metered_channel::Receiver<Certificate>,
     /// Outputs the sequence of ordered certificates to the primary (for cleanup and feedback).
-    tx_committed_certificates: metered_channel::Sender<Certificate>,
+    tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
     /// Outputs the sequence of ordered certificates to the application layer.
     tx_sequence: metered_channel::Sender<ConsensusOutput>,
 
@@ -250,7 +250,7 @@ where
         cert_store: CertificateStore,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
-        tx_committed_certificates: metered_channel::Sender<Certificate>,
+        tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
         tx_sequence: metered_channel::Sender<ConsensusOutput>,
         protocol: Protocol,
         metrics: Arc<ConsensusMetrics>,
@@ -331,6 +331,7 @@ where
                     }
 
                     // Process the certificate using the selected consensus protocol.
+                    let commit_round_leader = certificate.header.round;
                     let sequence =
                         self.protocol
                             .process_certificate(&mut self.state, self.consensus_index, certificate)?;
@@ -341,7 +342,7 @@ where
                     // We extract a list of headers from this specific validator that
                     // have been agreed upon, and signal this back to the narwhal sub-system
                     // to be used to re-send batches that have not made it to a commit.
-                    // let mut own_commited_batches = Vec::new();
+                    let mut commited_certificates = Vec::new();
 
                     // Output the sequence in the right order.
                     for output in sequence {
@@ -368,14 +369,18 @@ where
                                 .set((mysten_util_mem::malloc_size(&self.state.dag) + std::mem::size_of::<Dag>()) as i64);
                         }
 
-                        self.tx_committed_certificates
-                            .send(certificate.clone())
-                            .await
-                            .expect("Failed to send certificate to primary");
+                        commited_certificates.push(certificate.clone());
 
                         if let Err(e) = self.tx_sequence.send(output).await {
                             tracing::warn!("Failed to output certificate: {e}");
                         }
+                    }
+
+                    if !commited_certificates.is_empty(){
+                        self.tx_committed_certificates
+                        .send((commit_round_leader, commited_certificates))
+                        .await
+                        .expect("Failed to send certificate to primary");
                     }
 
                     self.metrics

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -338,6 +338,11 @@ where
                     // Update the consensus index.
                     self.consensus_index += sequence.len() as u64;
 
+                    // We extract a list of headers from this specific validator that
+                    // have been agreed upon, and signal this back to the narwhal sub-system
+                    // to be used to re-send batches that have not made it to a commit.
+                    // let mut own_commited_batches = Vec::new();
+
                     // Output the sequence in the right order.
                     for output in sequence {
                         let certificate = &output.certificate;

--- a/narwhal/node/src/lib.rs
+++ b/narwhal/node/src/lib.rs
@@ -292,7 +292,7 @@ impl Node {
         execution_state: State,
         tx_reconfigure: &watch::Sender<ReconfigureNotification>,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
-        tx_committed_certificates: metered_channel::Sender<Certificate>,
+        tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
         registry: &Registry,
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where

--- a/narwhal/primary/src/block_remover.rs
+++ b/narwhal/primary/src/block_remover.rs
@@ -169,6 +169,7 @@ impl BlockRemover {
             // Unwrap safe since list is not empty.
             let highest_round = certificates.iter().map(|c| c.header.round).max().unwrap();
 
+            // !!!!! WHY ARE WE SENDING THESE TO THE COMMITTED CHANNEL BACK?
             self.tx_committed_certificates
                 .send((highest_round, all_certs))
                 .await

--- a/narwhal/primary/src/block_remover.rs
+++ b/narwhal/primary/src/block_remover.rs
@@ -16,6 +16,7 @@ use store::{rocks::TypedStoreError, Store};
 use tracing::{debug, instrument, warn};
 use types::{
     metered_channel::Sender, BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest,
+    Round,
 };
 
 #[cfg(test)]
@@ -50,7 +51,7 @@ pub struct BlockRemover {
     worker_network: P2pNetwork,
 
     /// Outputs all the successfully deleted certificates
-    tx_committed_certificates: Sender<Certificate>,
+    tx_committed_certificates: Sender<(Round, Vec<Certificate>)>,
 }
 
 impl BlockRemover {
@@ -63,7 +64,7 @@ impl BlockRemover {
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         dag: Option<Arc<Dag>>,
         worker_network: P2pNetwork,
-        tx_committed_certificates: Sender<Certificate>,
+        tx_committed_certificates: Sender<(Round, Vec<Certificate>)>,
     ) -> BlockRemover {
         Self {
             name,
@@ -163,9 +164,13 @@ impl BlockRemover {
             .map_err(Either::Left)?;
 
         // Now output all the removed certificates
-        for certificate in certificates.clone() {
+        if !certificates.is_empty() {
+            let all_certs = certificates.clone();
+            // Unwrap safe since list is not empty.
+            let highest_round = certificates.iter().map(|c| c.header.round).max().unwrap();
+
             self.tx_committed_certificates
-                .send(certificate)
+                .send((highest_round, all_certs))
                 .await
                 .expect("Couldn't forward removed certificates to channel");
         }

--- a/narwhal/primary/src/block_remover.rs
+++ b/narwhal/primary/src/block_remover.rs
@@ -169,7 +169,7 @@ impl BlockRemover {
             // Unwrap safe since list is not empty.
             let highest_round = certificates.iter().map(|c| c.header.round).max().unwrap();
 
-            // !!!!! WHY ARE WE SENDING THESE TO THE COMMITTED CHANNEL BACK?
+            // We signal that these certificates must have been committed by the external consensus
             self.tx_committed_certificates
                 .send((highest_round, all_certs))
                 .await

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -86,6 +86,8 @@ pub struct PrimaryChannelMetrics {
     pub tx_committed_certificates: IntGauge,
     /// occupancy of the channel from the `primary::Core` to the `Consensus`
     pub tx_new_certificates: IntGauge,
+    /// occupancy of the channel signaling own committed headers
+    pub tx_commited_own_headers: IntGauge,
 
     // totals
     /// total received on channel from the `primary::WorkerReceiverHandler` to the `primary::PayloadReceiver`
@@ -116,6 +118,8 @@ pub struct PrimaryChannelMetrics {
     pub tx_committed_certificates_total: IntCounter,
     /// total received on channel from the `primary::Core` to the `Consensus`
     pub tx_new_certificates_total: IntCounter,
+    /// total received on the channel signaling own committed headers
+    pub tx_commited_own_headers_total: IntCounter,
 }
 
 impl PrimaryChannelMetrics {
@@ -213,6 +217,11 @@ impl PrimaryChannelMetrics {
                 Self::DESC_NEW_CERTS,
                 registry
             ).unwrap(),
+            tx_commited_own_headers: register_int_gauge_with_registry!(
+                "tx_commited_own_headers",
+                "occupancy of the channel signaling own committed headers.",
+                registry
+            ).unwrap(),
 
             // totals
             tx_others_digests_total: register_int_counter_with_registry!(
@@ -285,6 +294,12 @@ impl PrimaryChannelMetrics {
                 Self::DESC_NEW_CERTS_TOTAL,
                 registry
             ).unwrap(),
+            tx_commited_own_headers_total: register_int_counter_with_registry!(
+                "tx_commited_own_headers_total",
+                "total received on channel signaling own committed headers.",
+                registry
+            ).unwrap(),
+
 
 
 

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -92,11 +92,11 @@ impl Primary {
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         vote_digest_store: Store<PublicKey, RoundVoteDigestPair>,
         tx_new_certificates: Sender<Certificate>,
-        rx_committed_certificates: Receiver<Certificate>,
+        rx_committed_certificates: Receiver<(Round, Vec<Certificate>)>,
         dag: Option<Arc<Dag>>,
         network_model: NetworkModel,
         tx_reconfigure: watch::Sender<ReconfigureNotification>,
-        tx_committed_certificates: Sender<Certificate>,
+        tx_committed_certificates: Sender<(Round, Vec<Certificate>)>,
         registry: &Registry,
         // See comments in Subscriber::spawn
         rx_executor_network: Option<oneshot::Sender<P2pNetwork>>,

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -163,6 +163,11 @@ impl Primary {
             &primary_channel_metrics.tx_state_handler,
             &primary_channel_metrics.tx_state_handler_total,
         );
+        let (tx_commited_own_headers, rx_commited_own_headers) = channel_with_total(
+            CHANNEL_CAPACITY,
+            &primary_channel_metrics.tx_commited_own_headers,
+            &primary_channel_metrics.tx_commited_own_headers_total,
+        );
 
         // we need to hack the gauge from this consensus channel into the primary registry
         // This avoids a cyclic dependency in the initialization of consensus and primary
@@ -427,6 +432,7 @@ impl Primary {
             rx_parents,
             rx_our_digests,
             tx_headers,
+            rx_commited_own_headers,
             node_metrics,
         );
 
@@ -439,6 +445,7 @@ impl Primary {
             tx_consensus_round_updates,
             rx_state_handler,
             tx_reconfigure,
+            Some(tx_commited_own_headers),
             P2pNetwork::new(network.clone()),
         );
 

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -74,6 +74,8 @@ impl StateHandler {
             // Trigger cleanup on the primary.
             let _ = self.tx_consensus_round_updates.send(round); // ignore error when receivers dropped.
         }
+
+        // Now we are going to signal which of our own batches have been committed.
     }
 
     fn update_committee(&mut self, committee: Committee) {

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use sui_metrics::spawn_monitored_task;
 use tap::TapOptional;
 use tokio::{sync::watch, task::JoinHandle};
-use tracing::{info, warn};
+use tracing::{info, warn, debug};
 use types::{
     metered_channel::Receiver, Certificate, ReconfigureNotification, Round,
     WorkerReconfigureMessage,
@@ -76,6 +76,17 @@ impl StateHandler {
         }
 
         // Now we are going to signal which of our own batches have been committed.
+        let own_rounds_committed: Vec<_> = _certificates
+            .iter()
+            .filter_map(|cert| {
+                if cert.header.author == self.name {
+                    Some(cert.header.round)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        debug!("Own committed rounds {:?} at round {:?}", own_rounds_committed, round);
     }
 
     fn update_committee(&mut self, committee: Committee) {

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -69,9 +69,7 @@ impl StateHandler {
         })
     }
 
-    async fn handle_sequenced(&mut self, round: Round, _certificates: Vec<Certificate>) {
-        // TODO [issue #9]: Re-include batch digests that have not been sequenced into our next block.
-
+    async fn handle_sequenced(&mut self, round: Round, certificates: Vec<Certificate>) {
         if round > self.last_committed_round {
             self.last_committed_round = round;
 
@@ -80,7 +78,7 @@ impl StateHandler {
         }
 
         // Now we are going to signal which of our own batches have been committed.
-        let own_rounds_committed: Vec<_> = _certificates
+        let own_rounds_committed: Vec<_> = certificates
             .iter()
             .filter_map(|cert| {
                 if cert.header.author == self.name {

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -165,12 +165,26 @@ async fn test_successful_blocks_delete() {
 
     // ensure deleted certificates have been populated to output channel
     let mut total_deleted = 0;
-    while let Ok(Some(c)) = timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await {
+
+    /*while let Ok(Some(c)) = 
+        timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await 
+    {
         assert!(
             digests.contains(&c.digest()),
             "Deleted certificate not found"
         );
-        total_deleted += 1;
+        total_deleted += 1; */
+
+    while let Ok(Some((_round, certs))) =
+        timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await
+    {
+        for ci in certs {
+            assert!(
+                digests.contains(&ci.digest()),
+                "Deleted certificate not found"
+            );
+            total_deleted += 1;
+        }
     }
 
     assert_eq!(total_deleted, digests.len());

--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -166,8 +166,8 @@ async fn test_successful_blocks_delete() {
     // ensure deleted certificates have been populated to output channel
     let mut total_deleted = 0;
 
-    /*while let Ok(Some(c)) = 
-        timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await 
+    /*while let Ok(Some(c)) =
+        timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await
     {
         assert!(
             digests.contains(&c.digest()),

--- a/narwhal/primary/src/tests/proposer_tests.rs
+++ b/narwhal/primary/src/tests/proposer_tests.rs
@@ -19,6 +19,7 @@ async fn propose_empty() {
     let (_tx_reconfigure, rx_reconfigure) =
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (_tx_parents, rx_parents) = test_utils::test_channel!(1);
+    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
     let (_tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
 
@@ -38,6 +39,7 @@ async fn propose_empty() {
         /* rx_core */ rx_parents,
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
+        rx_commited_own_headers,
         metrics,
     );
 
@@ -61,6 +63,7 @@ async fn propose_payload() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_parents, rx_parents) = test_utils::test_channel!(1);
     let (tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
+    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
 
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -82,6 +85,7 @@ async fn propose_payload() {
         /* rx_core */ rx_parents,
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
+        rx_commited_own_headers,
         metrics,
     );
 
@@ -150,7 +154,7 @@ async fn equivocation_protection() {
     let (tx_parents, rx_parents) = test_utils::test_channel!(1);
     let (tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
-
+    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the proposer.
@@ -168,6 +172,7 @@ async fn equivocation_protection() {
         /* rx_core */ rx_parents,
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
+        rx_commited_own_headers,
         metrics,
     );
 
@@ -210,7 +215,7 @@ async fn equivocation_protection() {
     let (tx_parents, rx_parents) = test_utils::test_channel!(1);
     let (tx_our_digests, rx_our_digests) = test_utils::test_channel!(1);
     let (tx_headers, mut rx_headers) = test_utils::test_channel!(1);
-
+    let (_tx_commited_own_headers, rx_commited_own_headers) = test_utils::test_channel!(1);
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     let _proposer_handle = Proposer::spawn(
@@ -227,6 +232,7 @@ async fn equivocation_protection() {
         /* rx_core */ rx_parents,
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
+        rx_commited_own_headers,
         metrics,
     );
 


### PR DESCRIPTION
This PR creates an in-memory facility for the primary to offer some stronger delivery guarantees for its own batches:
* The primary only responds to the worker once it has recorded a digest provided to the list that feeds the next header. (This completes the e2e reliability story by which the client of the worker only keys an ack once the primary records the batch with its transaction).
* The primary records all created & sent headers, and the batch digest they contain in the proposer (in memory).
* A feedback channel from consensus informs the proposer of headers that are committed and the commit round, which allows the proposer to forget committed headers, and re-include batches in non committed headers in future batches.