### PR TITLE
[docs/sdk/rust] Update refs to SuiClient::new

### DIFF
--- a/doc/src/build/rust-sdk.md
+++ b/doc/src/build/rust-sdk.md
@@ -5,7 +5,7 @@ title: Interact with Sui over Rust SDK
 ## Overview
 The [Sui SDK](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) is a collection of Rust language JSON-RPC wrapper and crypto utilities you can use to interact with the [Sui Devnet](../build/devnet.md) and [Sui Full node](fullnode.md).
 
-The [`SuiClient`](cli-client.md) can be used to create an HTTP or a WebSocket client (`SuiClient::new_rpc_client`).
+The [`SuiClient`](cli-client.md) can be used to create an HTTP or a WebSocket client (`SuiClient::new`).
 See our [JSON-RPC](json-rpc.md#sui-json-rpc-methods) doc for the list of available methods.
 
 > Note: As of [Sui version 0.6.0](https://github.com/MystenLabs/sui/releases/tag/devnet-0.6.0), the WebSocket client is for [subscription only](event_api.md#subscribe-to-sui-events); use the HTTP client for other API methods.
@@ -43,7 +43,7 @@ use sui_sdk::SuiClient;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new_rpc_client("https://fullnode.devnet.sui.io:443", None).await?;
+    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
     let address = SuiAddress::from_str("0xec11cad080d0496a53bafcea629fcbcfff2a9866")?;
     let objects = sui.read_api().get_objects_owned_by_address(address).await?;
     println!("{:?}", objects);
@@ -71,7 +71,7 @@ use sui_sdk::{
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new_rpc_client("https://fullnode.devnet.sui.io:443", None).await?;
+    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", None, None).await?;
     // Load keystore from ~/.sui/sui_config/sui.keystore
     let keystore_path = match dirs::home_dir() {
         Some(v) => v.join(".sui").join("sui_config").join("sui.keystore"),
@@ -115,7 +115,7 @@ use sui_sdk::SuiClient;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let sui = SuiClient::new_rpc_client("https://fullnode.devnet.sui.io:443", Some("ws://127.0.0.1:9001")).await?;
+    let sui = SuiClient::new("https://fullnode.devnet.sui.io:443", Some("ws://127.0.0.1:9001"), None).await?;
     let mut subscribe_all = sui.event_api().subscribe_event(SuiEventFilter::All(vec![])).await?;
     loop {
         println!("{:?}", subscribe_all.next().await);


### PR DESCRIPTION
367da131 Updates the API for creating `SuiClient` instances (changes the name and adds a parameter).  Reflect this in the docs.