### PR TITLE
crypto: send serialized signature flag || signature || pubkey

### DIFF
--- a/crates/sui-json-rpc/src/api.rs
+++ b/crates/sui-json-rpc/src/api.rs
@@ -476,6 +476,7 @@ pub trait TransactionExecutionApi {
     ///     makes sure this node is aware of this transaction when client fires subsequent queries.
     ///     However if the node fails to execute the transaction locally in a timely manner,
     ///     a bool type in the response is set to false to indicated the case.
+    // TODO(joyqvq): remove this and rename executeTransactionSerializedSig to executeTransaction
     #[method(name = "executeTransaction")]
     async fn execute_transaction(
         &self,
@@ -487,6 +488,17 @@ pub trait TransactionExecutionApi {
         signature: Base64,
         /// signer's public key, as base-64 encoded string
         pub_key: Base64,
+        /// The request type
+        request_type: ExecuteTransactionRequestType,
+    ) -> RpcResult<SuiExecuteTransactionResponse>;
+
+    #[method(name = "executeTransactionSerializedSig")]
+    async fn execute_transaction_serialized_sig(
+        &self,
+        /// transaction data bytes, as base-64 encoded string
+        tx_bytes: Base64,
+        /// `flag || signature || pubkey` bytes, as base-64 encoded string
+        signature: Base64,
         /// The request type
         request_type: ExecuteTransactionRequestType,
     ) -> RpcResult<SuiExecuteTransactionResponse>;

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -356,6 +356,170 @@
       ]
     },
     {
+      "name": "sui_executeTransactionSerializedSig",
+      "tags": [
+        {
+          "name": "APIs to execute transactions."
+        }
+      ],
+      "params": [
+        {
+          "name": "tx_bytes",
+          "description": "transaction data bytes, as base-64 encoded string",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Base64"
+          }
+        },
+        {
+          "name": "signature",
+          "description": "`flag || signature || pubkey` bytes, as base-64 encoded string",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Base64"
+          }
+        },
+        {
+          "name": "request_type",
+          "description": "The request type",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/ExecuteTransactionRequestType"
+          }
+        }
+      ],
+      "result": {
+        "name": "SuiExecuteTransactionResponse",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/SuiExecuteTransactionResponse"
+        }
+      },
+      "examples": [
+        {
+          "name": "Execute an transaction with serialized signature",
+          "params": [
+            {
+              "name": "tx_bytes",
+              "value": "VHJhbnNhY3Rpb25EYXRhOjoAAG78RO21zT3+MvS/bD6KxC7vE4XgFAPkmkspatyyLqJ9PJLkziJWrGQCAAAAAAAAACDj8oL6SLPgEDupu+1qBhU7n8SG4QHw6eJwOshmbQauzLUWBLUYN139/dtd9SR4/whdIVoLXLq9w2zxufLshIGibKfYEWlVl5QCAAAAAAAAACACi48C5DAqVZXYiJpnxtMcbJcOVn8D72fYEaT4Q2ZbjQEAAAAAAAAA6AMAAAAAAAA="
+            },
+            {
+              "name": "signature",
+              "value": "ACKEmGsaz85GBvHaUVX0s1f6Eev26tiIPpRN3qvpUeYGG+h8/svy0+xxFSbsy8pw/rGUl2t74ZRiMwhsKmXApwQETxNsaJH6UBKN/GfiZ46X8iMV/dyLU/zHwVMrBp9VTQ=="
+            },
+            {
+              "name": "request_type",
+              "value": "WaitForLocalExecution"
+            }
+          ],
+          "result": {
+            "name": "Result",
+            "value": {
+              "certificate": {
+                "transactionDigest": "ewa++QvMPU1gkIJuz9F9r5RMGyAjOGZWB5+jBqkmDfg=",
+                "data": {
+                  "transactions": [
+                    {
+                      "TransferObject": {
+                        "recipient": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0",
+                        "objectRef": {
+                          "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
+                          "version": 2,
+                          "digest": "4/KC+kiz4BA7qbvtagYVO5/EhuEB8OnicDrIZm0Grsw="
+                        }
+                      }
+                    }
+                  ],
+                  "sender": "0xb51604b518375dfdfddb5df52478ff085d215a0b",
+                  "gasPayment": {
+                    "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794",
+                    "version": 2,
+                    "digest": "AouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40="
+                  },
+                  "gasBudget": 1000
+                },
+                "txSignature": "ACKEmGsaz85GBvHaUVX0s1f6Eev26tiIPpRN3qvpUeYGG+h8/svy0+xxFSbsy8pw/rGUl2t74ZRiMwhsKmXApwQETxNsaJH6UBKN/GfiZ46X8iMV/dyLU/zHwVMrBp9VTQ==",
+                "authSignInfo": {
+                  "epoch": 0,
+                  "signature": "",
+                  "signers_map": [
+                    58,
+                    48,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                  ]
+                }
+              },
+              "effects": {
+                "status": {
+                  "status": "success"
+                },
+                "gasUsed": {
+                  "computationCost": 100,
+                  "storageCost": 100,
+                  "storageRebate": 10
+                },
+                "transactionDigest": "Td9+eSajYZcMZaWxLEOAXQ1vVAKnrQ2lvexUnHzeoGs=",
+                "mutated": [
+                  {
+                    "owner": {
+                      "AddressOwner": "0xb51604b518375dfdfddb5df52478ff085d215a0b"
+                    },
+                    "reference": {
+                      "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794",
+                      "version": 2,
+                      "digest": "AouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40="
+                    }
+                  },
+                  {
+                    "owner": {
+                      "AddressOwner": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0"
+                    },
+                    "reference": {
+                      "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
+                      "version": 2,
+                      "digest": "4/KC+kiz4BA7qbvtagYVO5/EhuEB8OnicDrIZm0Grsw="
+                    }
+                  }
+                ],
+                "gasObject": {
+                  "owner": {
+                    "ObjectOwner": "0xb51604b518375dfdfddb5df52478ff085d215a0b"
+                  },
+                  "reference": {
+                    "objectId": "0x5cbabdc36cf1b9f2ec8481a26ca7d81169559794",
+                    "version": 2,
+                    "digest": "AouPAuQwKlWV2IiaZ8bTHGyXDlZ/A+9n2BGk+ENmW40="
+                  }
+                },
+                "events": [
+                  {
+                    "transferObject": {
+                      "packageId": "0x0000000000000000000000000000000000000002",
+                      "transactionModule": "native",
+                      "sender": "0xb51604b518375dfdfddb5df52478ff085d215a0b",
+                      "recipient": {
+                        "AddressOwner": "0x6efc44edb5cd3dfe32f4bf6c3e8ac42eef1385e0"
+                      },
+                      "objectType": "0x2::example::Object",
+                      "objectId": "0x1403e49a4b296adcb22ea27d3c92e4ce2256ac64",
+                      "version": 2
+                    }
+                  }
+                ]
+              },
+              "timestamp_ms": null,
+              "parsed_data": null
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "sui_getCoinMetadata",
       "tags": [
         {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -78,6 +78,7 @@ impl RpcExampleProvider {
             self.get_transaction(),
             self.get_transactions(),
             self.get_events(),
+            self.execute_transaction_serialized_sig_example(),
         ]
         .into_iter()
         .map(|example| (example.function_name, example.examples))
@@ -179,6 +180,27 @@ impl RpcExampleProvider {
                         "pub_key",
                         json!(Base64::from_bytes(signature.public_key_bytes())),
                     ),
+                    (
+                        "request_type",
+                        json!(ExecuteTransactionRequestType::WaitForLocalExecution),
+                    ),
+                ],
+                json!(result),
+            )],
+        )
+    }
+
+    fn execute_transaction_serialized_sig_example(&mut self) -> Examples {
+        let (data, signature, _, _, result, _) = self.get_transfer_data_response();
+        let tx_bytes = TransactionBytes::from_data(data).unwrap();
+
+        Examples::new(
+            "sui_executeTransactionSerializedSig",
+            vec![ExamplePairing::new(
+                "Execute an transaction with serialized signature",
+                vec![
+                    ("tx_bytes", json!(tx_bytes.tx_bytes)),
+                    ("signature", json!(Base64::from_bytes(signature.as_ref()))),
                     (
                         "request_type",
                         json!(ExecuteTransactionRequestType::WaitForLocalExecution),

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -900,12 +900,20 @@ impl Transaction {
         Self::from_data(data, signature)
     }
 
+    // TODO(joyqvq): remove and prefer to_tx_bytes_and_signature()
     pub fn to_network_data_for_execution(&self) -> (Base64, SignatureScheme, Base64, Base64) {
         (
             Base64::from_bytes(&self.data().data.to_bytes()),
             self.data().tx_signature.scheme(),
             Base64::from_bytes(self.data().tx_signature.signature_bytes()),
             Base64::from_bytes(self.data().tx_signature.public_key_bytes()),
+        )
+    }
+
+    pub fn to_tx_bytes_and_signature(&self) -> (Base64, Base64) {
+        (
+            Base64::from_bytes(&self.data().data.to_bytes()),
+            Base64::from_bytes(self.data().tx_signature.as_ref()),
         )
     }
 }


### PR DESCRIPTION
this is to add a new RPC endpoint to submit serialized signature instead of three separate field of flag, pubkey and signature. in a separate PR, client can call this new endpoint `sui_executeTransactionSerializedSig` if sui version > x, else use legacy `sui_executeTransaction`

I attempted to implement BCSSignable for Signature, but because `enum Signature` has its custom `serialize` and `deserialize` such that the enum variant is untagged instead of derived, `serde_name::trace_name::<Self>().expect("Self must be a struct or an enum");` would panic. 

If the serde is derived instead of customized, this issue would go away, but the open rpc schema would be serializing the variant name which is undesirable. 

I cannot think of a better way to workaround the trace_name limitation, so i instead use a plain concat of `flag || signature || pubkey` here. IMO this is fine and easier for client to construct, esp we want to eliminate the pubkey if flag == secp256k1. 

