### PR TITLE
[cli] omit argument names for single-argument commands

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -100,7 +100,7 @@ pub enum SuiClientCommands {
     #[clap(name = "object")]
     Object {
         /// Object ID of the object to fetch
-        #[clap(long)]
+        #[clap(name = "object_id")]
         id: ObjectID,
     },
 
@@ -109,8 +109,7 @@ pub enum SuiClientCommands {
     Publish {
         /// Path to directory containing a Move package
         #[clap(
-            long = "path",
-            short = 'p',
+            name = "package_path",
             global = true,
             parse(from_os_str),
             default_value = "."
@@ -288,11 +287,12 @@ pub enum SuiClientCommands {
         derivation_path: Option<DerivationPath>,
     },
 
-    /// Obtain all objects owned by the address.
+    /// Obtain all objects owned by the address
     #[clap(name = "objects")]
     Objects {
         /// Address owning the objects
-        #[clap(long)]
+        /// Shows all objects owned by `sui client active-address` if no argument is passed
+        #[clap(name = "owner_address")]
         address: Option<SuiAddress>,
     },
 
@@ -300,7 +300,7 @@ pub enum SuiClientCommands {
     #[clap(name = "gas")]
     Gas {
         /// Address owning the objects
-        #[clap(long)]
+        #[clap(name = "owner_address")]
         address: Option<SuiAddress>,
     },
 

--- a/doc/src/build/cli-client.md
+++ b/doc/src/build/cli-client.md
@@ -90,7 +90,7 @@ $ sui client addresses
 
 ### Active address
 
-You can specify an active address or default address to use to execute commands. 
+You can specify an active address or default address to use to execute commands.
 
 Sui sets a default address to use for commands. It uses the active address for commands that require an address. To view the current active address, use the `active-address` command.
 
@@ -126,7 +126,7 @@ $ sui client objects
  0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 |     0      | j8qLxVk/Bm9iMdhPf9b7HcIMQIAM+qCd8LfPAwKYrFo= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
 ```
 ```shell
-$ sui client objects --address 0x913cf36f370613ed131868ac6f9da2420166062e
+$ sui client objects 0x913cf36f370613ed131868ac6f9da2420166062e
                  Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  0x66eaa38c8ea99673a92a076a00101ab9b3a06b55 |     0      | j8qLxVk/Bm9iMdhPf9b7HcIMQIAM+qCd8LfPAwKYrFo= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
@@ -155,7 +155,7 @@ $ sui client gas
 You can specify an address to see the amount of gas for that address instead of the active address.
 
 ```shell
-$ sui client gas --address 0x562f07cf6369e8d22dbf226a5bfedc6300014837
+$ sui client gas 0x562f07cf6369e8d22dbf226a5bfedc6300014837
 ```
 
 ## Create new account addresses
@@ -168,7 +168,7 @@ Sui Client CLI includes 1 address by default. To add more, create new addresses 
 $ sui client new-address ed25519
 ```
 
-You must specify the key scheme, either `ed25519` or `secp256k1`. 
+You must specify the key scheme, either `ed25519` or `secp256k1`.
 
 ### Add existing accounts to client.yaml
 
@@ -184,16 +184,16 @@ Use the `objects` command to view the objects an address owns.
 sui client objects
 ```
 
-To view the objects for a different address than the active address, use `--address` in the command and specify the address to see objects for.
+To view the objects for a different address than the active address, specify the address to see objects for.
 
 ```shell
-$ sui client objects --address 0x66af3898e7558b79e115ab61184a958497d1905a
+$ sui client objects 0x66af3898e7558b79e115ab61184a958497d1905a
 ```
 
 To view more information about an object, use the `object` command.
 
 ```shell
-    sui client object --id <ID>
+    sui client object <ID>
 ```
 
 The result shows some basic information about the object, the owner,
@@ -202,7 +202,7 @@ version, ID, if the object is immutable and the type of the object.
 To view the JSON representation of the object, include `--json` in the command.
 
 ```shell
-    sui client object --id <ID> --json
+    sui client object <ID> --json
 ```
 
 ## Transfer objects
@@ -307,7 +307,7 @@ You need at lease three coin objects to merge coins, two coins to merge and one 
 Use the following command to view the objects that the specified address owns.
 
 ```shell
-$ sui client objects --address 0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75
+$ sui client objects 0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75
 ```
 
 Use the IDs returns from the previous command in the `merge-coin` command.
@@ -337,7 +337,7 @@ To split a coin you need at least 2 coin objects, one to split and one to pay fo
 
 Use the following command to view the objects the address owns.
 ```shell
-$ sui client objects --address 0x08da15bee6a3f5b01edbbd402654a75421d81397
+$ sui client objects 0x08da15bee6a3f5b01edbbd402654a75421d81397
 ```
 
 Then use the IDs returned in the `split-coin` command.
@@ -351,7 +351,7 @@ $ sui client split-coin --coin-id 0x4a2853304fd2c243dae7d1ba58260bb7c40724e1 --a
 Use the `objects` command to view the new coin objects.
 
 ```
-$ sui client objects --address 0x08da15bee6a3f5b01edbbd402654a75421d81397
+$ sui client objects 0x08da15bee6a3f5b01edbbd402654a75421d81397
 ```
 
 The following example splits a coin into three equal parts. To split a coin evenly, don't include the `--amount` argument in the command.
@@ -382,7 +382,7 @@ simplicity.
 Let us examine objects owned by address `0x48ff0a932b12976caec91d521265b009ad5b2225`:
 
 ```shell
-$ sui client objects --address 0x48ff0a932b12976caec91d521265b009ad5b2225
+$ sui client objects 0x48ff0a932b12976caec91d521265b009ad5b2225
                  Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  0x471c8e241d0473c34753461529b70f9c4ed3151b |     0      | MCQIALghS9kQUWMclChmsd6jCuLiUxNjEn9VRV+AhSA= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
@@ -433,9 +433,9 @@ Note the third argument to the `transfer` function representing
 is a required argument for all functions callable from Sui and is
 auto-injected by the platform at the point of a function call.
 
-> **Important:** If you use a shell that interprets square brackets ([ ]) as special characters (such as the `zsh` shell), you must enclose the brackets in single quotes. For example, instead of `[7,42]` you must use `'[7,42]'`. 
+> **Important:** If you use a shell that interprets square brackets ([ ]) as special characters (such as the `zsh` shell), you must enclose the brackets in single quotes. For example, instead of `[7,42]` you must use `'[7,42]'`.
 >
-> Additionally, when you specify a vector of object IDs, you must enclose each ID in double quotes. For example, 
+> Additionally, when you specify a vector of object IDs, you must enclose each ID in double quotes. For example,
 > `'["0x471c8e241d0473c34753461529b70f9c4ed3151b","0x53b50e3020a01e1fd6acf832a871feee240183f0"]'`
 
 To gain a deeper view into the object, include the
@@ -473,7 +473,7 @@ of the `transfer` function) by querying objects that are now owned by
 the sender:
 
 ```shell
-$ sui client objects --address 0x48ff0a932b12976caec91d521265b009ad5b2225
+$ sui client objects 0x48ff0a932b12976caec91d521265b009ad5b2225
                  Object ID                  |  Version   |                    Digest                    |   Owner Type    |               Object Type
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  0x53b50e3020a01e1fd6acf832a871feee240183f0 |     1      | st6KVE+nTPsQgtEtxSbgJZCzSSuSB2ZsJAMbXFNLw/k= |  AddressOwner   |      0x2::coin::Coin<0x2::sui::SUI>
@@ -488,7 +488,7 @@ And if we inspect this object, we can see it has the new
 owner, different from the original one:
 
 ```shell
-$ sui client object --id 0x471c8e241d0473c34753461529b70f9c4ed3151b
+$ sui client object 0x471c8e241d0473c34753461529b70f9c4ed3151b
 ```
 
 Resulting in:
@@ -528,7 +528,7 @@ an upper limit we use 1000 as our gas budget.
 Let us use the same address for publishing that we used for calling Move code in the previous [section](#calling-move-code) (`0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75`) which now has 4 objects left:
 
 ```shell
-$ sui client objects --address 0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75
+$ sui client objects 0x3cbf06e9997b3864e3baad6bc0f0ef8ec423cd75
 ```
 
 Outputting:

--- a/doc/src/build/programming-with-objects/ch1-object-basics.md
+++ b/doc/src/build/programming-with-objects/ch1-object-basics.md
@@ -188,7 +188,7 @@ $ export OBJECT=0x5eb2c3e55693282faa7f5b07ce1c4803e6fdc1bb
 ```
 We can inspect this object and see what kind of object it is:
 ```
-$ sui client object --id $OBJECT
+$ sui client object $OBJECT
 ```
 This will show you the metadata of the object with its type:
 ```
@@ -202,7 +202,7 @@ As we can see, it's owned by the current default client address that we saw earl
 
 You can also look at the data content of the object by adding the `--json` parameter:
 ```
-$ sui client object --id $OBJECT --json
+$ sui client object $OBJECT --json
 ```
 This will print the values of all the fields in the Move object, such as the values of `red`, `green`, and `blue`.
 

--- a/doc/src/build/programming-with-objects/ch2-using-objects.md
+++ b/doc/src/build/programming-with-objects/ch2-using-objects.md
@@ -184,7 +184,7 @@ $ sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" -
 ```
 Now let's see what objects the `RECIPIENT` owns:
 ```
-$ sui client objects --address $RECIPIENT
+$ sui client objects $RECIPIENT
 ```
 We should be able to see that one of the objects in the list is the new `ColorObject`! This means the transfer was successful.
 
@@ -205,7 +205,7 @@ $ sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" -
 In the output, you will see in the `Transaction Effects` section a list of deleted objects.
 This shows that the object was successfully deleted. If we run this again:
 ```
-$ sui client objects --address $RECIPIENT
+$ sui client objects $RECIPIENT
 ```
 We will see that this object is no longer there in the address.
 

--- a/doc/src/build/programming-with-objects/ch3-immutable-objects.md
+++ b/doc/src/build/programming-with-objects/ch3-immutable-objects.md
@@ -102,7 +102,7 @@ To summarize, we introduced two new API functions to interact with immutable obj
 First of all, take a look at the current list of objects you own:
 ```
 $ export ADDR=`sui client active-address`
-$ sui client objects --address=$ADDR
+$ sui client objects $ADDR
 ```
 
 Let's publish the `ColorObject` code on-chain using the Sui CLI client:
@@ -117,7 +117,7 @@ $ sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" -
 ```
 Set the newly created object ID to `$OBJECT`. If we look at the list of objects in the current active address:
 ```
-$ sui client objects --address=$ADDR
+$ sui client objects $ADDR
 ```
 There should be one more, with ID `$OBJECT`. Let's turn it into an immutable object:
 ```
@@ -125,11 +125,11 @@ $ sui client call --gas-budget 1000 --package $PACKAGE --module "color_object" -
 ```
 Now let's look at the list of objects we own again:
 ```
-$ sui client objects --address=$ADDR
+$ sui client objects $ADDR
 ```
 `$OBJECT` is no longer there. It's no longer owned by anyone. You can see that it's now immutable by querying the object information:
 ```
-$ sui client object --id $OBJECT
+$ sui client object $OBJECT
 Owner: Immutable
 ...
 ```

--- a/doc/src/explore/tutorials.md
+++ b/doc/src/explore/tutorials.md
@@ -92,7 +92,7 @@ ECF53CE22D1B2FB588573924057E9ADDAD1D8385
 DB4C7667636471AFF396B900EB7B63FACAF629B6
 A6BBB1930E01495EE93CE912EA01C29695E07890
 ```
-Note that since these addresses are randomly generated, they are different from the values you see when you run the command. We need three addresses to play TicTacToe. Let's pick the first three addresses. Let's call them ADMIN, PLAYER_X and PLAYER_O. 
+Note that since these addresses are randomly generated, they are different from the values you see when you run the command. We need three addresses to play TicTacToe. Let's pick the first three addresses. Let's call them ADMIN, PLAYER_X and PLAYER_O.
 
 Since we will be using these addresses and gas objects repeatedly in the rest of this tutorial, let's make them environment variables so that we don't have to retype them every time:
 ```
@@ -201,21 +201,21 @@ Mutated Objects:
 ```
 The preceding call created three objects. For each object, it printed out a tuple of three values (object_id, version, object_digest). Object ID is what we care about here. Since we don't have a real application here to display things for us, we need a bit of object printing magic to figure out which object is which. Let's print out the metadata of each created object (replace the object ID with what you see on your screen):
 ```
-$ sui client object --id 5851B7EA07B93E68696BC0CF811D2E266DFB880D
+$ sui client object 5851B7EA07B93E68696BC0CF811D2E266DFB880D
 Owner: AddressOwner(k#251cf224b6ba3a019d04b6041357c20490f7a322)
 Version: 1
 ID: 5851B7EA07B93E68696BC0CF811D2E266DFB880D
 Readonly: false
 Type: 0xa613a7ff8cb03e0dfc0d157e232bba50c5f19d17::TicTacToe::MarkMintCap
 
-$ sui client object --id A6D3B507D4533822E690291166891D42694A2721
+$ sui client object A6D3B507D4533822E690291166891D42694A2721
 Owner: AddressOwner(k#7b61da6aaced7f28c1187d998955f10464beae55)
 Version: 1
 ID: A6D3B507D4533822E690291166891D42694A2721
 Readonly: false
 Type: 0xa613a7ff8cb03e0dfc0d157e232bba50c5f19d17::TicTacToe::MarkMintCap
 
-$ sui client object --id F1B8161BD97D3CD6627E739AD675089C5ACFB452
+$ sui client object F1B8161BD97D3CD6627E739AD675089C5ACFB452
 Owner: AddressOwner(k#ecf53ce22d1b2fb588573924057e9addad1d8385)
 Version: 1
 ID: F1B8161BD97D3CD6627E739AD675089C5ACFB452
@@ -404,7 +404,7 @@ Mutated Objects:
 
 Cool! The last transaction created a new object. Let's find out what object was created:
 ```shell
-$ sui client object --id 54B58C0D5B14A269B1CD424B3CCAB1E315C43343
+$ sui client object 54B58C0D5B14A269B1CD424B3CCAB1E315C43343
 ```
 
 See output resembling:


### PR DESCRIPTION
This allows CLI users to write `sui client object <id>`, `sui client objects <address>`, and `sui client gas <id>` without needing to include `--id` or `--address`.