### PR TITLE
[reconfig] Initial reconfiguration APIs for checkpoint v2

### DIFF
--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -43,10 +43,6 @@ pub struct TransactionNotifier {
     notify: Notify,
     has_stream: AtomicBool,
     is_closed: AtomicBool,
-    /// Indicate that we would temporarily stop giving out new tickets, due to epoch change.
-    /// In special cases (i.e. executing known-to-be-finalized transactions) we will bypass
-    /// this.
-    is_paused: AtomicBool,
     inner: Mutex<LockedNotifier>,
     notifier_metrics: TransactionNotifierMetrics,
 }
@@ -69,7 +65,6 @@ impl TransactionNotifier {
             notify: Notify::new(),
             has_stream: AtomicBool::new(false),
             is_closed: AtomicBool::new(false),
-            is_paused: AtomicBool::new(false),
 
             // Keep a set of the tickets that are still being processed
             // This is the size of the number of concurrent processes.
@@ -102,42 +97,10 @@ impl TransactionNotifier {
         self.notify.notify_one();
     }
 
-    pub fn pause(&self) {
-        self.is_paused.store(true, Ordering::SeqCst);
-    }
-
-    pub fn unpause(&self) {
-        self.is_paused.store(false, Ordering::SeqCst);
-    }
-
-    pub fn is_paused(&self) -> bool {
-        self.is_paused.load(Ordering::SeqCst)
-    }
-
-    /// Check that we have drained all tickets (i.e. low watermark reached high watermark).
-    /// Return the watermark if we have drained.
-    pub fn ticket_drained(&self) -> Option<u64> {
-        // Hold the lock till the end of the function to ensure there is no data race.
-        // This is just to be safe, high_watermark is not expected to be changing when this function
-        // is being called.
-        let lock = self.inner.lock();
-        let high_watermark = lock.high_watermark;
-        let low_watermark = self.low_watermark.load(Ordering::SeqCst);
-        if high_watermark == low_watermark {
-            Some(high_watermark)
-        } else {
-            debug!(?high_watermark, ?low_watermark, "Ticket not drained yet.");
-            None
-        }
-    }
-
     /// Get a ticket with a sequence number
-    pub fn ticket(self: &Arc<Self>, bypass_pause: bool) -> SuiResult<TransactionNotifierTicket> {
+    pub fn ticket(self: &Arc<Self>) -> SuiResult<TransactionNotifierTicket> {
         if self.is_closed.load(Ordering::SeqCst) {
             return Err(SuiError::ClosedNotifierError);
-        }
-        if !bypass_pause && self.is_paused() {
-            return Err(SuiError::ValidatorHaltedAtEpochEnd);
         }
 
         let mut inner = self.inner.lock();
@@ -308,19 +271,19 @@ mod tests {
         // TEST 1: Happy sequence
 
         {
-            let t0 = notifier.ticket(false).expect("ok");
+            let t0 = notifier.ticket().expect("ok");
             store.side_sequence(t0.seq(), &ExecutionDigests::random());
             t0.notify();
         }
 
         {
-            let t0 = notifier.ticket(false).expect("ok");
+            let t0 = notifier.ticket().expect("ok");
             store.side_sequence(t0.seq(), &ExecutionDigests::random());
             t0.notify();
         }
 
         {
-            let t0 = notifier.ticket(false).expect("ok");
+            let t0 = notifier.ticket().expect("ok");
             store.side_sequence(t0.seq(), &ExecutionDigests::random());
             t0.notify();
         }
@@ -344,13 +307,13 @@ mod tests {
         // TEST 2: Drop a ticket
 
         {
-            let t0 = notifier.ticket(false).expect("ok");
+            let t0 = notifier.ticket().expect("ok");
             assert_eq!(t0.seq(), 3);
             t0.notify();
         }
 
         {
-            let t0 = notifier.ticket(false).expect("ok");
+            let t0 = notifier.ticket().expect("ok");
             store.side_sequence(t0.seq(), &ExecutionDigests::random());
             t0.notify();
         }
@@ -364,10 +327,10 @@ mod tests {
 
         // TEST 3: Drop & out of order
 
-        let t5 = notifier.ticket(false).expect("ok");
-        let t6 = notifier.ticket(false).expect("ok");
-        let t7 = notifier.ticket(false).expect("ok");
-        let t8 = notifier.ticket(false).expect("ok");
+        let t5 = notifier.ticket().expect("ok");
+        let t6 = notifier.ticket().expect("ok");
+        let t7 = notifier.ticket().expect("ok");
+        let t8 = notifier.ticket().expect("ok");
 
         store.side_sequence(t6.seq(), &ExecutionDigests::random());
         t6.notify();

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -151,6 +151,8 @@ pub struct AuthorityPerpetualTables<S> {
 
     /// A sequence of batches indexing into the sequence of executed transactions.
     pub batches: DBMap<TxSequenceNumber, SignedBatch>,
+
+    pub reconfig_state: DBMap<u64, ReconfigState>,
 }
 
 impl<S> AuthorityPerpetualTables<S>

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -376,13 +376,7 @@ impl ValidatorService {
         let certificate = certificate.verify(&state.committee.load())?;
         drop(cert_verif_metrics_guard);
 
-        // 3) If the validator is already halted, we stop here, to avoid
-        // sending the transaction to consensus.
-        if state.is_halted() && !certificate.data().data.kind.is_system_tx() {
-            return Err(tonic::Status::from(SuiError::ValidatorHaltedAtEpochEnd));
-        }
-
-        // 4) All certificates are sent to consensus (at least by some authorities)
+        // 3) All certificates are sent to consensus (at least by some authorities)
         // For shared objects this will wait until either timeout or we have heard back from consensus.
         // For owned objects this will return without waiting for certificate to be sequenced
         // First do quick dirty non-async check
@@ -405,7 +399,7 @@ impl ValidatorService {
                 .await?;
         }
 
-        // 5) Execute the certificate.
+        // 4) Execute the certificate.
         // Often we cannot execute a cert due to dependenties haven't been executed, and we will
         // observe TransactionInputObjectsErrors. In such case, we can wait and retry. It should eventually
         // succeed.

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -255,8 +255,16 @@ impl ConsensusAdapter {
                 .as_ref()
                 .map(|m| m.sequencing_acknowledge_latency.start_timer());
 
-            // todo - we need stronger guarantees for checkpoints here (issue #5763)
-            // todo - for owned objects this can also be done async
+            // TODO - we need stronger guarantees for checkpoints here (issue #5763)
+            // TODO - for owned objects this can also be done async
+            //
+            // TODO: Somewhere here we check whether we should have stopped sending transactions
+            // to consensus due to epoch boundary.
+            // For normal transactions, we call state.get_reconfig_state_read_lock_guard first
+            // to hold the guard before sending the transaction;
+            // For the last EndOfPublish message, we call state.get_reconfig_state_write_lock_guard
+            // to hold the guard before sending the last message, and then call
+            // state.close_user_certs with the guard.
             self.consensus_client
                 .submit_to_consensus(&transaction)
                 .await?;

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -217,7 +217,7 @@ async fn test_batch_manager_happy_path() {
 
     // Send a transaction.
     {
-        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t0 = authority_state.batch_notifier.ticket().expect("ok");
         store.side_sequence(t0.seq(), &ExecutionDigests::random());
         t0.notify();
     }
@@ -233,7 +233,7 @@ async fn test_batch_manager_happy_path() {
     assert!(matches!(rx.recv().await.unwrap(), UpdateItem::Batch(_)));
 
     {
-        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t0 = authority_state.batch_notifier.ticket().expect("ok");
         store.side_sequence(t0.seq(), &ExecutionDigests::random());
         t0.notify();
     }
@@ -290,10 +290,10 @@ async fn test_batch_manager_out_of_order() {
     let mut rx = authority_state.subscribe_batch();
 
     {
-        let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
-        let t1 = authority_state.batch_notifier.ticket(false).expect("ok");
-        let t2 = authority_state.batch_notifier.ticket(false).expect("ok");
-        let t3 = authority_state.batch_notifier.ticket(false).expect("ok");
+        let t0 = authority_state.batch_notifier.ticket().expect("ok");
+        let t1 = authority_state.batch_notifier.ticket().expect("ok");
+        let t2 = authority_state.batch_notifier.ticket().expect("ok");
+        let t3 = authority_state.batch_notifier.ticket().expect("ok");
 
         store.side_sequence(t1.seq(), &ExecutionDigests::random());
         store.side_sequence(t3.seq(), &ExecutionDigests::random());
@@ -361,10 +361,10 @@ async fn test_batch_manager_drop_out_of_order() {
     // Send transactions out of order
     let mut rx = authority_state.subscribe_batch();
 
-    let t0 = authority_state.batch_notifier.ticket(false).expect("ok");
-    let t1 = authority_state.batch_notifier.ticket(false).expect("ok");
-    let t2 = authority_state.batch_notifier.ticket(false).expect("ok");
-    let t3 = authority_state.batch_notifier.ticket(false).expect("ok");
+    let t0 = authority_state.batch_notifier.ticket().expect("ok");
+    let t1 = authority_state.batch_notifier.ticket().expect("ok");
+    let t2 = authority_state.batch_notifier.ticket().expect("ok");
+    let t3 = authority_state.batch_notifier.ticket().expect("ok");
 
     store.side_sequence(t1.seq(), &ExecutionDigests::random());
     t1.notify();

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -90,7 +90,7 @@ async fn test_subscription() {
 
     let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
-        let ticket = state.batch_notifier.ticket(false).expect("all good");
+        let ticket = state.batch_notifier.ticket().expect("all good");
         db.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
@@ -142,10 +142,7 @@ async fn test_subscription() {
     let _handle2 = tokio::spawn(async move {
         for i in 105..120 {
             tokio::time::sleep(Duration::from_millis(20)).await;
-            let ticket = inner_server2
-                .batch_notifier
-                .ticket(false)
-                .expect("all good");
+            let ticket = inner_server2.batch_notifier.ticket().expect("all good");
             db2.perpetual_tables
                 .executed_sequence
                 .insert(&ticket.seq(), &tx_zero)
@@ -220,10 +217,7 @@ async fn test_subscription() {
 
     loop {
         // Send a transaction
-        let ticket = inner_server2
-            .batch_notifier
-            .ticket(false)
-            .expect("all good");
+        let ticket = inner_server2.batch_notifier.ticket().expect("all good");
         db3.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
@@ -297,7 +291,7 @@ async fn test_subscription_safe_client() {
 
     let tx_zero = ExecutionDigests::random();
     for _i in 0u64..105 {
-        let ticket = server.state.batch_notifier.ticket(false).expect("all good");
+        let ticket = server.state.batch_notifier.ticket().expect("all good");
         db.perpetual_tables
             .executed_sequence
             .insert(&ticket.seq(), &tx_zero)
@@ -359,7 +353,7 @@ async fn test_subscription_safe_client() {
             let ticket = inner_server2
                 .state
                 .batch_notifier
-                .ticket(false)
+                .ticket()
                 .expect("all good");
             db2.perpetual_tables
                 .executed_sequence
@@ -433,7 +427,7 @@ async fn test_subscription_safe_client() {
         let ticket = inner_server2
             .state
             .batch_notifier
-            .ticket(false)
+            .ticket()
             .expect("all good");
         db3.perpetual_tables
             .executed_sequence


### PR DESCRIPTION
This PR adds the following:
1. A ReconfigState and a set of APIs that would allow us to stop accepting user certs and consensus certs. The checks are also put in the right place. We just need to activate them at the right time.
2. A boolean value added to the checkpoint interfaces to indicate that it's the last checkpoint of the epoch.