### PR TITLE
Notify batch notifier for actual sequence number because it could be blocking it

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -393,6 +393,13 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         }
     }
 
+    pub async fn get_tx_sequence(
+        &self,
+        tx: TransactionDigest,
+    ) -> SuiResult<Option<TxSequenceNumber>> {
+        self.lock_service.get_tx_sequence(tx).await
+    }
+
     /// Get the transaction envelope that currently locks the given object,
     /// or returns Err(TransactionLockDoesNotExist) if the lock does not exist.
     pub async fn get_object_locking_transaction(


### PR DESCRIPTION
Authority notifier gets stuck if the previous attempt of commiting a certificate sequenced the transaction but failed to commit. In this case, we should notify both previous and old sequence.
Also, if we failed to lock a sequence number and failed to commit, we should notify the ticket as well