### PR TITLE
[fe] Lower sentry sample rate

### DIFF
--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -21,10 +21,7 @@ if (import.meta.env.PROD) {
     Sentry.init({
         dsn: 'https://e4251274d1b141d7ba272103fa0f8d83@o1314142.ingest.sentry.io/6564988',
         integrations: [new BrowserTracing()],
-
-        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-        // TODO: Adjust this to a lower value once the Explorer has more traffic
-        tracesSampleRate: 1.0,
+        tracesSampleRate: 0.2,
     });
 }
 

--- a/apps/wallet/src/shared/sentry.ts
+++ b/apps/wallet/src/shared/sentry.ts
@@ -18,7 +18,7 @@ export default function initSentry() {
         dsn: SENTRY_DSN,
         integrations: [new BrowserTracing()],
         release: WALLET_VERSION,
-        tracesSampleRate: 1.0,
+        tracesSampleRate: 0.2,
     });
 }
 


### PR DESCRIPTION
We currently sample 100% of traces, which is fairly expensive. Lowering this to 20% for now to buy us headroom.