### PR TITLE
[consensus_adapter] use notify_read instead of ConsensusListener

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2131,7 +2131,7 @@ impl AuthorityState {
         // todo - ideally move this metric in NotifyRead once we have metrics in AuthorityStore
         self.metrics
             .pending_notify_read
-            .set(self.database.notify_read.num_pending() as i64);
+            .set(self.database.effects_notify_read.num_pending() as i64);
         // We only notify i.e. update low watermark once database changes are committed
         notifier_ticket.notify();
         Ok(seq)
@@ -2161,6 +2161,17 @@ impl AuthorityState {
             .consensus_message_processed(certificate.digest())
     }
 
+    /// Check whether certificate was processed by consensus.
+    /// Returned future is immediately ready if consensus message was already processed.
+    /// Otherwise returns future that waits for message to be processed by consensus.
+    pub async fn consensus_message_processed_notify(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<(), SuiError> {
+        self.database
+            .consensus_message_processed_notify(digest)
+            .await
+    }
     /// Get a read reference to an object/seq lock
     pub async fn get_transaction_lock(
         &self,


### PR DESCRIPTION
This change fixes a race condition between reading `consensus_message_processed` table and registering waiter for `ConsensusListener`.

This race condition becomes critical when we change `should_submit` to return value other than `true`, which we need to reduce consensus write amplification.

More details on the race condition can be read in conversation [here](https://github.com/MystenLabs/sui/pull/4979#issuecomment-1268804384).

After this change is merged we can merge #4979 and see 3x decrease of load on consensus.

Note that this change essentially eliminate use of `ConsensusListener`. However, I am not deleting it yet because it is used in checkpoints v1. `ConsensusListener` will be deleted once checkpoints v1 code is deleted.

https://github.com/MystenLabs/sui/issues/5763