### PR TITLE
relax transaction input checker to not require signature

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -559,9 +559,11 @@ impl AuthorityState {
             return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 
-        let (_gas_status, input_objects) =
-            transaction_input_checker::check_transaction_input(&self.database, &transaction)
-                .await?;
+        let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
+            &self.database,
+            &transaction.signed_data.data,
+        )
+        .await?;
 
         let owned_objects = input_objects.filter_owned_objects();
 
@@ -951,9 +953,9 @@ impl AuthorityState {
         Ok((inner_temp_store, signed_effects))
     }
 
-    pub async fn dry_run_transaction(
+    pub async fn dry_exec_transaction(
         &self,
-        transaction: VerifiedTransaction,
+        transaction: TransactionData,
         transaction_digest: TransactionDigest,
     ) -> Result<SuiTransactionEffects, anyhow::Error> {
         let (gas_status, input_objects) =
@@ -968,7 +970,7 @@ impl AuthorityState {
             execution_engine::execute_transaction_to_effects(
                 shared_object_refs,
                 temporary_store,
-                transaction.signed_data.data.clone(),
+                transaction,
                 transaction_digest,
                 transaction_dependencies,
                 &self.move_vm,

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -735,8 +735,11 @@ where
         self.download_object_from_authorities(SUI_SYSTEM_STATE_OBJECT_ID)
             .await?;
 
-        let (_gas_status, input_objects) =
-            transaction_input_checker::check_transaction_input(&self.store, transaction).await?;
+        let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
+            &self.store,
+            &transaction.signed_data.data,
+        )
+        .await?;
 
         let owned_objects = input_objects.filter_owned_objects();
         if let Err(err) = self

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -184,7 +184,7 @@ async fn test_dry_run_transaction() {
     let transaction_digest = *transaction.digest();
 
     let response = authority
-        .dry_run_transaction(transaction, transaction_digest)
+        .dry_exec_transaction(transaction.signed_data.data.clone(), transaction_digest)
         .await;
     assert!(response.is_ok());
 

--- a/crates/sui-cost/src/estimator.rs
+++ b/crates/sui-cost/src/estimator.rs
@@ -140,7 +140,8 @@ pub async fn estimate_transaction_computation_cost(
     let tx = to_sender_signed_transaction(tx_data, &keypair);
 
     let (_gas_status, input_objects) =
-        transaction_input_checker::check_transaction_input(&state.db(), &tx).await?;
+        transaction_input_checker::check_transaction_input(&state.db(), &tx.signed_data.data)
+            .await?;
     let in_mem_temporary_store =
         TemporaryStore::new(state.db(), input_objects, TransactionDigest::random());
 

--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -116,13 +116,7 @@ pub trait RpcReadApi {
 #[rpc(server, client, namespace = "sui")]
 pub trait RpcFullNodeReadApi {
     #[method(name = "dryRunTransaction")]
-    async fn dry_run_transaction(
-        &self,
-        tx_bytes: Base64,
-        sig_scheme: SignatureScheme,
-        signature: Base64,
-        pub_key: Base64,
-    ) -> RpcResult<SuiTransactionEffects>;
+    async fn dry_run_transaction(&self, tx_bytes: Base64) -> RpcResult<SuiTransactionEffects>;
 
     /// Return the argument types of a Move function,
     /// based on normalized Type.

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -156,27 +156,6 @@
           "schema": {
             "$ref": "#/components/schemas/Base64"
           }
-        },
-        {
-          "name": "sig_scheme",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/SignatureScheme"
-          }
-        },
-        {
-          "name": "signature",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/Base64"
-          }
-        },
-        {
-          "name": "pub_key",
-          "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/Base64"
-          }
         }
       ],
       "result": {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -749,6 +749,16 @@ impl TransactionData {
         &self.gas_payment
     }
 
+    pub fn contains_shared_object(&self) -> bool {
+        self.shared_input_objects().next().is_some()
+    }
+
+    pub fn shared_input_objects(
+        &self,
+    ) -> impl Iterator<Item = (&ObjectID, /* shared at version */ &SequenceNumber)> {
+        self.kind.shared_input_objects()
+    }
+
     pub fn move_calls(&self) -> Vec<&MoveCall> {
         self.kind
             .single_transactions()


### PR DESCRIPTION
the input checker does not have to take a signed txn, the signature verification of prod txn execution path is done elsewhere.
here it is useful for dry_run_transaction, more context can be found in https://mysten-labs.slack.com/archives/C043CJH1HCK/p1667579885385269