### PR TITLE
[BUGFIX][deps] Explicitly set patched version of sqlx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,3 @@ telemetry-subscribers = { path = "crates/telemetry-subscribers" }
 mysten-util-mem = { path = "crates/mysten-util-mem" }
 typed-store = { path = "crates/typed-store" }
 typed-store-derive = { path = "crates/typed-store-derive" }
-
-# patch sqlx to a version using libsqlite3-sys v0.25.1 or later, see
-# https://github.com/launchbadge/sqlx/pull/2176
-[patch.crates-io]
-sqlx = { git="https://github.com/huitseeker/sqlx", branch="update_libsqlite3" }

--- a/crates/sui-storage/Cargo.toml
+++ b/crates/sui-storage/Cargo.toml
@@ -19,7 +19,9 @@ tokio = { version = "1.20.1", features = ["full", "tracing"] }
 tokio-stream = "^0.1"
 rocksdb = "0.19.0"
 tracing = "0.1.36"
-sqlx = { version = "0.6", features = [ "runtime-tokio-rustls", "sqlite" ] }
+# patch sqlx to a version using libsqlite3-sys v0.25.1 or later, see
+# https://github.com/launchbadge/sqlx/pull/2176
+sqlx = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", features = [ "runtime-tokio-rustls", "sqlite" ] }
 strum = "^0.24"
 strum_macros = "^0.24"
 anyhow = "1.0.64"


### PR DESCRIPTION
Sui's dependency on `sqlx` needs to be overridden with a patched version that uses a more recent version of `libsqlite3-sys`.  The previous approach used a `patch` configuration in the root `Cargo.toml`.

This works for builds within this project, but seems to break for builds that originate from outside the workspace, but depend on one of the workspace crates.

In this scenario, the patch doesn't apply on the dependency on `sqlx` in `sui-storage`, so it ends up conflicting with the dependency in `workspace-hack`.

The most common example of this is someone depending on the Rust SDK (`sui-sdk`).

This diff ditches the `patch` and sets the dependency override explicitly on `sui-storage`.

## Test Plan

Sui builds and runs:

```
sui$ cargo build
sui$ cargo simtest
sui$ cargo nextest run
```

Dependents on the Sui SDK build and run, e.g. following the instructions at https://docs.sui.io/build/rust-sdk succeeds.

Closes #5887