### PR TITLE
[explorer] Better error handling for vercel builds

### DIFF
--- a/apps/explorer/scripts/vercel-ignored-build.js
+++ b/apps/explorer/scripts/vercel-ignored-build.js
@@ -23,6 +23,15 @@ const ref =
         : 'HEAD^';
 
 async function main() {
+    // Run once without `--json` flag for better debugging.
+    await execFile('pnpm', [
+        'list',
+        '--filter',
+        `...[${ref}]`,
+        '--depth',
+        '-1',
+    ]);
+
     const { stdout, stderr } = await execFile('pnpm', [
         'list',
         '--filter',
@@ -47,6 +56,7 @@ async function main() {
 }
 
 main().catch((e) => {
+    console.log(e.message);
     // In the case of an error, play it safe and build:
     console.error('Vercel Ignored Build Step Failed', e);
     doNotBuild();

--- a/apps/explorer/scripts/vercel-ignored-build.js
+++ b/apps/explorer/scripts/vercel-ignored-build.js
@@ -59,5 +59,5 @@ main().catch((e) => {
     console.log(e.message);
     // In the case of an error, play it safe and build:
     console.error('Vercel Ignored Build Step Failed', e);
-    doNotBuild();
+    requiresBuild();
 });


### PR DESCRIPTION
When the build detection fails, we want to rebuild, not ignore it.