### PR TITLE
Split debuginfo into a separate file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,15 @@ version = "0.15.0"
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces
 debug = 1
+split-debuginfo = 'packed'
 strip = 'none'
 # Exit process with SIGABRT when any thread panics
 panic = 'abort'
 
+# Inherits from the release profile above.
 [profile.bench]
-# debug = 1 means line charts only, which is minimum needed for good stack traces
-debug = 1
-strip = 'none'
+# For convenience.
+split-debuginfo = 'off'
 
 [profile.simulator]
 inherits = "test"


### PR DESCRIPTION
We have users complaining about large binary size in release 0.14. It looks like debug sections are the main contributor at >750MB.

```
$ size -A -d -t /usr/local/bin/sui-node
/usr/local/bin/sui-node  :
section                    size       addr
.interp                      28        736
.note.gnu.build-id           36        764
.note.ABI-tag                32        800
.gnu.hash                   752        832
.dynsym                   11952       1584
.dynstr                   12577      13536
.gnu.version                996      26114
.gnu.version_r              896      27112
.rela.dyn               2236752      28008
.rela.plt                  5376    2264760
.init                        27    2273280
.plt                       3600    2273312
.plt.got                    384    2276912
.text                  34933764    2277312
.fini                        13   37211076
.rodata                 3608976   37212160
.debug_gdb_scripts           34   40821136
.eh_frame_hdr            506332   40821172
.eh_frame               3143344   41327504
.gcc_except_table        136440   44470848
.tdata                       88   44613936
.tbss                      2040   44614032
.init_array                1216   44614032
.fini_array                   8   44615248
.data.rel.ro            1304592   44615264
.dynamic                    624   45919856
.got                      57120   45920480
.data                     55920   45977600
.bss                      38656   46033536
.comment                     64          0
.debug_aranges          3754800          0
.debug_pubnames       251906443          0
.debug_info           297748064          0
.debug_abbrev           2887547          0
.debug_line            60695335          0
.debug_frame              68392          0
.debug_str            207283741          0
.debug_loc             95676680          0
.debug_pubtypes           55818          0
.debug_ranges          80397408          0
.debug_macro              10373          0
.debug_addr                  16          0
.debug_loclists              65          0
.debug_str_offsets           76          0
.debug_line_str             173          0
Total                1046547570
```

We may as well try out the `split-debuginfo` option just added to Rust 1.65. It should change binary size and debug tooling output to what they were when debuginfo was stripped. Many tools support using a separate file for debug info.

Also, enable runtime integer overflow check on the `release` build. This is the recommendation from audits.