### PR TITLE
Add sally api and reference implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10413,6 +10413,7 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 name = "typed-store"
 version = "0.4.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "collectable",
  "eyre",
@@ -10420,6 +10421,7 @@ dependencies = [
  "hdrhistogram",
  "num_cpus",
  "once_cell",
+ "ouroboros 0.15.5",
  "proc-macro2 1.0.49",
  "prometheus",
  "quote 1.0.23",

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -288,10 +288,13 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
     let generics = &input.generics;
     let generics_names = extract_generics_names(generics);
 
-    let allowed_types_with_post_process_fn: BTreeMap<_, _> =
-        [("DBMap", ""), ("Store", "typed_store::Store::new")]
-            .into_iter()
-            .collect();
+    let allowed_types_with_post_process_fn: BTreeMap<_, _> = [
+        ("SallyColumn", ""),
+        ("DBMap", ""),
+        ("Store", "typed_store::Store::new"),
+    ]
+    .into_iter()
+    .collect();
     let allowed_strs = allowed_types_with_post_process_fn
         .keys()
         .map(|s| s.to_string())
@@ -629,6 +632,372 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     self.table_summary(table_name.as_str())
                 }
 
+
+        }
+
+    })
+}
+
+#[proc_macro_derive(SallyDB, attributes(default_options_override_fn))]
+pub fn derive_sallydb_general(input: TokenStream) -> TokenStream {
+    //log_syntax!("here");
+    let input = parse_macro_input!(input as ItemStruct);
+    let name = &input.ident;
+    let generics = &input.generics;
+    let generics_names = extract_generics_names(generics);
+
+    let allowed_types_with_post_process_fn: BTreeMap<_, _> =
+        [("SallyColumn", "")].into_iter().collect();
+    let allowed_strs = allowed_types_with_post_process_fn
+        .keys()
+        .map(|s| s.to_string())
+        .collect();
+
+    // TODO: use `parse_quote` over `parse()`
+    // TODO: Eventually this should return a Vec<Vec<GeneralTableOptions>> to capture default table options for each column type i.e. RockDB, TestDB, etc
+    let (field_names, inner_types, derived_table_options, simple_field_type_name_str) =
+        extract_struct_info(input.clone(), allowed_strs);
+
+    let (key_names, value_names): (Vec<_>, Vec<_>) = inner_types
+        .iter()
+        .map(|q| (q.args.first().unwrap(), q.args.last().unwrap()))
+        .unzip();
+
+    // This is the actual name of the type which was found
+    let post_process_fn_str = allowed_types_with_post_process_fn
+        .get(&simple_field_type_name_str.as_str())
+        .unwrap();
+    let post_process_fn: proc_macro2::TokenStream = post_process_fn_str.parse().unwrap();
+
+    let default_options_override_fn_names: Vec<proc_macro2::TokenStream> = derived_table_options
+        .iter()
+        .map(|q| {
+            let GeneralTableOptions::OverrideFunction(fn_name) = q;
+            fn_name.parse().unwrap()
+        })
+        .collect();
+
+    let generics_bounds =
+        "std::fmt::Debug + serde::Serialize + for<'de> serde::de::Deserialize<'de>";
+    let generics_bounds_token: proc_macro2::TokenStream = generics_bounds.parse().unwrap();
+
+    let config_struct_name_str = format!("{}SallyConfigurator", name);
+    let sally_config_struct_name: proc_macro2::TokenStream =
+        config_struct_name_str.parse().unwrap();
+
+    let intermediate_db_map_struct_name_str = format!("{}Primary", name);
+    let intermediate_db_map_struct_name: proc_macro2::TokenStream =
+        intermediate_db_map_struct_name_str.parse().unwrap();
+
+    let secondary_db_map_struct_name_str = format!("{}ReadOnly", name);
+    let secondary_db_map_struct_name: proc_macro2::TokenStream =
+        secondary_db_map_struct_name_str.parse().unwrap();
+
+    TokenStream::from(quote! {
+
+        // <----------- This section generates the configurator struct -------------->
+
+        /// Create config structs for configuring SallyColumns
+        pub struct #sally_config_struct_name {
+            #(
+                pub #field_names : typed_store::sally::SallyColumnOptions,
+            )*
+        }
+
+        impl #sally_config_struct_name {
+            /// Initialize to defaults
+            pub fn init() -> Self {
+                Self {
+                    #(
+                        #field_names : typed_store::sally::default_column_options(),
+                    )*
+                }
+            }
+
+            /// Build a config
+            pub fn build(&self) -> typed_store::sally::SallyDBConfigMap {
+                typed_store::sally::SallyDBConfigMap::new([
+                    #(
+                        (stringify!(#field_names).to_owned(), self.#field_names.clone()),
+                    )*
+                ].into_iter().collect())
+            }
+        }
+
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #name #generics {
+
+                pub fn configurator() -> #sally_config_struct_name {
+                    #sally_config_struct_name::init()
+                }
+        }
+
+
+        // <----------- This section generates the core open logic for opening sally columns -------------->
+
+        /// Create an intermediate struct used to open the DBMap tables in primary mode
+        /// This is only used internally
+        struct #intermediate_db_map_struct_name #generics {
+                #(
+                    pub #field_names : SallyColumn #inner_types,
+                )*
+        }
+
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #intermediate_db_map_struct_name #generics {
+            /// Opens a set of tables in read-write mode
+            /// If as_secondary_with_path is set, the DB is opened in read only mode with the path specified
+            pub fn init(db_options: typed_store::sally::SallyDBOptions) -> Self {
+                match db_options {
+                    typed_store::sally::SallyDBOptions::TestDB => {
+                        let (
+                            #(
+                                #field_names
+                            ),*
+                        ) = (#(
+                            SallyColumn::TestDB((typed_store::test_db::TestDB::#inner_types::open(), typed_store::sally::SallyConfig::default()))
+                            ),*);
+
+                        Self {
+                            #(
+                                #field_names,
+                            )*
+                        }
+                    },
+                    typed_store::sally::SallyDBOptions::RocksDB((path, access_type, global_db_options_override, tables_db_options_override)) => {
+                        let path = &path;
+                        let db = {
+                            let opt_cfs = match tables_db_options_override {
+                                None => [
+                                    #(
+                                        (stringify!(#field_names).to_owned(), #default_options_override_fn_names().clone()),
+                                    )*
+                                ],
+                                Some(o) => [
+                                    #(
+                                        (stringify!(#field_names).to_owned(), o.to_map().get(stringify!(#field_names)).unwrap().clone()),
+                                    )*
+                                ]
+                            };
+                            // Safe to call unwrap because we will have atleast one field_name entry in the struct
+                            let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), &q.1.options)).collect();
+                            let db = match access_type {
+                                RocksDBAccessType::Secondary(Some(p)) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, &opt_cfs),
+                                _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, &opt_cfs)
+                            };
+                            db
+                        }.expect("Cannot open DB.");
+                        let (
+                            #(
+                                #field_names
+                            ),*
+                        ) = (#(
+                            SallyColumn::RocksDB((DBMap::#inner_types::reopen(&db, Some(stringify!(#field_names))).expect(&format!("Cannot open {} CF.", stringify!(#field_names))[..]), typed_store::sally::SallyConfig::default()))
+                            ),*);
+
+                        Self {
+                            #(
+                                #field_names,
+                            )*
+                        }
+                    }
+                }
+            }
+        }
+
+
+        // <----------- This section generates the read-write open logic and other common utils -------------->
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #name #generics {
+            /// Opens a set of tables in read-write mode
+            /// Only one process is allowed to do this at a time
+            /// `global_db_options_override` apply to the whole DB
+            /// `tables_db_options_override` apply to each table. If `None`, the attributes from `default_options_override_fn` are used if any
+            #[allow(unused_parens)]
+            pub fn init(
+                db_options: typed_store::sally::SallyDBOptions
+            ) -> Self {
+                let inner = #intermediate_db_map_struct_name::init(db_options);
+                Self {
+                    #(
+                        #field_names: #post_process_fn(inner.#field_names),
+                    )*
+                }
+            }
+
+            /// Returns a list of the tables name and type pairs
+            pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
+                vec![#(
+                    (stringify!(#field_names).to_owned(), (stringify!(#key_names).to_owned(), stringify!(#value_names).to_owned())),
+                )*].into_iter().collect()
+            }
+
+            /// This opens the DB in read only mode and returns a struct which exposes debug features
+            pub fn get_read_only_handle (
+                db_options: typed_store::sally::SallyReadOnlyDBOptions
+                ) -> #secondary_db_map_struct_name #generics {
+                #secondary_db_map_struct_name::init_read_only(db_options)
+            }
+        }
+
+        // <----------- This section generates the features that use read-only open logic -------------->
+        /// Create an intermediate struct used to open the DBMap tables in secondary mode
+        /// This is only used internally
+        pub struct #secondary_db_map_struct_name #generics {
+            #(
+                pub #field_names : SallyColumn #inner_types,
+            )*
+        }
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #secondary_db_map_struct_name #generics {
+            /// Open in read only mode. No limitation on number of processes to do this
+            pub fn init_read_only(
+                db_options: typed_store::sally::SallyReadOnlyDBOptions,
+            ) -> Self {
+                match db_options {
+                    typed_store::sally::SallyReadOnlyDBOptions::TestDB => {
+                        let inner = #intermediate_db_map_struct_name::init(SallyDBOptions::TestDB);
+                        Self {
+                            #(
+                                #field_names: inner.#field_names,
+                            )*
+                        }
+                    },
+                    typed_store::sally::SallyReadOnlyDBOptions::RocksDB((primary_path, with_secondary_path, global_db_options_override)) => {
+                        let inner = match with_secondary_path {
+                            Some(q) => #intermediate_db_map_struct_name::init(SallyDBOptions::RocksDB((primary_path, RocksDBAccessType::Secondary(Some(q)), global_db_options_override, None))),
+                            None => {
+                                let p: std::path::PathBuf = tempfile::tempdir()
+                                    .expect("Failed to open temporary directory")
+                                    .into_path();
+                                #intermediate_db_map_struct_name::init(SallyDBOptions::RocksDB((primary_path, RocksDBAccessType::Secondary(Some(p)), global_db_options_override, None)))
+                            }
+                        };
+                        Self {
+                            #(
+                                #field_names: inner.#field_names,
+                            )*
+                        }
+                    }
+                }
+            }
+
+            /// Dump all key-value pairs in the page at the given table name
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn dump(&self, table_name: &str, page_size: u16,
+                page_number: usize) -> eyre::Result<std::collections::BTreeMap<String, String>> {
+                Ok(match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            match &self.#field_names {
+                                SallyColumn::RocksDB((db_map, typed_store::sally::SallyConfig { mode: typed_store::sally::SallyRunMode::FallbackToDB })) => {
+                                    typed_store::traits::Map::try_catch_up_with_primary(db_map)?;
+                                    typed_store::traits::Map::iter(db_map)
+                                        .skip((page_number * (page_size) as usize))
+                                        .take(page_size as usize)
+                                        .map(|(k, v)| (format!("{:?}", k), format!("{:?}", v)))
+                                        .collect::<std::collections::BTreeMap<_, _>>()
+                                }
+                                _ => unimplemented!(),
+                            }
+                        }
+                    )*
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                })
+            }
+
+            pub fn table_summary(&self, table_name: &str) -> eyre::Result<typed_store::traits::TableSummary> {
+                let mut count = 0;
+                let mut key_bytes = 0;
+                let mut value_bytes = 0;
+                match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            match &self.#field_names {
+                                SallyColumn::RocksDB((db_map, typed_store::sally::SallyConfig { mode: typed_store::sally::SallyRunMode::FallbackToDB })) => {
+                                    typed_store::traits::Map::try_catch_up_with_primary(db_map)?;
+                                    db_map.table_summary()
+                                }
+                                _ => unimplemented!(),
+                            }
+                        }
+                    )*
+
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                }
+            }
+
+            /// Count the keys in this table
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn count_keys(&self, table_name: &str) -> eyre::Result<usize> {
+                Ok(match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            match &self.#field_names {
+                                SallyColumn::RocksDB((db_map, typed_store::sally::SallyConfig { mode: typed_store::sally::SallyRunMode::FallbackToDB })) => {
+                                    typed_store::traits::Map::try_catch_up_with_primary(db_map)?;
+                                    typed_store::traits::Map::iter(db_map).count()
+                                }
+                                _ => unimplemented!(),
+                            }
+                        }
+                    )*
+
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                })
+            }
+
+            pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
+                vec![#(
+                    (stringify!(#field_names).to_owned(), (stringify!(#key_names).to_owned(), stringify!(#value_names).to_owned())),
+                )*].into_iter().collect()
+            }
+        }
+
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > TypedStoreDebug for #secondary_db_map_struct_name #generics {
+                fn dump_table(
+                    &self,
+                    table_name: String,
+                    page_size: u16,
+                    page_number: usize,
+                ) -> eyre::Result<std::collections::BTreeMap<String, String>> {
+                    self.dump(table_name.as_str(), page_size, page_number)
+                }
+
+                fn primary_db_name(&self) -> String {
+                    stringify!(#name).to_owned()
+                }
+
+                fn describe_all_tables(&self) -> std::collections::BTreeMap<String, (String, String)> {
+                    Self::describe_tables()
+                }
+
+                fn count_table_keys(&self, table_name: String) -> eyre::Result<usize> {
+                    self.count_keys(table_name.as_str())
+                }
+                fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary> {
+                    self.table_summary(table_name.as_str())
+                }
 
         }
 

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -24,8 +24,11 @@ serde = { version = "1.0.140", features = ["derive"] }
 thiserror = "1.0.37"
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing = "0.1.37"
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 sui-macros = { path = "../sui-macros" }
+ouroboros = "0.15.5"
+rand = "0.8.5"
+async-trait = "0.1.57"
+workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -26,6 +26,8 @@ pub use traits::Map;
 pub mod metrics;
 pub mod rocks;
 use crate::rocks::RocksDB;
