### PR TITLE
[TypeScript SDK] - add getCommitteeInfo method

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -56,6 +56,7 @@ import {
   CheckpointContents,
   CheckpointDigest,
   CheckPointContentsDigest,
+  CommitteeInfo,
 } from '../types';
 import { DynamicFieldPage } from '../types/dynamic_fields';
 import {
@@ -1074,4 +1075,17 @@ export class JsonRpcProvider extends Provider {
     }
   }
 
+  async getCommitteeInfo(epoch?: number): Promise<CommitteeInfo> {
+    try {
+      const committeeInfo = await this.client.requestWithType(
+        'sui_getCommitteeInfo',
+        [epoch],
+        CommitteeInfo
+      );
+
+      return committeeInfo;
+    } catch (error) {
+      throw new Error(`Error getCommitteeInfo : ${error}`);
+    }
+  }
 }

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -410,7 +410,7 @@ export abstract class Provider {
 
   /**
    * Return the committee information for the asked epoch
-   * @param epoch The epoch of interest. If None, default to the latest epoch
+   * @param epoch The epoch of interest. If null, default to the latest epoch
    * @return {CommitteeInfo} the committee information
    */
   abstract getCommitteeInfo(epoch?: number): Promise<CommitteeInfo>;

--- a/sdk/typescript/src/providers/provider.ts
+++ b/sdk/typescript/src/providers/provider.ts
@@ -42,6 +42,7 @@ import {
   CheckpointContents,
   CheckpointDigest,
   CheckPointContentsDigest,
+  CommitteeInfo,
 } from '../types';
 
 import { DynamicFieldPage } from '../types/dynamic_fields';
@@ -369,7 +370,6 @@ export abstract class Provider {
    * Getting the reference gas price for the network
    */
   abstract getReferenceGasPrice(): Promise<number>;
-  // TODO: add more interface methods
 
   /**
    * Get the sequence number of the latest checkpoint that has been executed
@@ -408,4 +408,12 @@ export abstract class Provider {
     digest: CheckPointContentsDigest
   ): Promise<CheckpointContents>;
 
+  /**
+   * Return the committee information for the asked epoch
+   * @param epoch The epoch of interest. If None, default to the latest epoch
+   * @return {CommitteeInfo} the committee information
+   */
+  abstract getCommitteeInfo(epoch?: number): Promise<CommitteeInfo>;
+
+  // TODO: add more interface methods
 }

--- a/sdk/typescript/src/providers/void-provider.ts
+++ b/sdk/typescript/src/providers/void-provider.ts
@@ -43,6 +43,7 @@ import {
   CheckpointContents,
   CheckpointDigest,
   CheckPointContentsDigest,
+  CommitteeInfo,
 } from '../types';
 import { Provider } from './provider';
 
@@ -317,5 +318,9 @@ export class VoidProvider extends Provider {
     _digest: CheckPointContentsDigest,
   ): Promise<CheckpointContents> {
     throw this.newError('getCheckpointContentsByDigest');
+  }
+
+  async getCommitteeInfo(_epoch?: number): Promise<CommitteeInfo> {
+    throw this.newError('getCommitteeInfo');
   }
 }

--- a/sdk/typescript/src/types/transactions.ts
+++ b/sdk/typescript/src/types/transactions.ts
@@ -270,7 +270,8 @@ export type TransactionQuery =
   | { ToAddress: SuiAddress };
 
 export type EmptySignInfo = object;
