### PR TITLE
[Doc] - Fix eventID in event query example doc

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -442,7 +442,10 @@
             },
             {
               "name": "cursor",
-              "value": "10:0"
+              "value": {
+                "txSeq": 500,
+                "eventSeq": 10
+              }
             },
             {
               "name": "limit",
@@ -2911,18 +2914,18 @@
               "TimeRange": {
                 "type": "object",
                 "required": [
-                  "end_time",
-                  "start_time"
+                  "endTime",
+                  "startTime"
                 ],
                 "properties": {
-                  "end_time": {
-                    "description": "right endpoint of time interval, exclusive",
+                  "endTime": {
+                    "description": "right endpoint of time interval, milliseconds since epoch, exclusive",
                     "type": "integer",
                     "format": "uint64",
                     "minimum": 0.0
                   },
-                  "start_time": {
-                    "description": "left endpoint of time interval, inclusive",
+                  "startTime": {
+                    "description": "left endpoint of time interval, milliseconds since epoch, inclusive",
                     "type": "integer",
                     "format": "uint64",
                     "minimum": 0.0

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -497,7 +497,13 @@ impl RpcExampleProvider {
                             result.certificate.transaction_digest
                         )),
                     ),
-                    ("cursor", json!("10:0")),
+                    (
+                        "cursor",
+                        json!(EventID {
+                            event_seq: 10,
+                            tx_seq: 500
+                        }),
+                    ),
                     ("limit", json!(events.len())),
                     ("descending_order", json!(false)),
                 ],

--- a/crates/sui-types/src/query.rs
+++ b/crates/sui-types/src/query.rs
@@ -59,10 +59,11 @@ pub enum EventQuery {
     /// Return events associated with the given object
     Object(ObjectID),
     /// Return events emitted in [start_time, end_time] interval
+    #[serde(rename_all = "camelCase")]
     TimeRange {
-        /// left endpoint of time interval, inclusive
+        /// left endpoint of time interval, milliseconds since epoch, inclusive
         start_time: u64,
-        /// right endpoint of time interval, exclusive
+        /// right endpoint of time interval, milliseconds since epoch, exclusive
         end_time: u64,
     },
 }

--- a/doc/src/build/event_api.md
+++ b/doc/src/build/event_api.md
@@ -138,17 +138,17 @@ Users can query the full node using `EventQuery` criteria object to get the exac
 
 ### List of queryable criteria
 
-| Query       | Description                                                      |                               JSON-RPC Parameter Example                               |
-|-------------|------------------------------------------------------------------|:--------------------------------------------------------------------------------------:|
-| All         | All events                                                       |                                        {"All"}                                         |
-| Transaction | Events emitted by the given transaction.                         |                         {"Transaction":"<Transaction Digest>"}                         |
-| MoveModule  | Events emitted in a specified Move module                        |                {"MoveModule":{"package":"0x2", "module":"devnet_nft"}}                 |
-| MoveEvent   | Move struct name of the event                                    |                      {"MoveEvent":"0x2::event_nft::MintNFTEvent"}                      |
-| EventType   | Type of event described in the [Events](#type-of-events) section |                               {"EventType": "NewObject"}                               |
-| Sender      | Query by sender address                                          |                {"Sender":"0x70613f4f17ae1363f7a7e7251daab5c5b06f68c1"}                 |
-| Recipient   | Query by recipient                                               |      {"Recipient":{"AddressOwner":"0x70613f4f17ae1363f7a7e7251daab5c5b06f68c1"}}       |
-| Object      | Return events associated with the given object                   |                {"Object":"0xe3a6bc7bf1dba4d17a91724009c461bd69870719"}                 |
-| TimeRange   | Return events emitted in [start_time, end_time] interval         | {"TimeRange":{"start":<milliseconds since epoch>, "start":<milliseconds since epoch>}} |
+| Query       | Description                                                      |                         JSON-RPC Parameter Example                          |
+|-------------|------------------------------------------------------------------|:---------------------------------------------------------------------------:|
+| All         | All events                                                       |                                   {"All"}                                   |
+| Transaction | Events emitted by the given transaction.                         |       {"Transaction":"DGUe2TXiJdN3FI6MH1FwghYbiHw+NKu8Nh579zdFtUk="}        |
+| MoveModule  | Events emitted in a specified Move module                        |           {"MoveModule":{"package":"0x2", "module":"devnet_nft"}}           |
+| MoveEvent   | Move struct name of the event                                    |                {"MoveEvent":"0x2::event_nft::MintNFTEvent"}                 |
+| EventType   | Type of event described in the [Events](#type-of-events) section |                         {"EventType": "NewObject"}                          |
+| Sender      | Query by sender address                                          |           {"Sender":"0x70613f4f17ae1363f7a7e7251daab5c5b06f68c1"}           |
+| Recipient   | Query by recipient                                               | {"Recipient":{"AddressOwner":"0x70613f4f17ae1363f7a7e7251daab5c5b06f68c1"}} |
+| Object      | Return events associated with the given object                   |           {"Object":"0xe3a6bc7bf1dba4d17a91724009c461bd69870719"}           |
+| TimeRange   | Return events emitted in [start_time, end_time] interval         |     {"TimeRange":{"startTime":1669039504014, "endTime":1669039604014}}      |
 
 ## Pagination
 


### PR DESCRIPTION
also fixed event_api.md, "List of queryable criteria" is not rendering correctly due to `<>`.