### PR TITLE
chore(ci): fix use of pnpm output

### DIFF
--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -4,7 +4,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isClient: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-explorer') || steps.diff.outputs.isRust }}
+      isClient: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-explorer') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -4,7 +4,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isTypescriptSDK: ${{ contains(fromJson(steps.pnpm.outputs.packages), '@mysten/sui.js') || steps.diff.outputs.isRust }}
+      isTypescriptSDK: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), '@mysten/sui.js') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -4,8 +4,8 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     outputs:
-      isWalletExt: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') || steps.diff.outputs.isRust }}
-      isSrcChange: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') }}
+      isWalletExt: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') || steps.diff.outputs.isRust }}
+      isSrcChange: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)


### PR DESCRIPTION
Continuation of #5881: make other flow dependent on pnpm skip properly when the output is empty. This should unblock dependabot PRs.