### PR TITLE
[sui-core] Sign timestamp in headers

### DIFF
--- a/narwhal/node/src/generate_format.rs
+++ b/narwhal/node/src/generate_format.rs
@@ -75,6 +75,7 @@ fn get_registry() -> Result<Registry> {
     let header = header_builder
         .author(kp.public().clone())
         .epoch(0)
+        .created_at(0)
         .round(1)
         .payload((0..4u32).map(|wid| (BatchDigest([0u8; 32]), wid)).collect())
         .parents(certificates.iter().map(|x| x.digest()).collect())

--- a/narwhal/node/tests/staged/narwhal.yaml
+++ b/narwhal/node/tests/staged/narwhal.yaml
@@ -50,6 +50,7 @@ Header:
     - author: STR
     - round: U64
     - epoch: U64
+    - created_at: U64
     - payload:
         SEQ:
           TUPLE:
@@ -60,8 +61,6 @@ Header:
           TYPENAME: CertificateDigest
     - signature:
         TYPENAME: BLS12381Signature
-    - metadata:
-        TYPENAME: Metadata
 HeaderDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -420,7 +420,7 @@ impl Core {
         // Broadcast the certificate.
         let epoch = certificate.epoch();
         let round = certificate.header.round;
-        let created_at = certificate.header.metadata.created_at;
+        let created_at = certificate.header.created_at;
         let network_keys = self
             .committee
             .others_primaries(&self.name)

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -49,12 +49,13 @@ use tokio::{sync::oneshot, time::Instant};
 use tokio::{sync::watch, task::JoinHandle};
 use tower::ServiceBuilder;
 use tracing::{debug, error, info, instrument, warn};
+
 pub use types::PrimaryMessage;
 use types::{
     ensure,
     error::{DagError, DagResult},
     metered_channel::{channel_with_total, Receiver, Sender},
-    BatchDigest, Certificate, CertificateDigest, FetchCertificatesRequest,
+    now, BatchDigest, Certificate, CertificateDigest, FetchCertificatesRequest,
     FetchCertificatesResponse, GetCertificatesRequest, GetCertificatesResponse, Header,
     HeaderDigest, PayloadAvailabilityRequest, PayloadAvailabilityResponse, PrimaryToPrimary,
     PrimaryToPrimaryServer, ReconfigureNotification, RequestVoteRequest, RequestVoteResponse,
@@ -738,6 +739,27 @@ impl PrimaryReceiverHandler {
         self.synchronizer
             .sync_batches(header, network, /* max_age */ 0)
             .await?;
+
+        // Check that the time of the header is smaller than the current time. If not but the difference is
+        // small, just wait. Otherwise reject with an error.
+        const TOLERANCE: u64 = 15 * 1000; // 15 sec in milliseconds
+        let current_time = now();
+        if current_time < header.created_at {
+            if header.created_at - current_time < TOLERANCE {
+                // for a small difference we simply wait
+                tokio::time::sleep(Duration::from_millis(header.created_at - current_time)).await;
+            } else {
+                // For larger differences return an error, and log it
+                warn!(
+                    "Rejected header {:?} due to timestamp {} newer than {current_time}",
+                    header, header.created_at
+                );
+                return Err(DagError::InvalidTimestamp {
+                    created_time: header.created_at,
+                    local_time: current_time,
+                });
+            }
+        }
 
         // Store the header.
         self.header_store

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -16,6 +16,7 @@ use tokio::{
     time::{sleep, Duration},
 };
 use tracing::{debug, error, info};
+use types::now;
 use types::{
     error::{DagError, DagResult},
     metered_channel::{Receiver, Sender},
@@ -192,6 +193,22 @@ impl Proposer {
         let num_of_digests = self.digests.len().min(self.max_header_num_of_batches);
         let digests: Vec<_> = self.digests.drain(..num_of_digests).collect();
         let parents: Vec<_> = self.last_parents.drain(..).collect();
+
+        // Here we check that the timestamp we will include in the header is consistent with the
+        // parents, ie our current time is *after* the timestamp in all the included headers. If
+        // not we log an error and hope a kind operator fixes the clock.
+        let current_time = now();
+        let parent_max_time = parents
+            .iter()
+            .map(|c| c.header.created_at)
+            .max()
+            .unwrap_or(0);
+        if current_time < parent_max_time {
+            error!(
+                "Current time {} earlier than max parent time {}",
+                current_time, parent_max_time
+            );
+        }
 
         let header = Header::new(
             self.name.clone(),

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -1252,5 +1252,5 @@ async fn test_request_vote_created_at_in_future() {
     assert!(response.body().vote.is_some());
 
     // We are now later
-    assert!(created_at < now() );
+    assert!(created_at < now());
 }

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -36,7 +36,7 @@ use test_utils::{temp_dir, CommitteeFixture};
 use tokio::sync::watch;
 
 use types::{
-    error::DagError, BatchDigest, Certificate, CertificateDigest, FetchCertificatesRequest,
+    error::DagError, now, BatchDigest, Certificate, CertificateDigest, FetchCertificatesRequest,
     MockPrimaryToWorker, PayloadAvailabilityRequest, PrimaryToPrimary, PrimaryToWorkerServer,
     ReconfigureNotification, RequestVoteRequest, Round,
 };
@@ -1106,4 +1106,148 @@ async fn test_process_payload_availability_when_failures() {
     });
     let result = handler.get_payload_availability(request).await;
     assert!(result.is_err(), "expected error reading certificates");
+}
+
+#[tokio::test]
+async fn test_request_vote_created_at_in_future() {
+    telemetry_subscribers::init_for_testing();
+    let fixture = CommitteeFixture::builder()
+        .randomize_ports(true)
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .build();
+    let worker_cache = fixture.shared_worker_cache();
+    let primary = fixture.authorities().next().unwrap();
+    let name = primary.public_key();
+    let author = fixture.authorities().nth(2).unwrap();
+    let signature_service = SignatureService::new(primary.keypair().copy());
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+    let network = test_utils::test_network(primary.network_keypair(), primary.address());
+
+    let (header_store, certificate_store, payload_store) = create_db_stores();
+    let (tx_certificates, _rx_certificates) = test_utils::test_channel!(100);
+    let (tx_certificate_waiter, _rx_certificate_waiter) = test_utils::test_channel!(1);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(1u64);
+    let (_tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(1u64);
+
+    let synchronizer = Arc::new(Synchronizer::new(
+        name.clone(),
+        fixture.committee().into(),
+        worker_cache.clone(),
+        certificate_store.clone(),
+        payload_store.clone(),
+        tx_certificate_waiter,
+        rx_consensus_round_updates,
+        None,
+    ));
+    let handler = PrimaryReceiverHandler {
+        name: name.clone(),
+        committee: fixture.committee().into(),
+        worker_cache: worker_cache.clone(),
+        synchronizer: synchronizer.clone(),
+        signature_service,
+        tx_certificates,
+        header_store: header_store.clone(),
+        certificate_store: certificate_store.clone(),
+        payload_store: payload_store.clone(),
+        vote_digest_store: crate::common::create_test_vote_store(),
+        rx_narwhal_round_updates,
+        metrics: metrics.clone(),
+        request_vote_inflight: Arc::new(DashSet::new()),
+    };
+
+    // Make some mock certificates that are parents of our new header.
+    let mut certificates = HashMap::new();
+    for primary in fixture.authorities().filter(|a| a.public_key() != name) {
+        let header = primary
+            .header_builder(&fixture.committee())
+            .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 0)
+            .build(primary.keypair())
+            .unwrap();
+
+        let certificate = fixture.certificate(&header);
+        let digest = certificate.clone().digest();
+
+        certificates.insert(digest, certificate.clone());
+        certificate_store.write(certificate.clone()).unwrap();
+        for payload in certificate.header.payload {
+            payload_store.async_write(payload, 1).await;
+        }
+    }
+
+    // Set up mock worker.
+    let worker = primary.worker(1);
+    let worker_address = &worker.info().worker_address;
+    let mut mock_server = MockPrimaryToWorker::new();
+    // Always Synchronize successfully.
+    mock_server
+        .expect_synchronize()
+        .returning(|_| Ok(anemo::Response::new(())));
+    let routes = anemo::Router::new().add_rpc_service(PrimaryToWorkerServer::new(mock_server));
+    let _worker_network = worker.new_network(routes);
+    let address = network::multiaddr_to_address(worker_address).unwrap();
+    let peer_id = anemo::PeerId(worker.keypair().public().0.to_bytes());
+    network
+        .connect_with_peer_id(address, peer_id)
+        .await
+        .unwrap();
+
+    // Verify Handler generates a Vote.
+
+    // Set the creation time to be deep in the future (an hour)
+    let created_at = now() + 60 * 60 * 1000;
+
+    let test_header = author
+        .header_builder(&fixture.committee())
+        .round(2)
+        .parents(certificates.keys().cloned().collect())
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .created_at(created_at)
+        .build(author.keypair())
+        .unwrap();
+
+    let mut request = anemo::Request::new(RequestVoteRequest {
+        header: test_header.clone(),
+        parents: Vec::new(),
+    });
+    assert!(request
+        .extensions_mut()
+        .insert(network.downgrade())
+        .is_none());
+    assert!(request
+        .extensions_mut()
+        .insert(anemo::PeerId(author.network_public_key().0.to_bytes()))
+        .is_none());
+
+    // For such a future header we get back an error
+    assert!(handler.request_vote(request).await.is_err());
+
+    // Verify Handler generates a Vote.
+
+    // Set the creation time to be a bit in the future (a second)
+    let created_at = now() + 1000;
+
+    let test_header = author
+        .header_builder(&fixture.committee())
+        .round(2)
+        .parents(certificates.keys().cloned().collect())
+        .with_payload_batch(test_utils::fixture_batch_with_transactions(10), 1)
+        .created_at(created_at)
+        .build(author.keypair())
+        .unwrap();
+
+    let mut request = anemo::Request::new(RequestVoteRequest {
+        header: test_header.clone(),
+        parents: Vec::new(),
+    });
+    assert!(request
+        .extensions_mut()
+        .insert(network.downgrade())
+        .is_none());
+    assert!(request
+        .extensions_mut()
+        .insert(anemo::PeerId(author.network_public_key().0.to_bytes()))
+        .is_none());
+
+    let response = handler.request_vote(request).await.unwrap();
+    assert!(response.body().vote.is_some());
 }

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -1250,4 +1250,7 @@ async fn test_request_vote_created_at_in_future() {
 
     let response = handler.request_vote(request).await.unwrap();
     assert!(response.body().vote.is_some());
+
+    // We are now later
+    assert!(created_at < now() );
 }

--- a/narwhal/types/src/error.rs
+++ b/narwhal/types/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{HeaderDigest, Round, VoteDigest};
+use crate::{HeaderDigest, Round, TimestampMs, VoteDigest};
 use config::Epoch;
 use fastcrypto::hash::Digest;
 use store::StoreError;
@@ -90,6 +90,12 @@ pub enum DagError {
 
     #[error("Invalid round (expected {expected}, received {received})")]
     InvalidRound { expected: Round, received: Round },
+
+    #[error("Invalid timestamp (created at {created_time}, received at {local_time})")]
+    InvalidTimestamp {
+        created_time: TimestampMs,
+        local_time: TimestampMs,
+    },
 
     #[error("Too many certificates in the FetchCertificatesResponse {0} > {1}")]
     TooManyFetchedCertificatesReturned(usize, usize),

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -61,7 +61,7 @@ fn now() -> TimestampMs {
     }
 }
 
-// Additional metadata information for an entity. 
+// Additional metadata information for an entity.
 //
 // The structure as a whole is not signed. As a result this data
 // should not be treated as trustworthy data and should be used
@@ -70,7 +70,7 @@ fn now() -> TimestampMs {
 // safety or liveness.
 //
 // However selected fields, such as
-// - Header::metadata::created_at 
+// - Header::metadata::created_at
 // are signed to support commit timestamps.
 #[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq, Eq, Arbitrary, MallocSizeOf)]
 pub struct Metadata {
@@ -90,7 +90,7 @@ impl Batch {
     pub fn new(transactions: Vec<Transaction>) -> Self {
         Batch {
             transactions,
-            metadata: Metadata { created_at : now() },
+            metadata: Metadata { created_at: now() },
         }
     }
 }

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -54,7 +54,7 @@ impl Timestamp for TimestampMs {
 }
 // Returns the current time expressed as UNIX
 // timestamp in milliseconds
-fn now() -> TimestampMs {
+pub fn now() -> TimestampMs {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
         Ok(n) => n.as_millis() as TimestampMs,
         Err(_) => panic!("SystemTime before UNIX EPOCH!"),

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -169,7 +169,7 @@ impl HeaderBuilder {
             author: self.author.unwrap(),
             round: self.round.unwrap(),
             epoch: self.epoch.unwrap(),
-            created_at: 0,
+            created_at: self.created_at.unwrap_or(0),
             payload: self.payload.unwrap(),
             parents: self.parents.unwrap(),
             digest: OnceCell::default(),

--- a/narwhal/types/src/tests/primary_type_tests.rs
+++ b/narwhal/types/src/tests/primary_type_tests.rs
@@ -12,7 +12,7 @@ use proptest::{collection, prelude::*, strategy::Strategy};
 use rand::{rngs::StdRng, SeedableRng};
 use signature::Signer;
 
-use crate::{BatchDigest, CertificateDigest, Header, HeaderDigest, Metadata};
+use crate::{BatchDigest, CertificateDigest, Header, HeaderDigest};
 
 fn arb_keypair() -> impl Strategy<Value = KeyPair> {
     (any::<[u8; 32]>())
@@ -42,11 +42,11 @@ fn clean_signed_header(kp: KeyPair) -> impl Strategy<Value = Header> {
                 author: kp.public().clone(),
                 round,
                 epoch,
+                created_at: 0,
                 payload,
                 parents,
                 digest: OnceCell::default(),
                 signature: Signature::default(),
-                metadata: Metadata::default(),
             };
             Header {
                 digest: OnceCell::with_value(Hash::digest(&header)),

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -168,9 +168,7 @@ async fn handle_clients_transactions() {
         .withf(move |request| {
             let message = request.body();
 
-            message.digest == batch_digest
-                && message.worker_id == worker_id
-                && message.metadata.created_at > 0
+            message.digest == batch_digest && message.worker_id == worker_id
         })
         .times(1)
         .returning(move |_| {


### PR DESCRIPTION
We now include the header creation timestamp in the signed header data, so that we may extract a timestamp upon a commit. Signing a header is conditional on its creation time being in the past, ensuring that the created_at in all headers is in the past. in case the header is not in the past we wait for a short time, or return an error.
