### PR TITLE
Actually strip debug info from sui binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,15 +72,17 @@ version = "0.16.0"
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces
 debug = 1
+# Write debug info into a separate file.
 split-debuginfo = 'packed'
-strip = 'none'
+# Without stripping, sui binary size would be > 1GB.
+strip = 'debuginfo'
 # Exit process with SIGABRT when any thread panics
 panic = 'abort'
 
 # Inherits from the release profile above.
 [profile.bench]
 # For convenience.
-split-debuginfo = 'off'
+strip = 'none'
 
 [profile.simulator]
 inherits = "test"


### PR DESCRIPTION
It seems by specifying `split = 'none'`, debug info still exist in the binary. If we specify the `strip` option, we may need to be explicit that debug info should be stripped.