### PR TITLE
doc: fixed test_sword_transactions arguments error

### DIFF
--- a/doc/src/build/move/build-test.md
+++ b/doc/src/build/move/build-test.md
@@ -282,7 +282,7 @@ function.
         {
             let forge = test_scenario::take_from_sender<Forge>(scenario);
             // create the sword and transfer it to the initial owner
-            sword_create(&mut forge, 42, 7, initial_owner, test_scenario::ctx(scenario));
+            sword_create(42, 7, initial_owner, test_scenario::ctx(scenario));
             test_scenario::return_to_sender(scenario, forge)
         };
         // third transaction executed by the initial sword owner


### PR DESCRIPTION
I'm not very sure is correct, but I got the error and try to remove the first argument.

```
error[E04017]: too many arguments
   ┌─ ./sources/my_module.move:97:9
   │
97 │         sword_create(&mut forge, 42, 7, initial_owner, test_scenario::ctx(scenario));
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │           │
   │         │           Found 5 argument(s) here
   │         Invalid call of '(my_first_package=0x0)::my_module::sword_create'. The call expected 4 argument(s) but got 5
```

pass test.