### PR TITLE
[core] Use Envelope for TransactionEffects

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -45,7 +45,7 @@ impl ExecutionEffects {
     pub fn mutated(&self) -> Vec<(ObjectRef, Owner)> {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects) => {
-                certified_effects.effects.mutated.clone()
+                certified_effects.data().mutated.clone()
             }
             ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => sui_tx_effects
                 .mutated
@@ -59,7 +59,7 @@ impl ExecutionEffects {
     pub fn created(&self) -> Vec<(ObjectRef, Owner)> {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects) => {
-                certified_effects.effects.created.clone()
+                certified_effects.data().created.clone()
             }
             ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => sui_tx_effects
                 .created
@@ -73,7 +73,7 @@ impl ExecutionEffects {
     pub fn quorum_sig(&self) -> Option<&AuthorityStrongQuorumSignInfo> {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects) => {
-                Some(&certified_effects.auth_signature)
+                Some(certified_effects.auth_sig())
             }
             ExecutionEffects::SuiTransactionEffects(_) => None,
         }
@@ -82,7 +82,7 @@ impl ExecutionEffects {
     pub fn gas_object(&self) -> (ObjectRef, Owner) {
         match self {
             ExecutionEffects::CertifiedTransactionEffects(certified_effects) => {
-                certified_effects.effects.gas_object
+                certified_effects.data().gas_object
             }
             ExecutionEffects::SuiTransactionEffects(sui_tx_effects) => {
                 let refe = &sui_tx_effects.gas_object;
@@ -275,7 +275,7 @@ impl ValidatorProxy for FullNodeProxy {
     }
 
     async fn reconfig(&self) {
-        // TOOD poll FN untils it has proceeds to next epoch
+        // TODO poll FN until it has proceeds to next epoch
         // and update self.committee
         return;
     }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -683,7 +683,7 @@ impl AuthorityState {
         let digest = *certificate.digest();
         debug!(?digest, "handle_certificate_with_effects");
         fp_ensure!(
-            effects.effects.transaction_digest == digest,
+            effects.data().transaction_digest == digest,
             SuiError::ErrorWhileProcessingCertificate {
                 err: "effects/tx digest mismatch".to_string()
             }
@@ -694,7 +694,7 @@ impl AuthorityState {
         if certificate.contains_shared_object() {
             self.database.acquire_shared_locks_from_effects(
                 certificate,
-                &effects.effects,
+                effects.data(),
                 &tx_guard,
             )?;
         }
@@ -710,7 +710,7 @@ impl AuthorityState {
             error!(
                 ?expected_effects_digest,
                 ?observed_effects_digest,
-                ?effects.effects,
+                expected_effects=?effects.data(),
                 ?resp.signed_effects,
                 input_objects = ?certificate.data().data.input_objects(),
                 "Locally executed effects do not match canonical effects!");
@@ -878,7 +878,7 @@ impl AuthorityState {
             };
 
         let input_object_count = inner_temporary_store.objects.len();
-        let shared_object_count = signed_effects.effects.shared_objects.len();
+        let shared_object_count = signed_effects.data().shared_objects.len();
 
         // If commit_certificate returns an error, tx_guard will be dropped and the certificate
         // will be persisted in the log for later recovery.
@@ -1060,7 +1060,8 @@ impl AuthorityState {
             );
 
         // TODO: Distribute gas charge and rebate, which can be retrieved from effects.
-        let signed_effects = effects.to_sign_effects(self.epoch(), &self.name, &*self.secret);
+        let signed_effects =
+            SignedTransactionEffects::new(self.epoch(), effects, &*self.secret, self.name);
         Ok((inner_temp_store, signed_effects))
     }
 
@@ -1126,7 +1127,7 @@ impl AuthorityState {
                 .iter()
                 .map(|o| o.object_id()),
             effects
-                .effects
+                .data()
                 .all_mutated()
                 .map(|(obj_ref, owner, _kind)| (*obj_ref, *owner)),
             cert.data()
@@ -1191,14 +1192,14 @@ impl AuthorityState {
         // Emit events
         if let Some(event_handler) = &self.event_handler {
             event_handler
-                .process_events(&effects.effects, timestamp_ms, seq)
+                .process_events(effects.data(), timestamp_ms, seq)
                 .await
                 .tap_ok(|_| self.metrics.post_processing_total_tx_had_event_processed.inc())
                 .tap_err(|e| warn!(tx_digest=?digest, "Post processing - Couldn't process events for tx: {}", e))?;
 
             self.metrics
                 .post_processing_total_events_emitted
-                .inc_by(effects.effects.events.len() as u64);
+                .inc_by(effects.data().events.len() as u64);
         }
 
         Ok(())
@@ -1967,15 +1968,18 @@ impl AuthorityState {
         // obtain an effects certificate at the current epoch.
         if let Some(effects) = info.signed_effects.take() {
             let cur_epoch = self.epoch();
-            let new_effects = if effects.auth_signature.epoch < cur_epoch {
+            let new_effects = if effects.epoch() < cur_epoch {
                 debug!(
-                    effects_epoch=?effects.auth_signature.epoch,
+                    effects_epoch=?effects.epoch(),
                     ?cur_epoch,
                     "Re-signing the effects with the current epoch"
                 );
-                effects
-                    .effects
-                    .to_sign_effects(cur_epoch, &self.name, &*self.secret)
+                SignedTransactionEffects::new(
+                    cur_epoch,
+                    effects.into_data(),
+                    &*self.secret,
+                    self.name,
+                )
             } else {
                 effects
             };

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -95,7 +95,7 @@ async fn pending_exec_notify_ready_certificates() {
 
             // Check whether this is a success?
             assert!(matches!(
-                effects.effects.status,
+                effects.data().status,
                 ExecutionStatus::Success { .. }
             ));
             println!("Execute at {:?}", tokio::time::Instant::now());
@@ -186,7 +186,7 @@ async fn pending_exec_full() {
 
             // Check whether this is a success?
             assert!(matches!(
-                effects.effects.status,
+                effects.data().status,
                 ExecutionStatus::Success { .. }
             ));
             println!("Execute at {:?}", tokio::time::Instant::now());

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -19,6 +19,7 @@ use sui_types::batch::{AuthorityBatch, SignedBatch, UpdateItem};
 use sui_types::committee::Committee;
 use sui_types::crypto::{get_key_pair, AuthorityKeyPair};
 use sui_types::error::SuiError;
+use sui_types::message_envelope::Message;
 use sui_types::messages::{
     AccountInfoRequest, AccountInfoResponse, BatchInfoRequest, BatchInfoResponseItem,
     CertifiedTransaction, CommitteeInfoRequest, CommitteeInfoResponse, ObjectInfoRequest,

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -342,8 +342,8 @@ async fn test_cross_epoch_effects_cert() {
     net.committee.epoch += 1;
     // Call to execute_transaction can still succeed.
     let (tx_cert, effects_cert) = net.execute_transaction(&transaction).await.unwrap();
-    assert_eq!(tx_cert.auth_sig().epoch, 0);
-    assert_eq!(effects_cert.auth_signature.epoch, 1);
+    assert_eq!(tx_cert.epoch(), 0);
+    assert_eq!(effects_cert.epoch(), 1);
 }
 
 fn enable_reconfig(states: &[Arc<AuthorityState>]) {

--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -418,7 +418,7 @@ mod test {
                 .unwrap();
 
             assert!(matches!(
-                effects.effects.status,
+                effects.data().status,
                 ExecutionStatus::Success { .. }
             ));
         }

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -23,6 +23,7 @@ use futures::StreamExt;
 use sui_types::base_types::{random_object_ref, AuthorityName, ExecutionDigests};
 use sui_types::committee::Committee;
 use sui_types::gas::GasCostSummary;
+use sui_types::message_envelope::Message;
 use sui_types::messages::{CertifiedTransaction, ExecutionStatus, TransactionEffects};
 use sui_types::object::Owner;
 use tokio::time::sleep;

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -358,7 +358,7 @@ where
         .unwrap()
         .signed_effects
         .unwrap()
-        .effects
+        .into_data()
 }
 
 pub async fn do_cert_configurable<A>(authority: &A, cert: &CertifiedTransaction)

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -688,7 +688,7 @@ async fn test_publish_dependent_module_ok() {
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap();
-    response.signed_effects.unwrap().effects.status.unwrap();
+    response.signed_effects.unwrap().into_data().status.unwrap();
 
     // check that the dependent module got published
     assert!(authority.get_object(&dependent_module_id).await.is_ok());
@@ -715,7 +715,7 @@ async fn test_publish_module_no_dependencies_ok() {
     let response = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap();
-    response.signed_effects.unwrap().effects.status.unwrap();
+    response.signed_effects.unwrap().into_data().status.unwrap();
 
     // check that the module actually got published
     assert!(response.certified_transaction.is_some());
@@ -1011,7 +1011,7 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         .handle_certificate(&certified_transfer_transaction)
         .await
         .unwrap();
-    response.signed_effects.unwrap().effects.status.unwrap();
+    response.signed_effects.unwrap().into_data().status.unwrap();
     let account = authority_state
         .get_object(&object_id)
         .await
@@ -1065,7 +1065,7 @@ async fn test_handle_confirmation_transaction_ok() {
         .handle_certificate(&certified_transfer_transaction.clone())
         .await
         .unwrap();
-    info.signed_effects.unwrap().effects.status.unwrap();
+    info.signed_effects.unwrap().into_data().status.unwrap();
     // Key check: the ownership has changed
 
     let new_account = authority_state
@@ -1273,19 +1273,13 @@ async fn test_handle_confirmation_transaction_idempotent() {
         .handle_certificate(&certified_transfer_transaction)
         .await
         .unwrap();
-    assert!(info.signed_effects.as_ref().unwrap().effects.status.is_ok());
+    assert!(info.signed_effects.as_ref().unwrap().data().status.is_ok());
 
     let info2 = authority_state
         .handle_certificate(&certified_transfer_transaction)
         .await
         .unwrap();
-    assert!(info2
-        .signed_effects
-        .as_ref()
-        .unwrap()
-        .effects
-        .status
-        .is_ok());
+    assert!(info2.signed_effects.as_ref().unwrap().data().status.is_ok());
 
     // this is valid because we're checking the authority state does not change the certificate
     compare_transaction_info_responses(&info, &info2);
@@ -1417,7 +1411,7 @@ async fn test_move_call_insufficient_gas() {
         .unwrap()
         .signed_effects
         .unwrap()
-        .effects;
+        .into_data();
     let gas_used = effects.gas_used.gas_used();
     let obj_ref = authority_state
         .get_object(&object_id)
@@ -1445,7 +1439,7 @@ async fn test_move_call_insufficient_gas() {
     let response = send_and_confirm_transaction(&authority_state, transaction)
         .await
         .unwrap();
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().into_data();
     assert!(effects.status.is_err());
     let obj = authority_state
         .get_object(&object_id)
@@ -1750,8 +1744,8 @@ async fn test_idempotent_reversed_confirmation() {
         .await;
     assert!(result2.is_ok());
     assert_eq!(
-        result1.unwrap().signed_effects.unwrap().effects,
-        result2.unwrap().signed_effects.unwrap().effects
+        result1.unwrap().signed_effects.unwrap().into_data(),
+        result2.unwrap().signed_effects.unwrap().into_data()
     );
 }
 
@@ -1807,7 +1801,7 @@ async fn test_change_epoch_transaction() {
         .handle_certificate(&certificate)
         .await
         .unwrap();
-    assert!(result.signed_effects.unwrap().effects.status.is_ok());
+    assert!(result.signed_effects.unwrap().into_data().status.is_ok());
     let sui_system_object = authority_state.get_sui_system_state_object().await.unwrap();
     assert_eq!(sui_system_object.epoch, 1);
 }
@@ -1841,7 +1835,7 @@ async fn test_transfer_sui_no_amount() {
         .handle_certificate(&certificate)
         .await
         .unwrap();
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().into_data();
     // Check that the transaction was successful, and the gas object is the only mutated object,
     // and got transferred. Also check on its version and new balance.
     assert!(effects.status.is_ok());
@@ -1884,7 +1878,7 @@ async fn test_transfer_sui_with_amount() {
         .handle_certificate(&certificate)
         .await
         .unwrap();
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().into_data();
     // Check that the transaction was successful, the gas object remains in the original owner,
     // and an amount is split out and send to the recipient.
     assert!(effects.status.is_ok());
@@ -2228,7 +2222,7 @@ pub async fn call_move_with_shared(
     let transaction = to_sender_signed_transaction(data, sender_key);
     let response =
         send_and_confirm_transaction_with_shared(authority, transaction, with_shared).await?;
-    Ok(response.signed_effects.unwrap().effects)
+    Ok(response.signed_effects.unwrap().into_data())
 }
 
 pub async fn create_move_object(
@@ -2476,7 +2470,7 @@ async fn test_consensus_message_processed() {
                 .unwrap()
         };
 
-        assert_eq!(effects1.effects, effects2.effects);
+        assert_eq!(effects1.data(), effects2.data());
 
         // If we didn't send consensus before handle_node_sync_certificate, we need to do it now.
         if !send_first {
@@ -2490,7 +2484,7 @@ async fn test_consensus_message_processed() {
 
         // Update to the new gas object for new tx
         gas_object_ref = *effects1
-            .effects
+            .data()
             .mutated
             .iter()
             .map(|(objref, _)| objref)

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -66,7 +66,7 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
 
     let tx = to_sender_signed_transaction(data, &sender_key);
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().into_data();
     assert!(effects.status.is_ok());
     assert_eq!((effects.created.len(), effects.mutated.len()), (N, N + 1),);
     assert!(effects
@@ -131,7 +131,7 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
     let tx = to_sender_signed_transaction(data, &sender_key);
 
     let response = send_and_confirm_transaction(&authority_state, tx).await?;
-    let effects = response.signed_effects.unwrap().effects;
+    let effects = response.signed_effects.unwrap().into_data();
     assert!(effects.status.is_err());
     assert_eq!((effects.created.len(), effects.mutated.len()), (0, N + 1));
 

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -1897,7 +1897,7 @@ async fn build_and_publish_test_package(
     .await
     .signed_effects
     .unwrap()
-    .effects;
+    .into_data();
     assert!(
         matches!(effects.status, ExecutionStatus::Success { .. }),
         "{:?}",

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -22,7 +22,7 @@ async fn test_pay_sui_failure_empty_recipients() {
 
     let res = execute_pay_sui(vec![coin1], vec![], vec![], sender, sender_key, 100).await;
 
-    let effects = res.txn_result.unwrap().signed_effects.unwrap().effects;
+    let effects = res.txn_result.unwrap().signed_effects.unwrap().into_data();
     assert_eq!(
         effects.status,
         ExecutionStatus::new_failure(ExecutionFailureStatus::EmptyRecipients)
@@ -46,7 +46,7 @@ async fn test_pay_sui_failure_arity_mismatch() {
     )
     .await;
 
-    let effects = res.txn_result.unwrap().signed_effects.unwrap().effects;
+    let effects = res.txn_result.unwrap().signed_effects.unwrap().into_data();
     assert_eq!(
         effects.status,
         ExecutionStatus::new_failure(ExecutionFailureStatus::RecipientsAmountsArityMismatch)
@@ -195,7 +195,7 @@ async fn test_pay_sui_success_one_input_coin() -> anyhow::Result<()> {
     )
     .await;
 
-    let effects = res.txn_result.unwrap().signed_effects.unwrap().effects;
+    let effects = res.txn_result.unwrap().signed_effects.unwrap().into_data();
     assert_eq!(effects.status, ExecutionStatus::Success);
     // make sure each recipient receives the specified amount
     assert_eq!(effects.created.len(), 3);
@@ -274,7 +274,7 @@ async fn test_pay_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     .await;
     let recipient_amount_map: HashMap<_, u64> =
         HashMap::from([(recipient1, 500), (recipient2, 1500)]);
-    let effects = res.txn_result.unwrap().signed_effects.unwrap().effects;
+    let effects = res.txn_result.unwrap().signed_effects.unwrap().into_data();
     assert_eq!(effects.status, ExecutionStatus::Success);
 
     // make sure each recipient receives the specified amount
@@ -369,7 +369,7 @@ async fn test_pay_all_sui_success_one_input_coin() -> anyhow::Result<()> {
     let recipient = dbg_addr(2);
     let res = execute_pay_all_sui(vec![&coin_obj], recipient, sender, sender_key, 1000).await;
 
-    let effects = res.txn_result.unwrap().signed_effects.unwrap().effects;
+    let effects = res.txn_result.unwrap().signed_effects.unwrap().into_data();
     assert_eq!(effects.status, ExecutionStatus::Success);
 
     // make sure the first object now belongs to the recipient,
@@ -401,7 +401,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
     )
     .await;
 
-    let effects = res.txn_result.unwrap().signed_effects.unwrap().effects;
+    let effects = res.txn_result.unwrap().signed_effects.unwrap().into_data();
     assert_eq!(effects.status, ExecutionStatus::Success);
 
     // make sure the first object now belongs to the recipient,

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1774,10 +1774,12 @@ impl SuiCertifiedTransactionEffects {
         cert: CertifiedTransactionEffects,
         resolver: &impl GetModule,
     ) -> Result<Self, anyhow::Error> {
+        let digest = *cert.digest();
+        let (effects, auth_sign_info) = cert.into_data_and_sig();
         Ok(Self {
-            transaction_effects_digest: *cert.digest(),
-            effects: SuiTransactionEffects::try_from(cert.effects, resolver)?,
-            auth_sign_info: cert.auth_signature,
+            transaction_effects_digest: digest,
+            effects: SuiTransactionEffects::try_from(effects, resolver)?,
+            auth_sign_info,
         })
     }
 }

--- a/crates/sui-json-rpc/src/streaming_api.rs
+++ b/crates/sui-json-rpc/src/streaming_api.rs
@@ -52,7 +52,7 @@ impl TransactionStreamingApiServer for TransactionStreamingApiImpl {
             async move {
                 let sui_tx_cert = SuiCertifiedTransaction::try_from(tx_cert)?;
                 let sui_tx_effects = SuiTransactionEffects::try_from(
-                    signed_effects.effects,
+                    signed_effects.into_data(),
                     state_clone.module_cache.as_ref(),
                 )?;
                 let digest = sui_tx_cert.transaction_digest;

--- a/crates/sui-types/src/message_envelope.rs
+++ b/crates/sui-types/src/message_envelope.rs
@@ -51,6 +51,11 @@ impl<T: Message, S> Envelope<T, S> {
         (data, auth_signature)
     }
 
+    /// Remove the authority signatures `S` from this envelope.
+    pub fn into_unsigned(self) -> Envelope<T, EmptySignInfo> {
+        Envelope::<T, EmptySignInfo>::new(self.into_data())
+    }
+
     pub fn auth_sig(&self) -> &S {
         &self.auth_signature
     }
@@ -111,10 +116,6 @@ where
 
     pub fn epoch(&self) -> EpochId {
         self.auth_signature.epoch
-    }
-
-    pub fn into_unsigned(self) -> Envelope<T, EmptySignInfo> {
-        Envelope::<T, EmptySignInfo>::new(self.into_data())
     }
 
     pub fn verify_signature(&self, committee: &Committee) -> SuiResult {
@@ -259,9 +260,7 @@ impl<T: Message, S> VerifiedEnvelope<T, S> {
 
     /// Remove the authority signatures `S` from this envelope.
     pub fn into_unsigned(self) -> VerifiedEnvelope<T, EmptySignInfo> {
-        VerifiedEnvelope::<T, EmptySignInfo>::new_from_verified(Envelope::<T, EmptySignInfo>::new(
-            self.into_inner().into_data(),
-        ))
+        VerifiedEnvelope::<T, EmptySignInfo>::new_from_verified(self.into_inner().into_unsigned())
     }
 }
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -13,7 +13,8 @@ use crate::crypto::bcs_signable_test::{get_obligation_input, Foo};
 use crate::crypto::Secp256k1SuiSignature;
 use crate::crypto::SuiKeyPair;
 use crate::crypto::{
-    get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes, SuiAuthoritySignature,
+    get_key_pair, AccountKeyPair, AuthorityKeyPair, AuthorityPublicKeyBytes,
+    AuthoritySignInfoTrait, SuiAuthoritySignature,
 };
 use crate::messages_checkpoint::CheckpointContents;
 use crate::messages_checkpoint::CheckpointSummary;
@@ -470,14 +471,18 @@ fn test_digest_caching() {
         ..Default::default()
     };
 
-    let mut signed_effects = effects.to_sign_effects(
+    let mut signed_effects = SignedTransactionEffects::new(
         committee.epoch(),
-        &AuthorityPublicKeyBytes::from(sec1.public()),
+        effects,
         &sec1,
+        AuthorityPublicKeyBytes::from(sec1.public()),
     );
 
     let initial_effects_digest = *signed_effects.digest();
-    signed_effects.effects.gas_used.computation_cost += 1;
+    signed_effects
+        .data_mut_for_testing()
+        .gas_used
+        .computation_cost += 1;
 
     // digest is cached
     assert_eq!(initial_effects_digest, *signed_effects.digest());

--- a/crates/sui/tests/quorum_driver_tests.rs
+++ b/crates/sui/tests/quorum_driver_tests.rs
@@ -56,7 +56,7 @@ async fn test_execute_transaction_immediate() {
     let handle = tokio::task::spawn(async move {
         let (cert, effects) = quorum_driver_handler.subscribe().recv().await.unwrap();
         assert_eq!(*cert.digest(), digest);
-        assert_eq!(effects.effects.transaction_digest, digest);
+        assert_eq!(effects.data().transaction_digest, digest);
     });
     assert!(matches!(
         quorum_driver
@@ -83,7 +83,7 @@ async fn test_execute_transaction_wait_for_cert() {
     let handle = tokio::task::spawn(async move {
         let (cert, effects) = quorum_driver_handler.subscribe().recv().await.unwrap();
         assert_eq!(*cert.digest(), digest);
-        assert_eq!(effects.effects.transaction_digest, digest);
+        assert_eq!(effects.data().transaction_digest, digest);
     });
     if let QuorumDriverResponse::TxCert(cert) = quorum_driver
         .execute_transaction(QuorumDriverRequest {
@@ -112,7 +112,7 @@ async fn test_execute_transaction_wait_for_effects() {
     let handle = tokio::task::spawn(async move {
         let (cert, effects) = quorum_driver_handler.subscribe().recv().await.unwrap();
         assert_eq!(*cert.digest(), digest);
-        assert_eq!(effects.effects.transaction_digest, digest);
+        assert_eq!(effects.data().transaction_digest, digest);
     });
     if let QuorumDriverResponse::EffectsCert(result) = quorum_driver
         .execute_transaction(QuorumDriverRequest {
@@ -124,7 +124,7 @@ async fn test_execute_transaction_wait_for_effects() {
     {
         let (cert, effects) = *result;
         assert_eq!(*cert.digest(), digest);
-        assert_eq!(effects.effects.transaction_digest, digest);
+        assert_eq!(effects.data().transaction_digest, digest);
     } else {
         unreachable!();
     }
@@ -210,7 +210,7 @@ async fn test_retry_on_object_locked() -> Result<(), anyhow::Error> {
             assert_eq!(conflicting_tx_digest, *tx.digest());
             assert!(!conflicting_tx_retry_success);
         },
-        // If aggregator gets two good responses from client 2 and 3 before two bad responses from 0 and 1, 
+        // If aggregator gets two good responses from client 2 and 3 before two bad responses from 0 and 1,
         // tx will not be retried.
         Err(SuiError::QuorumFailedToProcessTransaction {..}) => (),
         _ => panic!("expect Err(SuiError::QuorumFailedToProcessTransactionWithConflictingTransactionRetried) or QuorumFailedToProcessTransaction but got {:?}", res),

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -442,10 +442,11 @@ pub fn make_tx_certs_and_signed_effects_with_committee(
             {
                 tx_certs.push(tx_cert.verify(committee).unwrap());
                 let effects = dummy_transaction_effects(&tx);
-                let signed_effects = effects.to_sign_effects(
+                let signed_effects = SignedTransactionEffects::new(
                     committee.epoch(),
-                    &AuthorityPublicKeyBytes::from(key.public()),
+                    effects,
                     &key,
+                    AuthorityPublicKeyBytes::from(key.public()),
                 );
                 effect_sigs.push(signed_effects);
                 break;

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -21,6 +21,7 @@ use sui_types::base_types::ObjectRef;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
 use sui_types::committee::Committee;
 use sui_types::error::SuiResult;
+use sui_types::message_envelope::Message;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::messages::{
     CallArg, ObjectArg, ObjectInfoRequest, ObjectInfoResponse, Transaction, TransactionData,
@@ -477,7 +478,7 @@ pub async fn submit_shared_object_transaction_with_committee(
 pub fn get_unique_effects(replies: Vec<TransactionInfoResponse>) -> TransactionEffects {
     let mut all_effects = HashMap::new();
     for reply in replies {
-        let effects = reply.signed_effects.unwrap().effects;
+        let effects = reply.signed_effects.unwrap().into_data();
         all_effects.insert(effects.digest(), effects);
     }
     assert_eq!(all_effects.len(), 1);


### PR DESCRIPTION
Consolidate effects envelope data structure. Main changes are in messages.rs. Rest are just refactorings.