### PR TITLE
[TypeScript SDK] Add retry for the faucet to e2e tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,6 +415,7 @@ importers:
       size-limit: ^7.0.8
       ts-auto-guard: ^2.4.1
       ts-node: ^10.9.1
+      ts-retry-promise: ^0.7.0
       tslib: ^2.3.1
       tsup: ^6.2.2
       tweetnacl: ^1.0.3
@@ -450,6 +451,7 @@ importers:
       size-limit: 7.0.8
       ts-auto-guard: 2.4.1
       ts-node: 10.9.1_typescript@4.8.3
+      ts-retry-promise: 0.7.0
       tslib: 2.4.0
       tsup: 6.2.2_qv3zdqwr5cvvfboiktsp7a3dfa
       typedoc: 0.23.11_typescript@4.8.3
@@ -18836,6 +18838,11 @@ packages:
       typescript: 4.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
+
+  /ts-retry-promise/0.7.0:
+    resolution: {integrity: sha512-x6yWZXC4BfXy4UyMweOFvbS1yJ/Y5biSz/mEPiILtJZLrqD3ZxIpzVOGGgifHHdaSe3WxzFRtsRbychI6zofOg==}
+    engines: {node: '>=6'}
     dev: true
 
   /tsconfig-paths/3.14.1:

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -77,6 +77,7 @@
     "size-limit": "^7.0.8",
     "ts-auto-guard": "^2.4.1",
     "ts-node": "^10.9.1",
+    "ts-retry-promise": "^0.7.0",
     "tslib": "^2.3.1",
     "tsup": "^6.2.2",
     "typedoc": "^0.23.11",

--- a/sdk/typescript/src/rpc/faucet-client.ts
+++ b/sdk/typescript/src/rpc/faucet-client.ts
@@ -6,6 +6,8 @@ import fetch from 'cross-fetch';
 import { FaucetResponse, SuiAddress } from '../types';
 import { HttpHeaders } from './client';
 
+export class FaucetRateLimitError extends Error {}
+
 export async function requestSuiFromFaucet(
   endpoint: string,
   recipient: SuiAddress,
@@ -23,8 +25,20 @@ export async function requestSuiFromFaucet(
       ...(httpHeaders || {}),
     },
   });
-  const parsed = await res.json();
 
+  if (res.status === 429) {
+    throw new FaucetRateLimitError(
+      `Too many requests from this client have been sent to the faucet. Please retry later`
+    );
+  }
+  let parsed;
+  try {
+    parsed = await res.json();
+  } catch (e) {
+    throw new Error(
+      `Ecountered error when parsing response from faucet, error: ${e}, status ${res.status}, response ${res}`
+    );
+  }
   if (parsed.error) {
     throw new Error(`Faucet returns error: ${parsed.error}`);
   }


### PR DESCRIPTION
Some workflow ([example](https://github.com/MystenLabs/sui/actions/runs/3534676874/jobs/5931837516)) may fail temporarily due to the timeout issue in the faucet client if there's a high load. This transient issue should resolve itself after some retry