### PR TITLE
chore(ci): specify repo token in setup-protoc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,6 +95,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
       - uses: taiki-e/install-action@nextest
       - uses: arduino/setup-protoc@v1
+        # this avoids rate-limiting
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: cargo build
         run: |
           cargo build --all-features
@@ -138,6 +141,9 @@ jobs:
     runs-on: [ubuntu-ghcloud]
     steps:
       - uses: arduino/setup-protoc@v1
+        # this avoids rate-limiting
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
We need to specify the token to avoid rate limits. Relevant doc:
https://github.com/arduino/setup-protoc#usage
Example failure:
https://github.com/MystenLabs/sui/actions/runs/3516672054/jobs/5893534181