### PR TITLE
[dynamic child objects][cleanup] Remove creation of locks for child objects

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1264,7 +1264,7 @@ impl AuthorityState {
                 match self.get_object(&request.object_id).await {
                     Ok(Some(object)) => {
                         let lock = if !object.is_address_owned() {
-                            // Unowned objects have no locks.
+                            // Only address owned objects have locks.
                             None
                         } else {
                             self.get_transaction_lock(&object.compute_object_reference())

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1263,7 +1263,7 @@ impl AuthorityState {
             ObjectInfoRequestKind::LatestObjectInfo(request_layout) => {
                 match self.get_object(&request.object_id).await {
                     Ok(Some(object)) => {
-                        let lock = if !object.is_owned_or_quasi_shared() {
+                        let lock = if !object.is_address_owned() {
                             // Unowned objects have no locks.
                             None
                         } else {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -829,7 +829,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
 
         let owned_inputs: Vec<_> = active_inputs
             .iter()
-            .filter(|(id, _, _)| objects.get(id).unwrap().is_owned_or_quasi_shared())
+            .filter(|(id, _, _)| objects.get(id).unwrap().is_address_owned())
             .cloned()
             .collect();
 
@@ -935,7 +935,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             let new_locks_to_init: Vec<_> = written
                 .iter()
                 .filter_map(|(_, (object_ref, new_object, _kind))| {
-                    if new_object.is_owned_or_quasi_shared() {
+                    if new_object.is_address_owned() {
                         Some(*object_ref)
                     } else {
                         None

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -289,13 +289,12 @@ impl Owner {
         matches!(self, Owner::Immutable)
     }
 
-    /// Is owned by an address or an object
-    /// In the object case, it might be owned by an address owned object, a shared object, or
-    /// another object owned object.
-    /// If the root of this ownership is a shared object, we refer to these objects as
-    /// "quasi-shared", as they are not shared themselves, but behave similarly in some cases
-    pub fn is_owned_or_quasi_shared(&self) -> bool {
-        matches!(self, Owner::AddressOwner(_) | Owner::ObjectOwner(_))
+    pub fn is_address_owned(&self) -> bool {
+        matches!(self, Owner::AddressOwner(_))
+    }
+
+    pub fn is_child_object(&self) -> bool {
+        matches!(self, Owner::ObjectOwner(_))
     }
 
     pub fn is_shared(&self) -> bool {
@@ -383,8 +382,12 @@ impl Object {
         self.owner.is_immutable()
     }
 
-    pub fn is_owned_or_quasi_shared(&self) -> bool {
-        self.owner.is_owned_or_quasi_shared()
+    pub fn is_address_owned(&self) -> bool {
+        self.owner.is_address_owned()
+    }
+
+    pub fn is_child_object(&self) -> bool {
+        self.owner.is_child_object()
     }
 
     pub fn is_shared(&self) -> bool {


### PR DESCRIPTION
- Child objects are no longer valid transaction arguments
- They do not need locks? I think