### PR TITLE
Change Type of 'Order' From "String" To "Boolean"

### DIFF
--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -413,8 +413,8 @@ export function isSequenceNumber(obj: any, _argumentName?: string): obj is Seque
 
 export function isOrder(obj: any, _argumentName?: string): obj is Order {
     return (
-        (obj === "ascending" ||
-            obj === "descending")
+        (obj === false ||
+            obj === true)
     )
 }
 

--- a/sdk/typescript/src/types/objects.ts
+++ b/sdk/typescript/src/types/objects.ts
@@ -157,7 +157,7 @@ export type GetObjectDataResponse = {
 export type ObjectDigest = string;
 export type ObjectId = string;
 export type SequenceNumber = number;
-export type Order = 'ascending' | 'descending';
+export type Order = false | true;
 
 /* -------------------------------------------------------------------------- */
 /*                              Helper functions                              */


### PR DESCRIPTION
hi. i'm jihwan from south korea. 
while i making a Wallet with '@mysten/sui.js', i found a little problem. 

whenever i used a function 'provider.getTransactionsForAddress()', i got error everytime.
the error was '{code: -32602, message: 'invalid type: string "Descending", expected a boolean at line 1 column 12'}'

so i cheched Sui Docs and Sui SDK source code, finally i got it what problem is. 
the problem is 'Type of Ordeing object' 

Sui Docs say " descending_order : <boolean> - query result ordering, default to false (ascending order), oldest record first."
but my sdk source is "export declare type Ordering = 'Ascending' | 'Descending';"

therefore that function not working. 

finally i change to Type of Order Object. 
please check my commit 
thanks.
