### PR TITLE
[cleanup] leverage collect() to eliminate error cases in transaction_…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8860,7 +8860,6 @@ dependencies = [
  "sui-json",
  "sui-json-rpc-types",
  "sui-types",
- "tracing",
  "workspace-hack",
 ]
 

--- a/crates/sui-transaction-builder/Cargo.toml
+++ b/crates/sui-transaction-builder/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.64"
 async-trait = "0.1.57"
 futures = "0.3.23"
 bcs = "0.1.4"
-tracing = "0.1.36"
 
 sui-json-rpc-types= { path = "../sui-json-rpc-types" }
 sui-types = { path = "../sui-types" }


### PR DESCRIPTION
…builder

Rust's `collect` is quite powerful--it will turn a `Vec<Result<T>>` into a `Result<Vec<T>>` for you, which usually leads to much shorter code.

Leverage this in a few places in the tx builder code to get rid of some error cases + shorten the code.