### PR TITLE
wallet-ext: use pay and paySui for transferring coins

### DIFF
--- a/.changeset/sixty-ants-switch.md
+++ b/.changeset/sixty-ants-switch.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+adds coin transfer method to framework that uses pay and paySui

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepOne.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import BigNumber from 'bignumber.js';
 import cl from 'classnames';
 import { ErrorMessage, Field, Form, useFormikContext } from 'formik';
 import { useEffect, useRef, memo } from 'react';
@@ -10,36 +11,66 @@ import Button from '_app/shared/button';
 import ActiveCoinsCard from '_components/active-coins-card';
 import Icon, { SuiIcons } from '_components/icon';
 import NumberInput from '_components/number-input';
+import { useCoinDecimals } from '_hooks';
 
 import type { FormValues } from '../';
 
 import st from './TransferCoinForm.module.scss';
 
+function parseAmount(amount: string, coinDecimals: number) {
+    try {
+        return BigInt(
+            new BigNumber(amount)
+                .shiftedBy(coinDecimals)
+                .integerValue()
+                .toString()
+        );
+    } catch (e) {
+        return BigInt(0);
+    }
+}
+
 export type TransferCoinFormProps = {
-    submitError: string | null;
-    coinBalance: string;
     coinSymbol: string;
     coinType: string;
     onClearSubmitError: () => void;
+    onAmountChanged: (amount: bigint) => void;
 };
 
 function StepOne({
-    submitError,
-    coinBalance,
     coinSymbol,
     coinType,
     onClearSubmitError,
+    onAmountChanged,
 }: TransferCoinFormProps) {
     const {
         isValid,
+        validateForm,
         values: { amount },
     } = useFormikContext<FormValues>();
-
     const onClearRef = useRef(onClearSubmitError);
     onClearRef.current = onClearSubmitError;
     useEffect(() => {
         onClearRef.current();
     }, [amount]);
+    const [coinDecimals, { isLoading: isCoinDecimalsLoading }] =
+        useCoinDecimals(coinType);
+    useEffect(() => {
+        if (!isCoinDecimalsLoading) {
+            const parsedAmount = parseAmount(amount, coinDecimals);
+            onAmountChanged(parsedAmount);
+            // seems changing the validationSchema doesn't rerun the validation for the form
+            // trigger re-validation here when the amount to send is changed
+            // (changing the amount will probably change the gasBudget and in the end the validationSchema)
+            validateForm();
+        }
+    }, [
+        amount,
+        onAmountChanged,
+        coinDecimals,
+        isCoinDecimalsLoading,
+        validateForm,
+    ]);
     return (
         <Form
             className={cl(st.container, st.amount)}

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepTwo.tsx
@@ -12,11 +12,7 @@ import AddressInput from '_components/address-input';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
 import { useCoinDecimals, useFormatCoin } from '_hooks';
-import {
-    DEFAULT_GAS_BUDGET_FOR_TRANSFER,
-    GAS_SYMBOL,
-    GAS_TYPE_ARG,
-} from '_redux/slices/sui-objects/Coin';
+import { GAS_SYMBOL, GAS_TYPE_ARG } from '_redux/slices/sui-objects/Coin';
 
 import type { FormValues } from '../';
 
@@ -24,17 +20,17 @@ import st from './TransferCoinForm.module.scss';
 
 export type TransferCoinFormProps = {
     submitError: string | null;
-    coinBalance: string;
     coinSymbol: string;
     coinType: string;
+    gasBudget: number;
     onClearSubmitError: () => void;
 };
 
 function StepTwo({
     submitError,
-    coinBalance,
     coinSymbol,
     coinType,
+    gasBudget,
     onClearSubmitError,
 }: TransferCoinFormProps) {
     const {
@@ -57,7 +53,7 @@ function StepTwo({
         [amount, decimals]
     );
 
-    const totalAmount = new BigNumber(DEFAULT_GAS_BUDGET_FOR_TRANSFER)
+    const totalAmount = new BigNumber(gasBudget)
         .plus(GAS_SYMBOL === coinSymbol ? amountWithoutDecimals : 0)
         .toString();
 
@@ -65,10 +61,7 @@ function StepTwo({
 
     const [formattedBalance] = useFormatCoin(amountWithoutDecimals, coinType);
     const [formattedTotal] = useFormatCoin(totalAmount, GAS_TYPE_ARG);
-    const [formattedGas] = useFormatCoin(
-        DEFAULT_GAS_BUDGET_FOR_TRANSFER,
-        GAS_TYPE_ARG
-    );
+    const [formattedGas] = useFormatCoin(gasBudget, GAS_TYPE_ARG);
 
     return (
         <Form className={st.container} autoComplete="off" noValidate={true}>

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -18,7 +18,8 @@ export function createValidationSchemaStepOne(
     coinSymbol: string,
     gasBalance: bigint,
     decimals: number,
-    gasDecimals: number
+    gasDecimals: number,
+    gasBudget: number
 ) {
     return Yup.object({
         amount: createTokenValidation(
@@ -27,7 +28,8 @@ export function createValidationSchemaStepOne(
             coinSymbol,
             gasBalance,
             decimals,
-            gasDecimals
+            gasDecimals,
+            gasBudget
         ),
     });
 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -10,16 +10,12 @@ import type {
     RawSigner,
     SuiAddress,
     JsonRpcProvider,
-    PayTransaction,
     SuiExecuteTransactionResponse,
 } from '@mysten/sui.js';
 
 const COIN_TYPE = '0x2::coin::Coin';
 const COIN_TYPE_ARG_REGEX = /^0x2::coin::Coin<(.+)>$/;
-export const DEFAULT_GAS_BUDGET_FOR_SPLIT = 10000;
-export const DEFAULT_GAS_BUDGET_FOR_MERGE = 10000;
-export const DEFAULT_GAS_BUDGET_FOR_TRANSFER = 100;
-export const DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI = 100;
+
 export const DEFAULT_GAS_BUDGET_FOR_PAY = 150;
 export const DEFAULT_GAS_BUDGET_FOR_STAKE = 10000;
 export const GAS_TYPE_ARG = '0x2::sui::SUI';
@@ -60,188 +56,20 @@ export class Coin {
         return `${COIN_TYPE}<${coinTypeArg}>`;
     }
 
-    /**
-     * Transfer `amount` of Coin<T> to `recipient`.
-     *
-     * @param signer A signer with connection to fullnode
-     * @param coins A list of Coins owned by the signer with the same generic type(e.g., 0x2::Sui::Sui)
-     * @param amount The amount to be transfer
-     * @param recipient The sui address of the recipient
-     */
-    public static async transferCoin(
-        signer: RawSigner,
+    public static computeGasBudgetForPay(
         coins: SuiMoveObject[],
-        amount: bigint,
-        recipient: SuiAddress
-    ): Promise<SuiExecuteTransactionResponse> {
-        const inputCoins =
-            await CoinAPI.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
-                coins,
-                amount
-            );
-        if (inputCoins.length === 0) {
-            const totalBalance = CoinAPI.totalBalance(coins);
-            throw new Error(
-                `Coin balance ${totalBalance.toString()} is not sufficient to cover the transfer amount ` +
-                    `${amount.toString()}. Try reducing the transfer amount to ${totalBalance}.`
-            );
-        }
-
-        const inputCoinIDs = inputCoins.map((c) => CoinAPI.getID(c));
-        const gasBudget = Coin.computeGasCostForPay(inputCoins.length);
-        const payTxn: PayTransaction = {
-            inputCoins: inputCoinIDs,
-            recipients: [recipient],
-            amounts: [Number(amount)],
-            gasBudget,
-            gasPayment: await Coin.selectGasPayment(
-                coins,
-                inputCoinIDs,
-                BigInt(gasBudget)
-            ),
-        };
-        return await signer.pay(payTxn);
-    }
-
-    private static computeGasCostForPay(numInputCoins: number): number {
+        amountToSend: bigint
+    ): number {
         // TODO: improve the gas budget estimation
+        const numInputCoins =
+            CoinAPI.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+                coins,
+                amountToSend
+            ).length;
         return (
             DEFAULT_GAS_BUDGET_FOR_PAY *
             Math.max(2, Math.min(100, numInputCoins / 2))
         );
-    }
-
-    private static async selectGasPayment(
-        coins: SuiMoveObject[],
-        exclude: ObjectId[],
-        amount: bigint
-    ): Promise<ObjectId> {
-        const gasPayment =
-            await CoinAPI.selectCoinWithBalanceGreaterThanOrEqual(
-                coins,
-                amount,
-                exclude
-            );
-        if (gasPayment === undefined) {
-            throw new Error(
-                `Unable to find a coin to cover the gas budget ${amount.toString()}`
-            );
-        }
-        return CoinAPI.getID(gasPayment);
-    }
-
-    /**
-     * Transfer `amount` of Coin<Sui> to `recipient`.
-     *
-     * @param signer A signer with connection to fullnode
-     * @param coins A list of Sui Coins owned by the signer
-     * @param amount The amount to be transferred
-     * @param recipient The sui address of the recipient
-     */
-    public static async transferSui(
-        signer: RawSigner,
-        coins: SuiMoveObject[],
-        amount: bigint,
-        recipient: SuiAddress
-    ): Promise<SuiExecuteTransactionResponse> {
-        const targetAmount =
-            amount + BigInt(DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI);
-        const coinsWithSufficientAmount =
-            await CoinAPI.selectCoinsWithBalanceGreaterThanOrEqual(
-                coins,
-                targetAmount
-            );
-        if (coinsWithSufficientAmount.length > 0) {
-            const txn = {
-                suiObjectId: CoinAPI.getID(coinsWithSufficientAmount[0]),
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI,
-                recipient: recipient,
-                amount: Number(amount),
-            };
-            return await signer.transferSui(txn);
-        }
-
-        // TODO: use PaySui Transaction when it is ready
-        // If there is not a coin with sufficient balance, use the pay API
-        const gasCostForPay = Coin.computeGasCostForPay(coins.length);
-        let inputCoins = await Coin.assertAndGetCoinsWithBalanceGte(
-            coins,
-            amount,
-            gasCostForPay
-        );
-
-        // In this case, all coins are needed to cover the transfer amount plus gas budget, leaving
-        // no coins for gas payment. This won't be a problem once we introduce `PaySui`. But for now,
-        // we address this case by splitting an extra coin.
-        if (inputCoins.length === coins.length) {
-            // We need to pay for an additional `transferSui` transaction now, assert that we have sufficient balance
-            // to cover the additional cost
-            await Coin.assertAndGetCoinsWithBalanceGte(
-                coins,
-                amount,
-                gasCostForPay + DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI
-            );
-
-            // Split the gas budget from the coin with largest balance for simplicity. We can also use any coin
-            // that has amount greater than or equal to `DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI * 2`
-            const coinWithLargestBalance = inputCoins[inputCoins.length - 1];
-
-            if (
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                CoinAPI.getBalance(coinWithLargestBalance)! <
-                gasCostForPay + DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI
-            ) {
-                throw new Error(
-                    `None of the coins has sufficient balance to cover gas fee`
-                );
-            }
-
-            const txn = {
-                suiObjectId: CoinAPI.getID(coinWithLargestBalance),
-                gasBudget: DEFAULT_GAS_BUDGET_FOR_TRANSFER_SUI,
-                recipient: await signer.getAddress(),
-                amount: gasCostForPay,
-            };
-            await signer.transferSui(txn);
-
-            inputCoins =
-                await signer.provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
-                    await signer.getAddress(),
-                    amount,
-                    SUI_TYPE_ARG,
-                    []
-                );
-        }
-        const txn = {
-            inputCoins: inputCoins.map((c) => CoinAPI.getID(c)),
-            recipients: [recipient],
-            amounts: [Number(amount)],
-            gasBudget: gasCostForPay,
-        };
-        return await signer.pay(txn);
-    }
-
-    private static async assertAndGetCoinsWithBalanceGte(
-        coins: SuiMoveObject[],
-        amount: bigint,
-        gasBudget?: number
-    ) {
-        const inputCoins =
-            await CoinAPI.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
-                coins,
-                amount + BigInt(gasBudget ?? 0)
-            );
-        if (inputCoins.length === 0) {
-            const totalBalance = CoinAPI.totalBalance(coins);
-            const maxTransferAmount = totalBalance - BigInt(gasBudget ?? 0);
-            const gasText = gasBudget ? ` plus gas budget ${gasBudget}` : '';
-            throw new Error(
-                `Coin balance ${totalBalance.toString()} is not sufficient to cover the transfer amount ` +
-                    `${amount.toString()}${gasText}. ` +
-                    `Try reducing the transfer amount to ${maxTransferAmount.toString()}.`
-            );
-        }
-        return inputCoins;
     }
 
     /**
@@ -289,11 +117,13 @@ export class Coin {
             return coinWithExactAmount;
         }
         // use transferSui API to get a coin with the exact amount
-        await Coin.transferSui(
+        await CoinAPI.transfer(
             signer,
             coins,
+            SUI_TYPE_ARG,
             amount,
-            await signer.getAddress()
+            await signer.getAddress(),
+            Coin.computeGasBudgetForPay(coins, amount)
         );
 
         const coinWithExactAmount2 = await Coin.selectSuiCoinWithExactAmount(

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -1,13 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getTransactionDigest, isSuiMoveObject } from '@mysten/sui.js';
+import {
+    getTransactionDigest,
+    isSuiMoveObject,
+    Coin as CoinAPI,
+} from '@mysten/sui.js';
 import {
     createAsyncThunk,
     createEntityAdapter,
     createSlice,
 } from '@reduxjs/toolkit';
 
+import { accountCoinsSelector } from '_redux/slices/account';
 import {
     fetchAllOwnedAndRequiredObjects,
     suiObjectsAdapterSelectors,
@@ -40,35 +45,23 @@ export const sendTokens = createAsyncThunk<
         { getState, extra: { api, keypairVault }, dispatch }
     ) => {
         const state = getState();
-        const coinType = Coin.getCoinTypeFromArg(tokenTypeArg);
-        const coins: SuiMoveObject[] = suiObjectsAdapterSelectors
-            .selectAll(state)
-            .filter(
-                (anObj) =>
-                    isSuiMoveObject(anObj.data) && anObj.data.type === coinType
-            )
-            .map(({ data }) => data as SuiMoveObject);
-
+        const coins: SuiMoveObject[] = accountCoinsSelector(state);
         const signer = api.getSignerInstance(keypairVault.getKeyPair());
-
-        const response =
-            Coin.getCoinSymbol(tokenTypeArg) === 'SUI'
-                ? await Coin.transferSui(
-                      signer,
-                      coins,
-                      amount,
-                      recipientAddress
-                  )
-                : await Coin.transferCoin(
-                      signer,
-                      coins,
-                      amount,
-                      recipientAddress
-                  );
-
+        const response = await CoinAPI.transfer(
+            signer,
+            coins,
+            tokenTypeArg,
+            amount,
+            recipientAddress,
+            Coin.computeGasBudgetForPay(
+                coins.filter(
+                    (aCoin) => Coin.getCoinTypeArg(aCoin) === tokenTypeArg
+                ),
+                amount
+            )
+        );
         // TODO: better way to sync latest objects
         dispatch(fetchAllOwnedAndRequiredObjects());
-        // TODO: is this correct? Find a better way to do it
         return response;
     }
 );

--- a/apps/wallet/src/ui/app/staking/stake/validation.ts
+++ b/apps/wallet/src/ui/app/staking/stake/validation.ts
@@ -3,7 +3,11 @@
 
 import * as Yup from 'yup';
 
-import { GAS_TYPE_ARG, GAS_SYMBOL } from '_redux/slices/sui-objects/Coin';
+import {
+    GAS_TYPE_ARG,
+    GAS_SYMBOL,
+    DEFAULT_GAS_BUDGET_FOR_STAKE,
+} from '_redux/slices/sui-objects/Coin';
 import { createTokenValidation } from '_src/shared/validation';
 
 export function createValidationSchema(
@@ -22,7 +26,8 @@ export function createValidationSchema(
             coinSymbol,
             gasBalance,
             decimals,
-            gasDecimals
+            gasDecimals,
+            DEFAULT_GAS_BUDGET_FOR_STAKE
         ).test(
             'num-gas-coins-check',
             `Need at least 2 ${GAS_SYMBOL} coins to stake a ${GAS_SYMBOL} coin`,

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -206,14 +206,13 @@ export class Coin {
 
   /**
    * Creates and executes a transaction to transfer coins to a recipient address.
-   * see {@link Coin.newTransferTx}
-   * @param signer
-   * @param allCoins
-   * @param coinTypeArg
-   * @param amountToSend
-   * @param recipient
-   * @param gasBudget
-   * @returns
+   * @param signer User's signer
+   * @param allCoins All the coins that are owned by the user. Can be only the relevant type of coins for the transfer, Sui for gas and the coins with the same type as the type to send.
+   * @param coinTypeArg The coin type argument (Coin<T> the T) of the coin to send
+   * @param amountToSend Total amount to send to recipient
+   * @param recipient Recipient's address
+   * @param gasBudget Gas budget for the tx
+   * @throws in case of insufficient funds, network errors etc
    */
   public static async transfer(
     signer: SignerWithProvider,
@@ -235,7 +234,7 @@ export class Coin {
   }
 
   /**
-   * Create a new transaction for sending coins ready to be singed and executed.
+   * Create a new transaction for sending coins ready to be signed and executed.
    * @param signer User's signer
    * @param allCoins All the coins that are owned by the user. Can be only the relevant type of coins for the transfer, Sui for gas and the coins with the same type as the type to send.
    * @param coinTypeArg The coin type argument (Coin<T> the T) of the coin to send


### PR DESCRIPTION
* ts-sdk: add transfer functionality to framework coin
* wallet-ext: use pay and paySui for transferring coins


https://user-images.githubusercontent.com/10210143/202043796-51dedd55-6a80-4fc6-acb1-99a69819302d.mov


closes APPS-128
