### PR TITLE
[genesis] Open authority store with genesis

### DIFF
--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -262,7 +262,11 @@ mod tests {
         let path = dir.join(format!("DB_{:?}", ObjectID::random()));
         fs::create_dir(&path).unwrap();
 
-        let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+        let store = Arc::new(
+            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+                .await
+                .unwrap(),
+        );
 
         let notifier = Arc::new(
             TransactionNotifier::new(store.clone(), &prometheus::Registry::default()).unwrap(),

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1677,7 +1677,11 @@ async fn test_authority_persist() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+    let store = Arc::new(
+        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
     let authority =
         crate::authority_batch::batch_tests::init_state(committee, authority_key, store).await;
 
@@ -1702,7 +1706,11 @@ async fn test_authority_persist() {
         crate::authority_batch::batch_tests::init_state_parameters_from_rng(
             &mut StdRng::from_seed(seed),
         );
-    let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+    let store = Arc::new(
+        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
     let authority2 =
         crate::authority_batch::batch_tests::init_state(committee, authority_key, store).await;
     let obj2 = authority2.get_object(&object_id).await.unwrap().unwrap();

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -3,6 +3,7 @@
 
 use fastcrypto::traits::KeyPair;
 use rand::{prelude::StdRng, SeedableRng};
+use sui_config::genesis::Genesis;
 use sui_storage::node_sync_store::NodeSyncStore;
 use sui_types::committee::Committee;
 use sui_types::crypto::get_key_pair;
@@ -95,7 +96,6 @@ pub(crate) async fn init_state(
         None,
         None,
         None,
-        &sui_config::genesis::Genesis::get_default_genesis(),
         &prometheus::Registry::new(),
         tx_reconfigure_consensus,
         checkpoint_service,
@@ -118,7 +118,11 @@ async fn test_open_manager() {
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     {
         // Create an authority
-        let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+        let store = Arc::new(
+            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+                .await
+                .unwrap(),
+        );
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
         // TEST 1: init from an empty database should return to a zero block
@@ -149,7 +153,11 @@ async fn test_open_manager() {
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     {
         // Create an authority
-        let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+        let store = Arc::new(
+            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+                .await
+                .unwrap(),
+        );
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
         let last_block = authority_state
@@ -176,7 +184,11 @@ async fn test_open_manager() {
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
     {
         // Create an authority
-        let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+        let store = Arc::new(
+            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+                .await
+                .unwrap(),
+        );
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
         let last_block = authority_state.init_batches_from_database().unwrap();
@@ -198,7 +210,11 @@ async fn test_batch_manager_happy_path() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+    let store = Arc::new(
+        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -272,7 +288,11 @@ async fn test_batch_manager_out_of_order() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+    let store = Arc::new(
+        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -342,7 +362,11 @@ async fn test_batch_manager_drop_out_of_order() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(AuthorityStore::open(&path, None).unwrap());
+    let store = Arc::new(
+        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
 
     // Make a test key pair
     let seed = [1u8; 32];
@@ -717,7 +741,11 @@ async fn test_safe_batch_stream() {
     authorities.insert(public_key_bytes, 1);
     let committee = Committee::new(0, authorities).unwrap();
     // Create an authority
-    let store = Arc::new(AuthorityStore::open(&path.join("store"), None).unwrap());
+    let store = Arc::new(
+        AuthorityStore::open(&path.join("store"), None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
     let state = init_state(committee.clone(), authority_key, store).await;
     let committee_store = state.committee_store().clone();
 

--- a/crates/sui-core/src/unit_tests/gateway_state_tests.rs
+++ b/crates/sui-core/src/unit_tests/gateway_state_tests.rs
@@ -32,7 +32,11 @@ async fn create_gateway_state_with_object_basics_ref(
         .collect();
     let (authorities, _, pkg_ref) = init_local_authorities(4, genesis_objects).await;
     let path = tempfile::tempdir().unwrap().into_path();
-    let gateway_store = Arc::new(GatewayStore::open(&path, None).unwrap());
+    let gateway_store = Arc::new(
+        GatewayStore::open(&path, None, &Genesis::get_default_genesis())
+            .await
+            .unwrap(),
+    );
     let gateway = GatewayState::new_with_authorities(
         gateway_store,
         authorities,
@@ -653,7 +657,11 @@ async fn test_multiple_gateways() {
     let path = tempfile::tempdir().unwrap().into_path();
     // gateway2 shares the same set of authorities as gateway1.
     let gateway2 = GatewayState::new_with_authorities(
-        Arc::new(GatewayStore::open(&path, None).unwrap()),
+        Arc::new(
+            GatewayStore::open(&path, None, &Genesis::get_default_genesis())
+                .await
+                .unwrap(),
+        ),
         gateway1.authorities.clone(),
         GatewayMetrics::new_for_tests(),
     )

--- a/crates/sui-gateway/src/main.rs
+++ b/crates/sui-gateway/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     let prometheus_registry = sui_node::metrics::start_prometheus_server(prom_binding);
 
     let gateway_config = PersistedConfig::read(&config_path)?;
-    let client = GatewayState::create_client(&gateway_config, Some(&prometheus_registry))?;
+    let client = GatewayState::create_client(&gateway_config, Some(&prometheus_registry)).await?;
 
     let address = SocketAddr::new(IpAddr::V4(options.host), options.port);
     let mut server =

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -110,7 +110,8 @@ impl SuiNode {
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
         let committee = genesis.committee()?;
-        let store = Arc::new(AuthorityStore::open(&config.db_path().join("store"), None)?);
+        let store =
+            Arc::new(AuthorityStore::open(&config.db_path().join("store"), None, genesis).await?);
         let committee_store = Arc::new(CommitteeStore::new(
             config.db_path().join("epochs"),
             &committee,
@@ -194,7 +195,6 @@ impl SuiNode {
                 index_store.clone(),
                 event_store,
                 transaction_streamer,
-                genesis,
                 &prometheus_registry,
                 tx_reconfigure_consensus,
                 checkpoint_service,

--- a/crates/sui-sdk/src/embedded_gateway.rs
+++ b/crates/sui-sdk/src/embedded_gateway.rs
@@ -50,7 +50,7 @@ impl SuiClient {
 }
 
 impl SuiClient {
-    pub fn new(sui_config_dir: &Path) -> Result<Self, anyhow::Error> {
+    pub async fn new(sui_config_dir: &Path) -> Result<Self, anyhow::Error> {
         let network_path = sui_config_dir.join(SUI_NETWORK_CONFIG);
         let network_conf: NetworkConfig = PersistedConfig::read(&network_path)?;
         let db_folder_path = sui_config_dir.join("gateway_client_db");
@@ -59,7 +59,7 @@ impl SuiClient {
             db_folder_path,
             ..Default::default()
         };
-        let api = GatewayState::create_client(&gateway_conf, None)?;
+        let api = GatewayState::create_client(&gateway_conf, None).await?;
         let read_api = Arc::new(ReadApi { api: api.clone() });
         let quorum_driver = QuorumDriver { api: api.clone() };
         let transaction_builder =

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -884,7 +884,8 @@ impl WalletContext {
             .create_rpc_client(request_timeout)
             .await?;
         #[cfg(msim)]
-        let client = sui_sdk::embedded_gateway::SuiClient::new(&config_path.parent().unwrap())?;
+        let client =
+            sui_sdk::embedded_gateway::SuiClient::new(&config_path.parent().unwrap()).await?;
         #[cfg(msim)]
         let _request_timeout = request_timeout; // silence linter.
 


### PR DESCRIPTION
Today we pass genesis to AuthorityState's constructor, and if the store is empty, we initialize it with the genesis.
This adds an extra layer of initialization dependency: we should be able to pass the genesis to the store constructor directly.
We could even take one step further by passing the list of genesis objects, instead of genesis, however I want to leave the door open for now in case we have more complex genesis logic down the road (i.e. more than just objects)