### PR TITLE
Enable runtime integer overflow check in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ debug = 1
 strip = 'none'
 # Exit process with SIGABRT when any thread panics
 panic = 'abort'
+# Crash on runtime integer overflow
+overflow-checks = true
 
 [profile.bench]
 # debug = 1 means line charts only, which is minimum needed for good stack traces


### PR DESCRIPTION
I believe this is the recommendation from external security audit.