### PR TITLE
[DynamicField] Make hash_type_and_key public

### DIFF
--- a/crates/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/sources/dynamic_field.move
@@ -135,7 +135,7 @@ public(friend) fun field_ids<Name: copy + drop + store>(
     (object::uid_to_address(&field.id), object::id_to_address(&option::destroy_some(field.value)))
 }
 
-public(friend) native fun hash_type_and_key<K: copy + drop + store>(parent: address, k: K): address;
+public native fun hash_type_and_key<K: copy + drop + store>(parent: address, k: K): address;
 
 public(friend) native fun add_child_object<Child: key>(parent: address, child: Child);
 


### PR DESCRIPTION
This function should be public for smart contracts to use.

`sui::bag::add` does not return the id of the newly created object.

We hope to calculate the id of the new object through `hash_type_and_key` and store it in the event.