### PR TITLE
wallet-ext: estimate gas cost using ts-sdk in transfer nft page

### DIFF
--- a/apps/wallet/src/ui/app/hooks/index.ts
+++ b/apps/wallet/src/ui/app/hooks/index.ts
@@ -16,3 +16,4 @@ export { default as useNFTBasicData } from './useNFTBasicData';
 export { useObjectsState } from './useObjectsState';
 export { useWaitForElement } from './useWaitForElement';
 export { useFormatCoin, useCoinDecimals } from './useFormatCoin';
+export * from './useSigner';

--- a/apps/wallet/src/ui/app/hooks/useSigner.ts
+++ b/apps/wallet/src/ui/app/hooks/useSigner.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { thunkExtras } from '_redux/store/thunk-extras';
+
+export function useSigner() {
+    const { api, keypairVault } = thunkExtras;
+    return api.getSignerInstance(keypairVault.getKeyPair());
+}

--- a/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/TransferNFTForm.tsx
@@ -1,44 +1,77 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useQuery } from '@tanstack/react-query';
 import cl from 'classnames';
 import { Form, Field, useFormikContext } from 'formik';
-import { useEffect, useRef, memo } from 'react';
+import { useEffect, useRef, memo, useMemo } from 'react';
 
 import { Content } from '_app/shared/bottom-menu-layout';
 import Button from '_app/shared/button';
 import AddressInput from '_components/address-input';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
-import { DEFAULT_NFT_TRANSFER_GAS_FEE } from '_redux/slices/sui-objects/Coin';
+import { useAppSelector, useSigner } from '_hooks';
+import { accountAggregateBalancesSelector } from '_redux/slices/account';
+import {
+    DEFAULT_NFT_TRANSFER_GAS_FEE,
+    GAS_TYPE_ARG,
+} from '_redux/slices/sui-objects/Coin';
 
 import type { FormValues } from '.';
