### PR TITLE
[TypeScript SDK] Fix bug in LocalTxnSerializer

### DIFF
--- a/.changeset/silly-badgers-run.md
+++ b/.changeset/silly-badgers-run.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Fix callArg serialization bug in LocalTxnSerializer

--- a/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/call-arg-serializer.ts
@@ -156,7 +156,10 @@ export class CallArgSerializer {
     }
 
     const structVal = extractStructTag(expectedType);
-    if (structVal != null) {
+    if (
+      structVal != null ||
+      (typeof expectedType === 'object' && 'TypeParameter' in expectedType)
+    ) {
       if (typeof argVal !== 'string') {
         throw new Error(
           `${MOVE_CALL_SER_ERROR} expect the argument to be an object id string, got ${JSON.stringify(

--- a/sdk/typescript/test/e2e/data/serializer/Move.toml
+++ b/sdk/typescript/test/e2e/data/serializer/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "serializer"
+version = "0.0.1"
+
+[dependencies]
+Sui = { local = "../../../../../../crates/sui-framework" }
+
+[addresses]
+serializer =  "0x0"

--- a/sdk/typescript/test/e2e/data/serializer/sources/serializer.move
+++ b/sdk/typescript/test/e2e/data/serializer/sources/serializer.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module serializer::serializer_tests {
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    public entry fun list<T: key + store, C>(
+        item: T,
+        ctx: &mut TxContext
+    ) {
+        transfer::transfer(item, tx_context::sender(ctx))
+    }
+}


### PR DESCRIPTION
For functions like

```
public entry fun list<T: key + store, C>(
        item: T,
        ctx: &mut TxContext
    ) {
        transfer::transfer(item, tx_context::sender(ctx))
    }
```
The normalized type for `item` is `{TypeParameter: 0}`, and we should serialize them into `Object` in this case. Here's the corresponding Rust implementation: https://github.com/MystenLabs/sui/blob/954d3629452dace6fe82dbb5844aef326550804b/crates/sui-json/src/lib.rs#L565-L568


closes https://github.com/MystenLabs/sui/issues/5993