### PR TITLE
[narwhal] initialize GC round on recovery

### DIFF
--- a/narwhal/consensus/src/tests/consensus_tests.rs
+++ b/narwhal/consensus/src/tests/consensus_tests.rs
@@ -54,6 +54,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee.clone());
@@ -74,6 +75,7 @@ async fn test_consensus_recovery_with_bullshark() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         bullshark,
         metrics.clone(),
@@ -143,6 +145,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let storage = NodeStorage::reopen(temp_dir());
 
@@ -163,6 +166,7 @@ async fn test_consensus_recovery_with_bullshark() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         bullshark,
         metrics.clone(),
@@ -215,6 +219,7 @@ async fn test_consensus_recovery_with_bullshark() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(100);
     let (tx_primary, _rx_primary) = test_utils::test_channel!(100);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let bullshark = Bullshark::new(
         committee.clone(),
@@ -230,6 +235,7 @@ async fn test_consensus_recovery_with_bullshark() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         bullshark,
         metrics.clone(),

--- a/narwhal/consensus/src/tests/tusk_tests.rs
+++ b/narwhal/consensus/src/tests/tusk_tests.rs
@@ -40,6 +40,7 @@ async fn commit_one() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -57,6 +58,7 @@ async fn commit_one() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         tusk,
         metrics,
@@ -105,6 +107,7 @@ async fn dead_node() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -122,6 +125,7 @@ async fn dead_node() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         tusk,
         metrics,
@@ -224,6 +228,7 @@ async fn not_enough_support() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -241,6 +246,7 @@ async fn not_enough_support() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         tusk,
         metrics,
@@ -312,6 +318,7 @@ async fn missing_leader() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -329,6 +336,7 @@ async fn missing_leader() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         tusk,
         metrics,
@@ -373,6 +381,7 @@ async fn epoch_change() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -390,6 +399,7 @@ async fn epoch_change() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         tusk,
         metrics,
@@ -458,6 +468,7 @@ async fn restart_with_new_committee() {
         let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
         let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
         let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+        let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
         let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
         let (tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -474,6 +485,7 @@ async fn restart_with_new_committee() {
             rx_reconfigure,
             rx_waiter,
             tx_primary,
+            tx_consensus_round_updates,
             tx_output,
             tusk,
             metrics.clone(),

--- a/narwhal/executor/tests/consensus_integration_tests.rs
+++ b/narwhal/executor/tests/consensus_integration_tests.rs
@@ -50,6 +50,7 @@ async fn test_recovery() {
     let (tx_waiter, rx_waiter) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
     let (tx_output, mut rx_output) = test_utils::test_channel!(1);
+    let (tx_consensus_round_updates, _rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(initial_committee);
@@ -70,6 +71,7 @@ async fn test_recovery() {
         rx_reconfigure,
         rx_waiter,
         tx_primary,
+        tx_consensus_round_updates,
         tx_output,
         bullshark,
         metrics,

--- a/narwhal/node/src/lib.rs
+++ b/narwhal/node/src/lib.rs
@@ -85,8 +85,8 @@ impl Node {
         // Compute the public key of this authority.
         let name = keypair.public().clone();
         let mut handles = Vec::new();
-        let mut last_committed_round = 0;
-        let (rx_executor_network, tx_executor_network) = oneshot::channel();
+        let (tx_executor_network, rx_executor_network) = oneshot::channel();
+        let (tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Bullshark");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
@@ -98,7 +98,7 @@ impl Node {
         } else {
             let consensus_handles = Self::spawn_consensus(
                 name.clone(),
-                tx_executor_network,
+                rx_executor_network,
                 worker_cache.clone(),
                 committee.clone(),
                 store,
@@ -107,18 +107,12 @@ impl Node {
                 &tx_reconfigure,
                 rx_new_certificates,
                 tx_committed_certificates.clone(),
+                tx_consensus_round_updates,
                 registry,
             )
             .await?;
 
             handles.extend(consensus_handles);
-            last_committed_round = store
-                .consensus_store
-                .read_last_committed()
-                .values()
-                .max()
-                .cloned()
-                .unwrap_or_default();
 
             (None, NetworkModel::PartiallySynchronous)
         };
@@ -153,13 +147,13 @@ impl Node {
             store.vote_digest_store.clone(),
             tx_new_certificates,
             rx_committed_certificates,
+            rx_consensus_round_updates,
             dag,
             network_model,
             tx_reconfigure,
             tx_committed_certificates,
-            last_committed_round,
             registry,
-            Some(rx_executor_network),
+            Some(tx_executor_network),
         );
         handles.extend(primary_handles);
 
@@ -186,7 +180,7 @@ impl Node {
     /// Spawn the consensus core and the client executing transactions.
     async fn spawn_consensus<State>(
         name: PublicKey,
-        network: oneshot::Receiver<P2pNetwork>,
+        rx_executor_network: oneshot::Receiver<P2pNetwork>,
         worker_cache: SharedWorkerCache,
         committee: SharedCommittee,
         store: &NodeStorage,
@@ -195,6 +189,7 @@ impl Node {
         tx_reconfigure: &watch::Sender<ReconfigureNotification>,
         rx_new_certificates: metered_channel::Receiver<Certificate>,
         tx_committed_certificates: metered_channel::Sender<(Round, Vec<Certificate>)>,
+        tx_consensus_round_updates: watch::Sender<Round>,
         registry: &Registry,
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where
@@ -240,6 +235,7 @@ impl Node {
             tx_reconfigure.subscribe(),
             rx_new_certificates,
             tx_committed_certificates,
+            tx_consensus_round_updates,
             tx_sequence,
             ordering_engine,
             consensus_metrics.clone(),
@@ -250,7 +246,7 @@ impl Node {
         // subscriber handler if it missed some transactions.
         let executor_handles = Executor::spawn(
             name,
-            network,
+            rx_executor_network,
             worker_cache,
             (**committee.load()).clone(),
             execution_state,

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -48,7 +48,7 @@ use store::Store;
 use tokio::{sync::oneshot, time::Instant};
 use tokio::{sync::watch, task::JoinHandle};
 use tower::ServiceBuilder;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 pub use types::PrimaryMessage;
 use types::{
     ensure,
@@ -101,6 +101,7 @@ impl Primary {
         network_model: NetworkModel,
         tx_reconfigure: watch::Sender<ReconfigureNotification>,
         tx_committed_certificates: Sender<(Round, Vec<Certificate>)>,
+        last_committed_round: Round,
         registry: &Registry,
         // See comments in Subscriber::spawn
         rx_executor_network: Option<oneshot::Sender<P2pNetwork>>,
@@ -183,6 +184,11 @@ impl Primary {
             .replace_registered_new_certificates_metric(registry, Box::new(new_certificates_gauge));
 
         let (tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0u64);
+        // Initialize gc round.
+        tx_consensus_round_updates
+            .send(last_committed_round)
+            .expect("Failed to send last_committed_round on initialization!");
+
         let (tx_narwhal_round_updates, rx_narwhal_round_updates) = watch::channel(0u64);
 
         let synchronizer = Arc::new(Synchronizer::new(
@@ -907,7 +913,9 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
         request: anemo::Request<FetchCertificatesRequest>,
     ) -> Result<anemo::Response<FetchCertificatesResponse>, anemo::rpc::Status> {
         let time_start = Instant::now();
-        let peer = request.peer_id().cloned();
+        let peer = request
+            .peer_id()
+            .map_or_else(|| "None".to_string(), |peer_id| format!("{}", peer_id));
         let request = request.into_body();
         let mut response = FetchCertificatesResponse {
             certificates: Vec::new(),
@@ -929,6 +937,14 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
 
         let mut fetch_queue = BinaryHeap::new();
         for (origin, rounds) in &skip_rounds {
+            if rounds.len() > 50 {
+                warn!(
+                    "{} rounds are available locally for origin {}. elapsed = {}ms",
+                    rounds.len(),
+                    origin,
+                    time_start.elapsed().as_millis(),
+                );
+            }
             let next_round = self.find_next_round(origin, lower_bound, rounds)?;
             if let Some(r) = next_round {
                 fetch_queue.push(Reverse((r, origin.clone())));

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -15,6 +15,7 @@ use types::{
 };
 
 /// Receives the highest round reached by consensus and update it for all tasks.
+/// TODO: merge this with Consensus?
 pub struct StateHandler {
     /// The public key of this authority.
     name: PublicKey,

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -78,6 +78,7 @@ async fn get_network_peers_from_admin_server() {
         )
         .unwrap(),
     );
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -95,8 +96,9 @@ async fn get_network_peers_from_admin_server() {
         store.proposer_store.clone(),
         store.payload_store.clone(),
         store.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates, consensus_metrics).1,
@@ -104,7 +106,6 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -191,6 +192,7 @@ async fn get_network_peers_from_admin_server() {
         )
         .unwrap(),
     );
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure_2, _rx_reconfigure_2) = watch::channel(initial_committee);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -210,6 +212,7 @@ async fn get_network_peers_from_admin_server() {
         store.vote_digest_store.clone(),
         /* tx_consensus */ tx_new_certificates_2,
         /* rx_consensus */ rx_feedback_2,
+        rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates_2, consensus_metrics).1,
@@ -217,7 +220,6 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure_2,
         tx_feedback_2,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/primary/src/tests/primary_tests.rs
+++ b/narwhal/primary/src/tests/primary_tests.rs
@@ -104,6 +104,7 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -216,6 +217,7 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure_2,
         tx_feedback_2,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -51,6 +51,7 @@ async fn test_simple_epoch_change() {
         let (tx_feedback, rx_feedback) =
             test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
         tx_channels.push(tx_feedback.clone());
+        let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
         let initial_committee = ReconfigureNotification::NewEpoch(committee_0.clone());
         let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -70,13 +71,13 @@ async fn test_simple_epoch_change() {
             store.proposer_store.clone(),
             store.payload_store.clone(),
             store.vote_digest_store.clone(),
-            /* tx_consensus */ tx_new_certificates,
-            /* rx_consensus */ rx_feedback,
+            tx_new_certificates,
+            rx_feedback,
+            rx_consensus_round_updates,
             /* dag */ None,
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
-            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -173,6 +174,8 @@ async fn test_partial_committee_change() {
         let (tx_feedback, rx_feedback) =
             test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
         epoch_0_tx_channels.push(tx_feedback.clone());
+        let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
+
         let initial_committee = ReconfigureNotification::NewEpoch(committee_0.clone());
         let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
 
@@ -191,13 +194,13 @@ async fn test_partial_committee_change() {
             store.proposer_store.clone(),
             store.payload_store.clone(),
             store.vote_digest_store.clone(),
-            /* tx_consensus */ tx_new_certificates,
-            /* rx_consensus */ rx_feedback,
+            tx_new_certificates,
+            rx_feedback,
+            rx_consensus_round_updates,
             /* dag */ None,
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
-            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -261,6 +264,7 @@ async fn test_partial_committee_change() {
         let (tx_feedback, rx_feedback) =
             test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
         epoch_1_tx_channels.push(tx_feedback.clone());
+        let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
         let initial_committee = ReconfigureNotification::NewEpoch(committee_1.clone());
         let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -280,13 +284,13 @@ async fn test_partial_committee_change() {
             store.proposer_store.clone(),
             store.payload_store,
             store.vote_digest_store,
-            /* tx_consensus */ tx_new_certificates,
-            /* rx_consensus */ rx_feedback,
+            tx_new_certificates,
+            rx_feedback,
+            rx_consensus_round_updates,
             /* dag */ None,
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
-            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -341,6 +345,7 @@ async fn test_restart_with_new_committee_change() {
         let (tx_feedback, rx_feedback) =
             test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
         tx_channels.push(tx_feedback.clone());
+        let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
         let initial_committee = ReconfigureNotification::NewEpoch(committee_0.clone());
         let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -360,13 +365,13 @@ async fn test_restart_with_new_committee_change() {
             store.proposer_store.clone(),
             store.payload_store.clone(),
             store.vote_digest_store.clone(),
-            /* tx_consensus */ tx_new_certificates,
-            /* rx_consensus */ rx_feedback,
+            tx_new_certificates,
+            rx_feedback,
+            rx_consensus_round_updates,
             /* dag */ None,
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
-            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -430,6 +435,7 @@ async fn test_restart_with_new_committee_change() {
             let (tx_feedback, rx_feedback) =
                 test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
             tx_channels.push(tx_feedback.clone());
+            let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
             let initial_committee = ReconfigureNotification::NewEpoch(new_committee.clone());
             let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -449,13 +455,13 @@ async fn test_restart_with_new_committee_change() {
                 store.proposer_store.clone(),
                 store.payload_store.clone(),
                 store.vote_digest_store.clone(),
-                /* tx_consensus */ tx_new_certificates,
-                /* rx_consensus */ rx_feedback,
+                tx_new_certificates,
+                rx_feedback,
+                rx_consensus_round_updates,
                 /* dag */ None,
                 NetworkModel::Asynchronous,
                 tx_reconfigure,
                 /* tx_committed_certificates */ tx_feedback,
-                /* last_committed_round */ 0,
                 &Registry::new(),
                 None,
             );
@@ -533,6 +539,7 @@ async fn test_simple_committee_update() {
         let (tx_feedback, rx_feedback) =
             test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
         tx_channels.push(tx_feedback.clone());
+        let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
         let initial_committee = ReconfigureNotification::NewEpoch(committee_0.clone());
         let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -552,13 +559,13 @@ async fn test_simple_committee_update() {
             store.proposer_store.clone(),
             store.payload_store.clone(),
             store.vote_digest_store.clone(),
-            /* tx_consensus */ tx_new_certificates,
-            /* rx_consensus */ rx_feedback,
+            tx_new_certificates,
+            rx_feedback,
+            rx_consensus_round_updates,
             /* dag */ None,
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
-            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -76,6 +76,7 @@ async fn test_simple_epoch_change() {
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
+            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -196,6 +197,7 @@ async fn test_partial_committee_change() {
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
+            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -284,6 +286,7 @@ async fn test_partial_committee_change() {
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
+            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -363,6 +366,7 @@ async fn test_restart_with_new_committee_change() {
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
+            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );
@@ -451,6 +455,7 @@ async fn test_restart_with_new_committee_change() {
                 NetworkModel::Asynchronous,
                 tx_reconfigure,
                 /* tx_committed_certificates */ tx_feedback,
+                /* last_committed_round */ 0,
                 &Registry::new(),
                 None,
             );
@@ -553,6 +558,7 @@ async fn test_simple_committee_update() {
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
+            /* last_committed_round */ 0,
             &Registry::new(),
             None,
         );

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -117,6 +117,7 @@ async fn test_rounds_errors() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -199,6 +200,7 @@ async fn test_rounds_return_successful_response() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -350,6 +352,7 @@ async fn test_node_read_causal_signed_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -391,6 +394,7 @@ async fn test_node_read_causal_signed_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/primary/tests/integration_tests_proposer_api.rs
+++ b/narwhal/primary/tests/integration_tests_proposer_api.rs
@@ -80,6 +80,7 @@ async fn test_rounds_errors() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
 
@@ -108,8 +109,9 @@ async fn test_rounds_errors() {
         store_primary.proposer_store,
         store_primary.payload_store,
         store_primary.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* external_consensus */
         Some(Arc::new(
             Dag::new(&no_name_committee, rx_new_certificates, consensus_metrics).1,
@@ -117,7 +119,6 @@ async fn test_rounds_errors() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -175,6 +176,7 @@ async fn test_rounds_return_successful_response() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
 
@@ -194,13 +196,13 @@ async fn test_rounds_return_successful_response() {
         store_primary.proposer_store,
         store_primary.payload_store,
         store_primary.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* external_consensus */ Some(dag.clone()),
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -323,6 +325,7 @@ async fn test_node_read_causal_signed_certificates() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
 
@@ -346,13 +349,13 @@ async fn test_node_read_causal_signed_certificates() {
         primary_store_1.proposer_store.clone(),
         primary_store_1.payload_store.clone(),
         primary_store_1.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -360,6 +363,7 @@ async fn test_node_read_causal_signed_certificates() {
     let (tx_new_certificates_2, rx_new_certificates_2) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates_2, rx_consensus_round_updates_2) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -385,8 +389,9 @@ async fn test_node_read_causal_signed_certificates() {
         primary_store_2.proposer_store,
         primary_store_2.payload_store,
         primary_store_2.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates_2,
-        /* rx_consensus */ rx_feedback_2,
+        tx_new_certificates_2,
+        rx_feedback_2,
+        rx_consensus_round_updates_2,
         /* external_consensus */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates_2, consensus_metrics_2).1,
@@ -394,7 +399,6 @@ async fn test_node_read_causal_signed_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -103,6 +103,7 @@ async fn test_get_collections() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -119,8 +120,9 @@ async fn test_get_collections() {
         store.proposer_store.clone(),
         store.payload_store.clone(),
         store.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates, consensus_metrics).1,
@@ -128,7 +130,6 @@ async fn test_get_collections() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -300,6 +301,7 @@ async fn test_remove_collections() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
 
@@ -315,13 +317,13 @@ async fn test_remove_collections() {
         store.proposer_store.clone(),
         store.payload_store.clone(),
         store.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -504,6 +506,7 @@ async fn test_read_causal_signed_certificates() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -528,13 +531,13 @@ async fn test_read_causal_signed_certificates() {
         primary_store_1.proposer_store.clone(),
         primary_store_1.payload_store.clone(),
         primary_store_1.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -543,6 +546,7 @@ async fn test_read_causal_signed_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates_2) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -568,8 +572,9 @@ async fn test_read_causal_signed_certificates() {
         primary_store_2.proposer_store,
         primary_store_2.payload_store,
         primary_store_2.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates_2,
-        /* rx_consensus */ rx_feedback_2,
+        tx_new_certificates_2,
+        rx_feedback_2,
+        rx_consensus_round_updates_2,
         /* external_consensus */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates_2, consensus_metrics_2).1,
@@ -577,7 +582,6 @@ async fn test_read_causal_signed_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -724,6 +728,7 @@ async fn test_read_causal_unsigned_certificates() {
 
     let (tx_feedback, rx_feedback) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -741,13 +746,13 @@ async fn test_read_causal_unsigned_certificates() {
         primary_store_1.proposer_store.clone(),
         primary_store_1.payload_store.clone(),
         primary_store_1.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -756,6 +761,7 @@ async fn test_read_causal_unsigned_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates_2) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -774,8 +780,9 @@ async fn test_read_causal_unsigned_certificates() {
         primary_store_2.proposer_store,
         primary_store_2.payload_store,
         primary_store_2.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates_2,
-        /* rx_consensus */ rx_feedback_2,
+        tx_new_certificates_2,
+        rx_feedback_2,
+        rx_consensus_round_updates_2,
         /* external_consensus */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates_2, consensus_metrics_2).1,
@@ -783,7 +790,6 @@ async fn test_read_causal_unsigned_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -926,6 +932,7 @@ async fn test_get_collections_with_missing_certificates() {
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_1, rx_feedback_1) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -942,8 +949,9 @@ async fn test_get_collections_with_missing_certificates() {
         store_primary_1.proposer_store,
         store_primary_1.payload_store,
         store_primary_1.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates_1,
-        /* rx_consensus */ rx_feedback_1,
+        tx_new_certificates_1,
+        rx_feedback_1,
+        rx_consensus_round_updates,
         /* external_consensus */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates_1, consensus_metrics).1,
@@ -951,7 +959,6 @@ async fn test_get_collections_with_missing_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_1,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -976,6 +983,7 @@ async fn test_get_collections_with_missing_certificates() {
     let (tx_new_certificates_2, _) = test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) =
         test_utils::test_committed_certificates_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
 
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
@@ -1004,14 +1012,14 @@ async fn test_get_collections_with_missing_certificates() {
         store_primary_2.proposer_store,
         store_primary_2.payload_store,
         store_primary_2.vote_digest_store,
-        /* tx_consensus */ tx_new_certificates_2,
-        /* rx_consensus */ rx_feedback_2,
+        tx_new_certificates_2,
+        rx_feedback_2,
+        rx_consensus_round_updates,
         /* external_consensus */
         None,
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/primary/tests/integration_tests_validator_api.rs
+++ b/narwhal/primary/tests/integration_tests_validator_api.rs
@@ -128,6 +128,7 @@ async fn test_get_collections() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -320,6 +321,7 @@ async fn test_remove_collections() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -532,6 +534,7 @@ async fn test_read_causal_signed_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -574,6 +577,7 @@ async fn test_read_causal_signed_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -743,6 +747,7 @@ async fn test_read_causal_unsigned_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -778,6 +783,7 @@ async fn test_read_causal_unsigned_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -945,6 +951,7 @@ async fn test_get_collections_with_missing_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_1,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -1004,6 +1011,7 @@ async fn test_get_collections_with_missing_certificates() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback_2,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/types/src/consensus.rs
+++ b/narwhal/types/src/consensus.rs
@@ -160,7 +160,7 @@ impl ConsensusStore {
         self.last_committed.iter().collect()
     }
 
-    /// Load the last committed round of each validator.
+    /// Load the last committed round of a validator.
     pub fn read_last_committed_round(
         &self,
         validator: &PublicKey,

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -252,6 +252,7 @@ async fn get_network_peers_from_admin_server() {
     let (tx_new_certificates, rx_new_certificates) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback, rx_feedback) = test_utils::test_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -269,8 +270,9 @@ async fn get_network_peers_from_admin_server() {
         store.proposer_store.clone(),
         store.payload_store.clone(),
         store.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates,
-        /* rx_consensus */ rx_feedback,
+        tx_new_certificates,
+        rx_feedback,
+        rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates, consensus_metrics).1,
@@ -278,7 +280,6 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -365,6 +366,7 @@ async fn get_network_peers_from_admin_server() {
     let (tx_new_certificates_2, rx_new_certificates_2) =
         test_utils::test_new_certificates_channel!(CHANNEL_CAPACITY);
     let (tx_feedback_2, rx_feedback_2) = test_utils::test_channel!(CHANNEL_CAPACITY);
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(0);
     let initial_committee = ReconfigureNotification::NewEpoch(committee.clone());
     let (tx_reconfigure_2, _rx_reconfigure_2) = watch::channel(initial_committee);
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -382,8 +384,9 @@ async fn get_network_peers_from_admin_server() {
         store.proposer_store.clone(),
         store.payload_store.clone(),
         store.vote_digest_store.clone(),
-        /* tx_consensus */ tx_new_certificates_2,
-        /* rx_consensus */ rx_feedback_2,
+        tx_new_certificates_2,
+        rx_feedback_2,
+        rx_consensus_round_updates,
         /* dag */
         Some(Arc::new(
             Dag::new(&committee, rx_new_certificates_2, consensus_metrics).1,
@@ -391,7 +394,6 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure_2,
         tx_feedback_2,
-        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );

--- a/narwhal/worker/src/tests/worker_tests.rs
+++ b/narwhal/worker/src/tests/worker_tests.rs
@@ -278,6 +278,7 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure,
         tx_feedback,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );
@@ -390,6 +391,7 @@ async fn get_network_peers_from_admin_server() {
         NetworkModel::Asynchronous,
         tx_reconfigure_2,
         tx_feedback_2,
+        /* last_committed_round */ 0,
         &Registry::new(),
         None,
     );


### PR DESCRIPTION
`CertificateWaiter` relies on `tx_consensus_round_updates` to calculate the GC round, which serves as the basis for fetching certificates from remote nodes (certificates earlier than GC round will not make into the DAG). However after a node restarts, `tx_consensus_round_updates` is initialized to the default value 0 and not recovered.

In practice after a primary has accumulated many certificates locally, the above is more problematic: when fetching certificates, `CertificateWaiter` sends the GC round and bitmaps for the rounds where it has certificates above the GC round. When there are millions of certificates above the GC round, the server takes a long time to scan through the bitmaps of rounds to avoid sending back duplicated certificate. The `CertificateWaiter` client can time out during the period, and not make any progress.

This PR moves the sender of `tx_consensus_round_updates` to the consensus component, and initializes the last committed round on recovery to avoid the issue.

Also, add more debug logs to `fetch_certificate` handler, and load certificates for at most 10s, to avoid clients timing out and wasting work.

And fix the calculation of commit round sent from consensus to primary. Currently it is the round of the certificate triggering commit, but this certificate is the child of the leader, not the leader itself. So the existing logic was sending committed round + 1 to primary. Fix this by using the highest round of committed certificates instead.