### PR TITLE
[core] Refactor Transaction to use MessageEnvelope

### DIFF
--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -134,7 +134,9 @@ impl TestContext {
             .get_fullnode_client()
             .quorum_driver()
             .execute_transaction(
-                Transaction::new(txn_data, signature).verify().unwrap(),
+                Transaction::from_data(txn_data, signature)
+                    .verify()
+                    .unwrap(),
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await
@@ -286,8 +288,8 @@ impl ClusterTest {
         let mut success_cnt = 0;
         let total_cnt = tests.len() as i32;
         for t in tests {
-            let is_sucess = t.run(&mut ctx).await as i32;
-            success_cnt += is_sucess;
+            let is_success = t.run(&mut ctx).await as i32;
+            success_cnt += is_success;
         }
         if success_cnt < total_cnt {
             // If any test failed, panic to bubble up the signal

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -12,10 +12,11 @@ use std::path::Path;
 use sui_storage::default_db_options;
 use sui_types::base_types::{ExecutionDigests, SequenceNumber};
 use sui_types::batch::{SignedBatch, TxSequenceNumber};
-use sui_types::messages::{TrustedCertificate, TrustedTransactionEnvelope};
+use sui_types::messages::TrustedCertificate;
 use typed_store::rocks::{DBMap, DBOptions};
 use typed_store::traits::TypedStoreDebug;
 
+use sui_types::message_envelope::TrustedEnvelope;
 use typed_store_derive::DBMapUtils;
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
@@ -23,7 +24,7 @@ use typed_store_derive::DBMapUtils;
 pub struct AuthorityEpochTables<S> {
     /// This is map between the transaction digest and transactions found in the `transaction_lock`.
     #[default_options_override_fn = "transactions_table_default_config"]
-    pub(crate) transactions: DBMap<TransactionDigest, TrustedTransactionEnvelope<S>>,
+    pub(crate) transactions: DBMap<TransactionDigest, TrustedEnvelope<SenderSignedData, S>>,
 
     /// The pending execution table holds a sequence of transactions that are present
     /// in the certificates table, but may not have yet been executed, and should be executed.

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -368,7 +368,7 @@ impl ValidatorService {
         let span = tracing::debug_span!(
             "validator_state_process_tx",
             ?tx_digest,
-            tx_kind = transaction.signed_data.data.kind_as_str()
+            tx_kind = transaction.data().data.kind_as_str()
         );
 
         let info = state
@@ -409,7 +409,7 @@ impl ValidatorService {
 
         // 3) If the validator is already halted, we stop here, to avoid
         // sending the transaction to consensus.
-        if state.is_halted() && !certificate.signed_data.data.kind.is_system_tx() {
+        if state.is_halted() && !certificate.data().data.kind.is_system_tx() {
             return Err(tonic::Status::from(SuiError::ValidatorHaltedAtEpochEnd));
         }
 
@@ -442,7 +442,7 @@ impl ValidatorService {
             let span = tracing::debug_span!(
                 "validator_state_process_cert",
                 ?tx_digest,
-                tx_kind = certificate.signed_data.data.kind_as_str()
+                tx_kind = certificate.data().data.kind_as_str()
             );
             match state
                 .handle_certificate(&certificate)

--- a/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
+++ b/crates/sui-core/src/checkpoints/tests/checkpoint_tests.rs
@@ -1181,14 +1181,12 @@ async fn set_fragment_external() {
         for key_pair in keys.iter() {
             sigs.push(AuthoritySignInfo::new(
                 0,
-                &tx.signed_data,
+                tx.data(),
                 key_pair.public().into(),
                 key_pair,
             ));
         }
-        let mut certificate =
-            CertifiedTransaction::new_with_auth_sign_infos(tx, sigs, &committee).unwrap();
-        certificate.auth_sign_info.epoch = committee.epoch();
+        let certificate = CertifiedTransaction::new(tx.into_message(), sigs, &committee).unwrap();
         fragment12.data.certs.insert(digest, certificate);
     }
     // let fragment13 = p1.diff_with(&p3);

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -168,7 +168,7 @@ where
             let err = match self
                 .net
                 .load()
-                .process_transaction(advance_epoch_tx.clone().to_transaction())
+                .process_transaction(advance_epoch_tx.clone().into_unsigned())
                 .await
             {
                 Ok(certificate) => match self.state.handle_certificate(&certificate).await {

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -118,18 +118,13 @@ async fn test_start_epoch_change() {
     // Test that when validator is halted, we cannot send any certificate.
     let sigs = states
         .iter()
-        .map(|state| {
-            AuthoritySignInfo::new(0, &transaction.signed_data, state.name, &*state.secret)
-        })
+        .map(|state| AuthoritySignInfo::new(0, transaction.data(), state.name, &*state.secret))
         .collect();
-    let certificate = CertifiedTransaction::new_with_auth_sign_infos(
-        transaction.clone(),
-        sigs,
-        &genesis_committee,
-    )
-    .unwrap()
-    .verify(&genesis_committee)
-    .unwrap();
+    let certificate =
+        CertifiedTransaction::new(transaction.clone().into_message(), sigs, &genesis_committee)
+            .unwrap()
+            .verify(&genesis_committee)
+            .unwrap();
     assert_eq!(
         state.handle_certificate(&certificate).await.unwrap_err(),
         SuiError::ValidatorHaltedAtEpochEnd
@@ -347,7 +342,7 @@ async fn test_cross_epoch_effects_cert() {
     net.committee.epoch += 1;
     // Call to execute_transaction can still succeed.
     let (tx_cert, effects_cert) = net.execute_transaction(&transaction).await.unwrap();
-    assert_eq!(tx_cert.auth_sign_info.epoch, 0);
+    assert_eq!(tx_cert.auth_sig().epoch, 0);
     assert_eq!(effects_cert.auth_signature.epoch, 1);
 }
 

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -631,7 +631,7 @@ where
     /// If any object does not exist in the store, give it a chance
     /// to download from authorities.
     async fn sync_input_objects_with_authorities(&self, transaction: &Transaction) -> SuiResult {
-        let input_objects = transaction.signed_data.data.input_objects()?;
+        let input_objects = transaction.data().data.input_objects()?;
         let mut objects = self.read_objects_from_store(&input_objects).await?;
         for (object_opt, kind) in objects.iter_mut().zip(&input_objects) {
             if object_opt.is_none() {
@@ -665,7 +665,7 @@ where
         let span = tracing::debug_span!(
             "execute_transaction",
             tx_digest = ?tx_digest,
-            tx_kind = transaction.signed_data.data.kind_as_str()
+            tx_kind = transaction.data().data.kind_as_str()
         );
         let exec_result = self
             .authorities
@@ -737,7 +737,7 @@ where
 
         let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
             &self.store,
-            &transaction.signed_data.data,
+            &transaction.data().data,
         )
         .await?;
 
@@ -1026,8 +1026,8 @@ where
         equal_parts: bool,
     ) -> anyhow::Result<SuiParsedTransactionResponse> {
         let call = Self::try_get_move_call(&certificate)?;
-        let signer = certificate.signed_data.data.signer();
-        let (gas_payment, _, _) = certificate.signed_data.data.gas();
+        let signer = certificate.data().data.signer();
+        let (gas_payment, _, _) = certificate.data().data.gas();
         let (coin_object_id, split_arg) = match call.arguments.as_slice() {
             [CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))), CallArg::Pure(arg)] => {
                 (id, arg)
@@ -1099,7 +1099,7 @@ where
                 .into())
             }
         };
-        let (gas_payment, _, _) = certificate.signed_data.data.gas();
+        let (gas_payment, _, _) = certificate.data().data.gas();
 
         if let ExecutionStatus::Failure { error } = effects.status {
             return Err(error.into());
@@ -1131,7 +1131,7 @@ where
 
     fn try_get_move_call(certificate: &CertifiedTransaction) -> Result<&MoveCall, anyhow::Error> {
         if let TransactionKind::Single(SingleTransactionKind::Call(ref call)) =
-            certificate.signed_data.data.kind
+            certificate.data().data.kind
         {
             Ok(call)
         } else {
@@ -1325,7 +1325,7 @@ where
         where
             A: AuthorityAPI + Send + Sync + 'static + Clone,
         {
-            let tx_kind = tx.signed_data.data.kind.clone();
+            let tx_kind = tx.data().data.kind.clone();
             let tx_digest = tx.digest();
 
             debug!(tx_digest = ?tx_digest, "Received execute_transaction request");
@@ -1338,7 +1338,7 @@ where
                         let span = tracing::debug_span!(
                             "gateway_execute_transaction",
                             ?tx_digest,
-                            tx_kind = tx.signed_data.data.kind_as_str()
+                            tx_kind = tx.data().data.kind_as_str()
                         );
 
                         // Use start_coarse_time() if the below turns out to have a perf impact

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -24,7 +24,6 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     CertifiedTransaction, CertifiedTransactionEffects, QuorumDriverRequest,
     QuorumDriverRequestType, QuorumDriverResponse, VerifiedTransaction,
-    VerifiedTransactionEnvelope,
 };
 
 const TASK_QUEUE_SIZE: usize = 5000;
@@ -296,7 +295,7 @@ where
         let mut conflicting_tx_digests = Vec::from_iter(conflicting_tx_digests.iter());
         conflicting_tx_digests.sort_by(|lhs, rhs| rhs.1 .1.cmp(&lhs.1 .1));
         if conflicting_tx_digests.is_empty() {
-            error!("This path in unreachable with an emtpy conflicting_tx_digests.");
+            error!("This path in unreachable with an empty conflicting_tx_digests.");
             return Ok(None);
         }
 
@@ -397,9 +396,7 @@ where
         }
 
         if let Some(signed_transaction) = signed_transaction {
-            let transaction = signed_transaction.into_inner().to_transaction();
-            // SafeClient checked the transaction is legit in `handle_transaction_info_request`
-            let verified_transaction = VerifiedTransactionEnvelope::new_unchecked(transaction);
+            let verified_transaction = signed_transaction.into_unsigned();
             // Now ask validators to execute this transaction.
             let result = self
                 .validators

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -119,11 +119,11 @@ pub fn create_fake_cert_and_effect_digest<'a>(
     committee: &Committee,
 ) -> (ExecutionDigests, CertifiedTransaction) {
     let transaction = create_fake_transaction();
-    let cert = CertifiedTransaction::new_with_auth_sign_infos(
-        transaction.clone(),
+    let cert = CertifiedTransaction::new(
+        transaction.data().clone(),
         signers
             .map(|(name, signer)| {
-                AuthoritySignInfo::new(committee.epoch, &transaction.signed_data, *name, signer)
+                AuthoritySignInfo::new(committee.epoch, transaction.data(), *name, signer)
             })
             .collect(),
         committee,
@@ -141,9 +141,9 @@ pub fn to_sender_signed_transaction(
     data: TransactionData,
     signer: &dyn Signer<Signature>,
 ) -> VerifiedTransaction {
-    let signature = Signature::new_temp(&data.to_bytes(), signer);
+    let signature = Signature::new(&data, signer);
     // let signature = Signature::new_secure(&data, Intent::default(), signer).unwrap();
-    VerifiedTransaction::new_unchecked(Transaction::new(data, signature))
+    VerifiedTransaction::new_unchecked(Transaction::from_data(data, signature))
 }
 
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
@@ -163,7 +163,7 @@ pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
         wrapped: Vec::new(),
         gas_object: (
             random_object_ref(),
-            Owner::AddressOwner(tx.signed_data.data.signer()),
+            Owner::AddressOwner(tx.data().data.signer()),
         ),
         events: Vec::new(),
         dependencies: Vec::new(),

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -78,10 +78,10 @@ pub async fn check_certificate_input<S>(
 where
     S: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
 {
-    let gas_status = get_gas_status(store, &cert.signed_data.data).await?;
-    let input_objects = cert.signed_data.data.input_objects()?;
+    let gas_status = get_gas_status(store, &cert.data().data).await?;
+    let input_objects = cert.data().data.input_objects()?;
 
-    let tx_data = &cert.signed_data.data;
+    let tx_data = &cert.data().data;
     let objects = if tx_data.kind.is_change_epoch_tx() {
         // When changing the epoch, we update a the system object, which is shared, without going
         // through sequencing, so we must bypass the sequence checks here.
@@ -89,7 +89,7 @@ where
     } else {
         store.get_sequenced_input_objects(cert.digest(), &input_objects)?
     };
-    let input_objects = check_objects(&cert.signed_data.data, input_objects, objects).await?;
+    let input_objects = check_objects(&cert.data().data, input_objects, objects).await?;
     Ok((gas_status, input_objects))
 }
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -334,20 +334,15 @@ where
             .handle_transaction_info_request(TransactionInfoRequest::from(*transaction_digest))
             .await
         {
-            votes.push(signed.auth_sign_info.clone());
+            votes.push(signed.auth_sig().clone());
             if let Some(inner_transaction) = transaction {
-                assert!(inner_transaction.signed_data.data == signed.signed_data.data);
+                assert!(inner_transaction.data().data == signed.data().data);
             }
             transaction = Some(signed);
         }
     }
 
-    CertifiedTransaction::new_with_auth_sign_infos(
-        transaction.unwrap().to_transaction(),
-        votes,
-        committee,
-    )
-    .unwrap()
+    CertifiedTransaction::new(transaction.unwrap().into_message(), votes, committee).unwrap()
 }
 
 pub async fn do_cert<A>(

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -279,7 +279,7 @@ async fn test_publish_gas() -> anyhow::Result<()> {
         .certified_transaction
         .as_ref()
         .unwrap()
-        .signed_data
+        .data()
         .data
         .kind
         .single_transactions()

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -71,7 +71,7 @@ async fn public_transfer_object(
 
     let signature = key.sign(&data.to_bytes());
     let result = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await?;
     Ok(result)
 }
@@ -160,7 +160,7 @@ async fn test_publish() {
 
     let signature = key1.sign(&data.to_bytes());
     gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap();
 }
@@ -191,7 +191,7 @@ async fn test_coin_split() {
 
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap()
         .parsed_data
@@ -245,7 +245,7 @@ async fn test_coin_split_insufficient_gas() {
 
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await;
     // Tx should fail due to out of gas, and no transactions should remain pending.
     // Objects are not locked either.
@@ -291,7 +291,7 @@ async fn test_coin_merge() {
 
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap()
         .parsed_data
@@ -364,7 +364,7 @@ async fn test_equivocation_resilient() {
             let gateway_copy = gateway.clone();
             async move {
                 gateway_copy
-                    .execute_transaction(Transaction::new(data, signature))
+                    .execute_transaction(Transaction::from_data(data, signature))
                     .await
             }
         });
@@ -538,7 +538,7 @@ async fn test_get_owner_object() {
 
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap()
         .parsed_data
@@ -563,7 +563,7 @@ async fn test_get_owner_object() {
         .unwrap();
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap();
     let parent = &response.effects.created.first().unwrap().reference;
@@ -582,7 +582,7 @@ async fn test_get_owner_object() {
         .unwrap();
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap();
     let child = &response.effects.created.first().unwrap().reference;
@@ -606,7 +606,7 @@ async fn test_get_owner_object() {
         .unwrap();
     let signature = key1.sign(&data.to_bytes());
     let response = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap();
     let field_object = &response.effects.created.first().unwrap().reference;
@@ -730,7 +730,7 @@ async fn test_batch_transaction() {
         .unwrap();
     let signature = key1.sign(&data.to_bytes());
     let effects = gateway
-        .execute_transaction(Transaction::new(data, signature))
+        .execute_transaction(Transaction::from_data(data, signature))
         .await
         .unwrap()
         .effects;

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -450,7 +450,7 @@ async fn execute_pay_sui(
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
 
     let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature).verify().unwrap();
+    let tx = Transaction::from_data(data, signature).verify().unwrap();
     let txn_result = send_and_confirm_transaction(&authority_state, tx)
         .await
         .map(|t| t.into());
@@ -485,7 +485,7 @@ async fn execute_pay_all_sui(
     }));
     let data = TransactionData::new_with_gas_price(kind, sender, gas_object_ref, gas_budget, 1);
     let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature).verify().unwrap();
+    let tx = Transaction::from_data(data, signature).verify().unwrap();
 
     let txn_result = send_and_confirm_transaction(&authority_state, tx)
         .await

--- a/crates/sui-cost/src/estimator.rs
+++ b/crates/sui-cost/src/estimator.rs
@@ -140,13 +140,12 @@ pub async fn estimate_transaction_computation_cost(
     let tx = to_sender_signed_transaction(tx_data, &keypair);
 
     let (_gas_status, input_objects) =
-        transaction_input_checker::check_transaction_input(&state.db(), &tx.signed_data.data)
-            .await?;
+        transaction_input_checker::check_transaction_input(&state.db(), &tx.data().data).await?;
     let in_mem_temporary_store =
         TemporaryStore::new(state.db(), input_objects, TransactionDigest::random());
 
     estimate_transaction_inner(
-        tx.into_inner().signed_data.data.kind,
+        tx.into_inner().into_data().data.kind,
         computation_gas_unit_price,
         storage_gas_unit_price,
         mutated_object_sizes_after,

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -274,7 +274,7 @@ async fn run_actual_and_estimate_costs(
             .with_async(|node| async move {
                 let state = node.state();
                 estimate_transaction_computation_cost(
-                    tx.into_inner().signed_data.data,
+                    tx.into_inner().into_data().data,
                     state.clone(),
                     None,
                     None,

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -351,7 +351,7 @@ impl SimpleFaucet {
             .keystore
             .sign(&signer, &txn_data.to_bytes())?;
 
-        let tx = Transaction::new(txn_data, signature).verify()?;
+        let tx = Transaction::from_data(txn_data, signature).verify()?;
         let tx_digest = *tx.digest();
         info!(
             ?tx_digest,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1722,11 +1722,13 @@ impl TryFrom<CertifiedTransaction> for SuiCertifiedTransaction {
     type Error = anyhow::Error;
 
     fn try_from(cert: CertifiedTransaction) -> Result<Self, Self::Error> {
+        let digest = *cert.digest();
+        let (data, sig) = cert.into_data_and_sig();
         Ok(Self {
-            transaction_digest: *cert.digest(),
-            data: cert.signed_data.data.try_into()?,
-            tx_signature: cert.signed_data.tx_signature,
-            auth_sign_info: cert.auth_sign_info,
+            transaction_digest: digest,
+            data: data.data.try_into()?,
+            tx_signature: data.tx_signature,
+            auth_sign_info: sig,
         })
     }
 }

--- a/crates/sui-json-rpc/src/gateway_api.rs
+++ b/crates/sui-json-rpc/src/gateway_api.rs
@@ -20,6 +20,7 @@ use sui_json_rpc_types::{
 use sui_open_rpc::Module;
 use sui_types::batch::TxSequenceNumber;
 use sui_types::crypto::SignatureScheme;
+use sui_types::messages::SenderSignedData;
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TransactionDigest},
     crypto,
@@ -90,7 +91,7 @@ impl RpcGatewayApiServer for RpcGatewayImpl {
         .map_err(|e| anyhow!(e))?;
         let result = self
             .client
-            .execute_transaction(Transaction::new(data, signature))
+            .execute_transaction(Transaction::new(SenderSignedData::new(data, signature)))
             .await;
         Ok(result?)
     }

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -18,7 +18,9 @@ use sui_json_rpc_types::SuiExecuteTransactionResponse;
 use sui_metrics::spawn_monitored_task;
 use sui_open_rpc::Module;
 use sui_types::crypto::SignatureScheme;
-use sui_types::messages::{ExecuteTransactionRequest, ExecuteTransactionRequestType};
+use sui_types::messages::{
+    ExecuteTransactionRequest, ExecuteTransactionRequestType, SenderSignedData,
+};
 use sui_types::{
     crypto,
     crypto::SignableBytes,
@@ -64,7 +66,7 @@ impl TransactionExecutionApiServer for FullNodeTransactionExecutionApi {
             .concat(),
         )
         .map_err(|e| anyhow!(e))?;
-        let txn = Transaction::new(data, signature);
+        let txn = Transaction::new(SenderSignedData::new(data, signature));
         let txn_digest = *txn.digest();
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -413,7 +413,7 @@ impl RpcExampleProvider {
 
         let tx = to_sender_signed_transaction(data, &kp);
         let tx1 = tx.clone();
-        let signature = tx.into_inner().signed_data.tx_signature;
+        let signature = tx.into_inner().into_data().tx_signature;
 
         let tx_digest = tx1.digest();
         let sui_event = SuiEvent::TransferObject {

--- a/crates/sui-rosetta/src/block.rs
+++ b/crates/sui-rosetta/src/block.rs
@@ -45,7 +45,7 @@ pub async fn transaction(
     let digest = request.transaction_identifier.hash;
     let (cert, effects) = context.state.get_transaction(digest).await?;
     let hash = *cert.digest();
-    let data = &cert.signed_data.data;
+    let data = &cert.data().data;
 
     let operations = Operation::from_data_and_events(data, &effects.status, &effects.events)?;
 

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -248,7 +248,7 @@ impl PseudoBlockProvider {
                 let (tx, effect) = state.get_transaction(digest).await?;
 
                 let ops = Operation::from_data_and_events(
-                    &tx.signed_data.data,
+                    &tx.data().data,
                     &effect.status,
                     &effect.events,
                 )?;

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -285,7 +285,9 @@ async fn test_transaction(
     let response = client
         .quorum_driver()
         .execute_transaction(
-            Transaction::new(data.clone(), signature).verify().unwrap(),
+            Transaction::from_data(data.clone(), signature)
+                .verify()
+                .unwrap(),
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await

--- a/crates/sui-sdk/examples/tic_tac_toe.rs
+++ b/crates/sui-sdk/examples/tic_tac_toe.rs
@@ -99,7 +99,7 @@ impl TicTacToe {
             .client
             .quorum_driver()
             .execute_transaction(
-                Transaction::new(create_game_call, signature).verify()?,
+                Transaction::from_data(create_game_call, signature).verify()?,
                 Some(ExecuteTransactionRequestType::WaitForLocalExecution),
             )
             .await?;
@@ -195,7 +195,7 @@ impl TicTacToe {
                 .client
                 .quorum_driver()
                 .execute_transaction(
-                    Transaction::new(place_mark_call, signature).verify()?,
+                    Transaction::from_data(place_mark_call, signature).verify()?,
                     Some(ExecuteTransactionRequestType::WaitForLocalExecution),
                 )
                 .await?;

--- a/crates/sui-sdk/examples/transfer_coins.rs
+++ b/crates/sui-sdk/examples/transfer_coins.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let transaction_response = sui
         .quorum_driver()
         .execute_transaction(
-            Transaction::new(transfer_tx, signature).verify()?,
+            Transaction::from_data(transfer_tx, signature).verify()?,
             Some(ExecuteTransactionRequestType::WaitForLocalExecution),
         )
         .await?;

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -461,7 +461,7 @@ impl<'a> SuiTestAdapter<'a> {
         let gas_status = gas::start_gas_metering(gas_budget, 1, 1).unwrap();
         let transaction_digest = TransactionDigest::new(self.rng.gen());
         let objects_by_kind = transaction
-            .signed_data
+            .data()
             .data
             .input_objects()?
             .into_iter()
@@ -496,7 +496,7 @@ impl<'a> SuiTestAdapter<'a> {
         ) = execution_engine::execute_transaction_to_effects(
             shared_object_refs,
             temporary_store,
-            transaction.into_inner().signed_data.data,
+            transaction.into_inner().into_data().data,
             transaction_digest,
             transaction_dependencies,
             &self.vm,

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -673,7 +673,7 @@ impl CheckpointFragment {
             let cert = self.data.certs.get(digest).ok_or_else(|| {
                 SuiError::from(format!("Missing cert with digest {digest:?}").as_str())
             })?;
-            cert.verify_signatures(committee)?;
+            cert.verify_signature(committee)?;
         }
 
         Ok(())

--- a/crates/sui-types/src/unit_tests/intent_tests.rs
+++ b/crates/sui-types/src/unit_tests/intent_tests.rs
@@ -63,11 +63,11 @@ fn test_authority_signature_intent() {
         10000,
     );
     let signature = Signature::new(&data, &sender_key);
-    let tx = Transaction::new(data, signature);
+    let tx = Transaction::from_data(data, signature);
 
     // Create an intent with signed data.
     let intent = Intent::default_with_scope(IntentScope::TransactionData);
-    let intent_bcs = bcs::to_bytes(&IntentMessage::new(intent, &tx.signed_data)).unwrap();
+    let intent_bcs = bcs::to_bytes(&IntentMessage::new(intent, tx.data())).unwrap();
 
     // Check that the first 3 bytes are the domain separation information.
     assert_eq!(
@@ -80,11 +80,11 @@ fn test_authority_signature_intent() {
     );
 
     // Check that intent's last bytes match the signed_data's bsc bytes.
-    let signed_data_bcs = bcs::to_bytes(&tx.signed_data).unwrap();
+    let signed_data_bcs = bcs::to_bytes(tx.data()).unwrap();
     assert_eq!(&intent_bcs[3..], signed_data_bcs);
 
     // Let's ensure we can sign and verify intents.
-    let s = AuthoritySignature::new_secure(&tx.signed_data, intent, &kp);
-    let verification = s.verify_secure(&tx.signed_data, intent, kp.public().into());
+    let s = AuthoritySignature::new_secure(tx.data(), intent, &kp);
+    let verification = s.verify_secure(tx.data(), intent, kp.public().into());
     assert!(verification.is_ok())
 }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -431,7 +431,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&sender, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
 
                 SuiClientCommandResult::Publish(response)
@@ -474,7 +474,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -501,7 +501,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -543,7 +543,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&from, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
                 let cert = response.certificate;
                 let effects = response.effects;
@@ -586,7 +586,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
 
                 let cert = response.certificate;
@@ -618,7 +618,7 @@ impl SuiClientCommands {
 
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
 
                 let cert = response.certificate;
@@ -706,7 +706,7 @@ impl SuiClientCommands {
                 };
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
                 SuiClientCommandResult::SplitCoin(response)
             }
@@ -724,7 +724,7 @@ impl SuiClientCommands {
                     .await?;
                 let signature = context.config.keystore.sign(&signer, &data.to_bytes())?;
                 let response = context
-                    .execute_transaction(Transaction::new(data, signature).verify()?)
+                    .execute_transaction(Transaction::from_data(data, signature).verify()?)
                     .await?;
 
                 SuiClientCommandResult::MergeCoin(response)
@@ -813,7 +813,7 @@ impl SuiClientCommands {
                         .to_vec()
                         .map_err(|e| anyhow!(e))?,
                 )?;
-                let signed_tx = Transaction::new(
+                let signed_tx = Transaction::from_data(
                     data,
                     Signature::from_bytes(
                         &[
@@ -1215,7 +1215,7 @@ pub async fn call_move(
         )
         .await?;
     let signature = context.config.keystore.sign(&sender, &data.to_bytes())?;
-    let transaction = Transaction::new(data, signature).verify()?;
+    let transaction = Transaction::from_data(data, signature).verify()?;
 
     let response = context.execute_transaction(transaction).await?;
     let cert = response.certificate;

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -433,12 +433,10 @@ pub fn make_tx_certs_and_signed_effects_with_committee(
                 key.public().into(),
                 &key,
             );
-            sigs.push(vote.auth_sign_info.clone());
-            if let Ok(tx_cert) = CertifiedTransaction::new_with_auth_sign_infos(
-                vote.clone().to_transaction(),
-                sigs.clone(),
-                committee,
-            ) {
+            sigs.push(vote.auth_sig().clone());
+            if let Ok(tx_cert) =
+                CertifiedTransaction::new(vote.into_inner().into_data(), sigs.clone(), committee)
+            {
                 tx_certs.push(tx_cert.verify(committee).unwrap());
                 let effects = dummy_transaction_effects(&tx);
                 let signed_effects = effects.to_sign_effects(

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -105,7 +105,7 @@ pub async fn publish_basics_package(context: &WalletContext, sender: SuiAddress)
             .keystore
             .sign(&sender, &data.to_bytes())
             .unwrap();
-        Transaction::new(data, signature).verify().unwrap()
+        Transaction::from_data(data, signature).verify().unwrap()
     };
 
     let resp = context
@@ -162,7 +162,7 @@ pub async fn submit_move_transaction(
         .keystore
         .sign(&sender, &data.to_bytes())
         .unwrap();
-    let tx = Transaction::new(data, signature).verify().unwrap();
+    let tx = Transaction::from_data(data, signature).verify().unwrap();
     let tx_digest = tx.digest();
     debug!(?tx_digest, "submitting move transaction");
 
@@ -388,7 +388,7 @@ pub async fn delete_devnet_nft(
         .keystore
         .sign(sender, &data.to_bytes())
         .unwrap();
-    let tx = Transaction::new(data, signature).verify().unwrap();
+    let tx = Transaction::from_data(data, signature).verify().unwrap();
 
     let resp = context
         .client

--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -5,7 +5,7 @@ title: Interact with Sui over Rust SDK
 ## Overview
 The [Sui SDK](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) is a collection of Rust language JSON-RPC wrapper and crypto utilities you can use to interact with the [Sui Devnet](../build/devnet.md) and [Sui Full node](fullnode.md).
 
-The [`SuiClient`](cli-client.md) can be used to create an HTTP or a WebSocket client (`SuiClient::new_rpc_client`).  
+The [`SuiClient`](cli-client.md) can be used to create an HTTP or a WebSocket client (`SuiClient::new_rpc_client`).
 See our [JSON-RPC](json-rpc.md#sui-json-rpc-methods) doc for the list of available methods.
 
 > Note: As of [Sui version 0.6.0](https://github.com/MystenLabs/sui/releases/tag/devnet-0.6.0), the WebSocket client is for [subscription only](event_api.md#subscribe-to-sui-events); use the HTTP client for other API methods.
@@ -91,11 +91,11 @@ async fn main() -> Result<(), anyhow::Error> {
     // Sign transaction
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let signature = keystore.sign(&my_address, &transfer_tx)?;
-    
+
     // Execute the transaction
     let transaction_response = sui
         .quorum_driver()
-        .execute_transaction(Transaction::new(transfer_tx, signature))
+        .execute_transaction(Transaction::from_data(transfer_tx, signature))
         .await?;
 
     println!("{:?}", transaction_response);


### PR DESCRIPTION
Currently Transaction type is defined using its own Envelope (i.e. TransactionEnvelope)
This PR changes it to use the MessageEnvelope that all authenticated data structures can use.
The primary change is in message_envelope.rs and messages.rs, where we consolidate the definition of Transaction.