### PR TITLE
[data model] enforce max package size

### DIFF
--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -378,7 +378,7 @@ pub fn store_package_and_init_modules<
 
     // wrap the modules in an object, write it to the store
     // The call to unwrap() will go away once we remove address owner from Immutable objects.
-    let package_object = Object::new_package(modules, ctx.digest());
+    let package_object = Object::new_package(modules, ctx.digest())?;
     let id = package_object.id();
     let changes = BTreeMap::from([(
         id,

--- a/crates/sui-adapter/src/genesis.rs
+++ b/crates/sui-adapter/src/genesis.rs
@@ -39,9 +39,10 @@ pub fn get_genesis_context() -> TxContext {
 fn create_genesis_module_objects() -> Genesis {
     let sui_modules = sui_framework::get_sui_framework();
     let std_modules = sui_framework::get_move_stdlib();
+    // unwraps safe because genesis packages should never exceed max size
     let objects = vec![
-        Object::new_package(std_modules.clone(), TransactionDigest::genesis()),
-        Object::new_package(sui_modules.clone(), TransactionDigest::genesis()),
+        Object::new_package(std_modules.clone(), TransactionDigest::genesis()).unwrap(),
+        Object::new_package(sui_modules.clone(), TransactionDigest::genesis()).unwrap(),
     ];
     let modules = vec![std_modules, sui_modules];
     Genesis { objects, modules }

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -85,7 +85,7 @@ pub async fn init_local_authorities(
         .into_iter()
         .cloned()
         .collect();
-    let pkg = Object::new_package(modules, TransactionDigest::genesis());
+    let pkg = Object::new_package(modules, TransactionDigest::genesis()).unwrap();
     let pkg_ref = pkg.compute_object_reference();
     genesis_objects.push(pkg);
 
@@ -443,7 +443,7 @@ async fn test_quorum_map_and_reduce_timeout() {
         .into_iter()
         .cloned()
         .collect();
-    let pkg = Object::new_package(modules, TransactionDigest::genesis());
+    let pkg = Object::new_package(modules, TransactionDigest::genesis()).unwrap();
     let pkg_ref = pkg.compute_object_reference();
     let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
     let gas_object1 = Object::with_owner_for_testing(addr1);

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -158,58 +158,63 @@ ExecutionFailureStatus:
     6:
       MoveObjectTooBig:
         STRUCT:
-          - object_size: U32
-          - max_object_size: U32
+          - object_size: U64
+          - max_object_size: U64
     7:
-      InvalidTransferObject: UNIT
+      MovePackageTooBig:
+        STRUCT:
+          - object_size: U64
+          - max_object_size: U64
     8:
-      InvalidTransferSui: UNIT
+      InvalidTransferObject: UNIT
     9:
-      InvalidTransferSuiInsufficientBalance: UNIT
+      InvalidTransferSui: UNIT
     10:
-      InvalidCoinObject: UNIT
+      InvalidTransferSuiInsufficientBalance: UNIT
     11:
-      InvalidCoinMetadataObject: UNIT
+      InvalidCoinObject: UNIT
     12:
-      EmptyInputCoins: UNIT
+      InvalidCoinMetadataObject: UNIT
     13:
-      EmptyRecipients: UNIT
+      EmptyInputCoins: UNIT
     14:
-      RecipientsAmountsArityMismatch: UNIT
+      EmptyRecipients: UNIT
     15:
-      InsufficientBalance: UNIT
+      RecipientsAmountsArityMismatch: UNIT
     16:
-      CoinTypeMismatch: UNIT
+      InsufficientBalance: UNIT
     17:
-      NonEntryFunctionInvoked: UNIT
+      CoinTypeMismatch: UNIT
     18:
-      EntryTypeArityMismatch: UNIT
+      NonEntryFunctionInvoked: UNIT
     19:
+      EntryTypeArityMismatch: UNIT
+    20:
       EntryArgumentError:
         NEWTYPE:
           TYPENAME: EntryArgumentError
-    20:
+    21:
       EntryTypeArgumentError:
         NEWTYPE:
           TYPENAME: EntryTypeArgumentError
-    21:
+    22:
       CircularObjectOwnership:
         NEWTYPE:
           TYPENAME: CircularObjectOwnership
-    22:
+    23:
       InvalidChildObjectArgument:
         NEWTYPE:
           TYPENAME: InvalidChildObjectArgument
-    23:
+    24:
       InvalidSharedByValue:
         NEWTYPE:
           TYPENAME: InvalidSharedByValue
-    24:
+    25:
       TooManyChildObjects:
         STRUCT:
           - object:
               TYPENAME: ObjectID
-    25:
+    26:
       InvalidParentDeletion:
         STRUCT:
           - parent:
@@ -217,32 +222,32 @@ ExecutionFailureStatus:
           - kind:
               OPTION:
                 TYPENAME: DeleteKind
-    26:
+    27:
       InvalidParentFreezing:
         STRUCT:
           - parent:
               TYPENAME: ObjectID
-    27:
-      PublishErrorEmptyPackage: UNIT
     28:
-      PublishErrorNonZeroAddress: UNIT
+      PublishErrorEmptyPackage: UNIT
     29:
-      PublishErrorDuplicateModule: UNIT
+      PublishErrorNonZeroAddress: UNIT
     30:
-      SuiMoveVerificationError: UNIT
+      PublishErrorDuplicateModule: UNIT
     31:
+      SuiMoveVerificationError: UNIT
+    32:
       MovePrimitiveRuntimeError:
         NEWTYPE:
           OPTION:
             TYPENAME: MoveLocation
-    32:
+    33:
       MoveAbort:
         TUPLE:
           - TYPENAME: MoveLocation
           - U64
-    33:
-      VMVerificationOrDeserializationError: UNIT
     34:
+      VMVerificationOrDeserializationError: UNIT
+    35:
       VMInvariantViolation: UNIT
 ExecutionStatus:
   ENUM:

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -544,7 +544,7 @@ impl TryInto<Object> for SuiObject<SuiRawData> {
                     )?
                 })
             }
-            SuiRawData::Package(p) => Data::Package(MovePackage::new(p.id, &p.module_map)),
+            SuiRawData::Package(p) => Data::Package(MovePackage::new(p.id, &p.module_map)?),
         };
         Ok(Object {
             data,

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -402,7 +402,8 @@ fn test_basic_args_linter_top_level() {
     let path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sui_programmability/examples/nfts");
     let compiled_modules = BuildConfig::default().build(path).unwrap().into_modules();
-    let example_package = Object::new_package(compiled_modules, TransactionDigest::genesis());
+    let example_package =
+        Object::new_package(compiled_modules, TransactionDigest::genesis()).unwrap();
     let example_package = example_package.data.try_as_package().unwrap();
 
     let module = Identifier::new("geniteam").unwrap();
@@ -504,7 +505,8 @@ fn test_basic_args_linter_top_level() {
     let path =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../sui_programmability/examples/basics");
     let compiled_modules = BuildConfig::default().build(path).unwrap().into_modules();
-    let example_package = Object::new_package(compiled_modules, TransactionDigest::genesis());
+    let example_package =
+        Object::new_package(compiled_modules, TransactionDigest::genesis()).unwrap();
     let framework_pkg = example_package.data.try_as_package().unwrap();
 
     let module = Identifier::new("object_basics").unwrap();
@@ -583,7 +585,8 @@ fn test_basic_args_linter_top_level() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../sui-core/src/unit_tests/data/entry_point_vector");
     let compiled_modules = BuildConfig::default().build(path).unwrap().into_modules();
-    let example_package = Object::new_package(compiled_modules, TransactionDigest::genesis());
+    let example_package =
+        Object::new_package(compiled_modules, TransactionDigest::genesis()).unwrap();
     let example_package = example_package.data.try_as_package().unwrap();
 
     let module = Identifier::new("entry_point_vector").unwrap();

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -320,7 +320,7 @@ impl TransactionBuilder {
             .try_as_package()
             .cloned()
             .ok_or_else(|| anyhow!("Object [{}] is not a move package.", package_id))?;
-        let package: MovePackage = MovePackage::new(package.id, &package.module_map);
+        let package: MovePackage = MovePackage::new(package.id, &package.module_map)?;
 
         let json_args = resolve_move_function_args(
             &package,

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -1229,8 +1229,12 @@ pub enum ExecutionFailureStatus {
     FunctionNotFound,
     InvariantViolation,
     MoveObjectTooBig {
-        object_size: u32,
-        max_object_size: u32,
+        object_size: u64,
+        max_object_size: u64,
+    },
+    MovePackageTooBig {
+        object_size: u64,
+        max_object_size: u64,
     },
 
     //
@@ -1408,6 +1412,7 @@ impl Display for ExecutionFailureStatus {
             }
             ExecutionFailureStatus::ModuleNotFound => write!(f, "Module Not Found."),  
             ExecutionFailureStatus::MoveObjectTooBig { object_size, max_object_size } => write!(f, "Move object with size {object_size} is larger than the maximum object size {max_object_size}"),       
+            ExecutionFailureStatus::MovePackageTooBig { object_size, max_object_size } => write!(f, "Move package with size {object_size} is larger than the maximum object size {max_object_size}"),       
             ExecutionFailureStatus::FunctionNotFound => write!(f, "Function Not Found."),
             ExecutionFailureStatus::InvariantViolation => write!(f, "INVARIANT VIOLATION."),
             ExecutionFailureStatus::InvalidTransferObject => write!(

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -333,7 +333,7 @@ fn test_move_object_size_for_gas_metering() {
 #[test]
 fn test_move_package_size_for_gas_metering() {
     let module = file_format::empty_module();
-    let package = Object::new_package(vec![module], TransactionDigest::genesis());
+    let package = Object::new_package(vec![module], TransactionDigest::genesis()).unwrap();
     let size = package.object_size_for_gas_metering();
     let serialized = bcs::to_bytes(&package).unwrap();
     // If the following assertion breaks, it's likely you have changed MovePackage's fields.


### PR DESCRIPTION
Enforce a max Move package size of 100 KB. Ideally, we would like to enforce a size limit of 500 KB, but the gas cost calculation for packages is quite conservative at the moment, and any attempt to set a more permissive limit goes over the max budget of 10,000 mist.