### PR TITLE
[checkpoint] Add Arc<AuthorityState> to checkpoint components

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, Guard};
 use chrono::prelude::*;
 use fastcrypto::traits::KeyPair;
 use move_bytecode_utils::module_cache::SyncModuleCache;
@@ -561,6 +561,7 @@ pub struct AuthorityState {
     reconfig_state_mem: RwLock<ReconfigState>,
 
     /// A channel to tell consensus to reconfigure.
+    /// TODO: This does not really belong to AuthorityState. We should move it out.
     _tx_reconfigure_consensus: mpsc::Sender<ReconfigConsensusMessage>,
 }
 
@@ -1579,8 +1580,12 @@ impl AuthorityState {
         self.database.clone()
     }
 
+    pub fn committee(&self) -> Guard<Arc<Committee>> {
+        self.committee.load()
+    }
+
     pub fn clone_committee(&self) -> Committee {
-        self.committee.load().clone().deref().clone()
+        self.committee().clone().deref().clone()
     }
 
     pub fn get_reconfig_state_read_lock_guard(

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -287,11 +287,11 @@ impl ValidatorService {
         });
 
         let checkpoint_service = CheckpointService::spawn(
+            state.clone(),
             checkpoint_store,
             Box::new(state.database.clone()),
             checkpoint_output,
             Box::new(certified_checkpoint_output),
-            state.clone_committee(),
             CheckpointMetrics::new(&prometheus_registry),
         );
 


### PR DESCRIPTION
Today we are passing epoch and committee into checkpoint service. This creates an extra vector for reconfiguration, which is not ideal.
After a few refactorings we are now able to pass the authority state directly into the checkpoint service. This eliminates the need for adding epoch/committee there.