### PR TITLE
[TypeScript SDK] Fix e2e test

### DIFF
--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -618,7 +618,11 @@ export function isEventQuery(obj: any, _argumentName?: string): obj is EventQuer
 
 export function isEventId(obj: any, _argumentName?: string): obj is EventId {
     return (
-        typeof obj === "string"
+        (obj !== null &&
+            typeof obj === "object" ||
+            typeof obj === "function") &&
+        isSuiMoveTypeParameterIndex(obj.txSeq) as boolean &&
+        isSuiMoveTypeParameterIndex(obj.eventSeq) as boolean
     )
 }
 
@@ -629,7 +633,7 @@ export function isPaginatedEvents(obj: any, _argumentName?: string): obj is Pagi
             typeof obj === "function") &&
         isSuiEvents(obj.data) as boolean &&
         (obj.nextCursor === null ||
-            isTransactionDigest(obj.nextCursor) as boolean)
+            isEventId(obj.nextCursor) as boolean)
     )
 }
 
@@ -717,6 +721,7 @@ export function isSuiEventEnvelope(obj: any, _argumentName?: string): obj is Sui
             typeof obj === "function") &&
         isSuiMoveTypeParameterIndex(obj.timestamp) as boolean &&
         isTransactionDigest(obj.txDigest) as boolean &&
+        isEventId(obj.id) as boolean &&
         isSuiEvent(obj.event) as boolean
     )
 }

--- a/sdk/typescript/test/e2e/read-events.test.ts
+++ b/sdk/typescript/test/e2e/read-events.test.ts
@@ -12,25 +12,25 @@ describe('Event Reading API', () => {
   });
 
   it('Get All Events', async () => {
-    const allEvents = await toolbox.provider.getEvents("All", null, null, null);
+    const allEvents = await toolbox.provider.getEvents("All", null, null);
     expect(allEvents.data.length).to.greaterThan(0);
     expect(allEvents.nextCursor).toEqual(null);
   });
 
   it('Get all event paged', async () => {
-    const page1 = await toolbox.provider.getEvents("All",null,2, true);
+    const page1 = await toolbox.provider.getEvents("All", null, 2);
     expect(page1.nextCursor).to.not.equal(null);
-    const page2 = await toolbox.provider.getEvents("All",page1.nextCursor,1000, true);
+    const page2 = await toolbox.provider.getEvents("All", page1.nextCursor, 1000);
     expect(page2.nextCursor).toEqual(null);
   });
 
   it('Get events by sender paginated', async () => {
-    const query1 = await toolbox.provider.getEvents({Sender: toolbox.address()}, null, 2, true);
+    const query1 = await toolbox.provider.getEvents({Sender: toolbox.address()}, null, 2);
     expect(query1.data.length).toEqual(0);
   });
 
   it('Get events by recipient paginated', async () => {
-    const query2 = await toolbox.provider.getEvents({Recipient: {AddressOwner: toolbox.address()}}, null, 2, true);
+    const query2 = await toolbox.provider.getEvents({Recipient: {AddressOwner: toolbox.address()}}, null, 2);
     expect(query2.data.length).toEqual(2);
   });
 });

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -21,7 +21,6 @@ describe('Transaction Reading API', () => {
       'All',
       null,
       1,
-      true
     );
     const digest = resp.data[0];
     const txn = await toolbox.provider.getTransactionWithEffects(digest);
@@ -39,7 +38,6 @@ describe('Transaction Reading API', () => {
       'All',
       null,
       10,
-      false
     );
     expect(allTransactions.data.length).to.greaterThan(0);
 
@@ -47,13 +45,11 @@ describe('Transaction Reading API', () => {
       { ToAddress: toolbox.address() },
       null,
       null,
-      false
     );
     const resp3 = await toolbox.provider.getTransactions(
       { FromAddress: toolbox.address() },
       null,
       null,
-      false
     );
     expect([...resp2.data, ...resp3.data]).toEqual(resp);
   });


### PR DESCRIPTION
The e2e tests do not match function definition:

https://github.com/MystenLabs/sui/blob/f9698507a4cfe274676e940c863b4ecd518ff39e/sdk/typescript/src/providers/json-rpc-provider.ts#L583-L588

which expects a string in the last argument instead of a boolean