### PR TITLE
[2/x][lamport] Clean up some references to SequenceNumber

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -22,12 +22,12 @@ use sui_storage::{
     write_ahead_log::{DBWriteAheadLog, WriteAheadLog},
     LockService,
 };
-use sui_types::batch::TxSequenceNumber;
 use sui_types::crypto::{AuthoritySignInfo, EmptySignInfo};
 use sui_types::message_envelope::VerifiedEnvelope;
 use sui_types::object::Owner;
 use sui_types::storage::{ChildObjectResolver, SingleTxContext, WriteKind};
 use sui_types::{base_types::SequenceNumber, storage::ParentSync};
+use sui_types::{batch::TxSequenceNumber, object::PACKAGE_VERSION};
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tracing::{debug, info, trace};
 use typed_store::rocks::DBBatch;
@@ -368,11 +368,9 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                     };
                 }
                 InputObjectKind::MovePackage(id) => {
-                    // Move package always uses version 1.
-                    let version = VersionNumber::from_u64(1);
-                    if !self.object_exists(id, version)? {
+                    if !self.object_exists(id, PACKAGE_VERSION)? {
                         // The cert cannot have been formed if immutable inputs were missing.
-                        missing.push(ObjectKey(*id, version));
+                        missing.push(ObjectKey(*id, PACKAGE_VERSION));
                     }
                 }
                 InputObjectKind::ImmOrOwnedMoveObject(objref) => {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -35,7 +35,7 @@ use sui_types::messages::{
     CallArg, ExecuteTransactionRequestType, MoveCall, SingleTransactionKind, TransactionData,
     TransactionKind, TransferObject,
 };
-use sui_types::object::Owner;
+use sui_types::object::{Owner, PACKAGE_VERSION};
 use sui_types::query::EventQuery;
 use sui_types::query::TransactionQuery;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
@@ -113,7 +113,7 @@ impl RpcExampleProvider {
                 SingleTransactionKind::Call(MoveCall {
                     package: (
                         SUI_FRAMEWORK_OBJECT_ID,
-                        SequenceNumber::from_u64(1),
+                        PACKAGE_VERSION,
                         ObjectDigest::new(self.rng.gen()),
                     ),
                     module: Identifier::from_str("devnet_nft").unwrap(),

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -39,12 +39,10 @@ use std::{
 use sui_adapter::{adapter::new_move_vm, genesis};
 use sui_core::{execution_engine, test_utils::to_sender_signed_transaction};
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
-use sui_types::in_memory_storage::InMemoryStorage;
 use sui_types::temporary_store::TemporaryStore;
 use sui_types::{
     base_types::{
-        ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
-        SUI_ADDRESS_LENGTH,
+        ObjectDigest, ObjectID, ObjectRef, SuiAddress, TransactionDigest, SUI_ADDRESS_LENGTH,
     },
     crypto::{get_key_pair_from_rng, AccountKeyPair},
     event::Event,
@@ -55,6 +53,7 @@ use sui_types::{
     object::{self, Object, ObjectFormatOptions, GAS_VALUE_FOR_TESTING},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
+use sui_types::{in_memory_storage::InMemoryStorage, object::PACKAGE_VERSION};
 pub(crate) type FakeID = u64;
 
 // initial value for fake object ID mapping
@@ -283,11 +282,7 @@ impl<'a> MoveTestAdapter<'a> for SuiTestAdapter<'a> {
         let package_ref = match self.storage.get_object(&package_id) {
             Some(obj) => obj.compute_object_reference(),
             // object not found
-            None => (
-                package_id,
-                SequenceNumber::from(1),
-                ObjectDigest::new([0; 32]),
-            ),
+            None => (package_id, PACKAGE_VERSION, ObjectDigest::new([0; 32])),
         };
 
         let gas_budget = gas_budget.unwrap_or(GAS_VALUE_FOR_TESTING);

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1742,11 +1742,7 @@ impl Default for TransactionEffects {
             deleted: Vec::new(),
             wrapped: Vec::new(),
             gas_object: (
-                (
-                    ObjectID::random(),
-                    SequenceNumber::new(),
-                    ObjectDigest::new([0; 32]),
-                ),
+                random_object_ref(),
                 Owner::AddressOwner(SuiAddress::default()),
             ),
             events: Vec::new(),

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -31,6 +31,9 @@ use crate::{
 pub const GAS_VALUE_FOR_TESTING: u64 = 1_000_000_u64;
 pub const OBJECT_START_VERSION: SequenceNumber = SequenceNumber::from_u64(1);
 
+/// Packages are immutable, version is always 1
+pub const PACKAGE_VERSION: SequenceNumber = OBJECT_START_VERSION;
+
 #[serde_as]
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MoveObject {
@@ -427,7 +430,7 @@ impl Object {
 
         match &self.data {
             Move(v) => v.version(),
-            Package(_) => SequenceNumber::from(1), // modules are immutable, version is always 1
+            Package(_) => PACKAGE_VERSION,
         }
     }
 

--- a/crates/sui-types/src/unit_tests/event_filter_tests.rs
+++ b/crates/sui-types/src/unit_tests/event_filter_tests.rs
@@ -12,8 +12,8 @@ use crate::event::EventType;
 use crate::event::{Event, EventEnvelope};
 use crate::filter::{EventFilter, Filter};
 use crate::gas_coin::GasCoin;
-use crate::object::Owner;
-use crate::{ObjectID, SequenceNumber, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
+use crate::object::{Owner, PACKAGE_VERSION};
+use crate::{ObjectID, MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS};
 
 #[test]
 fn test_move_event_filter() {
@@ -200,7 +200,7 @@ fn test_new_object_filter() {
         recipient,
         object_type: "0x2::example::Object".into(),
         object_id,
-        version: SequenceNumber::from_u64(1),
+        version: PACKAGE_VERSION,
     };
     let envelope = EventEnvelope {
         timestamp: 0,

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -9,6 +9,7 @@ use fastcrypto::traits::AggregateAuthenticator;
 use fastcrypto::traits::KeyPair;
 use roaring::RoaringBitmap;
 
+use crate::base_types::random_object_ref;
 use crate::crypto::bcs_signable_test::{get_obligation_input, Foo};
 use crate::crypto::Secp256k1SuiSignature;
 use crate::crypto::SuiKeyPair;
@@ -21,13 +22,6 @@ use crate::messages_checkpoint::CheckpointSummary;
 use crate::object::Owner;
 
 use super::*;
-fn random_object_ref() -> ObjectRef {
-    (
-        ObjectID::random(),
-        SequenceNumber::new(),
-        ObjectDigest::new([0; 32]),
-    )
-}
 
 #[test]
 fn test_signed_values() {


### PR DESCRIPTION
- Consolidate uses and implementations of `random_object_ref`.
- Give a name to the immutable `PACKAGE_VERSION`, rather than creating it fresh with a comment explaining it every time.