### PR TITLE
[narwhal] restarter not working

### DIFF
--- a/narwhal/node/src/restarter.rs
+++ b/narwhal/node/src/restarter.rs
@@ -113,16 +113,16 @@ impl NodeRestarter {
                 .await
                 .unwrap();
 
-            tracing::debug!("Committee reconfiguration message successfully sent");
+            tracing::info!("Committee reconfiguration message successfully sent");
 
             // Wait for the components to shut down.
             join_all(handles.drain(..)).await;
-            tracing::debug!("All tasks successfully exited");
+            tracing::info!("All tasks successfully exited");
 
             // Give it an extra second in case the last task to exit is a network server. The OS
             // may need a moment to make the TCP ports available again.
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-            tracing::debug!("Epoch E{} terminated", committee.epoch());
+            tracing::info!("Epoch E{} terminated", committee.epoch());
 
             // Update the settings for the next epoch.
             primary_keypair = new_keypair;

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -5,7 +5,9 @@
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use config::{Committee, NetworkAdminServerParameters, Parameters, SharedWorkerCache, WorkerCache, WorkerId};
+use config::{
+    Committee, NetworkAdminServerParameters, Parameters, SharedWorkerCache, WorkerCache, WorkerId,
+};
 use crypto::{KeyPair, NetworkKeyPair, PublicKey};
 use executor::{ExecutionIndices, ExecutionState};
 use fastcrypto::traits::KeyPair as _;
@@ -19,7 +21,10 @@ use std::{
 };
 use storage::NodeStorage;
 use test_utils::CommitteeFixture;
-use tokio::{sync::mpsc::{channel, Receiver, Sender}, time::{interval, sleep, Duration, MissedTickBehavior}};
+use tokio::{
+    sync::mpsc::{channel, Receiver, Sender},
+    time::{interval, sleep, Duration, MissedTickBehavior},
+};
 use types::ConsensusOutput;
 use types::{ReconfigureNotification, TransactionProto, TransactionsClient};
 use worker::TrivialTransactionValidator;
@@ -260,7 +265,9 @@ async fn restart() {
         }));
     }
 
-    try_join_all(handles).await.expect("No error should occurred");
+    try_join_all(handles)
+        .await
+        .expect("No error should occurred");
 }
 
 #[tokio::test]

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -162,6 +162,7 @@ async fn run_client(
     }
 }
 
+#[ignore]
 #[tokio::test]
 async fn restart() {
     telemetry_subscribers::init_for_testing();

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -5,9 +5,7 @@
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use config::{
-    Committee, NetworkAdminServerParameters, Parameters, SharedWorkerCache, WorkerCache, WorkerId,
-};
+use config::{Committee, Parameters, SharedWorkerCache, WorkerCache, WorkerId};
 use crypto::{KeyPair, NetworkKeyPair, PublicKey};
 use executor::{ExecutionIndices, ExecutionState};
 use fastcrypto::traits::KeyPair as _;
@@ -171,12 +169,6 @@ async fn restart() {
     let committee = fixture.committee();
     let worker_cache = fixture.shared_worker_cache();
 
-    let parameters = Parameters {
-        batch_size: 200,
-        max_header_num_of_batches: 1,
-        ..Parameters::default()
-    };
-
     // Spawn the nodes.
     let mut rx_nodes = Vec::new();
     for a in fixture.authorities() {
@@ -200,9 +192,11 @@ async fn restart() {
         let committee = committee.clone();
         let worker_cache = worker_cache.clone();
 
-        let mut parameters = parameters.clone();
-        // acquire a new admin port for this node
-        parameters.network_admin_server = NetworkAdminServerParameters::default();
+        let parameters = Parameters {
+            batch_size: 200,
+            max_header_num_of_batches: 1,
+            ..Parameters::default()
+        };
 
         let keypair = a.keypair().copy();
         let network_keypair = a.network_keypair().copy();


### PR DESCRIPTION
The `restart` test for reconfiguration wasn't really working as expected. Although it was not failing, it seems that failures were not caught and the underlying issues not exposed.

Refactored the test and now it surfaces the issues. Once this test passes again then we'll know that restart approach for reconfiguration works - at least on a basic level.

Looking further into this I've discovered two underlying issues:
* during node restart we use the same prometheus registry - as expected. This is causing the nodes trying to re-register the same metrics leading to a panic
* admin network addresses seem to be already occupied - indicating that previous shutdown wasn't successful (there is a known issue with anemo library which can cause nodes not terminate properly - so let's take this with a grain of salt until we have upgraded to the latest anemo version)

**PS:** before deploy this I'll disable the test as it will fail - and re-enable once the right fixes in the code are in