### PR TITLE
wallet-ext: add error-boundaries

### DIFF
--- a/apps/wallet/package.json
+++ b/apps/wallet/package.json
@@ -107,6 +107,7 @@
         "mitt": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^3.1.4",
         "react-intl": "^6.0.5",
         "react-number-format": "^4.9.3",
         "react-redux": "^8.0.2",

--- a/apps/wallet/src/ui/app/components/alert/Alert.module.scss
+++ b/apps/wallet/src/ui/app/components/alert/Alert.module.scss
@@ -1,5 +1,6 @@
 @use '_values/colors';
 @use '_utils';
+@use '_values/sizing' as s;
 
 .container {
     display: flex;
@@ -9,6 +10,10 @@
     padding: 8px 10px;
     gap: 6px;
     border-radius: 10px;
+
+    :global(.app-initializing) & {
+        width: s.$popup-width;
+    }
 
     @include utils.typography('ParagraphPrimary/P2-M');
 
@@ -38,6 +43,7 @@
 
 .message {
     overflow-wrap: anywhere;
+    flex: 1;
 
     @include utils.typography('ParagraphPrimary/P2-M');
 }

--- a/apps/wallet/src/ui/app/components/error-boundary/index.tsx
+++ b/apps/wallet/src/ui/app/components/error-boundary/index.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
+import { useLocation } from 'react-router-dom';
+
+import Alert from '_components/alert';
+
+import type { ReactNode } from 'react';
+import type { FallbackProps } from 'react-error-boundary';
+
+function Fallback({ error }: FallbackProps) {
+    return (
+        <div className="p-2">
+            <Alert mode="warning">
+                <div className="mb-1 font-semibold">Something went wrong</div>
+                <div className="font-mono">{error.message}</div>
+            </Alert>
+        </div>
+    );
+}
+
+export type ErrorBoundaryProps = {
+    children: ReactNode | ReactNode[];
+};
+
+export function ErrorBoundary({ children }: ErrorBoundaryProps) {
+    const location = useLocation();
+    return (
+        <ReactErrorBoundary FallbackComponent={Fallback} resetKeys={[location]}>
+            {children}
+        </ReactErrorBoundary>
+    );
+}

--- a/apps/wallet/src/ui/app/components/menu/content/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/index.tsx
@@ -8,6 +8,7 @@ import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import Account from './account';
 import MenuList from './menu-list';
 import Network from './network';
+import { ErrorBoundary } from '_components/error-boundary';
 import {
     useMenuIsOpen,
     useMenuUrl,
@@ -45,15 +46,19 @@ function MenuContent() {
         <div className={st.container}>
             <div className={st.backdrop} onClick={handleOnCloseMenu} />
             <div className={cl(st.content, { [st.expanded]: expanded })}>
-                <Routes location={menuUrl || ''}>
-                    <Route path="/" element={<MenuList />} />
-                    <Route path="/account" element={<Account />} />
-                    <Route path="/network" element={<Network />} />
-                    <Route
-                        path="*"
-                        element={<Navigate to={menuHomeUrl} replace={true} />}
-                    />
-                </Routes>
+                <ErrorBoundary>
+                    <Routes location={menuUrl || ''}>
+                        <Route path="/" element={<MenuList />} />
+                        <Route path="/account" element={<Account />} />
+                        <Route path="/network" element={<Network />} />
+                        <Route
+                            path="*"
+                            element={
+                                <Navigate to={menuHomeUrl} replace={true} />
+                            }
+                        />
+                    </Routes>
+                </ErrorBoundary>
             </div>
         </div>
     );

--- a/apps/wallet/src/ui/app/components/transactions-card/RecentTransactions.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/RecentTransactions.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect } from 'react';
 
+import { ErrorBoundary } from '_components/error-boundary';
 import Loading from '_components/loading';
 import TransactionCard from '_components/transactions-card';
 import { useAppSelector, useAppDispatch } from '_hooks';
@@ -36,7 +37,9 @@ function RecentTransactions({ coinType }: Props) {
         <>
             <Loading loading={loading} className={st.centerLoading}>
                 {txByAddress.map((txn) => (
-                    <TransactionCard txn={txn} key={txn.txId} />
+                    <ErrorBoundary key={txn.txId}>
+                        <TransactionCard txn={txn} />
+                    </ErrorBoundary>
                 ))}
             </Loading>
         </>

--- a/apps/wallet/src/ui/app/index.tsx
+++ b/apps/wallet/src/ui/app/index.tsx
@@ -46,6 +46,7 @@ const App = () => {
     );
     useEffect(() => {
         document.body.classList[isPopup ? 'add' : 'remove']('is-popup');
+        document.body.classList.remove('app-initializing');
     }, [isPopup]);
     const location = useLocation();
     useEffect(() => {

--- a/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nfts/index.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { Content } from '_app/shared/bottom-menu-layout';
 import PageTitle from '_app/shared/page-title';
+import { ErrorBoundary } from '_components/error-boundary';
 import NFTdisplay from '_components/nft-display';
 import { useAppSelector } from '_hooks';
 import { accountNftsSelector } from '_redux/slices/account';
@@ -31,7 +32,9 @@ function NftsPage() {
                                 }).toString()}`}
                                 key={nft.reference.objectId}
                             >
-                                <NFTdisplay nftobj={nft} showlabel={true} />
+                                <ErrorBoundary>
+                                    <NFTdisplay nftobj={nft} showlabel={true} />
+                                </ErrorBoundary>
                             </Link>
                         ))}
                     </section>

--- a/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
+++ b/apps/wallet/src/ui/app/shared/page-main-layout/index.tsx
@@ -5,6 +5,7 @@ import cl from 'classnames';
 import { Link } from 'react-router-dom';
 
 import DappStatus from '_app/shared/dapp-status';
+import { ErrorBoundary } from '_components/error-boundary';
 import Logo from '_components/logo';
 import { MenuButton, MenuContent } from '_components/menu';
 import Navigation from '_components/navigation';
@@ -54,7 +55,7 @@ export default function PageMainLayout({
                         className
                     )}
                 >
-                    {children}
+                    <ErrorBoundary>{children}</ErrorBoundary>
                 </main>
                 {bottomNavEnabled ? <Navigation /> : null}
                 {topNavMenuEnabled ? <MenuContent /> : null}

--- a/apps/wallet/src/ui/index.template.html
+++ b/apps/wallet/src/ui/index.template.html
@@ -8,7 +8,7 @@
             content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
     </head>
-    <body>
+    <body class="app-initializing">
         <div id="root"></div>
     </body>
 </html>

--- a/apps/wallet/src/ui/index.tsx
+++ b/apps/wallet/src/ui/index.tsx
@@ -11,6 +11,7 @@ import { HashRouter } from 'react-router-dom';
 import App from './app';
 import { growthbook, loadFeatures } from './app/experimentation/feature-gating';
 import { queryClient } from './app/helpers/queryClient';
+import { ErrorBoundary } from '_components/error-boundary';
 import { initAppType, initNetworkFromStorage } from '_redux/slices/app';
 import { getFromLocationSearch } from '_redux/slices/app/AppType';
 import initSentry from '_src/shared/sentry';
@@ -43,7 +44,9 @@ function renderApp() {
                 <Provider store={store}>
                     <IntlProvider locale={navigator.language}>
                         <QueryClientProvider client={queryClient}>
-                            <App />
+                            <ErrorBoundary>
+                                <App />
+                            </ErrorBoundary>
                         </QueryClientProvider>
                     </IntlProvider>
                 </Provider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,7 @@ importers:
       prettier: ^2.7.1
       react: ^18.2.0
       react-dom: ^18.2.0
+      react-error-boundary: ^3.1.4
       react-intl: ^6.0.5
       react-number-format: ^4.9.3
       react-redux: ^8.0.2
@@ -275,6 +276,7 @@ importers:
       mitt: 3.0.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      react-error-boundary: 3.1.4_react@18.2.0
       react-intl: 6.0.8_n4upredruleo7vrbwztywbpoxq
       react-number-format: 4.9.3_biqbaboplfbrettd7655fr4n2y
       react-redux: 8.0.2_6hrpdt74nuubt2lijsfizev3cu
@@ -16171,6 +16173,16 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-is: 18.1.0
     dev: true
+
+  /react-error-boundary/3.1.4_react@18.2.0:
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.18.9
+      react: 18.2.0
+    dev: false
 
   /react-fast-compare/2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}


### PR DESCRIPTION
* top level
  <img width="948" alt="Screenshot 2022-11-04 at 11 37 22" src="https://user-images.githubusercontent.com/10210143/199967938-2fb003f5-7301-43b2-9f04-068893220e0a.png">
  <img width="486" alt="Screenshot 2022-11-04 at 11 37 47" src="https://user-images.githubusercontent.com/10210143/199967943-e06938b5-bed3-4906-a301-0540ddb6bac5.png">
* main page content
  <img width="400" alt="Screenshot 2022-11-04 at 10 58 12" src="https://user-images.githubusercontent.com/10210143/199968144-85d011ed-5e72-41ff-8573-6d980f8e97c5.png">
* nft-details
  <img width="486" alt="Screenshot 2022-11-04 at 11 44 09" src="https://user-images.githubusercontent.com/10210143/199967971-cbe87372-fba3-496e-8cd7-78089c63c3e3.png">
* transactions
  <img width="400" alt="Screenshot 2022-11-04 at 10 58 05" src="https://user-images.githubusercontent.com/10210143/199968034-f2b0c97b-e45d-4bde-87bb-c8fc7c2c12a8.png">
  <img width="486" alt="Screenshot 2022-11-04 at 11 49 30" src="https://user-images.githubusercontent.com/10210143/199968038-6de844f2-0060-4110-aaf5-9a137dcf18d1.png">

closes: APPS-95