### PR TITLE
Enable unwind table in rust

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -11,4 +11,4 @@ xclippy = [
 xlint = "run --package x --bin x -- lint"
 
 [build]
-rustflags = ["-C", "force-frame-pointers=yes"]
+rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]


### PR DESCRIPTION
This is needed since Sui has `panic = 'abort'`. It should be another piece that helps us to get more complete stack trace in profiles. More background at https://github.com/rust-lang/rust/issues/94815