### PR TITLE
use rolling sum of gas costs in checkpoints

### DIFF
--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -393,7 +393,7 @@ impl CommitteeFixture {
             sequence_number: 0,
             content_digest: empty_contents().digest(),
             previous_digest: None,
-            gas_cost_summary: Default::default(),
+            epoch_rolling_gas_cost_summary: Default::default(),
             next_epoch_committee: None,
         };
 
@@ -447,7 +447,7 @@ impl CommitteeFixture {
                 sequence_number: prev.summary.sequence_number + 1,
                 content_digest: empty_contents().digest(),
                 previous_digest: Some(prev.summary.digest()),
-                gas_cost_summary: Default::default(),
+                epoch_rolling_gas_cost_summary: Default::default(),
                 next_epoch_committee: None,
             };
 

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -57,6 +57,14 @@ pub struct GasCostSummary {
 }
 
 impl GasCostSummary {
+    pub fn new(computation_cost: u64, storage_cost: u64, storage_rebate: u64) -> GasCostSummary {
+        GasCostSummary {
+            computation_cost,
+            storage_cost,
+            storage_rebate,
+        }
+    }
+
     pub fn gas_used(&self) -> u64 {
         self.computation_cost + self.storage_cost
     }


### PR DESCRIPTION
This way during epoch change we just need to use the last checkpoint's gas cost summary for rewards distribution.