### PR TITLE
chore: Make tests run faster

### DIFF
--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -34,7 +34,7 @@ use crate::{
     test_utils::to_sender_signed_transaction,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_start_epoch_change() {
     // Create a sender, owning an object and a gas object.
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -76,7 +76,7 @@ async fn public_transfer_object(
     Ok(result)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_public_transfer_object() {
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
     let (addr2, _key2): (_, AccountKeyPair) = get_key_pair();
@@ -165,7 +165,7 @@ async fn test_publish() {
         .unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_coin_split() {
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
 
@@ -698,7 +698,7 @@ async fn test_multiple_gateways() {
     assert!(response.effects.status.is_ok());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_batch_transaction() {
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
     let (addr2, _key2): (_, AccountKeyPair) = get_key_pair();

--- a/crates/sui-storage/src/mutex_table.rs
+++ b/crates/sui-storage/src/mutex_table.rs
@@ -290,7 +290,7 @@ async fn test_mutex_table() {
     assert!(map.unwrap().is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_mutex_table_bg_cleanup() {
     let mutex_table = MutexTable::<String>::new_with_cleanup(
         1,

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -17,7 +17,7 @@ use tokio::sync::watch;
 use types::ReconfigureNotification;
 
 /// The epoch changes but the stake distribution and network addresses stay the same.
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_simple_epoch_change() {
     ensure_test_environment();
 

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -847,7 +847,7 @@ async fn test_read_causal_unsigned_certificates() {
 /// from primary 2. All in all the end goal is to:
 /// * Primary 1 be able to retrieve both certificates 1 & 2 successfully
 /// * Primary 1 be able to fetch the payload for certificates 1 & 2
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_get_collections_with_missing_certificates() {
     // GIVEN keys for two primary nodes
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();

--- a/narwhal/primary/tests/nodes_bootstrapping_tests.rs
+++ b/narwhal/primary/tests/nodes_bootstrapping_tests.rs
@@ -5,7 +5,7 @@ use test_utils::cluster::{setup_tracing, Cluster};
 
 use types::{PublicKeyProto, RoundsRequest};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_shutdown_bug() {
     // Enabled debug tracing so we can easily observe the
     // nodes logs.

--- a/narwhal/test-utils/src/tests/cluster_tests.rs
+++ b/narwhal/test-utils/src/tests/cluster_tests.rs
@@ -37,7 +37,7 @@ async fn basic_cluster_setup() {
     assert!(cluster.authorities().await.is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn cluster_setup_with_consensus_disabled() {
     ensure_test_environment();
     let mut cluster = Cluster::new(None, false);


### PR DESCRIPTION
... By advancing time automatically when there's no work left. Changes computed experimentally, this is only the low-hanging fruit.

Here are the runtime gains (in s):
```
2.127 cluster::cluster_tests::basic_cluster_setup PASS [ 6.092s] narwhal-test-utils PASS [ 3.965s] narwhal-test-utils
2.173 test_get_collections_with_missing_certificates PASS [ 3.526s] narwhal-primary::integration_tests_validator_api PASS [ 1.353s] narwhal-primary::integration_tests_validator_api
2.292 test_simple_epoch_change PASS [ 12.098s] narwhal-primary::epoch_change PASS [ 9.806s] narwhal-primary::epoch_change
3.436 gateway_state::gateway_state_tests::test_public_transfer_object PASS [ 10.637s] sui-core PASS [ 7.201s] sui-core
3.494 epoch::reconfiguration_tests::test_start_epoch_change PASS [ 11.515s] sui-core PASS [ 8.021s] sui-core
5.059 test_shutdown_bug PASS [ 20.459s] narwhal-primary::nodes_bootstrapping_tests PASS [ 15.400s] narwhal-primary::nodes_bootstrapping_tests
7.076 gateway_state::gateway_state_tests::test_batch_transaction PASS [ 11.704s] sui-core PASS [ 4.628s] sui-core
10.001 mutex_table::test_mutex_table_bg_cleanup PASS [ 10.025s] sui-storage PASS [ 0.024s] sui-storage
10.064 gateway_state::gateway_state_tests::test_coin_split PASS [ 16.025s] sui-core PASS [ 5.961s] sui-core
```

Full list of expected gains: https://gist.github.com/745ad2177a62ed965bb29c234ea9edb7