### PR TITLE
[checkpoint] Move CheckpointService to ConsensusHandler

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5,6 +5,7 @@
 use crate::{
     authority_client::{AuthorityAPI, NetworkAuthorityClient, NetworkAuthorityClientMetrics},
     authority_server::AuthorityServer,
+    checkpoints::CheckpointServiceNoop,
     test_utils::to_sender_signed_transaction,
 };
 
@@ -2511,7 +2512,7 @@ async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertificate) 
     };
     if let Ok(transaction) = authority.verify_consensus_transaction(&output, transaction) {
         authority
-            .handle_consensus_transaction(&output, transaction)
+            .handle_consensus_transaction(&output, transaction, &Arc::new(CheckpointServiceNoop {}))
             .await
             .unwrap();
     }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
+use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_handler::VerifiedSequencedConsensusTransaction;
 use crate::test_utils::to_sender_signed_transaction;
 use move_core_types::{account_address::AccountAddress, ident_str};
@@ -124,6 +125,7 @@ async fn submit_transaction_to_consensus_adapter() {
                 .handle_consensus_transaction(
                     &output,
                     VerifiedSequencedConsensusTransaction::new_test(transaction.clone()),
+                    &Arc::new(CheckpointServiceNoop {}),
                 )
                 .await
         }


### PR DESCRIPTION
Previously CheckpointService is part of AuthorityState. This creates a strange requirement that even a fullnode needs to run checkpoint service.
This PR moves the checkpoint service to be under consensus handler instead. Now only validator runs checkpoint service, further simplify node start up process.