### PR TITLE
Use jemalloc as default memory allocator

### DIFF
--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -44,7 +44,9 @@ RUN cargo build --profile $PROFILE --bin sui-node
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
+# Use jemalloc as memory allocator
 RUN apt-get update && apt-get install -y libjemalloc-dev
+ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
 ARG PROFILE=release
 WORKDIR sui
 # Both bench and release profiles copy from release dir


### PR DESCRIPTION
Otherwise, the Docker image will fall back to the glibc allocator, which may not be ideal.

Profiling will be enabled separately.