### PR TITLE
Add femver to the SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,7 @@ importers:
       '@scure/bip32': ^1.1.0
       '@scure/bip39': ^1.1.0
       '@size-limit/preset-small-lib': ^7.0.8
+      '@suchipi/femver': ^1.0.0
       '@types/lossless-json': ^1.0.1
       axios: ^0.27.2
       cross-fetch: ^3.1.5
@@ -428,6 +429,7 @@ importers:
       '@noble/secp256k1': 1.6.3
       '@scure/bip32': 1.1.0
       '@scure/bip39': 1.1.0
+      '@suchipi/femver': 1.0.0
       cross-fetch: 3.1.5
       jayson: 3.7.0
       js-sha3: 0.8.0
@@ -4974,6 +4976,10 @@ packages:
   /@storybook/ui/7.0.0-alpha.38:
     resolution: {integrity: sha512-ZGoAmDuSjEAbAnw+OlqAC8wKC6BjzMs0sohrp4Dk2gYyULX0+zJ1U3G3IKIOicZSqanIzvITLrnEefCT0+tXIA==}
     dev: true
+
+  /@suchipi/femver/1.0.0:
+    resolution: {integrity: sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==}
+    dev: false
 
   /@svgr/babel-plugin-add-jsx-attribute/6.3.1_@babel+core@7.19.3:
     resolution: {integrity: sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w==}

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -90,6 +90,7 @@
     "@noble/secp256k1": "^1.6.3",
     "@scure/bip32": "^1.1.0",
     "@scure/bip39": "^1.1.0",
+    "@suchipi/femver": "^1.0.0",
     "cross-fetch": "^3.1.5",
     "jayson": "^3.6.6",
     "js-sha3": "^0.8.0",

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -1026,7 +1026,10 @@ export function isTransactionEffects(obj: any, _argumentName?: string): obj is T
             )) &&
         isOwnedObjectRef(obj.gasObject) as boolean &&
         (typeof obj.events === "undefined" ||
-            Array.isArray(obj.events)) &&
+            Array.isArray(obj.events) &&
+            obj.events.every((e: any) =>
+                isSuiEvent(e) as boolean
+            )) &&
         (typeof obj.dependencies === "undefined" ||
             Array.isArray(obj.dependencies) &&
             obj.dependencies.every((e: any) =>

--- a/sdk/typescript/src/types/version.ts
+++ b/sdk/typescript/src/types/version.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { parse } from '@suchipi/femver';
+
 export type RpcApiVersion = {
   major: number;
   minor: number;
@@ -10,10 +12,5 @@ export type RpcApiVersion = {
 export function parseVersionFromString(
   version: string
 ): RpcApiVersion | undefined {
-  const versions = version.split('.');
-  return {
-    major: parseInt(versions[0], 10),
-    minor: parseInt(versions[1], 10),
-    patch: parseInt(versions[2], 10),
-  };
+  return parse(version);
 }


### PR DESCRIPTION
This adds [femver](https://www.npmjs.com/package/@suchipi/femver), which is a lightweight alternative to semver. Right now it just is used for parsing, but the idea is that this is a better way to do version checks in the SDK. This gives us access to functions like `lt` and `gt` which will let us easily express version checks in the SDK. Right now we don't have much version-gated functionality, but when we do I think this will make it a lot easier.

I verified the bundle size was hardly impacted by the inclusion, so I think this makes sense to add.