### PR TITLE
wallet-ext: improve gas estimations for nft and coin transfers 

### DIFF
--- a/.changeset/brown-bears-count.md
+++ b/.changeset/brown-bears-count.md
@@ -1,0 +1,6 @@
+---
+"@mysten/sui.js": minor
+---
+
+- adds method to estimate gas cost and suggested gas budget to signer
+- fixes edge cases with pay txs

--- a/apps/wallet/src/ui/app/hooks/index.ts
+++ b/apps/wallet/src/ui/app/hooks/index.ts
@@ -17,3 +17,4 @@ export { useObjectsState } from './useObjectsState';
 export { useWaitForElement } from './useWaitForElement';
 export { useFormatCoin, useCoinDecimals } from './useFormatCoin';
 export * from './useSigner';
+export * from './useIndividualCoinMaxBalance';

--- a/apps/wallet/src/ui/app/hooks/useIndividualCoinMaxBalance.ts
+++ b/apps/wallet/src/ui/app/hooks/useIndividualCoinMaxBalance.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import useAppSelector from './useAppSelector';
+import { accountItemizedBalancesSelector } from '_redux/slices/account';
+
+export function useIndividualCoinMaxBalance(coinTypeArg: string) {
+    const allCoins = useAppSelector(accountItemizedBalancesSelector);
+    const maxGasCoinBalance = useMemo(
+        () =>
+            allCoins[coinTypeArg]?.reduce(
+                (max, aBalance) => (max < aBalance ? aBalance : max),
+                BigInt(0)
+            ) || BigInt(0),
+        [allCoins, coinTypeArg]
+    );
+    return maxGasCoinBalance;
+}

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.module.scss
@@ -49,10 +49,6 @@
     }
 }
 
-.error {
-    @include utils.error-message-box;
-}
-
 .muted {
     font-size: 12px;
     font-weight: 400;

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.tsx
@@ -1,43 +1,39 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQuery } from '@tanstack/react-query';
+import { SUI_TYPE_ARG } from '@mysten/sui.js';
 import cl from 'classnames';
 import { Form, Field, useFormikContext } from 'formik';
-import { useEffect, useRef, memo, useMemo } from 'react';
+import { useEffect, useRef, memo } from 'react';
 
 import { Content } from '_app/shared/bottom-menu-layout';
 import Button from '_app/shared/button';
 import AddressInput from '_components/address-input';
+import Alert from '_components/alert';
 import Icon, { SuiIcons } from '_components/icon';
 import LoadingIndicator from '_components/loading/LoadingIndicator';
-import { useAppSelector, useSigner } from '_hooks';
-import { accountAggregateBalancesSelector } from '_redux/slices/account';
-import {
-    DEFAULT_NFT_TRANSFER_GAS_FEE,
-    GAS_TYPE_ARG,
-} from '_redux/slices/sui-objects/Coin';
+import { useIndividualCoinMaxBalance } from '_hooks';
 
 import type { FormValues } from '.';
