### PR TITLE
[reconfiguration] Add and record EndOfPublish message

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -1212,6 +1212,22 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(())
     }
 
+    pub fn sent_end_of_publish(&self, authority: &AuthorityName) -> SuiResult<bool> {
+        Ok(self.epoch_tables().end_of_publish.contains_key(authority)?)
+    }
+
+    pub async fn record_end_of_publish(
+        &self,
+        authority: AuthorityName,
+        transaction: &ConsensusTransaction,
+        consensus_index: ExecutionIndicesWithHash,
+    ) -> SuiResult {
+        let write_batch = self.epoch_tables().last_consensus_index.batch();
+        let write_batch =
+            write_batch.insert_batch(&self.epoch_tables().end_of_publish, [(authority, ())])?;
+        self.finish_consensus_transaction_process(write_batch, transaction, consensus_index)
+    }
+
     pub async fn record_consensus_transaction_processed(
         &self,
         transaction: &ConsensusTransaction,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -72,6 +72,9 @@ pub struct AuthorityEpochTables<S> {
     /// The key in this table is incremental index and value is corresponding narwhal
     /// consensus output index
     pub(crate) checkpoint_boundary: DBMap<u64, u64>,
+
+    /// Validators that have sent EndOfPublish message in this epoch
+    pub(crate) end_of_publish: DBMap<AuthorityName, ()>,
 }
 
 impl<S> AuthorityEpochTables<S>

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -850,7 +850,6 @@ mod tests {
 
     #[tokio::test]
     pub async fn checkpoint_builder_test() {
-        let _guard = setup_tracing();
         let tempdir = tempdir().unwrap();
         let mut store: HashMap<TransactionDigest, TransactionEffects> = HashMap::new();
         store.insert(
@@ -1014,21 +1013,5 @@ mod tests {
             /* voting right */ 1,
         );
         (authority_key, Committee::new(0, authorities).unwrap())
-    }
-
-    fn setup_tracing() -> telemetry_subscribers::TelemetryGuards {
-        // Setup tracing
-        let tracing_level = "debug";
-        let network_tracing_level = "info";
-
-        let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
-
-        telemetry_subscribers::TelemetryConfig::new("narwhal")
-            // load env variables
-            .with_env()
-            // load special log filter
-            .with_log_level(&log_filter)
-            .init()
-            .0
     }
 }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -96,13 +96,13 @@ impl ExecutionState for ConsensusHandler {
         };
         let verified_transaction = match self
             .state
-            .verify_consensus_transaction(sequenced_transaction)
+            .verify_consensus_transaction(consensus_output.as_ref(), sequenced_transaction)
         {
             Ok(verified_transaction) => verified_transaction,
             Err(()) => return,
         };
         self.state
-            .handle_consensus_transaction(verified_transaction)
+            .handle_consensus_transaction(consensus_output.as_ref(), verified_transaction)
             .await
             .expect("Unrecoverable error in consensus handler");
     }

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -51,6 +51,7 @@ impl TransactionValidator for ConsensusTxValidator {
                     warn!("Ignoring malformed signature (failed to verify): {err}");
                 })?;
             }
+            ConsensusTransactionKind::EndOfPublish(_) => {}
         }
         Ok(())
     }
@@ -85,6 +86,7 @@ impl TransactionValidator for ConsensusTxValidator {
                         .auth_signature
                         .add_to_verification_obligation(&committee, &mut obligation, idx)?;
                 }
+                ConsensusTransactionKind::EndOfPublish(_) => {}
             }
         }
         // verify the user transaction signatures as a batch

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -41,6 +41,7 @@ use sui_types::{
 };
 use sui_types::{crypto::AuthorityPublicKeyBytes, object::Data};
 
+use narwhal_types::Certificate;
 use tracing::info;
 
 pub enum TestCallArg {
@@ -2153,10 +2154,14 @@ async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertificate) 
     let transaction = SequencedConsensusTransaction::new_test(
         ConsensusTransaction::new_certificate_message(&authority.name, cert.clone().into_inner()),
     );
-
-    if let Ok(transaction) = authority.verify_consensus_transaction(transaction) {
+    let certificate = Certificate::new_test_empty(authority.name.try_into().unwrap());
+    let output = ConsensusOutput {
+        certificate,
+        ..Default::default()
+    };
+    if let Ok(transaction) = authority.verify_consensus_transaction(&output, transaction) {
         authority
-            .handle_consensus_transaction(transaction)
+            .handle_consensus_transaction(&output, transaction)
             .await
             .unwrap();
     }

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1932,12 +1932,14 @@ pub struct ConsensusTransaction {
 pub enum ConsensusTransactionKey {
     Certificate(TransactionDigest),
     CheckpointSignature(AuthorityName, CheckpointSequenceNumber),
+    EndOfPublish(AuthorityName),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConsensusTransactionKind {
     UserTransaction(Box<CertifiedTransaction>),
     CheckpointSignature(Box<CheckpointSignatureMessage>),
+    EndOfPublish(AuthorityName),
 }
 
 impl ConsensusTransaction {
@@ -1978,6 +1980,7 @@ impl ConsensusTransaction {
                 certificate.verify_signature(committee)
             }
             ConsensusTransactionKind::CheckpointSignature(data) => data.verify(committee),
+            ConsensusTransactionKind::EndOfPublish(_) => Ok(()),
         }
     }
 
@@ -1991,6 +1994,9 @@ impl ConsensusTransaction {
                     data.summary.auth_signature.authority,
                     data.summary.summary.sequence_number,
                 )
+            }
+            ConsensusTransactionKind::EndOfPublish(authority) => {
+                ConsensusTransactionKey::EndOfPublish(*authority)
             }
         }
     }

--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -521,6 +521,17 @@ impl Certificate {
         Self::new_unsafe(committee, header, votes, false)
     }
 
+    pub fn new_test_empty(author: PublicKey) -> Self {
+        let header = Header {
+            author,
+            ..Default::default()
+        };
+        Self {
+            header,
+            ..Default::default()
+        }
+    }
+
     fn new_unsafe(
         committee: &Committee,
         header: Header,


### PR DESCRIPTION
This PR introduces `EndOfPublish` message and records it in ConsensusHandler.

This message will be sent by ConsensusAdapter when list of pending consensus certificates is drained.

https://github.com/MystenLabs/sui/issues/5763