### PR TITLE
Increase rocksdb parallelism to recommended value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10223,6 +10223,7 @@ dependencies = [
  "collectable",
  "eyre",
  "fdlimit",
+ "num_cpus",
  "once_cell",
  "proc-macro2 1.0.47",
  "prometheus",

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -15,6 +15,7 @@ eyre = "0.6.8"
 fdlimit = "0.2.1"
 once_cell = "1.15.0"
 tap = "1.0.1"
+num_cpus = "1.13.1"
 prometheus = "0.13.3"
 # deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
 rocksdb = { version = "0.19.0", features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"], default-features = false }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -917,6 +917,9 @@ pub fn default_db_options() -> DBOptions {
     opt.set_max_total_wal_size(
         read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
     );
+    // According to docs, we almost certainly want to set this to number of cores to not be bottlenecked
+    // by rocksdb
+    opt.increase_parallelism((num_cpus::get() as i32) / 8);
     DBOptions { options: opt }
 }
 


### PR DESCRIPTION
By default, RocksDB uses only one background thread for flush and compaction. Calling this function will set it up such that total of `total_threads` is used. Good value for `total_threads` is the number of cores according to rocksdb recommendation