+pub mod sally;
+pub mod test_db;
 pub use metrics::DBMetrics;
 
 #[cfg(test)]

--- a/crates/typed-store/src/sally/mod.rs
+++ b/crates/typed-store/src/sally/mod.rs
@@ -1,0 +1,507 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage Atomicity Layer Library (aka Sally) is a wrapper around pluggable storage backends
+//! which implement a common key value interface. It enables users to switch storage backends
+//! in their code with simple options. It is also designed to be able to support atomic operations
+//! across different columns of the db even when they are backed by different storage instances.
+//!
+//! # Examples
+//!
+//! ```
+//! use typed_store::rocks::*;
+//! use typed_store::test_db::*;
+//! use typed_store::sally::SallyDBOptions;
+//! use typed_store_derive::SallyDB;
+//! use typed_store::sally::SallyColumn;
+//! use typed_store::traits::TypedStoreDebug;
+//! use typed_store::traits::TableSummary;
+//! use crate::typed_store::Map;
+//!
+//! // `ExampleTable` is a sally db instance where each column is first initialized with TestDB
+//! // (btree map) backend and later switched to a RocksDB column family
+//!
+//! #[derive(SallyDB)]
+//! pub struct ExampleTable {
+//!   col1: SallyColumn<String, String>,
+//!   col2: SallyColumn<i32, String>,
+//! }
+//!
+//! async fn insert_key_vals(table: &ExampleTable) {
+//!     // create a write batch and do atomic commit across columns in the table
+//!     let keys_vals = (1..100).map(|i| (i, i.to_string()));
+//!     let mut wb = table.col1.batch();
+//!     wb.insert_batch(&table.col2, keys_vals).expect("Failed to batch insert");
+//!     wb.delete_range(&table.col2, &50, &100).expect("Failed to batch delete");
+//!     wb.write().await.expect("Failed to commit batch");
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), TypedStoreError> {
+//!     // use a btree map backend first
+//!     let mut table = ExampleTable::init(SallyDBOptions::TestDB);
+//!     insert_key_vals(&table).await;
+//!     // switch to rocksdb backend
+//!     let primary_path = tempfile::tempdir().expect("Failed to open db path").into_path();
+//!     table = ExampleTable::init(SallyDBOptions::RocksDB((primary_path, RocksDBAccessType::Primary, None, None)));
+//!     insert_key_vals(&table).await;
+//!     Ok(())
+//! }
+//! ```
+use crate::{
+    rocks::{
+        default_db_options, keys::Keys, values::Values, DBBatch, DBMap, DBOptions,
+        RocksDBAccessType, TypedStoreError,
+    },
+    test_db::{TestDB, TestDBIter, TestDBKeys, TestDBValues, TestDBWriteBatch},
+    traits::{AsyncMap, Map},
+};
+
+use crate::rocks::iter::Iter as RocksDBIter;
+use crate::rocks::DBMapTableConfigMap;
+use async_trait::async_trait;
+use collectable::TryExtend;
+use rocksdb::Options;
+use serde::{de::DeserializeOwned, Serialize};
+use std::borrow::Borrow;
+use std::{collections::BTreeMap, path::PathBuf};
+
+pub enum SallyRunMode {
+    // Whether Sally should use its own memtable and wal for read/write or just fallback to
+    // reading/writing directly from the backend db. When columns in the db are backed by different
+    // backend stores, we should never use `FallbackToDB` as that would lose atomicity,
+    // transactions and db recovery
+    FallbackToDB,
+}
+
+pub struct SallyConfig {
+    pub mode: SallyRunMode,
+}
+
+impl Default for SallyConfig {
+    fn default() -> Self {
+        Self {
+            mode: SallyRunMode::FallbackToDB,
+        }
+    }
+}
+
+/// A Sally column could be anything that implements key value interface. We will eventually have
+/// Sally serve read/writes using its own memtable and wal when columns in the db are backend by more then
+/// one backend store (e.g different rocksdb instances and/or distributed key value stores)
+pub enum SallyColumn<K, V> {
+    RocksDB((DBMap<K, V>, SallyConfig)),
+    TestDB((TestDB<K, V>, SallyConfig)),
+}
+
+impl<K, V> SallyColumn<K, V> {
+    pub fn new_single_rocksdb(db: DBMap<K, V>) -> Self {
+        // When all columns in the db are backed by a single rocksdb instance, we will fallback to
+        // using native rocksdb read and write apis and use default config
+        SallyColumn::RocksDB((db, SallyConfig::default()))
+    }
+    pub fn new_testdb(db: TestDB<K, V>) -> Self {
+        SallyColumn::TestDB((db, SallyConfig::default()))
+    }
+    pub fn batch(&self) -> SallyWriteBatch {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyWriteBatch::RocksDB(db_map.batch()),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyWriteBatch::TestDB(test_db.batch()),
+        }
+    }
+}
+
+#[async_trait]
+impl<'a, K, V> AsyncMap<'a, K, V> for SallyColumn<K, V>
+where
+    K: Serialize + DeserializeOwned + std::marker::Sync,
+    V: Serialize + DeserializeOwned + std::marker::Sync + std::marker::Send,
+{
+    type Error = TypedStoreError;
+    type Iterator = SallyIter<'a, K, V>;
+    type Keys = SallyKeys<'a, K>;
+    type Values = SallyValues<'a, V>;
+
+    async fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.contains_key(key),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.contains_key(key),
+        }
+    }
+    async fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.get(key),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.get(key),
+        }
+    }
+    async fn get_raw_bytes(&self, key: &K) -> Result<Option<Vec<u8>>, TypedStoreError> {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.get_raw_bytes(key),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.get_raw_bytes(key),
+        }
+    }
+    async fn is_empty(&self) -> bool {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.is_empty(),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.is_empty(),
+        }
+    }
+    async fn iter(&'a self) -> Self::Iterator {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyIter::RocksDB(db_map.iter()),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyIter::TestDB(test_db.iter()),
+        }
+    }
+    async fn keys(&'a self) -> Self::Keys {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyKeys::RocksDB(db_map.keys()),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyKeys::TestDB(test_db.keys()),
+        }
+    }
+    async fn values(&'a self) -> Self::Values {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyValues::RocksDB(db_map.values()),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => SallyValues::TestDB(test_db.values()),
+        }
+    }
+    async fn multi_get<J>(
+        &self,
+        keys: impl IntoIterator<Item = J> + std::marker::Send,
+    ) -> Result<Vec<Option<V>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.multi_get(keys),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.multi_get(keys),
+        }
+    }
+    async fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => Ok(db_map.try_catch_up_with_primary()?),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => Ok(test_db.try_catch_up_with_primary()?),
+        }
+    }
+}
+
+impl<J, K, U, V> TryExtend<(J, U)> for SallyColumn<K, V>
+where
+    J: Borrow<K> + std::clone::Clone,
+    U: Borrow<V> + std::clone::Clone,
+    K: Serialize,
+    V: Serialize,
+{
+    type Error = TypedStoreError;
+
+    fn try_extend<T>(&mut self, iter: &mut T) -> Result<(), Self::Error>
+    where
+        T: Iterator<Item = (J, U)>,
+    {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.try_extend(iter),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.try_extend(iter),
+        }
+    }
+    fn try_extend_from_slice(&mut self, slice: &[(J, U)]) -> Result<(), Self::Error> {
+        match self {
+            SallyColumn::RocksDB((
+                db_map,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => db_map.try_extend_from_slice(slice),
+            SallyColumn::TestDB((
+                test_db,
+                SallyConfig {
+                    mode: SallyRunMode::FallbackToDB,
+                },
+            )) => test_db.try_extend_from_slice(slice),
+        }
+    }
+}
+
+/// A Sally write batch provides a mutable struct which holds a collection of db mutation operations and
+/// applies them atomically to the db.
+/// Once sally has its own memtable and wal, atomic commits across multiple db instances will be possible.
+pub enum SallyWriteBatch {
+    // Write batch for RocksDB backend when `fallback_to_db` is set as true
+    RocksDB(DBBatch),
+    // Write batch for btree map based backend
+    TestDB(TestDBWriteBatch),
+}
+
+impl SallyWriteBatch {
+    pub async fn write(self) -> Result<(), TypedStoreError> {
+        match self {
+            SallyWriteBatch::RocksDB(db_batch) => db_batch.write(),
+            SallyWriteBatch::TestDB(write_batch) => write_batch.write(),
+        }
+    }
+    /// Deletes a set of keys given as an iterator
+    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
+        &mut self,
+        db: &SallyColumn<K, V>,
+        purged_vals: impl IntoIterator<Item = J>,
+    ) -> Result<(), TypedStoreError> {
+        match (self, db) {
+            (SallyWriteBatch::RocksDB(db_batch), SallyColumn::RocksDB((db_map, _))) => {
+                db_batch.delete_batch_non_consuming(db_map, purged_vals)
+            }
+            (SallyWriteBatch::TestDB(write_batch), SallyColumn::TestDB((test_db, _))) => {
+                write_batch.delete_batch(test_db, purged_vals)
+            }
+            _ => unimplemented!(),
+        }
+    }
+    /// Deletes a range of keys between `from` (inclusive) and `to` (non-inclusive)
+    pub fn delete_range<'a, K: Serialize, V>(
+        &mut self,
+        db: &'a SallyColumn<K, V>,
+        from: &K,
+        to: &K,
+    ) -> Result<(), TypedStoreError> {
+        match (self, db) {
+            (SallyWriteBatch::RocksDB(db_batch), SallyColumn::RocksDB((db_map, _))) => {
+                db_batch.delete_range_non_consuming(db_map, from, to)
+            }
+            (SallyWriteBatch::TestDB(write_batch), SallyColumn::TestDB((test_db, _))) => {
+                write_batch.delete_range(test_db, from, to)
+            }
+            _ => unimplemented!(),
+        }
+    }
+    /// inserts a range of (key, value) pairs given as an iterator
+    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        db: &SallyColumn<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), TypedStoreError> {
+        match (self, db) {
+            (SallyWriteBatch::RocksDB(db_batch), SallyColumn::RocksDB((db_map, _))) => {
+                db_batch.insert_batch_non_consuming(db_map, new_vals)
+            }
+            (SallyWriteBatch::TestDB(write_batch), SallyColumn::TestDB((test_db, _))) => {
+                write_batch.insert_batch(test_db, new_vals)
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+/// A SallyIter provides an iterator over all key values in a sally column
+pub enum SallyIter<'a, K, V> {
+    // Iter for a rocksdb backed sally column when `fallback_to_db` is true
+    RocksDB(RocksDBIter<'a, K, V>),
+    TestDB(TestDBIter<'a, K, V>),
+}
+
+impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for SallyIter<'a, K, V> {
+    type Item = (K, V);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            SallyIter::RocksDB(iter) => iter.next(),
+            SallyIter::TestDB(iter) => iter.next(),
+        }
+    }
+}
+
+/// A SallyIter provides an iterator over all keys in a sally column
+pub enum SallyKeys<'a, K> {
+    // Iter for a rocksdb backed sally column when `fallback_to_db` is true
+    RocksDB(Keys<'a, K>),
+    TestDB(TestDBKeys<'a, K>),
+}
+
+impl<'a, K: DeserializeOwned> Iterator for SallyKeys<'a, K> {
+    type Item = K;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            SallyKeys::RocksDB(keys) => keys.next(),
+            SallyKeys::TestDB(iter) => iter.next(),
+        }
+    }
+}
+
+/// A SallyIter provides an iterator over all values in a sally column
+pub enum SallyValues<'a, V> {
+    // Iter for a rocksdb backed sally column when `fallback_to_db` is true
+    RocksDB(Values<'a, V>),
+    TestDB(TestDBValues<'a, V>),
+}
+
+impl<'a, V: DeserializeOwned> Iterator for SallyValues<'a, V> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            SallyValues::RocksDB(values) => values.next(),
+            SallyValues::TestDB(iter) => iter.next(),
+        }
+    }
+}
+
+/// Options to configure a sally db instance at the global level
+pub enum SallyDBOptions {
+    // Options when sally db instance is backed by a single rocksdb instance
+    RocksDB(
+        (
+            PathBuf,
+            RocksDBAccessType,
+            Option<Options>,
+            Option<DBMapTableConfigMap>,
+        ),
+    ),
+    TestDB,
+}
+
+/// Options to configure a sally db instance for performing read only operations at the global level
+pub enum SallyReadOnlyDBOptions {
+    // Options when sally db instance is backed by a single rocksdb instance
+    RocksDB((PathBuf, Option<PathBuf>, Option<Options>)),
+    TestDB,
+}
+
+/// Options to configure an individual column in a sally db instance
+#[derive(Clone)]
+pub enum SallyColumnOptions {
+    // Options to configure a rocksdb column family backed sally column
+    RocksDB(DBOptions),
+    TestDB,
+}
+
+impl SallyColumnOptions {
+    pub fn get_rocksdb_options(&self) -> Option<&DBOptions> {
+        match self {
+            SallyColumnOptions::RocksDB(db_options) => Some(db_options),
+            _ => None,
+        }
+    }
+}
+
+/// Creates a default RocksDB option, to be used when RocksDB option is not specified..
+pub fn default_column_options() -> SallyColumnOptions {
+    SallyColumnOptions::RocksDB(default_db_options())
+}
+
+#[derive(Clone)]
+pub struct SallyDBConfigMap(BTreeMap<String, SallyColumnOptions>);
+impl SallyDBConfigMap {
+    pub fn new(map: BTreeMap<String, SallyColumnOptions>) -> Self {
+        Self(map)
+    }
+
+    pub fn to_map(&self) -> BTreeMap<String, SallyColumnOptions> {
+        self.0.clone()
+    }
+}

