### PR TITLE
[README]  JsonRpcProvider faucetURL needs /gas

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -101,7 +101,7 @@ import { JsonRpcProvider } from '@mysten/sui.js';
 // connect to a custom RPC server
 const provider = new JsonRpcProvider('https://fullnode.devnet.sui.io', {
   // you can also skip providing this field if you don't plan to interact with the faucet
-  faucetURL: 'https://faucet.devnet.sui.io',
+  faucetURL: 'https://faucet.devnet.sui.io/gas',
 });
 // get tokens from a custom faucet server
 await provider.requestSuiFromFaucet(


### PR DESCRIPTION
Docs were missing the `/gas` path and the error was kind of obtuse -- it just said the error was "invalid-json".  Fixing the docs here so people don't get misled, but the error representation should also be tackled separately.