### PR TITLE
Force frame pointers in release builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -9,3 +9,6 @@ xclippy = [
     "-Wclippy::disallowed_methods",
 ]
 xlint = "run --package x --bin x -- lint"
+
+[build]
+rustflags = ["-C", "force-frame-pointers=yes"]


### PR DESCRIPTION
This will make it easier to capture profiles of running release builds. I believe it will also make the jeprof traces we capture readable.