### PR TITLE
sui-node: 2-phase tx commit

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -52,10 +52,11 @@ use sui_json_rpc_types::{
     type_and_fields_from_move_struct, SuiEvent, SuiEventEnvelope, SuiTransactionEffects,
 };
 use sui_simulator::nondeterministic;
+use sui_storage::write_ahead_log::{TransactionCommitPhase, WriteAheadLog};
 use sui_storage::{
     event_store::{EventStore, EventStoreType, StoredEvent},
     node_sync_store::NodeSyncStore,
-    write_ahead_log::{DBTxGuard, TxGuard, WriteAheadLog},
+    write_ahead_log::{DBTxGuard, TxGuard},
     IndexStore,
 };
 use sui_types::committee::EpochId;
@@ -839,6 +840,23 @@ impl AuthorityState {
             });
         }
 
+        // first check to see if we have already executed and committed the tx
+        // to the WAL
+        if let Some((inner_temporary_storage, signed_effects)) = self
+            .database
+            .wal
+            .get_intermediate_objs(certificate.digest())?
+        {
+            return self
+                .commit_cert_and_notify(
+                    certificate,
+                    inner_temporary_storage,
+                    signed_effects,
+                    tx_guard,
+                )
+                .await;
+        }
+
         let digest = *certificate.digest();
         // The cert could have been processed by a concurrent attempt of the same cert, so check if
         // the effects have already been written.
@@ -861,6 +879,56 @@ impl AuthorityState {
                 Ok(res) => res,
             };
 
