### PR TITLE
[rosetta] Feature fix rosetta /block endpoint

### DIFF
--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -240,7 +240,7 @@ impl PseudoBlockProvider {
 
                 let transaction = Transaction {
                     transaction_identifier: TransactionIdentifier { hash: digest },
-                    operations: operations,
+                    operations,
                     related_transactions: vec![],
                     metadata: None,
                 };

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -257,7 +257,7 @@ impl PseudoBlockProvider {
                         transactions: vec![transaction],
                         metadata: None,
                     },
-                    other_transactions: vec![TransactionIdentifier { hash: digest }],
+                    other_transactions: vec![],
                 };
 
                 let ops = Operation::from_data_and_events(

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -228,10 +228,10 @@ impl PseudoBlockProvider {
                     index,
                     hash: digest.as_ref().try_into()?,
                 };
-                
+
                 // update balance
-                let (tx, effect) = state.get_transaction(digest).await?; 
-                
+                let (tx, effect) = state.get_transaction(digest).await?;
+
                 let operations = Operation::from_data_and_events(
                     &tx.data().data,
                     &effect.status,

--- a/crates/sui-rosetta/src/state.rs
+++ b/crates/sui-rosetta/src/state.rs
@@ -228,6 +228,22 @@ impl PseudoBlockProvider {
                     index,
                     hash: digest.as_ref().try_into()?,
                 };
+                
+                // update balance
+                let (tx, effect) = state.get_transaction(digest).await?; 
+                
+                let operations = Operation::from_data_and_events(
+                    &tx.data().data,
+                    &effect.status,
+                    &effect.events,
+                )?;
+
+                let transaction = Transaction {
+                    transaction_identifier: TransactionIdentifier { hash: digest },
+                    operations: operations,
+                    related_transactions: vec![],
+                    metadata: None,
+                };
 
                 let new_block = BlockResponse {
                     block: Block {
@@ -238,14 +254,11 @@ impl PseudoBlockProvider {
                             .map_err(|e| Error::new_with_cause(InternalError, e))?
                             .as_millis()
                             .try_into()?,
-                        transactions: vec![],
+                        transactions: vec![transaction],
                         metadata: None,
                     },
                     other_transactions: vec![TransactionIdentifier { hash: digest }],
                 };
-
-                // update balance
-                let (tx, effect) = state.get_transaction(digest).await?;
 
                 let ops = Operation::from_data_and_events(
                     &tx.data().data,


### PR DESCRIPTION
# The issue
The `/block` endpoint of rosetta currently returns an empty transactions array with the hash of the transaction in the block, included in the other transactions section. This means a call to `/block/transaction` is always necessary in order to get the operations of a singular transaction.

# This PR
By adding the transaction as part of the transactions array in the `create_next_block` function, the endpoint will now return the relevant transaction and its accompanied operations as part of the `/block` call.