### PR TITLE
[narwhal] Create certificate only once

### DIFF
--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -322,7 +322,10 @@ impl Core {
         // If we already have a certificate for this round, no need to
         // re-create the certificate, we read and return it.
         if let Some(certificate) = certificate_store.read_by_index(name.clone(), header.round)? {
-            return Ok(certificate);
+            // In case change of epoch we may have different headers for the same round.
+            if certificate.header == header {
+                return Ok(certificate);
+            }
         }
 
         // Reset the votes aggregator and sign our own header.

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -319,6 +319,12 @@ impl Core {
             .with_label_values(&[&header.epoch.to_string()])
             .set(header.round as i64);
 
+        // If we already have a certificate for this round, no need to
+        // re-create the certificate, we read and return it.
+        if let Some(certificate) = certificate_store.read_by_index(name.clone(), header.round)? {
+            return Ok(certificate);
+        }
+
         // Reset the votes aggregator and sign our own header.
         let mut votes_aggregator = VotesAggregator::new(metrics.clone());
         let vote = Vote::new(&header, &name, &signature_service).await;
@@ -418,6 +424,8 @@ impl Core {
         }?;
 
         // Broadcast the certificate.
+        debug!("Broadcast certificate {:?}", certificate);
+
         let epoch = certificate.epoch();
         let round = certificate.header.round;
         let created_at = certificate.header.created_at;

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -20,6 +20,7 @@ use types::ReconfigureNotification;
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_simple_epoch_change() {
     ensure_test_environment();
+    telemetry_subscribers::init_for_testing();
 
     // The configuration of epoch 0.
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();


### PR DESCRIPTION
If a NW certificate for a local header exists, re-use this certificate to re-send, rather than making a new one. Bonus: log in debug, when a certificate is broadcast.