### PR TITLE
Double check json number is u64

### DIFF
--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -175,7 +175,15 @@ impl SuiJsonValue {
             (JsonValue::Number(n), MoveTypeLayout::U32) => {
                 MoveValue::U32(u32::try_from(n.as_u64().unwrap())?)
             }
-            (JsonValue::Number(n), MoveTypeLayout::U64) => MoveValue::U64(n.as_u64().unwrap()),
+            (JsonValue::Number(n), MoveTypeLayout::U64) => match n.as_u64() {
+                Some(q) => MoveValue::U64(q),
+                None => {
+                    return Err(SuiJsonValueError::new(
+                        val,
+                        SuiJsonValueErrorKind::ValueTypeNotAllowed,
+                    ))
+                }
+            },
 
             // u8, u16, u32, u64, u128, u256 can be encoded as String
             (JsonValue::String(s), MoveTypeLayout::U8) => {

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -175,17 +175,42 @@ impl SuiJsonValue {
             (JsonValue::Bool(b), MoveTypeLayout::Bool) => MoveValue::Bool(*b),
 
             // In constructor, we have already checked that the JSON number is unsigned int of at most U64
-            // Hence it is okay to unwrap() numbers
-            (JsonValue::Number(n), MoveTypeLayout::U8) => {
-                MoveValue::U8(u8::try_from(n.as_u64().unwrap())?)
-            }
-            (JsonValue::Number(n), MoveTypeLayout::U16) => {
-                MoveValue::U16(u16::try_from(n.as_u64().unwrap())?)
-            }
-            (JsonValue::Number(n), MoveTypeLayout::U32) => {
-                MoveValue::U32(u32::try_from(n.as_u64().unwrap())?)
-            }
-            (JsonValue::Number(n), MoveTypeLayout::U64) => MoveValue::U64(n.as_u64().unwrap()),
+            (JsonValue::Number(n), MoveTypeLayout::U8) => match n.as_u64() {
+                Some(x) => MoveValue::U8(u8::try_from(x)?),
+                None => {
+                    return Err(anyhow!(format!(
+                        "{} is not a valid number. Only u64 allowed.",
+                        n
+                    )))
+                }
+            },
+            (JsonValue::Number(n), MoveTypeLayout::U16) => match n.as_u64() {
+                Some(x) => MoveValue::U16(u16::try_from(x)?),
+                None => {
+                    return Err(anyhow!(format!(
+                        "{} is not a valid number. Only u64 allowed.",
+                        n
+                    )))
+                }
+            },
+            (JsonValue::Number(n), MoveTypeLayout::U32) => match n.as_u64() {
+                Some(x) => MoveValue::U32(u32::try_from(x)?),
+                None => {
+                    return Err(anyhow!(format!(
+                        "{} is not a valid number. Only u64 allowed.",
+                        n
+                    )))
+                }
+            },
+            (JsonValue::Number(n), MoveTypeLayout::U64) => match n.as_u64() {
+                Some(x) => MoveValue::U64(x),
+                None => {
+                    return Err(anyhow!(format!(
+                        "{} is not a valid number. Only u64 allowed.",
+                        n
+                    )))
+                }
+            },
 
             // u8, u16, u32, u64, u128, u256 can be encoded as String
             (JsonValue::String(s), MoveTypeLayout::U8) => {

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -163,10 +163,10 @@ impl SuiJsonValue {
         // Double check that all numbers conform
         if let JsonValue::Number(n) = val {
             if n.as_u64().is_none() {
-                return Err(SuiJsonValueError::new(
-                    val,
-                    SuiJsonValueErrorKind::ValueTypeNotAllowed,
-                ));
+                return Err(anyhow!(format!(
+                    "{} is not a valid number. Only u64 allowed.",
+                    n
+                )));
             }
         }
 

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -160,16 +160,6 @@ impl SuiJsonValue {
     }
 
     fn to_move_value(val: &JsonValue, ty: &MoveTypeLayout) -> Result<MoveValue, anyhow::Error> {
-        // Double check that all numbers conform
-        if let JsonValue::Number(n) = val {
-            if n.as_u64().is_none() {
-                return Err(anyhow!(format!(
-                    "{} is not a valid number. Only u64 allowed.",
-                    n
-                )));
-            }
-        }
-
         Ok(match (val, ty) {
             // Bool to Bool is simple
             (JsonValue::Bool(b), MoveTypeLayout::Bool) => MoveValue::Bool(*b),
@@ -177,39 +167,19 @@ impl SuiJsonValue {
             // In constructor, we have already checked that the JSON number is unsigned int of at most U64
             (JsonValue::Number(n), MoveTypeLayout::U8) => match n.as_u64() {
                 Some(x) => MoveValue::U8(u8::try_from(x)?),
-                None => {
-                    return Err(anyhow!(format!(
-                        "{} is not a valid number. Only u64 allowed.",
-                        n
-                    )))
-                }
+                None => return Err(anyhow!("{} is not a valid number. Only u8 allowed.", n)),
             },
             (JsonValue::Number(n), MoveTypeLayout::U16) => match n.as_u64() {
                 Some(x) => MoveValue::U16(u16::try_from(x)?),
-                None => {
-                    return Err(anyhow!(format!(
-                        "{} is not a valid number. Only u64 allowed.",
-                        n
-                    )))
-                }
+                None => return Err(anyhow!("{} is not a valid number. Only u16 allowed.", n)),
             },
             (JsonValue::Number(n), MoveTypeLayout::U32) => match n.as_u64() {
                 Some(x) => MoveValue::U32(u32::try_from(x)?),
-                None => {
-                    return Err(anyhow!(format!(
-                        "{} is not a valid number. Only u64 allowed.",
-                        n
-                    )))
-                }
+                None => return Err(anyhow!("{} is not a valid number. Only u32 allowed.", n)),
             },
             (JsonValue::Number(n), MoveTypeLayout::U64) => match n.as_u64() {
                 Some(x) => MoveValue::U64(x),
-                None => {
-                    return Err(anyhow!(format!(
-                        "{} is not a valid number. Only u64 allowed.",
-                        n
-                    )))
-                }
+                None => return Err(anyhow!("{} is not a valid number. Only u64 allowed.", n)),
             },
 
             // u8, u16, u32, u64, u128, u256 can be encoded as String


### PR DESCRIPTION
Sui Json validation checks for conforming numbers are getting bypassed [here](https://github.com/MystenLabs/sui/blob/main/crates/sui-json/src/lib.rs#L91) and [here](https://github.com/MystenLabs/sui/blob/main/crates/sui-json/src/lib.rs#L338)
This PR adds a secondary check for conformance to get things going.
Will dig into root cause.