+import type { ObjectId } from '@mysten/sui.js';
 
 import st from './TransferNFTForm.module.scss';
 
 export type TransferNFTFormProps = {
+    nftID: ObjectId;
     submitError: string | null;
-    gasBalance: string;
     onClearSubmitError: () => void;
 };
 
 function TransferNFTForm({
+    nftID,
     submitError,
-    gasBalance,
     onClearSubmitError,
 }: TransferNFTFormProps) {
     const {
         isSubmitting,
         isValid,
-        values: { to, amount },
+        values: { to },
     } = useFormikContext<FormValues>();
-
     const onClearRef = useRef(onClearSubmitError);
     onClearRef.current = onClearSubmitError;
     useEffect(() => {
         onClearRef.current();
-    }, [to, amount]);
-
+    }, [to]);
+    const aggregateBalances = useAppSelector(accountAggregateBalancesSelector);
+    const gasAggregateBalance = useMemo(
+        () => aggregateBalances[GAS_TYPE_ARG] || BigInt(0),
+        [aggregateBalances]
+    );
+    const signer = useSigner();
+    const gasEstimationResult = useQuery({
+        queryKey: ['nft-transfer', nftID, 'gas-estimation', to, isValid],
+        queryFn: async () => {
+            if (isValid && nftID && to) {
+                const tx = await signer.serializer.newTransferObject(
+                    await signer.getAddress(),
+                    {
+                        objectId: nftID,
+                        recipient: to,
+                        gasBudget: DEFAULT_NFT_TRANSFER_GAS_FEE,
+                    }
+                );
+                return signer.getGasCostEstimation(tx);
+            }
+            return null;
+        },
+    });
+    const gasEstimation = gasEstimationResult.isError
+        ? DEFAULT_NFT_TRANSFER_GAS_FEE
+        : gasEstimationResult.data ?? null; // make undefined null
+    const isInsufficientGas =
+        gasEstimation !== null ? gasAggregateBalance < gasEstimation : null;
     return (
         <div className={st.sendNft}>
             <Content>
@@ -61,33 +94,37 @@ function TransferNFTForm({
                             className={st.input}
                         />
                     </div>
-
-                    {BigInt(gasBalance) < DEFAULT_NFT_TRANSFER_GAS_FEE && (
+                    {isInsufficientGas ? (
                         <div className={st.error}>
                             * Insufficient balance to cover transfer cost
                         </div>
-                    )}
-
+                    ) : null}
                     {submitError ? (
                         <div className={st.error}>{submitError}</div>
                     ) : null}
-
                     <div className={st.formcta}>
                         <Button
                             size="large"
                             mode="primary"
                             type="submit"
-                            disabled={!isValid || isSubmitting}
+                            disabled={
+                                !isValid ||
+                                isSubmitting ||
+                                isInsufficientGas ||
+                                gasEstimationResult.isLoading
+                            }
                             className={cl(st.action, 'btn', st.sendNftBtn)}
                         >
-                            Send NFT Now
-                            {isSubmitting ? (
+                            {isSubmitting || gasEstimationResult.isLoading ? (
                                 <LoadingIndicator />
                             ) : (
-                                <Icon
-                                    icon={SuiIcons.ArrowRight}
-                                    className={st.arrowActionIcon}
-                                />
+                                <>
+                                    Send NFT Now
+                                    <Icon
+                                        icon={SuiIcons.ArrowRight}
+                                        className={st.arrowActionIcon}
+                                    />
+                                </>
                             )}
                         </Button>
                     </div>

--- a/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/nft-details/transfer-nft/validation.ts
@@ -6,7 +6,6 @@ import * as Yup from 'yup';
 import { SUI_ADDRESS_VALIDATION } from '_components/address-input/validation';
 
 export function createValidationSchema(
-    gasBalance: bigint,
     senderAddress: string,
     objectId: string
 ) {
@@ -22,16 +21,5 @@ export function createValidationSchema(
             `NFT address must be different from receiver address`,
             (value) => objectId !== value
         ),
-        amount: Yup.number()
-            .integer()
-            .required()
-            .test(
-                'nft-gas-balance-check',
-                `Insufficient balance to cover gas fee`,
-                (amount) => {
-                    return gasBalance >= BigInt(amount || 0);
-                }
-            )
-            .label('Amount'),
     });
 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/NFT.ts
@@ -32,17 +32,4 @@ export class ExampleNFT {
             gasBudget: 10000,
         });
     }
-
-    public static async TransferNFT(
-        signer: RawSigner,
-        nftId: string,
-        recipientID: string,
-        transferCost: number
-    ): Promise<SuiExecuteTransactionResponse> {
-        return await signer.transferObject({
-            objectId: nftId,
-            gasBudget: transferCost,
-            recipient: recipientID,
-        });
-    }
 }

--- a/sdk/typescript/src/signers/signer-with-provider.ts
+++ b/sdk/typescript/src/signers/signer-with-provider.ts
@@ -139,12 +139,14 @@ export abstract class SignerWithProvider implements Signer {
    * @param tx the transaction as SignableTransaction or string (in base64) that will dry run
    * @returns The transaction effects
    */
-  async dryRunTransaction(tx: SignableTransaction | string): Promise<TransactionEffects> {
+  async dryRunTransaction(tx: SignableTransaction | string | Base64DataBuffer): Promise<TransactionEffects> {
     const address = await this.getAddress();
     let dryRunTxBytes: string;
     if (typeof tx === 'string') {
       dryRunTxBytes = tx;
-    } else {
+    } else if (tx instanceof Base64DataBuffer){
+      dryRunTxBytes = tx.toString();
+    }else{
       switch (tx.kind) {
         case 'bytes':
           dryRunTxBytes = new Base64DataBuffer(tx.data).toString();
@@ -330,7 +332,7 @@ export abstract class SignerWithProvider implements Signer {
    * @returns total gas cost estimation
    * @throws whens fails to estimate the gas cost
    */
-  async getGasCostEstimation(tx: SignableTransaction | string) {
+  async getGasCostEstimation(tx: Parameters<SignerWithProvider['dryRunTransaction']>['0']) {
     const txEffects = await this.dryRunTransaction(tx);
     const gasEstimation = getTotalGasUsed(txEffects);
     if (typeof gasEstimation === 'undefined') {


### PR DESCRIPTION
* ts-sdk: dryRunTransaction accept Base64Buffer transaction
* wallet-ext: 
  * estimate the gas cost for the transfer and use that one for validation (this view doesn't show gas cost to the user)
  * use the predefined constant cost in case of error to allow user send the transaction
  * disables send button and shows loading indicator while calculating gas cost
  
  

https://user-images.githubusercontent.com/10210143/201705711-0b12a76c-252f-4958-bfd9-4bc6cd19fd49.mov


https://user-images.githubusercontent.com/10210143/201704877-7c4ca426-aa39-444f-afd3-7444ec2c8b43.mov


Part of: APPS-149
