### PR TITLE
chore: expose ws port in fullnode's docker compose file

### DIFF
--- a/docker/fullnode/docker-compose.yaml
+++ b/docker/fullnode/docker-compose.yaml
@@ -5,9 +5,11 @@ services:
     image: mysten/sui-node:stable
     ports:
     - "9000:9000"
+    - "9001:9001"
     - "9184:9184"
     expose:
     - "9000"
+    - "9001"
     - "9184"
     volumes:
     - ./fullnode-template.yaml:/sui/fullnode.yaml:ro


### PR DESCRIPTION
Hi, I thought it would make sense to also port map the websocket API in the reference `docker-compose.yaml` for the fullnode -- I was just debugging why my node was refusing websocket connections 😄 