### PR TITLE
tracing: bump level of network request spans to INFO

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anemo_tower::callback::CallbackLayer;
+use anemo_tower::trace::DefaultMakeSpan;
 use anemo_tower::trace::TraceLayer;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -338,14 +339,20 @@ impl SuiNode {
                 NetworkConnectionMetrics::new("sui", &prometheus_registry);
 
             let service = ServiceBuilder::new()
-                .layer(TraceLayer::new_for_server_errors())
+                .layer(
+                    TraceLayer::new_for_server_errors()
+                        .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+                )
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(inbound_network_metrics),
                 )))
                 .service(routes);
 
             let outbound_layer = ServiceBuilder::new()
-                .layer(TraceLayer::new_for_client_and_server_errors())
+                .layer(
+                    TraceLayer::new_for_client_and_server_errors()
+                        .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+                )
                 .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                     Arc::new(outbound_network_metrics),
                 )))

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -19,7 +19,7 @@ use anemo::{types::PeerInfo, Network, PeerId};
 use anemo_tower::{
     auth::{AllowedPeers, RequireAuthorizationLayer},
     callback::CallbackLayer,
-    trace::TraceLayer,
+    trace::{DefaultMakeSpan, TraceLayer},
 };
 use async_trait::async_trait;
 use config::{Parameters, SharedCommittee, SharedWorkerCache, WorkerId, WorkerInfo};
@@ -250,14 +250,20 @@ impl Primary {
             .merge(worker_to_primary_router);
 
         let service = ServiceBuilder::new()
-            .layer(TraceLayer::new_for_server_errors())
+            .layer(
+                TraceLayer::new_for_server_errors()
+                    .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+            )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 inbound_network_metrics,
             )))
             .service(routes);
 
         let outbound_layer = ServiceBuilder::new()
-            .layer(TraceLayer::new_for_client_and_server_errors())
+            .layer(
+                TraceLayer::new_for_client_and_server_errors()
+                    .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+            )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 outbound_network_metrics,
             )))

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -14,7 +14,7 @@ use anemo::{types::PeerInfo, Network, PeerId};
 use anemo_tower::{
     auth::{AllowedPeers, RequireAuthorizationLayer},
     callback::CallbackLayer,
-    trace::TraceLayer,
+    trace::{DefaultMakeSpan, TraceLayer},
 };
 use async_trait::async_trait;
 use config::{Parameters, SharedCommittee, SharedWorkerCache, WorkerId};
@@ -166,14 +166,20 @@ impl Worker {
             .merge(primary_to_worker_router);
 
         let service = ServiceBuilder::new()
-            .layer(TraceLayer::new_for_server_errors())
+            .layer(
+                TraceLayer::new_for_server_errors()
+                    .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+            )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 inbound_network_metrics,
             )))
             .service(routes);
 
         let outbound_layer = ServiceBuilder::new()
-            .layer(TraceLayer::new_for_client_and_server_errors())
+            .layer(
+                TraceLayer::new_for_client_and_server_errors()
+                    .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO)),
+            )
             .layer(CallbackLayer::new(MetricsMakeCallbackHandler::new(
                 outbound_network_metrics,
             )))


### PR DESCRIPTION
Increase the level of network request spans to INFO so that they'll be enabled and able to provide more context when network request errors occur.