### PR TITLE
GUI Sui tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tsconfig.tsbuildinfo
 wallet.log.*
 sui.log.*
 .vercel
+
+# rocket templates
+/templates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
 ]
@@ -159,7 +159,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -507,13 +507,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atomicwrites"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb8f2cd6962fa53c0e2a9d3f97eaa7dbd1e3cbbeeb4745403515b42ae07b3ff6"
 dependencies = [
  "tempfile",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -524,7 +533,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -626,7 +635,7 @@ checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -701,6 +710,12 @@ name = "bimap"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
+
+[[package]]
+name = "binascii"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
@@ -848,7 +863,7 @@ dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "constant_time_eq",
  "digest 0.10.5",
 ]
@@ -1106,6 +1121,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -1123,7 +1144,7 @@ dependencies = [
  "serde 1.0.147",
  "time 0.1.44",
  "wasm-bindgen",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1267,7 +1288,7 @@ checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
 dependencies = [
  "error-code",
  "str-buf",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1326,7 +1347,7 @@ checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static 1.4.0",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1399,7 +1420,7 @@ dependencies = [
  "libc",
  "terminal_size",
  "unicode-width",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1451,6 +1472,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "cookie"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+dependencies = [
+ "aes-gcm",
+ "base64",
+ "hkdf",
+ "hmac",
+ "percent-encoding",
+ "rand 0.8.5",
+ "sha2 0.10.6",
+ "subtle",
+ "time 0.3.15",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,7 +1520,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1514,7 +1553,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1597,7 +1636,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -1611,7 +1650,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1621,7 +1660,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1633,7 +1672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static 1.4.0",
  "memoffset",
@@ -1646,7 +1685,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1656,7 +1695,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static 1.4.0",
 ]
 
@@ -1673,7 +1712,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1689,7 +1728,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1705,7 +1744,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1714,7 +1753,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1723,7 +1762,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1933,7 +1972,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -2093,6 +2132,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
+name = "devise"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c7580b072f1c8476148f16e0a0d5dedddab787da98d86c5082c5e9ed8ab595"
+dependencies = [
+ "devise_codegen",
+ "devise_core",
+]
+
+[[package]]
+name = "devise_codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123c73e7a6e51b05c75fe1a1b2f4e241399ea5740ed810b0e3e6cacd9db5e7b2"
+dependencies = [
+ "devise_core",
+ "quote 1.0.21",
+]
+
+[[package]]
+name = "devise_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0"
+dependencies = [
+ "bitflags",
+ "proc-macro2 1.0.47",
+ "proc-macro2-diagnostics",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "dhat"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,7 +2260,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -2200,7 +2272,7 @@ checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2211,7 +2283,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2377,7 +2449,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2429,7 +2501,7 @@ checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2573,7 +2645,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11dcc7e4d79a8c89b9ab4c6f5c30b1fc4a83c420792da3542fd31179ed5f517"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.36.1",
 ]
@@ -2604,6 +2676,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec9f20e8cd0badcd280ad9be817f0799fe27c45301d096a7e28c9244ad3ace"
 
 [[package]]
+name = "figment"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e56602b469b2201400dec66a66aec5a9b8761ee97cd1b8c96ab2483fcc16cc9"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde 1.0.147",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,7 +2710,7 @@ dependencies = [
  "cc",
  "lazy_static 1.4.0",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2720,6 +2818,41 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -2847,6 +2980,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,7 +3010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2873,7 +3019,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2884,7 +3030,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -2999,7 +3145,7 @@ checksum = "8751f3598db532ad3e924c2ccb3f1f067931e4a13ae194f197a4cc19843be082"
 dependencies = [
  "camino",
  "cargo_metadata",
- "cfg-if",
+ "cfg-if 1.0.0",
  "debug-ignore",
  "fixedbitset 0.4.2",
  "guppy-summaries",
@@ -3027,7 +3173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd039b8f587513b48754811cfa37c2ba079df537b490b602fa641ce18f6e72a"
 dependencies = [
  "camino",
- "cfg-if",
+ "cfg-if 1.0.0",
  "diffus",
  "guppy-workspace-hack",
  "semver 1.0.14",
@@ -3069,7 +3215,7 @@ dependencies = [
  "atomicwrites",
  "bimap",
  "camino",
- "cfg-if",
+ "cfg-if 1.0.0",
  "debug-ignore",
  "diffy",
  "guppy",
@@ -3204,7 +3350,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3335,7 +3481,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3498,6 +3644,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,7 +3701,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3556,6 +3728,15 @@ name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -3819,7 +4000,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.6",
@@ -3831,6 +4012,16 @@ name = "keccak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "lazy_static"
@@ -3864,7 +4055,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec 0.5.2",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -3881,8 +4072,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if",
- "winapi",
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3976,8 +4167,23 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde 1.0.147",
+]
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "serde 1.0.147",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber 0.3.15",
 ]
 
 [[package]]
@@ -4079,15 +4285,34 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4103,12 +4328,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
 name = "miow"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4117,7 +4366,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static 1.4.0",
@@ -4132,7 +4381,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "syn 1.0.103",
@@ -4868,6 +5117,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed4198ce7a4cbd2a57af78d28c6fbb57d81ac5f1d6ad79ac6c5587419cbdf22"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.4",
+ "tokio",
+ "tokio-util 0.7.4",
+ "version_check",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,7 +5261,7 @@ dependencies = [
 name = "mysten-util-mem"
 version = "0.11.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ed25519-consensus",
  "fastcrypto",
  "hashbrown 0.12.3",
@@ -5043,7 +5312,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "thiserror",
  "widestring",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5075,7 +5344,7 @@ dependencies = [
  "arc-swap",
  "bincode",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.0",
  "criterion 0.3.6",
  "fastcrypto",
  "futures",
@@ -5244,7 +5513,7 @@ dependencies = [
  "axum",
  "bincode",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clap 2.34.0",
  "dhat",
  "eyre",
@@ -5520,6 +5789,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 
 [[package]]
+name = "net2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nexlint"
 version = "0.1.0"
 source = "git+https://github.com/nextest-rs/nexlint.git?rev=8df9c4ea982e2be6b528e7b288a82d79d2d4bf20#8df9c4ea982e2be6b528e7b288a82d79d2d4bf20"
@@ -5567,7 +5847,7 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset",
 ]
@@ -5579,7 +5859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -5624,12 +5904,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "normpath"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04aaf5e9cb0fbf883cc0423159eacdf96a9878022084b35c462c428cab73bcaf"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae03c8c853dba7bfd23e571ff0cff7bc9dceb40a4cd684cd1681824183f45257"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5639,7 +5946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5827,7 +6134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -6036,7 +6343,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6104,12 +6411,12 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6118,7 +6425,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -6156,6 +6463,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.5",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "proc-macro2-diagnostics",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -6364,7 +6694,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -6377,7 +6707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e20150f965e0e4c925982b9356da71c84bcd56cb66ef4e894825837cbcf6613e"
 dependencies = [
  "backtrace",
- "cfg-if",
+ "cfg-if 1.0.0",
  "criterion 0.4.0",
  "findshlibs",
  "inferno",
@@ -6526,12 +6856,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static 1.4.0",
  "memchr",
@@ -6608,7 +6951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae5a4388762d5815a9fc0dea33c56b021cdc8dde0c55e0c9ca57197254b0cab"
 dependencies = [
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cmake",
  "heck 0.4.0",
  "itertools",
@@ -7056,7 +7399,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros 1.8.0 (git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=53fa543dd930cc5177783ff2b865e8ef1eab64e4)",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7131,7 +7474,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7209,7 +7552,7 @@ dependencies = [
  "spin 0.5.2",
  "untrusted 0.7.1",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7230,6 +7573,100 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "retain_mut",
+]
+
+[[package]]
+name = "rocket"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ead083fce4a405feb349cf09abdf64471c6077f14e0ce59364aa90d4b99317"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "atomic",
+ "atty",
+ "binascii",
+ "bytes",
+ "either",
+ "figment",
+ "futures",
+ "indexmap",
+ "log",
+ "memchr",
+ "multer",
+ "num_cpus",
+ "parking_lot 0.12.1",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "ref-cast",
+ "rocket_codegen",
+ "rocket_http",
+ "serde 1.0.147",
+ "state",
+ "tempfile",
+ "time 0.3.15",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.4",
+ "ubyte",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "rocket_codegen"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6aeb6bb9c61e9cd2c00d70ea267bf36f76a4cc615e5908b349c2f9d93999b47"
+dependencies = [
+ "devise",
+ "glob",
+ "indexmap",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "rocket_http",
+ "syn 1.0.103",
+ "unicode-xid 0.2.4",
+]
+
+[[package]]
+name = "rocket_dyn_templates"
+version = "0.1.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab13df598440527c200f46fb944dc55d8d67a1818b617eb5a3981dcd8b63fd2"
+dependencies = [
+ "glob",
+ "normpath",
+ "notify",
+ "rocket",
+ "tera",
+]
+
+[[package]]
+name = "rocket_http"
+version = "0.5.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ded65d127954de3c12471630bf4b81a2792f065984461e65b91d0fdaafc17a2"
+dependencies = [
+ "cookie",
+ "either",
+ "futures",
+ "http",
+ "hyper",
+ "indexmap",
+ "log",
+ "memchr",
+ "pear",
+ "percent-encoding",
+ "pin-project-lite",
+ "ref-cast",
+ "serde 1.0.147",
+ "smallvec",
+ "stable-pattern",
+ "state",
+ "time 0.3.15",
+ "tokio",
+ "uncased",
 ]
 
 [[package]]
@@ -7375,7 +7812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clipboard-win",
  "dirs-next",
  "fd-lock",
@@ -7389,7 +7826,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -7452,6 +7889,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.103",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -7754,7 +8197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -7766,7 +8209,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -7777,7 +8220,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -7789,7 +8232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -7801,7 +8244,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -7969,7 +8412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -8106,10 +8549,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable-pattern"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "state"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "static_assertions"
@@ -8213,7 +8674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -8383,6 +8844,8 @@ dependencies = [
  "reqwest",
  "serde 1.0.147",
  "serde_json",
+ "strum",
+ "strum_macros",
  "sui",
  "sui-config",
  "sui-core",
@@ -9057,14 +9520,18 @@ dependencies = [
  "colored",
  "eyre",
  "futures",
+ "hex",
  "itertools",
  "multiaddr 0.16.0",
  "mysten-network 0.1.0",
+ "rocket",
+ "rocket_dyn_templates",
  "rocksdb",
  "serde 1.0.147",
  "serde_with",
  "strum",
  "strum_macros",
+ "sui-cluster-test",
  "sui-config",
  "sui-core",
  "sui-network",
@@ -9322,12 +9789,12 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -9368,7 +9835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -9556,7 +10023,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -9649,7 +10116,7 @@ dependencies = [
  "socket2",
  "tokio-macros 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -9974,7 +10441,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -10153,7 +10620,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -10209,6 +10676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "ubyte"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c81f0dae7d286ad0d9366d7679a77934cfc3cf3a8d67e82669794412b2368fe6"
+dependencies = [
+ "serde 1.0.147",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10232,6 +10708,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
 dependencies = [
+ "serde 1.0.147",
  "version_check",
 ]
 
@@ -10498,7 +10975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -10536,7 +11013,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde 1.0.147",
  "serde_json",
  "wasm-bindgen-macro",
@@ -10563,7 +11040,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -10657,6 +11134,12 @@ checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -10664,6 +11147,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -10677,7 +11166,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -10685,6 +11174,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -10722,6 +11224,12 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
@@ -10731,6 +11239,12 @@ name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10746,6 +11260,12 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
@@ -10755,6 +11275,12 @@ name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10776,6 +11302,12 @@ checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
@@ -10792,7 +11324,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -10843,6 +11375,7 @@ dependencies = [
  "async-stream-impl",
  "async-trait",
  "atoi",
+ "atomic",
  "atomicwrites",
  "atty",
  "autocfg",
@@ -10861,6 +11394,7 @@ dependencies = [
  "better_any",
  "better_typeid_derive",
  "bimap",
+ "binascii",
  "bincode",
  "bindgen",
  "bip32",
@@ -10900,7 +11434,8 @@ dependencies = [
  "cc",
  "cexpr",
  "cfg-expr",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "chrono-tz",
  "chrono-tz-build",
@@ -10930,6 +11465,7 @@ dependencies = [
  "console-subscriber",
  "const-oid",
  "constant_time_eq",
+ "cookie",
  "core-foundation",
  "core-foundation-sys",
  "core2",
@@ -10983,6 +11519,9 @@ dependencies = [
  "derive_builder_macro",
  "determinator",
  "deunicode",
+ "devise",
+ "devise_codegen",
+ "devise_core",
  "dhat",
  "diff",
  "difference",
@@ -11028,6 +11567,8 @@ dependencies = [
  "fdlimit",
  "ff",
  "fiat-crypto",
+ "figment",
+ "filetime",
  "findshlibs",
  "fixed-hash",
  "fixedbitset 0.2.0",
@@ -11042,6 +11583,8 @@ dependencies = [
  "form_urlencoded",
  "fragile",
  "fs_extra",
+ "fsevent",
+ "fsevent-sys",
  "funty",
  "futures",
  "futures-channel",
@@ -11112,12 +11655,16 @@ dependencies = [
  "indexmap",
  "indicatif",
  "inferno",
+ "inlinable_string",
+ "inotify",
+ "inotify-sys",
  "inout",
  "insta",
  "instant",
  "integer-encoding",
  "internment",
  "io-lifetimes",
+ "iovec",
  "ipnet",
  "itertools",
  "itoa 0.4.8",
@@ -11167,8 +11714,10 @@ dependencies = [
  "minimal-lexical",
  "miniz_oxide",
  "mintex",
+ "mio 0.6.23",
  "mio 0.7.14",
  "mio 0.8.4",
+ "mio-extras",
  "mockall",
  "mockall_derive",
  "move-abigen",
@@ -11206,6 +11755,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
+ "multer",
  "multiaddr 0.14.0",
  "multiaddr 0.16.0",
  "multibase",
@@ -11216,6 +11766,7 @@ dependencies = [
  "named-lock",
  "native-tls",
  "nested",
+ "net2",
  "nexlint",
  "nexlint-lints",
  "nibble_vec",
@@ -11225,6 +11776,8 @@ dependencies = [
  "nom 6.1.2",
  "nom 7.1.1",
  "normalize-line-endings",
+ "normpath",
+ "notify",
  "nu-ansi-term",
  "num",
  "num-bigint",
@@ -11275,6 +11828,8 @@ dependencies = [
  "paste",
  "pathdiff",
  "pbkdf2",
+ "pear",
+ "pear_codegen",
  "peeking_take_while",
  "pem",
  "percent-encoding",
@@ -11312,6 +11867,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 0.4.30",
  "proc-macro2 1.0.47",
+ "proc-macro2-diagnostics",
  "prometheus",
  "proptest",
  "proptest-derive",
@@ -11366,6 +11922,10 @@ dependencies = [
  "ring",
  "ripemd",
  "roaring",
+ "rocket",
+ "rocket_codegen",
+ "rocket_dyn_templates",
+ "rocket_http",
  "rocksdb",
  "rust-ini",
  "rust_decimal",
@@ -11448,7 +12008,9 @@ dependencies = [
  "sqlx-core",
  "sqlx-macros",
  "sqlx-rt",
+ "stable-pattern",
  "stable_deref_trait",
+ "state",
  "static_assertions",
  "str-buf",
  "str_stack",
@@ -11538,6 +12100,7 @@ dependencies = [
  "twox-hash",
  "typed-arena",
  "typenum",
+ "ubyte",
  "ucd-trie",
  "uint",
  "uncased",
@@ -11587,10 +12150,12 @@ dependencies = [
  "which",
  "whoami",
  "widestring",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
  "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
  "windows_x86_64_msvc 0.36.1",
+ "windows_x86_64_msvc 0.42.0",
  "winreg",
  "wyhash",
  "wyz",
@@ -11602,6 +12167,16 @@ dependencies = [
  "zeroize",
  "zeroize_derive",
  "zstd-sys",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/crates/sui-cluster-test/Cargo.toml
+++ b/crates/sui-cluster-test/Cargo.toml
@@ -18,6 +18,8 @@ clap = { version = "3.1.14", features = ["derive"] }
 reqwest = { version = "0.11.11", features = ["blocking", "json"] }
 async-trait = "0.1.57"
 anyhow = { version = "1.0.64", features = ["backtrace"] }
+strum_macros = "0.24.3"
+strum = "0.24.1"
 bcs = "0.1.4"
 uuid = {version = "1.1.2", features = [ "v4", "fast-rng"]}
 prometheus = "0.13.3"

--- a/crates/sui-cluster-test/src/config.rs
+++ b/crates/sui-cluster-test/src/config.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use clap::*;
+use anyhow::{anyhow, bail};
+use clap::{ArgEnum, Parser};
 
-#[derive(Parser, Clone, ArgEnum)]
+#[derive(Parser, Clone, ArgEnum, Debug, strum_macros::Display)]
 pub enum Env {
     Devnet,
     Staging,
@@ -12,7 +13,7 @@ pub enum Env {
     NewLocal,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone, Debug)]
 #[clap(name = "", rename_all = "kebab-case")]
 pub struct ClusterTestOpt {
     #[clap(arg_enum)]
@@ -32,6 +33,23 @@ impl ClusterTestOpt {
             faucet_address: None,
             fullnode_address: None,
             websocket_address: None,
+        }
+    }
+}
+
+impl TryFrom<&String> for ClusterTestOpt {
+    type Error = anyhow::Error;
+    fn try_from(env: &String) -> Result<Self, Self::Error> {
+        match Env::from_str(env, true).map_err(|_| anyhow!("Failed to parse {env} as Env"))? {
+            Env::CustomRemote | Env::NewLocal => {
+                bail!("Can't parse from Env::CustomRemote | Env::NewLocal");
+            }
+            other_env => Ok(ClusterTestOpt {
+                env: other_env,
+                faucet_address: None,
+                fullnode_address: None,
+                websocket_address: None,
+            }),
         }
     }
 }

--- a/crates/sui-cluster-test/src/faucet.rs
+++ b/crates/sui-cluster-test/src/faucet.rs
@@ -43,7 +43,10 @@ impl FaucetClientFactory {
 /// Faucet Client abstraction
 #[async_trait]
 pub trait FaucetClient {
-    async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse;
+    async fn request_sui_coins(
+        &self,
+        request_address: SuiAddress,
+    ) -> anyhow::Result<FaucetResponse>;
 }
 
 /// Client for a remote faucet that is accessible by POST requests
@@ -52,7 +55,7 @@ pub struct RemoteFaucetClient {
 }
 
 impl RemoteFaucetClient {
-    fn new(url: String) -> Self {
+    pub fn new(url: String) -> Self {
         info!("Use remote faucet: {}", url);
         Self { remote_url: url }
     }
@@ -62,7 +65,10 @@ impl RemoteFaucetClient {
 impl FaucetClient for RemoteFaucetClient {
     /// Request test SUI coins from faucet.
     /// It also verifies the effects are observed by gateway/fullnode.
-    async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
+    async fn request_sui_coins(
+        &self,
+        request_address: SuiAddress,
+    ) -> anyhow::Result<FaucetResponse> {
         let gas_url = format!("{}/gas", self.remote_url);
         debug!("Getting coin from remote faucet {}", gas_url);
         let data = HashMap::from([("recipient", Hex::encode(request_address))]);
@@ -82,14 +88,13 @@ impl FaucetClient for RemoteFaucetClient {
             .unwrap_or_else(|e| panic!("Failed to talk to remote faucet {:?}: {:?}", gas_url, e));
         let full_bytes = response.bytes().await.unwrap();
         let faucet_response: FaucetResponse = serde_json::from_slice(&full_bytes)
-            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {:?}: {e}", full_bytes))
-            .unwrap();
+            .map_err(|e| anyhow::anyhow!("json deser failed with bytes {:?}: {e}", full_bytes))?;
 
         if let Some(error) = faucet_response.error {
-            panic!("Failed to get gas tokens with error: {}", error)
+            anyhow::bail!("Failed to get gas tokens with error: {}", error);
         };
 
-        faucet_response
+        Ok(faucet_response)
     }
 }
 
@@ -106,13 +111,16 @@ impl LocalFaucetClient {
 }
 #[async_trait]
 impl FaucetClient for LocalFaucetClient {
-    async fn request_sui_coins(&self, request_address: SuiAddress) -> FaucetResponse {
+    async fn request_sui_coins(
+        &self,
+        request_address: SuiAddress,
+    ) -> anyhow::Result<FaucetResponse> {
         let receipt = self
             .simple_faucet
             .send(Uuid::new_v4(), request_address, &[200000; 5])
             .await
             .unwrap_or_else(|err| panic!("Failed to get gas tokens with error: {}", err));
 
-        receipt.into()
+        Ok(receipt.into())
     }
 }

--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -57,7 +57,7 @@ pub struct TestContext {
 impl TestContext {
     async fn get_sui_from_faucet(&self, minimum_coins: Option<usize>) -> Vec<GasCoin> {
         let addr = self.get_wallet_address();
-        let faucet_response = self.faucet.request_sui_coins(addr).await;
+        let faucet_response = self.faucet.request_sui_coins(addr).await.unwrap();
 
         let coin_info = faucet_response
             .transferred_gas_objects
@@ -229,11 +229,11 @@ impl TestContext {
 }
 
 pub struct TestCase<'a> {
-    test_case: Box<dyn TestCaseImpl + 'a>,
+    test_case: Box<dyn TestCaseImpl + Send + Sync + 'a>,
 }
 
 impl<'a> TestCase<'a> {
-    pub fn new(test_case: impl TestCaseImpl + 'a) -> Self {
+    pub fn new(test_case: impl TestCaseImpl + Send + Sync + 'a) -> Self {
         TestCase {
             test_case: (Box::new(test_case)),
         }

--- a/crates/sui-test-validator/src/main.rs
+++ b/crates/sui-test-validator/src/main.rs
@@ -118,7 +118,7 @@ async fn faucet_request(
 ) -> impl IntoResponse {
     let result = match payload {
         FaucetRequest::FixedAmountRequest(FixedAmountRequest { recipient }) => {
-            state.faucet.request_sui_coins(recipient).await
+            state.faucet.request_sui_coins(recipient).await.unwrap()
         }
     };
 

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -24,14 +24,21 @@ strum_macros = "^0.24"
 strum = "0.24.1"
 serde = { version = "1.0.144", features = ["derive"] }
 eyre = "0.6.8"
+hex = "0.4.3"
+rocket = "0.5.0-rc.2"
 
 sui-storage = { path = "../sui-storage" }
 sui-core = { path = "../sui-core" }
 sui-config = { path = "../sui-config" }
 sui-types = { path = "../sui-types" }
 sui-network = { path = "../sui-network" }
+sui-cluster-test = { path = "../sui-cluster-test" }
 
 telemetry-subscribers.workspace = true
 
 colored = "2.0.0"
 workspace-hack.workspace = true
+
+[dependencies.rocket_dyn_templates]
+version = "0.1.0-rc.2"
+features = ["tera"]

--- a/crates/sui-tool/src/bin/cli-tool.rs
+++ b/crates/sui-tool/src/bin/cli-tool.rs
@@ -6,8 +6,7 @@ use clap::*;
 use colored::Colorize;
 use sui_types::exit_main;
 
-mod commands;
-use commands::ToolCommand;
+use sui_tool::commands::ToolCommand;
 
 #[tokio::main]
 async fn main() {

--- a/crates/sui-tool/src/bin/gui-tool.rs
+++ b/crates/sui-tool/src/bin/gui-tool.rs
@@ -1,0 +1,349 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GUI is a web tool application for Sui network. Example:
+//! ```
+//! FAUCET_URL=https://faucet.devnet.sui.io \
+//! GENESIS_PATH=genesis.blob \
+//! ENV=devnet \
+//! cargo run --bin gui-tool
+//! ```
+//! You need to have templates folder in the working directory where you
+//! launch the program. For example, you could:
+//! ```
+//! ln -s crates/sui-tool/src/bin/templates/ templates
+//! ```
+//! After launch, open http://127.0.0.1:8000 with your browser
+
+#![allow(clippy::unnecessary_lazy_evaluations)]
+
+#[macro_use]
+extern crate rocket;
+
+use futures::FutureExt;
+use rocket::form::Form;
+use rocket::http::Status;
+use rocket::response::status::Custom;
+use rocket::response::Redirect;
+use rocket::Request;
+use rocket::State;
+use rocket_dyn_templates::{context, Template};
+use serde::Serialize;
+use serde_with::serde_as;
+use std::env;
+use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
+use std::str::FromStr;
+use sui_cluster_test::config::ClusterTestOpt;
+use sui_cluster_test::faucet::{FaucetClient, RemoteFaucetClient};
+use sui_cluster_test::ClusterTest;
+use sui_config::genesis::Genesis;
+use sui_config::ValidatorInfo;
+use sui_tool::get_transaction;
+use sui_tool::{get_object, GrouppedObjectOutput};
+use sui_types::base_types::TransactionDigest;
+use sui_types::base_types::{ObjectID, SuiAddress};
+use telemetry_subscribers::FilterHandle;
+use telemetry_subscribers::TelemetryGuards;
+use tokio::sync::Mutex;
+use tracing::info;
+
+const CLUSTER_TEST_STR: &str = "cluster_test";
+
+#[get("/")]
+async fn cluster_test_home(config: &State<Config>) -> Template {
+    info!("cluster_test_home");
+    let env = &config.cluster_test_opt.env.to_string();
+    Template::render(
+        "cluster-test-home",
+        context![title: "Cluste Test", network: env],
+    )
+}
+
+#[post("/")]
+async fn cluster_test_submit(config: &State<Config>) -> Template {
+    info!("cluster_test_submit");
+    let opt = config.cluster_test_opt.clone();
+
+    let future = ClusterTest::run(opt);
+
+    if let Err(err) = AssertUnwindSafe(future).catch_unwind().await {
+        let panic_str = match err.downcast::<String>() {
+            Ok(v) => *v,
+            Err(_) => "Panic info cannot be stringified.".to_owned(),
+        };
+
+        return Template::render(
+            "error",
+            context! {
+                title: "Cluster Test Run Failed!",
+                error: format!(r#"{:#?}"#, panic_str),
+            },
+        );
+    }
+    Template::render(
+        "cluster-test",
+        context! {
+            title: "Cluster Test",
+            response: "All passed!",
+        },
+    )
+}
+
+#[catch(500)]
+fn internal_server_error(req: &Request) -> Template {
+    info!(?req, "internal_server_error");
+    Template::render(
+        "error",
+        context! {
+            title: "",
+            error: "Oops, some internal server error occurred.".to_owned(),
+        },
+    )
+}
+
+#[get("/")]
+async fn faucet_home() -> Template {
+    info!("faucet_home");
+    Template::render("faucet-home", context![title: "Faucet"])
+}
+
+#[post("/", data = "<address>")]
+async fn faucet_submit(address: Form<String>) -> Redirect {
+    info!(?address, "faucet_submit");
+    let address = address.into_inner();
+    Redirect::to(format!("/faucet/{}", address))
+}
+
+#[get("/<address>")]
+async fn faucet(address: String, config: &State<Config>) -> Template {
+    info!(address, "faucet");
+    let address = ObjectID::from_hex_literal(&address)
+        .map_err(|_e| Custom(Status::BadRequest, "Invalid hex address."));
+    let address = return_if_error!(address);
+
+    let faucet_url = config.faucet_url.clone();
+
+    let faucet_client = RemoteFaucetClient::new(faucet_url);
+    let faucet_response = faucet_client
+        .request_sui_coins(SuiAddress::from(address))
+        .await;
+    Template::render(
+        "faucet",
+        context! {
+            title: "Faucet",
+            response: format!(r#"{:#?}"#, faucet_response)
+        },
+    )
+}
+
+#[get("/")]
+fn validators(config: &State<Config>) -> Template {
+    info!("validators");
+    let genesis_path = config.genesis_path.clone();
+    let genesis = Genesis::load(genesis_path).map_err(|err| {
+        Custom(
+            Status::InternalServerError,
+            format!("Can't load genesis.blob, err: {:?}", err),
+        )
+    });
+    let genesis = return_if_error!(genesis);
+    let validators = genesis
+        .validator_set()
+        .iter()
+        .map(|v| ValidatorInfoForDisplay {
+            inner: v.clone(),
+            account_key_hex: hex::encode(v.account_key()),
+            protocol_key_hex: hex::encode(v.protocol_key()),
+            worker_key_hex: hex::encode(v.worker_key()),
+            network_key_hex: hex::encode(v.network_key()),
+        })
+        .collect::<Vec<_>>();
+    Template::render(
+        "validators",
+        context! {
+            title: "Validators",
+            validators: &validators,
+        },
+    )
+}
+
+#[get("/")]
+async fn object_home() -> Template {
+    info!("object_home");
+    Template::render("object-home", context![title: "Faucet"])
+}
+
+#[derive(FromForm, Debug)]
+struct ObjectQueryForm {
+    object_id: String,
+    #[allow(clippy::all)]
+    object_version: Option<u64>,
+}
+
+const LATEST_VERSION_STR: &str = "latest";
+
+#[post("/", data = "<object_query>")]
+async fn object_query(object_query: Form<ObjectQueryForm>) -> Redirect {
+    info!(?object_query, "object_query");
+    let object_query = object_query.into_inner();
+    let object_version = if let Some(v) = object_query.object_version {
+        v.to_string()
+    } else {
+        LATEST_VERSION_STR.to_owned()
+    };
+    Redirect::to(format!(
+        "/object/{}/{}",
+        object_query.object_id, object_version
+    ))
+}
+
+#[get("/<object_id>/<object_version>")]
+async fn object(object_id: String, object_version: String, config: &State<Config>) -> Template {
+    info!(object_id, object_version, "object");
+    let object_id = ObjectID::from_hex_literal(&object_id)
+        .map_err(|_e| Custom(Status::BadRequest, "Invalid hex address."));
+    let object_id = return_if_error!(object_id);
+    let object_version = if object_version == LATEST_VERSION_STR {
+        None
+    } else {
+        Some(return_if_error!(object_version.parse::<u64>()))
+    };
+
+    let data = get_object(
+        object_id,
+        object_version,
+        None,
+        PathBuf::from(config.genesis_path.clone()),
+        false,
+    )
+    .await;
+    let data = return_if_error!(data);
+    let response = format!(r#"{}"#, GrouppedObjectOutput(data));
+
+    Template::render(
+        "object",
+        context! {
+            title: format!("Object: {:?}", object_id),
+            response,
+        },
+    )
+}
+
+#[get("/")]
+async fn tx_home() -> Template {
+    info!("tx_home");
+    Template::render("transaction-home", context![title: "Faucet"])
+}
+
+#[post("/", data = "<tx_digest>")]
+async fn tx_query(tx_digest: Form<String>) -> Redirect {
+    info!(?tx_digest, "tx_digest");
+    let tx_digest = tx_digest.into_inner();
+    Redirect::to(format!("/transaction/{}", tx_digest))
+}
+
+#[get("/<tx_digest>")]
+async fn tx(tx_digest: String, config: &State<Config>) -> Template {
+    info!(tx_digest, "tx");
+    let tx_digest = TransactionDigest::from_str(&tx_digest)
+        .map_err(|_e| Custom(Status::BadRequest, "Invalid transaction digest."));
+
+    let tx_digest = return_if_error!(tx_digest);
+
+    let data = get_transaction(tx_digest, PathBuf::from(config.genesis_path.clone())).await;
+    let data = return_if_error!(data);
+
+    Template::render(
+        "transaction",
+        context! {
+            title: format!("Transaction: {:?}", tx_digest),
+            response: data
+        },
+    )
+}
+
+#[get("/")]
+fn index() -> Template {
+    info!("index");
+    Template::render(
+        "index",
+        context! {
+            title: "Home",
+        },
+    )
+}
+
+struct Config {
+    genesis_path: String,
+    faucet_url: String,
+    cluster_test_opt: ClusterTestOpt,
+    _guard: Mutex<(TelemetryGuards, FilterHandle)>,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "genesis_path: {}", self.genesis_path)?;
+        writeln!(f, "faucet_url: {}", self.faucet_url)?;
+        write!(f, "cluster_test_opt: {:?}", self.cluster_test_opt)
+    }
+}
+
+#[launch]
+fn rocket() -> _ {
+    let _guard = Mutex::new(
+        telemetry_subscribers::TelemetryConfig::new(env!("CARGO_BIN_NAME"))
+            .with_env()
+            .init(),
+    );
+    let env = env::var("ENV").expect("Env var $ENV is set");
+    let opt = ClusterTestOpt::try_from(&env).expect("Expect valid $ENV");
+    let config = Config {
+        genesis_path: env::var("GENESIS_PATH").expect("Env var $GENESIS_PATH is set"),
+        faucet_url: env::var("FAUCET_URL").expect("Env var $FAUCET_URL is set"),
+        cluster_test_opt: opt,
+        _guard,
+    };
+    info!(?config, "Rocket Server Starts.");
+    rocket::build()
+        .manage(config)
+        .mount("/", routes![index])
+        .mount("/validators", routes![validators])
+        .mount("/faucet", routes![faucet, faucet_submit, faucet_home])
+        .mount("/object", routes![object, object_query, object_home])
+        .mount("/transaction", routes![tx, tx_query, tx_home])
+        .mount(
+            format!("/{}", CLUSTER_TEST_STR),
+            routes![cluster_test_home, cluster_test_submit],
+        )
+        .register("/", catchers![internal_server_error])
+        .attach(Template::fairing())
+}
+
+#[serde_as]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ValidatorInfoForDisplay {
+    pub inner: ValidatorInfo,
+    pub account_key_hex: String,
+    pub protocol_key_hex: String,
+    pub worker_key_hex: String,
+    pub network_key_hex: String,
+}
+
+#[macro_export]
+macro_rules! return_if_error {
+    ($val:expr) => {
+        if let Err(e) = $val {
+            return Template::render(
+                "error",
+                context! {
+                    title: "",
+                    error: format!(r#"{:#?}"#, e)
+                },
+            );
+        } else {
+            $val.unwrap()
+        }
+    };
+}

--- a/crates/sui-tool/src/bin/gui-tool.rs
+++ b/crates/sui-tool/src/bin/gui-tool.rs
@@ -177,7 +177,6 @@ async fn object_home() -> Template {
 #[derive(FromForm, Debug)]
 struct ObjectQueryForm {
     object_id: String,
-    #[allow(clippy::all)]
     object_version: Option<u64>,
 }
 
@@ -233,19 +232,11 @@ async fn object(object_id: String, object_version: String, config: &State<Config
 #[get("/")]
 async fn tx_home() -> Template {
     info!("tx_home");
-    Template::render("transaction-home", context![title: "Faucet"])
+    Template::render("transaction-home", context![title: "Transaction"])
 }
 
-#[post("/", data = "<tx_digest>")]
-async fn tx_query(tx_digest: Form<String>) -> Redirect {
-    info!(?tx_digest, "tx_digest");
-    let tx_digest = tx_digest.into_inner();
-    Redirect::to(format!("/transaction/{}", tx_digest))
-}
-
-#[get("/<tx_digest>")]
-async fn tx(tx_digest: String, config: &State<Config>) -> Template {
-    info!(tx_digest, "tx");
+#[get("/query?<tx_digest>")]
+async fn tx_query(tx_digest: String, config: &State<Config>) ->Template {
     let tx_digest = TransactionDigest::from_str(&tx_digest)
         .map_err(|_e| Custom(Status::BadRequest, "Invalid transaction digest."));
 
@@ -311,7 +302,7 @@ fn rocket() -> _ {
         .mount("/validators", routes![validators])
         .mount("/faucet", routes![faucet, faucet_submit, faucet_home])
         .mount("/object", routes![object, object_query, object_home])
-        .mount("/transaction", routes![tx, tx_query, tx_home])
+        .mount("/transaction", routes![tx_query, tx_home])
         .mount(
             format!("/{}", CLUSTER_TEST_STR),
             routes![cluster_test_home, cluster_test_submit],

--- a/crates/sui-tool/src/bin/templates/base.html.tera
+++ b/crates/sui-tool/src/bin/templates/base.html.tera
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title> Sui GUI Tool - {{ title }}</title>
+  </head>
+  <body>
+    {% include "nav" %}
+
+    {% block content %}{% endblock content %}
+
+  </body>
+</html>

--- a/crates/sui-tool/src/bin/templates/cluster-test-home.html.tera
+++ b/crates/sui-tool/src/bin/templates/cluster-test-home.html.tera
@@ -1,0 +1,12 @@
+{% extends "base" %}
+
+{% block content %}
+    <div class="row">
+      <h4>Run Cluster Test</h4>
+      <form action="/cluster_test" method="post">
+        <div>
+          <input type="submit" value="Go {{network}}">
+        </div>
+      </form>
+    </div>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/cluster-test.html.tera
+++ b/crates/sui-tool/src/bin/templates/cluster-test.html.tera
@@ -1,0 +1,6 @@
+{% extends "base" %}
+
+{% block content %}
+    <h3>Cluster Test Response</h3>
+    <pre> {{response}} </pre>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/error.html.tera
+++ b/crates/sui-tool/src/bin/templates/error.html.tera
@@ -1,0 +1,7 @@
+{% extends "base" %}
+
+{% block content %}
+    <h1>Error!</h1>
+    <h3>{{title}}</h3>
+    <pre>{{error}}</pre>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/faucet-home.html.tera
+++ b/crates/sui-tool/src/bin/templates/faucet-home.html.tera
@@ -1,0 +1,15 @@
+{% extends "base" %}
+
+{% block content %}
+    <div class="row">
+      <h4>Get Coins from Faucet</h4>
+      <form action="/faucet" method="post">
+        <div>
+          <input type="text" placeholder="Hex address starting with '0x'" style="width: 200px;"
+            name="address" id="address" value="" autofocus
+          />
+          <input type="submit" value="Get Gas">
+        </div>
+      </form>
+    </div>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/faucet.html.tera
+++ b/crates/sui-tool/src/bin/templates/faucet.html.tera
@@ -1,0 +1,6 @@
+{% extends "base" %}
+
+{% block content %}
+    <h3>Faucet Response</h3>
+    <pre> {{response}} </pre>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/index.html.tera
+++ b/crates/sui-tool/src/bin/templates/index.html.tera
@@ -1,0 +1,6 @@
+{% extends "base" %}
+
+{% block content %}
+    <h1>Yo!</h1>
+    <h3>Navigate to the right tools in header.</h3>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/nav.html.tera
+++ b/crates/sui-tool/src/bin/templates/nav.html.tera
@@ -1,0 +1,1 @@
+<a href="/">Home</a> | <a href="/validators">Validators</a> | <a href="/faucet">Faucet</a> | <a href="/cluster_test">Run Cluster Test</a> | <a href="/object">Object</a> | <a href="/transaction">Transaction</a>

--- a/crates/sui-tool/src/bin/templates/object-home.html.tera
+++ b/crates/sui-tool/src/bin/templates/object-home.html.tera
@@ -1,0 +1,18 @@
+{% extends "base" %}
+
+{% block content %}
+    <div class="row">
+      <h4>Query Object</h4>
+      <form action="/object" method="post">
+        <div>
+          <input type="text" placeholder="Object Id" style="width: 200px;"
+            name="object_id" id="object_id" value="" autofocus
+          />
+          <input type="text" placeholder="latest" style="width: 200px;"
+            name="object_version" id="object_version" value="" autofocus
+          /> 
+          <input type="submit" value="Query">
+        </div>
+      </form>
+    </div>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/object-home.html.tera
+++ b/crates/sui-tool/src/bin/templates/object-home.html.tera
@@ -3,12 +3,12 @@
 {% block content %}
     <div class="row">
       <h4>Query Object</h4>
-      <form action="/object" method="post">
+      <form action="/object/query" method="get">
         <div>
           <input type="text" placeholder="Object Id" style="width: 200px;"
             name="object_id" id="object_id" value="" autofocus
           />
-          <input type="text" placeholder="latest" style="width: 200px;"
+          <input type="text" placeholder="" style="width: 200px;"
             name="object_version" id="object_version" value="" autofocus
           /> 
           <input type="submit" value="Query">

--- a/crates/sui-tool/src/bin/templates/object.html.tera
+++ b/crates/sui-tool/src/bin/templates/object.html.tera
@@ -1,0 +1,6 @@
+{% extends "base" %}
+
+{% block content %}
+    <h3>Object Response</h3>
+    <pre>{{response}})</pre>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/transaction-home.html.tera
+++ b/crates/sui-tool/src/bin/templates/transaction-home.html.tera
@@ -1,0 +1,15 @@
+{% extends "base" %}
+
+{% block content %}
+    <div class="row">
+      <h4>Query Transaction</h4>
+      <form action="/transaction" method="post">
+        <div>
+          <input type="text" placeholder="Transaction Digest" style="width: 200px;"
+            name="tx_digest" id="tx_digest" value="" autofocus
+          />
+          <input type="submit" value="Query">
+        </div>
+      </form>
+    </div>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/transaction-home.html.tera
+++ b/crates/sui-tool/src/bin/templates/transaction-home.html.tera
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="row">
       <h4>Query Transaction</h4>
-      <form action="/transaction" method="post">
+      <form action="/transaction/query" method="get">
         <div>
           <input type="text" placeholder="Transaction Digest" style="width: 200px;"
             name="tx_digest" id="tx_digest" value="" autofocus

--- a/crates/sui-tool/src/bin/templates/transaction.html.tera
+++ b/crates/sui-tool/src/bin/templates/transaction.html.tera
@@ -1,0 +1,6 @@
+{% extends "base" %}
+
+{% block content %}
+    <h3>Transaction Response</h3>
+    <pre>{{response}})</pre>
+{% endblock content %}

--- a/crates/sui-tool/src/bin/templates/validators.html.tera
+++ b/crates/sui-tool/src/bin/templates/validators.html.tera
@@ -1,0 +1,32 @@
+{% extends "base" %}
+
+{% block content %}
+  <body>
+    <div class="container">
+    <h1>Validators</h1>
+      <ol>
+          {% for key in validators %}
+              <li>
+                <strong>{{ key.inner.name }}</strong> 
+                    <ul>
+                      <li> account key: {{key["inner"]["account-key"] }}</li>
+                      <li> account key hex: 0x{{key["account-key-hex"] }}</li>
+                      <li> protocol key: {{key["inner"]["protocol-key"] }}</li>
+                      <li> protocol key hex: 0x{{key["protocol-key-hex"] }}</li>
+                      <li> worker key: {{key["inner"]["worker-key"] }}</li>
+                      <li> worker key hex: 0x{{key["worker-key-hex"] }}</li>
+                      <li> network key: {{key["inner"]["network-key"] }}</li>
+                      <li> network key hex: 0x{{key["network-key-hex"] }}</li>
+                      <li> stake: {{key["inner"]["stake"] }}</li>
+                      <li> delegation: {{key["inner"]["delegation"] }}</li>
+                      <li> gas price: {{key["inner"]["gas-price"] }}</li>
+                      <li> network address: {{key["inner"]["network-address"] }}</li>
+                      <li> narwhal primary address: {{key["inner"]["narwhal-primary-address"] }}</li>
+                      <li> narwhal worker address: {{key["inner"]["narwhal-worker-address"] }}</li>
+                      <li> narwhal consensus address: {{key["inner"]["narwhal-consensus-address"] }}</li>
+                    </ul>
+              </li>
+          {% endfor %}
+      </ol>
+  </body>
+{% endblock content %}

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -63,10 +63,11 @@ pub enum ToolCommand {
         /// Concise mode groups responses by results.
         /// prints tabular output suitable for processing with unix tools. For
         /// instance, to quickly check that all validators agree on the history of an object:
-        ///
-        ///     $ sui-tool fetch-object --id 0x260efde76ebccf57f4c5e951157f5c361cde822c \
+        ///     ```
+        ///     cli-tool fetch-object --id 0x260efde76ebccf57f4c5e951157f5c361cde822c \
         ///         --genesis $HOME/.sui/sui_config/genesis.blob \
         ///         --history --verbosity concise --concise-no-header
+        ///     ```
         ///
         #[clap(
             arg_enum,

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -1,34 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-use futures::future::join_all;
-use itertools::Itertools;
-use multiaddr::Multiaddr;
-use std::cmp::min;
-use std::collections::BTreeMap;
-use std::path::PathBuf;
-use std::sync::Arc;
-use sui_config::{genesis::Genesis, ValidatorInfo};
-use sui_network::default_mysten_network_config;
-use sui_tool::db_tool::{execute_db_tool_command, print_db_all_tables, DbToolCommand};
-use sui_types::message_envelope::Message;
-use tokio::time::Instant;
-
-use sui_core::authority_client::{
-    AuthorityAPI, NetworkAuthorityClient, NetworkAuthorityClientMetrics,
+use crate::{
+    db_tool::{execute_db_tool_command, print_db_all_tables, DbToolCommand},
+    get_transaction,
 };
-use sui_types::{base_types::*, batch::*, messages::*, object::Owner};
+use anyhow::Result;
+use std::cmp::min;
+use std::path::PathBuf;
+use sui_config::genesis::Genesis;
 
-use anyhow::anyhow;
-use futures::stream::StreamExt;
+use sui_core::authority_client::AuthorityAPI;
+use sui_types::{base_types::*, messages::*};
 
+use crate::{
+    get_object, handle_batch, make_clients, ConciseObjectOutput, GrouppedObjectOutput,
+    VerboseObjectOutput,
+};
 use clap::*;
 use sui_core::authority::MAX_ITEMS_LIMIT;
 use sui_types::messages_checkpoint::{
     CheckpointRequest, CheckpointResponse, CheckpointSequenceNumber,
 };
-use sui_types::object::ObjectFormatOptions;
 
 #[derive(Parser, Clone, ArgEnum)]
 pub enum Verbosity {
@@ -161,356 +154,6 @@ pub enum ToolCommand {
     },
 }
 
-fn make_clients(
-    genesis: PathBuf,
-) -> Result<BTreeMap<AuthorityName, (ValidatorInfo, NetworkAuthorityClient)>> {
-    let net_config = default_mysten_network_config();
-
-    let genesis = Genesis::load(genesis)?;
-
-    let mut authority_clients = BTreeMap::new();
-
-    for validator in genesis.into_validator_set() {
-        let channel = net_config
-            .connect_lazy(validator.network_address())
-            .map_err(|err| anyhow!(err.to_string()))?;
-        let client = NetworkAuthorityClient::new(
-            channel,
-            Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-        );
-        let public_key_bytes = validator.protocol_key();
-        authority_clients.insert(public_key_bytes, (validator, client));
-    }
-
-    Ok(authority_clients)
-}
-
-type ObjectVersionResponses = Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)>;
-struct ObjectData {
-    requested_id: ObjectID,
-    responses: Vec<(AuthorityName, Multiaddr, ObjectVersionResponses)>,
-}
-
-trait OptionDebug<T> {
-    fn opt_debug(&self, def_str: &str) -> String;
-}
-trait OptionDisplay<T> {
-    fn opt_display(&self, def_str: &str) -> String;
-}
-
-impl<T> OptionDebug<T> for Option<T>
-where
-    T: std::fmt::Debug,
-{
-    fn opt_debug(&self, def_str: &str) -> String {
-        match self {
-            None => def_str.to_string(),
-            Some(t) => format!("{:?}", t),
-        }
-    }
-}
-
-impl<T> OptionDisplay<T> for Option<T>
-where
-    T: std::fmt::Display,
-{
-    fn opt_display(&self, def_str: &str) -> String {
-        match self {
-            None => def_str.to_string(),
-            Some(t) => format!("{}", t),
-        }
-    }
-}
-
-struct OwnerOutput(Owner);
-
-// grep/awk-friendly output for Owner
-impl std::fmt::Display for OwnerOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            Owner::AddressOwner(address) => {
-                write!(f, "address({})", address)
-            }
-            Owner::ObjectOwner(address) => {
-                write!(f, "object({})", address)
-            }
-            Owner::Immutable => {
-                write!(f, "immutable")
-            }
-            Owner::Shared { .. } => {
-                write!(f, "shared")
-            }
-        }
-    }
-}
-
-struct GrouppedObjectOutput(ObjectData);
-
-#[allow(clippy::format_in_format_args)]
-impl std::fmt::Display for GrouppedObjectOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let responses = self
-            .0
-            .responses
-            .iter()
-            .flat_map(|(name, multiaddr, resp)| {
-                resp.iter().map(|(seq_num, r, timespent)| {
-                    (*name, multiaddr.clone(), seq_num, r, timespent)
-                })
-            })
-            .sorted_by(|a, b| Ord::cmp(&b.2, &a.2))
-            .group_by(|(_, _, seq_num, _r, _ts)| **seq_num);
-        for (seq_num, group) in &responses {
-            writeln!(f, "seq num: {}", seq_num.opt_debug("latest-seq-num"))?;
-            let cur_version_resp = group.group_by(|(_, _, _, r, _)| match r {
-                Ok(result) => {
-                    let parent_tx_digest = result.parent_certificate.as_ref().map(|tx| tx.digest());
-                    let obj_digest = result
-                        .requested_object_reference
-                        .as_ref()
-                        .map(|(_, _, digest)| digest);
-                    let lock = result
-                        .object_and_lock
-                        .as_ref()
-                        .map(|obj_n_lock| obj_n_lock.lock.as_ref().map(|lock| *lock.digest()));
-                    let owner = result
-                        .object_and_lock
-                        .as_ref()
-                        .map(|obj_n_lock| obj_n_lock.object.owner);
-                    Some((parent_tx_digest, obj_digest, lock, owner))
-                }
-                Err(_) => None,
-            });
-            for (result, group) in &cur_version_resp {
-                match result {
-                    Some((parent_tx_digest, obj_digest, lock, owner)) => {
-                        let objref = obj_digest.opt_debug("objref-not-available");
-                        let parent_cert = parent_tx_digest.opt_debug("<genesis>");
-                        let owner = owner.opt_display("no-owner-available");
-                        let lock = lock.opt_debug("no-known-lock");
-                        writeln!(f, "obj ref: {objref}")?;
-                        writeln!(f, "parent cert: {parent_cert}")?;
-                        writeln!(f, "owner: {owner}")?;
-                        writeln!(f, "lock: {lock}")?;
-                        for (i, (name, multiaddr, _, _, timespent)) in group.enumerate() {
-                            writeln!(
-                                f,
-                                "        {:<4} {:<66} {:<56} (using {:.3} seconds)",
-                                i,
-                                name,
-                                format!("{}", multiaddr),
-                                timespent
-                            )?;
-                        }
-                    }
-                    None => {
-                        writeln!(f, " error")?;
-                        for (i, (name, multiaddr, _, resp, timespent)) in group.enumerate() {
-                            writeln!(
-                                f,
-                                "        {:<4} {:<66} {:<56} (using {:.3} seconds) {:?}",
-                                i,
-                                name,
-                                format!("{}", multiaddr),
-                                timespent,
-                                resp
-                            )?;
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-struct ConciseObjectOutput(ObjectData);
-
-impl ConciseObjectOutput {
-    fn header() -> String {
-        format!(
-            "{:<66} {:<8} {:<66} {:<45} {}",
-            "validator", "version", "digest", "parent_cert", "owner"
-        )
-    }
-}
-
-impl std::fmt::Display for ConciseObjectOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (name, _multi_addr, versions) in &self.0.responses {
-            for (version, resp, _time_elapsed) in versions {
-                write!(
-                    f,
-                    "{:<66} {:<8}",
-                    format!("{:?}", name),
-                    version.map(|s| s.value()).opt_debug("-")
-                )?;
-                match resp {
-                    Err(_) => writeln!(
-                        f,
-                        "{:<66} {:<45} {:<51}",
-                        "object-fetch-failed", "no-cert-available", "no-owner-available"
-                    )?,
-                    Ok(resp) => {
-                        let objref = resp
-                            .requested_object_reference
-                            .map(|(_, _, digest)| digest)
-                            .opt_debug("objref-not-available");
-                        let cert = resp
-                            .parent_certificate
-                            .as_ref()
-                            .map(|c| *c.digest())
-                            .opt_debug("<genesis>");
-                        let owner = resp
-                            .object_and_lock
-                            .as_ref()
-                            .map(|o| OwnerOutput(o.object.owner))
-                            .opt_display("no-owner-available");
-                        write!(f, " {:<66} {:<45} {:<51}", objref, cert, owner)?;
-                    }
-                }
-                writeln!(f)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-struct VerboseObjectOutput(ObjectData);
-
-impl std::fmt::Display for VerboseObjectOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Object: {}", self.0.requested_id)?;
-
-        for (name, multiaddr, versions) in &self.0.responses {
-            writeln!(f, "validator: {:?}, addr: {:?}", name, multiaddr)?;
-
-            for (version, resp, timespent) in versions {
-                writeln!(
-                    f,
-                    "-- version: {} (using {:.3} seconds)",
-                    version.opt_debug("<version not available>"),
-                    timespent,
-                )?;
-
-                match resp {
-                    Err(e) => writeln!(f, "Error fetching object: {}", e)?,
-                    Ok(resp) => {
-                        let objref = resp.requested_object_reference.opt_debug("<no object>");
-                        writeln!(f, "  -- ref: {}", objref)?;
-
-                        write!(f, "  -- cert:")?;
-                        match &resp.parent_certificate {
-                            None => writeln!(f, " <genesis>")?,
-                            Some(cert) => {
-                                let cert = format!("{}", cert);
-                                let cert = textwrap::indent(&cert, "     | ");
-                                write!(f, "\n{}", cert)?;
-                            }
-                        }
-
-                        if let Some(ObjectResponse {
-                            lock,
-                            object,
-                            layout,
-                        }) = &resp.object_and_lock
-                        {
-                            if object.is_package() {
-                                writeln!(f, "  -- object: <Move Package>")?;
-                            } else if let Some(layout) = layout {
-                                writeln!(
-                                    f,
-                                    "  -- object: Move Object: {}",
-                                    object
-                                        .data
-                                        .try_as_move()
-                                        .unwrap()
-                                        .to_move_struct(layout)
-                                        .unwrap()
-                                )?;
-                            }
-                            writeln!(f, "  -- owner: {}", object.owner)?;
-                            writeln!(f, "  -- locked by: {}", lock.opt_debug("<not locked>"))?;
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-async fn get_object(
-    client: &NetworkAuthorityClient,
-    id: ObjectID,
-    start_version: Option<u64>,
-    full_history: bool,
-) -> Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)> {
-    let mut ret = Vec::new();
-    let mut version = start_version;
-
-    loop {
-        let start = Instant::now();
-        let resp = client
-            .handle_object_info_request(ObjectInfoRequest {
-                object_id: id,
-                request_kind: match version {
-                    None => ObjectInfoRequestKind::LatestObjectInfo(Some(
-                        ObjectFormatOptions::default(),
-                    )),
-                    Some(v) => ObjectInfoRequestKind::PastObjectInfoDebug(
-                        SequenceNumber::from_u64(v),
-                        Some(ObjectFormatOptions::default()),
-                    ),
-                },
-            })
-            .await
-            .map_err(anyhow::Error::from);
-        let elapsed = start.elapsed().as_secs_f64();
-
-        let resp_version = resp
-            .as_ref()
-            .ok()
-            .and_then(|r| r.requested_object_reference)
-            .map(|(_, v, _)| v.value());
-        ret.push((resp_version.map(SequenceNumber::from), resp, elapsed));
-
-        version = match (version, resp_version) {
-            (Some(v), _) | (None, Some(v)) => {
-                if v == 1 || !full_history {
-                    break;
-                } else {
-                    Some(v - 1)
-                }
-            }
-            _ => break,
-        };
-    }
-
-    ret
-}
-
-async fn handle_batch(client: &dyn AuthorityAPI, req: &BatchInfoRequest) {
-    let mut streamx = Box::pin(client.handle_batch_stream(req.clone()).await.unwrap());
-
-    while let Some(item) = streamx.next().await {
-        match item {
-            Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
-                println!("batch: {:?}", signed_batch);
-            }
-
-            Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digests)))) => {
-                println!("item: {:?}, {:?}", seq, digests);
-            }
-
-            // Return any errors.
-            Err(err) => {
-                println!("error: {}", err);
-            }
-        }
-    }
-}
-
 impl ToolCommand {
     #[allow(clippy::format_in_format_args)]
     pub async fn execute(self) -> Result<(), anyhow::Error> {
@@ -565,29 +208,8 @@ impl ToolCommand {
                 verbosity,
                 concise_no_header,
             } => {
-                let clients = make_clients(genesis)?;
+                let output = get_object(id, version, validator, genesis, history).await?;
 
-                let responses = join_all(
-                    clients
-                        .iter()
-                        .filter(|(name, _)| {
-                            if let Some(v) = validator {
-                                v == **name
-                            } else {
-                                true
-                            }
-                        })
-                        .map(|(name, (v, client))| async {
-                            let object_versions = get_object(client, id, version, history).await;
-                            (*name, v.network_address().clone(), object_versions)
-                        }),
-                )
-                .await;
-
-                let output = ObjectData {
-                    requested_id: id,
-                    responses,
-                };
                 match verbosity {
                     Verbosity::Groupped => {
                         println!("{}", GrouppedObjectOutput(output));
@@ -604,75 +226,7 @@ impl ToolCommand {
                 }
             }
             ToolCommand::FetchTransaction { genesis, digest } => {
-                let clients = make_clients(genesis)?;
-                let timer = Instant::now();
-                let responses = join_all(clients.iter().map(|(name, (v, client))| async {
-                    let result = client
-                        .handle_transaction_info_request(TransactionInfoRequest {
-                            transaction_digest: digest,
-                        })
-                        .await;
-                    (
-                        *name,
-                        v.network_address().clone(),
-                        result,
-                        timer.elapsed().as_secs_f64(),
-                    )
-                }))
-                .await;
-
-                let responses = responses
-                    .iter()
-                    .sorted_by(|(_, _, resp_a, _), (_, _, resp_b, _)| {
-                        let sort_key_a = resp_a
-                            .as_ref()
-                            .map(|ok_result| {
-                                (ok_result.signed_effects)
-                                    .as_ref()
-                                    .map(|effects| *effects.digest())
-                            })
-                            .ok();
-                        let sort_key_b = resp_b
-                            .as_ref()
-                            .map(|ok_result| {
-                                (ok_result.signed_effects)
-                                    .as_ref()
-                                    .map(|effects| *effects.digest())
-                            })
-                            .ok();
-                        Ord::cmp(&sort_key_a, &sort_key_b)
-                    })
-                    .group_by(|(_name, _addr, resp, _ts)| {
-                        resp.as_ref().map(|ok_result| {
-                            (ok_result.signed_effects)
-                                .as_ref()
-                                .map(|effects| (effects.data(), effects.data().digest()))
-                        })
-                    });
-                for (i, (st, group)) in (&responses).into_iter().enumerate() {
-                    match st {
-                        Ok(Some((effects, effect_digest))) => {
-                            println!(
-                                "#{:<2} tx_digest: {:<68?} effects_digest: {:?}",
-                                i, digest, effect_digest
-                            );
-                            println!("{:#?}", effects);
-                        }
-                        other => {
-                            println!("#{:<2} {:#?}", i, other);
-                        }
-                    }
-                    for (j, res) in group.enumerate() {
-                        println!(
-                            "        {:<4} {:<66} {:<56} (using {:.3} seconds)",
-                            j,
-                            res.0,
-                            format!("{}", res.1),
-                            res.3
-                        );
-                    }
-                    println!();
-                }
+                print!("{}", get_transaction(digest, genesis).await?);
             }
             ToolCommand::DbTool { db_path, cmd } => {
                 let path = PathBuf::from(db_path);

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -2,4 +2,484 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
+use futures::future::join_all;
+use futures::stream::StreamExt;
+use itertools::Itertools;
+use multiaddr::Multiaddr;
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use sui_config::{genesis::Genesis, ValidatorInfo};
+use sui_core::authority_client::{
+    AuthorityAPI, NetworkAuthorityClient, NetworkAuthorityClientMetrics,
+};
+use sui_network::default_mysten_network_config;
+use sui_types::message_envelope::Message;
+use sui_types::object::ObjectFormatOptions;
+use sui_types::{base_types::*, batch::*, messages::*, object::Owner};
+use tokio::time::Instant;
+
+use anyhow::anyhow;
+
+pub mod commands;
 pub mod db_tool;
+
+fn make_clients(
+    genesis: PathBuf,
+) -> Result<BTreeMap<AuthorityName, (ValidatorInfo, NetworkAuthorityClient)>> {
+    let net_config = default_mysten_network_config();
+
+    let genesis = Genesis::load(genesis)?;
+
+    let mut authority_clients = BTreeMap::new();
+
+    for validator in genesis.into_validator_set() {
+        let channel = net_config
+            .connect_lazy(validator.network_address())
+            .map_err(|err| anyhow!(err.to_string()))?;
+        let client = NetworkAuthorityClient::new(
+            channel,
+            Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
+        );
+        let public_key_bytes = validator.protocol_key();
+        authority_clients.insert(public_key_bytes, (validator, client));
+    }
+
+    Ok(authority_clients)
+}
+
+type ObjectVersionResponses = Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)>;
+pub struct ObjectData {
+    requested_id: ObjectID,
+    responses: Vec<(AuthorityName, Multiaddr, ObjectVersionResponses)>,
+}
+
+trait OptionDebug<T> {
+    fn opt_debug(&self, def_str: &str) -> String;
+}
+trait OptionDisplay<T> {
+    fn opt_display(&self, def_str: &str) -> String;
+}
+
+impl<T> OptionDebug<T> for Option<T>
+where
+    T: std::fmt::Debug,
+{
+    fn opt_debug(&self, def_str: &str) -> String {
+        match self {
+            None => def_str.to_string(),
+            Some(t) => format!("{:?}", t),
+        }
+    }
+}
+
+impl<T> OptionDisplay<T> for Option<T>
+where
+    T: std::fmt::Display,
+{
+    fn opt_display(&self, def_str: &str) -> String {
+        match self {
+            None => def_str.to_string(),
+            Some(t) => format!("{}", t),
+        }
+    }
+}
+
+struct OwnerOutput(Owner);
+
+// grep/awk-friendly output for Owner
+impl std::fmt::Display for OwnerOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Owner::AddressOwner(address) => {
+                write!(f, "address({})", address)
+            }
+            Owner::ObjectOwner(address) => {
+                write!(f, "object({})", address)
+            }
+            Owner::Immutable => {
+                write!(f, "immutable")
+            }
+            Owner::Shared { .. } => {
+                write!(f, "shared")
+            }
+        }
+    }
+}
+
+pub struct GrouppedObjectOutput(pub ObjectData);
+
+#[allow(clippy::format_in_format_args)]
+impl std::fmt::Display for GrouppedObjectOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let responses = self
+            .0
+            .responses
+            .iter()
+            .flat_map(|(name, multiaddr, resp)| {
+                resp.iter().map(|(seq_num, r, timespent)| {
+                    (*name, multiaddr.clone(), seq_num, r, timespent)
+                })
+            })
+            .sorted_by(|a, b| Ord::cmp(&b.2, &a.2))
+            .group_by(|(_, _, seq_num, _r, _ts)| **seq_num);
+        for (seq_num, group) in &responses {
+            writeln!(f, "seq num: {}", seq_num.opt_debug("latest-seq-num"))?;
+            let cur_version_resp = group.group_by(|(_, _, _, r, _)| match r {
+                Ok(result) => {
+                    let parent_tx_digest = result.parent_certificate.as_ref().map(|tx| tx.digest());
+                    let obj_digest = result
+                        .requested_object_reference
+                        .as_ref()
+                        .map(|(_, _, digest)| digest);
+                    let lock = result
+                        .object_and_lock
+                        .as_ref()
+                        .map(|obj_n_lock| obj_n_lock.lock.as_ref().map(|lock| *lock.digest()));
+                    let owner = result
+                        .object_and_lock
+                        .as_ref()
+                        .map(|obj_n_lock| obj_n_lock.object.owner);
+                    Some((parent_tx_digest, obj_digest, lock, owner))
+                }
+                Err(_) => None,
+            });
+            for (result, group) in &cur_version_resp {
+                match result {
+                    Some((parent_tx_digest, obj_digest, lock, owner)) => {
+                        let objref = obj_digest.opt_debug("objref-not-available");
+                        let parent_cert = parent_tx_digest.opt_debug("<genesis>");
+                        let owner = owner.opt_display("no-owner-available");
+                        let lock = lock.opt_debug("no-known-lock");
+                        writeln!(f, "obj ref: {objref}")?;
+                        writeln!(f, "parent cert: {parent_cert}")?;
+                        writeln!(f, "owner: {owner}")?;
+                        writeln!(f, "lock: {lock}")?;
+                        for (i, (name, multiaddr, _, _, timespent)) in group.enumerate() {
+                            writeln!(
+                                f,
+                                "        {:<4} {:<66} {:<56} (using {:.3} seconds)",
+                                i,
+                                name,
+                                format!("{}", multiaddr),
+                                timespent
+                            )?;
+                        }
+                    }
+                    None => {
+                        writeln!(f, " error")?;
+                        for (i, (name, multiaddr, _, resp, timespent)) in group.enumerate() {
+                            writeln!(
+                                f,
+                                "        {:<4} {:<66} {:<56} (using {:.3} seconds) {:?}",
+                                i,
+                                name,
+                                format!("{}", multiaddr),
+                                timespent,
+                                resp
+                            )?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+struct ConciseObjectOutput(ObjectData);
+
+impl ConciseObjectOutput {
+    fn header() -> String {
+        format!(
+            "{:<66} {:<8} {:<66} {:<45} {}",
+            "validator", "version", "digest", "parent_cert", "owner"
+        )
+    }
+}
+
+impl std::fmt::Display for ConciseObjectOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (name, _multi_addr, versions) in &self.0.responses {
+            for (version, resp, _time_elapsed) in versions {
+                write!(
+                    f,
+                    "{:<66} {:<8}",
+                    format!("{:?}", name),
+                    version.map(|s| s.value()).opt_debug("-")
+                )?;
+                match resp {
+                    Err(_) => writeln!(
+                        f,
+                        "{:<66} {:<45} {:<51}",
+                        "object-fetch-failed", "no-cert-available", "no-owner-available"
+                    )?,
+                    Ok(resp) => {
+                        let objref = resp
+                            .requested_object_reference
+                            .map(|(_, _, digest)| digest)
+                            .opt_debug("objref-not-available");
+                        let cert = resp
+                            .parent_certificate
+                            .as_ref()
+                            .map(|c| *c.digest())
+                            .opt_debug("<genesis>");
+                        let owner = resp
+                            .object_and_lock
+                            .as_ref()
+                            .map(|o| OwnerOutput(o.object.owner))
+                            .opt_display("no-owner-available");
+                        write!(f, " {:<66} {:<45} {:<51}", objref, cert, owner)?;
+                    }
+                }
+                writeln!(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct VerboseObjectOutput(ObjectData);
+
+impl std::fmt::Display for VerboseObjectOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Object: {}", self.0.requested_id)?;
+
+        for (name, multiaddr, versions) in &self.0.responses {
+            writeln!(f, "validator: {:?}, addr: {:?}", name, multiaddr)?;
+
+            for (version, resp, timespent) in versions {
+                writeln!(
+                    f,
+                    "-- version: {} (using {:.3} seconds)",
+                    version.opt_debug("<version not available>"),
+                    timespent,
+                )?;
+
+                match resp {
+                    Err(e) => writeln!(f, "Error fetching object: {}", e)?,
+                    Ok(resp) => {
+                        let objref = resp.requested_object_reference.opt_debug("<no object>");
+                        writeln!(f, "  -- ref: {}", objref)?;
+
+                        write!(f, "  -- cert:")?;
+                        match &resp.parent_certificate {
+                            None => writeln!(f, " <genesis>")?,
+                            Some(cert) => {
+                                let cert = format!("{}", cert);
+                                let cert = textwrap::indent(&cert, "     | ");
+                                write!(f, "\n{}", cert)?;
+                            }
+                        }
+
+                        if let Some(ObjectResponse {
+                            lock,
+                            object,
+                            layout,
+                        }) = &resp.object_and_lock
+                        {
+                            if object.is_package() {
+                                writeln!(f, "  -- object: <Move Package>")?;
+                            } else if let Some(layout) = layout {
+                                writeln!(
+                                    f,
+                                    "  -- object: Move Object: {}",
+                                    object
+                                        .data
+                                        .try_as_move()
+                                        .unwrap()
+                                        .to_move_struct(layout)
+                                        .unwrap()
+                                )?;
+                            }
+                            writeln!(f, "  -- owner: {}", object.owner)?;
+                            writeln!(f, "  -- locked by: {}", lock.opt_debug("<not locked>"))?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub async fn get_object(
+    obj_id: ObjectID,
+    version: Option<u64>,
+    validator: Option<AuthorityName>,
+    genesis: PathBuf,
+    history: bool,
+) -> Result<ObjectData> {
+    let clients = make_clients(genesis)?;
+
+    let responses = join_all(
+        clients
+            .iter()
+            .filter(|(name, _)| {
+                if let Some(v) = validator {
+                    v == **name
+                } else {
+                    true
+                }
+            })
+            .map(|(name, (v, client))| async {
+                let object_versions = get_object_impl(client, obj_id, version, history).await;
+                (*name, v.network_address().clone(), object_versions)
+            }),
+    )
+    .await;
+
+    Ok(ObjectData {
+        requested_id: obj_id,
+        responses,
+    })
+}
+
+pub async fn get_transaction(tx_digest: TransactionDigest, genesis: PathBuf) -> Result<String> {
+    let clients = make_clients(genesis)?;
+    let timer = Instant::now();
+    let responses = join_all(clients.iter().map(|(name, (v, client))| async {
+        let result = client
+            .handle_transaction_info_request(TransactionInfoRequest {
+                transaction_digest: tx_digest,
+            })
+            .await;
+        (
+            *name,
+            v.network_address().clone(),
+            result,
+            timer.elapsed().as_secs_f64(),
+        )
+    }))
+    .await;
+
+    let responses = responses
+        .iter()
+        .sorted_by(|(_, _, resp_a, _), (_, _, resp_b, _)| {
+            let sort_key_a = resp_a
+                .as_ref()
+                .map(|ok_result| {
+                    (ok_result.signed_effects)
+                        .as_ref()
+                        .map(|effects| *effects.digest())
+                })
+                .ok();
+            let sort_key_b = resp_b
+                .as_ref()
+                .map(|ok_result| {
+                    (ok_result.signed_effects)
+                        .as_ref()
+                        .map(|effects| *effects.digest())
+                })
+                .ok();
+            Ord::cmp(&sort_key_a, &sort_key_b)
+        })
+        .group_by(|(_name, _addr, resp, _ts)| {
+            resp.as_ref().map(|ok_result| {
+                (ok_result.signed_effects)
+                    .as_ref()
+                    .map(|effects| (effects.data(), effects.data().digest()))
+            })
+        });
+    let mut s = String::new();
+    for (i, (st, group)) in (&responses).into_iter().enumerate() {
+        match st {
+            Ok(Some((effects, effect_digest))) => {
+                writeln!(
+                    &mut s,
+                    "#{:<2} tx_digest: {:<68?} effects_digest: {:?}",
+                    i, tx_digest, effect_digest
+                )?;
+                writeln!(&mut s, "{:#?}", effects)?;
+            }
+            other => {
+                writeln!(&mut s, "#{:<2} {:#?}", i, other)?;
+            }
+        }
+        for (j, res) in group.enumerate() {
+            writeln!(
+                &mut s,
+                "        {:<4} {:<66} {:<56} (using {:.3} seconds)",
+                j,
+                res.0,
+                format!("{}", res.1),
+                res.3
+            )?;
+        }
+        writeln!(&mut s)?;
+    }
+    Ok(s)
+}
+
+async fn get_object_impl(
+    client: &NetworkAuthorityClient,
+    id: ObjectID,
+    start_version: Option<u64>,
+    full_history: bool,
+) -> Vec<(Option<SequenceNumber>, Result<ObjectInfoResponse>, f64)> {
+    let mut ret = Vec::new();
+    let mut version = start_version;
+
+    loop {
+        let start = Instant::now();
+        let resp = client
+            .handle_object_info_request(ObjectInfoRequest {
+                object_id: id,
+                request_kind: match version {
+                    None => ObjectInfoRequestKind::LatestObjectInfo(Some(
+                        ObjectFormatOptions::default(),
+                    )),
+                    Some(v) => ObjectInfoRequestKind::PastObjectInfoDebug(
+                        SequenceNumber::from_u64(v),
+                        Some(ObjectFormatOptions::default()),
+                    ),
+                },
+            })
+            .await
+            .map_err(anyhow::Error::from);
+        let elapsed = start.elapsed().as_secs_f64();
+
+        let resp_version = resp
+            .as_ref()
+            .ok()
+            .and_then(|r| r.requested_object_reference)
+            .map(|(_, v, _)| v.value());
+        ret.push((resp_version.map(SequenceNumber::from), resp, elapsed));
+
+        version = match (version, resp_version) {
+            (Some(v), _) | (None, Some(v)) => {
+                if v == 1 || !full_history {
+                    break;
+                } else {
+                    Some(v - 1)
+                }
+            }
+            _ => break,
+        };
+    }
+
+    ret
+}
+
+async fn handle_batch(client: &dyn AuthorityAPI, req: &BatchInfoRequest) {
+    let mut streamx = Box::pin(client.handle_batch_stream(req.clone()).await.unwrap());
+
+    while let Some(item) = streamx.next().await {
+        match item {
+            Ok(BatchInfoResponseItem(UpdateItem::Batch(signed_batch))) => {
+                println!("batch: {:?}", signed_batch);
+            }
+
+            Ok(BatchInfoResponseItem(UpdateItem::Transaction((seq, digests)))) => {
+                println!("item: {:?}, {:?}", seq, digests);
+            }
+
+            // Return any errors.
+            Err(err) => {
+                println!("error: {}", err);
+            }
+        }
+    }
+}

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -48,6 +48,7 @@ asn1-rs = { version = "0.5", features = ["datetime", "std", "time"] }
 async-lock = { version = "2", default-features = false }
 async-stream = { version = "0.3", default-features = false }
 atoi = { version = "1", default-features = false }
+atomic = { version = "0.5", features = ["fallback"] }
 atomicwrites = { version = "0.3", default-features = false }
 atty = { version = "0.2", default-features = false }
 axum = { version = "0.5", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "serde_json", "serde_urlencoded", "tower-log"] }
@@ -63,6 +64,7 @@ bcs = { version = "0.1", default-features = false }
 beef = { version = "0.5", features = ["impl_serde", "serde"] }
 better_any = { version = "0.1", default-features = false }
 bimap = { version = "0.6", features = ["std"] }
+binascii = { version = "0.1", features = ["decode", "encode"] }
 bincode = { version = "1", default-features = false }
 bip32 = { version = "0.4", features = ["alloc", "bip39", "k256", "mnemonic", "once_cell", "pbkdf2", "secp256k1", "std"] }
 bit-set = { version = "0.5", features = ["std"] }
@@ -98,7 +100,7 @@ cassowary = { version = "0.3", default-features = false }
 cast = { version = "0.3", default-features = false }
 cbc = { version = "0.1", features = ["alloc", "block-padding", "std"] }
 cfg-expr = { version = "0.12", features = ["target-lexicon", "targets"] }
-cfg-if = { version = "1", default-features = false }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
 chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
 chrono-tz = { version = "0.6", features = ["std"] }
 cipher = { version = "0.4", default-features = false, features = ["alloc", "block-padding", "std"] }
@@ -120,6 +122,7 @@ console-api = { version = "0.4", default-features = false, features = ["transpor
 console-subscriber = { version = "0.1", features = ["env-filter"] }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
+cookie = { version = "0.16", default-features = false, features = ["aes-gcm", "base64", "hkdf", "hmac", "key-expansion", "percent-encode", "percent-encoding", "private", "rand", "secure", "sha2", "signed", "subtle"] }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
@@ -180,6 +183,7 @@ ed25519-dalek = { version = "1", features = ["rand", "serde_crate", "std", "u64_
 ed25519-dalek-fiat = { version = "0.1", default-features = false, features = ["fiat_u64_backend", "rand", "serde", "serde_bytes", "serde_crate", "std"] }
 either = { version = "1", features = ["use_std"] }
 elliptic-curve = { version = "0.12", default-features = false, features = ["arithmetic", "digest", "ff", "group", "hazmat", "sec1"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
 endian-type = { version = "0.1", default-features = false }
 env_logger = { version = "0.9", features = ["atty", "humantime", "regex", "termcolor"] }
 ethnum = { version = "1", default-features = false }
@@ -193,6 +197,8 @@ fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
 ff = { version = "0.12", default-features = false }
 fiat-crypto = { version = "0.1", features = ["std"] }
+figment = { version = "0.10", default-features = false, features = ["env", "parse-value", "pear", "toml"] }
+filetime = { version = "0.2", default-features = false }
 fixed-hash = { version = "0.7", default-features = false, features = ["byteorder", "rand", "rustc-hex", "std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
 fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", default-features = false }
@@ -261,8 +267,9 @@ impl-codec = { version = "0.5", default-features = false, features = ["std"] }
 impl-serde = { version = "0.3", default-features = false }
 include_dir = { version = "0.7", features = ["glob"] }
 indenter = { version = "0.3" }
-indexmap = { version = "1", default-features = false, features = ["serde", "std"] }
+indexmap = { version = "1", default-features = false, features = ["serde", "serde-1", "std"] }
 indicatif = { version = "0.17", features = ["unicode-width"] }
+inlinable_string = { version = "0.1", default-features = false }
 inout = { version = "0.1", default-features = false, features = ["block-padding", "std"] }
 insta = { version = "1", features = ["colors", "console", "json", "pest", "pest_derive", "redactions", "serde", "yaml"] }
 instant = { version = "0.1", default-features = false }
@@ -345,6 +352,7 @@ move-unit-test = { git = "https://github.com/move-language/move", rev = "0800fc7
 move-vm-runtime = { git = "https://github.com/move-language/move", rev = "0800fc79a98ca304bd449878f545cdcaff6f94bb", features = ["debugging", "testing"] }
 move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "0800fc79a98ca304bd449878f545cdcaff6f94bb" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "0800fc79a98ca304bd449878f545cdcaff6f94bb" }
+multer = { version = "2", features = ["tokio", "tokio-io", "tokio-util"] }
 multiaddr-582f2526e08bb6a0 = { package = "multiaddr", version = "0.14", features = ["url"] }
 multiaddr-986da7b5efc2b80e = { package = "multiaddr", version = "0.16", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
@@ -359,6 +367,8 @@ nom-cdf1610d3e1514e9 = { package = "nom", version = "5", features = ["alloc", "l
 nom-a490c3000a992113 = { package = "nom", version = "6", features = ["alloc", "bitvec", "funty", "lexical", "lexical-core", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
+normpath = { version = "0.3", default-features = false }
+notify = { version = "4", default-features = false }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.4", features = ["num-bigint", "std"] }
 num-bigint = { version = "0.4", features = ["std"] }
@@ -396,6 +406,7 @@ parking_lot_core-c38e5c1d305a1b54 = { package = "parking_lot_core", version = "0
 parking_lot_core-274715c4dabd11b0 = { package = "parking_lot_core", version = "0.9", default-features = false }
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
 pbkdf2 = { version = "0.11", default-features = false }
+pear = { version = "0.2", features = ["color", "yansi"] }
 pem = { version = "1", default-features = false }
 percent-encoding = { version = "2", features = ["alloc"] }
 pest = { version = "2", features = ["std", "thiserror"] }
@@ -460,6 +471,9 @@ rfc6979 = { version = "0.3", default-features = false }
 ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_cell"] }
 ripemd = { version = "0.1", default-features = false }
 roaring = { version = "0.10", default-features = false }
+rocket = { version = "0.5.0-rc.2", features = ["http2"] }
+rocket_dyn_templates = { version = "0.1.0-rc.2", default-features = false, features = ["tera", "tera_"] }
+rocket_http = { version = "0.5.0-rc.2", features = ["http2", "serde", "serde_"] }
 rocksdb = { version = "0.19", features = ["bzip2", "lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
 rust-ini = { version = "0.13", default-features = false }
 rust_decimal = { version = "1", default-features = false }
@@ -522,7 +536,9 @@ sqlformat = { version = "0.2", default-features = false }
 sqlx = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", features = ["_rt-tokio", "macros", "migrate", "runtime-tokio-rustls", "sqlite", "sqlx-macros"] }
 sqlx-core = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", default-features = false, features = ["_rt-tokio", "_tls-rustls", "any", "crc", "flume", "futures-executor", "libsqlite3-sys", "migrate", "runtime-tokio-rustls", "rustls", "rustls-pemfile", "sha2", "sqlite", "tokio-stream", "webpki-roots"] }
 sqlx-rt = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", default-features = false, features = ["_rt-tokio", "_tls-rustls", "once_cell", "runtime-tokio-rustls", "tokio", "tokio-rustls"] }
+stable-pattern = { version = "0.1", features = ["std"] }
 stable_deref_trait = { version = "1", features = ["alloc", "std"] }
+state = { version = "0.5", default-features = false }
 static_assertions = { version = "1", default-features = false }
 stringprep = { version = "0.1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
@@ -530,7 +546,7 @@ strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-featur
 strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
 structopt = { version = "0.3" }
 strum = { version = "0.24", features = ["derive", "std", "strum_macros"] }
-subtle = { version = "2", default-features = false, features = ["i128", "std"] }
+subtle = { version = "2", features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
@@ -565,8 +581,8 @@ tokio = { version = "1", features = ["bytes", "fs", "full", "io-std", "io-util",
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls = { version = "0.23", features = ["logging", "tls12"] }
-tokio-stream = { version = "0.1", features = ["fs", "net", "sync", "time", "tokio-util"] }
-tokio-util = { version = "0.7", features = ["codec", "compat", "futures-io", "tracing"] }
+tokio-stream = { version = "0.1", features = ["fs", "net", "signal", "sync", "time", "tokio-util"] }
+tokio-util = { version = "0.7", features = ["codec", "compat", "futures-io", "io", "tracing"] }
 toml = { version = "0.5", features = ["indexmap", "preserve_order"] }
 toml_edit = { version = "0.14", features = ["easy", "serde"] }
 tonic-ca01ad9e24f5d932 = { package = "tonic", version = "0.7", features = ["async-trait", "axum", "channel", "codegen", "h2", "hyper", "hyper-timeout", "prost", "prost-derive", "prost1", "tokio", "tower", "tracing-futures", "transport"] }
@@ -593,9 +609,10 @@ tui = { version = "0.17", features = ["crossterm"] }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
 typenum = { version = "1", default-features = false }
+ubyte = { version = "0.10", features = ["serde"] }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
 uint = { version = "0.9", features = ["std"] }
-uncased = { version = "0.9", default-features = false }
+uncased = { version = "0.9", features = ["alloc", "serde", "with-serde-alloc"] }
 unescape = { version = "0.1", default-features = false }
 unic-char-property = { version = "0.9", default-features = false }
 unic-char-range = { version = "0.9" }
@@ -683,6 +700,7 @@ async-stream = { version = "0.3", default-features = false }
 async-stream-impl = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 atoi = { version = "1", default-features = false }
+atomic = { version = "0.5", features = ["fallback"] }
 atomicwrites = { version = "0.3", default-features = false }
 atty = { version = "0.2", default-features = false }
 autocfg = { version = "1", default-features = false }
@@ -700,6 +718,7 @@ beef = { version = "0.5", features = ["impl_serde", "serde"] }
 better_any = { version = "0.1", default-features = false }
 better_typeid_derive = { version = "0.1", default-features = false }
 bimap = { version = "0.6", features = ["std"] }
+binascii = { version = "0.1", features = ["decode", "encode"] }
 bincode = { version = "1", default-features = false }
 bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 bip32 = { version = "0.4", features = ["alloc", "bip39", "k256", "mnemonic", "once_cell", "pbkdf2", "secp256k1", "std"] }
@@ -739,7 +758,7 @@ cbc = { version = "0.1", features = ["alloc", "block-padding", "std"] }
 cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
 cexpr = { version = "0.6", default-features = false }
 cfg-expr = { version = "0.12", features = ["target-lexicon", "targets"] }
-cfg-if = { version = "1", default-features = false }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
 chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
 chrono-tz = { version = "0.6", features = ["std"] }
 chrono-tz-build = { version = "0.0.3", default-features = false }
@@ -765,6 +784,7 @@ console-api = { version = "0.4", default-features = false, features = ["transpor
 console-subscriber = { version = "0.1", features = ["env-filter"] }
 const-oid = { version = "0.9", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
+cookie = { version = "0.16", default-features = false, features = ["aes-gcm", "base64", "hkdf", "hmac", "key-expansion", "percent-encode", "percent-encoding", "private", "rand", "secure", "sha2", "signed", "subtle"] }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
@@ -808,6 +828,9 @@ derive_builder_core = { version = "0.11", default-features = false }
 derive_builder_macro = { version = "0.11", default-features = false }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
+devise = { version = "0.3", default-features = false }
+devise_codegen = { version = "0.3", default-features = false }
+devise_core = { version = "0.3", default-features = false }
 dhat = { version = "0.3", default-features = false }
 diff = { version = "0.1", default-features = false }
 difference = { version = "2" }
@@ -834,6 +857,7 @@ ed25519-dalek = { version = "1", features = ["rand", "serde_crate", "std", "u64_
 ed25519-dalek-fiat = { version = "0.1", default-features = false, features = ["fiat_u64_backend", "rand", "serde", "serde_bytes", "serde_crate", "std"] }
 either = { version = "1", features = ["use_std"] }
 elliptic-curve = { version = "0.12", default-features = false, features = ["arithmetic", "digest", "ff", "group", "hazmat", "sec1"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
 endian-type = { version = "0.1", default-features = false }
 enum_dispatch = { version = "0.3", default-features = false }
 env_logger = { version = "0.9", features = ["atty", "humantime", "regex", "termcolor"] }
@@ -849,6 +873,8 @@ fd-lock = { version = "3", default-features = false }
 fdlimit = { version = "0.2", default-features = false }
 ff = { version = "0.12", default-features = false }
 fiat-crypto = { version = "0.1", features = ["std"] }
+figment = { version = "0.10", default-features = false, features = ["env", "parse-value", "pear", "toml"] }
+filetime = { version = "0.2", default-features = false }
 fixed-hash = { version = "0.7", default-features = false, features = ["byteorder", "rand", "rustc-hex", "std"] }
 fixedbitset-6f8ce4dd05d13bba = { package = "fixedbitset", version = "0.2", default-features = false }
 fixedbitset-9fbad63c4bcf4a8f = { package = "fixedbitset", version = "0.4", default-features = false }
@@ -925,8 +951,9 @@ impl-trait-for-tuples = { version = "0.2", default-features = false }
 include_dir = { version = "0.7", features = ["glob"] }
 include_dir_macros = { version = "0.7", default-features = false }
 indenter = { version = "0.3" }
-indexmap = { version = "1", default-features = false, features = ["serde", "std"] }
+indexmap = { version = "1", default-features = false, features = ["serde", "serde-1", "std"] }
 indicatif = { version = "0.17", features = ["unicode-width"] }
+inlinable_string = { version = "0.1", default-features = false }
 inout = { version = "0.1", default-features = false, features = ["block-padding", "std"] }
 insta = { version = "1", features = ["colors", "console", "json", "pest", "pest_derive", "redactions", "serde", "yaml"] }
 instant = { version = "0.1", default-features = false }
@@ -1014,6 +1041,7 @@ move-unit-test = { git = "https://github.com/move-language/move", rev = "0800fc7
 move-vm-runtime = { git = "https://github.com/move-language/move", rev = "0800fc79a98ca304bd449878f545cdcaff6f94bb", features = ["debugging", "testing"] }
 move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "0800fc79a98ca304bd449878f545cdcaff6f94bb" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "0800fc79a98ca304bd449878f545cdcaff6f94bb" }
+multer = { version = "2", features = ["tokio", "tokio-io", "tokio-util"] }
 multiaddr-582f2526e08bb6a0 = { package = "multiaddr", version = "0.14", features = ["url"] }
 multiaddr-986da7b5efc2b80e = { package = "multiaddr", version = "0.16", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
@@ -1030,6 +1058,8 @@ nom-cdf1610d3e1514e9 = { package = "nom", version = "5", features = ["alloc", "l
 nom-a490c3000a992113 = { package = "nom", version = "6", features = ["alloc", "bitvec", "funty", "lexical", "lexical-core", "std"] }
 nom-15128469a54ed75a = { package = "nom", version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
+normpath = { version = "0.3", default-features = false }
+notify = { version = "4", default-features = false }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.4", features = ["num-bigint", "std"] }
 num-bigint = { version = "0.4", features = ["std"] }
@@ -1073,6 +1103,8 @@ parse-zoneinfo = { version = "0.3", default-features = false }
 paste = { version = "1", default-features = false }
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
 pbkdf2 = { version = "0.11", default-features = false }
+pear = { version = "0.2", features = ["color", "yansi"] }
+pear_codegen = { version = "0.2", default-features = false }
 peeking_take_while = { version = "0.1", default-features = false }
 pem = { version = "1", default-features = false }
 percent-encoding = { version = "2", features = ["alloc"] }
@@ -1109,6 +1141,7 @@ proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
 proc-macro-error-attr = { version = "1", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro", "span-locations"] }
+proc-macro2-diagnostics = { version = "0.9", features = ["colors", "yansi"] }
 prometheus = { version = "0.13", features = ["protobuf"] }
 proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 proptest-derive = { version = "0.3", default-features = false }
@@ -1159,6 +1192,10 @@ rfc6979 = { version = "0.3", default-features = false }
 ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_cell"] }
 ripemd = { version = "0.1", default-features = false }
 roaring = { version = "0.10", default-features = false }
+rocket = { version = "0.5.0-rc.2", features = ["http2"] }
+rocket_codegen = { version = "0.5.0-rc.2", default-features = false }
+rocket_dyn_templates = { version = "0.1.0-rc.2", default-features = false, features = ["tera", "tera_"] }
+rocket_http = { version = "0.5.0-rc.2", features = ["http2", "serde", "serde_"] }
 rocksdb = { version = "0.19", features = ["bzip2", "lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
 rust-ini = { version = "0.13", default-features = false }
 rust_decimal = { version = "1", default-features = false }
@@ -1233,7 +1270,9 @@ sqlx = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3
 sqlx-core = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", default-features = false, features = ["_rt-tokio", "_tls-rustls", "any", "crc", "flume", "futures-executor", "libsqlite3-sys", "migrate", "runtime-tokio-rustls", "rustls", "rustls-pemfile", "sha2", "sqlite", "tokio-stream", "webpki-roots"] }
 sqlx-macros = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", default-features = false, features = ["_rt-tokio", "migrate", "runtime-tokio-rustls", "sha2", "sqlite"] }
 sqlx-rt = { git = "https://github.com/huitseeker/sqlx", branch = "update_libsqlite3", default-features = false, features = ["_rt-tokio", "_tls-rustls", "once_cell", "runtime-tokio-rustls", "tokio", "tokio-rustls"] }
+stable-pattern = { version = "0.1", features = ["std"] }
 stable_deref_trait = { version = "1", features = ["alloc", "std"] }
+state = { version = "0.5", default-features = false }
 static_assertions = { version = "1", default-features = false }
 stringprep = { version = "0.1", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
@@ -1244,7 +1283,7 @@ structopt-derive = { version = "0.4", default-features = false }
 strum = { version = "0.24", features = ["derive", "std", "strum_macros"] }
 strum_macros = { version = "0.24", default-features = false }
 subprocess = { version = "0.2", default-features = false }
-subtle = { version = "2", default-features = false, features = ["i128", "std"] }
+subtle = { version = "2", features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
@@ -1285,8 +1324,8 @@ tokio-io-timeout = { version = "1", default-features = false }
 tokio-macros = { version = "1", default-features = false }
 tokio-retry = { version = "0.3", default-features = false }
 tokio-rustls = { version = "0.23", features = ["logging", "tls12"] }
-tokio-stream = { version = "0.1", features = ["fs", "net", "sync", "time", "tokio-util"] }
-tokio-util = { version = "0.7", features = ["codec", "compat", "futures-io", "tracing"] }
+tokio-stream = { version = "0.1", features = ["fs", "net", "signal", "sync", "time", "tokio-util"] }
+tokio-util = { version = "0.7", features = ["codec", "compat", "futures-io", "io", "tracing"] }
 toml = { version = "0.5", features = ["indexmap", "preserve_order"] }
 toml_edit = { version = "0.14", features = ["easy", "serde"] }
 tonic-ca01ad9e24f5d932 = { package = "tonic", version = "0.7", features = ["async-trait", "axum", "channel", "codegen", "h2", "hyper", "hyper-timeout", "prost", "prost-derive", "prost1", "tokio", "tower", "tracing-futures", "transport"] }
@@ -1318,9 +1357,10 @@ tui = { version = "0.17", features = ["crossterm"] }
 twox-hash = { version = "1", default-features = false }
 typed-arena = { version = "2", features = ["std"] }
 typenum = { version = "1", default-features = false }
+ubyte = { version = "0.10", features = ["serde"] }
 ucd-trie = { version = "0.1", default-features = false, features = ["std"] }
 uint = { version = "0.9", features = ["std"] }
-uncased = { version = "0.9", default-features = false }
+uncased = { version = "0.9", features = ["alloc", "serde", "with-serde-alloc"] }
 unescape = { version = "0.1", default-features = false }
 unic-char-property = { version = "0.9", default-features = false }
 unic-char-range = { version = "0.9" }
@@ -1389,9 +1429,10 @@ cpufeatures = { version = "0.2", default-features = false }
 criterion-9fbad63c4bcf4a8f = { package = "criterion", version = "0.4", features = ["cargo_bench_support", "plotters", "rayon"] }
 criterion-plot-d8f496e17d97b5cb = { package = "criterion-plot", version = "0.5", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
 errno = { version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
+fsevent = { version = "0.4", default-features = false }
+fsevent-sys = { version = "2", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["indexmap", "nameattr"] }
 io-lifetimes = { version = "0.7", default-features = false }
@@ -1436,10 +1477,11 @@ cpufeatures = { version = "0.2", default-features = false }
 criterion-9fbad63c4bcf4a8f = { package = "criterion", version = "0.4", features = ["cargo_bench_support", "plotters", "rayon"] }
 criterion-plot-d8f496e17d97b5cb = { package = "criterion-plot", version = "0.5", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
 errno = { version = "0.2", default-features = false }
 findshlibs = { version = "0.10", default-features = false }
 fs_extra = { version = "1", default-features = false }
+fsevent = { version = "0.4", default-features = false }
+fsevent-sys = { version = "2", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["indexmap", "nameattr"] }
 io-lifetimes = { version = "0.7", default-features = false }
@@ -1474,6 +1516,7 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 anes = { version = "0.1" }
+cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
 ciborium = { version = "0.2", features = ["std"] }
 ciborium-io = { version = "0.2", default-features = false, features = ["alloc", "std"] }
 ciborium-ll = { version = "0.2", default-features = false }
@@ -1482,21 +1525,27 @@ cpufeatures = { version = "0.2", default-features = false }
 criterion-9fbad63c4bcf4a8f = { package = "criterion", version = "0.4", features = ["cargo_bench_support", "plotters", "rayon"] }
 criterion-plot-d8f496e17d97b5cb = { package = "criterion-plot", version = "0.5", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
 findshlibs = { version = "0.10", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["indexmap", "nameattr"] }
+inotify = { version = "0.7", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
 io-lifetimes = { version = "0.7", default-features = false }
+iovec = { version = "0.1", default-features = false }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5", features = ["background_threads_runtime_support"] }
+lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memmap2 = { version = "0.5", default-features = false }
+mio-3b31131e45eafb45 = { package = "mio", version = "0.6", features = ["with-deprecated"] }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["net", "os-ext", "os-poll", "os-util", "uds"] }
+mio-extras = { version = "2", default-features = false }
 native-tls = { version = "0.2", default-features = false }
+net2 = { version = "0.2", features = ["duration"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
 nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "process", "signal"] }
 num-format = { version = "0.4", default-features = false }
@@ -1523,6 +1572,7 @@ web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 anes = { version = "0.1" }
 autotools = { version = "0.2", default-features = false }
+cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
 ciborium = { version = "0.2", features = ["std"] }
 ciborium-io = { version = "0.2", default-features = false, features = ["alloc", "std"] }
 ciborium-ll = { version = "0.2", default-features = false }
@@ -1531,22 +1581,27 @@ cpufeatures = { version = "0.2", default-features = false }
 criterion-9fbad63c4bcf4a8f = { package = "criterion", version = "0.4", features = ["cargo_bench_support", "plotters", "rayon"] }
 criterion-plot-d8f496e17d97b5cb = { package = "criterion-plot", version = "0.5", default-features = false }
 debugid = { version = "0.8", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
 findshlibs = { version = "0.10", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 fs_extra = { version = "1", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 inferno = { version = "0.11", default-features = false, features = ["indexmap", "nameattr"] }
+inotify = { version = "0.7", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
 io-lifetimes = { version = "0.7", default-features = false }
+iovec = { version = "0.1", default-features = false }
 ipnet = { version = "2" }
 jemalloc-ctl = { version = "0.5" }
 jemalloc-sys = { version = "0.5", features = ["background_threads_runtime_support"] }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 linux-raw-sys = { version = "0.0.46", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memmap2 = { version = "0.5", default-features = false }
+mio-3b31131e45eafb45 = { package = "mio", version = "0.6", features = ["with-deprecated"] }
 mio-ca01ad9e24f5d932 = { package = "mio", version = "0.7", features = ["net", "os-ext", "os-poll", "os-util", "uds"] }
+mio-extras = { version = "2", default-features = false }
 native-tls = { version = "0.2", default-features = false }
+net2 = { version = "0.2", features = ["duration"] }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
 nix-adf3d7031871b0af = { package = "nix", version = "0.24", default-features = false, features = ["fs", "process", "signal"] }
 num-format = { version = "0.4", default-features = false }
@@ -1578,7 +1633,6 @@ cpufeatures = { version = "0.2", default-features = false }
 crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0.8", default-features = false }
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
 encode_unicode = { version = "0.3", features = ["std"] }
-encoding_rs = { version = "0.8", features = ["alloc"] }
 error-code = { version = "2", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 ipnet = { version = "2" }
@@ -1593,10 +1647,12 @@ tokio = { version = "1", default-features = false, features = ["winapi"] }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5", features = ["alloc", "std"] }
-winapi = { version = "0.3", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys = { version = "0.36", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authentication", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_WindowsProgramming"] }
-windows_x86_64_msvc = { version = "0.36", default-features = false }
+windows-sys-4e55305914c60c55 = { package = "windows-sys", version = "0.36", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authentication", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_WindowsProgramming"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32", "Win32_Foundation", "Win32_Storage", "Win32_Storage_FileSystem"] }
+windows_x86_64_msvc-4e55305914c60c55 = { package = "windows_x86_64_msvc", version = "0.36", default-features = false }
+windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
 winreg = { version = "0.10", default-features = false }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
@@ -1606,7 +1662,6 @@ crossterm_winapi-c38e5c1d305a1b54 = { package = "crossterm_winapi", version = "0
 crossterm_winapi-274715c4dabd11b0 = { package = "crossterm_winapi", version = "0.9", default-features = false }
 ctor = { version = "0.1", default-features = false }
 encode_unicode = { version = "0.3", features = ["std"] }
-encoding_rs = { version = "0.8", features = ["alloc"] }
 error-code = { version = "2", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 ipnet = { version = "2" }
@@ -1621,10 +1676,12 @@ tokio = { version = "1", default-features = false, features = ["winapi"] }
 tokio-native-tls = { version = "0.3", default-features = false }
 web-sys = { version = "0.3", default-features = false, features = ["Worker"] }
 widestring = { version = "0.5", features = ["alloc", "std"] }
-winapi = { version = "0.3", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "roapi", "shellapi", "shlobj", "std", "stringapiset", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys = { version = "0.36", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authentication", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_WindowsProgramming"] }
-windows_x86_64_msvc = { version = "0.36", default-features = false }
+windows-sys-4e55305914c60c55 = { package = "windows-sys", version = "0.36", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authentication", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_WindowsProgramming"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32", "Win32_Foundation", "Win32_Storage", "Win32_Storage_FileSystem"] }
+windows_x86_64_msvc-4e55305914c60c55 = { package = "windows_x86_64_msvc", version = "0.36", default-features = false }
+windows_x86_64_msvc-b32c9ddb6d93a9d2 = { package = "windows_x86_64_msvc", version = "0.42", default-features = false }
 winreg = { version = "0.10", default-features = false }
 
 ### END HAKARI SECTION

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -37,6 +37,8 @@ RUN cargo build --release
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 COPY narwhal narwhal
+COPY sui_programmability/examples/basics sui_programmability/examples/basics
+
 RUN cargo build --release \
     --bin sui-node \
     --bin sui \
@@ -44,6 +46,9 @@ RUN cargo build --release \
     --bin sui-faucet \
     --bin stress \
     --bin sui-cluster-test
+
+# build gui-tool in debug mode so it doesn't crash on panic
+RUN cargo build --bin gui-tool
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
@@ -54,6 +59,13 @@ COPY --from=builder /sui/target/release/rpc-server /usr/local/bin
 COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin
 COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin
+
+
+# GUI tool
+COPY --from=builder /sui/target/debug/gui-tool /usr/local/bin
+COPY --from=builder /sui/crates/sui-tool/src/bin/templates /usr/local/bin/templates
+COPY --from=builder /sui/sui_programmability/examples/basics /usr/local/bin/sui_programmability/examples/basics
+COPY --from=builder /sui/crates/sui-framework /usr/local/bin/crates/sui-framework
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
This PR implements a [rocket-based](https://rocket.rs/) web tool for Sui probing, debugging and handling other stuff. We currently have a `cli-tool` binary, but it requires building on the right commit, and the right genesis blob. With this gui tool, we can deploy the images along with network deployment, and access those functionalities more conveniently in a browser. 

1. any party can operate this gui-tool.
2. the application works with only rust code and simple html, so it's easy to add new features even for people who is not specialized in frontend development (the trade-off is the interface is not pretty).

The initial version includes the following functionalities:
1. show validator info, given a genesis blob
3. request faucet token, given a faucet url
4. run cluster test, given env var `env`
5. fetch object from all validators
6. fetch transaction from all validators

The PR:
1. bootstraps the application, 
2. refactors some code in `commands.rs` (moved to `lib.rs`)
3. renames `sui-tool` binary to `cli-tool`
4. builds the aforementioned functionalities in binary `gui-tool`
5. updates `Dockerfile` so `gui` image is built along with `sui-node`

How to run gui locally:
```
FAUCET_URL=https://faucet.devnet.sui.io \
GENESIS_PATH=genesis.blob \
ENV=devnet \
cargo run --bin gui-tool
```

You need to have templates folder in the working directory where you
launch the program. For example, you could:
```
ln -s crates/sui-tool/src/bin/templates/ templates
```
