### PR TITLE
wallet-adapters: make react provider auto-connect configurable

### DIFF
--- a/.changeset/honest-ghosts-run.md
+++ b/.changeset/honest-ghosts-run.md
@@ -1,0 +1,5 @@
+---
+"@mysten/wallet-adapter-react": minor
+---
+
+Make auto-connect configurable for WalletProvider

--- a/sdk/wallet-adapter/packages/react-providers/src/WalletContext.tsx
+++ b/sdk/wallet-adapter/packages/react-providers/src/WalletContext.tsx
@@ -47,15 +47,16 @@ export const WalletContext = createContext<WalletContextState | null>(null);
 
 // TODO: Add storage adapter interface
 // TODO: Add storage key option
-// TODO: Add autoConnect option
 export interface WalletProviderProps {
   children: ReactNode;
   adapters: WalletAdapterList;
+  autoConnect?: boolean;
 }
 
 export const WalletProvider: FC<WalletProviderProps> = ({
   children,
   adapters,
+  autoConnect = true,
 }) => {
   const wallets = useWalletAdapters(adapters);
 
@@ -101,13 +102,13 @@ export const WalletProvider: FC<WalletProviderProps> = ({
 
   // Auto-connect to the preferred wallet if there is one in storage:
   useEffect(() => {
-    if (!wallet && !connected && !connecting) {
+    if (!wallet && !connected && !connecting && autoConnect) {
       let preferredWallet = localStorage.getItem(DEFAULT_STORAGE_KEY);
       if (typeof preferredWallet === "string") {
         select(preferredWallet);
       }
     }
-  }, [wallet, connected, connecting, select]);
+  }, [wallet, connected, connecting, select, autoConnect]);
 
   const walletContext = useMemo<WalletContextState>(
     () => ({


### PR DESCRIPTION
This will help mitigate the issue where the adapter tries to connect to a wallet that was earlier connected but was disconnected by other means than the adapter (eg from the wallet itself). Ideally for this situation we should have 'silent connect' that wont trigger UIs (for permissions)

With auto-connect


https://user-images.githubusercontent.com/10210143/203543356-f587e842-d09a-40b2-8f10-2f335434264a.mov


Without


https://user-images.githubusercontent.com/10210143/203543410-b9b5c815-8e13-4fd2-b851-433875437b26.mov


Part of: APPS-41