### PR TITLE
RFC [move][verifier][adapter] Allow return values from entry functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8157,6 +8157,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-vm-runtime",
+ "move-vm-types",
  "once_cell",
  "sui-cost-tables",
  "sui-framework",

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_param.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_param.exp
@@ -2,4 +2,4 @@ processed 2 tasks
 
 task 1 'publish'. lines 5-24:
 Error: Transaction Effects Status: Sui Move Bytecode Verification Error. Please run the Sui Move Verifier for more information.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last (and at most second) parameter for _::M1::init to be &mut sui::tx_context::TxContext, but found &mut sui::tx_context::TxContext") } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: SuiMoveVerificationError, source: Some("Expected last (and at most second) parameter for _::M1::init to be &mut or & `sui::tx_context::TxContext`, but found &mut sui::tx_context::TxContext") } }

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -19,6 +19,7 @@ move-binary-format.workspace = true
 move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
 move-vm-runtime.workspace = true
+move-vm-types.workspace = true
 
 sui-framework = { path = "../sui-framework" }
 sui-json = { path = "../sui-json" }

--- a/crates/sui-verifier/src/one_time_witness_verifier.rs
+++ b/crates/sui-verifier/src/one_time_witness_verifier.rs
@@ -167,10 +167,10 @@ fn verify_init_single_param(
     let fn_sig = view.signature_at(fn_handle.parameters);
     if fn_sig.len() != 1 {
         return Err(format!(
-            "Expected last (and at most second) parameter for {}::{} to be &mut {}::{}::{}; \
+            "Expected last (and at most second) parameter for {}::{} to be &mut or & `{}::{}::{}`; \
              optional first parameter must be of one-time witness type whose name is the same as \
-             the capitalized module name ({}::{}) and which has no fields or a single field of type \
-             bool",
+             the capitalized module name ({}::{}) and which has no fields or a single field of \
+             type bool",
             module.self_id(),
             INIT_FN_NAME,
             SUI_FRAMEWORK_ADDRESS,


### PR DESCRIPTION
- Allow return values from entry functions
- Non-object values must have drop
- Object values must have store
- Object values are given to the transaction sender

- First step in addressing #5836 