### PR TITLE
Add option to sui start to start without fullnode

### DIFF
--- a/crates/sui-rosetta/docker/sui-rosetta-local/docker-compose.yaml
+++ b/crates/sui-rosetta/docker/sui-rosetta-local/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - -c
       - |
         /usr/local/bin/sui-rosetta generate-rosetta-cli-config &
-        /usr/local/bin/sui start &> /sui/sui.log &
+        /usr/local/bin/sui start --no-full-node &> /sui/sui.log &
         /usr/local/bin/sui-rosetta start-online-server
     stdin_open: true
     tty: true

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -45,6 +45,7 @@ async fn test_genesis() -> Result<(), anyhow::Error> {
     // Start network without authorities
     let start = SuiCommand::Start {
         config: Some(config),
+        no_full_node: false,
     }
     .execute()
     .await;


### PR DESCRIPTION
starting fullnode automatically in sui start is breaking rosetta local docker run because rosetta starts a fullnode internally, which causes port clashes, adding an option to start without fullnode