### PR TITLE
Check for lock existence before attempting tx execution.

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -51,7 +51,11 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load() {
-        let test_cluster = init_cluster_builder_env_aware().build().await.unwrap();
+        let test_cluster = init_cluster_builder_env_aware()
+            .with_num_validators(get_var("SIM_STRESS_TEST_NUM_VALIDATORS", 4))
+            .build()
+            .await
+            .unwrap();
         let swarm = &test_cluster.swarm;
         let context = &test_cluster.wallet;
         let sender = test_cluster.get_address_0();
@@ -85,7 +89,12 @@ mod test {
         );
 
         for w in workloads.iter_mut() {
-            w.workload.init(5, proxy.clone()).await;
+            w.workload
+                .init(
+                    get_var("SIM_STRESS_TEST_NUM_SHARED_OBJECTS", 5),
+                    proxy.clone(),
+                )
+                .await;
         }
 
         let driver = BenchDriver::new(5);

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -768,6 +768,11 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
+    async fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
+        self.database.check_owned_locks(owned_object_refs).await
+    }
+
+    #[instrument(level = "trace", skip_all)]
     async fn check_shared_locks(
         &self,
         transaction_digest: &TransactionDigest,
@@ -1037,6 +1042,9 @@ impl AuthorityState {
         let _metrics_guard = start_timer(self.metrics.prepare_certificate_latency.clone());
         let (gas_status, input_objects) =
             transaction_input_checker::check_certificate_input(&self.database, certificate).await?;
+
+        let owned_object_refs = input_objects.filter_owned_objects();
+        self.check_owned_locks(&owned_object_refs).await?;
 
         // At this point we need to check if any shared objects need locks,
         // and whether they have them.

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -406,6 +406,10 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         }
 
         if !probe_lock_exists.is_empty() {
+            // It is possible that we probed the objects after they are written, but before the
+            // locks are created. In that case, if we attempt to execute the transaction, it will
+            // fail. Because the objects_committed() call is made only after the locks are written,
+            // the tx manager will be awoken after the locks are written.
             missing.extend(
                 self.lock_service
                     .get_missing_locks(probe_lock_exists)

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -409,7 +409,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             missing.extend(
                 self.lock_service
                     .get_missing_locks(probe_lock_exists)
-                    .await?,
+                    .await?
+                    .into_iter()
+                    .map(ObjectKey::from),
             );
         }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -388,7 +388,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                     };
                 }
                 InputObjectKind::MovePackage(id) => {
-                    if !self.object_version_exists(id, version)? {
+                    if !self.object_version_exists(id, PACKAGE_VERSION)? {
                         // The cert cannot have been formed if immutable inputs were missing.
                         missing.push(ObjectKey(*id, PACKAGE_VERSION));
                     }
@@ -1212,7 +1212,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     pub fn object_exists(&self, object_id: ObjectID) -> SuiResult<bool> {
         match self.get_latest_parent_entry(object_id)? {
             None => Ok(false),
-            Some(entry) => Ok(entry.is_alive()),
+            Some(entry) => Ok(entry.0 .2.is_alive()),
         }
     }
 
@@ -1227,7 +1227,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         for (object_id, _) in transaction.shared_input_objects() {
             sequenced_to_delete.push((*transaction_digest, *object_id));
 
-            if !self.object_exists(object_id)? {
+            if !self.object_exists(*object_id)? {
                 schedule_to_delete.push(*object_id);
             }
         }

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -124,7 +124,7 @@ where
                     }
                     // Assume only transient failure can happen. Permanent failure is probably
                     // a bug. There would be nothing that can be done for permanent failures.
-                    warn!(tx_digest=?digest, "Failed to execute certified transaction! attempt {attempts}, {e}");
+                    error!(tx_digest=?digest, "Failed to execute certified transaction! attempt {attempts}, {e}");
                     sleep(EXECUTION_FAILURE_RETRY_INTERVAL).await;
                 } else {
                     break;

--- a/crates/sui-core/src/authority_active/gossip/tests.rs
+++ b/crates/sui-core/src/authority_active/gossip/tests.rs
@@ -90,6 +90,7 @@ pub async fn test_gossip_after_revert() {
             state
                 .database
                 .revert_state_update(&digests[0].transaction)
+                .await
                 .unwrap();
             break;
         }
@@ -99,6 +100,7 @@ pub async fn test_gossip_after_revert() {
             state
                 .database
                 .revert_state_update(&digests[1].transaction)
+                .await
                 .unwrap();
         }
     }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -80,6 +80,7 @@ impl TransactionManager {
             let missing = self
                 .authority_store
                 .get_missing_input_objects(&digest, &cert.data().data.input_objects()?)
+                .await
                 .expect("Are shared object locks set prior to enqueueing certificates?");
 
             if missing.is_empty() {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1942,7 +1942,7 @@ async fn test_store_revert_transfer_sui() {
         .unwrap();
 
     let db = &authority_state.database;
-    db.revert_state_update(&tx_digest).unwrap();
+    db.revert_state_update(&tx_digest).await.unwrap();
 
     assert_eq!(
         db.get_object(&gas_object_id).unwrap().unwrap().owner,
@@ -2021,7 +2021,7 @@ async fn test_store_revert_wrap_move_call() {
     let wrapper_v0 = wrap_effects.created[0].0;
 
     let db = &authority_state.database;
-    db.revert_state_update(&wrap_digest).unwrap();
+    db.revert_state_update(&wrap_digest).await.unwrap();
 
     // The wrapped object is unwrapped once again (accessible from storage).
     let object = db.get_object(&object_v0.0).unwrap().unwrap();
@@ -2108,7 +2108,7 @@ async fn test_store_revert_unwrap_move_call() {
 
     let db = &authority_state.database;
 
-    db.revert_state_update(&unwrap_digest).unwrap();
+    db.revert_state_update(&unwrap_digest).await.unwrap();
 
     // The unwrapped object is wrapped once again
     assert!(db.get_object(&object_v0.0).unwrap().is_none());
@@ -2205,7 +2205,7 @@ async fn test_store_revert_add_ofield() {
     assert_eq!(inner.version(), inner_v1.1);
     assert_eq!(inner.owner, Owner::ObjectOwner(field_v0.0.into()));
 
-    db.revert_state_update(&add_digest).unwrap();
+    db.revert_state_update(&add_digest).await.unwrap();
 
     let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v0.1);
@@ -2311,7 +2311,7 @@ async fn test_store_revert_remove_ofield() {
     assert_eq!(inner.owner, Owner::AddressOwner(sender));
     assert_eq!(inner.version(), inner_v2.1);
 
-    db.revert_state_update(&remove_ofield_digest).unwrap();
+    db.revert_state_update(&remove_ofield_digest).await.unwrap();
 
     let outer = db.get_object(&outer_v0.0).unwrap().unwrap();
     assert_eq!(outer.version(), outer_v1.1);

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -817,7 +817,7 @@ impl LockService {
     /// Returns any locks from the input list that are still missing.
     pub async fn get_missing_locks(&self, objects: Vec<ObjectRef>) -> SuiResult<Vec<ObjectRef>> {
         block_on_future_in_sim(async move {
-            let (os_sender, os_receiver) = oneshot::channel::<SuiResult>();
+            let (os_sender, os_receiver) = oneshot::channel::<SuiResult<Vec<ObjectRef>>>();
             self.inner
                 .query_sender()
                 .send(LockServiceQueries::GetMissingLocks {

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -77,6 +77,10 @@ enum LockServiceQueries {
         objects: Vec<ObjectRef>,
         resp: oneshot::Sender<SuiResult>,
     },
+    GetMissingLocks {
+        objects: Vec<ObjectRef>,
+        resp: oneshot::Sender<SuiResult<Vec<ObjectRef>>>,
+    },
     GetTxSequence {
         tx: TransactionDigest,
         resp: oneshot::Sender<Result<Option<TxSequenceNumber>, SuiError>>,
@@ -196,6 +200,17 @@ impl LockServiceImpl {
                 }
             },
         )
+    }
+
+    fn get_missing_locks(&self, objects: &[ObjectRef]) -> SuiResult<Vec<ObjectRef>> {
+        let locks = self.transaction_lock.multi_get(objects)?;
+        let mut missing = Vec::new();
+        for (lock, obj_ref) in locks.into_iter().zip(objects) {
+            if lock.is_none() {
+                missing.push(*obj_ref);
+            }
+        }
+        Ok(missing)
     }
 
     /// Checks multiple object locks exist.
@@ -526,6 +541,11 @@ impl LockServiceImpl {
                         warn!("Could not respond to sender, sender dropped!");
                     }
                 }
+                LockServiceQueries::GetMissingLocks { objects, resp } => {
+                    if let Err(_e) = resp.send(self.get_missing_locks(&objects)) {
+                        warn!("Could not respond to sender, sender dropped!");
+                    }
+                }
                 LockServiceQueries::GetTxSequence { tx, resp } => {
                     if let Err(_e) = resp.send(self.get_tx_sequence(tx)) {
                         warn!("Could not respond to sender, sender dropped!");
@@ -782,6 +802,25 @@ impl LockService {
             self.inner
                 .query_sender()
                 .send(LockServiceQueries::CheckLocksExist {
+                    objects,
+                    resp: os_sender,
+                })
+                .await
+                .expect("Could not send message to inner LockService");
+            os_receiver
+                .await
+                .expect("Response from lockservice was cancelled, should not happen!")
+        })
+        .await
+    }
+
+    /// Returns any locks from the input list that are still missing.
+    pub async fn get_missing_locks(&self, objects: Vec<ObjectRef>) -> SuiResult<Vec<ObjectRef>> {
+        block_on_future_in_sim(async move {
+            let (os_sender, os_receiver) = oneshot::channel::<SuiResult>();
+            self.inner
+                .query_sender()
+                .send(LockServiceQueries::GetMissingLocks {
                     objects,
                     resp: os_sender,
                 })

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -97,6 +97,7 @@ pub struct TestClusterBuilder {
     fullnode_rpc_port: Option<u16>,
     fullnode_ws_port: Option<u16>,
     do_not_build_fullnode: bool,
+    num_validators: Option<usize>,
 }
 
 impl TestClusterBuilder {
@@ -106,6 +107,7 @@ impl TestClusterBuilder {
             fullnode_rpc_port: None,
             fullnode_ws_port: None,
             do_not_build_fullnode: false,
+            num_validators: None,
         }
     }
 
@@ -129,6 +131,11 @@ impl TestClusterBuilder {
         self
     }
 
+    pub fn with_num_validators(mut self, num: usize) -> Self {
+        self.num_validators = Some(num);
+        self
+    }
+
     pub async fn build(self) -> anyhow::Result<TestCluster> {
         let cluster = self.start_test_network_with_customized_ports().await?;
         #[cfg(msim)]
@@ -141,7 +148,9 @@ impl TestClusterBuilder {
         Ok(cluster)
     }
 
-    async fn start_test_network_with_customized_ports(self) -> Result<TestCluster, anyhow::Error> {
+    async fn start_test_network_with_customized_ports(
+        mut self,
+    ) -> Result<TestCluster, anyhow::Error> {
         // Where does wallet client connect to?
         // 1. `start_test_swarm_with_fullnodes` init the wallet to use an embedded
         //  Gateway. If `use_embedded_gateway` is true, the config remains intact.
@@ -150,7 +159,7 @@ impl TestClusterBuilder {
         // 3. Otherwise, the wallet connects to Fullnode rpc server, unless
         //   `do_not_build_fullnode` is false, in which case the wallet is connected
         //  with the initial embedded Gateway.
-        let swarm = Self::start_test_swarm_with_fullnodes(self.genesis_config).await?;
+        let swarm = self.start_test_swarm_with_fullnodes().await?;
         let working_dir = swarm.dir();
 
         let mut wallet_conf: SuiClientConfig =
@@ -195,13 +204,12 @@ impl TestClusterBuilder {
     }
 
     /// Start a Swarm and set up WalletConfig with an embedded Gateway
-    async fn start_test_swarm_with_fullnodes(
-        genesis_config: Option<GenesisConfig>,
-    ) -> Result<Swarm, anyhow::Error> {
-        let mut builder: SwarmBuilder =
-            Swarm::builder().committee_size(NonZeroUsize::new(NUM_VALIDAOTR).unwrap());
+    async fn start_test_swarm_with_fullnodes(&mut self) -> Result<Swarm, anyhow::Error> {
+        let mut builder: SwarmBuilder = Swarm::builder().committee_size(
+            NonZeroUsize::new(self.num_validators.unwrap_or(NUM_VALIDAOTR)).unwrap(),
+        );
 
-        if let Some(genesis_config) = genesis_config {
+        if let Some(genesis_config) = self.genesis_config.take() {
             builder = builder.initial_accounts_config(genesis_config);
         }
 


### PR DESCRIPTION
This fixes a race where this error could trigger:

https://github.com/MystenLabs/sui/blob/main/crates/sui-storage/src/lock_service.rs#L185-L188

The race, briefly explained: 
- tx A writes object (O1, v1), then creates the lock for that object
- tx B consumes (O1, v1) as an input
- tx manager notices that the object exists before the lock has been written
- it attempts to execute tx B
- tx B makes it through transaction_input_checker (which doesn't actually check for lock existence) and then produces this strange error.

Also included are changes I used to repro the problem in the simulator.