### PR TITLE
[explorer] Preserve network through search params

### DIFF
--- a/apps/explorer/.eslintrc.js
+++ b/apps/explorer/.eslintrc.js
@@ -130,6 +130,21 @@ module.exports = {
 
         // We may eventually want to turn this on but it requires migration:
         'react/no-array-index-key': 'off',
+
+        // Require usage of the custom Link component:
+        'no-restricted-imports': [
+            'error',
+            {
+                paths: [
+                    {
+                        name: 'react-router-dom',
+                        importNames: ['Link'],
+                        message:
+                            'Please use `LinkWithQuery` from "~/ui/utils/LinkWithQuery" instead.',
+                    },
+                ],
+            },
+        ],
     },
     overrides: [
         {

--- a/apps/explorer/src/components/header/Header.tsx
+++ b/apps/explorer/src/components/header/Header.tsx
@@ -1,25 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Link } from 'react-router-dom';
-
 import { ReactComponent as SuiLogo } from '../../assets/Sui Logo.svg';
 import NetworkSelect from '../network/Network';
 import Search from '../search/Search';
 
 import styles from './Header.module.css';
 
+import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
+
 function Header() {
     return (
         <header>
-            <Link
+            <LinkWithQuery
                 id="homeBtn"
                 data-testid="nav-logo-button"
                 className={styles.suititle}
                 to="/"
             >
                 <SuiLogo />
-            </Link>
+            </LinkWithQuery>
 
             <div className={styles.search}>
                 <Search />

--- a/apps/explorer/src/components/longtext/Longtext.tsx
+++ b/apps/explorer/src/components/longtext/Longtext.tsx
@@ -3,7 +3,7 @@
 
 import { useCallback, useState, useContext } from 'react';
 import toast from 'react-hot-toast';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { ReactComponent as ContentArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
 import { ReactComponent as ContentCopyIcon16 } from '../../assets/SVGIcons/16px/Copy.svg';
@@ -15,6 +15,8 @@ import ExternalLink from '../external-link/ExternalLink';
 import type { ReactNode } from 'react';
 
 import styles from './Longtext.module.css';
+
+import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
 
 function Longtext({
     text,
@@ -111,12 +113,12 @@ function Longtext({
         } else {
             textComponent = (
                 <div>
-                    <Link
+                    <LinkWithQuery
                         className={styles.longtext}
                         to={`/${category}/${encodeURIComponent(text)}`}
                     >
                         {alttext ? alttext : text} {iconButton}
-                    </Link>
+                    </LinkWithQuery>
                 </div>
             );
         }

--- a/apps/explorer/src/components/module/ModuleView.tsx
+++ b/apps/explorer/src/components/module/ModuleView.tsx
@@ -4,7 +4,6 @@ import { useQuery } from '@tanstack/react-query';
 import cl from 'clsx';
 import Highlight, { defaultProps, Prism } from 'prism-react-renderer';
 import 'prism-themes/themes/prism-one-light.css';
-import { Link } from 'react-router-dom';
 
 import codestyle from '../../styles/bytecode.module.css';
 import { normalizeSuiAddress } from '../../utils/stringUtils';
@@ -15,6 +14,7 @@ import type { Language } from 'prism-react-renderer';
 import styles from './ModuleView.module.css';
 
 import { useRpc } from '~/hooks/useRpc';
+import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
 
 // Include Rust language support.
 // TODO: Write a custom prismjs syntax for Move Bytecode.
@@ -141,7 +141,7 @@ function ModuleView({ id, name, code }: Props) {
                                             const href = `/objects/${reference.address}?module=${reference.module}`;
 
                                             return (
-                                                <Link
+                                                <LinkWithQuery
                                                     key={key}
                                                     {...getTokenProps({
                                                         token,

--- a/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
+++ b/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
@@ -9,7 +9,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import cl from 'clsx';
 import { useState, useCallback, useMemo } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { ReactComponent as ArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
 import TabFooter from '../../components/tabs/TabFooter';
@@ -29,6 +29,7 @@ import { Banner } from '~/ui/Banner';
 import { PlaceholderTable } from '~/ui/PlaceholderTable';
 import { TableCard } from '~/ui/TableCard';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
 
 const TRUNCATE_LENGTH = 10;
 const NUMBER_OF_TX_PER_PAGE = 20;
@@ -193,9 +194,9 @@ export function LatestTxCard({
             />
         ) : (
             <TabFooter stats={stats}>
-                <Link className={styles.moretxbtn} to="/transactions">
+                <LinkWithQuery className={styles.moretxbtn} to="/transactions">
                     <div>More Transactions</div> <ArrowRight />
-                </Link>
+                </LinkWithQuery>
             </TabFooter>
         );
 

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
 
 import { ReactComponent as PreviewMediaIcon } from '../../../assets/SVGIcons/preview-media.svg';
 import DisplayBox from '../../../components/displaybox/DisplayBox';
@@ -24,6 +23,9 @@ import {
 import { type DataType } from '../ObjectResultType';
 
 import styles from './ObjectView.module.css';
+
+import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
+
 function TokenView({ data }: { data: DataType }) {
     const viewedData = {
         ...data,
@@ -85,12 +87,12 @@ function TokenView({ data }: { data: DataType }) {
                             <tr>
                                 <td>Type</td>
                                 <td>
-                                    <Link
+                                    <LinkWithQuery
                                         to={genhref(viewedData.objType)}
                                         className={styles.objecttypelink}
                                     >
                                         {trimStdLibPrefix(viewedData.objType)}
-                                    </Link>
+                                    </LinkWithQuery>
                                 </td>
                             </tr>
                             <tr>

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -15,7 +15,6 @@ import {
     SUI_TYPE_ARG,
 } from '@mysten/sui.js';
 import cl from 'clsx';
-import { Link } from 'react-router-dom';
 
 import {
     eventToDisplay,
@@ -50,6 +49,7 @@ import { Banner } from '~/ui/Banner';
 import { PageHeader } from '~/ui/PageHeader';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
+import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
 
 type TxDataProps = CertifiedTransaction & {
     status: ExecutionStatusType;
@@ -225,12 +225,12 @@ function ItemView({ data }: { data: TxItemView }) {
                                         copyButton="16"
                                     />
                                 ) : item.href ? (
-                                    <Link
+                                    <LinkWithQuery
                                         to={item.href}
                                         className={styles.customhreflink}
                                     >
                                         {item.value}
-                                    </Link>
+                                    </LinkWithQuery>
                                 ) : (
                                     item.value
                                 )}

--- a/apps/explorer/src/ui/utils/ButtonOrLink.tsx
+++ b/apps/explorer/src/ui/utils/ButtonOrLink.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type ComponentProps, forwardRef } from 'react';
-import { Link, type LinkProps } from 'react-router-dom';
+
+import { LinkWithQuery, type LinkProps } from './LinkWithQuery';
 
 export interface ButtonOrLinkProps
     extends Omit<
@@ -30,7 +31,7 @@ export const ButtonOrLink = forwardRef<
 
     // Internal router link:
     if (to) {
-        return <Link to={to} ref={ref} {...props} />;
+        return <LinkWithQuery to={to} ref={ref} {...props} />;
     }
 
     // We set the default type to be "button" to avoid accidentally submitting forms.

--- a/apps/explorer/src/ui/utils/LinkWithQuery.tsx
+++ b/apps/explorer/src/ui/utils/LinkWithQuery.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { forwardRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { Link, useLocation, type LinkProps } from 'react-router-dom';
+
+export { LinkProps };
+
+export const LinkWithQuery = forwardRef<HTMLAnchorElement, LinkProps>(
+    ({ to, ...props }) => {
+        const { search } = useLocation();
+
+        return <Link to={`${to}${search}`} {...props} />;
+    }
+);

--- a/apps/explorer/src/utils/envUtil.ts
+++ b/apps/explorer/src/utils/envUtil.ts
@@ -8,4 +8,4 @@ export const DEFAULT_NETWORK =
     (import.meta.env.DEV ? Network.LOCAL : Network.DEVNET);
 
 export const IS_STATIC_ENV = DEFAULT_NETWORK === Network.STATIC;
-export const IS_STAGING_ENV = DEFAULT_NETWORK === Network.STAGING;
+export const IS_STAGING_ENV = DEFAULT_NETWORK === Network.LOCAL;


### PR DESCRIPTION
Now that the url params are the source of truth for the network (#5948), we need to preserve the query params while we navigate around. This updates to do that.