--- a/crates/typed-store/src/test_db.rs
+++ b/crates/typed-store/src/test_db.rs
@@ -1,0 +1,702 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::await_holding_lock)]
+
+use std::{
+    borrow::Borrow,
+    collections::{btree_map::Iter, BTreeMap, HashMap, VecDeque},
+    marker::PhantomData,
+    sync::{Arc, RwLock},
+};
+
+use crate::{
+    rocks::{be_fix_int_ser, TypedStoreError},
+    Map,
+};
+use bincode::Options;
+use collectable::TryExtend;
+use ouroboros::self_referencing;
+use rand::distributions::{Alphanumeric, DistString};
+use serde::{de::DeserializeOwned, Serialize};
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+/// An interface to a btree map backed sally database. This is mainly intended
+/// for tests and performing benchmark comparisons
+#[derive(Clone, Debug)]
+pub struct TestDB<K, V> {
+    pub rows: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+    pub name: String,
+    _phantom: PhantomData<fn(K) -> V>,
+}
+
+impl<K, V> TestDB<K, V> {
+    pub fn open() -> Self {
+        TestDB {
+            rows: Arc::new(RwLock::new(BTreeMap::new())),
+            name: Alphanumeric.sample_string(&mut rand::thread_rng(), 16),
+            _phantom: PhantomData,
+        }
+    }
+    pub fn batch(&self) -> TestDBWriteBatch {
+        TestDBWriteBatch::default()
+    }
+}
+
+#[self_referencing]
+pub struct TestDBIter<'a, K, V> {
+    rows: RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>,
+    #[borrows(mut rows)]
+    #[covariant]
+    iter: Iter<'this, Vec<u8>, Vec<u8>>,
+    phantom: PhantomData<(K, V)>,
+}
+
+#[self_referencing]
+pub struct TestDBKeys<'a, K> {
+    rows: RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>,
+    #[borrows(mut rows)]
+    #[covariant]
+    iter: Iter<'this, Vec<u8>, Vec<u8>>,
+    phantom: PhantomData<K>,
+}
+
+#[self_referencing]
+pub struct TestDBValues<'a, V> {
+    rows: RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>,
+    #[borrows(mut rows)]
+    #[covariant]
+    iter: Iter<'this, Vec<u8>, Vec<u8>>,
+    phantom: PhantomData<V>,
+}
+
+impl<'a, K: DeserializeOwned, V: DeserializeOwned> Iterator for TestDBIter<'a, K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut out: Option<Self::Item> = None;
+        let config = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding();
+        self.with_mut(|fields| {
+            if let Some((raw_key, raw_value)) = fields.iter.next() {
+                let key: K = config.deserialize(raw_key).ok().unwrap();
+                let value: V = bincode::deserialize(raw_value).ok().unwrap();
+                out = Some((key, value));
+            }
+        });
+        out
+    }
+}
+
+impl<'a, K: DeserializeOwned> Iterator for TestDBKeys<'a, K> {
+    type Item = K;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut out: Option<Self::Item> = None;
+        self.with_mut(|fields| {
+            let config = bincode::DefaultOptions::new()
+                .with_big_endian()
+                .with_fixint_encoding();
+            if let Some((raw_key, _)) = fields.iter.next() {
+                let key: K = config.deserialize(raw_key).ok().unwrap();
+                out = Some(key);
+            }
+        });
+        out
+    }
+}
+
+impl<'a, V: DeserializeOwned> Iterator for TestDBValues<'a, V> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut out: Option<Self::Item> = None;
+        self.with_mut(|fields| {
+            if let Some((_, raw_value)) = fields.iter.next() {
+                let value: V = bincode::deserialize(raw_value).ok().unwrap();
+                out = Some(value);
+            }
+        });
+        out
+    }
+}
+
+impl<'a, K, V> Map<'a, K, V> for TestDB<K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    type Error = TypedStoreError;
+    type Iterator = TestDBIter<'a, K, V>;
+    type Keys = TestDBKeys<'a, K>;
+    type Values = TestDBValues<'a, V>;
+
+    fn contains_key(&self, key: &K) -> Result<bool, Self::Error> {
+        let raw_key = be_fix_int_ser(key)?;
+        let locked = self.rows.read().unwrap();
+        Ok(locked.contains_key(&raw_key))
+    }
+
+    fn get(&self, key: &K) -> Result<Option<V>, Self::Error> {
+        let raw_key = be_fix_int_ser(key)?;
+        let locked = self.rows.read().unwrap();
+        let res = locked.get(&raw_key);
+        Ok(res.map(|raw_value| bincode::deserialize(raw_value).ok().unwrap()))
+    }
+
+    fn get_raw_bytes(&self, key: &K) -> Result<Option<Vec<u8>>, Self::Error> {
+        let raw_key = be_fix_int_ser(key)?;
+        let locked = self.rows.read().unwrap();
+        let res = locked.get(&raw_key);
+        Ok(res.cloned())
+    }
+
+    fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error> {
+        let raw_key = be_fix_int_ser(key)?;
+        let raw_value = bincode::serialize(value)?;
+        let mut locked = self.rows.write().unwrap();
+        locked.insert(raw_key, raw_value);
+        Ok(())
+    }
+
+    fn remove(&self, key: &K) -> Result<(), Self::Error> {
+        let raw_key = be_fix_int_ser(key)?;
+        let mut locked = self.rows.write().unwrap();
+        locked.remove(&raw_key);
+        Ok(())
+    }
+
+    fn clear(&self) -> Result<(), Self::Error> {
+        let mut locked = self.rows.write().unwrap();
+        locked.clear();
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        let locked = self.rows.read().unwrap();
+        locked.is_empty()
+    }
+
+    fn iter(&'a self) -> Self::Iterator {
+        TestDBIterBuilder {
+            rows: self.rows.read().unwrap(),
+            iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| rows.iter(),
+            phantom: PhantomData,
+        }
+        .build()
+    }
+
+    fn keys(&'a self) -> Self::Keys {
+        TestDBKeysBuilder {
+            rows: self.rows.read().unwrap(),
+            iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| rows.iter(),
+            phantom: PhantomData,
+        }
+        .build()
+    }
+
+    fn values(&'a self) -> Self::Values {
+        TestDBValuesBuilder {
+            rows: self.rows.read().unwrap(),
+            iter_builder: |rows: &mut RwLockReadGuard<'a, BTreeMap<Vec<u8>, Vec<u8>>>| rows.iter(),
+            phantom: PhantomData,
+        }
+        .build()
+    }
+
+    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<J, K, U, V> TryExtend<(J, U)> for TestDB<K, V>
+where
+    J: Borrow<K>,
+    U: Borrow<V>,
+    K: Serialize,
+    V: Serialize,
+{
+    type Error = TypedStoreError;
+
+    fn try_extend<T>(&mut self, iter: &mut T) -> Result<(), Self::Error>
+    where
+        T: Iterator<Item = (J, U)>,
+    {
+        let mut wb = self.batch();
+        wb.insert_batch(self, iter)?;
+        wb.write()
+    }
+
+    fn try_extend_from_slice(&mut self, slice: &[(J, U)]) -> Result<(), Self::Error> {
+        let slice_of_refs = slice.iter().map(|(k, v)| (k.borrow(), v.borrow()));
+        let mut wb = self.batch();
+        wb.insert_batch(self, slice_of_refs)?;
+        wb.write()
+    }
+}
+
+pub type DeleteBatchPayload = (
+    Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+    String,
+    Vec<Vec<u8>>,
+);
+pub type DeleteRangePayload = (
+    Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+    String,
+    (Vec<u8>, Vec<u8>),
+);
+pub type InsertBatchPayload = (
+    Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+    String,
+    Vec<(Vec<u8>, Vec<u8>)>,
+);
+type DBAndName = (Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>, String);
+
+pub enum WriteBatchOp {
+    DeleteBatch(DeleteBatchPayload),
+    DeleteRange(DeleteRangePayload),
+    InsertBatch(InsertBatchPayload),
+}
+
+#[derive(Default)]
+pub struct TestDBWriteBatch {
+    pub ops: VecDeque<WriteBatchOp>,
+}
+
+#[self_referencing]
+pub struct DBLocked {
+    db: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+    #[borrows(db)]
+    #[covariant]
+    db_guard: RwLockWriteGuard<'this, BTreeMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl TestDBWriteBatch {
+    pub fn write(self) -> Result<(), TypedStoreError> {
+        let mut dbs: Vec<DBAndName> = self
+            .ops
+            .iter()
+            .map(|op| match op {
+                WriteBatchOp::DeleteBatch((db, name, _)) => (db.clone(), name.clone()),
+                WriteBatchOp::DeleteRange((db, name, _)) => (db.clone(), name.clone()),
+                WriteBatchOp::InsertBatch((db, name, _)) => (db.clone(), name.clone()),
+            })
+            .collect();
+        dbs.sort_by_key(|(_k, v)| v.clone());
+        dbs.dedup_by_key(|(_k, v)| v.clone());
+        // lock all databases
+        let mut db_locks = HashMap::new();
+        dbs.iter().for_each(|(db, name)| {
+            if !db_locks.contains_key(name) {
+                db_locks.insert(
+                    name.clone(),
+                    DBLockedBuilder {
+                        db: db.clone(),
+                        db_guard_builder: |db: &Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>| {
+                            db.write().unwrap()
+                        },
+                    }
+                    .build(),
+                );
+            }
+        });
+        self.ops.iter().for_each(|op| match op {
+            WriteBatchOp::DeleteBatch((_, id, keys)) => {
+                let locked = db_locks.get_mut(id).unwrap();
+                locked.with_db_guard_mut(|db| {
+                    keys.iter().for_each(|key| {
+                        db.remove(key);
+                    });
+                });
+            }
+            WriteBatchOp::DeleteRange((_, id, (from, to))) => {
+                let locked = db_locks.get_mut(id).unwrap();
+                locked.with_db_guard_mut(|db| {
+                    db.retain(|k, _| k < from || k >= to);
+                });
+            }
+            WriteBatchOp::InsertBatch((_, id, key_values)) => {
+                let locked = db_locks.get_mut(id).unwrap();
+                locked.with_db_guard_mut(|db| {
+                    key_values.iter().for_each(|(k, v)| {
+                        db.insert(k.clone(), v.clone());
+                    });
+                });
+            }
+        });
+        // unlock in the reverse order
+        dbs.iter().rev().for_each(|(_db, id)| {
+            if db_locks.contains_key(id) {
+                db_locks.remove(id);
+            }
+        });
+        Ok(())
+    }
+    /// Deletes a set of keys given as an iterator
+    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
+        &mut self,
+        db: &TestDB<K, V>,
+        purged_vals: impl IntoIterator<Item = J>,
+    ) -> Result<(), TypedStoreError> {
+        self.ops.push_back(WriteBatchOp::DeleteBatch((
+            db.rows.clone(),
+            db.name.clone(),
+            purged_vals
+                .into_iter()
+                .map(|key| be_fix_int_ser(&key.borrow()).unwrap())
+                .collect(),
+        )));
+        Ok(())
+    }
+    /// Deletes a range of keys between `from` (inclusive) and `to` (non-inclusive)
+    pub fn delete_range<'a, K: Serialize, V>(
+        &mut self,
+        db: &'a TestDB<K, V>,
+        from: &K,
+        to: &K,
+    ) -> Result<(), TypedStoreError> {
+        let raw_from = be_fix_int_ser(from.borrow()).unwrap();
+        let raw_to = be_fix_int_ser(to.borrow()).unwrap();
+        self.ops.push_back(WriteBatchOp::DeleteRange((
+            db.rows.clone(),
+            db.name.clone(),
+            (raw_from, raw_to),
+        )));
+        Ok(())
+    }
+    /// inserts a range of (key, value) pairs given as an iterator
+    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        db: &TestDB<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), TypedStoreError> {
+        self.ops.push_back(WriteBatchOp::InsertBatch((
+            db.rows.clone(),
+            db.name.clone(),
+            new_vals
+                .into_iter()
+                .map(|(key, value)| {
+                    (
+                        be_fix_int_ser(&key.borrow()).unwrap(),
+                        bincode::serialize(&value.borrow()).unwrap(),
+                    )
+                })
+                .collect(),
+        )));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{test_db::TestDB, Map};
+
+    #[test]
+    fn test_contains_key() {
+        let db = TestDB::open();
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+        assert!(db
+            .contains_key(&123456789)
+            .expect("Failed to call contains key"));
+        assert!(!db
+            .contains_key(&000000000)
+            .expect("Failed to call contains key"));
+    }
+
+    #[test]
+    fn test_get() {
+        let db = TestDB::open();
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+        assert_eq!(
+            Some("123456789".to_string()),
+            db.get(&123456789).expect("Failed to get")
+        );
+        assert_eq!(None, db.get(&000000000).expect("Failed to get"));
+    }
+
+    #[test]
+    fn test_get_raw() {
+        let db = TestDB::open();
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+
+        let val_bytes = db
+            .get_raw_bytes(&123456789)
+            .expect("Failed to get_raw_bytes")
+            .unwrap();
+
+        assert_eq!(
+            bincode::serialize(&"123456789".to_string()).unwrap(),
+            val_bytes
+        );
+        assert_eq!(
+            None,
+            db.get_raw_bytes(&000000000)
+                .expect("Failed to get_raw_bytes")
+        );
+    }
+
+    #[test]
+    fn test_multi_get() {
+        let db = TestDB::open();
+        db.insert(&123, &"123".to_string())
+            .expect("Failed to insert");
+        db.insert(&456, &"456".to_string())
+            .expect("Failed to insert");
+
+        let result = db.multi_get([123, 456, 789]).expect("Failed to multi get");
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], Some("123".to_string()));
+        assert_eq!(result[1], Some("456".to_string()));
+        assert_eq!(result[2], None);
+    }
+
+    #[test]
+    fn test_remove() {
+        let db = TestDB::open();
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+        assert!(db.get(&123456789).expect("Failed to get").is_some());
+
+        db.remove(&123456789).expect("Failed to remove");
+        assert!(db.get(&123456789).expect("Failed to get").is_none());
+    }
+
+    #[test]
+    fn test_iter() {
+        let db = TestDB::open();
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+
+        let mut iter = db.iter();
+        assert_eq!(Some((123456789, "123456789".to_string())), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn test_iter_reverse() {
+        let db = TestDB::open();
+        db.insert(&1, &"1".to_string()).expect("Failed to insert");
+        db.insert(&2, &"2".to_string()).expect("Failed to insert");
+        db.insert(&3, &"3".to_string()).expect("Failed to insert");
+        let mut iter = db.iter();
+
+        assert_eq!(Some((1, "1".to_string())), iter.next());
+        assert_eq!(Some((2, "2".to_string())), iter.next());
+        assert_eq!(Some((3, "3".to_string())), iter.next());
+        assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn test_keys() {
+        let db = TestDB::open();
+
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+
+        let mut keys = db.keys();
+        assert_eq!(Some(123456789), keys.next());
+        assert_eq!(None, keys.next());
+    }
+
+    #[test]
+    fn test_values() {
+        let db = TestDB::open();
+
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+
+        let mut values = db.values();
+        assert_eq!(Some("123456789".to_string()), values.next());
+        assert_eq!(None, values.next());
+    }
+
+    #[test]
+    fn test_insert_batch() {
+        let db = TestDB::open();
+        let keys_vals = (1..100).map(|i| (i, i.to_string()));
+        let mut wb = db.batch();
+        wb.insert_batch(&db, keys_vals.clone())
+            .expect("Failed to batch insert");
+        wb.write().expect("Failed to execute batch");
+        for (k, v) in keys_vals {
+            let val = db.get(&k).expect("Failed to get inserted key");
+            assert_eq!(Some(v), val);
+        }
+    }
+
+    #[test]
+    fn test_insert_batch_across_cf() {
+        let db_cf_1 = TestDB::open();
+        let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
+
+        let db_cf_2 = TestDB::open();
+        let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
+
+        let mut wb = db_cf_1.batch();
+        wb.insert_batch(&db_cf_1, keys_vals_1.clone())
+            .expect("Failed to batch insert");
+        wb.insert_batch(&db_cf_2, keys_vals_2.clone())
+            .expect("Failed to batch insert");
+        wb.write().expect("Failed to execute batch");
+        for (k, v) in keys_vals_1 {
+            let val = db_cf_1.get(&k).expect("Failed to get inserted key");
+            assert_eq!(Some(v), val);
+        }
+
+        for (k, v) in keys_vals_2 {
+            let val = db_cf_2.get(&k).expect("Failed to get inserted key");
+            assert_eq!(Some(v), val);
+        }
+    }
+
+    #[test]
+    fn test_delete_batch() {
+        let db: TestDB<i32, String> = TestDB::open();
+
+        let keys_vals = (1..100).map(|i| (i, i.to_string()));
+        let mut wb = db.batch();
+        wb.insert_batch(&db, keys_vals)
+            .expect("Failed to batch insert");
+
+        // delete the odd-index keys
+        let deletion_keys = (1..100).step_by(2);
+        wb.delete_batch(&db, deletion_keys)
+            .expect("Failed to batch delete");
+
+        wb.write().expect("Failed to execute batch");
+
+        for k in db.keys() {
+            assert_eq!(k % 2, 0);
+        }
+    }
+
+    #[test]
+    fn test_delete_range() {
+        let db: TestDB<i32, String> = TestDB::open();
+
+        // Note that the last element is (100, "100".to_owned()) here
+        let keys_vals = (0..101).map(|i| (i, i.to_string()));
+        let mut wb = db.batch();
+        wb.insert_batch(&db, keys_vals)
+            .expect("Failed to batch insert");
+
+        wb.delete_range(&db, &50, &100)
+            .expect("Failed to delete range");
+
+        wb.write().expect("Failed to execute batch");
+
+        for k in 0..50 {
+            assert!(db.contains_key(&k).expect("Failed to query legal key"),);
+        }
+        for k in 50..100 {
+            assert!(!db.contains_key(&k).expect("Failed to query legal key"));
+        }
+
+        // range operator is not inclusive of to
+        assert!(db.contains_key(&100).expect("Failed to query legel key"));
+    }
+
+    #[test]
+    fn test_clear() {
+        let db: TestDB<i32, String> = TestDB::open();
+
+        // Test clear of empty map
+        let _ = db.clear();
+
+        let keys_vals = (0..101).map(|i| (i, i.to_string()));
+        let mut wb = db.batch();
+        wb.insert_batch(&db, keys_vals)
+            .expect("Failed to batch insert");
+
+        wb.write().expect("Failed to execute batch");
+
+        // Check we have multiple entries
+        assert!(db.iter().count() > 1);
+        let _ = db.clear();
+        assert_eq!(db.iter().count(), 0);
+        // Clear again to ensure safety when clearing empty map
+        let _ = db.clear();
+        assert_eq!(db.iter().count(), 0);
+        // Clear with one item
+        let _ = db.insert(&1, &"e".to_string());
+        assert_eq!(db.iter().count(), 1);
+        let _ = db.clear();
+        assert_eq!(db.iter().count(), 0);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let db: TestDB<i32, String> = TestDB::open();
+
+        // Test empty map is truly empty
+        assert!(db.is_empty());
+        let _ = db.clear();
+        assert!(db.is_empty());
+
+        let keys_vals = (0..101).map(|i| (i, i.to_string()));
+        let mut wb = db.batch();
+        wb.insert_batch(&db, keys_vals)
+            .expect("Failed to batch insert");
+
+        wb.write().expect("Failed to execute batch");
+
+        // Check we have multiple entries and not empty
+        assert!(db.iter().count() > 1);
+        assert!(!db.is_empty());
+
+        // Clear again to ensure empty works after clearing
+        let _ = db.clear();
+        assert_eq!(db.iter().count(), 0);
+        assert!(db.is_empty());
+    }
+
+    #[test]
+    fn test_multi_insert() {
+        // Init a DB
+        let db: TestDB<i32, String> = TestDB::open();
+
+        // Create kv pairs
+        let keys_vals = (0..101).map(|i| (i, i.to_string()));
+
+        db.multi_insert(keys_vals.clone())
+            .expect("Failed to multi-insert");
+
+        for (k, v) in keys_vals {
+            let val = db.get(&k).expect("Failed to get inserted key");
+            assert_eq!(Some(v), val);
+        }
+    }
+
+    #[test]
+    fn test_multi_remove() {
+        // Init a DB
+        let db: TestDB<i32, String> = TestDB::open();
+
+        // Create kv pairs
+        let keys_vals = (0..101).map(|i| (i, i.to_string()));
+
+        db.multi_insert(keys_vals.clone())
+            .expect("Failed to multi-insert");
+
+        // Check insertion
+        for (k, v) in keys_vals.clone() {
+            let val = db.get(&k).expect("Failed to get inserted key");
+            assert_eq!(Some(v), val);
+        }
+
+        // Remove 50 items
+        db.multi_remove(keys_vals.clone().map(|kv| kv.0).take(50))
+            .expect("Failed to multi-remove");
+        assert_eq!(db.iter().count(), 101 - 50);
+
+        // Check that the remaining are present
+        for (k, v) in keys_vals.skip(50) {
+            let val = db.get(&k).expect("Failed to get inserted key");
+            assert_eq!(Some(v), val);
+        }
+    }
+}

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -14,11 +14,16 @@ use typed_store::metrics::SamplingInterval;
 use typed_store::rocks::be_fix_int_ser;
 use typed_store::rocks::list_tables;
 use typed_store::rocks::DBMap;
+use typed_store::rocks::RocksDBAccessType;
+use typed_store::sally::SallyColumn;
+use typed_store::sally::SallyDBOptions;
+use typed_store::sally::SallyReadOnlyDBOptions;
 use typed_store::traits::Map;
 use typed_store::traits::TableSummary;
 use typed_store::traits::TypedStoreDebug;
 use typed_store::Store;
 use typed_store_derive::DBMapUtils;
+use typed_store_derive::SallyDB;
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
@@ -154,6 +159,88 @@ async fn macro_test() {
     assert_eq!(format!("\"2\""), *m.get(&"\"2\"".to_string()).unwrap());
 
     let m = tbls_secondary.dump("table1", 3, 2).unwrap();
+    assert_eq!(3, m.len());
+    assert_eq!(format!("\"7\""), *m.get(&"\"7\"".to_string()).unwrap());
+    assert_eq!(format!("\"8\""), *m.get(&"\"8\"".to_string()).unwrap());
+}
+
+#[derive(SallyDB)]
+pub struct SallyDBExample {
+    col1: SallyColumn<String, String>,
+    col2: SallyColumn<i32, String>,
+}
+
+#[tokio::test]
+async fn test_sallydb() {
+    let primary_path = temp_dir();
+    let example_db = SallyDBExample::init(SallyDBOptions::RocksDB((
+        primary_path.clone(),
+        RocksDBAccessType::Primary,
+        None,
+        None,
+    )));
+
+    // Write to both columns
+    let keys_vals_1 = (1..10).map(|i| (i.to_string(), i.to_string()));
+    let mut wb = example_db.col1.batch();
+    wb.insert_batch(&example_db.col1, keys_vals_1.clone())
+        .expect("Failed to insert");
+
+    let keys_vals_2 = (3..10).map(|i| (i, i.to_string()));
+    wb.insert_batch(&example_db.col2, keys_vals_2.clone())
+        .expect("Failed to insert");
+
+    wb.write().await.expect("Failed to commit write batch");
+
+    // Open in secondary mode
+    let example_db_secondary = SallyDBExample::get_read_only_handle(
+        SallyReadOnlyDBOptions::RocksDB((primary_path.clone(), None, None)),
+    );
+
+    // Check all the tables can be listed
+    let actual_table_names: HashSet<_> = list_tables(primary_path).unwrap().into_iter().collect();
+    let observed_table_names: HashSet<_> = SallyDBExample::describe_tables()
+        .iter()
+        .map(|q| q.0.clone())
+        .collect();
+
+    let exp: HashSet<String> =
+        HashSet::from_iter(vec!["col1", "col2"].into_iter().map(|s| s.to_owned()));
+    assert_eq!(HashSet::from_iter(actual_table_names), exp);
+    assert_eq!(HashSet::from_iter(observed_table_names), exp);
+
+    // Check the counts
+    assert_eq!(9, example_db_secondary.count_keys("col1").unwrap());
+    assert_eq!(7, example_db_secondary.count_keys("col2").unwrap());
+
+    // Test all entries
+    let m = example_db_secondary.dump("col1", 100, 0).unwrap();
+    for (k, v) in keys_vals_1 {
+        assert_eq!(format!("\"{v}\""), *m.get(&format!("\"{k}\"")).unwrap());
+    }
+
+    let m = example_db_secondary.dump("col2", 100, 0).unwrap();
+    for (k, v) in keys_vals_2 {
+        assert_eq!(format!("\"{v}\""), *m.get(&k.to_string()).unwrap());
+    }
+
+    // Check that catchup logic works
+    let keys_vals_1 = (100..110).map(|i| (i.to_string(), i.to_string()));
+    let mut wb = example_db.col1.batch();
+    wb.insert_batch(&example_db.col1, keys_vals_1.clone())
+        .expect("Failed to insert");
+    wb.write().await.expect("Failed to commit write batch");
+
+    // New entries should be present in secondary
+    assert_eq!(19, example_db_secondary.count_keys("col1").unwrap());
+
+    // Test pagination
+    let m = example_db_secondary.dump("col1", 2, 0).unwrap();
+    assert_eq!(2, m.len());
+    assert_eq!(format!("\"1\""), *m.get(&"\"1\"".to_string()).unwrap());
+    assert_eq!(format!("\"2\""), *m.get(&"\"2\"".to_string()).unwrap());
+
+    let m = example_db_secondary.dump("col1", 3, 2).unwrap();
     assert_eq!(3, m.len());
     assert_eq!(format!("\"7\""), *m.get(&"\"7\"".to_string()).unwrap());
     assert_eq!(format!("\"8\""), *m.get(&"\"8\"".to_string()).unwrap());


### PR DESCRIPTION
Adding sally api and reference implementation for two backends - rocksdb and newly added test db (btree map) based. It still does not support atomicity across different db instances (todo) but as a first pass it allows for replacing storage backends with ease (as long as they implement the common interface) without impacting sui code . The below example basically shows how it could be useful when switching between storage backends:
```
//! Storage Atomicity Layer Library (aka Sally) is a wrapper around pluggable storage backends
//! which implement a common key value interface. It enables users to switch storage backends
//! in their code with simple options. It is also designed to be able to support atomic operations
//! across different columns of the db even when they are backed by different storage instances.
//!
//! # Examples
//!
//! ```
//! use typed_store::rocks::*;
//! use typed_store::test_db::*;
//! use typed_store::sally::SallyDBOptions;
//! use typed_store_derive::SallyDB;
//! use typed_store::sally::SallyColumn;
//! use typed_store::traits::TypedStoreDebug;
//! use crate::typed_store::Map;
//!
//! // `ExampleTable` is a sally db instance where each column is first initialized with TestDB
//! // (btree map) backend and later switched to a RocksDB column family
//!
//! #[derive(SallyDB)]
//! pub struct ExampleTable {
//!   col1: SallyColumn<String, String>,
//!   col2: SallyColumn<i32, String>,
//! }
//!
//! fn update_table(table: &ExampleTable) {
//!     table.col1.insert(&"key1".to_string(), &"value1".to_string());
//!     table.col2.insert(&1, &"test".to_string());
//!     // create a write batch and do atomic commit
//!     let keys_vals = (1..100).map(|i| (i, i.to_string()));
//!     let mut wb = table.col1.batch();
//!     wb = wb.insert_batch(&table.col2, keys_vals).expect("Failed to batch insert");
//!     wb = wb.delete_range(&table.col2, &50, &100).expect("Failed to batch delete");
//!     wb.write();
//! }
//!
//! #[tokio::main]
//! async fn main() -> Result<(), TypedStoreError> {
//!     // use a btree map backend first
//!     let mut table = ExampleTable::init(SallyDBOptions::TestDB);
//!     update_table(&table);
//!     let primary_path = tempfile::tempdir().expect("Failed to open path").into_path();
//!     // switch to rocksdb backend
//!     table = ExampleTable::init(SallyDBOptions::RocksDB((primary_path, RocksDBAccessType::Primary, None, None)));
//!     update_table(&table);
//!     Ok(())
//! }
//! ```