### PR TITLE
[crypto] Simplify `VerificationObligation`.

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -843,7 +843,7 @@ impl Signer<Signature> for Secp256k1KeyPair {
 // This struct exists due to the limitations of the `enum_dispatch` library.
 //
 pub trait SuiSignatureInner: Sized + signature::Signature + PartialEq + Eq + Hash {
-    type Sig: Authenticator<PubKey = Self::PubKey> + ToObligationSignature;
+    type Sig: Authenticator<PubKey = Self::PubKey>;
     type PubKey: VerifyingKey<Sig = Self::Sig> + SuiPublicKey;
     type KeyPair: KeypairTraits<PubKey = Self::PubKey, Sig = Self::Sig>;
 
@@ -958,7 +958,6 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
                 error: format!("{}", e),
             })
     }
-
 }
 
 /// AuthoritySignInfoTrait is a trait used specifically for a few structs in messages.rs
@@ -1371,37 +1370,6 @@ pub fn sha3_hash<S: Signable<Sha3_256>>(signable: &S) -> [u8; 32] {
     hash.into()
 }
 
-//
-// Helper enum to statically dispatch sender sigs to verification obligation.
-//
-
-pub enum ObligationSignature<'a> {
-    AuthoritySig((&'a AuthoritySignature, &'a AuthorityPublicKey)),
-    None, // Do not verify signature/public key pair
-}
-
-pub trait ToObligationSignature: Authenticator {
-    fn to_obligation_signature<'a>(
-        &'a self,
-        _pubkey: &'a <Self as Authenticator>::PubKey,
-    ) -> ObligationSignature<'a> {
-        ObligationSignature::None
-    }
-}
-
-impl ToObligationSignature for AuthoritySignature {
-    fn to_obligation_signature<'a>(
-        &'a self,
-        pubkey: &'a <Self as Authenticator>::PubKey,
-    ) -> ObligationSignature<'a> {
-        ObligationSignature::AuthoritySig((self, pubkey))
-    }
-}
-// Careful, the implementation may be overlapping with the AuthoritySignature implementation. Be sure to fix it if it does:
-// TODO: Change all these into macros.
-impl ToObligationSignature for Secp256k1Signature {}
-impl ToObligationSignature for Ed25519Signature {}
-
 #[derive(Default)]
 pub struct VerificationObligation {
     pub messages: Vec<Vec<u8>>,
@@ -1411,9 +1379,7 @@ pub struct VerificationObligation {
 
 impl VerificationObligation {
     pub fn new() -> VerificationObligation {
-        VerificationObligation {
-            ..Default::default()
-        }
+        VerificationObligation::default()
     }
 
     /// Add a new message to the list of messages to be verified.
@@ -1433,32 +1399,24 @@ impl VerificationObligation {
     }
 
     // Attempts to add signature and public key to the obligation. If this fails, ensure to call `verify` manually.
-    pub fn add_signature_and_public_key<
-        S: ToObligationSignature + Authenticator<PubKey = P>,
-        P: VerifyingKey<Sig = S>,
-    >(
+    pub fn add_signature_and_public_key(
         &mut self,
-        signature: S,
-        public_key: P,
+        signature: &AuthoritySignature,
+        public_key: &AuthorityPublicKey,
         idx: usize,
     ) -> SuiResult<()> {
-        match signature.to_obligation_signature(&public_key) {
-            ObligationSignature::AuthoritySig((sig, pubkey)) => {
-                self.public_keys
-                    .get_mut(idx)
-                    .ok_or(SuiError::InvalidAuthenticator)?
-                    .push(pubkey.clone());
-                self.signatures
-                    .get_mut(idx)
-                    .ok_or(SuiError::InvalidAuthenticator)?
-                    .add_signature(sig.clone())
-                    .map_err(|_| SuiError::InvalidSignature {
-                        error: "Failed to add signature to obligation".to_string(),
-                    })?;
-                Ok(())
-            }
-            ObligationSignature::None => Err(SuiError::SenderSigUnbatchable),
-        }
+        self.public_keys
+            .get_mut(idx)
+            .ok_or(SuiError::InvalidAuthenticator)?
+            .push(public_key.clone());
+        self.signatures
+            .get_mut(idx)
+            .ok_or(SuiError::InvalidAuthenticator)?
+            .add_signature(signature.clone())
+            .map_err(|_| SuiError::InvalidSignature {
+                error: "Failed to add signature to obligation".to_string(),
+            })?;
+        Ok(())
     }
 
     pub fn verify_all(self) -> SuiResult<()> {

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -908,13 +908,6 @@ pub trait SuiSignature: Sized + signature::Signature {
     fn verify_secure<T>(&self, value: &T, intent: Intent, author: SuiAddress) -> SuiResult<()>
     where
         T: Serialize;
-
-    fn add_to_verification_obligation_or_verify(
-        &self,
-        author: SuiAddress,
-        obligation: &mut VerificationObligation,
-        idx: usize,
-    ) -> SuiResult<()>;
 }
 
 impl<S: SuiSignatureInner + Sized> SuiSignature for S {
@@ -966,24 +959,6 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
             })
     }
 
-    fn add_to_verification_obligation_or_verify(
-        &self,
-        author: SuiAddress,
-        obligation: &mut VerificationObligation,
-        idx: usize,
-    ) -> SuiResult<()> {
-        let (sig, pk) = self.get_verification_inputs(author)?;
-        match obligation.add_signature_and_public_key(sig.clone(), pk.clone(), idx) {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                let msg = &obligation.messages[idx][..];
-                pk.verify(msg, &sig)
-                    .map_err(|_| SuiError::InvalidSignature {
-                        error: err.to_string(),
-                    })
-            }
-        }
-    }
 }
 
 /// AuthoritySignInfoTrait is a trait used specifically for a few structs in messages.rs


### PR DESCRIPTION
The main contribution it the last commit (the first is straightforward).

## Context
The `VerificationObligation` is an accumulator for **batch verification of signatures on the same message**. It works predicated on the `batch_verify` method of the `VerifyingKey` trait, which as we know works in this way:
- performs a batch verification on these schemes that can (Ed25519, BLS),
- performs an iterated verification on these schemes that can't (Secp256k1)

## Issue
The trait `ToObligationSignature`, despite comments to the contrary, was doing runtime detection of the argument's type in the call to the `VerificationObligation::add_signature_and_public_key`, which took any signature as argument, converted some of them to an obligation (for BLS), the others to an `Obligation::None` (for the other two schemes, despite Ed25519 having a valid batch verification semantic), and errored upon encountering any `Obligation::None`.

The reason for this behavior isn't that we want to address verification generically somehow, it is that we want to build accumulators (`VerificationObligation`) for the authority signatures: if you happen to want to add a signature to the batch that's not of the authority's scheme (in our case, BLS), that's an error.

## This PR
A simple way of detecting this statically is to make `VerificationObligation` monomorphic, making calling `add_signature_and_public_key` on anything but the authority's chosen scheme a compilation error. That's what this commit does.
