### PR TITLE
Rename channels for ConsensusListener to {tx,rx}_consensus_listener

### DIFF
--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -118,7 +118,7 @@ async fn listen_to_sequenced_transaction() {
         .unwrap();
 
     // Spawn a consensus listener.
-    ConsensusListener::spawn(/* rx_consensus_input */ rx_sui_to_consensus);
+    ConsensusListener::spawn(/* rx_consensus_listener */ rx_sui_to_consensus);
 
     // Submit a sample consensus transaction.
     let (waiter, signals) = ConsensusWaiter::new();
@@ -138,7 +138,7 @@ async fn listen_to_sequenced_transaction() {
 }
 
 #[tokio::test]
-async fn submit_transaction_to_consensus() {
+async fn submit_transaction_to_consensus_adapter() {
     let port = sui_config::utils::get_available_port();
     let consensus_address: Multiaddr = format!("/dns/localhost/tcp/{port}/http").parse().unwrap();
     let (tx_consensus_listener, mut rx_consensus_listener) = channel(1);
@@ -156,8 +156,8 @@ async fn submit_transaction_to_consensus() {
     let state_guard = Arc::new(state);
     let metrics = ConsensusAdapterMetrics::new_test();
 
-    // Make a new consensus submitter instance.
-    let submitter = ConsensusAdapter::new(
+    // Make a new consensus adapter instance.
+    let adapter = ConsensusAdapter::new(
         consensus_address.clone(),
         tx_consensus_listener,
         /* timeout */ Duration::from_secs(5),
@@ -167,7 +167,7 @@ async fn submit_transaction_to_consensus() {
     // Spawn a network listener to receive the transaction (emulating the consensus node).
     let mut handle = ConsensusMockServer::spawn(consensus_address);
 
-    // Notify the submitter when a consensus transaction has been sequenced and executed.
+    // Notify the adapter when a consensus transaction has been sequenced and executed.
     tokio::spawn(async move {
         while let Some(message) = rx_consensus_listener.recv().await {
             let (serialized, replier) = match message {
@@ -185,23 +185,28 @@ async fn submit_transaction_to_consensus() {
             // Set the shared object locks.
             state_guard
                 .handle_consensus_transaction(VerifiedSequencedConsensusTransaction::new_test(
-                    ConsensusTransaction::new_certificate_message(&name, *certificate),
+                    ConsensusTransaction::new_certificate_message(&name, *certificate.clone()),
                 ))
                 .await
                 .unwrap();
 
-            // Reply to the submitter.
+            // Reply to the adapter. This fails when Narwhal is not running when submitting in
+            // ConsensusAdapter, dropping the receiver. But this is ok because the submit will
+            // be retried.
             let result = Ok(());
-            replier.0.send(result).unwrap();
+            let _ = replier
+                .0
+                .send(result)
+                .tap_err(|err| println!("Failed to send success signal: {:?}", err));
         }
     });
 
     let certificate = certificate.verify(&committee).unwrap();
 
-    // Submit the transaction and ensure the submitter reports success to the caller. Note
+    // Submit the transaction and ensure the adapter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).
     loop {
-        match submitter.submit(&name, &certificate).await {
+        match adapter.submit(&name, &certificate).await {
             Ok(_) => break,
             Err(SuiError::ConsensusConnectionBroken(..)) => (),
             Err(e) => panic!("Unexpected error message: {e}"),


### PR DESCRIPTION
This makes the channel name more consistent across usages, and easier to track.

Also, a few other miscellaneous fixes.