### PR TITLE
Fix narwhal example config

### DIFF
--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -23,7 +23,7 @@ bench_params = {
     'mem_profiling': False
 }
 ```
-They specify the number of primaries (`nodes`) and workers per primary (`workers`) to deploy, the input rate (transactions per second, or tx/s) at which the clients submit transactions to the system (`rate`), the size of each transaction in bytes (`tx_size`), the number of faulty nodes ('faults`), and the duration of the benchmark in seconds (`duration`). The minimum transaction size is 9 bytes; this ensures the transactions of a client are all different.
+They specify the number of primaries (`nodes`) and workers per primary (`workers`) to deploy, the input rate (transactions per second, or tx/s) at which the clients submit transactions to the system (`rate`), the size of each transaction in bytes (`tx_size`), the number of faulty nodes (`faults`), and the duration of the benchmark in seconds (`duration`). The minimum transaction size is 9 bytes; this ensures the transactions of a client are all different.
 
 The benchmarking script will deploy as many clients as workers and divide the input rate equally amongst each client. For instance, if you configure the testbed with four nodes, one worker per node, and an input rate of 1,000 tx/s (as in the example above), the scripts will deploy four clients each submitting transactions to one node at a rate of 250 tx/s. When the parameter `faults` is set to `f > 0`, the last `f` nodes and clients are not booted; the system will thus run with `n-f` nodes (and `n-f` clients).
 

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -99,7 +99,12 @@ def demo(ctx, debug=True):
         'prometheus_metrics': {
             # Use a random available local port.
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http"
-        }
+        },
+        "network_admin_server": {
+            # Use a random available local port.
+            "primary_network_admin_server_port": 0,
+            "worker_network_admin_server_base_port": 0
+        },
     }
     try:
         ret = Demo(bench_params, node_params).run(debug)


### PR DESCRIPTION
Fixes a typo and some missing config that lead to the following error when running `fab demo`:
```
ERROR:root:'NoneType' object has no attribute 'group'
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/opt/homebrew/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/Users/paul/Projects/sui/narwhal/benchmark/benchmark/logs.py", line 295, in _parse_primaries
    r'Consensus API gRPC Server listening on /ip4/.+/tcp/(.+)/http', log).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
"""
```