### PR TITLE
[store] Add epoch_id to transaction lock query

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1347,8 +1347,11 @@ impl AuthorityState {
                             // Only address owned objects have locks.
                             None
                         } else {
-                            self.get_transaction_lock(&object.compute_object_reference())
-                                .await?
+                            self.get_transaction_lock(
+                                &object.compute_object_reference(),
+                                self.epoch(),
+                            )
+                            .await?
                         };
                         let layout = match request_layout {
                             Some(format) => {
@@ -2134,13 +2137,15 @@ impl AuthorityState {
     ) -> Result<(), SuiError> {
         self.database.consensus_message_processed_notify(key).await
     }
+
     /// Get a read reference to an object/seq lock
     pub async fn get_transaction_lock(
         &self,
         object_ref: &ObjectRef,
+        epoch_id: EpochId,
     ) -> Result<Option<VerifiedSignedTransaction>, SuiError> {
         self.database
-            .get_object_locking_transaction(object_ref)
+            .get_object_locking_transaction(object_ref, epoch_id)
             .await
     }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -271,13 +271,13 @@ async fn test_handle_transfer_transaction_bad_signature() {
         .unwrap()
         .unwrap();
     assert!(authority_state
-        .get_transaction_lock(&object.compute_object_reference())
+        .get_transaction_lock(&object.compute_object_reference(), 0)
         .await
         .unwrap()
         .is_none());
 
     assert!(authority_state
-        .get_transaction_lock(&object.compute_object_reference())
+        .get_transaction_lock(&object.compute_object_reference(), 0)
         .await
         .unwrap()
         .is_none());
@@ -377,13 +377,13 @@ async fn test_handle_transfer_transaction_unknown_sender() {
         .unwrap()
         .unwrap();
     assert!(authority_state
-        .get_transaction_lock(&object.compute_object_reference())
+        .get_transaction_lock(&object.compute_object_reference(), 0)
         .await
         .unwrap()
         .is_none());
 
     assert!(authority_state
-        .get_transaction_lock(&object.compute_object_reference())
+        .get_transaction_lock(&object.compute_object_reference(), 0)
         .await
         .unwrap()
         .is_none());
@@ -451,12 +451,12 @@ async fn test_handle_transfer_transaction_ok() {
 
     // Check the initial state of the locks
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 0.into(), test_object.digest()))
+        .get_transaction_lock(&(object_id, 0.into(), test_object.digest()), 0)
         .await
         .unwrap()
         .is_none());
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 1.into(), test_object.digest()))
+        .get_transaction_lock(&(object_id, 1.into(), test_object.digest()), 0)
         .await
         .is_err());
 
@@ -471,7 +471,7 @@ async fn test_handle_transfer_transaction_ok() {
         .unwrap()
         .unwrap();
     let pending_confirmation = authority_state
-        .get_transaction_lock(&object.compute_object_reference())
+        .get_transaction_lock(&object.compute_object_reference(), 0)
         .await
         .unwrap()
         .unwrap();
@@ -482,13 +482,13 @@ async fn test_handle_transfer_transaction_ok() {
 
     // Check the final state of the locks
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 0.into(), object.digest()))
+        .get_transaction_lock(&(object_id, 0.into(), object.digest()), 0)
         .await
         .unwrap()
         .is_some());
     assert_eq!(
         authority_state
-            .get_transaction_lock(&(object_id, 0.into(), object.digest()))
+            .get_transaction_lock(&(object_id, 0.into(), object.digest()), 0)
             .await
             .unwrap()
             .as_ref()
@@ -1092,11 +1092,11 @@ async fn test_handle_confirmation_transaction_ok() {
 
     // Check locks are set and archived correctly
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 0.into(), old_account.digest()))
+        .get_transaction_lock(&(object_id, 0.into(), old_account.digest()), 0)
         .await
         .is_err());
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 1.into(), new_account.digest()))
+        .get_transaction_lock(&(object_id, 1.into(), new_account.digest()), 0)
         .await
         .expect("Exists")
         .is_none());

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -320,6 +320,7 @@ pub enum SuiError {
         obj_refs: Vec<ObjectRef>,
         locked_epoch: EpochId,
         new_epoch: EpochId,
+        locked_by_tx: TransactionDigest,
     },
     #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{:?}].", digest)]
     TransactionNotFound { digest: TransactionDigest },


### PR DESCRIPTION
When we are querying the lock of a given object, we need to know which epoch we are asking for, because a lock is only valid for one epoch.
Also this API is only used by debugging tool (i.e. sui-tool) now, there is no need to retry for high consistency.