### PR TITLE
[narwhal] Narwhal Worker validation of batches & transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8395,6 +8395,7 @@ dependencies = [
  "narwhal-executor",
  "narwhal-node",
  "narwhal-types",
+ "narwhal-worker",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5395,6 +5395,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "bytes",
+ "eyre",
  "fastcrypto",
  "futures",
  "multiaddr 0.16.0",
@@ -11591,7 +11592,7 @@ dependencies = [
 [[package]]
 name = "ying-profiler"
 version = "0.1.0"
-source = "git+https://github.com/velvia/ying-profiler#d1763c711c4bcf1a98fa7d80c79f31fdafe88ad1"
+source = "git+https://github.com/velvia/ying-profiler#1a3e476299bfc1ff4a3168edd9fcf1ccda521aea"
 dependencies = [
  "backtrace",
  "chrono",

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -54,6 +54,7 @@ narwhal-consensus = { path = "../../narwhal/consensus" }
 narwhal-executor = { path = "../../narwhal/executor" }
 narwhal-node = { path = "../../narwhal/node" }
 narwhal-types = { path = "../../narwhal/types" }
+narwhal-worker = { path = "../../narwhal/worker" }
 telemetry-subscribers.workspace = true
 typed-store.workspace = true
 typed-store-derive.workspace = true

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     authority::{AuthorityState, ReconfigConsensusMessage},
-    consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics},
+    consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, SuiTxValidator},
     metrics::start_timer,
 };
 use anyhow::anyhow;
