### PR TITLE
[explorer] fix: transactions package detail 'Argument' parse style

### DIFF
--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -13,6 +13,7 @@ import {
     getTransferSuiTransaction,
     getTransferSuiAmount,
     SUI_TYPE_ARG,
+    SuiJsonValue
 } from '@mysten/sui.js';
 import cl from 'clsx';
 import { Link } from 'react-router-dom';
@@ -325,6 +326,23 @@ function TransactionView({ txdata }: { txdata: DataType }) {
         </div>
     ));
 
+    const argumentDisplay = (argumentValue: SuiJsonValue[] | undefined) => (
+        argumentValue
+        ? (
+            <div className="flex flex-col">
+            {
+                argumentValue?.map?.((item: SuiJsonValue, index: number) => (
+                    <div className="mt-3 first:mt-0" key={index}>
+                        "{item}"
+                    </div>
+                ))
+                || JSON.stringify(argumentValue)
+            }
+            </div>
+        )
+        : null
+    );
+
     const transactionSignatureData = {
         title: 'Transaction Signatures',
         content: [
@@ -414,7 +432,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                       {
                           label: 'Argument',
                           monotypeClass: true,
-                          value: JSON.stringify(txKindData.arguments.value),
+                          value: argumentDisplay(txKindData.arguments.value)
                       },
                   ],
               }


### PR DESCRIPTION
transactions package detail 'Argument' parse style, Increase readability

desktop orgin: 
![image](https://user-images.githubusercontent.com/53848281/200804795-9e61e4cd-2100-464e-9728-a9f929cf0dea.png)

desktop change:
![image](https://user-images.githubusercontent.com/53848281/200804992-fabae1d0-4fc4-419f-b672-d9ef4a646f64.png)

mobile origin:
![image](https://user-images.githubusercontent.com/53848281/200806344-eebaee57-c406-4739-bd83-572d86380b7d.png)

mobile change:
![image](https://user-images.githubusercontent.com/53848281/200806390-fab6048a-3da2-4582-a733-862fe7d51bfc.png)