+        // Write tx output to WAL as first commit phase. In second phase
+        // we write from WAL to permanent storage. The purpose of this scheme
+        // is to allow for retrying phase 2 from phase 1 in the case where we
+        // fail mid-write. We prefer this over making the write to permanent
+        // storage atomic as this allows for sharding storage across nodes, which
+        // would be more difficult in the alternative.
+        self.database.wal.write_intermediate_objs(
+            &digest,
+            inner_temporary_store.clone(),
+            signed_effects.clone(),
+        )?;
+
+        self.commit_cert_and_notify(certificate, inner_temporary_store, signed_effects, tx_guard)
+            .await
+    }
+
+    async fn commit_and_notify_from_recovery(
+        &self,
+        certificate: &VerifiedCertificate,
+        inner_temporary_store: InnerTemporaryStore,
+        signed_effects: SignedTransactionEffects,
+        tx_guard: CertTxGuard<'_>,
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
+        if certificate.epoch() != self.epoch() {
+            tx_guard.release();
+            return Err(SuiError::WrongEpoch {
+                expected_epoch: self.epoch(),
+                actual_epoch: certificate.epoch(),
+            });
+        }
+
+        let digest = *certificate.digest();
+
+        if let Some(info) = self.get_tx_info_already_executed(&digest).await? {
+            tx_guard.release();
+            return Ok(info);
+        }
+
+        self.commit_cert_and_notify(certificate, inner_temporary_store, signed_effects, tx_guard)
+            .await
+    }
+
+    async fn commit_cert_and_notify(
+        &self,
+        certificate: &VerifiedCertificate,
+        inner_temporary_store: InnerTemporaryStore,
+        signed_effects: SignedTransactionEffects,
+        tx_guard: CertTxGuard<'_>,
+    ) -> SuiResult<VerifiedTransactionInfoResponse> {
+        let digest = *certificate.digest();
         let input_object_count = inner_temporary_store.objects.len();
         let shared_object_count = signed_effects.data().shared_objects.len();
 
@@ -1529,28 +1597,49 @@ impl AuthorityState {
         let mut limit = limit.unwrap_or(usize::MAX);
         while limit > 0 {
             limit -= 1;
-            if let Some((cert, tx_guard)) = self.database.wal.read_one_recoverable_tx().await? {
+            if let Some((cert, commit_phase, tx_guard)) =
+                self.database.wal.read_one_recoverable_tx().await?
+            {
                 let digest = tx_guard.tx_id();
                 debug!(?digest, "replaying failed cert from log");
 
-                if tx_guard.retry_num() >= MAX_TX_RECOVERY_RETRY {
-                    // This tx will be only partially executed, however the store will be in a safe
-                    // state. We will simply never reach eventual consistency for this TX.
-                    // TODO: Should we revert the tx entirely? I'm not sure the effort is
-                    // warranted, since the only way this can happen is if we are repeatedly
-                    // failing to write to the db, in which case a revert probably won't succeed
-                    // either.
-                    error!(
-                        ?digest,
-                        "Abandoning in-progress TX after {} retries.", MAX_TX_RECOVERY_RETRY
-                    );
-                    // prevent the tx from going back into the recovery list again.
-                    tx_guard.release();
-                    continue;
-                }
+                // If we have already committed to WAL, then the tx has already been executed
+                // and will not be re-executed, therefore there is no longer a threat of poison pill.
+                // We can safely retry past the limit.
+                match commit_phase {
+                    TransactionCommitPhase::Uncommitted => {
+                        if tx_guard.retry_num() >= MAX_TX_RECOVERY_RETRY {
+                            // This tx will be only partially executed, however the store will be in a safe
+                            // state. We will simply never reach eventual consistency for this TX.
+                            // TODO: Should we revert the tx entirely? I'm not sure the effort is
+                            // warranted, since the only way this can happen is if we are repeatedly
+                            // failing to write to the db, in which case a revert probably won't succeed
+                            // either.
+                            error!(
+                                ?digest,
+                                "Abandoning in-progress TX after {} retries.",
+                                MAX_TX_RECOVERY_RETRY
+                            );
+                            // prevent the tx from going back into the recovery list again.
+                            tx_guard.release();
+                            continue;
+                        }
 
-                if let Err(e) = self.process_certificate(tx_guard, &cert.into()).await {
-                    warn!(?digest, "Failed to process in-progress certificate: {e}");
+                        if let Err(e) = self.process_certificate(tx_guard, &cert.into()).await {
+                            warn!(?digest, "Failed to process in-progress certificate: {e}");
+                        }
+                    }
+                    TransactionCommitPhase::CommittedToWal(store, fx) => {
+                        if let Err(e) = self
+                            .commit_and_notify_from_recovery(&cert.into(), store, fx, tx_guard)
+                            .await
+                        {
+                            warn!(
+                                ?digest,
+                                "Failed to commit transaction results to permanent storage: {e}"
+                            );
+                        }
+                    }
                 }
             } else {
                 break;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -845,7 +845,7 @@ impl AuthorityState {
         if let Some((inner_temporary_storage, signed_effects)) = self
             .database
             .wal
-            .get_intermediate_objs(certificate.digest())?
+            .get_execution_output(certificate.digest())?
         {
             return self
                 .commit_cert_and_notify(
@@ -885,7 +885,7 @@ impl AuthorityState {
         // fail mid-write. We prefer this over making the write to permanent
         // storage atomic as this allows for sharding storage across nodes, which
         // would be more difficult in the alternative.
-        self.database.wal.write_intermediate_objs(
+        self.database.wal.write_execution_output(
             &digest,
             inner_temporary_store.clone(),
             signed_effects.clone(),
@@ -1629,7 +1629,7 @@ impl AuthorityState {
                             warn!(?digest, "Failed to process in-progress certificate: {e}");
                         }
                     }
-                    TransactionCommitPhase::CommittedToWal(store, fx) => {
+                    TransactionCommitPhase::Executed(store, fx) => {
                         if let Err(e) = self
                             .commit_and_notify_from_recovery(&cert.into(), store, fx, tx_guard)
                             .await

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -132,7 +132,8 @@ pub const MAX_ITEMS_LIMIT: u64 = 1_000;
 const BROADCAST_CAPACITY: usize = 10_000;
 
 pub(crate) const MAX_TX_RECOVERY_RETRY: u32 = 3;
-type CertTxGuard<'a> = DBTxGuard<'a, TrustedCertificate>;
+type CertTxGuard<'a> =
+    DBTxGuard<'a, TrustedCertificate, (InnerTemporaryStore, SignedTransactionEffects)>;
 
 pub type ReconfigConsensusMessage = (
     AuthorityKeyPair,
@@ -887,8 +888,7 @@ impl AuthorityState {
         // would be more difficult in the alternative.
         self.database.wal.write_execution_output(
             &digest,
-            inner_temporary_store.clone(),
-            signed_effects.clone(),
+            (inner_temporary_store.clone(), signed_effects.clone()),
         )?;
 
         self.commit_cert_and_notify(certificate, inner_temporary_store, signed_effects, tx_guard)

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -57,7 +57,8 @@ const RECONFIG_STATE_INDEX: u64 = 0;
 pub struct SuiDataStore<S> {
     /// A write-ahead/recovery log used to ensure we finish fully processing certs after errors or
     /// crashes.
-    pub wal: Arc<DBWriteAheadLog<TrustedCertificate>>,
+    pub wal:
+        Arc<DBWriteAheadLog<TrustedCertificate, (InnerTemporaryStore, SignedTransactionEffects)>>,
 
     /// The LockService this store depends on for locking functionality
     lock_service: LockService,

--- a/crates/sui-storage/benches/write_ahead_log.rs
+++ b/crates/sui-storage/benches/write_ahead_log.rs
@@ -21,7 +21,7 @@ fn main() {
     // TODO: this is not a very good benchmark but perhaps it can at least find regressions
     let duration = runtime.block_on(async move {
         let working_dir = tempfile::tempdir().unwrap();
-        let wal = Arc::new(DBWriteAheadLog::<usize>::new(
+        let wal = Arc::new(DBWriteAheadLog::<usize, u32>::new(
             working_dir.path().to_path_buf(),
         ));
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -323,6 +323,11 @@ pub enum SuiError {
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{:?}].", digest)]
     TransactionNotFound { digest: TransactionDigest },
     #[error(
+        "Attempt to move to `Executed` state an transaction that has already been executed: {:?}.",
+        digest
+    )]
+    TransactionAlreadyExecuted { digest: TransactionDigest },
+    #[error(
         "Could not find the referenced object {:?} at version {:?}.",
         object_id,
         version

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -8,6 +8,8 @@ use std::ops::Neg;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::resolver::{ModuleResolver, ResourceResolver};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use tracing::trace;
 
 use crate::coin::Coin;
@@ -30,6 +32,8 @@ use crate::{
     },
 };
 
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct InnerTemporaryStore {
     pub objects: BTreeMap<ObjectID, Object>,
     pub mutable_inputs: Vec<ObjectRef>,

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InnerTemporaryStore {
     pub objects: BTreeMap<ObjectID, Object>,
     pub mutable_inputs: Vec<ObjectRef>,


### PR DESCRIPTION
Attempt at addressing data consistency shortcomings in transaction execution. The loss of the Big Atomic Write resulted in a number of bugs which generally stemmed from intermediate representations of tx output making its way to the WAL as a result of failures during write, and retry attempts failing while trying to re-execute against inconsistent object versions. 

The fix is to split transaction execution into two phases: `Uncommitted` and `Executed` (with a third, "committed to permanent store" phase implicit). Recovery can then leverage the WAL directly as a source of truth for the object versions that need to be persisted. As a side effect, this eliminates consistency issues with sharding permanent store, as the WAL can be host specific or can be a separate distributed service available to all executors.

