### PR TITLE
[Explorer] In the Events Section of the Tx Page, renders objects as strings

### DIFF
--- a/apps/explorer/src/components/events/eventDisplay.tsx
+++ b/apps/explorer/src/components/events/eventDisplay.tsx
@@ -76,7 +76,10 @@ function fieldsContent(fields: { [key: string]: any } | undefined) {
     return Object.keys(fields).map((k) => {
         return {
             label: k,
-            value: fields[k].toString(),
+            value:
+                typeof fields[k] === 'object'
+                    ? JSON.stringify(fields[k])
+                    : fields[k].toString(),
             monotypeClass: true,
         };
     });


### PR DESCRIPTION
As discussed, this initial PR renders the data as a string.

#### Before
https://explorer.devnet.sui.io/transactions/Wqw8tUh91MW5IL%2FVREfyt%2FoUxL%2F7Op7DvHuiWXInUM0%3D

#### Under PR
![image](https://user-images.githubusercontent.com/11377188/200285018-2d8f534e-c688-4642-a101-480d8454e86c.png)
