### PR TITLE
[Event Store] Pragmas and periodic task to limit WAL size

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1445,8 +1445,11 @@ impl AuthorityState {
         }
         let committee = committee_store.get_latest_committee();
         let module_cache = Arc::new(SyncModuleCache::new(ResolverWrapper(store.clone())));
-        let event_handler =
-            event_store.map(|es| Arc::new(EventHandler::new(es, module_cache.clone())));
+        let event_handler = event_store.map(|es| {
+            let handler = EventHandler::new(es, module_cache.clone());
+            handler.regular_cleanup_task();
+            Arc::new(handler)
+        });
         let metrics = Arc::new(AuthorityMetrics::new(prometheus_registry));
         let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
         let transaction_manager = Arc::new(tokio::sync::Mutex::new(

--- a/crates/sui-core/src/event_handler.rs
+++ b/crates/sui-core/src/event_handler.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::time::Duration;
 use std::sync::Arc;
 
 use move_bytecode_utils::module_cache::SyncModuleCache;
@@ -42,6 +43,17 @@ impl EventHandler {
             module_cache,
             event_streamer: streamer,
             event_store,
+        }
+    }
+
+    /// Run a regular cleanup task on the store
+    pub fn regular_cleanup_task(&self) {
+        let store_copy = self.event_store.clone();
+        match store_copy.as_ref() {
+            EventStoreType::SqlEventStore(db) => {
+                // Start periodic task to clean up WAL
+                let _handle = db.wal_cleanup_thread(Some(Duration::from_secs(300)));
+            }
         }
     }
 

--- a/crates/sui-storage/src/event_store/sql.rs
+++ b/crates/sui-storage/src/event_store/sql.rs
@@ -145,6 +145,7 @@ impl SqlEventStore {
 
     /// Force the SQLite WAL to be truncated.  This mighyt be occasionally necessary if somehow the WAL
     /// grows too big.
+    #[instrument(level = "debug", skip_all, err)]
     pub async fn force_wal_truncation(&self) -> Result<(), SuiError> {
         self.pool
             .execute("PRAGMA wal_checkpoint(TRUNCATE)")


### PR DESCRIPTION
We had a prod incident where the disk space on full nodes was filling up with SQLite WAL file growing really huge and not being cleaned up.

This small change 
1) Adds two PRAGMAs to limit the size of WALs, partly by checkpointing more aggressively and limiting the disk size.
2) Adding a periodic task to run a truncate checkpoint on the WAL, which should shrink it to basically 0 again.