### PR TITLE
[Authority] Track size of compiled module cache

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -96,6 +96,7 @@ use crate::consensus_handler::{
 };
 use crate::epoch::committee_store::CommitteeStore;
 use crate::metrics::TaskUtilizationExt;
+use crate::module_cache_gauge::ModuleCacheGauge;
 use crate::scoped_counter;
 use crate::{
     authority_batch::{BroadcastReceiver, BroadcastSender},
@@ -1557,6 +1558,10 @@ impl AuthorityState {
             tx_reconfigure_consensus,
             checkpoint_service,
         };
+
+        prometheus_registry
+            .register(Box::new(ModuleCacheGauge::new(&state.module_cache)))
+            .unwrap();
 
         // Process tx recovery log first, so that the batch and checkpoint recovery (below)
         // don't observe partially-committed txes.

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod test_utils;
 pub mod checkpoints2;
 mod consensus_handler;
 mod histogram;
+mod module_cache_gauge;
 mod node_sync;
 mod query_helpers;
 mod transaction_manager;

--- a/crates/sui-core/src/module_cache_gauge.rs
+++ b/crates/sui-core/src/module_cache_gauge.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{Arc, Weak};
+
+use move_bytecode_utils::module_cache::SyncModuleCache;
+use move_core_types::resolver::ModuleResolver;
+use prometheus::{
+    core::{Collector, Desc},
+    labels,
+    proto::{Gauge, Metric, MetricFamily, MetricType},
+};
+
+/// Holds the module cache to collect its size and pass it to Prometheus, for monitoring in Grafana.
+pub struct ModuleCacheGauge<R: ModuleResolver> {
+    desc: Desc,
+    module_cache: Weak<SyncModuleCache<R>>,
+}
+
+impl<R: ModuleResolver> ModuleCacheGauge<R> {
+    pub fn new(module_cache: &Arc<SyncModuleCache<R>>) -> Self {
+        Self {
+            desc: Desc::new(
+                "module_cache_size".into(),
+                "Number of compiled move modules in the authority's cache.".into(),
+                /* variable_labels */ vec![],
+                /* const_labels */ labels! {},
+            )
+            .unwrap(),
+            module_cache: Arc::downgrade(module_cache),
+        }
+    }
+
+    fn metric(&self) -> Option<Metric> {
+        let cache = self.module_cache.upgrade()?;
+        let mut m = Metric::default();
+        let mut gauge = Gauge::default();
+        // NB. lossy conversion from usize to f64, to match prometheus' API.
+        gauge.set_value(cache.len() as f64);
+        m.set_gauge(gauge);
+        Some(m)
+    }
+}
+
+impl<R: ModuleResolver + Send + Sync> Collector for ModuleCacheGauge<R> {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let mut m = MetricFamily::default();
+
+        m.set_name(self.desc.fq_name.clone());
+        m.set_help(self.desc.help.clone());
+        m.set_field_type(MetricType::GAUGE);
+
+        if let Some(metric) = self.metric() {
+            m.mut_metric().push(metric);
+        }
+
+        vec![m]
+    }
+}


### PR DESCRIPTION
New Prometheus collector outputting a gauge metric to track the number of modules in Move's `SyncModuleCache`.

## Test Plan

Will take advice here on the best way to test a new gauge, apart from the usual:

```
$ cargo simtest
$ cargo nextest run
```