### PR TITLE
crypto: use get instead of panic for slice

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -4,7 +4,6 @@
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
-    convert::TryFrom,
     fmt::Debug,
 };
 
@@ -568,8 +567,13 @@ fn process_successful_execution<S: Storage + ParentSync>(
         let has_public_transfer = abilities.has_store();
         debug_assert_eq!(
             id,
-            ObjectID::try_from(&contents[0..ID_END_INDEX])
-                .expect("object contents should start with an id")
+            ObjectID::from_bytes(contents.get(0..ID_END_INDEX).ok_or_else(|| {
+                ExecutionError::new_with_source(
+                    ExecutionErrorKind::InvariantViolation,
+                    "Cannot parse Object ID",
+                )
+            })?)
+            .expect("object contents should start with an id")
         );
         let old_object_opt = by_value_objects.get(&id);
         let loaded_child_version_opt = loaded_child_objects.get(&id);

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -225,7 +225,15 @@ impl ConsensusAdapter {
         tx_digest: &TransactionDigest,
     ) -> bool {
         // the 32 is as requirement of the deault StdRng::from_seed choice
-        let digest_bytes: [u8; 32] = tx_digest.to_bytes()[..32].try_into().unwrap();
+        let digest_bytes = if let Some(b) = tx_digest.to_bytes().get(0..32) {
+            if let Ok(bytes) = b.try_into() {
+                bytes
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        };
 
         // permute the validators deterministically, based on the digest
         let mut rng = StdRng::from_seed(digest_bytes);

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -94,7 +94,9 @@ pub fn hash_type_and_key(
     let hash = hasher.finalize();
 
     // truncate into an ObjectID and return
+    // OK to access slice because Sha3_256 should never be shorter than ObjectID::LENGTH.
     let id = ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap();
+
     Ok(NativeResult::ok(
         legacy_emit_cost(),
         smallvec![Value::address(id.into())],

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -205,6 +205,7 @@ impl From<&AuthorityPublicKeyBytes> for SuiAddress {
         let g_arr = hasher.finalize();
 
         let mut res = [0u8; SUI_ADDRESS_LENGTH];
+        // OK to access slice because Sha3_256 should never be shorter than SUI_ADDRESS_LENGTH.
         res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);
         SuiAddress(res)
     }
@@ -218,6 +219,7 @@ impl<T: SuiPublicKey> From<&T> for SuiAddress {
         let g_arr = hasher.finalize();
 
         let mut res = [0u8; SUI_ADDRESS_LENGTH];
+        // OK to access slice because Sha3_256 should never be shorter than SUI_ADDRESS_LENGTH.
         res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);
         SuiAddress(res)
     }
@@ -231,6 +233,7 @@ impl From<&PublicKey> for SuiAddress {
         let g_arr = hasher.finalize();
 
         let mut res = [0u8; SUI_ADDRESS_LENGTH];
+        // OK to access slice because Sha3_256 should never be shorter than SUI_ADDRESS_LENGTH.
         res.copy_from_slice(&AsRef::<[u8]>::as_ref(&g_arr)[..SUI_ADDRESS_LENGTH]);
         SuiAddress(res)
     }
@@ -444,6 +447,7 @@ impl TransactionDigest {
         let hash = hasher.finalize();
 
         // truncate into an ObjectID.
+        // OK to access slice because Sha3_256 should never be shorter than ObjectID::LENGTH.
         ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap()
     }
 

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -98,8 +98,8 @@ impl MoveObject {
     pub fn has_public_transfer(&self) -> bool {
         self.has_public_transfer
     }
-
     pub fn id(&self) -> ObjectID {
+        // TODO: Ensure safe index to to parse ObjectID. https://github.com/MystenLabs/sui/issues/6278
         ObjectID::try_from(&self.contents[0..ID_END_INDEX]).unwrap()
     }
 
@@ -110,12 +110,9 @@ impl MoveObject {
     /// Contents of the object that are specific to its type--i.e., not its ID and version, which all objects have
     /// For example if the object was declared as `struct S has key { id: ID, f1: u64, f2: bool },
     /// this returns the slice containing `f1` and `f2`.
+    #[cfg(test)]
     pub fn type_specific_contents(&self) -> &[u8] {
         &self.contents[ID_END_INDEX..]
-    }
-
-    pub fn id_contents(&self) -> &[u8] {
-        &self.contents[..ID_END_INDEX]
     }
 
     /// Update the contents of this object and increment its version

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -231,7 +231,10 @@ pub fn read_network_keypair_from_file<P: AsRef<std::path::Path>>(
     let bytes = Base64::decode(value.as_str()).map_err(|e| anyhow::anyhow!(e))?;
     if let Some(flag) = bytes.first() {
         if flag == &Ed25519SuiSignature::SCHEME.flag() {
-            let sk = Ed25519PrivateKey::from_bytes(&bytes[1 + Ed25519PublicKey::LENGTH..])?;
+            let priv_key_bytes = bytes
+                .get(1 + Ed25519PublicKey::LENGTH..)
+                .ok_or_else(|| anyhow!("Invalid length"))?;
+            let sk = Ed25519PrivateKey::from_bytes(priv_key_bytes)?;
             return Ok(<Ed25519KeyPair as From<Ed25519PrivateKey>>::from(sk));
         }
     }

--- a/narwhal/config/src/lib.rs
+++ b/narwhal/config/src/lib.rs
@@ -449,7 +449,13 @@ impl std::fmt::Display for WorkerCache {
             self.epoch(),
             self.workers
                 .iter()
-                .map(|(k, v)| { format!("{}: {}", k.encode_base64().get(0..16).unwrap(), v) })
+                .map(|(k, v)| {
+                    if let Some(x) = k.encode_base64().get(0..16) {
+                        format!("{}: {}", x, v)
+                    } else {
+                        format!("Invalid key: {}", k)
+                    }
+                })
                 .collect::<Vec<_>>()
         )
     }
@@ -580,7 +586,13 @@ impl std::fmt::Display for Committee {
             self.epoch(),
             self.authorities
                 .keys()
-                .map(|x| { x.encode_base64().get(0..16).unwrap().to_string() })
+                .map(|x| {
+                    if let Some(k) = x.encode_base64().get(0..16) {
+                        k.to_owned()
+                    } else {
+                        format!("Invalid key: {}", x)
+                    }
+                })
                 .collect::<Vec<_>>()
         )
     }

--- a/narwhal/dag/src/node_dag.rs
+++ b/narwhal/dag/src/node_dag.rs
@@ -277,13 +277,13 @@ mod tests {
 
     impl fmt::Debug for TestDigest {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-            write!(f, "{}", Hex::encode(self.0).get(0..16).unwrap())
+            write!(f, "{}", Hex::encode(self.0).get(0..16).ok_or(fmt::Error)?)
         }
     }
 
     impl fmt::Display for TestDigest {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-            write!(f, "{}", Hex::encode(self.0).get(0..16).unwrap())
+            write!(f, "{}", Hex::encode(self.0).get(0..16).ok_or(fmt::Error)?)
         }
     }
 

--- a/narwhal/primary/src/block_synchronizer/peers.rs
+++ b/narwhal/primary/src/block_synchronizer/peers.rs
@@ -400,7 +400,11 @@ mod tests {
 
     impl fmt::Display for MockDigest {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-            write!(f, "{}", base64::encode(self.0).get(0..16).unwrap())
+            write!(
+                f,
+                "{}",
+                base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+            )
         }
     }
 

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -119,7 +119,11 @@ impl fmt::Debug for BatchDigest {
 
 impl fmt::Display for BatchDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0).get(0..16).unwrap())
+        write!(
+            f,
+            "{}",
+            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+        )
     }
 }
 
@@ -299,7 +303,11 @@ impl fmt::Debug for HeaderDigest {
 
 impl fmt::Display for HeaderDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0).get(0..16).unwrap())
