### PR TITLE
wallet-ext: use session storage to unlock wallet

### DIFF
--- a/apps/wallet/configs/webpack/webpack.config.common.ts
+++ b/apps/wallet/configs/webpack/webpack.config.common.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { randomBytes } from '@noble/hashes/utils';
 import { exec } from 'child_process';
 import CopyPlugin from 'copy-webpack-plugin';
 import DotEnv from 'dotenv-webpack';
@@ -177,6 +178,9 @@ const commonConfig: () => Promise<Configuration> = async () => {
                 // TODO: check if this is worth investigating a fix and maybe do a separate build for UI and bg?
                 // 'typeof window': JSON.stringify(typeof {}),
                 'process.env.NODE_DEBUG': false,
+                'process.env.WALLET_KEYRING_PASSWORD': JSON.stringify(
+                    Buffer.from(randomBytes(64)).toString('hex')
+                ),
             }),
             new ProvidePlugin({
                 Buffer: ['buffer', 'Buffer'],

--- a/apps/wallet/src/background/connections/KeepAliveConnection.ts
+++ b/apps/wallet/src/background/connections/KeepAliveConnection.ts
@@ -4,6 +4,7 @@
 import { BehaviorSubject, filter, map, take } from 'rxjs';
 
 import Keyring from '_src/background/keyring';
+import { IS_SESSION_STORAGE_SUPPORTED } from '_src/background/keyring/VaultStorage';
 import { MSG_DISABLE_AUTO_RECONNECT } from '_src/content-script/keep-bg-alive';
 
 import type { Runtime } from 'webextension-polyfill';
@@ -18,6 +19,10 @@ export class KeepAliveConnection {
     private autoDisconnectTimeout: number | null = null;
 
     constructor(private port: Runtime.Port) {
+        if (IS_SESSION_STORAGE_SUPPORTED) {
+            this.forcePortDisconnect(false);
+            return;
+        }
         Keyring.on('lockedStatusUpdate', this.onKeyringLockedStatusUpdate);
         this.port.onDisconnect.addListener(this.onPortDisconnected);
         this.onKeyringLockedStatusUpdate(Keyring.isLocked);

--- a/apps/wallet/src/background/keyring/VaultStorage.ts
+++ b/apps/wallet/src/background/keyring/VaultStorage.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { randomBytes } from '@noble/hashes/utils';
+import Browser from 'webextension-polyfill';
+
+import { Vault } from './Vault';
+import { getRandomEntropy, toEntropy } from '_shared/utils/bip39';
+
+import type { StoredData } from './Vault';
+import type { Storage } from 'webextension-polyfill';
+
+export const IS_SESSION_STORAGE_SUPPORTED = 'chrome' in global;
+const SESSION_STORAGE: Storage.LocalStorageArea | null =
+    // @ts-expect-error chrome
+    IS_SESSION_STORAGE_SUPPORTED ? global.chrome.storage.session : null;
+const LOCAL_STORAGE = Browser.storage.local;
+
+// we use this password + a random one for each time we store the encrypted
+// vault to session storage
+const PASSWORD =
+    process.env.WALLET_KEYRING_PASSWORD ||
+    '344c6f7d04a65c24f35f5c710b0e91e2f2e2f88c038562622d5602019b937bc2c2aa2821e65cc94775fe5acf2fee240d38f1abbbe00b0e6682646a4ce10e908e';
+const VAULT_KEY = 'vault';
+const EPHEMERAL_PASSWORD_KEY = '244e4b24e667ebf';
+const EPHEMERAL_VAULT_KEY = 'a8e451b8ae8a1b4';
+
+async function getFromStorage<T>(
+    storage: Storage.LocalStorageArea,
+    key: string
+): Promise<T | null> {
+    return (await storage.get({ [key]: null }))[key];
+}
+
+async function setToStorage<T>(
+    storage: Storage.LocalStorageArea,
+    key: string,
+    value: T
+): Promise<void> {
+    return await storage.set({ [key]: value });
+}
+
+async function ifSessionStorage(
+    execFN: (sessionStorage: Storage.LocalStorageArea) => Promise<void>
+) {
+    if (SESSION_STORAGE) {
+        return execFN(SESSION_STORAGE);
+    }
+}
+
+function getRandomPassword() {
+    return Buffer.from(randomBytes(64)).toString('hex');
+}
+
+function makeEphemeraPassword(rndPass: string) {
+    return `${PASSWORD}${rndPass}`;
+}
+
+export class VaultStorage {
+    #vault: Vault | null = null;
+
+    /**
+     * See {@link Keyring.createVault}
+     * @param password
+     * @param importedEntropy
+     */
+    public async create(password: string, importedEntropy?: string) {
+        if (await this.isWalletInitialized()) {
+            throw new Error(
+                'Mnemonic already exists, creating a new one will override it. Clear the existing one first.'
+            );
+        }
+        let vault: Vault | null = new Vault(
+            importedEntropy ? toEntropy(importedEntropy) : getRandomEntropy()
+        );
+        await setToStorage(
+            LOCAL_STORAGE,
+            VAULT_KEY,
+            await vault.encrypt(password)
+        );
+        vault = null;
+    }
+
+    public async unlock(password: string) {
+        const encryptedVault = await getFromStorage<StoredData>(
+            LOCAL_STORAGE,
+            VAULT_KEY
+        );
+        if (!encryptedVault) {
+            throw new Error(
+                'Wallet is not initialized. Create a new one first.'
+            );
+        }
+        this.#vault = await Vault.from(
+            password,
+            encryptedVault,
+            async (aVault) =>
+                setToStorage(
+                    LOCAL_STORAGE,
+                    VAULT_KEY,
+                    await aVault.encrypt(password)
+                )
+        );
+        await ifSessionStorage(async (sessionStorage) => {
+            if (!this.#vault) {
+                return;
+            }
+            const rndPass = getRandomPassword();
+            const ephemeralPass = makeEphemeraPassword(rndPass);
+            await setToStorage(sessionStorage, EPHEMERAL_PASSWORD_KEY, rndPass);
+            await setToStorage(
+                sessionStorage,
+                EPHEMERAL_VAULT_KEY,
+                await this.#vault.encrypt(ephemeralPass)
+            );
+        });
+    }
+
+    public async lock() {
+        this.#vault = null;
+        await ifSessionStorage(async (sessionStorage) => {
+            await setToStorage(sessionStorage, EPHEMERAL_PASSWORD_KEY, null);
+            await setToStorage(sessionStorage, EPHEMERAL_VAULT_KEY, null);
+        });
+    }
+
+    public async revive(): Promise<boolean> {
+        let unlocked = false;
+        await ifSessionStorage(async (sessionStorage) => {
+            const rndPass = await getFromStorage<string>(
+                sessionStorage,
+                EPHEMERAL_PASSWORD_KEY
+            );
+            if (rndPass) {
+                const ephemeralPass = makeEphemeraPassword(rndPass);
+                const ephemeralEncryptedVault =
+                    await getFromStorage<StoredData>(
+                        sessionStorage,
+                        EPHEMERAL_VAULT_KEY
+                    );
+                if (ephemeralEncryptedVault) {
+                    this.#vault = await Vault.from(
+                        ephemeralPass,
+                        ephemeralEncryptedVault
+                    );
+                    unlocked = true;
+                }
+            }
+        });
+        return unlocked;
+    }
+
+    public async clear() {
+        await this.lock();
+        await setToStorage(LOCAL_STORAGE, VAULT_KEY, null);
+    }
+
+    public async isWalletInitialized() {
+        return !!(await getFromStorage<StoredData>(LOCAL_STORAGE, VAULT_KEY));
+    }
+
+    public getMnemonic() {
+        return this.#vault?.getMnemonic() || null;
+    }
+
+    public get entropy() {
+        return this.#vault?.entropy || null;
+    }
+}


### PR DESCRIPTION
* when supported store the encrypted vault to session storage
* use a random generated password to encrypt it
* password has 2 parts one same for everyone that changes every time we build the wallet and a random part that is being generated every time we store the vault to the session storage
* store the random part of the password in session storage
* disable keep-alive connection when session storage is supported

closes: APPS-106
