### PR TITLE
[3/x][lamport] wrap/unwrap transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
@@ -1,0 +1,36 @@
+processed 8 tasks
+
+init:
+A: object(100)
+
+task 1 'publish'. lines 8-41:
+created: object(104)
+written: object(103)
+
+task 2 'run'. lines 43-43:
+created: object(106)
+written: object(105)
+
+task 3 'view-object'. lines 45-45:
+Owner: Account Address ( A )
+Version: 1
+Contents: a::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}}
+
+task 4 'run'. lines 47-47:
+created: object(108)
+written: object(107)
+deleted: object(106)
+
+task 5 'view-object'. lines 49-49:
+Owner: Account Address ( A )
+Version: 1
+Contents: a::m::T {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}, s: a::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}}}
+
+task 6 'run'. lines 51-51:
+written: object(106), object(109)
+deleted: object(108)
+
+task 7 'view-object'. lines 53-53:
+Owner: Account Address ( A )
+Version: 2
+Contents: a::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.move
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// test impact to versions for wrapping and unwrapping an object
+
+//# init --addresses a=0x0 --accounts A
+
+//# publish
+module a::m {
+    use sui::object;
+    use sui::tx_context::{Self, TxContext};
+
+    struct S has key, store {
+        id: object::UID,
+    }
+
+    struct T has key, store {
+        id: object::UID,
+        s: S,
+    }
+
+    entry fun mint(ctx: &mut TxContext) {
+        sui::transfer::transfer(
+            S { id: object::new(ctx) },
+            tx_context::sender(ctx),
+        );
+    }
+
+    entry fun wrap(s: S, ctx: &mut TxContext) {
+        sui::transfer::transfer(
+            T { id: object::new(ctx), s },
+            tx_context::sender(ctx),
+        );
+    }
+
+    entry fun unwrap(t: T, ctx: &mut TxContext) {
+        let T { id, s } = t;
+        object::delete(id);
+        sui::transfer::transfer(s, tx_context::sender(ctx));
+    }
+}
+
+//# run a::m::mint --sender A
+
+//# view-object 106
+
+//# run a::m::wrap --sender A --args object(106)
+
+//# view-object 108
+
+//# run a::m::unwrap --sender A --args object(108)
+
+//# view-object 106


### PR DESCRIPTION
Add a new transactional test to witness what happens to versions when
the object is wrapped and then unwrapped (the version needs to
increase) in preparation for lamport timestamps.

## Test Plan

```
cargo simtest -E 'package(sui-adapter-transactional-tests)' 'wrap_unwrap'
```

Stacked on #6160 (bottom commit)