-export type AuthorityName = string;
+export type AuthorityName = Infer<typeof AuthorityName>;
+export const AuthorityName = string();
 
 export const TransactionBytes = object({
   txBytes: string(),

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -12,8 +12,11 @@ import {
   union,
   Infer,
   optional,
+  nullable,
+  tuple,
 } from 'superstruct';
 import { SuiAddress } from './common';
+import { AuthorityName } from './transactions';
 
 export const ValidatorMetaData = object({
   sui_address: SuiAddress,
@@ -39,6 +42,7 @@ export type ValidatorMetaData = Infer<typeof ValidatorMetaData>;
 export type ValidatorsFields = Infer<typeof ValidatorsFields>;
 export type Validators = Infer<typeof Validators>;
 export type ActiveValidator = Infer<typeof ActiveValidator>;
+export type CommitteeInfo = Infer<typeof CommitteeInfo>;
 
 // Staking
 export const Id = object({
@@ -227,4 +231,9 @@ export const Validators = object({
   type: string(),
   has_public_transfer: boolean(),
   fields: ValidatorsFields,
+});
+
+export const CommitteeInfo = object({
+  epoch: number(),
+  committee_info: nullable(array(tuple([AuthorityName, number()]))),
 });

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -233,9 +233,8 @@ export const Validators = object({
   fields: ValidatorsFields,
 });
 
-export type StakeUnit = number;
-
 export const CommitteeInfo = object({
   epoch: number(),
+  /* array of (validator public key, stake unit) tuple */
   committee_info: nullable(array(tuple([AuthorityName, StakeUnit]))),
 });

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -233,7 +233,9 @@ export const Validators = object({
   fields: ValidatorsFields,
 });
 
+export type StakeUnit = number;
+
 export const CommitteeInfo = object({
   epoch: number(),
-  committee_info: nullable(array(tuple([AuthorityName, number()]))),
+  committee_info: nullable(array(tuple([AuthorityName, StakeUnit]))),
 });

--- a/sdk/typescript/src/types/validator.ts
+++ b/sdk/typescript/src/types/validator.ts
@@ -236,5 +236,5 @@ export const Validators = object({
 export const CommitteeInfo = object({
   epoch: number(),
   /* array of (validator public key, stake unit) tuple */
-  committee_info: nullable(array(tuple([AuthorityName, StakeUnit]))),
+  committee_info: nullable(array(tuple([AuthorityName, number()]))),
 });

--- a/sdk/typescript/test/e2e/rpc-endpoint.test.ts
+++ b/sdk/typescript/test/e2e/rpc-endpoint.test.ts
@@ -22,10 +22,27 @@ describe('Invoke any RPC endpoint', () => {
         expect(gasObjects).toStrictEqual(gasObjectsExpected);
     });
 
-    it('sui_getObjectOwnedByAddress Error', async () => {
+  it('sui_getObjectOwnedByAddress Error', async () => {
         expect(toolbox.provider.call(
             'sui_getObjectsOwnedByAddress',
             [],
         )).rejects.toThrowError();
     })
+
+    it('sui_getCommitteeInfo', async () => {
+      const committeeInfoExpected = await toolbox.provider.getCommitteeInfo();
+
+      const committeeInfo = await toolbox.provider.call(
+        'sui_getCommitteeInfo',
+        []
+      );
+
+      expect(committeeInfo).toStrictEqual(committeeInfoExpected);
+    });
+
+    it('sui_getCommitteeInfo Error', async () => {
+      expect(
+        toolbox.provider.call('sui_getCommitteeInfo', [])
+      ).rejects.toThrowError();
+    });
 });

--- a/sdk/typescript/test/e2e/rpc-endpoint.test.ts
+++ b/sdk/typescript/test/e2e/rpc-endpoint.test.ts
@@ -40,9 +40,4 @@ describe('Invoke any RPC endpoint', () => {
       expect(committeeInfo).toStrictEqual(committeeInfoExpected);
     });
 
-    it('sui_getCommitteeInfo Error', async () => {
-      expect(
-        toolbox.provider.call('sui_getCommitteeInfo', [])
-      ).rejects.toThrowError();
-    });
 });


### PR DESCRIPTION
#6363 added getCommitteeInfo method. 

This PR :
- expose `getCommitteeInfo` method in the `JsonRpcProvider` Class