### PR TITLE
[checkpoint] Define CheckpointStore

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -81,7 +81,9 @@ use sui_types::{
 
 use crate::authority::authority_notifier::TransactionNotifierTicket;
 use crate::authority::authority_notify_read::NotifyRead;
-use crate::checkpoints::{CheckpointMetrics, CheckpointService, LogCheckpointOutput};
+use crate::checkpoints::{
+    CheckpointMetrics, CheckpointService, CheckpointStore, LogCheckpointOutput,
+};
 use crate::consensus_handler::{
     SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction,
 };
@@ -1501,8 +1503,10 @@ impl AuthorityState {
             None,
         ));
 
+        let checkpoint_store = CheckpointStore::new(&path.join("checkpoints"));
+
         let checkpoint_service = CheckpointService::spawn(
-            &path.join("checkpoint2"),
+            checkpoint_store,
             Box::new(store.clone()),
             LogCheckpointOutput::boxed(),
             LogCheckpointOutput::boxed_certified(),

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -141,11 +141,11 @@ impl<A> ActiveAuthority<A> {
         authority: Arc<AuthorityState>,
         net: AuthorityAggregator<A>,
         prometheus_registry: &Registry,
-        network_metrics: Arc<NetworkAuthorityClientMetrics>,
     ) -> SuiResult<Self> {
         let committee = authority.clone_committee();
 
         let net = Arc::new(net);
+        let network_metrics = net.network_client_metrics.clone();
 
         Ok(ActiveAuthority {
             health: Arc::new(Mutex::new(
@@ -172,12 +172,7 @@ impl<A> ActiveAuthority<A> {
         authority: Arc<AuthorityState>,
         net: AuthorityAggregator<A>,
     ) -> SuiResult<Self> {
-        Self::new(
-            authority,
-            net,
-            &Registry::new(),
-            Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-        )
+        Self::new(authority, net, &Registry::new())
     }
 
     /// Returns the amount of time we should wait to be able to contact at least

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -264,7 +264,7 @@ pub fn make_network_authority_client_sets_from_system_state(
     sui_system_state: &SuiSystemState,
     network_config: &Config,
     network_metrics: Arc<NetworkAuthorityClientMetrics>,
-) -> anyhow::Result<BTreeMap<AuthorityPublicKeyBytes, NetworkAuthorityClient>> {
+) -> anyhow::Result<BTreeMap<AuthorityName, NetworkAuthorityClient>> {
     let mut authority_clients = BTreeMap::new();
     for validator in &sui_system_state.validators.active_validators {
         let address = Multiaddr::try_from(validator.metadata.net_address.clone())?;
@@ -272,8 +272,8 @@ pub fn make_network_authority_client_sets_from_system_state(
             .connect_lazy(&address)
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel, network_metrics.clone());
-        let name: &[u8] = &validator.metadata.name;
-        let public_key_bytes = AuthorityPublicKeyBytes::from_bytes(name)?;
+        let name: &[u8] = &validator.metadata.pubkey_bytes;
+        let public_key_bytes = AuthorityName::from_bytes(name)?;
         authority_clients.insert(public_key_bytes, client);
     }
     Ok(authority_clients)
@@ -283,7 +283,7 @@ pub fn make_network_authority_client_sets_from_committee(
     committee: &CommitteeWithNetAddresses,
     network_config: &Config,
     network_metrics: Arc<NetworkAuthorityClientMetrics>,
-) -> anyhow::Result<BTreeMap<AuthorityPublicKeyBytes, NetworkAuthorityClient>> {
+) -> anyhow::Result<BTreeMap<AuthorityName, NetworkAuthorityClient>> {
     let mut authority_clients = BTreeMap::new();
     for (name, _stakes) in &committee.committee.voting_rights {
         let address = committee.net_addresses.get(name).ok_or_else(|| {

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -20,21 +20,21 @@ use sui_types::storage::WriteStore;
 use typed_store::Map;
 
 use crate::authority::AuthorityStore;
-use crate::checkpoints::CheckpointService;
+use crate::checkpoints::CheckpointStore;
 use crate::epoch::committee_store::CommitteeStore;
 
 #[derive(Clone)]
 pub struct RocksDbStore {
     authority_store: Arc<AuthorityStore>,
     committee_store: Arc<CommitteeStore>,
-    checkpoint_store: Arc<CheckpointService>,
+    checkpoint_store: Arc<CheckpointStore>,
 }
 
 impl RocksDbStore {
     pub fn new(
         authority_store: Arc<AuthorityStore>,
         committee_store: Arc<CommitteeStore>,
-        checkpoint_store: Arc<CheckpointService>,
+        checkpoint_store: Arc<CheckpointStore>,
     ) -> Self {
         Self {
             authority_store,


### PR DESCRIPTION
Make the checkpoint tables public as CheckpointStore. This allows us to use it directly inside RocksDbStore without accessing it through the CheckpointService. Removed all the indirect accesses.