### PR TITLE
[data model] enforce 250 KB size limit for Move objects

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.exp
@@ -1,0 +1,34 @@
+processed 9 tasks
+
+task 1 'publish'. lines 8-79:
+created: object(103)
+written: object(102)
+
+task 2 'run'. lines 80-82:
+Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveObjectTooBig { object_size: 256001, max_object_size: 256000 }, source: None } }
+
+task 3 'run'. lines 83-85:
+created: object(106)
+written: object(105)
+
+task 4 'run'. lines 86-88:
+created: object(108)
+written: object(107)
+
+task 5 'run'. lines 89-91:
+Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveObjectTooBig { object_size: 256001, max_object_size: 256000 }, source: None } }
+
+task 6 'run'. lines 92-92:
+created: object(111)
+written: object(110)
+
+task 7 'run'. lines 94-94:
+created: object(113)
+written: object(112)
+deleted: object(111)
+
+task 8 'run'. lines 96-96:
+Error: Transaction Effects Status: Move object with size 256001 is larger than the maximum object size 256000
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveObjectTooBig { object_size: 256001, max_object_size: 256000 }, source: None } }

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/move_object_size_limit.move
@@ -1,0 +1,99 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test creating objects just below the size limit, and above it
+
+//# init --addresses Test=0x0
+
+//# publish
+
+module Test::M1 {
+    use std::vector;
+    use sui::bcs;
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+
+    struct S has key, store {
+        id: UID,
+        contents: vector<u8>
+    }
+
+    struct Wrapper has key {
+        id: UID,
+        s: S,
+    }
+
+    // create an object whose Move BCS representation is `n` bytes
+    public fun create_object_with_size(n: u64, ctx: &mut TxContext): S {
+        // minimum object size for S is 20 bytes for UID + 1 byte for vector length
+        assert!(n > 21, 0);
+        let contents = vector[];
+        let i = 0;
+        let bytes_to_add = n - 21;
+        while (i < bytes_to_add) {
+            vector::push_back(&mut contents, 9);
+            i = i + 1;
+        };
+        let s = S { id: object::new(ctx), contents };
+        let size = vector::length(&bcs::to_bytes(&s));
+        // shrink by 1 byte until we match size. mismatch happens because of len(UID) + vector length byte
+        while (size > n) {
+            let _ = vector::pop_back(&mut s.contents);
+            // hack: assume this doesn't change the size of the BCS length byte
+            size = size - 1;
+        };
+        // double-check that we got the size right
+        assert!(vector::length(&bcs::to_bytes(&s)) == n, 1);
+        s
+    }
+
+    public entry fun transfer_object_with_size(n: u64, ctx: &mut TxContext) {
+        transfer::transfer(create_object_with_size(n, ctx), tx_context::sender(ctx))
+    }
+
+    /// Add a byte to `s`
+    public entry fun add_byte(s: &mut S) {
+        vector::push_back(&mut s.contents, 9)
+    }
+
+    /// Wrap `s`
+    public entry fun wrap(s: S, ctx: &mut TxContext) {
+        transfer::transfer(Wrapper { id: object::new(ctx), s }, tx_context::sender(ctx))
+    }
+
+    /// Add `n` bytes to the `s` inside `wrapper`, then unwrap it. This should fail
+    /// if `s` is larger than the max object size
+    public entry fun add_bytes_then_unwrap(wrapper: Wrapper, n: u64, ctx: &mut TxContext) {
+        let i = 0;
+        while (i < n) {
+            vector::push_back(&mut wrapper.s.contents, 7);
+            i = i + 1
+        };
+        let Wrapper { id, s } = wrapper;
+        object::delete(id);
+        transfer::transfer(s, tx_context::sender(ctx))
+    }
+}
+
+// create above size limit should fail
+//# run Test::M1::transfer_object_with_size --args 256001
+
+// create under size limit should succeed
+//# run Test::M1::transfer_object_with_size --args 255999
+
+// create at size limit should succeed
+//# run Test::M1::transfer_object_with_size --args 256000
+
+// addding 1 byte to an object at the size limit should fail
+//# run Test::M1::add_byte --args object(108)
+
+// create at size limit, wrap, increase to over size limit while wrapped, then unwrap. should fail
+//# run Test::M1::transfer_object_with_size --args 255980
+
+//# run Test::M1::wrap --args object(111)
+
+//# run Test::M1::add_bytes_then_unwrap --args object(113) 21
+
+
+

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -563,7 +563,7 @@ fn process_successful_execution<S: Storage + ParentSync>(
         obj.data
             .try_as_move_mut()
             .expect("We previously checked that mutable ref inputs are Move objects")
-            .update_contents_and_increment_version(new_contents);
+            .update_contents_and_increment_version(new_contents)?;
 
         changes.insert(
             obj_id,
@@ -625,7 +625,7 @@ fn process_successful_execution<S: Storage + ParentSync>(
         };
         // safe because `has_public_transfer` was properly determined from the abilities
         let mut move_obj =
-            unsafe { MoveObject::new_from_execution(tag, has_public_transfer, version, contents) };
+            unsafe { MoveObject::new_from_execution(tag, has_public_transfer, version, contents)? };
 
         #[cfg(debug_assertions)]
         {

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -1405,6 +1405,7 @@ pub fn make_response_from_sui_system_state(
             SequenceNumber::from_u64(1),
             move_content,
         )
+        .unwrap()
     };
     let initial_shared_version = move_object.version();
     let object = Object::new_move(

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -131,11 +131,8 @@ async fn construct_shared_object_transaction_with_sequence_number(
 
     let shared_object_id = ObjectID::random();
     let shared_object = {
-        use sui_types::gas_coin::GasCoin;
         use sui_types::object::MoveObject;
-
-        let content = GasCoin::new(shared_object_id, 10);
-        let obj = MoveObject::new_gas_coin(sequence_number, content.to_bcs_bytes());
+        let obj = MoveObject::new_gas_coin(sequence_number, shared_object_id, 10);
         Object::new_move(
             obj,
             Owner::Shared {
@@ -957,7 +954,8 @@ async fn test_handle_confirmation_transaction_bad_sequence_number() {
         let o = sender_object.data.try_as_move_mut().unwrap();
         let old_contents = o.contents().to_vec();
         // update object contents, which will increment the sequence number
-        o.update_contents_and_increment_version(old_contents);
+        o.update_contents_and_increment_version(old_contents)
+            .unwrap();
         authority_state.insert_genesis_object(sender_object).await;
     }
 
@@ -1168,11 +1166,8 @@ async fn test_handle_certificate_interrupted_retry() {
 
     let shared_object_id = ObjectID::random();
     let shared_object = {
-        use sui_types::gas_coin::GasCoin;
         use sui_types::object::MoveObject;
-
-        let content = GasCoin::new(shared_object_id, 10);
-        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, content.to_bcs_bytes());
+        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
         let owner = Owner::Shared {
             initial_shared_version: obj.version(),
         };
@@ -2674,11 +2669,8 @@ async fn shared_object() {
 
     let shared_object_id = ObjectID::random();
     let shared_object = {
-        use sui_types::gas_coin::GasCoin;
         use sui_types::object::MoveObject;
-
-        let content = GasCoin::new(shared_object_id, 10);
-        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, content.to_bcs_bytes());
+        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
         let owner = Owner::Shared {
             initial_shared_version: obj.version(),
         };
@@ -2751,11 +2743,8 @@ async fn test_consensus_message_processed() {
 
     let shared_object_id = ObjectID::random();
     let shared_object = {
-        use sui_types::gas_coin::GasCoin;
         use sui_types::object::MoveObject;
-
-        let content = GasCoin::new(shared_object_id, 10);
-        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, content.to_bcs_bytes());
+        let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
         let owner = Owner::Shared {
             initial_shared_version: obj.version(),
         };

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -14,7 +14,6 @@ use narwhal_types::{Empty, TransactionProto};
 use sui_network::tonic;
 use sui_types::{
     base_types::{ObjectID, TransactionDigest},
-    gas_coin::GasCoin,
     messages::{CallArg, CertifiedTransaction, ObjectArg, TransactionData},
     object::{MoveObject, Object, Owner, OBJECT_START_VERSION},
 };
@@ -38,8 +37,7 @@ pub fn test_gas_objects() -> Vec<Object> {
 pub fn test_shared_object() -> Object {
     let seed = "0x6666666666666660";
     let shared_object_id = ObjectID::from_hex_literal(seed).unwrap();
-    let content = GasCoin::new(shared_object_id, 10);
-    let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, content.to_bcs_bytes());
+    let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
     let owner = Owner::Shared {
         initial_shared_version: obj.version(),
     };

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -156,53 +156,58 @@ ExecutionFailureStatus:
     5:
       InvariantViolation: UNIT
     6:
-      InvalidTransferObject: UNIT
+      MoveObjectTooBig:
+        STRUCT:
+          - object_size: U32
+          - max_object_size: U32
     7:
-      InvalidTransferSui: UNIT
+      InvalidTransferObject: UNIT
     8:
-      InvalidTransferSuiInsufficientBalance: UNIT
+      InvalidTransferSui: UNIT
     9:
-      InvalidCoinObject: UNIT
+      InvalidTransferSuiInsufficientBalance: UNIT
     10:
-      EmptyInputCoins: UNIT
+      InvalidCoinObject: UNIT
     11:
-      EmptyRecipients: UNIT
+      EmptyInputCoins: UNIT
     12:
-      RecipientsAmountsArityMismatch: UNIT
+      EmptyRecipients: UNIT
     13:
-      InsufficientBalance: UNIT
+      RecipientsAmountsArityMismatch: UNIT
     14:
-      CoinTypeMismatch: UNIT
+      InsufficientBalance: UNIT
     15:
-      NonEntryFunctionInvoked: UNIT
+      CoinTypeMismatch: UNIT
     16:
-      EntryTypeArityMismatch: UNIT
+      NonEntryFunctionInvoked: UNIT
     17:
+      EntryTypeArityMismatch: UNIT
+    18:
       EntryArgumentError:
         NEWTYPE:
           TYPENAME: EntryArgumentError
-    18:
+    19:
       EntryTypeArgumentError:
         NEWTYPE:
           TYPENAME: EntryTypeArgumentError
-    19:
+    20:
       CircularObjectOwnership:
         NEWTYPE:
           TYPENAME: CircularObjectOwnership
-    20:
+    21:
       InvalidChildObjectArgument:
         NEWTYPE:
           TYPENAME: InvalidChildObjectArgument
-    21:
+    22:
       InvalidSharedByValue:
         NEWTYPE:
           TYPENAME: InvalidSharedByValue
-    22:
+    23:
       TooManyChildObjects:
         STRUCT:
           - object:
               TYPENAME: ObjectID
-    23:
+    24:
       InvalidParentDeletion:
         STRUCT:
           - parent:
@@ -210,32 +215,32 @@ ExecutionFailureStatus:
           - kind:
               OPTION:
                 TYPENAME: DeleteKind
-    24:
+    25:
       InvalidParentFreezing:
         STRUCT:
           - parent:
               TYPENAME: ObjectID
-    25:
-      PublishErrorEmptyPackage: UNIT
     26:
-      PublishErrorNonZeroAddress: UNIT
+      PublishErrorEmptyPackage: UNIT
     27:
-      PublishErrorDuplicateModule: UNIT
+      PublishErrorNonZeroAddress: UNIT
     28:
-      SuiMoveVerificationError: UNIT
+      PublishErrorDuplicateModule: UNIT
     29:
+      SuiMoveVerificationError: UNIT
+    30:
       MovePrimitiveRuntimeError:
         NEWTYPE:
           OPTION:
             TYPENAME: MoveLocation
-    30:
+    31:
       MoveAbort:
         TUPLE:
           - TYPENAME: MoveLocation
           - U64
-    31:
-      VMVerificationOrDeserializationError: UNIT
     32:
+      VMVerificationOrDeserializationError: UNIT
+    33:
       VMInvariantViolation: UNIT
 ExecutionStatus:
   ENUM:

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -500,7 +500,7 @@ impl TryInto<Object> for SuiObject<SuiRawData> {
                         o.has_public_transfer,
                         o.version,
                         o.bcs_bytes,
-                    )
+                    )?
                 })
             }
             SuiRawData::Package(p) => Data::Package(MovePackage::new(p.id, &p.module_map)),

--- a/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
@@ -37,9 +37,8 @@ fn test_move_value_to_sui_coin() {
     let id = ObjectID::random();
     let value = 10000;
     let coin = GasCoin::new(id, value);
-    let bcs = coin.to_bcs_bytes();
 
-    let move_object = MoveObject::new_gas_coin(SequenceNumber::new(), bcs);
+    let move_object = MoveObject::new_gas_coin(SequenceNumber::new(), id, value);
     let layout = GasCoin::layout();
 
     let move_struct = move_object.to_move_struct(&layout).unwrap();

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -467,7 +467,13 @@ pub fn deduct_gas(gas_object: &mut Object, deduct_amount: u64, rebate_amount: u6
     assert!(balance >= deduct_amount);
     let new_gas_coin = GasCoin::new(*gas_coin.id(), balance + rebate_amount - deduct_amount);
     let move_object = gas_object.data.try_as_move_mut().unwrap();
-    move_object.update_contents_and_increment_version(bcs::to_bytes(&new_gas_coin).unwrap());
+    // unwrap safe because GasCoin is guaranteed to serialize
+    let new_contents = bcs::to_bytes(&new_gas_coin).unwrap();
+    assert_eq!(move_object.contents().len(), new_contents.len());
+    // unwrap safe gas object cannot exceed max object size
+    move_object
+        .update_contents_and_increment_version(new_contents)
+        .unwrap();
 }
 
 pub fn refund_gas(gas_object: &mut Object, amount: u64) {
@@ -476,7 +482,12 @@ pub fn refund_gas(gas_object: &mut Object, amount: u64) {
     let balance = gas_coin.value();
     let new_gas_coin = GasCoin::new(*gas_coin.id(), balance + amount);
     let move_object = gas_object.data.try_as_move_mut().unwrap();
-    move_object.update_contents_and_increment_version(bcs::to_bytes(&new_gas_coin).unwrap());
+    // unwrap safe because GasCoin is guaranteed to serialize
+    let new_contents = bcs::to_bytes(&new_gas_coin).unwrap();
+    // unwrap because safe gas object cannot exceed max object size
+    move_object
+        .update_contents_and_increment_version(new_contents)
+        .unwrap();
 }
 
 pub fn get_gas_balance(gas_object: &Object) -> SuiResult<u64> {

--- a/crates/sui-types/src/gas_coin.rs
+++ b/crates/sui-types/src/gas_coin.rs
@@ -65,7 +65,7 @@ impl GasCoin {
     }
 
     pub fn to_object(&self, version: SequenceNumber) -> MoveObject {
-        MoveObject::new_gas_coin(version, self.to_bcs_bytes())
+        MoveObject::new_gas_coin(version, *self.id(), self.value())
     }
 
     pub fn layout() -> MoveStructLayout {

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1228,6 +1228,10 @@ pub enum ExecutionFailureStatus {
     ModuleNotFound,
     FunctionNotFound,
     InvariantViolation,
+    MoveObjectTooBig {
+        object_size: u32,
+        max_object_size: u32,
+    },
 
     //
     // Transfer errors
@@ -1401,7 +1405,8 @@ impl Display for ExecutionFailureStatus {
             ExecutionFailureStatus::InvalidTransactionUpdate => {
                 write!(f, "Invalid Transaction Update.")
             }
-            ExecutionFailureStatus::ModuleNotFound => write!(f, "Module Not Found."),
+            ExecutionFailureStatus::ModuleNotFound => write!(f, "Module Not Found."),  
+            ExecutionFailureStatus::MoveObjectTooBig { object_size, max_object_size } => write!(f, "Move object with size {object_size} is larger than the maximum object size {max_object_size}"),       
             ExecutionFailureStatus::FunctionNotFound => write!(f, "Function Not Found."),
             ExecutionFailureStatus::InvariantViolation => write!(f, "INVARIANT VIOLATION."),
             ExecutionFailureStatus::InvalidTransferObject => write!(

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -83,7 +83,9 @@ fn test_increment_version() {
     // everything else the same
     let old_contents = coin_obj.contents().to_vec();
     let old_type_specific_contents = coin_obj.type_specific_contents().to_vec();
-    coin_obj.update_contents_and_increment_version(old_contents);
+    coin_obj
+        .update_contents_and_increment_version(old_contents)
+        .unwrap();
     assert_eq!(coin_obj.version(), version.increment());
     assert_eq!(&coin_obj.id(), coin.id());
     assert_eq!(

--- a/crates/test-utils/src/objects.rs
+++ b/crates/test-utils/src/objects.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::test_account_keys;
 use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
-use sui_types::gas_coin::GasCoin;
 use sui_types::object::{MoveObject, Object, Owner, OBJECT_START_VERSION};
 
 /// Make a few test gas objects (all with the same owner).
@@ -72,8 +71,7 @@ where
 pub fn test_shared_object() -> Object {
     let seed = "0x6666666666666660";
     let shared_object_id = ObjectID::from_hex_literal(seed).unwrap();
-    let content = GasCoin::new(shared_object_id, 10);
-    let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, content.to_bcs_bytes());
+    let obj = MoveObject::new_gas_coin(OBJECT_START_VERSION, shared_object_id, 10);
     let owner = Owner::Shared {
         initial_shared_version: obj.version(),
     };


### PR DESCRIPTION
Don't allow the BCS bytes of a Move value object to be larger than 250 KB. This should mitigate some performance issues we are seeing from reading/writing/updating very large objects.

We have discussed a limit of 1-2MB before and may increase this limit accordingly, but want to start with something small to encourage folks to use the new dynamic fields feature (which is the recommended way for dealing with large collections or data).

We will enforce a separate, less stringent limit for package objects in a subsequent PR.