### PR TITLE
[core] Add API to create advance epoch tx cert

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
 use std::{
     collections::{HashMap, VecDeque},
     pin::Pin,
@@ -28,11 +29,13 @@ use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
 use parking_lot::RwLock;
 use prometheus::{
     exponential_buckets, register_histogram_with_registry, register_int_counter_with_registry,
-    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge,
+    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
 };
 use tap::TapFallible;
+use tokio::select;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::{broadcast::error::RecvError, mpsc};
+use tokio::time::interval;
 use tracing::Instrument;
 use tracing::{debug, error, instrument, warn};
 use typed_store::Map;
@@ -82,6 +85,7 @@ use sui_types::{
 
 use crate::authority::authority_notifier::TransactionNotifierTicket;
 use crate::authority::authority_notify_read::NotifyRead;
+use crate::authority_aggregator::AuthorityAggregator;
 use crate::checkpoints::CheckpointServiceNotify;
 use crate::consensus_handler::{
     SequencedConsensusTransaction, VerifiedSequencedConsensusTransaction,
@@ -102,6 +106,7 @@ use crate::{
     transaction_streamer::TransactionStreamer,
 };
 use narwhal_types::ConsensusOutput;
+use sui_types::gas::GasCostSummary;
 
 use self::authority_store::ObjectKey;
 
@@ -594,22 +599,6 @@ impl AuthorityState {
         transaction: VerifiedTransaction,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
         let transaction_digest = *transaction.digest();
-        // Ensure an idempotent answer.
-        // If a transaction was signed in a previous epoch, we should no longer reuse it.
-        if self
-            .database
-            .transaction_exists(self.epoch(), &transaction_digest)?
-        {
-            self.metrics.tx_already_processed.inc();
-            let transaction_info = self.make_transaction_info(&transaction_digest).await?;
-            return Ok(transaction_info);
-        }
-
-        // Validators should never sign an external system transaction.
-        fp_ensure!(
-            !transaction.is_system_tx(),
-            SuiError::InvalidSystemTransaction
-        );
 
         let (_gas_status, input_objects) = transaction_input_checker::check_transaction_input(
             &self.database,
@@ -1952,7 +1941,7 @@ impl AuthorityState {
     }
 
     /// Make an information response for a transaction
-    async fn make_transaction_info(
+    pub async fn make_transaction_info(
         &self,
         transaction_digest: &TransactionDigest,
     ) -> Result<VerifiedTransactionInfoResponse, SuiError> {
@@ -2314,5 +2303,61 @@ impl AuthorityState {
             checkpoint_service.notify_checkpoint(index, roots, false)?;
         }
         self.database.record_checkpoint_boundary(round)
+    }
+
+    pub async fn create_advance_epoch_tx_cert(
+        &self,
+        next_epoch: EpochId,
+        gas_cost_summary: &GasCostSummary,
+        timeout: Duration,
+        mut cancel: tokio::sync::oneshot::Receiver<()>,
+    ) -> anyhow::Result<VerifiedCertificate> {
+        let mut interval = interval(Duration::from_millis(100));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        let result = tokio::time::timeout(timeout, async {
+            loop {
+                select! {
+                    _ = interval.tick() => {
+                        match self.create_advance_epoch_tx_cert_impl(next_epoch, gas_cost_summary)
+                            .await
+                        {
+                            Ok(cert) => {
+                                return Ok(cert);
+                            }
+                            Err(err) => {
+                                error!("Failed to create advance epoch transaction cert: {:?}", err);
+                            }
+                        }
+                    },
+                    _ = &mut cancel => {
+                        return Err(SuiError::from("create_advance_epoch_tx_cert task canceled"));
+                    }
+                }
+
+            }
+        })
+        .await;
+        Ok(result??)
+    }
+
+    async fn create_advance_epoch_tx_cert_impl(
+        &self,
+        next_epoch: EpochId,
+        gas_cost_summary: &GasCostSummary,
+    ) -> anyhow::Result<VerifiedCertificate> {
+        let tx = VerifiedTransaction::new_change_epoch(
+            next_epoch,
+            gas_cost_summary.storage_cost,
+            gas_cost_summary.computation_cost,
+            gas_cost_summary.storage_rebate,
+        );
+        self.handle_transaction(tx.clone()).await?;
+        let net = AuthorityAggregator::new_from_system_state(
+            &self.database,
+            &self.committee_store,
+            &Registry::new(),
+        )?;
+        Ok(net.process_transaction(tx).await?)
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, Guard};
 use chrono::prelude::*;
 use fastcrypto::traits::KeyPair;
 use move_bytecode_utils::module_cache::SyncModuleCache;
@@ -561,6 +561,7 @@ pub struct AuthorityState {
     reconfig_state_mem: RwLock<ReconfigState>,
 
     /// A channel to tell consensus to reconfigure.
+    /// TODO: This does not really belong to AuthorityState. We should move it out.
     _tx_reconfigure_consensus: mpsc::Sender<ReconfigConsensusMessage>,
 }
 
@@ -1579,8 +1580,12 @@ impl AuthorityState {
         self.database.clone()
     }
 
+    pub fn committee(&self) -> Guard<Arc<Committee>> {
+        self.committee.load()
+    }
+
     pub fn clone_committee(&self) -> Committee {
-        self.committee.load().clone().deref().clone()
+        self.committee().clone().deref().clone()
     }
 
     pub fn get_reconfig_state_read_lock_guard(

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -287,11 +287,11 @@ impl ValidatorService {
         });
 
         let checkpoint_service = CheckpointService::spawn(
+            state.clone(),
             checkpoint_store,
             Box::new(state.database.clone()),
             checkpoint_output,
             Box::new(certified_checkpoint_output),
-            state.clone_committee(),
             CheckpointMetrics::new(&prometheus_registry),
         );
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -24,7 +24,7 @@ use sui_network::{
     tonic,
 };
 
-use sui_types::{error::*, fp_ensure, messages::*};
+use sui_types::{error::*, messages::*};
 use tap::TapFallible;
 use tokio::time::sleep;
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
@@ -341,23 +341,6 @@ impl ValidatorService {
         metrics: Arc<ValidatorServiceMetrics>,
     ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
         let transaction = request.into_inner();
-
-        let transaction_digest = *transaction.digest();
-        // Ensure an idempotent answer. This is checked before the system_tx check so that
-        // a validator is able to return the signed system tx if it was already signed locally.
-        if state
-            .database
-            .transaction_exists(state.epoch(), &transaction_digest)?
-        {
-            let transaction_info = state.make_transaction_info(&transaction_digest).await?;
-            return Ok(tonic::Response::new(transaction_info.into()));
-        }
-
-        // CRITICAL! Validators should never sign an external system transaction.
-        fp_ensure!(
-            !transaction.is_system_tx(),
-            SuiError::InvalidSystemTransaction.into()
-        );
 
         let is_consensus_tx = transaction.contains_shared_object();
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1774,38 +1774,6 @@ async fn test_genesis_sui_sysmtem_state_object() {
 }
 
 #[tokio::test]
-async fn test_change_epoch_transaction() {
-    let authority_state = init_state().await;
-    let mut committee = (**authority_state.committee.load()).clone();
-    committee.epoch += 1;
-    authority_state.committee.store(Arc::new(committee));
-
-    let tx = VerifiedTransaction::new_change_epoch(1, 100, 100, 0);
-    let signed_tx = authority_state
-        .handle_transaction(tx.clone().into_unsigned())
-        .await
-        .unwrap()
-        .signed_transaction
-        .unwrap();
-    let committee = authority_state.committee.load();
-    let certificate = CertifiedTransaction::new(
-        tx.into_message(),
-        vec![signed_tx.auth_sig().clone()],
-        &committee,
-    )
-    .unwrap()
-    .verify(&committee)
-    .unwrap();
-    let result = authority_state
-        .handle_certificate(&certificate)
-        .await
-        .unwrap();
-    assert!(result.signed_effects.unwrap().into_data().status.is_ok());
-    let sui_system_object = authority_state.get_sui_system_state_object().await.unwrap();
-    assert_eq!(sui_system_object.epoch, 1);
-}
-
-#[tokio::test]
 async fn test_transfer_sui_no_amount() {
     let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
     let recipient = dbg_addr(2);

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1780,25 +1780,16 @@ async fn test_change_epoch_transaction() {
     committee.epoch += 1;
     authority_state.committee.store(Arc::new(committee));
 
-    let signed_tx = VerifiedSignedTransaction::new_change_epoch(
-        1,
-        100,
-        100,
-        0,
-        authority_state.name,
-        &*authority_state.secret,
-    );
-    // Make sure that the raw transaction will never be accepted by the validator.
-    assert_eq!(
-        authority_state
-            .handle_transaction(signed_tx.clone().into_unsigned())
-            .await
-            .unwrap_err(),
-        SuiError::InvalidSystemTransaction
-    );
+    let tx = VerifiedTransaction::new_change_epoch(1, 100, 100, 0);
+    let signed_tx = authority_state
+        .handle_transaction(tx.clone().into_unsigned())
+        .await
+        .unwrap()
+        .signed_transaction
+        .unwrap();
     let committee = authority_state.committee.load();
     let certificate = CertifiedTransaction::new(
-        signed_tx.clone().into_message(),
+        tx.into_message(),
         vec![signed_tx.auth_sig().clone()],
         &committee,
     )

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -909,33 +909,12 @@ impl Transaction {
     }
 }
 
-/// A transaction that is signed by a sender and also by an authority.
-pub type SignedTransaction = Envelope<SenderSignedData, AuthoritySignInfo>;
-pub type VerifiedSignedTransaction = VerifiedEnvelope<SenderSignedData, AuthoritySignInfo>;
-
-impl VerifiedSignedTransaction {
-    /// Use signing key to create a signed object.
-    pub fn new(
-        epoch: EpochId,
-        transaction: VerifiedTransaction,
-        authority: AuthorityName,
-        secret: &dyn signature::Signer<AuthoritySignature>,
-    ) -> Self {
-        Self::new_from_verified(SignedTransaction::new(
-            epoch,
-            transaction.into_inner().into_data(),
-            secret,
-            authority,
-        ))
-    }
-
+impl VerifiedTransaction {
     pub fn new_change_epoch(
         next_epoch: EpochId,
         storage_charge: u64,
         computation_charge: u64,
         storage_rebate: u64,
-        authority: AuthorityName,
-        secret: &dyn signature::Signer<AuthoritySignature>,
     ) -> Self {
         let kind = TransactionKind::Single(SingleTransactionKind::ChangeEpoch(ChangeEpoch {
             epoch: next_epoch,
@@ -957,9 +936,25 @@ impl VerifiedSignedTransaction {
                 .unwrap()
                 .into(),
         };
+        Self::new_from_verified(Transaction::new(signed_data))
+    }
+}
+
+/// A transaction that is signed by a sender and also by an authority.
+pub type SignedTransaction = Envelope<SenderSignedData, AuthoritySignInfo>;
+pub type VerifiedSignedTransaction = VerifiedEnvelope<SenderSignedData, AuthoritySignInfo>;
+
+impl VerifiedSignedTransaction {
+    /// Use signing key to create a signed object.
+    pub fn new(
+        epoch: EpochId,
+        transaction: VerifiedTransaction,
+        authority: AuthorityName,
+        secret: &dyn signature::Signer<AuthoritySignature>,
+    ) -> Self {
         Self::new_from_verified(SignedTransaction::new(
-            next_epoch,
-            signed_data,
+            epoch,
+            transaction.into_inner().into_data(),
             secret,
             authority,
         ))

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -1,6 +1,86 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::iter;
+use std::time::Duration;
+use sui_core::authority_client::AuthorityAPI;
+use sui_types::error::SuiError;
+use sui_types::gas::GasCostSummary;
+use sui_types::messages::VerifiedTransaction;
+use test_utils::authority::{get_client, spawn_test_authorities, test_authority_configs};
+use tokio::time::Instant;
+
+#[tokio::test]
+async fn advance_epoch_tx_test() {
+    // This test checks the following functionalities related to advance epoch transaction:
+    // 1. The create_advance_epoch_tx_cert API in AuthorityState can properly sign an advance
+    //    epoch transaction locally and exchange with other validators to obtain a cert.
+    // 2. The timeout and cancellation channel in the API works as expected.
+    // 3. The certificate can be executed by each validator.
+    let configs = test_authority_configs();
+    let handles = spawn_test_authorities(iter::empty(), &configs).await;
+
+    let tx = VerifiedTransaction::new_change_epoch(1, 0, 0, 0);
+    let client0 = get_client(&configs.validator_set()[0]);
+    // Make sure that validators do not accept advance epoch sent externally.
+    assert!(matches!(
+        client0.handle_transaction(tx.into_inner()).await,
+        Err(SuiError::InvalidSystemTransaction)
+    ));
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let long_task = handles.first().unwrap().with_async(|node| async move {
+        node.state()
+            .create_advance_epoch_tx_cert(
+                1,
+                &GasCostSummary::new(0, 0, 0),
+                Duration::from_secs(1000), // A very very long time
+                rx,
+            )
+            .await
+    });
+    let start = Instant::now();
+    let cancel_task = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        tx.send(()).unwrap();
+    });
+    let result = long_task.await;
+    // Since we are only running the task on one validator, it will never get a quorum and hence
+    // never succeed. This tests that the cancelation works.
+    assert!(result.unwrap_err().to_string().contains("task canceled"));
+    assert!(start.elapsed() < Duration::from_secs(100));
+    assert!(cancel_task.is_finished());
+
+    let tasks: Vec<_> = handles
+        .iter()
+        .map(|handle| {
+            handle.with_async(|node| async move {
+                node.state()
+                    .create_advance_epoch_tx_cert(
+                        1,
+                        &GasCostSummary::new(0, 0, 0),
+                        Duration::from_secs(1000), // A very very long time
+                        tokio::sync::oneshot::channel().1,
+                    )
+                    .await
+            })
+        })
+        .collect();
+    let results = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()
+        .unwrap();
+    for (handle, cert) in handles.iter().zip(results) {
+        handle
+            .with_async(|node| async move {
+                // Check that every validator is able to execute such a cert.
+                node.state().handle_certificate(&cert).await.unwrap();
+            })
+            .await;
+    }
+}
+
 /*
 
 use futures::future::join_all;


### PR DESCRIPTION
This PR adds an API to AuthorityState to create an advance epoch tx certificate.
It loads the committee information from the system state object and constructs a network on the fly.
We will use this to create the last transaction of the epoch.
This API could also be used to do partial epoch changes on-chain without reconfiguration (to test tokenomics).