### PR TITLE
wallet-ext: small improvements for unlocking wallet from session storage

### DIFF
--- a/apps/wallet/configs/webpack/webpack.config.common.ts
+++ b/apps/wallet/configs/webpack/webpack.config.common.ts
@@ -202,7 +202,9 @@ const commonConfig: () => Promise<Configuration> = async () => {
                 // 'typeof window': JSON.stringify(typeof {}),
                 'process.env.NODE_DEBUG': false,
                 'process.env.WALLET_KEYRING_PASSWORD': JSON.stringify(
-                    Buffer.from(randomBytes(64)).toString('hex')
+                    IS_DEV
+                        ? 'DEV_PASS'
+                        : Buffer.from(randomBytes(64)).toString('hex')
                 ),
                 'process.env.WALLET_BETA': WALLET_BETA,
                 'process.env.APP_NAME': JSON.stringify(APP_NAME),

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -36,7 +36,10 @@ class Keyring {
 
     constructor() {
         this.#vault = new VaultStorage();
-        this.#reviveDone = this.revive();
+        this.#reviveDone = this.revive().catch((e) => {
+            // if for some reason decrypting the vault fails or anything else catch
+            // the error to allow the user to login using the password
+        });
     }
 
     /**


### PR DESCRIPTION
* add static secret for dev mode. Happened a few times already to me to have a valid 'session' but because of rebuilding the app to invalidate it
* fix when reviving from session storage fails to not break the app

before


https://user-images.githubusercontent.com/10210143/200916391-a4ddf323-393a-42b9-9bff-36409974daa7.mov


after


https://user-images.githubusercontent.com/10210143/200916432-5c48b1a7-c3ef-4157-9034-da526988335a.mov


related to: APPS-106