### PR TITLE
Improve LockService Return Info

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -465,44 +465,50 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         self.lock_service.get_tx_sequence(tx).await
     }
 
-    /// Get the transaction envelope that currently locks the given object,
-    /// or returns Err(TransactionLockDoesNotExist) if the lock does not exist.
+    /// Get the TransactionEnvelope that currently locks the given object, if any.
+    /// Returns SuiError::ObjectNotFound if no lock records for the given object can be found.
+    /// Returns SuiError::ObjectVersionUnavailableForConsumption if the object record is at a different version.
+    /// Returns Some(VerifiedEnvelope) if the given ObjectRef is locked by a certain transaction.
+    /// Returns None if the a lock record is initialized for the given ObjectRef but not yet locked by any transaction,
+    ///     or cannot find the transaction in transaction table, because of data race etc.
     pub async fn get_object_locking_transaction(
         &self,
         object_ref: &ObjectRef,
     ) -> SuiResult<Option<VerifiedEnvelope<SenderSignedData, S>>> {
-        let tx_lock = self.lock_service.get_lock(*object_ref).await?.ok_or(
-            SuiError::ObjectLockUninitialized {
-                obj_ref: *object_ref,
-            },
-        )?;
+        let lock_info = self.lock_service.get_lock(*object_ref).await?;
+        if !lock_info.is_initialized_or_locked_at_given_version() {
+            return Err(SuiError::ObjectVersionUnavailableForConsumption {
+                provided_obj_ref: *object_ref,
+                current_version: lock_info.current_object_record().1,
+            });
+        }
+        if !lock_info.is_locked_at_given_version() {
+            return Ok(None);
+        }
+        // safe to unwrap because is_locked_at_given_version == true
+        let lock_info = lock_info.tx_locks_given_version().unwrap();
 
         // Returns None if either no TX with the lock, or TX present but no entry in transactions table.
         // However we retry a couple times because the TX is written after the lock is acquired, so it might
         // just be a race.
-        match tx_lock {
-            Some(lock_info) => {
-                let tx_digest = &lock_info.tx_digest;
-                let mut retry_strategy = ExponentialBackoff::from_millis(2)
-                    .factor(10)
-                    .map(jitter)
-                    .take(3);
-                let mut tx_option = self.epoch_tables().transactions.get(tx_digest)?;
-                while tx_option.is_none() {
-                    if let Some(duration) = retry_strategy.next() {
-                        // Wait to retry
-                        tokio::time::sleep(duration).await;
-                        trace!(?tx_digest, "Retrying getting pending transaction");
-                    } else {
-                        // No more retries, just quit
-                        break;
-                    }
-                    tx_option = self.epoch_tables().transactions.get(tx_digest)?;
-                }
-                Ok(tx_option.map(|t| t.into()))
+        let tx_digest = &lock_info.tx_digest;
+        let mut retry_strategy = ExponentialBackoff::from_millis(2)
+            .factor(10)
+            .map(jitter)
+            .take(3);
+        let mut tx_option = self.epoch_tables().transactions.get(tx_digest)?;
+        while tx_option.is_none() {
+            if let Some(duration) = retry_strategy.next() {
+                // Wait to retry
+                tokio::time::sleep(duration).await;
+                trace!(?tx_digest, "Retrying getting pending transaction");
+            } else {
+                // No more retries, just quit
+                break;
             }
-            None => Ok(None),
+            tx_option = self.epoch_tables().transactions.get(tx_digest)?;
         }
+        Ok(tx_option.map(|t| t.into()))
     }
 
     /// Read a certificate and return an option with None if it does not exist.

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -28,11 +28,11 @@ use typed_store::traits::Map;
 use typed_store::traits::TypedStoreDebug;
 use typed_store_derive::DBMapUtils;
 
-use sui_types::base_types::{ObjectRef, TransactionDigest};
+use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber, TransactionDigest};
 use sui_types::batch::TxSequenceNumber;
 use sui_types::committee::EpochId;
 use sui_types::error::{SuiError, SuiResult};
-use sui_types::fp_ensure;
+use sui_types::{fp_bail, fp_ensure};
 
 use crate::{block_on_future_in_sim, default_db_options};
 
@@ -64,7 +64,7 @@ enum LockServiceCommands {
     },
 }
 
