### PR TITLE
[wallet-ext] Fix lint

### DIFF
--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -4,7 +4,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isClient: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-explorer') || steps.diff.outputs.isRust }}
+      isClient: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-explorer') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)

--- a/.github/workflows/ts-sdk.yml
+++ b/.github/workflows/ts-sdk.yml
@@ -4,7 +4,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isTypescriptSDK: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), '@mysten/sui.js') || steps.diff.outputs.isRust }}
+      isTypescriptSDK: ${{ contains(fromJson(steps.pnpm.outputs.packages), '@mysten/sui.js') || steps.diff.outputs.isRust }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)

--- a/.github/workflows/wallet-adapter.yml
+++ b/.github/workflows/wallet-adapter.yml
@@ -4,7 +4,7 @@ jobs:
   diff:
     runs-on: [ubuntu-latest]
     outputs:
-      isWalletAdapter: ${{ steps.diff.outputs.packages && contains(fromJson(steps.diff.outputs.packages), 'sui-wallet-adapter') }}
+      isWalletAdapter: ${{ contains(fromJson(steps.diff.outputs.packages), 'sui-wallet-adapter') }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes

--- a/.github/workflows/wallet-ext-prs.yml
+++ b/.github/workflows/wallet-ext-prs.yml
@@ -4,8 +4,8 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     outputs:
-      isWalletExt: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') || steps.diff.outputs.isRust }}
-      isSrcChange: ${{ steps.diff.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') }}
+      isWalletExt: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') || steps.diff.outputs.isRust }}
+      isSrcChange: ${{ contains(fromJson(steps.pnpm.outputs.packages), 'sui-wallet') }}
     steps:
       - uses: actions/checkout@v3
       - name: Detect Changes (pnpm)

--- a/apps/wallet/src/ui/app/ApiProvider.ts
+++ b/apps/wallet/src/ui/app/ApiProvider.ts
@@ -81,7 +81,6 @@ export const DEFAULT_API_ENV = getDefaultApiEnv();
 
 type NetworkTypes = keyof typeof API_ENV;
 
-
 export const generateActiveNetworkList = (): NetworkTypes[] => {
     const excludedNetworks: NetworkTypes[] = [];
 


### PR DESCRIPTION
This fixes a lint issue that made it to main and reverts #5909, which seems to break change detection for JS packages. That PR was supposed to unblock dependabot but that was for the oracle server that has since been removed.