@@ -276,6 +276,7 @@ impl ValidatorService {
         let consensus_storage_base_path = consensus_config.db_path().to_path_buf();
         let consensus_execution_state = ConsensusHandler::new(state.clone());
         let consensus_execution_state = Arc::new(consensus_execution_state);
+
         let consensus_parameters = consensus_config.narwhal_config().to_owned();
         let network_keypair = config.network_key_pair.copy();
 
@@ -289,6 +290,8 @@ impl ValidatorService {
             consensus_storage_base_path,
             consensus_execution_state,
             consensus_parameters,
+            // TODO: provide something more clever here to specify TX validity
+            SuiTxValidator::default(),
             rx_reconfigure_consensus,
             &registry,
         ));

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -335,7 +335,7 @@ impl<'a> Drop for InflightDropGuard<'a> {
 
 /// An implementation of the Narwhal TxValidator trait that validates transactions coming from Sui, and those coming from the network.
 // TODO: replace by a ConsensusTxValidator in order to make Narwhal-side validation effective
-pub use narwhal_worker::TrivialTxValidator as SuiTxValidator;
+pub use narwhal_worker::TrivialTransactionValidator as SuiTxValidator;
 
 #[cfg(test)]
 mod adapter_tests {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -333,6 +333,9 @@ impl<'a> Drop for InflightDropGuard<'a> {
     }
 }
 
+/// An implementation of the Narwhal TxValidator trait that validates transactions coming from Sui, and those coming from the network.
+pub use narwhal_worker::TrivialTxValidator as SuiTxValidator;
+
 #[cfg(test)]
 mod adapter_tests {
     use super::ConsensusAdapter;

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -334,6 +334,7 @@ impl<'a> Drop for InflightDropGuard<'a> {
 }
 
 /// An implementation of the Narwhal TxValidator trait that validates transactions coming from Sui, and those coming from the network.
+// TODO: replace by a ConsensusTxValidator in order to make Narwhal-side validation effective
 pub use narwhal_worker::TrivialTxValidator as SuiTxValidator;
 
 #[cfg(test)]

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::WrapErr;
+use std::sync::Arc;
+use tap::TapFallible;
+
+use narwhal_worker::TxValidator;
+use sui_types::{
+    crypto::{AuthoritySignInfoTrait, VerificationObligation},
+    message_envelope::Message,
+    messages::{ConsensusTransaction, ConsensusTransactionKind},
+};
+use tracing::warn;
+
+use crate::authority::AuthorityState;
+
+/// Allows verifying the validity of transactions
+#[derive(Clone)]
+struct ConsensusTxValidator {
+    // a pointer to the Authority state, mostly in order to get access to consensus
+    state: Arc<AuthorityState>,
+}
+
+impl ConsensusTxValidator {
+    #[allow(dead_code)]
+    pub fn new(state: Arc<AuthorityState>) -> Self {
+        Self { state }
+    }
+}
+
+fn tx_from_bytes(tx: &[u8]) -> Result<ConsensusTransaction, eyre::Report> {
+    bincode::deserialize::<ConsensusTransaction>(tx)
+        .wrap_err("Malformed transaction (failed to deserialize)")
+}
+
+impl TxValidator for ConsensusTxValidator {
+    type Error = eyre::Report;
+
+    fn validate(&self, tx: &[u8]) -> Result<(), Self::Error> {
+        let transaction = tx_from_bytes(tx)?;
+        match &transaction.kind {
+            ConsensusTransactionKind::UserTransaction(certificate) => {
+                certificate
+                    .verify_signature(&self.state.committee.load())
+                    .tap_err(|err| {
+                        warn!("Malformed transaction (failed to verify): {err}");
+                    })?;
+            }
+            ConsensusTransactionKind::Checkpoint(fragment) => {
+                fragment.verify().tap_err(|err| {
+                    warn!("Ignoring malformed fragment (failed to verify): {err}");
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_batch(&self, b: &narwhal_types::Batch) -> Result<(), Self::Error> {
+        let txs = b
+            .transactions
+            .iter()
+            .map(|tx| tx_from_bytes(tx))
+            .collect::<Result<Vec<_>, _>>()?;
+        let committee = self.state.committee.load();
+
+        let mut obligation = VerificationObligation::default();
+        for utx in user_transactions {
+            if let ConsensusTransactionKind::UserTransaction(certificate) = utx.kind {
+                // verify the inner user signature
+                certificate.data().verify()?;
+
+                let idx = obligation.add_message(certificate.data());
+                certificate.auth_sig().add_to_verification_obligation(
+                    &committee,
+                    &mut obligation,
+                    idx,
+                )?;
+            }
+        }
+        // verify the user transaction signatures as a batch
+        obligation
+            .verify_all()
+            .wrap_err("Malformed batch (failed to verify)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use fastcrypto::traits::KeyPair;
+    use narwhal_types::Batch;
+    use narwhal_worker::TxValidator;
+    use sui_types::{
+        base_types::AuthorityName,
+        committee::Committee,
+        crypto::{get_key_pair, AuthorityKeyPair, AuthorityPublicKeyBytes},
+        messages::ConsensusTransaction,
+    };
+
+    use crate::{
+        authority::authority_tests::init_state_with_objects_and_committee,
+        consensus_adapter::consensus_tests::{
+            test_certificates, test_gas_objects, test_shared_object,
+        },
+        consensus_validator::ConsensusTxValidator,
+    };
+
+    #[tokio::test]
+    async fn accept_valid_transaction() {
+        // Initialize an authority with a (owned) gas object and a shared object; then
+        // make a test certificate.
+        let mut objects = test_gas_objects();
+        objects.push(test_shared_object());
+
+        let mut authorities: BTreeMap<AuthorityPublicKeyBytes, u64> = BTreeMap::new();
+        let (_a1, sec1): (_, AuthorityKeyPair) = get_key_pair();
+        let (_a2, sec2): (_, AuthorityKeyPair) = get_key_pair();
+        let name1: AuthorityName = sec1.public().into();
+        let name2: AuthorityName = sec2.public().into();
+
+        authorities.insert(name1, 3);
+        authorities.insert(name2, 1);
+
+        let committee = Committee::new(0, authorities.clone()).unwrap();
+
+        let state =
+            init_state_with_objects_and_committee(objects, Some((committee.clone(), sec1))).await;
+        let certificates = test_certificates(&state).await;
+
+        let first_transaction = certificates[0].clone();
+        let first_transaction_bytes: Vec<u8> = bincode::serialize(
+            &ConsensusTransaction::new_certificate_message(&name1, first_transaction),
+        )
+        .unwrap();
+
+        let validator = ConsensusTxValidator::new(Arc::new(state));
+        let res = validator.validate(&first_transaction_bytes);
+        assert!(res.is_ok(), "{res:?}");
+
+        let transaction_bytes: Vec<_> = certificates
+            .into_iter()
+            .map(|cert| {
+                bincode::serialize(&ConsensusTransaction::new_certificate_message(&name1, cert))
+                    .unwrap()
+            })
+            .collect();
+
+        let batch = Batch::new(transaction_bytes);
+        let res_batch = validator.validate_batch(&batch);
+        assert!(res_batch.is_ok(), "{res_batch:?}");
+    }
+}

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod test_utils;
 
 pub mod checkpoints;
 mod consensus_handler;
+pub mod consensus_validator;
 mod histogram;
 mod node_sync;
 mod query_helpers;

--- a/narwhal/node/src/lib.rs
+++ b/narwhal/node/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, info};
 use types::{metered_channel, Certificate, ReconfigureNotification, Round};
-use worker::{metrics::initialise_metrics, Worker};
+use worker::{metrics::initialise_metrics, TxValidator, Worker};
 
 pub mod execution_state;
 pub mod metrics;
@@ -270,6 +270,8 @@ impl Node {
         store: &NodeStorage,
         // The configuration parameters.
         parameters: Parameters,
+        // The transaction validator defining Tx acceptance,
+        tx_validator: impl TxValidator,
         // The prometheus metrics Registry
         registry: &Registry,
     ) -> Vec<JoinHandle<()>> {
@@ -285,6 +287,7 @@ impl Node {
                 committee.clone(),
                 worker_cache.clone(),
                 parameters.clone(),
+                tx_validator.clone(),
                 store.batch_store.clone(),
                 metrics.clone(),
             );

--- a/narwhal/node/src/lib.rs
+++ b/narwhal/node/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, info};
 use types::{metered_channel, Certificate, ReconfigureNotification, Round};
-use worker::{metrics::initialise_metrics, TxValidator, Worker};
+use worker::{metrics::initialise_metrics, TransactionValidator, Worker};
 
 pub mod execution_state;
 pub mod metrics;
@@ -271,7 +271,7 @@ impl Node {
         // The configuration parameters.
         parameters: Parameters,
         // The transaction validator defining Tx acceptance,
-        tx_validator: impl TxValidator,
+        tx_validator: impl TransactionValidator,
         // The prometheus metrics Registry
         registry: &Registry,
     ) -> Vec<JoinHandle<()>> {

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -32,6 +32,7 @@ use tracing::info;
 use tracing::subscriber::set_global_default;
 #[cfg(feature = "benchmark")]
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use worker::TrivialTxValidator;
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
@@ -272,6 +273,8 @@ async fn run(
                 worker_cache,
                 &store,
                 parameters.clone(),
+                /* tx_validator */
+                TrivialTxValidator::default(),
                 &registry,
             )
         }

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -32,7 +32,7 @@ use tracing::info;
 use tracing::subscriber::set_global_default;
 #[cfg(feature = "benchmark")]
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
-use worker::TrivialTxValidator;
+use worker::TrivialTransactionValidator;
 
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
@@ -274,7 +274,7 @@ async fn run(
                 &store,
                 parameters.clone(),
                 /* tx_validator */
-                TrivialTxValidator::default(),
+                TrivialTransactionValidator::default(),
                 &registry,
             )
         }

--- a/narwhal/node/src/restarter.rs
+++ b/narwhal/node/src/restarter.rs
@@ -11,7 +11,7 @@ use prometheus::Registry;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::mpsc::Receiver;
 use types::ReconfigureNotification;
-use worker::TxValidator;
+use worker::TransactionValidator;
 
 // Module to start a node (primary, workers and default consensus), keep it running, and restarting it
 /// every time the committee changes.
@@ -27,7 +27,7 @@ impl NodeRestarter {
         storage_base_path: PathBuf,
         execution_state: Arc<State>,
         parameters: Parameters,
-        tx_validator: impl TxValidator,
+        tx_validator: impl TransactionValidator,
         mut rx_reconfigure: Receiver<(
             KeyPair,
             NetworkKeyPair,

--- a/narwhal/node/src/restarter.rs
+++ b/narwhal/node/src/restarter.rs
@@ -11,6 +11,7 @@ use prometheus::Registry;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::mpsc::Receiver;
 use types::ReconfigureNotification;
+use worker::TxValidator;
 
 // Module to start a node (primary, workers and default consensus), keep it running, and restarting it
 /// every time the committee changes.
@@ -26,6 +27,7 @@ impl NodeRestarter {
         storage_base_path: PathBuf,
         execution_state: Arc<State>,
         parameters: Parameters,
+        tx_validator: impl TxValidator,
         mut rx_reconfigure: Receiver<(
             KeyPair,
             NetworkKeyPair,
@@ -76,6 +78,7 @@ impl NodeRestarter {
                 worker_cache.clone(),
                 &store,
                 parameters.clone(),
+                tx_validator.clone(),
                 registry,
             );
 

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -25,7 +25,7 @@ use tokio::{
 };
 use types::ConsensusOutput;
 use types::{ReconfigureNotification, TransactionProto, TransactionsClient};
-use worker::TrivialTxValidator;
+use worker::TrivialTransactionValidator;
 
 /// A simple/dumb execution engine.
 struct SimpleExecutionState {
@@ -210,7 +210,7 @@ async fn restart() {
                 /* base_store_path */ test_utils::temp_dir(),
                 execution_state,
                 parameters,
-                TrivialTxValidator::default(),
+                TrivialTransactionValidator::default(),
                 rx_node_reconfigure,
                 &Registry::new(),
             )
@@ -336,7 +336,7 @@ async fn epoch_change() {
             worker_cache.clone(),
             &store,
             p,
-            TrivialTxValidator::default(),
+            TrivialTransactionValidator::default(),
             &Registry::new(),
         );
 

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -25,6 +25,7 @@ use tokio::{
 };
 use types::ConsensusOutput;
 use types::{ReconfigureNotification, TransactionProto, TransactionsClient};
+use worker::TrivialTxValidator;
 
 /// A simple/dumb execution engine.
 struct SimpleExecutionState {
@@ -209,6 +210,7 @@ async fn restart() {
                 /* base_store_path */ test_utils::temp_dir(),
                 execution_state,
                 parameters,
+                TrivialTxValidator::default(),
                 rx_node_reconfigure,
                 &Registry::new(),
             )
@@ -334,6 +336,7 @@ async fn epoch_change() {
             worker_cache.clone(),
             &store,
             p,
+            TrivialTxValidator::default(),
             &Registry::new(),
         );
 

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -32,7 +32,7 @@ use types::{
     BatchDigest, Certificate, CertificateDigest, FetchCertificatesRequest,
     PayloadAvailabilityRequest, PrimaryToPrimary, ReconfigureNotification, Round,
 };
-use worker::{metrics::initialise_metrics, Worker};
+use worker::{metrics::initialise_metrics, TrivialTxValidator, Worker};
 
 #[tokio::test]
 async fn get_network_peers_from_admin_server() {
@@ -119,6 +119,7 @@ async fn get_network_peers_from_admin_server() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         worker_1_parameters.clone(),
+        TrivialTxValidator::default(),
         store.batch_store,
         metrics_1,
     );

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -32,7 +32,7 @@ use types::{
     BatchDigest, Certificate, CertificateDigest, FetchCertificatesRequest,
     PayloadAvailabilityRequest, PrimaryToPrimary, ReconfigureNotification, Round,
 };
-use worker::{metrics::initialise_metrics, TrivialTxValidator, Worker};
+use worker::{metrics::initialise_metrics, TrivialTransactionValidator, Worker};
 
 #[tokio::test]
 async fn get_network_peers_from_admin_server() {
@@ -119,7 +119,7 @@ async fn get_network_peers_from_admin_server() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         worker_1_parameters.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store.batch_store,
         metrics_1,
     );

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -29,7 +29,7 @@ use types::{
     ReadCausalRequest, ReconfigureNotification, RemoveCollectionsRequest, RetrievalResult,
     Transaction, ValidatorClient,
 };
-use worker::{metrics::initialise_metrics, TrivialTxValidator, Worker};
+use worker::{metrics::initialise_metrics, TrivialTransactionValidator, Worker};
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_get_collections() {
@@ -143,7 +143,7 @@ async fn test_get_collections() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store.batch_store.clone(),
         metrics,
     );
@@ -362,7 +362,7 @@ async fn test_remove_collections() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store.batch_store.clone(),
         metrics,
     );
@@ -960,7 +960,7 @@ async fn test_get_collections_with_missing_certificates() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters_1.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store_primary_1.batch_store,
         metrics_1,
     );
@@ -1019,7 +1019,7 @@ async fn test_get_collections_with_missing_certificates() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters_2.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store_primary_2.batch_store,
         metrics_2,
     );

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -29,7 +29,7 @@ use types::{
     ReadCausalRequest, ReconfigureNotification, RemoveCollectionsRequest, RetrievalResult,
     Transaction, ValidatorClient,
 };
-use worker::{metrics::initialise_metrics, Worker};
+use worker::{metrics::initialise_metrics, TrivialTxValidator, Worker};
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_get_collections() {
@@ -143,6 +143,7 @@ async fn test_get_collections() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters.clone(),
+        TrivialTxValidator::default(),
         store.batch_store.clone(),
         metrics,
     );
@@ -361,6 +362,7 @@ async fn test_remove_collections() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters.clone(),
+        TrivialTxValidator::default(),
         store.batch_store.clone(),
         metrics,
     );
@@ -958,6 +960,7 @@ async fn test_get_collections_with_missing_certificates() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters_1.clone(),
+        TrivialTxValidator::default(),
         store_primary_1.batch_store,
         metrics_1,
     );
@@ -1016,6 +1019,7 @@ async fn test_get_collections_with_missing_certificates() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters_2.clone(),
+        TrivialTxValidator::default(),
         store_primary_2.batch_store,
         metrics_2,
     );

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -24,7 +24,7 @@ use tokio::{
 use tonic::transport::Channel;
 use tracing::info;
 use types::{ConfigurationClient, ProposerClient, TransactionsClient};
-use worker::TrivialTxValidator;
+use worker::TrivialTransactionValidator;
 
 #[cfg(test)]
 #[path = "tests/cluster_tests.rs"]
@@ -462,7 +462,7 @@ impl WorkerNodeDetails {
             self.worker_cache.clone(),
             &worker_store,
             self.parameters.clone(),
-            TrivialTxValidator::default(),
+            TrivialTransactionValidator::default(),
             &registry,
         );
 

--- a/narwhal/test-utils/src/cluster.rs
+++ b/narwhal/test-utils/src/cluster.rs
@@ -24,6 +24,7 @@ use tokio::{
 use tonic::transport::Channel;
 use tracing::info;
 use types::{ConfigurationClient, ProposerClient, TransactionsClient};
+use worker::TrivialTxValidator;
 
 #[cfg(test)]
 #[path = "tests/cluster_tests.rs"]
@@ -461,6 +462,7 @@ impl WorkerNodeDetails {
             self.worker_cache.clone(),
             &worker_store,
             self.parameters.clone(),
+            TrivialTxValidator::default(),
             &registry,
         );
 

--- a/narwhal/worker/Cargo.toml
+++ b/narwhal/worker/Cargo.toml
@@ -42,6 +42,7 @@ anemo-tower.workspace = true
 anyhow = "1.0.65"
 
 workspace-hack.workspace = true
+eyre = "0.6.8"
 
 [dev-dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -27,20 +27,23 @@ use types::{
 
 use sui_metrics::monitored_future;
 
+use crate::TxValidator;
+
 #[cfg(test)]
 #[path = "tests/handlers_tests.rs"]
 pub mod handlers_tests;
 
 /// Defines how the network receiver handles incoming workers messages.
 #[derive(Clone)]
-pub struct WorkerReceiverHandler {
+pub struct WorkerReceiverHandler<V> {
     pub id: WorkerId,
     pub tx_others_batch: Sender<WorkerOthersBatchMessage>,
     pub store: Store<BatchDigest, Batch>,
+    pub validator: V,
 }
 
 #[async_trait]
-impl WorkerToWorker for WorkerReceiverHandler {
+impl<V: TxValidator> WorkerToWorker for WorkerReceiverHandler<V> {
     async fn report_batch(
         &self,
         request: anemo::Request<WorkerBatchMessage>,

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -1,7 +1,7 @@
-use anemo::types::response::StatusCode;
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use anemo::types::response::StatusCode;
 use anyhow::Result;
 use async_trait::async_trait;
 use config::{Committee, SharedCommittee, SharedWorkerCache, WorkerCache, WorkerId, WorkerIndex};
@@ -50,11 +50,11 @@ impl<V: TxValidator> WorkerToWorker for WorkerReceiverHandler<V> {
         request: anemo::Request<WorkerBatchMessage>,
     ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
         let message = request.into_body();
-        if self.validator.validate_batch(&message.batch).is_err() {
+        if let Err(err) = self.validator.validate_batch(&message.batch) {
             // The batch is invalid, we don't want to process it.
             return Err(anemo::rpc::Status::new_with_message(
                 StatusCode::BadRequest,
-                "Invalid batch",
+                format!("Invalid batch: {err}"),
             ));
         }
         let digest = message.batch.digest();
@@ -86,7 +86,7 @@ impl<V: TxValidator> WorkerToWorker for WorkerReceiverHandler<V> {
 }
 
 /// Defines how the network receiver handles incoming primary messages.
-pub struct PrimaryReceiverHandler {
+pub struct PrimaryReceiverHandler<V> {
     // The public key of this authority.
     pub name: PublicKey,
     // The id of this worker.
@@ -103,10 +103,12 @@ pub struct PrimaryReceiverHandler {
     pub request_batch_retry_nodes: usize,
     /// Send reconfiguration update to other tasks.
     pub tx_reconfigure: watch::Sender<ReconfigureNotification>,
+    // Validate incoming batches
+    pub validator: V,
 }
 
 #[async_trait]
-impl PrimaryToWorker for PrimaryReceiverHandler {
+impl<V: TxValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
     async fn reconfigure(
         &self,
         request: anemo::Request<WorkerReconfigureMessage>,
@@ -251,6 +253,13 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
                 match result {
                     Ok(response) => {
                         if let Some(batch) = response.into_body().batch {
+                            if let Err(err) = self.validator.validate_batch(&batch) {
+                                // The batch is invalid, we don't want to process it.
+                                return Err(anemo::rpc::Status::new_with_message(
+                                    StatusCode::BadRequest,
+                                    format!("Invalid batch: {err}"),
+                                ));
+                            }
                             let digest = batch.digest();
                             if missing.remove(&digest) {
                                 self.store.sync_write(digest, batch).await.map_err(|e| {
@@ -293,7 +302,7 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
     }
 }
 
-impl PrimaryReceiverHandler {
+impl<V: TxValidator> PrimaryReceiverHandler<V> {
     fn update_worker_cache(&self, new_committee: &Committee) {
         self.worker_cache.swap(Arc::new(WorkerCache {
             epoch: new_committee.epoch,

--- a/narwhal/worker/src/handlers.rs
+++ b/narwhal/worker/src/handlers.rs
@@ -28,7 +28,7 @@ use types::{
 
 use sui_metrics::monitored_future;
 
-use crate::TxValidator;
+use crate::TransactionValidator;
 
 #[cfg(test)]
 #[path = "tests/handlers_tests.rs"]
@@ -44,7 +44,7 @@ pub struct WorkerReceiverHandler<V> {
 }
 
 #[async_trait]
-impl<V: TxValidator> WorkerToWorker for WorkerReceiverHandler<V> {
+impl<V: TransactionValidator> WorkerToWorker for WorkerReceiverHandler<V> {
     async fn report_batch(
         &self,
         request: anemo::Request<WorkerBatchMessage>,
@@ -108,7 +108,7 @@ pub struct PrimaryReceiverHandler<V> {
 }
 
 #[async_trait]
-impl<V: TxValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
+impl<V: TransactionValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
     async fn reconfigure(
         &self,
         request: anemo::Request<WorkerReconfigureMessage>,
@@ -302,7 +302,7 @@ impl<V: TxValidator> PrimaryToWorker for PrimaryReceiverHandler<V> {
     }
 }
 
-impl<V: TxValidator> PrimaryReceiverHandler<V> {
+impl<V: TransactionValidator> PrimaryReceiverHandler<V> {
     fn update_worker_cache(&self, new_committee: &Committee) {
         self.worker_cache.swap(Arc::new(WorkerCache {
             epoch: new_committee.epoch,

--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -13,8 +13,8 @@ mod handlers;
 pub mod metrics;
 mod primary_connector;
 mod quorum_waiter;
-mod validator;
+mod tx_validator;
 mod worker;
 
-pub use crate::validator::{TrivialTxValidator, TxValidator};
+pub use crate::tx_validator::{TrivialTxValidator, TxValidator};
 pub use crate::worker::Worker;

--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -13,6 +13,8 @@ mod handlers;
 pub mod metrics;
 mod primary_connector;
 mod quorum_waiter;
+mod validator;
 mod worker;
 
+pub use crate::validator::{TrivialTxValidator, TxValidator};
 pub use crate::worker::Worker;

--- a/narwhal/worker/src/lib.rs
+++ b/narwhal/worker/src/lib.rs
@@ -16,5 +16,5 @@ mod quorum_waiter;
 mod tx_validator;
 mod worker;
 
-pub use crate::tx_validator::{TrivialTxValidator, TxValidator};
+pub use crate::tx_validator::{TransactionValidator, TrivialTransactionValidator};
 pub use crate::worker::Worker;

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
+use crate::TrivialTransactionValidator;
 use fastcrypto::hash::Hash;
 use test_utils::CommitteeFixture;
 use types::{MockWorkerToWorker, WorkerToWorkerServer};
@@ -31,7 +32,7 @@ async fn synchronize() {
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
         tx_reconfigure,
-        validator: TrivialTxValidator,
+        validator: TrivialTransactionValidator,
     };
 
     // Set up mock behavior for child RequestBatches RPC.
@@ -104,7 +105,7 @@ async fn synchronize_when_batch_exists() {
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
         tx_reconfigure,
-        validator: TrivialTxValidator,
+        validator: TrivialTransactionValidator,
     };
 
     // Store the batch.
@@ -156,7 +157,7 @@ async fn delete_batches() {
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
         tx_reconfigure,
-        validator: TrivialTxValidator,
+        validator: TrivialTransactionValidator,
     };
     let message = WorkerDeleteBatchesMessage {
         digests: vec![digest],

--- a/narwhal/worker/src/tests/handlers_tests.rs
+++ b/narwhal/worker/src/tests/handlers_tests.rs
@@ -31,6 +31,7 @@ async fn synchronize() {
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
         tx_reconfigure,
+        validator: TrivialTxValidator,
     };
 
     // Set up mock behavior for child RequestBatches RPC.
@@ -103,6 +104,7 @@ async fn synchronize_when_batch_exists() {
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
         tx_reconfigure,
+        validator: TrivialTxValidator,
     };
 
     // Store the batch.
@@ -154,6 +156,7 @@ async fn delete_batches() {
         request_batch_timeout: Duration::from_secs(999),
         request_batch_retry_nodes: 3, // Not used in this test.
         tx_reconfigure,
+        validator: TrivialTxValidator,
     };
     let message = WorkerDeleteBatchesMessage {
         digests: vec![digest],

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use crate::metrics::initialise_metrics;
+use crate::{metrics::initialise_metrics, TrivialTxValidator};
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
@@ -50,6 +50,7 @@ async fn handle_clients_transactions() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters,
+        TrivialTxValidator::default(),
         store,
         metrics,
     );
@@ -199,6 +200,7 @@ async fn get_network_peers_from_admin_server() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         worker_1_parameters.clone(),
+        TrivialTxValidator::default(),
         store.batch_store.clone(),
         metrics_1.clone(),
     );
@@ -310,6 +312,7 @@ async fn get_network_peers_from_admin_server() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         worker_2_parameters.clone(),
+        TrivialTxValidator::default(),
         store.batch_store,
         metrics_2.clone(),
     );

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use crate::{metrics::initialise_metrics, TrivialTxValidator};
+use crate::{metrics::initialise_metrics, TrivialTransactionValidator};
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
@@ -25,7 +25,7 @@ use types::{
 // A test validator that rejects every transaction / batch
 #[derive(Clone)]
 struct NilTxValidator;
-impl TxValidator for NilTxValidator {
+impl TransactionValidator for NilTxValidator {
     type Error = eyre::Report;
 
     fn validate(&self, _tx: &[u8]) -> Result<(), Self::Error> {
@@ -151,7 +151,7 @@ async fn handle_clients_transactions() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         parameters,
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store,
         metrics,
     );
@@ -301,7 +301,7 @@ async fn get_network_peers_from_admin_server() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         worker_1_parameters.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store.batch_store.clone(),
         metrics_1.clone(),
     );
@@ -413,7 +413,7 @@ async fn get_network_peers_from_admin_server() {
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache.clone(),
         worker_2_parameters.clone(),
-        TrivialTxValidator::default(),
+        TrivialTransactionValidator::default(),
         store.batch_store,
         metrics_2.clone(),
     );

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -16,8 +16,109 @@ use prometheus::Registry;
 use std::time::Duration;
 use storage::NodeStorage;
 use store::rocks;
-use test_utils::{batch, temp_dir, CommitteeFixture};
-use types::{MockWorkerToPrimary, MockWorkerToWorker, TransactionsClient, WorkerToPrimaryServer};
+use test_utils::{batch, temp_dir, test_network, transaction, CommitteeFixture};
+use types::{
+    MockWorkerToPrimary, MockWorkerToWorker, TransactionsClient, WorkerBatchMessage,
+    WorkerToPrimaryServer, WorkerToWorkerClient,
+};
+
+// A test validator that rejects every transaction / batch
+#[derive(Clone)]
+struct NilTxValidator;
+impl TxValidator for NilTxValidator {
+    type Error = eyre::Report;
+
+    fn validate(&self, _tx: &[u8]) -> Result<(), Self::Error> {
+        eyre::bail!("Invalid transaction");
+    }
+    fn validate_batch(&self, _txs: &Batch) -> Result<(), Self::Error> {
+        eyre::bail!("Invalid batch");
+    }
+}
+
+#[tokio::test]
+async fn reject_invalid_clients_transactions() {
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let committee = fixture.committee();
+    let worker_cache = fixture.shared_worker_cache();
+
+    let worker_id = 0;
+    let my_primary = fixture.authorities().next().unwrap();
+    let myself = my_primary.worker(worker_id);
+    let name = my_primary.public_key();
+
+    let parameters = Parameters {
+        batch_size: 200, // Two transactions.
+        ..Parameters::default()
+    };
+
+    // Create a new test store.
+    let db = rocks::DBMap::<BatchDigest, Batch>::open(temp_dir(), None, Some("batches")).unwrap();
+    let store = Store::new(db);
+
+    let registry = Registry::new();
+    let metrics = initialise_metrics(&registry);
+
+    // Spawn a `Worker` instance with a reject-all validator.
+    Worker::spawn(
+        name.clone(),
+        myself.keypair(),
+        worker_id,
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
+        worker_cache.clone(),
+        parameters,
+        NilTxValidator,
+        store,
+        metrics,
+    );
+
+    // Wait till other services have been able to start up
+    tokio::task::yield_now().await;
+    // Send enough transactions to create a batch.
+    let address = worker_cache
+        .load()
+        .worker(&name, &worker_id)
+        .unwrap()
+        .transactions;
+    let config = mysten_network::config::Config::new();
+    let channel = config.connect_lazy(&address).unwrap();
+    let mut client = TransactionsClient::new(channel);
+    let tx = transaction();
+    let txn = TransactionProto {
+        transaction: Bytes::from(tx.clone()),
+    };
+
+    // Check invalid transactions are rejected
+    let res = client.submit_transaction(txn).await;
+    assert!(res.is_err());
+
+    let worker_pk = worker_cache.load().worker(&name, &worker_id).unwrap().name;
+
+    let batch = batch();
+    let batch_message = WorkerBatchMessage {
+        batch: batch.clone(),
+    };
+
+    // setup network : impersonate a send from another worker
+    let another_primary = fixture.authorities().nth(2).unwrap();
+    let another_worker = another_primary.worker(worker_id);
+    let network = test_network(
+        another_worker.keypair(),
+        &another_worker.info().worker_address,
+    );
+    // ensure that the networks are connected
+    network
+        .connect(network::multiaddr_to_address(&myself.info().worker_address).unwrap())
+        .await
+        .unwrap();
+    let peer = network.peer(PeerId(worker_pk.0.to_bytes())).unwrap();
+
+    // Check invalid batches are rejected
+    let res = WorkerToWorkerClient::new(peer)
+        .report_batch(batch_message)
+        .await;
+    assert!(res.is_err());
+}
 
 #[tokio::test]
 async fn handle_clients_transactions() {

--- a/narwhal/worker/src/tx_validator.rs
+++ b/narwhal/worker/src/tx_validator.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Display};
+
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use types::Batch;
@@ -6,16 +8,11 @@ use types::Batch;
 /// of a batch of transactions (from another validator). Invalid transactions will not receive
 /// further processing.
 pub trait TxValidator: Clone + Send + Sync + 'static {
-    type Error: Send + Sync + 'static;
-
+    type Error: Display + Debug + Send + Sync + 'static;
     /// Determines if a transaction valid for the worker to consider putting in a batch
-    fn validate(&self, _t: &[u8]) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    fn validate(&self, t: &[u8]) -> Result<(), Self::Error>;
     /// Determines if this batch can be voted on
-    fn validate_batch(&self, _b: &Batch) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    fn validate_batch(&self, b: &Batch) -> Result<(), Self::Error>;
 }
 
 /// Simple validator that accepts all transactions and batches.
@@ -23,4 +20,12 @@ pub trait TxValidator: Clone + Send + Sync + 'static {
 pub struct TrivialTxValidator;
 impl TxValidator for TrivialTxValidator {
     type Error = eyre::Report;
+
+    fn validate(&self, _t: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn validate_batch(&self, _b: &Batch) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }

--- a/narwhal/worker/src/tx_validator.rs
+++ b/narwhal/worker/src/tx_validator.rs
@@ -7,7 +7,7 @@ use types::Batch;
 /// Defines the validation procedure for receiving either a new single transaction (from a client)
 /// of a batch of transactions (from another validator). Invalid transactions will not receive
 /// further processing.
-pub trait TxValidator: Clone + Send + Sync + 'static {
+pub trait TransactionValidator: Clone + Send + Sync + 'static {
     type Error: Display + Debug + Send + Sync + 'static;
     /// Determines if a transaction valid for the worker to consider putting in a batch
     fn validate(&self, t: &[u8]) -> Result<(), Self::Error>;
@@ -17,8 +17,8 @@ pub trait TxValidator: Clone + Send + Sync + 'static {
 
 /// Simple validator that accepts all transactions and batches.
 #[derive(Debug, Clone, Default)]
-pub struct TrivialTxValidator;
-impl TxValidator for TrivialTxValidator {
+pub struct TrivialTransactionValidator;
+impl TransactionValidator for TrivialTransactionValidator {
     type Error = eyre::Report;
 
     fn validate(&self, _t: &[u8]) -> Result<(), Self::Error> {

--- a/narwhal/worker/src/validator.rs
+++ b/narwhal/worker/src/validator.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use types::Batch;
+
+/// Defines the validation procedure for receiving either a new single transaction (from a client)
+/// of a batch of transactions (from another validator). Invalid transactions will not receive
+/// further processing.
+pub trait TxValidator: Clone + Send + Sync + 'static {
+    /// Determines if a transaction valid for the worker to consider putting in a batch
+    fn validate(&self, _t: &[u8]) -> bool {
+        true
+    }
+    /// Determines if this batch can be voted on
+    fn validate_batch(&self, _b: &Batch) -> bool {
+        true
+    }
+}
+
+/// Simple validator that accepts all transactions and batches.
+#[derive(Debug, Clone, Default)]
+pub struct TrivialTxValidator;
+impl TxValidator for TrivialTxValidator {}

--- a/narwhal/worker/src/validator.rs
+++ b/narwhal/worker/src/validator.rs
@@ -1,23 +1,26 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 use types::Batch;
 
 /// Defines the validation procedure for receiving either a new single transaction (from a client)
 /// of a batch of transactions (from another validator). Invalid transactions will not receive
 /// further processing.
 pub trait TxValidator: Clone + Send + Sync + 'static {
+    type Error: Send + Sync + 'static;
+
     /// Determines if a transaction valid for the worker to consider putting in a batch
-    fn validate(&self, _t: &[u8]) -> bool {
-        true
+    fn validate(&self, _t: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
     }
     /// Determines if this batch can be voted on
-    fn validate_batch(&self, _b: &Batch) -> bool {
-        true
+    fn validate_batch(&self, _b: &Batch) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 
 /// Simple validator that accepts all transactions and batches.
 #[derive(Debug, Clone, Default)]
 pub struct TrivialTxValidator;
-impl TxValidator for TrivialTxValidator {}
+impl TxValidator for TrivialTxValidator {
+    type Error = eyre::Report;
+}

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -7,7 +7,7 @@ use crate::{
     metrics::WorkerChannelMetrics,
     primary_connector::PrimaryConnector,
     quorum_waiter::QuorumWaiter,
-    TxValidator,
+    TransactionValidator,
 };
 use anemo::types::Address;
 use anemo::{types::PeerInfo, Network, PeerId};
@@ -75,7 +75,7 @@ impl Worker {
         committee: SharedCommittee,
         worker_cache: SharedWorkerCache,
         parameters: Parameters,
-        validator: impl TxValidator,
+        validator: impl TransactionValidator,
         store: Store<BatchDigest, Batch>,
         metrics: Metrics,
     ) -> Vec<JoinHandle<()>> {
@@ -319,7 +319,7 @@ impl Worker {
         node_metrics: Arc<WorkerMetrics>,
         channel_metrics: Arc<WorkerChannelMetrics>,
         endpoint_metrics: WorkerEndpointMetrics,
-        validator: impl TxValidator,
+        validator: impl TransactionValidator,
         network: anemo::Network,
     ) -> Vec<JoinHandle<()>> {
         let (tx_batch_maker, rx_batch_maker) = channel_with_total(
@@ -393,7 +393,7 @@ struct TxReceiverHandler<V> {
     validator: V,
 }
 
-impl<V: TxValidator> TxReceiverHandler<V> {
+impl<V: TransactionValidator> TxReceiverHandler<V> {
     async fn wait_for_shutdown(mut rx_reconfigure: watch::Receiver<ReconfigureNotification>) {
         loop {
             let result = rx_reconfigure.changed().await;
@@ -429,7 +429,7 @@ impl<V: TxValidator> TxReceiverHandler<V> {
 }
 
 #[async_trait]
-impl<V: TxValidator> Transactions for TxReceiverHandler<V> {
+impl<V: TransactionValidator> Transactions for TxReceiverHandler<V> {
     async fn submit_transaction(
         &self,
         request: Request<TransactionProto>,


### PR DESCRIPTION
## The problem

Today, Sui validates each transaction, both on submission to Narwhal and when received back from Narwhal. Worse, it does it one by one. Those transaction validations involve signature verifications that are less expensive when batched. Narwhal has access to batches sooner, so we could have Narwhal validate transactions when submitted, and batches when received from others.

## Notes

- The verification of batches is already using all cores thanks to the underlying BLS libraries.

## This PR
- introduces the `TxValidator` trait in Narwhal,
- requires an instance of it in the worker constructor,
- uses that instance in Narwhal for transaction reception and batch reception,
- plugs in a trivial (all-accepting, aka no-op) transaction validator, so that this PR does not change behavior,
- implements a PoC validator `ConsensusTxValidator` that would batch the verification of batch certificates as well as fragment signatures.
 
## What this PR does not do, and that I recommend leaving for further PRs
- use the `ConsensusTxValidator` in Sui's instantiation of the Narwhal network,
- remove signature verification from Sui's consensus transaction submission,
- remove signature verification from Sui's consensus handler (sequenced transaction processing).

## Out of scope of this issue, but very welcome as future improvements
- making the `ConsensusTxValidator` do more cool stuff, including e.g. caching