+        write!(
+            f,
+            "{}",
+            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+        )
     }
 }
 
@@ -442,7 +450,11 @@ impl fmt::Debug for VoteDigest {
 
 impl fmt::Display for VoteDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0).get(0..16).unwrap())
+        write!(
+            f,
+            "{}",
+            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+        )
     }
 }
 
@@ -722,7 +734,11 @@ impl fmt::Debug for CertificateDigest {
 
 impl fmt::Display for CertificateDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", base64::encode(self.0).get(0..16).unwrap())
+        write!(
+            f,
+            "{}",
+            base64::encode(self.0).get(0..16).ok_or(fmt::Error)?
+        )
     }
 }
 

--- a/narwhal/types/src/worker.rs
+++ b/narwhal/types/src/worker.rs
@@ -45,7 +45,8 @@ pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> Result<BatchDigest, Di
     let sbm = sbm.as_ref();
     let mut offset = 0;
     let num_transactions = u64::from_le_bytes(
-        sbm[offset..offset + 8]
+        sbm.get(offset..offset + 8)
+            .ok_or(DigestError::InvalidLengthError)?
             .try_into()
             .map_err(|_| DigestError::InvalidArgumentError(offset))?,
     );
@@ -66,11 +67,14 @@ pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> Result<BatchDigest, Di
 pub enum DigestError {
     #[error("Invalid argument: invalid byte at {0}")]
     InvalidArgumentError(usize),
+    #[error("Invalid length")]
+    InvalidLengthError,
 }
 
 fn read_one_transaction(sbm: &[u8], offset: usize) -> Result<(&[u8], usize), DigestError> {
     let length = u64::from_le_bytes(
-        sbm[offset..offset + 8]
+        sbm.get(offset..offset + 8)
+            .ok_or(DigestError::InvalidLengthError)?
             .try_into()
             .map_err(|_| DigestError::InvalidArgumentError(offset))?,
     );


### PR DESCRIPTION
Issue: https://github.com/MystenLabs/sui/issues/6041

this is to replace all patterns of `foo[i..j]` with `foo.get(i..j)` and handles the Result instead of panic. there are few places I am not sure it makes sense to have handle a Result, open for discussion there. 

note that i ignored all of the ones written in tests and the marked methods that contains the pattern but used only by test with feature flag. 
