### PR TITLE
fix(ci): Make CI skip wallet tests when no package has been changed

### DIFF
--- a/.github/workflows/wallet-adapter.yml
+++ b/.github/workflows/wallet-adapter.yml
@@ -4,7 +4,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isWalletAdapter: ${{ contains(fromJson(steps.diff.outputs.packages), 'sui-wallet-adapter') }}
+      isWalletAdapter: ${{ steps.diff.outputs.packages && contains(fromJson(steps.diff.outputs.packages), 'sui-wallet-adapter') }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes


### PR DESCRIPTION
The action seems to fail when the PNPM detection returns an empty list of changed packages, e.g. https://github.com/MystenLabs/sui/actions/runs/3397036833/jobs/5648763612