### PR TITLE
[4/x][lamport] More detailed revert_state_update tests

### DIFF
--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -3,6 +3,7 @@
 
 /// Test CTURD object basics (create, transfer, update, read, delete)
 module examples::object_basics {
+    use sui::dynamic_object_field as ofield;
     use sui::event;
     use sui::object::{Self, UID};
     use sui::tx_context::{Self, TxContext};
@@ -61,5 +62,16 @@ module examples::object_basics {
         let Wrapper { id, o } = w;
         object::delete(id);
         transfer::transfer(o, tx_context::sender(ctx))
+    }
+
+    public entry fun add_ofield(o: &mut Object, v: Object) {
+        ofield::add(&mut o.id, true, v);
+    }
+
+    public entry fun remove_ofield(o: &mut Object, ctx: &mut TxContext) {
+        transfer::transfer(
+            ofield::remove<bool, Object>(&mut o.id, true),
+            tx_context::sender(ctx),
+        );
     }
 }


### PR DESCRIPTION
Add tests for authority store's `revert_state_update` to exercise:

- Wrapping and unwrapping
- Adding and removing dynamic fields (which involves dynamic child
  object laoding and modification)

To make sure lamport timestamps don't break this behaviour.

## Test Plan

```
cargo nextest run - 'package(sui-core)' test_store_revert
```

Stacked on #6161, #6160 (Bottom two commits)