### PR TITLE
[core] Clean up consensus submit logic

### DIFF
--- a/narwhal/primary/src/tests/block_remover_tests.rs
+++ b/narwhal/primary/src/tests/block_remover_tests.rs
@@ -166,15 +166,6 @@ async fn test_successful_blocks_delete() {
     // ensure deleted certificates have been populated to output channel
     let mut total_deleted = 0;
 
-    /*while let Ok(Some(c)) =
-        timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await
-    {
-        assert!(
-            digests.contains(&c.digest()),
-            "Deleted certificate not found"
-        );
-        total_deleted += 1; */
-
     while let Ok(Some((_round, certs))) =
         timeout(Duration::from_secs(1), rx_removed_certificates.recv()).await
     {


### PR DESCRIPTION
Following consensus giving stronger guarantees about sequencing, a few clean ups on the sui side:
- Added `sequencing_acknowledge_latency` metric to measure the time we wait for a consensus ack, before processing a transaction.
- Removed `sequencing_certificate_latency` which is captured by `consensus latency`  already.
- Removed some dead code in tests