-import type { ObjectId } from '@mysten/sui.js';
 
 import st from './TransferNFTForm.module.scss';
 
 export type TransferNFTFormProps = {
-    nftID: ObjectId;
     submitError: string | null;
+    gasBudget: number | null;
+    isGasEstimationLoading: boolean;
     onClearSubmitError: () => void;
 };
 
 function TransferNFTForm({
-    nftID,
     submitError,
+    gasBudget,
+    isGasEstimationLoading,
     onClearSubmitError,
 }: TransferNFTFormProps) {
     const {
         isSubmitting,
         isValid,
-        isValidating,
         values: { to },
     } = useFormikContext<FormValues>();
     const onClearRef = useRef(onClearSubmitError);
@@ -45,36 +41,9 @@ function TransferNFTForm({
     useEffect(() => {
         onClearRef.current();
     }, [to]);
-    const aggregateBalances = useAppSelector(accountAggregateBalancesSelector);
-    const gasAggregateBalance = useMemo(
-        () => aggregateBalances[GAS_TYPE_ARG] || BigInt(0),
-        [aggregateBalances]
-    );
-    const signer = useSigner();
-    const gasEstimationEnabled = !!(isValid && !isValidating && nftID && to);
-    const gasEstimationResult = useQuery({
-        queryKey: ['nft-transfer', nftID, 'gas-estimation', to],
-        queryFn: async () => {
-            const tx = await signer.serializer.serializeToBytes(
-                await signer.getAddress(),
-                {
-                    kind: 'transferObject',
-                    data: {
-                        objectId: nftID,
-                        recipient: to,
-                        gasBudget: DEFAULT_NFT_TRANSFER_GAS_FEE,
-                    },
-                }
-            );
-            return signer.getGasCostEstimation(tx);
-        },
-        enabled: gasEstimationEnabled,
-    });
-    const gasEstimation = gasEstimationResult.isError
-        ? DEFAULT_NFT_TRANSFER_GAS_FEE
-        : gasEstimationResult.data ?? null; // make undefined null
+    const maxGasCoinBalance = useIndividualCoinMaxBalance(SUI_TYPE_ARG);
     const isInsufficientGas =
-        gasEstimation !== null ? gasAggregateBalance < gasEstimation : null;
+        gasBudget !== null ? maxGasCoinBalance < BigInt(gasBudget) : null;
     return (
         <div className={st.sendNft}>
             <Content>
@@ -98,12 +67,18 @@ function TransferNFTForm({
                         />
                     </div>
                     {isInsufficientGas ? (
-                        <div className={st.error}>
-                            * Insufficient balance to cover transfer cost
+                        <div className="mt-2.5">
+                            <Alert>
+                                Insufficient balance, no individual coin found
+                                with enough balance to cover for the transfer
+                                cost
+                            </Alert>
                         </div>
                     ) : null}
                     {submitError ? (
-                        <div className={st.error}>{submitError}</div>
+                        <div className="mt-2.5">
+                            <Alert>{submitError}</Alert>
+                        </div>
                     ) : null}
                     <div className={st.formcta}>
                         <Button
@@ -114,13 +89,12 @@ function TransferNFTForm({
                                 !isValid ||
                                 isSubmitting ||
                                 isInsufficientGas ||
-                                gasEstimationResult.isLoading
+                                isGasEstimationLoading ||
+                                gasBudget === null
                             }
                             className={cl(st.action, 'btn', st.sendNftBtn)}
                         >
-                            {isSubmitting ||
-                            (gasEstimationEnabled &&
-                                gasEstimationResult.isLoading) ? (
+                            {isSubmitting || isGasEstimationLoading ? (
                                 <LoadingIndicator />
                             ) : (
                                 <>

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/useGasEstimation.ts
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/useGasEstimation.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { SUI_TYPE_ARG } from '@mysten/sui.js';
+import { useQuery } from '@tanstack/react-query';
+
+import { useSigner, useIndividualCoinMaxBalance } from '_hooks';
+
+import type { ObjectId } from '@mysten/sui.js';
+
+export function useGasEstimation(objectId: ObjectId | null) {
+    const suiCoinMaxBalance = useIndividualCoinMaxBalance(SUI_TYPE_ARG);
+    const signer = useSigner();
+    const estimationResult = useQuery({
+        queryKey: [
+            'gas-estimation',
+            'nft-transfer',
+            objectId,
+            suiCoinMaxBalance.toString(),
+        ],
+        queryFn: async () => {
+            const address = await signer.getAddress();
+            return await signer.getGasCostEstimationAndSuggestedBudget(
+                'transferObject',
+                async (gasBudget) => [
+                    await signer.serializer.serializeToBytes(address, {
+                        kind: 'transferObject',
+                        data: {
+                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                            objectId: objectId!,
+                            recipient: address, // gas cost is the same regardless the recipient
+                            gasBudget,
+                        },
+                    }),
+                ],
+                suiCoinMaxBalance
+            );
+        },
+        enabled: !!objectId,
+    });
+    return [
+        estimationResult.data?.suggestedGasBudget ?? null,
+        estimationResult.data?.gasCostEstimation ?? null,
+        estimationResult.isLoading,
+    ] as const;
+}

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepOne.tsx
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/StepOne.tsx
@@ -1,14 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import BigNumber from 'bignumber.js';
 import cl from 'classnames';
-import { ErrorMessage, Field, Form, useFormikContext } from 'formik';
+import { Field, Form, useFormikContext } from 'formik';
 import { useEffect, useRef, memo } from 'react';
 
+import { parseAmount } from './utils';
 import { Content, Menu } from '_app/shared/bottom-menu-layout';
 import Button from '_app/shared/button';
 import ActiveCoinsCard from '_components/active-coins-card';
+import Alert from '_components/alert';
 import Icon, { SuiIcons } from '_components/icon';
 import NumberInput from '_components/number-input';
 import { useCoinDecimals } from '_hooks';
@@ -16,19 +17,6 @@ import { useCoinDecimals } from '_hooks';
 import type { FormValues } from '../';
 
 import st from './TransferCoinForm.module.scss';
-
-function parseAmount(amount: string, coinDecimals: number) {
-    try {
-        return BigInt(
-            new BigNumber(amount)
-                .shiftedBy(coinDecimals)
-                .integerValue()
-                .toString()
-        );
-    } catch (e) {
-        return BigInt(0);
-    }
-}
 
 export type TransferCoinFormProps = {
     coinSymbol: string;
@@ -47,6 +35,8 @@ function StepOne({
         isValid,
         validateForm,
         values: { amount },
+        errors,
+        touched,
     } = useFormikContext<FormValues>();
     const onClearRef = useRef(onClearSubmitError);
     onClearRef.current = onClearSubmitError;
@@ -88,12 +78,11 @@ function StepOne({
                         className={st.input}
                         decimals
                     />
-
-                    <ErrorMessage
-                        className={st.error}
-                        name="amount"
-                        component="div"
-                    />
+                    {errors['amount'] && touched['amount'] ? (
+                        <div className="mt-[10px]">
+                            <Alert>{errors['amount']}</Alert>
+                        </div>
+                    ) : null}
                 </div>
                 <div className={st.activeCoinCard}>
                     <ActiveCoinsCard activeCoinType={coinType} />

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/TransferCoinForm.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/TransferCoinForm.module.scss
@@ -45,10 +45,6 @@
     color: colors.$gray-80;
 }
 
-.error {
-    @include utils.error-message-box;
-}
-
 .muted {
     font-size: 10px;
     font-weight: 400;

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/utils.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/TransferCoinForm/utils.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import BigNumber from 'bignumber.js';
+
+export function parseAmount(amount: string, coinDecimals: number) {
+    try {
+        return BigInt(
+            new BigNumber(amount)
+                .shiftedBy(coinDecimals)
+                .integerValue()
+                .toString()
+        );
+    } catch (e) {
+        return BigInt(0);
+    }
+}

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/useGasBudgetEstimation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/useGasBudgetEstimation.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Coin, SUI_TYPE_ARG } from '@mysten/sui.js';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAppSelector, useIndividualCoinMaxBalance, useSigner } from '_hooks';
+import { accountCoinsSelector } from '_redux/slices/account';
+
+export function useGasBudgetEstimation(
+    coinTypeArg: string | null,
+    amountToSend: bigint
+) {
+    const signer = useSigner();
+    const suiCoinMaxBalance = useIndividualCoinMaxBalance(SUI_TYPE_ARG);
+    const allCoins = useAppSelector(accountCoinsSelector);
+    const enabled = amountToSend > 0 && !!coinTypeArg;
+    const estimationResult = useQuery({
+        queryKey: [
+            'gas-estimation',
+            'nft-transfer',
+            coinTypeArg,
+            suiCoinMaxBalance.toString(),
+            amountToSend.toString(),
+        ],
+        queryFn: async () => {
+            return await Coin.getGasCostEstimationAndSuggestedBudget(
+                signer,
+                allCoins,
+                coinTypeArg || '',
+                amountToSend,
+                await signer.getAddress(), // any address will have the same gas cost
+                suiCoinMaxBalance
+            );
+        },
+        enabled,
+    });
+    return [
+        estimationResult.data?.suggestedGasBudget ?? null,
+        estimationResult.data?.gasCostEstimation ?? null,
+        estimationResult.isLoading,
+        suiCoinMaxBalance,
+        estimationResult.data?.insufficientGas ?? false,
+    ] as const;
+}

--- a/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
+++ b/apps/wallet/src/ui/app/pages/home/transfer-coin/validation.ts
@@ -13,23 +13,9 @@ export function createValidationSchemaStepTwo() {
 }
 
 export function createValidationSchemaStepOne(
-    coinType: string,
-    coinBalance: bigint,
-    coinSymbol: string,
-    gasBalance: bigint,
-    decimals: number,
-    gasDecimals: number,
-    gasBudget: number
+    ...args: Parameters<typeof createTokenValidation>
 ) {
     return Yup.object({
-        amount: createTokenValidation(
-            coinType,
-            coinBalance,
-            coinSymbol,
-            gasBalance,
-            decimals,
-            gasDecimals,
-            gasBudget
-        ),
+        amount: createTokenValidation(...args),
     });
 }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -16,10 +16,7 @@ import {
     createSlice,
 } from '@reduxjs/toolkit';
 
-import {
-    DEFAULT_NFT_TRANSFER_GAS_FEE,
-    SUI_SYSTEM_STATE_OBJECT_ID,
-} from './Coin';
+import { SUI_SYSTEM_STATE_OBJECT_ID } from './Coin';
 import { ExampleNFT } from './NFT';
 
 import type { SuiObject, SuiAddress, ObjectId } from '@mysten/sui.js';
@@ -108,15 +105,11 @@ type NFTTxResponse = {
 
 export const transferNFT = createAsyncThunk<
     NFTTxResponse,
-    { nftId: ObjectId; recipientAddress: SuiAddress },
+    { objectId: ObjectId; recipient: SuiAddress; gasBudget: number },
     AppThunkConfig
 >('transferNFT', async (data, { extra: { api, keypairVault }, dispatch }) => {
     const signer = api.getSignerInstance(keypairVault.getKeypair());
-    const txn = await signer.transferObject({
-        objectId: data.nftId,
-        recipient: data.recipientAddress,
-        gasBudget: DEFAULT_NFT_TRANSFER_GAS_FEE,
-    });
+    const txn = await signer.transferObject(data);
     await dispatch(fetchAllOwnedAndRequiredObjects());
     const txnResp = {
         timestamp_ms: getTimestampFromTransactionResponse(txn),

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -31,6 +31,7 @@ type SendTokensTXArgs = {
     tokenTypeArg: string;
     amount: bigint;
     recipientAddress: SuiAddress;
+    gasBudget: number;
 };
 type TransactionResult = SuiExecuteTransactionResponse;
 
@@ -41,7 +42,7 @@ export const sendTokens = createAsyncThunk<
 >(
     'sui-objects/send-tokens',
     async (
-        { tokenTypeArg, amount, recipientAddress },
+        { tokenTypeArg, amount, recipientAddress, gasBudget },
         { getState, extra: { api, keypairVault }, dispatch }
     ) => {
         const state = getState();
@@ -53,12 +54,7 @@ export const sendTokens = createAsyncThunk<
             tokenTypeArg,
             amount,
             recipientAddress,
-            Coin.computeGasBudgetForPay(
-                coins.filter(
-                    (aCoin) => Coin.getCoinTypeArg(aCoin) === tokenTypeArg
-                ),
-                amount
-            )
+            gasBudget
         );
         // TODO: better way to sync latest objects
         dispatch(fetchAllOwnedAndRequiredObjects());
@@ -69,6 +65,7 @@ export const sendTokens = createAsyncThunk<
 type StakeTokensTXArgs = {
     tokenTypeArg: string;
     amount: bigint;
+    suiMaxCoinBalance: bigint;
 };
 
 export const StakeTokens = createAsyncThunk<
@@ -78,7 +75,7 @@ export const StakeTokens = createAsyncThunk<
 >(
     'sui-objects/stake',
     async (
-        { tokenTypeArg, amount },
+        { tokenTypeArg, amount, suiMaxCoinBalance },
         { getState, extra: { api, keypairVault }, dispatch }
     ) => {
         const state = getState();
@@ -104,7 +101,8 @@ export const StakeTokens = createAsyncThunk<
             api.getSignerInstance(keypairVault.getKeypair()),
             coins,
             amount,
-            validatorAddress
+            validatorAddress,
+            suiMaxCoinBalance
         );
         dispatch(fetchAllOwnedAndRequiredObjects());
         return response;

--- a/apps/wallet/src/ui/app/staking/stake/validation.ts
+++ b/apps/wallet/src/ui/app/staking/stake/validation.ts
@@ -17,7 +17,8 @@ export function createValidationSchema(
     gasBalance: bigint,
     totalGasCoins: number,
     decimals: number,
-    gasDecimals: number
+    gasDecimals: number,
+    maxSuiSingleCoinBalance: bigint
 ) {
     return Yup.object({
         amount: createTokenValidation(
@@ -27,7 +28,9 @@ export function createValidationSchema(
             gasBalance,
             decimals,
             gasDecimals,
-            DEFAULT_GAS_BUDGET_FOR_STAKE
+            DEFAULT_GAS_BUDGET_FOR_STAKE,
+            maxSuiSingleCoinBalance,
+            false
         ).test(
             'num-gas-coins-check',
             `Need at least 2 ${GAS_SYMBOL} coins to stake a ${GAS_SYMBOL} coin`,

--- a/apps/wallet/testSetup.ts
+++ b/apps/wallet/testSetup.ts
@@ -3,7 +3,7 @@
 
 import { webcrypto } from 'crypto';
 
-if (!globalThis.defined) {
+if (!globalThis.crypto) {
     globalThis.crypto = webcrypto as Crypto;
 }
 

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -45,7 +45,7 @@ export interface PayTransaction {
 /// 2. accumulate all residual SUI from input coins left and deposit all SUI to the first
 /// input coin, then use the first input coin as the gas coin object.
 /// 3. the balance of the first input coin after tx is sum(input_coins) - sum(amounts) - actual_gas_cost
-/// 4. all other input coints other than the first one are deleted.
+/// 4. all other input coins other than the first one are deleted.
 export interface PaySuiTransaction {
   /**
    * use `provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual` to

--- a/sdk/typescript/src/utils/gas-estimation.ts
+++ b/sdk/typescript/src/utils/gas-estimation.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
+import { Coin, SuiMoveObject } from '../types';
+
+export type TxKind = UnserializedSignableTransaction['kind'];
+type BudgetMap = typeof DEFAULT_GAS_BUDGET_PER_TX_TYPE;
+export type GasBudgetGuessParams<txKind extends TxKind> =
+  txKind extends keyof BudgetMap
+    ? BudgetMap[txKind] extends (...args: any[]) => any
+      ? Parameters<BudgetMap[txKind]> extends [boolean, ...infer Params]
+        ? Params
+        : []
+      : []
+    : [];
+
+// The min-max were extracted by running a tx with too small (for min) and too big (for max) gasBudget
+// TODO: consider getting them in a more dynamic way (from rpc maybe?)
+/**
+ * The minimum value accepted for gas budget
+ */
+export const MIN_GAS_BUDGET = 10;
+/**
+ * The maximum value accepted for gas budget
+ */
+export const MAX_GAS_BUDGET = 1_000_000;
+
+/**
+ * This constant is a 'guessed' estimation of the total cost of a pay tx with only one coin input.
+ * We use this to calculate a 'guess' for the gas budget of a pay tx with multiple coins.
+ */
+const PAY_GAS_FEE_PER_COIN = 150;
+
+/**
+ * Make a guess for the gas budget of a pay tx
+ * @param coins All the coins of the type to send
+ * @param amount The amount to send
+ * @returns The gasBudget guess
+ */
+function computeTransferTxGasBudget(
+  optimizeGuessForDryRun: boolean,
+  coins: SuiMoveObject[],
+  amount: bigint
+) {
+  const numInputCoins = Coin.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+    coins,
+    amount
+  ).length;
+  let gasBudgetGuess = Math.min(
+    PAY_GAS_FEE_PER_COIN * Math.max(2, Math.min(100, numInputCoins / 2)),
+    MAX_GAS_BUDGET
+  );
+  const isSuiTransfer = Coin.isSUI(coins[0]);
+  if (isSuiTransfer && optimizeGuessForDryRun) {
+    // check if there is enough balance to cover for the amount + the gas
+    // if not lower the gasBudget to allow making better estimations for those cases
+    const totalSuiBalance = coins.reduce(
+      (sum, aCoin) => sum + (Coin.getBalance(aCoin) || BigInt(0)),
+      BigInt(0)
+    );
+    if (totalSuiBalance - BigInt(gasBudgetGuess) - amount < 0) {
+      gasBudgetGuess = Math.max(
+        Number(totalSuiBalance - amount),
+        MIN_GAS_BUDGET
+      );
+    }
+  }
+  return gasBudgetGuess;
+}
+
+const DEFAULT_GAS_BUDGET_PER_TX_TYPE = {
+  mergeCoin: 10_000,
+  moveCall: 10_000,
+  pay: computeTransferTxGasBudget,
+  paySui: computeTransferTxGasBudget,
+  payAllSui: computeTransferTxGasBudget,
+  publish: 10_000,
+  splitCoin: 10_000,
+  transferObject: 100,
+  transferSui: 100,
+} as const;
+
+export function getGasBudgetGuess<T extends TxKind>(
+  txKind: T,
+  maxGasCoinBalance: bigint | number | null,
+  optimizeGuessForDryRun: boolean,
+  budgetParams: GasBudgetGuessParams<T>
+): number {
+  const gasBudgetGuess =
+    typeof DEFAULT_GAS_BUDGET_PER_TX_TYPE[txKind] === 'function'
+      ? // @ts-expect-error
+        DEFAULT_GAS_BUDGET_PER_TX_TYPE[txKind](
+          optimizeGuessForDryRun,
+          ...budgetParams
+        )
+      : DEFAULT_GAS_BUDGET_PER_TX_TYPE[txKind];
+  return Math.max(
+    Math.min(
+      ...[
+        gasBudgetGuess,
+        optimizeGuessForDryRun ? maxGasCoinBalance : null,
+        MAX_GAS_BUDGET,
+      ]
+        .filter((aNum) => aNum !== null)
+        .map((aNum) => Number(aNum))
+    ),
+    MIN_GAS_BUDGET
+  );
+}


### PR DESCRIPTION
Draft to work on splitting this PR to smaller ones and improve gas estimation api

* [wallet-ext: fix crypto mock in test setup](https://github.com/MystenLabs/sui/pull/6156/commits/25666d51e5f65a4e0def6f0203c5f8c1be3cea73) 
  * it breaks the tests since now crypto seems to be defined
* [ts-sdk: adds method to estimate gas cost and suggested budget to signer](https://github.com/MystenLabs/sui/pull/6156/commits/1ab09c3278920cd9115a297dd4e40be4fdbc5775) 
 * also fixes some edge cases with pay txs (take into account that only the first coin is used for gas)
* [wallet-ext: improve gas estimations for nft transfer](https://github.com/MystenLabs/sui/pull/6156/commits/6e457dcf00cb6ee4464fe336b381fc43594638cc) 
  * fixes edge cases and uses new method from signer
  * use Alert component for errors
* [wallet-ext: improve token transfer gas budget estimations](https://github.com/MystenLabs/sui/pull/6156/commits/b8174d965d00d95e25cbda2e2f6fe3a1de6714d0) 
  * uses new method from signer to estimate gasCost and suggested gasBudget
  * updates token validation to include more cases
  * uses Alert for errors in send tokens form
  
<img width="375" alt="Screenshot 2022-11-18 at 22 33 42" src="https://user-images.githubusercontent.com/10210143/202814385-e8f9b9a7-75eb-4eed-8b40-6fe9e71833a8.png">
<img width="375" alt="Screenshot 2022-11-18 at 22 34 36" src="https://user-images.githubusercontent.com/10210143/202814391-716b5136-b243-4a3a-a664-7e2b118a2ec1.png">
<img width="375" alt="Screenshot 2022-11-18 at 22 34 48" src="https://user-images.githubusercontent.com/10210143/202814392-d07cf3c5-bb1c-4030-9ea9-bd9275b12634.png">



closes APPS-149