-type SuiLockResult = Result<Option<Option<LockInfo>>, SuiError>;
+type SuiLockResult = SuiResult<ObjectLockInfo>;
 
 /// Queries to the LockService state
 #[derive(Debug)]
@@ -84,7 +84,45 @@ enum LockServiceQueries {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LockInfo {
+pub struct ObjectLockInfo {
+    requested_object_ref_lock_details: Option<Option<LockDetails>>,
+    latest_object_ref: ObjectRef,
+}
+
+impl ObjectLockInfo {
+    /// If the given ObjectRef record is initailized or locked.
+    /// If true, the object version is ready for being used in transactions
+    /// If false, the object is currently locked at another version
+    pub fn is_initialized_or_locked_at_given_version(&self) -> bool {
+        self.requested_object_ref_lock_details.is_some()
+    }
+
+    /// If the given ObjectRef is locked by a certain transaction.
+    /// Returns false if the object is currently locked at another version,
+    ///     or the record is initialized but not locked by any transaction.
+    pub fn is_locked_at_given_version(&self) -> bool {
+        matches!(self.requested_object_ref_lock_details, Some(Some(_)))
+    }
+
+    /// Get the transaction that locks the given ObjectRef.
+    /// Returns None if the object is currently locked at another version
+    /// (namely `is_initialized_or_locked_at_given_version` returns false)
+    pub fn tx_locks_given_version(&self) -> Option<&LockDetails> {
+        if let Some(Some(details)) = &self.requested_object_ref_lock_details {
+            Some(details)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the ObjectRef record currently initialized/locked for this object
+    pub fn current_object_record(&self) -> ObjectRef {
+        self.latest_object_ref
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockDetails {
     pub epoch: EpochId,
     pub tx_digest: TransactionDigest,
 }
@@ -100,7 +138,7 @@ pub struct LockServiceImpl {
     /// the lock once it is set. After a certificate for this object is processed it can be
     /// forgotten.
     #[default_options_override_fn = "transaction_lock_table_default_config"]
-    transaction_lock: DBMap<ObjectRef, Option<LockInfo>>,
+    transaction_lock: DBMap<ObjectRef, Option<LockDetails>>,
 
     /// The semantics of transaction_lock ensure that certificates are always processed
     /// in causal order - that is, certificates naturally form a partial order. tx_sequence
@@ -125,25 +163,42 @@ impl LockServiceImpl {
         self.tx_sequence.get(&tx).map_err(SuiError::StorageError)
     }
 
-    /// Returns the state of a single lock.
-    /// * None - lock does not exist and is not initialized
-    /// * Some(None) - lock exists and is initialized, but not locked to a particular transaction
-    /// * Some(Some(lock_info)) - lock exists and set to some transaction.
-    fn get_lock(&self, object: ObjectRef) -> Result<Option<Option<LockInfo>>, SuiError> {
-        self.transaction_lock
-            .get(&object)
-            .map_err(SuiError::StorageError)
+    /// Gets ObjectLockInfo that represents state of lock on an object.
+    /// Returns SuiError::ObjectNotFound if cannot find lock record for this object
+    fn get_lock(&self, obj_ref: ObjectRef) -> SuiLockResult {
+        Ok(
+            if let Some(lock_info) = self
+                .transaction_lock
+                .get(&obj_ref)
+                .map_err(SuiError::StorageError)?
+            {
+                ObjectLockInfo {
+                    requested_object_ref_lock_details: Some(lock_info),
+                    latest_object_ref: obj_ref,
+                }
+            } else {
+                ObjectLockInfo {
+                    requested_object_ref_lock_details: None,
+                    latest_object_ref: self.get_latest_lock_for_object_id(obj_ref.0)?,
+                }
+            },
+        )
     }
 
     /// Checks multiple object locks exist.
-    /// Returns Err(TransactionLockDoesNotExist) if at least one object lock is not initialized.
+    /// Returns SuiError::ObjectNotFound if cannot find lock record for at least one of the objects.
+    /// Returns SuiError::ObjectVersionUnavailableForConsumption if at least one object lock is not initialized
+    ///     at the given version.
     fn locks_exist(&self, objects: &[ObjectRef]) -> SuiResult {
         let locks = self.transaction_lock.multi_get(objects)?;
         for (lock, obj_ref) in locks.into_iter().zip(objects) {
-            fp_ensure!(
-                lock.is_some(),
-                SuiError::ObjectLockUninitialized { obj_ref: *obj_ref }
-            );
+            if lock.is_none() {
+                let latest_lock = self.get_latest_lock_for_object_id(obj_ref.0)?;
+                fp_bail!(SuiError::ObjectVersionUnavailableForConsumption {
+                    provided_obj_ref: *obj_ref,
+                    current_version: latest_lock.1
+                });
+            }
         }
         debug!(?objects, "locks_exist: all locks do exist");
         Ok(())
@@ -241,7 +296,10 @@ impl LockServiceImpl {
     /// Acquires a lock for a transaction on the given objects if they have all been initialized previously
     /// to None state.  It is also OK if they have been set to the same transaction.
     /// The locks are all set to the given transaction digest.
-    /// Otherwise, SuiError(TransactionLockDoesNotExist, ConflictingTransaction) is returned.
+    /// Returns SuiError::ObjectNotFound if no lock record can be found for one of the objects.
+    /// Returns SuiError::ObjectVersionUnavailableForConsumption if one of the objects is not locked at the given version.
+    /// Returns SuiError::ObjectLockConflict if one of the objects is locked by a different transaction in the same epoch.
+    /// Returns SuiError::ObjectLockedAtFutureEpoch if one of the objects is locked in a future epoch (bug).
     fn acquire_locks(
         &self,
         epoch: EpochId,
@@ -254,11 +312,18 @@ impl LockServiceImpl {
 
         for ((i, lock), obj_ref) in locks.iter().enumerate().zip(owned_input_objects) {
             // The object / version must exist, and therefore lock initialized.
-            let lock = lock
-                .as_ref()
-                .ok_or(SuiError::ObjectLockUninitialized { obj_ref: *obj_ref })?;
+            let lock = lock.as_ref();
+            if lock.is_none() {
+                let latest_lock = self.get_latest_lock_for_object_id(obj_ref.0)?;
+                fp_bail!(SuiError::ObjectVersionUnavailableForConsumption {
+                    provided_obj_ref: *obj_ref,
+                    current_version: latest_lock.1
+                });
+            }
+            // Safe to unwrap as it is checked above
+            let lock = lock.unwrap();
 
-            if let Some(LockInfo {
+            if let Some(LockDetails {
                 epoch: previous_epoch,
                 tx_digest: previous_tx_digest,
             }) = lock
@@ -292,7 +357,7 @@ impl LockServiceImpl {
                 }
             }
             let obj_ref = owned_input_objects[i];
-            locks_to_write.push((obj_ref, Some(LockInfo { epoch, tx_digest })));
+            locks_to_write.push((obj_ref, Some(LockDetails { epoch, tx_digest })));
         }
 
         if !locks_to_write.is_empty() {
@@ -307,7 +372,7 @@ impl LockServiceImpl {
     }
 
     /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
-    /// If the lock already exists and is locked to a transaction, then return TransactionLockExists
+    /// Returns SuiError::ObjectLockAlreadyInitialized if the lock already exists and is locked to a transaction
     fn initialize_locks_impl(
         &self,
         write_batch: DBBatch,
@@ -358,6 +423,29 @@ impl LockServiceImpl {
         debug!(?objects, "delete_locks");
         self.transaction_lock.multi_remove(objects)?;
         Ok(())
+    }
+
+    /// Returns SuiError::ObjectNotFound if no lock records found for this object.
+    pub fn get_latest_lock_for_object_id(&self, object_id: ObjectID) -> SuiResult<ObjectRef> {
+        let mut iterator = self
+            .transaction_lock
+            .iter()
+            // Make the max possible entry for this object ID.
+            .skip_prior_to(&(object_id, SequenceNumber::MAX, ObjectDigest::MAX))?;
+        Ok(iterator
+            .next()
+            .and_then(|value| {
+                if value.0 .0 == object_id {
+                    Some(value)
+                } else {
+                    None
+                }
+            })
+            .ok_or(SuiError::ObjectNotFound {
+                object_id,
+                version: None,
+            })?
+            .0)
     }
 
     /// Loop to continuously process mutating commands in a single thread from async senders.
@@ -718,8 +806,8 @@ mod tests {
         LockService::new(path, None).expect("Could not create LockService")
     }
 
-    #[tokio::test]
     // Test acquire_locks() and initialize_locks()
+    #[tokio::test]
     async fn test_lockdb_acquire_init_multiple() {
         let ls = init_lockservice_db();
 
@@ -733,52 +821,114 @@ mod tests {
         // Should not be able to acquire lock for uninitialized locks
         assert_eq!(
             ls.acquire_locks(0, &[ref1, ref2], tx1),
-            Err(SuiError::ObjectLockUninitialized { obj_ref: ref1 })
+            Err(SuiError::ObjectNotFound {
+                object_id: ref1.0,
+                version: None
+            })
         );
-        assert_eq!(ls.get_lock(ref1), Ok(None));
+        assert_eq!(
+            ls.get_lock(ref1),
+            Err(SuiError::ObjectNotFound {
+                object_id: ref1.0,
+                version: None
+            })
+        );
 
         // Initialize 2 locks
         ls.initialize_locks(&[ref1, ref2], false /* is_force_reset */)
             .unwrap();
-        assert_eq!(ls.get_lock(ref2), Ok(Some(None)));
+        let lock_info = ls.get_lock(ref2).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref2);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(!lock_info.is_locked_at_given_version());
+        assert!(lock_info.tx_locks_given_version().is_none());
+
         assert_eq!(ls.locks_exist(&[ref1, ref2]), Ok(()));
 
         // Should not be able to acquire lock if not all objects initialized
         assert_eq!(
             ls.acquire_locks(0, &[ref1, ref2, ref3], tx1),
-            Err(SuiError::ObjectLockUninitialized { obj_ref: ref3 })
+            Err(SuiError::ObjectNotFound {
+                object_id: ref3.0,
+                version: None
+            })
         );
 
         // Should be able to acquire lock if all objects initialized
         ls.acquire_locks(0, &[ref1, ref2], tx1).unwrap();
+        let lock_info = ls.get_lock(ref2).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref2);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(lock_info.is_locked_at_given_version());
         assert_eq!(
-            ls.get_lock(ref2),
-            Ok(Some(Some(LockInfo {
+            lock_info.tx_locks_given_version(),
+            Some(&LockDetails {
                 epoch: 0,
                 tx_digest: tx1
-            })))
+            })
         );
 
         // Should be able to check locks exist for ref1 and ref2, but not others
         assert_eq!(ls.locks_exist(&[ref1, ref2]), Ok(()));
         assert_eq!(
             ls.locks_exist(&[ref2, ref3]),
-            Err(SuiError::ObjectLockUninitialized { obj_ref: ref3 })
+            Err(SuiError::ObjectNotFound {
+                object_id: ref3.0,
+                version: None
+            })
         );
 
-        // Should get TransactionLockExists if try to initialize already locked object
+        // Should get ObjectLockAlreadyInitialized because ref2's lock entry already exists
         assert!(matches!(
             ls.initialize_locks(&[ref2, ref3], false /* is_force_reset */),
             Err(SuiError::ObjectLockAlreadyInitialized { .. })
         ));
 
-        // Should not be able to acquire lock for diff tx if already locked
         ls.initialize_locks(&[ref3], false /* is_force_reset */)
             .unwrap();
+        // Should not be able to acquire lock because ref2 is locked to a different transaction
         assert!(matches!(
             ls.acquire_locks(0, &[ref2, ref3], tx2),
             Err(SuiError::ObjectLockConflict { .. })
         ));
+
+        // Now delete lock for ref2
+        ls.delete_locks(&[ref2]).unwrap();
+        // Confirm the deletion succeeded
+        assert_eq!(
+            ls.get_lock(ref2),
+            Err(SuiError::ObjectNotFound {
+                object_id: ref2.0,
+                version: None
+            })
+        );
+
+        // Initialize the object's entry to another version
+        let new_ref2 = (ref2.0, ref2.1.increment(), ref2.2);
+        ls.initialize_locks(&[new_ref2], false /* is_force_reset */)
+            .unwrap();
+
+        // Now we get ObjectVersionUnavailableForConsumption
+        let lock_info = ls.get_lock(ref2).unwrap();
+        assert_eq!(lock_info.current_object_record(), new_ref2);
+        assert!(!lock_info.is_initialized_or_locked_at_given_version());
+        assert!(!lock_info.is_locked_at_given_version());
+        assert_eq!(lock_info.tx_locks_given_version(), None);
+        assert!(matches!(
+            ls.acquire_locks(0, &[ref2, ref3], tx2),
+            Err(SuiError::ObjectVersionUnavailableForConsumption {
+                provided_obj_ref,
+                current_version,
+            })
+            if provided_obj_ref == ref2 && current_version == new_ref2.1
+        ));
+        assert_eq!(
+            ls.locks_exist(&[ref2, ref3]),
+            Err(SuiError::ObjectVersionUnavailableForConsumption {
+                provided_obj_ref: ref2,
+                current_version: new_ref2.1
+            })
+        );
     }
 
     #[tokio::test]
@@ -796,12 +946,16 @@ mod tests {
 
         // Should be able to acquire lock if all objects initialized
         ls.acquire_locks(0, &[ref1, ref2], tx1).unwrap();
+        let lock_info = ls.get_lock(ref2).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref2);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(lock_info.is_locked_at_given_version());
         assert_eq!(
-            ls.get_lock(ref2),
-            Ok(Some(Some(LockInfo {
+            lock_info.tx_locks_given_version(),
+            Some(&LockDetails {
                 epoch: 0,
                 tx_digest: tx1
-            })))
+            })
         );
 
         // Cannot initialize them again since they are locked already
@@ -812,7 +966,13 @@ mod tests {
 
         // Now remove the locks
         ls.delete_locks(&[ref1, ref2]).unwrap();
-        assert!(matches!(ls.get_lock(ref2), Ok(None)));
+        assert_eq!(
+            ls.get_lock(ref2),
+            Err(SuiError::ObjectNotFound {
+                object_id: ref2.0,
+                version: None
+            })
+        );
 
         // Now initialization should succeed
         ls.initialize_locks(&[ref1, ref2], false /* is_force_reset */)
@@ -840,8 +1000,12 @@ mod tests {
         let results = join_all(futures).await;
         assert!(results.iter().all(|res| res.is_ok()));
 
-        let lock_state = ls.get_lock(ref1).await;
-        assert!(matches!(lock_state, Ok(Some(None))));
+        let lock_info = ls.get_lock(ref1).await.unwrap();
+        assert_eq!(lock_info.current_object_record(), ref1);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(!lock_info.is_locked_at_given_version());
+        assert!(lock_info.tx_locks_given_version().is_none());
+
         assert_eq!(ls.locks_exist(vec![ref1, ref2]).await, Ok(()));
 
         // only one party should be able to successfully acquire the lock.  Use diff tx for each one
@@ -877,7 +1041,13 @@ mod tests {
         // Initialize 2 locks
         ls.initialize_locks(&[ref1, ref2], false /* is_force_reset */)
             .unwrap();
-        assert_eq!(ls.get_lock(ref2), Ok(Some(None)));
+
+        let lock_info = ls.get_lock(ref2).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref2);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(!lock_info.is_locked_at_given_version());
+        assert!(lock_info.tx_locks_given_version().is_none());
+
         assert_eq!(ls.locks_exist(&[ref1, ref2]), Ok(()));
 
         // Should be able to acquire lock if all objects initialized
@@ -886,14 +1056,22 @@ mod tests {
         // Try to acquire lock for the same object with a different transaction should fail.
         assert!(ls.acquire_locks(0, &[ref1], tx2).is_err());
         // The object is still locked at the same transaction.
-        assert_eq!(ls.get_lock(ref1).unwrap().unwrap().unwrap().tx_digest, tx1);
+        let lock_info = ls.get_lock(ref1).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref1);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(lock_info.is_locked_at_given_version());
+        assert_eq!(lock_info.tx_locks_given_version().unwrap().tx_digest, tx1);
 
         // We should be able to relock the same object with a different transaction from a new epoch.
         ls.acquire_locks(1, &[ref1], tx2).unwrap();
         // The object is now locked at transaction tx2.
+        let lock_info = ls.get_lock(ref1).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref1);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(lock_info.is_locked_at_given_version());
         assert_eq!(
-            ls.get_lock(ref1).unwrap().unwrap().unwrap(),
-            LockInfo {
+            lock_info.tx_locks_given_version().unwrap(),
+            &LockDetails {
                 epoch: 1,
                 tx_digest: tx2
             }
@@ -905,16 +1083,26 @@ mod tests {
         // ref1 is already locked by tx2, and hence this is a nop. ref2 is still locked by tx1 from
         // epoch 0, which will be overridden here.
         ls.acquire_locks(1, &[ref1, ref2], tx2).unwrap();
+
+        let lock_info = ls.get_lock(ref1).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref1);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(lock_info.is_locked_at_given_version());
         assert_eq!(
-            ls.get_lock(ref1).unwrap().unwrap().unwrap(),
-            LockInfo {
+            lock_info.tx_locks_given_version().unwrap(),
+            &LockDetails {
                 epoch: 1,
                 tx_digest: tx2
             }
         );
+
+        let lock_info = ls.get_lock(ref2).unwrap();
+        assert_eq!(lock_info.current_object_record(), ref2);
+        assert!(lock_info.is_initialized_or_locked_at_given_version());
+        assert!(lock_info.is_locked_at_given_version());
         assert_eq!(
-            ls.get_lock(ref2).unwrap().unwrap().unwrap(),
-            LockInfo {
+            lock_info.tx_locks_given_version().unwrap(),
+            &LockDetails {
                 epoch: 1,
                 tx_digest: tx2
             }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -302,8 +302,11 @@ pub enum SuiError {
     InvalidTxUpdate,
     #[error("Attempt to re-initialize a transaction lock for objects {:?}.", refs)]
     ObjectLockAlreadyInitialized { refs: Vec<ObjectRef> },
-    #[error("Object {obj_ref:?} lock has not been initialized.")]
-    ObjectLockUninitialized { obj_ref: ObjectRef },
+    #[error("Object {provided_obj_ref:?} is not available for consumption, its current version: {current_version:?}.")]
+    ObjectVersionUnavailableForConsumption {
+        provided_obj_ref: ObjectRef,
+        current_version: SequenceNumber,
+    },
     #[error(
         "Object {obj_ref:?} already locked by a different transaction: {pending_transaction:?}"
     )]


### PR DESCRIPTION
This PR improves LockService's return info on several functions. Currently the response for lock service is confusing.
 
An example: a user is interacting with a move module that touches a very hot shared object. The user submits a transaction but it unfortunately times out (due to missing dependency for execution on validators). After #5491 , client will see error `SharedObjectPriorVersionsPendingExecution` in this case, but if they mistakenly think the transaction failed, they may use the same gas object (or other owned objects) to issue another transaction. After the gas object is selected, and before the 2nd transaction hit validators, the first transaction was already successfully executed by execution driver, and the gas object's locked at the newer version, which causes `ObjectLockUninitialized` by transaction_input_checker. This error is un-actionable for clients and does not convoy the exact story. Eventually, we need to map every validator error into an client-actionable error. This PR makes us one step closer towards that goal.


In this PR, we
1. rename `ObjectLockUninitialized` to `ObjectVersionUnavailableForConsumption`, which has the current locked version if the given version is not locked.
2. return `ObjectNotFound` if no lock records for this object can be found at all.
3. introduce `ObjectLockInfo`, a much more understandable struct compared to `Option<Option<LockInfo>>`
4. add `fn get_latest_lock_for_object_id` which gets the latest lock record for an object.