### PR TITLE
[TransactionManager] Remove periodic scanning for available input objects

### DIFF
--- a/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/checkpoint_driver/tests.rs
@@ -114,7 +114,6 @@ async fn checkpoint_active_flow_crash_client_with_gossip() {
             );
 
             println!("Start active execution process.");
-            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
 
             // Spin the checkpoint service.
@@ -206,7 +205,6 @@ async fn checkpoint_active_flow_crash_client_no_gossip() {
             );
 
             println!("Start active execution process.");
-            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
 
             // Spin the gossip service.
@@ -296,7 +294,6 @@ async fn test_empty_checkpoint() {
                 .unwrap(),
             );
 
-            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
 
             // Spawn the checkpointing service.

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -169,7 +169,6 @@ async fn pending_exec_full() {
                     .run_batch_service(1, Duration::from_secs(1))
                     .await
             });
-            active_state.clone().spawn_transaction_manager_scanner();
             active_state.clone().spawn_execute_process().await;
             active_state
                 .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
@@ -289,7 +288,6 @@ async fn test_transaction_manager() {
             .run_batch_service(1, Duration::from_secs(1))
             .await
     });
-    active_state.clone().spawn_transaction_manager_scanner();
     active_state.clone().spawn_execute_process().await;
 
     // Basic test: add certs out of dependency order. They should still be executed.

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -148,7 +148,6 @@ async fn start_gossip_process(
                 ActiveAuthority::new_with_ephemeral_storage_for_test(state, inner_net).unwrap(),
             );
             active_state.clone().spawn_gossip_process(3).await;
-            active_state.clone().spawn_transaction_manager_scanner();
             active_state.spawn_execute_process().await;
         });
         active_authorities.push(handle);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -76,7 +76,6 @@ pub struct SuiNode {
     _batch_subsystem_handle: tokio::task::JoinHandle<()>,
     _post_processing_subsystem_handle: Option<tokio::task::JoinHandle<Result<()>>>,
     _gossip_handle: Option<tokio::task::JoinHandle<()>>,
-    _transaction_manager_scanner_handle: Option<tokio::task::JoinHandle<()>>,
     _execute_driver_handle: tokio::task::JoinHandle<()>,
     _checkpoint_process_handle: Option<tokio::task::JoinHandle<()>>,
     state: Arc<AuthorityState>,
@@ -269,8 +268,6 @@ impl SuiNode {
         } else {
             None
         };
-        let transaction_manager_scanner_handle =
-            Some(active_authority.clone().spawn_transaction_manager_scanner());
         let execute_driver_handle = active_authority.clone().spawn_execute_process().await;
         let checkpoint_process_handle = if config.enable_checkpoint && is_validator {
             Some(
@@ -374,7 +371,6 @@ impl SuiNode {
             _json_rpc_service: json_rpc_service,
             _ws_subscription_service: ws_subscription_service,
             _gossip_handle: gossip_handle,
-            _transaction_manager_scanner_handle: transaction_manager_scanner_handle,
             _execute_driver_handle: execute_driver_handle,
             _checkpoint_process_handle: checkpoint_process_handle,
             _batch_subsystem_handle: batch_subsystem_handle,


### PR DESCRIPTION
After discussions with @mystenmark and some investigations, it seems we do not need to periodic scanning of missing input objects in `TransactionManager` to see which becomes available. We can guarantee after inserting a missing input object in `TransactionManager`, `TransactionManager` will definitely get notified if the object gets written.