### PR TITLE
[Explorer] Fixes bugs relating to network and module search query interaction

### DIFF
--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -48,13 +48,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
     const [searchParams, setSearchParams] = useSearchParams();
     const [query, setQuery] = useState('');
 
-    const paramModule = searchParams.get('module') || modulenames?.[0] || null;
-
-    const [selectedModule, setSelectedModule] = useState(
-        !!paramModule && modulenames.includes(paramModule)
-            ? paramModule
-            : modulenames[0]
-    );
+    const [selectedModule, setSelectedModule] = useState(modulenames[0]);
 
     const filteredModules =
         query === ''
@@ -66,21 +60,37 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                   .map(([name]) => name);
 
     useEffect(() => {
-        const newSearchParams = new URLSearchParams(searchParams);
-        newSearchParams.set('module', selectedModule);
-        setSearchParams(newSearchParams);
-    }, [selectedModule, setSearchParams, searchParams]);
+        const paramModule =
+            searchParams.get('module') || modulenames?.[0] || null;
+        setSelectedModule(
+            !!paramModule && modulenames.includes(paramModule)
+                ? paramModule
+                : modulenames[0]
+        );
+    }, [searchParams, modulenames]);
+
+    const updateSelectedModule = useCallback(
+        (newModule: string) => () => {
+            const newSearchParams = new URLSearchParams(searchParams);
+            newSearchParams.set('module', newModule);
+            setSearchParams(newSearchParams);
+            setSelectedModule(newModule);
+        },
+        [searchParams, setSearchParams]
+    );
 
     const submitSearch = useCallback(() => {
-        setSelectedModule((prev: string) =>
-            filteredModules.length === 1 ? filteredModules[0] : prev
-        );
-    }, [filteredModules]);
+        if (filteredModules.length === 1)
+            updateSelectedModule(filteredModules[0]);
+    }, [filteredModules, updateSelectedModule]);
 
     return (
         <div className="flex flex-col md:flex-row md:flex-nowrap gap-5 border-0 border-y border-solid border-sui-grey-45">
             <div className="w-full md:w-1/5">
-                <Combobox value={selectedModule} onChange={setSelectedModule}>
+                <Combobox
+                    value={selectedModule}
+                    onChange={updateSelectedModule}
+                >
                     <div className="box-border border border-sui-grey-50 border-solid rounded-md shadow-sm placeholder-sui-grey-65 pl-3 w-full flex mt-2.5 justify-between py-1">
                         <Combobox.Input
                             onChange={(event) => setQuery(event.target.value)}
@@ -141,7 +151,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                             >
                                 <ListItem
                                     active={selectedModule === name}
-                                    onClick={() => setSelectedModule(name)}
+                                    onClick={updateSelectedModule(name)}
                                 >
                                     {name}
                                 </ListItem>

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -45,12 +45,25 @@ function ModuleViewWrapper({
 
 const getModule = (
     searchParams: URLSearchParams,
+    setSearchParams: (params: URLSearchParams) => void,
     modulenames: string[]
 ): string => {
     const paramModule = searchParams.get('module') || null;
-    return !!paramModule && modulenames.includes(paramModule)
-        ? paramModule
-        : modulenames[0];
+
+    // A module has been specified and the package has this module
+    if (!!paramModule && modulenames.includes(paramModule)) {
+        return paramModule;
+    }
+
+    // A module has been specified and the package does not have this module
+    if (!!paramModule) {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.delete('module');
+        setSearchParams(newSearchParams);
+    }
+
+    // The default is to return the first module in the list
+    return modulenames[0];
 };
 
 const setModule = (
@@ -92,7 +105,11 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
         <div className="flex flex-col md:flex-row md:flex-nowrap gap-5 border-0 border-y border-solid border-sui-grey-45">
             <div className="w-full md:w-1/5">
                 <Combobox
-                    value={getModule(searchParams, modulenames)}
+                    value={getModule(
+                        searchParams,
+                        setSearchParams,
+                        modulenames
+                    )}
                     onChange={onChangeModule}
                 >
                     <div className="box-border border border-sui-grey-50 border-solid rounded-md shadow-sm placeholder-sui-grey-65 pl-3 w-full flex mt-2.5 justify-between py-1">
@@ -155,8 +172,11 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                             >
                                 <ListItem
                                     active={
-                                        getModule(searchParams, modulenames) ===
-                                        name
+                                        getModule(
+                                            searchParams,
+                                            setSearchParams,
+                                            modulenames
+                                        ) === name
                                     }
                                     onClick={onChangeModule(name)}
                                 >
@@ -180,6 +200,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                                     modules={modules}
                                     selectedModuleName={getModule(
                                         searchParams,
+                                        setSearchParams,
                                         modulenames
                                     )}
                                 />

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -71,6 +71,12 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
         return modulenames[0];
     };
 
+    const selectedModule = getModule(
+        searchParams,
+        setSearchParams,
+        modulenames
+    );
+
     const setModule = (
         searchParams: URLSearchParams,
         setSearchParams: (params: URLSearchParams) => void,
@@ -104,14 +110,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
     return (
         <div className="flex flex-col md:flex-row md:flex-nowrap gap-5 border-0 border-y border-solid border-sui-grey-45">
             <div className="w-full md:w-1/5">
-                <Combobox
-                    value={getModule(
-                        searchParams,
-                        setSearchParams,
-                        modulenames
-                    )}
-                    onChange={onChangeModule}
-                >
+                <Combobox value={selectedModule} onChange={onChangeModule}>
                     <div className="box-border border border-sui-grey-50 border-solid rounded-md shadow-sm placeholder-sui-grey-65 pl-3 w-full flex mt-2.5 justify-between py-1">
                         <Combobox.Input
                             onChange={(event) => setQuery(event.target.value)}
@@ -171,13 +170,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                                 className="md:min-w-fit mx-0.5 mt-0.5"
                             >
                                 <ListItem
-                                    active={
-                                        getModule(
-                                            searchParams,
-                                            setSearchParams,
-                                            modulenames
-                                        ) === name
-                                    }
+                                    active={selectedModule === name}
                                     onClick={onChangeModule(name)}
                                 >
                                     {name}
@@ -198,11 +191,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                                 <ModuleViewWrapper
                                     id={id}
                                     modules={modules}
-                                    selectedModuleName={getModule(
-                                        searchParams,
-                                        setSearchParams,
-                                        modulenames
-                                    )}
+                                    selectedModuleName={selectedModule}
                                 />
                             </div>
                         </TabPanel>

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -4,7 +4,11 @@
 import { Combobox } from '@headlessui/react';
 import clsx from 'clsx';
 import { useState, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import {
+    useSearchParams,
+    type URLSearchParamsInit,
+    type NavigateOptions,
+} from 'react-router-dom';
 
 import ModuleView from './ModuleView';
 
@@ -50,7 +54,10 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
 
     const getModule = (
         searchParams: URLSearchParams,
-        setSearchParams: (params: URLSearchParams) => void,
+        setSearchParams: (
+            params: URLSearchParamsInit,
+            navigateOpts?: NavigateOptions
+        ) => void,
         modulenames: string[]
     ): string => {
         const paramModule = searchParams.get('module') || null;
@@ -64,7 +71,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
         if (!!paramModule) {
             const newSearchParams = new URLSearchParams(searchParams);
             newSearchParams.delete('module');
-            setSearchParams(newSearchParams);
+            setSearchParams(newSearchParams, { replace: true });
         }
 
         // The default is to return the first module in the list
@@ -79,12 +86,15 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
 
     const setModule = (
         searchParams: URLSearchParams,
-        setSearchParams: (params: URLSearchParams) => void,
+        setSearchParams: (
+            params: URLSearchParamsInit,
+            navigateOpts?: NavigateOptions
+        ) => void,
         newModule: string
     ): void => {
         const newSearchParams = new URLSearchParams(searchParams);
         newSearchParams.set('module', newModule);
-        setSearchParams(newSearchParams);
+        setSearchParams(newSearchParams, { replace: true });
     };
 
     const filteredModules =

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -43,43 +43,43 @@ function ModuleViewWrapper({
     return <ModuleView id={id} name={name} code={code} />;
 }
 
-const getModule = (
-    searchParams: URLSearchParams,
-    setSearchParams: (params: URLSearchParams) => void,
-    modulenames: string[]
-): string => {
-    const paramModule = searchParams.get('module') || null;
-
-    // A module has been specified and the package has this module
-    if (!!paramModule && modulenames.includes(paramModule)) {
-        return paramModule;
-    }
-
-    // A module has been specified and the package does not have this module
-    if (!!paramModule) {
-        const newSearchParams = new URLSearchParams(searchParams);
-        newSearchParams.delete('module');
-        setSearchParams(newSearchParams);
-    }
-
-    // The default is to return the first module in the list
-    return modulenames[0];
-};
-
-const setModule = (
-    searchParams: URLSearchParams,
-    setSearchParams: (params: URLSearchParams) => void,
-    newModule: string
-): void => {
-    const newSearchParams = new URLSearchParams(searchParams);
-    newSearchParams.set('module', newModule);
-    setSearchParams(newSearchParams);
-};
-
 function PkgModuleViewWrapper({ id, modules }: Props) {
     const modulenames = modules.map(([name]) => name);
     const [searchParams, setSearchParams] = useSearchParams();
     const [query, setQuery] = useState('');
+
+    const getModule = (
+        searchParams: URLSearchParams,
+        setSearchParams: (params: URLSearchParams) => void,
+        modulenames: string[]
+    ): string => {
+        const paramModule = searchParams.get('module') || null;
+
+        // A module has been specified and the package has this module
+        if (!!paramModule && modulenames.includes(paramModule)) {
+            return paramModule;
+        }
+
+        // A module has been specified and the package does not have this module
+        if (!!paramModule) {
+            const newSearchParams = new URLSearchParams(searchParams);
+            newSearchParams.delete('module');
+            setSearchParams(newSearchParams);
+        }
+
+        // The default is to return the first module in the list
+        return modulenames[0];
+    };
+
+    const setModule = (
+        searchParams: URLSearchParams,
+        setSearchParams: (params: URLSearchParams) => void,
+        newModule: string
+    ): void => {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.set('module', newModule);
+        setSearchParams(newSearchParams);
+    };
 
     const filteredModules =
         query === ''

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -3,7 +3,7 @@
 
 import { Combobox } from '@headlessui/react';
 import clsx from 'clsx';
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import ModuleView from './ModuleView';
@@ -48,11 +48,6 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
     const [searchParams, setSearchParams] = useSearchParams();
     const [query, setQuery] = useState('');
 
-    const convertedSearchParams = useMemo(
-        () => new URLSearchParams(searchParams),
-        [searchParams]
-    );
-
     // Extract module in URL or default to first module in list
     const selectedModule =
         searchParams.get('module') &&
@@ -83,17 +78,19 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
 
     const submitSearch = useCallback(() => {
         if (filteredModules.length === 1) {
+            const convertedSearchParams = new URLSearchParams(searchParams);
             convertedSearchParams.set('module', filteredModules[0]);
             setSearchParams(convertedSearchParams);
         }
-    }, [filteredModules, convertedSearchParams, setSearchParams]);
+    }, [filteredModules, setSearchParams, searchParams]);
 
     const onChangeModule = useCallback(
         (newModule: string) => () => {
+            const convertedSearchParams = new URLSearchParams(searchParams);
             convertedSearchParams.set('module', newModule);
             setSearchParams(convertedSearchParams);
         },
-        [convertedSearchParams, setSearchParams]
+        [setSearchParams, searchParams]
     );
 
     return (

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -84,14 +84,11 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
         }
     }, [filteredModules, setSearchParams, searchParams]);
 
-    const onChangeModule = useCallback(
-        (newModule: string) => () => {
-            const convertedSearchParams = new URLSearchParams(searchParams);
-            convertedSearchParams.set('module', newModule);
-            setSearchParams(convertedSearchParams);
-        },
-        [setSearchParams, searchParams]
-    );
+    const onChangeModule = (newModule: string) => {
+        const convertedSearchParams = new URLSearchParams(searchParams);
+        convertedSearchParams.set('module', newModule);
+        setSearchParams(convertedSearchParams);
+    };
 
     return (
         <div className="flex flex-col md:flex-row md:flex-nowrap gap-5 border-0 border-y border-solid border-sui-grey-45">
@@ -157,7 +154,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
                             >
                                 <ListItem
                                     active={selectedModule === name}
-                                    onClick={onChangeModule(name)}
+                                    onClick={() => onChangeModule(name)}
                                 >
                                     {name}
                                 </ListItem>

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -81,7 +81,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
     ): void => {
         const newSearchParams = new URLSearchParams(searchParams);
         newSearchParams.set('module', newModule);
-        setSearchParams(newSearchParams, { replace: true });
+        setSearchParams(newSearchParams);
     };
 
     const filteredModules =

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -3,7 +3,7 @@
 
 import { Combobox } from '@headlessui/react';
 import clsx from 'clsx';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
     useSearchParams,
     type URLSearchParamsInit,
@@ -52,37 +52,24 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
     const [searchParams, setSearchParams] = useSearchParams();
     const [query, setQuery] = useState('');
 
-    const getModule = (
-        searchParams: URLSearchParams,
-        setSearchParams: (
-            params: URLSearchParamsInit,
-            navigateOpts?: NavigateOptions
-        ) => void,
-        modulenames: string[]
-    ): string => {
-        const paramModule = searchParams.get('module') || null;
+    // Extract module in URL or default to first module in list
+    const selectedModule =
+        searchParams.get('module') &&
+        modulenames.includes(searchParams.get('module')!)
+            ? searchParams.get('module')!
+            : modulenames[0];
 
-        // A module has been specified and the package has this module
-        if (!!paramModule && modulenames.includes(paramModule)) {
-            return paramModule;
-        }
-
-        // A module has been specified and the package does not have this module
-        if (!!paramModule) {
+    // If module in URL exists but is not in module list, then delete module from URL
+    useEffect(() => {
+        if (
+            searchParams.get('module') &&
+            !modulenames.includes(searchParams.get('module')!)
+        ) {
             const newSearchParams = new URLSearchParams(searchParams);
             newSearchParams.delete('module');
             setSearchParams(newSearchParams, { replace: true });
         }
-
-        // The default is to return the first module in the list
-        return modulenames[0];
-    };
-
-    const selectedModule = getModule(
-        searchParams,
-        setSearchParams,
-        modulenames
-    );
+    }, [searchParams, setSearchParams, modulenames]);
 
     const setModule = (
         searchParams: URLSearchParams,

--- a/apps/explorer/src/ui/utils/LinkWithQuery.tsx
+++ b/apps/explorer/src/ui/utils/LinkWithQuery.tsx
@@ -38,10 +38,15 @@ export const LinkWithQuery = forwardRef<HTMLAnchorElement, LinkProps>(
         const [searchParams] = useSearchParams();
 
         const newParams = new URLSearchParams({
-            ...Object.fromEntries(toURLSearchParams),
             ...Object.fromEntries(searchParams),
+            ...Object.fromEntries(toURLSearchParams),
         });
 
-        return <Link to={`${toBaseURL}?${newParams}`} {...props} />;
+        return (
+            <Link
+                to={{ pathname: toBaseURL, search: newParams.toString() }}
+                {...props}
+            />
+        );
     }
 );

--- a/apps/explorer/src/ui/utils/LinkWithQuery.tsx
+++ b/apps/explorer/src/ui/utils/LinkWithQuery.tsx
@@ -31,12 +31,17 @@ export function useNavigateWithQuery() {
 
 export const LinkWithQuery = forwardRef<HTMLAnchorElement, LinkProps>(
     ({ to, ...props }) => {
+        const [toBaseURL, toSearchParamString] = (to as string).split('?');
+
+        const toURLSearchParams = new URLSearchParams(toSearchParamString);
+
         const [searchParams] = useSearchParams();
 
-        const networkParam =
-            (to.toString().includes('?') ? '&network=' : '?network=') +
-            searchParams.get('network');
+        const newParams = new URLSearchParams({
+            ...Object.fromEntries(toURLSearchParams),
+            ...Object.fromEntries(searchParams),
+        });
 
-        return <Link to={`${to}${networkParam}`} {...props} />;
+        return <Link to={`${toBaseURL}?${newParams}`} {...props} />;
     }
 );

--- a/apps/explorer/src/ui/utils/LinkWithQuery.tsx
+++ b/apps/explorer/src/ui/utils/LinkWithQuery.tsx
@@ -5,6 +5,7 @@ import { forwardRef, useCallback } from 'react';
 import {
     // eslint-disable-next-line no-restricted-imports
     Link,
+    useSearchParams,
     useLocation,
     // eslint-disable-next-line no-restricted-imports
     useNavigate,
@@ -29,9 +30,13 @@ export function useNavigateWithQuery() {
 }
 
 export const LinkWithQuery = forwardRef<HTMLAnchorElement, LinkProps>(
-    ({ to, ...props }, ref) => {
-        const { search } = useLocation();
+    ({ to, ...props }) => {
+        const [searchParams] = useSearchParams();
 
-        return <Link ref={ref} to={`${to}${search}`} {...props} />;
+        const networkParam =
+            (to.toString().includes('?') ? '&network=' : '?network=') +
+            searchParams.get('network');
+
+        return <Link to={`${to}${networkParam}`} {...props} />;
     }
 );


### PR DESCRIPTION
There's a bug whereby clicking on the Type in the Object Results Page or Module in the Transactions Page takes the user to the wrong module in the Package Results Page. Further investigation determined that the `LinkWithQuery` component needed updating. Also included with this PR are further improvements to `PkgModuleViewWrapper` that facilate being able to go back a module or page.

The first part of the below video shows the problem. Clicking on the Module should have taken the user to `marketplace_nofee` but instead the user sees `alchemy`. Once at the Package Results Page, the user cannot go back to the Transaction Results Page. 

The second part of the video shows how the proposed solution operates.

https://user-images.githubusercontent.com/11377188/202510058-4e032b57-c1f3-440c-a4ee-6d65640bd8b2.mp4

