### PR TITLE
[reconfiguration] Send EndOfPublish message

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -392,7 +392,7 @@ impl ValidatorService {
                 &state.name,
                 certificate.clone().into(),
             );
-            let waiter = consensus_adapter.submit(transaction).await?;
+            let waiter = consensus_adapter.submit(transaction)?;
             if certificate.contains_shared_object() {
                 // This is expect on tokio JoinHandle result, not SuiResult
                 waiter

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -44,6 +44,10 @@ impl ReconfigState {
         }
     }
 
+    pub fn is_reject_user_certs(&self) -> bool {
+        matches!(self.status, ReconfigCertStatus::RejectUserCerts)
+    }
+
     pub fn close_all_certs(&mut self) {
         self.status = ReconfigCertStatus::RejectAllCerts;
     }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -138,13 +138,7 @@ async fn submit_transaction_to_consensus_adapter() {
     // Submit the transaction and ensure the adapter reports success to the caller. Note
     // that consensus may drop some transactions (so we may need to resubmit them).
     let transaction = ConsensusTransaction::new_certificate_message(&state.name, certificate);
-    loop {
-        match adapter.submit(transaction.clone()).await {
-            Ok(_) => break,
-            Err(SuiError::ConsensusConnectionBroken(..)) => (),
-            Err(e) => panic!("Unexpected error message: {e}"),
-        }
-    }
+    adapter.submit(transaction.clone()).unwrap().await.unwrap();
 }
 
 pub struct ConsensusMockServer {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1968,6 +1968,16 @@ impl ConsensusTransaction {
         }
     }
 
+    pub fn new_end_of_publish(authority: AuthorityName) -> Self {
+        let mut hasher = DefaultHasher::new();
+        authority.hash(&mut hasher);
+        let tracking_id = hasher.finish().to_be_bytes();
+        Self {
+            tracking_id,
+            kind: ConsensusTransactionKind::EndOfPublish(authority),
+        }
+    }
+
     pub fn get_tracking_id(&self) -> u64 {
         (&self.tracking_id[..])
             .read_u64::<BigEndian>()
@@ -2003,6 +2013,10 @@ impl ConsensusTransaction {
 
     pub fn is_user_certificate(&self) -> bool {
         matches!(self.kind, ConsensusTransactionKind::UserTransaction(_))
+    }
+
+    pub fn is_end_of_publish(&self) -> bool {
+        matches!(self.kind, ConsensusTransactionKind::EndOfPublish(_))
     }
 }
 


### PR DESCRIPTION
This PR sends EndOfPublish when consensus queue is drained. Special care is taken around locks and restartability - see comments on appropriate lines of code.

TODO
- [ ] Unit tests

https://github.com/MystenLabs/sui/issues/5763