### PR TITLE
Add missing function `transfer`

### DIFF
--- a/sui_programmability/examples/objects_tutorial/sources/color_object.move
+++ b/sui_programmability/examples/objects_tutorial/sources/color_object.move
@@ -47,6 +47,10 @@ module tutorial::color_object {
         object::delete(id);
     }
 
+    public entry fun transfer(object: ColorObject, recipient: address) {
+        transfer::transfer(object, recipient)
+    }
+
     // == Functions covered in Chapter 3 ==
 
     public entry fun freeze_object(object: ColorObject) {


### PR DESCRIPTION
Add missing function `transfer` for the `sui_programmability/examples/objects_tutorial`

Reference:
https://docs.sui.io/build/programming-with-objects/ch2-using-objects#option-2-transfer-the-object
