### PR TITLE
[1/x][lamport] Get rid of TransactionEffects::is_object_mutated_here

### DIFF
--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1941,10 +1941,10 @@ where
     }
 
     pub async fn get_object_info_execute(&self, object_id: ObjectID) -> SuiResult<ObjectRead> {
-        let (object_map, cert_map) = self.get_object_by_id(object_id, false).await?;
+        let (object_map, _cert_map) = self.get_object_by_id(object_id, false).await?;
         let mut object_ref_stack: Vec<_> = object_map.into_iter().collect();
 
-        while let Some(((obj_ref, tx_digest), (obj_option, layout_option, authorities))) =
+        while let Some(((obj_ref, _tx_digest), (obj_option, layout_option, authorities))) =
             object_ref_stack.pop()
         {
             let stake: StakeUnit = authorities

--- a/crates/sui-core/src/authority_aggregator.rs
+++ b/crates/sui-core/src/authority_aggregator.rs
@@ -1952,31 +1952,9 @@ where
                 .map(|(name, _)| self.committee.weight(name))
                 .sum();
 
-            let mut is_ok = false;
+            // If we have f+1 stake telling us of the latest version of the object, we just accept
+            // it.
             if stake >= self.committee.validity_threshold() {
-                // If we have f+1 stake telling us of the latest version of the object, we just accept it.
-                is_ok = true;
-            } else if cert_map.contains_key(&tx_digest) {
-                // If we have less stake telling us about the latest state of an object
-                // we re-run the certificate on all authorities to ensure it is correct.
-                if let Ok(effects) = self
-                    .process_certificate(cert_map[&tx_digest].clone().into())
-                    .await
-                {
-                    if effects.effects.is_object_mutated_here(obj_ref) {
-                        is_ok = true;
-                    } else {
-                        // TODO: Throw a byzantine fault here
-                        error!(
-                            ?object_id,
-                            ?tx_digest,
-                            "get_object_info_execute. Byzantine failure!"
-                        );
-                        continue;
-                    }
-                }
-            }
-            if is_ok {
                 match obj_option {
                     Some(obj) => {
                         return Ok(ObjectRead::Exists(obj_ref, obj, layout_option));

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1957,34 +1957,6 @@ impl TransactionEffects {
         &self.gas_used
     }
 
-    pub fn is_object_mutated_here(&self, obj_ref: ObjectRef) -> bool {
-        // The mutated or created case
-        if self.all_mutated().any(|(oref, _, _)| *oref == obj_ref) {
-            return true;
-        }
-
-        // The deleted case
-        if obj_ref.2 == ObjectDigest::OBJECT_DIGEST_DELETED
-            && self
-                .deleted
-                .iter()
-                .any(|(id, seq, _)| *id == obj_ref.0 && seq.increment() == obj_ref.1)
-        {
-            return true;
-        }
-
-        // The wrapped case
-        if obj_ref.2 == ObjectDigest::OBJECT_DIGEST_WRAPPED
-            && self
-                .wrapped
-                .iter()
-                .any(|(id, seq, _)| *id == obj_ref.0 && seq.increment() == obj_ref.1)
-        {
-            return true;
-        }
-        false
-    }
-
     pub fn to_sign_effects(
         self,
         epoch: EpochId,


### PR DESCRIPTION
Spotted while working on lamport timestamps.  This function is only called in one place (`AuthorityAggregator::get_object_info_execute`) to check that a validator that object info is being read from isn't
Byzantine, but it is only used in Gateway, and benchmarks.  The former is going away soon, and the latter does not need to worry about byzantine validators.

Furthermore, the logic in this function for deleted and wrapped objects does not seem correct:  It asserts that an object is deleted in effects if it appears in the deleted effects at `version - 1`, but the logic in `TemporaryStore::delete_object` increments an object's version when it is deleted, so it should match.

Opting to remove the code to re-execute certificates instead of trying to make it work with lamport timestamps as there's a good chance it's not currently working and therefore needed.

## Test Plan

```
$ cargo simtest
$ cargo nextest run
```