### PR TITLE
[TransactionManager] lock transaction execution via `TransactionManager`

### DIFF
--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -11,27 +11,33 @@ use sui_types::{
     messages::VerifiedCertificate,
 };
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::authority::{authority_store::ObjectKey, AuthorityMetrics, AuthorityStore};
 
-/// TransactionManager is responsible for managing pending certificates and publishes a stream
-/// of certificates ready to be executed. It works together with AuthorityState for receiving
-/// pending certificates, and getting notified about committed objects. Executing driver
-/// subscribes to the stream of ready certificates published by the TransactionManager, and can
-/// execute them in parallel.
-/// TODO: use TransactionManager for fullnode.
+/// TransactionManager has the following responsibilities:
+/// - Ensure only a single certificate is in one of pending / executing and executed state.
+/// Notably, it avoids re-execution of certificates.
+/// - Receive pending certificates from AuthorityState, accept notifications about
+/// committed objects, discover pending certificates ready to run, and publish ready certificates
+/// to the execution driver.
+///
+/// If a source has a stream of certificates to be executed, it should follow the pattern:
+/// 1. Call enqueue_to_execute() to record and lock the execution of a certificate.
+/// 2. Acknowledge that the certificate will be executed to the source (e.g. Narwhal, checkpoint).
+///
+/// TODO: use TransactionManager for fullnode / handle_certificate_with_effects().
 pub(crate) struct TransactionManager {
     authority_store: Arc<AuthorityStore>,
     missing_inputs: BTreeMap<ObjectKey, (EpochId, TransactionDigest)>,
     pending_certificates: BTreeMap<(EpochId, TransactionDigest), BTreeSet<ObjectKey>>,
+    executing_certificates: BTreeMap<(EpochId, TransactionDigest), VerifiedCertificate>,
     tx_ready_certificates: UnboundedSender<VerifiedCertificate>,
     metrics: Arc<AuthorityMetrics>,
 }
 
 impl TransactionManager {
-    /// If a node restarts, transaction manager recovers in-memory data from pending certificates and
-    /// other persistent data.
+    /// If a node restarts, transaction manager recovers data from the pending_certificates table.
     pub(crate) async fn new(
         authority_store: Arc<AuthorityStore>,
         tx_ready_certificates: UnboundedSender<VerifiedCertificate>,
@@ -42,16 +48,16 @@ impl TransactionManager {
             metrics,
             missing_inputs: BTreeMap::new(),
             pending_certificates: BTreeMap::new(),
+            executing_certificates: BTreeMap::new(),
             tx_ready_certificates,
         };
         transaction_manager
-            .enqueue(
+            .add(
                 transaction_manager
                     .authority_store
                     .all_pending_certificates()
                     .unwrap(),
             )
-            .await
             .expect("Initialize TransactionManager with pending certificates failed.");
         transaction_manager
     }
@@ -59,13 +65,56 @@ impl TransactionManager {
     /// Enqueues certificates into TransactionManager. Once all of the input objects are available
     /// locally for a certificate, the certified transaction will be sent to execution driver.
     ///
-    /// REQUIRED: Shared object locks must be taken before calling this function on shared object
-    /// transactions!
+    /// This is  a no-op for certificates that are executing or have finished execution.
     ///
-    /// TODO: it may be less error prone to take shared object locks inside this function, or
-    /// require shared object lock versions get passed in as input. But this function should not
-    /// have many callsites. Investigate the alternatives here.
-    pub(crate) async fn enqueue(&mut self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
+    /// Takes shared object locks if needed, and persists the pending certificate for crash
+    /// recovery. Once this function returns success, the certificate will be guaranteed to
+    /// execute to completion.
+    pub(crate) async fn enqueue_to_execute(
+        &mut self,
+        certs: Vec<VerifiedCertificate>,
+    ) -> SuiResult<()> {
+        for cert in &certs {
+            // Skip processing if the certificate is already enqueued.
+            if self
+                .pending_certificates
+                .contains_key(&(cert.epoch(), *cert.digest()))
+            {
+                continue;
+            }
+            // Skip processing if the certificate is executing.
+            // Checking this before checking the effects table is correct, because a certificate
+            // is added to the executing_certificates table  before it is sent to execution driver,
+            // and removed after the transaction finished execution and effects are written.
+            if self
+                .executing_certificates
+                .contains_key(&(cert.epoch(), *cert.digest()))
+            {
+                continue;
+            }
+            // A certificate has been executed if it is available in the effects table.
+            if self.authority_store.effects_exists(cert.digest())? {
+                continue;
+            }
+
+            // Commit the necessary updates to the authority store.
+            if cert.contains_shared_object() {
+                self.authority_store
+                    .record_pending_shared_object_certificate(cert)
+                    .await?;
+            } else {
+                self.authority_store
+                    .record_pending_owned_object_certificate(cert)
+                    .await?;
+            }
+        }
+        self.add(certs)?;
+        Ok(())
+    }
+
+    /// Adds the pending certificates into TransactionManager, assuming the necessary persistent
+    /// data have been written into pending certificates, and shared locks tables if needed.
+    fn add(&mut self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
         for cert in certs {
             // Skip processing if the certificate is already enqueued.
             if self
@@ -85,15 +134,14 @@ impl TransactionManager {
             let cert_key = (cert.epoch(), *cert.digest());
             for obj_key in missing {
                 // A missing input object in TransactionManager will definitely be notified via
-                // objects_committed(), when the object actually gets committed, because:
+                // commit() of the certificate that outputs the object, because:
                 // 1. Assume rocksdb is strongly consistent, writing the object to the objects
                 // table must happen after not finding the object in get_missing_input_objects().
-                // 2. Notification via objects_committed() will happen after an object is written
-                // into the objects table.
-                // 3. TransactionManager is protected by a mutex. The notification via
-                // objects_committed() can only arrive after the current enqueue() call finishes.
-                // TODO: verify the key does not already exist.
-                self.missing_inputs.insert(obj_key, cert_key);
+                // 2. Notification via commit() will happen after an object is written into the
+                // objects table.
+                // 3. TransactionManager is protected by a mutex. The notification via commit()
+                // can only arrive after the current enqueue() call finishes.
+                assert!(self.missing_inputs.insert(obj_key, cert_key).is_none());
                 self.pending_certificates
                     .entry(cert_key)
                     .or_default()
@@ -109,8 +157,8 @@ impl TransactionManager {
         Ok(())
     }
 
-    /// Notifies TransactionManager that the given objects have been committed.
-    pub(crate) fn objects_committed(&mut self, object_keys: Vec<ObjectKey>) {
+    /// Notifies TransactionManager that the given objects have been committed and are available.
+    pub(crate) fn objects_avaiable(&mut self, object_keys: Vec<ObjectKey>) {
         for object_key in object_keys {
             let cert_key = if let Some(key) = self.missing_inputs.remove(&object_key) {
                 key
@@ -154,9 +202,30 @@ impl TransactionManager {
             .set(self.pending_certificates.len() as i64);
     }
 
+    /// Notifies TransactionManager that the given transaction and its output objects have been
+    /// committed. All certificates must call this function after execution.
+    pub(crate) fn commit(&mut self, epoch: EpochId, digest: &TransactionDigest) -> SuiResult<()> {
+        // Remove the pending certificate and associated shared object locks from storage.
+        let certificate = self
+            .executing_certificates
+            .remove(&(epoch, *digest))
+            .unwrap();
+        self.authority_store
+            .commit_pending_certificate(&certificate)
+    }
+
     /// Marks the given certificate as ready to be executed.
-    fn certificate_ready(&self, certificate: VerifiedCertificate) {
+    fn certificate_ready(&mut self, certificate: VerifiedCertificate) {
         self.metrics.transaction_manager_num_ready.inc();
-        let _ = self.tx_ready_certificates.send(certificate);
+        assert!(self
+            .executing_certificates
+            .insert(
+                (certificate.epoch(), *certificate.digest()),
+                certificate.clone()
+            )
+            .is_none());
+        if let Err(e) = self.tx_ready_certificates.send(certificate) {
+            warn!("Execution driver has shut down. {e}");
+        }
     }
 }


### PR DESCRIPTION
Currently it is a bit hard to lock transaction execution for all code paths we are interested in, because the scoped TxGuard object needs to be passed around. Since all transactions will go through `TransactionManager`, it seems a natural place to guarantee only one transaction is in any of pending / executing / executed state.

Also, the `pending_certificates` table used by `TransactionManager` for recover seems to duplicate the purpose of `wal` table. We should keep only one of them.

In this change,
- `TransactionManager::enqueue_to_execute()` takes on the responsibility of locking the execution of a transaction, writes the certificate to `pending_certificates` table, and taking shared object locks if needed.
- `TransactionManager::commit()` is added, which unlock the execution of a transaction, clears its entry in `pending_certificates` and shared object locks.

These two functions form a lock() / unlock() pair for certificate execution. After this change
- for consensus output, `TransactionManager` locking is active and encloses `CertTxGuard` acquire and release.
- for certificates from RPC, and certificates with effects, `TransactionManager` locking is not used.

There are additional refactoring possible:
- remove CertTxGuard API for locking certificate execution.
- remove `wal` table and the associated recovery logic.

But these require integrating `TransactionManager` with `handle_certificate_with_effects()` first, so all code paths are covered by `TransactionManager` locking. This will be a later change.