### PR TITLE
[explorer] Migrate to singular routes

### DIFF
--- a/apps/explorer/cypress/e2e/localnet/address.cy.ts
+++ b/apps/explorer/cypress/e2e/localnet/address.cy.ts
@@ -6,7 +6,7 @@ Cypress.config('baseUrl', 'http://localhost:3000');
 describe('Address', () => {
     it('can be directly visted', () => {
         cy.task('faucet').then((address) => {
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get('[data-testid=pageheader]').contains(address);
         });
     });

--- a/apps/explorer/cypress/e2e/localnet/objects.cy.ts
+++ b/apps/explorer/cypress/e2e/localnet/objects.cy.ts
@@ -13,13 +13,13 @@ describe('Objects', () => {
                 }
                 const { objectId } =
                     tx.EffectsCert.effects.effects.created![0].reference;
-                cy.visit(`/objects/${objectId}`);
+                cy.visit(`/object/${objectId}`);
                 cy.get('#objectID').contains(objectId);
             });
     });
 
     it('displays an error when no objects', () => {
-        cy.visit(`/objects/fakeAddress`);
+        cy.visit(`/object/fakeAddress`);
         cy.get('#errorResult');
     });
 
@@ -34,7 +34,7 @@ describe('Objects', () => {
 
                     const address = tx.EffectsCert.certificate.data.sender;
                     const [nft] = tx.EffectsCert.effects.effects.created!;
-                    cy.visit(`/addresses/${address}`);
+                    cy.visit(`/address/${address}`);
 
                     // Find a reference to the NFT:
                     cy.contains(nft.reference.objectId.slice(0, 4)).click();
@@ -42,7 +42,7 @@ describe('Objects', () => {
 
                     // Find a reference to the owning address:
                     cy.contains(address).click();
-                    cy.url().should('include', `/addresses/${address}`);
+                    cy.url().should('include', `/address/${address}`);
                 });
         });
     });

--- a/apps/explorer/cypress/e2e/localnet/search.cy.ts
+++ b/apps/explorer/cypress/e2e/localnet/search.cy.ts
@@ -8,7 +8,7 @@ describe('search', () => {
         cy.task('faucet').then((address) => {
             cy.visit('/');
             cy.get('[data-testid=search]').type(address).type('{enter}');
-            cy.url().should('include', `/addresses/${address}`);
+            cy.url().should('include', `/address/${address}`);
         });
     });
 
@@ -23,7 +23,7 @@ describe('search', () => {
                     tx.EffectsCert.effects.effects.created![0].reference;
                 cy.visit('/');
                 cy.get('[data-testid=search]').type(objectId).type('{enter}');
-                cy.url().should('include', `/objects/${objectId}`);
+                cy.url().should('include', `/object/${objectId}`);
             });
     });
 });

--- a/apps/explorer/cypress/e2e/static/e2e.cy.ts
+++ b/apps/explorer/cypress/e2e/static/e2e.cy.ts
@@ -36,12 +36,12 @@ describe('End-to-end Tests', () => {
         });
 
         it('can be reached through URL', () => {
-            cy.visit(`/transactions/${successID}`);
+            cy.visit(`/transaction/${successID}`);
             cy.get('[data-testid=pageheader]').contains(successID);
         });
 
         it('includes the sender time information', () => {
-            cy.visit(`/transactions/${successID}`);
+            cy.visit(`/transaction/${successID}`);
             // TODO - use the custom command date format function
             cy.get('[data-testid=transaction-timestamp]').contains(
                 new Intl.DateTimeFormat('en-US', {
@@ -57,7 +57,7 @@ describe('End-to-end Tests', () => {
 
     describe('Owned Objects have links that enable', () => {
         it('going from object to child object and back', () => {
-            cy.visit('/objects/player2');
+            cy.visit('/object/player2');
             cy.get(nftObject(1)).click();
             cy.get('#objectID').contains('Image1');
             cy.get(ownerButton).click();
@@ -66,7 +66,7 @@ describe('End-to-end Tests', () => {
 
         it('going from parent to broken image object and back', () => {
             const parentValue = 'ObjectWBrokenChild';
-            cy.visit(`/objects/${parentValue}`);
+            cy.visit(`/object/${parentValue}`);
             cy.get(nftObject(1)).click();
             cy.get('#noImage');
             cy.get(ownerButton).click();
@@ -79,7 +79,7 @@ describe('End-to-end Tests', () => {
 
         it('to go to the next page', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get(paginationContext).within(() => {
                 cy.get('[data-testid=nextBtn]:visible').click();
                 cy.get(nftObject(1)).click();
@@ -89,7 +89,7 @@ describe('End-to-end Tests', () => {
 
         it('to go to the last page', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get(paginationContext).within(() => {
                 cy.get('[data-testid=lastBtn]:visible').click();
                 cy.get(nftObject(1)).click();
@@ -99,7 +99,7 @@ describe('End-to-end Tests', () => {
 
         it('where last and next disappear in final page', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get(paginationContext).within(() => {
                 cy.get('[data-testid=lastBtn]:visible').click();
 
@@ -115,7 +115,7 @@ describe('End-to-end Tests', () => {
 
         it('to go back a page', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get(paginationContext).within(() => {
                 cy.get('[data-testid=lastBtn]:visible').click();
                 cy.get('[data-testid=backBtn]:visible').click();
@@ -126,7 +126,7 @@ describe('End-to-end Tests', () => {
 
         it('to go to first page', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get(paginationContext).within(() => {
                 cy.get('[data-testid=lastBtn]:visible').click();
                 cy.get('[data-testid=backBtn]:visible').click();
@@ -138,7 +138,7 @@ describe('End-to-end Tests', () => {
 
         it('where first and back disappear in first page', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
             cy.get(paginationContext).within(() => {
                 //Back and First buttons are disabled:
                 cy.get('[data-testid=backBtn]:visible').should('be.disabled');
@@ -160,7 +160,7 @@ describe('End-to-end Tests', () => {
             const count = '[data-testid=ownedcoinobjcount]';
             const balance = '[data-testid=ownedcoinbalance]';
 
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
 
             cy.get(`${rowCSSSelector(1)} ${label}`).contains('USD');
             cy.get(`${rowCSSSelector(1)} ${count}`).contains('2');
@@ -179,14 +179,14 @@ describe('End-to-end Tests', () => {
     describe('Transactions for ID', () => {
         it('are displayed from and to address', () => {
             const address = 'ownsAllAddress';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
 
             cy.get('[data-testid=tx] td').should('have.length.greaterThan', 0);
         });
 
         it('are displayed for input and mutated object', () => {
             const address = 'CollectionObject';
-            cy.visit(`/addresses/${address}`);
+            cy.visit(`/address/${address}`);
 
             cy.get('[data-testid=tx] td').should('have.length.greaterThan', 0);
         });

--- a/apps/explorer/src/components/events/eventDisplay.tsx
+++ b/apps/explorer/src/components/events/eventDisplay.tsx
@@ -56,7 +56,7 @@ function addressContent(label: string, addr: SuiAddress) {
         label: label,
         value: addr,
         link: true,
-        category: 'addresses' as Category,
+        category: 'address' as Category,
         monotypeClass: true,
     };
 }
@@ -66,7 +66,7 @@ function objectContent(label: string, id: ObjectId) {
         label: label,
         value: id,
         link: true,
-        category: 'objects' as Category,
+        category: 'object' as Category,
         monotypeClass: true,
     };
 }

--- a/apps/explorer/src/components/longtext/Longtext.tsx
+++ b/apps/explorer/src/components/longtext/Longtext.tsx
@@ -26,12 +26,7 @@ function Longtext({
     extra,
 }: {
     text: string;
-    category:
-        | 'object'
-        | 'transaction'
-        | 'address'
-        | 'validators'
-        | 'unknown';
+    category: 'object' | 'transaction' | 'address' | 'validators' | 'unknown';
     isLink?: boolean;
     alttext?: string;
     copyButton?: '16' | '24' | 'none';

--- a/apps/explorer/src/components/longtext/Longtext.tsx
+++ b/apps/explorer/src/components/longtext/Longtext.tsx
@@ -9,7 +9,6 @@ import { ReactComponent as ContentCopyIcon16 } from '../../assets/SVGIcons/16px/
 import { ReactComponent as ContentCopyIcon24 } from '../../assets/SVGIcons/24px/Copy.svg';
 import { NetworkContext } from '../../context';
 import { navigateWithUnknown } from '../../utils/searchUtil';
-import ExternalLink from '../external-link/ExternalLink';
 
 import type { ReactNode } from 'react';
 
@@ -28,10 +27,9 @@ function Longtext({
 }: {
     text: string;
     category:
-        | 'objects'
-        | 'transactions'
-        | 'addresses'
-        | 'ethAddress'
+        | 'object'
+        | 'transaction'
+        | 'address'
         | 'validators'
         | 'unknown';
     isLink?: boolean;
@@ -86,7 +84,7 @@ function Longtext({
 
     // temporary hack to make display of the genesis transaction clearer
     if (
-        category === 'transactions' &&
+        category === 'transaction' &&
         text === 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
     ) {
         text = 'Genesis';
@@ -100,14 +98,6 @@ function Longtext({
                 <div className={styles.longtext} onClick={navigateUnknown}>
                     {alttext ? alttext : text}
                 </div>
-            );
-        } else if (category === 'ethAddress') {
-            textComponent = (
-                <ExternalLink
-                    href={`https://etherscan.io/address/${text}`}
-                    label={text}
-                    className={styles.longtext}
-                />
             );
         } else {
             textComponent = (

--- a/apps/explorer/src/components/module/ModuleView.tsx
+++ b/apps/explorer/src/components/module/ModuleView.tsx
@@ -125,7 +125,7 @@ function ModuleView({ id, name, code }: Props) {
                                                 )) &&
                                             reference
                                         ) {
-                                            const href = `/objects/${reference.address}?module=${reference.module}`;
+                                            const href = `/object/${reference.address}?module=${reference.module}`;
 
                                             return (
                                                 <LinkWithQuery

--- a/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedCoinView.tsx
@@ -30,7 +30,7 @@ function CoinItem({
             <div className={styles.openrow}>
                 <div className={styles.label}>Object ID</div>
                 <div className={`${styles.oneline} ${styles.value}`}>
-                    <Longtext text={id} category="objects" />
+                    <Longtext text={id} category="object" />
                 </div>
             </div>
             <div className={styles.openrow}>

--- a/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
+++ b/apps/explorer/src/components/ownedobjects/views/OwnedNFTView.tsx
@@ -23,7 +23,7 @@ export default function OwnedNFTView({ results }: { results: DataType }) {
                         <div>
                             <Longtext
                                 text={entryObj.id}
-                                category="objects"
+                                category="object"
                                 alttext={alttextgen(entryObj.id)}
                             />
                         </div>

--- a/apps/explorer/src/components/recent-packages-card/RecentPackagesCard.tsx
+++ b/apps/explorer/src/components/recent-packages-card/RecentPackagesCard.tsx
@@ -60,7 +60,7 @@ const transformTable = (events: SuiEvents) => ({
                 sender: (
                     <Link
                         variant="mono"
-                        to={`/addresses/${encodeURIComponent(
+                        to={`/address/${encodeURIComponent(
                             event.publish.sender
                         )}`}
                     >
@@ -81,7 +81,7 @@ const transformTable = (events: SuiEvents) => ({
                 txnDigest: (
                     <Link
                         variant="mono"
-                        to={`/transactions/${encodeURIComponent(txDigest)}`}
+                        to={`/transaction/${encodeURIComponent(txDigest)}`}
                     >
                         {truncate(txDigest, TRUNCATE_LENGTH)}
                     </Link>

--- a/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
+++ b/apps/explorer/src/components/transaction-card/TxCardUtils.tsx
@@ -47,16 +47,11 @@ export type LinkObj = {
     url: string;
     name?: string;
     copy?: boolean;
-    category?: string;
+    category?: Category;
     isLink?: boolean;
 };
 
-type Category =
-    | 'objects'
-    | 'transactions'
-    | 'addresses'
-    | 'ethAddress'
-    | 'unknown';
+type Category = 'object' | 'transaction' | 'address' | 'unknown';
 
 type TxStatus = {
     txTypeName: TransactionKindName | undefined;
@@ -94,7 +89,7 @@ export function TxAddresses({ content }: { content: LinkObj[] }) {
                     <Longtext
                         text={itm.url}
                         alttext={itm.name}
-                        category={(itm.category as Category) || 'unknown'}
+                        category={itm.category || 'unknown'}
                         isLink={itm?.isLink}
                         copyButton={itm?.copy ? '16' : 'none'}
                     />
@@ -139,7 +134,7 @@ export const genTableDataFromTxData = (
                         {
                             url: txn.txId,
                             name: truncate(txn.txId, truncateLength),
-                            category: 'transactions',
+                            category: 'transaction',
                             isLink: true,
                             copy: false,
                         },
@@ -152,7 +147,7 @@ export const genTableDataFromTxData = (
                         {
                             url: txn.From,
                             name: truncate(txn.From, truncateLength),
-                            category: 'addresses',
+                            category: 'address',
                             isLink: true,
                             copy: false,
                         },
@@ -161,10 +156,10 @@ export const genTableDataFromTxData = (
                                   {
                                       url: txn.To,
                                       name: truncate(txn.To, truncateLength),
-                                      category: 'addresses',
+                                      category: 'address',
                                       isLink: true,
                                       copy: false,
-                                  },
+                                  } as const,
                               ]
                             : []),
                     ]}

--- a/apps/explorer/src/pages/config/AppRoutes.tsx
+++ b/apps/explorer/src/pages/config/AppRoutes.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router-dom';
 
 import AddressResult from '../address-result/AddressResult';
 import Home from '../home/Home';
@@ -12,17 +12,37 @@ import TransactionResult from '../transaction-result/TransactionResult';
 import Transactions from '../transactions/Transactions';
 import { ValidatorPageResult } from '../validators/Validators';
 
+function RedirectWithId({ base }: { base: string }) {
+    const params = useParams();
+    return <Navigate to={`/${base}/${params.id}`} replace />;
+}
+
 function AppRoutes() {
     return (
         <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/transactions" element={<Transactions />} />
-            <Route path="/objects/:id" element={<ObjectResult />} />
-            <Route path="/transactions/:id" element={<TransactionResult />} />
-            <Route path="/addresses/:id" element={<AddressResult />} />
+            <Route path="/object/:id" element={<ObjectResult />} />
+            <Route path="/transaction/:id" element={<TransactionResult />} />
+            <Route path="/address/:id" element={<AddressResult />} />
             <Route path="/validators" element={<ValidatorPageResult />} />
             <Route path="/search-result/:id" element={<SearchResult />} />
             <Route path="/error/:category/:id" element={<SearchError />} />
+
+            {/* Support the existing plural routes: */}
+            <Route
+                path="/objects/:id"
+                element={<RedirectWithId base="object" />}
+            />
+            <Route
+                path="/transactions/:id"
+                element={<RedirectWithId base="transaction" />}
+            />
+            <Route
+                path="/addresses/:id"
+                element={<RedirectWithId base="address" />}
+            />
+
             <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
     );

--- a/apps/explorer/src/pages/object-result/ObjectResultType.tsx
+++ b/apps/explorer/src/pages/object-result/ObjectResultType.tsx
@@ -22,7 +22,6 @@ export type DataType = {
     readonly?: string;
     objType: string;
     name?: string;
-    ethAddress?: string;
     ethTokenId?: string;
     publisherAddress?: string;
     contract_id?: { bytes: string };

--- a/apps/explorer/src/pages/object-result/views/PkgView.tsx
+++ b/apps/explorer/src/pages/object-result/views/PkgView.tsx
@@ -54,7 +54,7 @@ function PkgView({ data }: { data: DataType }) {
                                         >
                                             <Longtext
                                                 text={viewedData.id}
-                                                category="objects"
+                                                category="object"
                                                 isLink={false}
                                             />
                                         </td>
@@ -73,7 +73,7 @@ function PkgView({ data }: { data: DataType }) {
                                                     text={
                                                         viewedData.publisherAddress
                                                     }
-                                                    category="addresses"
+                                                    category="address"
                                                     isLink={!isPublisherGenesis}
                                                 />
                                             </td>

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -74,7 +74,7 @@ function TokenView({ data }: { data: DataType }) {
     const genhref = (objType: string) => {
         const metadataarr = objType.split('::');
         const address = normalizeSuiAddress(metadataarr[0]);
-        return `/objects/${address}?module=${metadataarr[1]}`;
+        return `/object/${address}?module=${metadataarr[1]}`;
     };
 
     return (

--- a/apps/explorer/src/pages/object-result/views/TokenView.tsx
+++ b/apps/explorer/src/pages/object-result/views/TokenView.tsx
@@ -100,7 +100,7 @@ function TokenView({ data }: { data: DataType }) {
                                 <td id="objectID" className={styles.objectid}>
                                     <Longtext
                                         text={viewedData.id}
-                                        category="objects"
+                                        category="object"
                                         isLink={false}
                                     />
                                 </td>
@@ -112,7 +112,7 @@ function TokenView({ data }: { data: DataType }) {
                                     <td>
                                         <Longtext
                                             text={viewedData.tx_digest}
-                                            category="transactions"
+                                            category="transaction"
                                             isLink
                                         />
                                     </td>
@@ -147,7 +147,7 @@ function TokenView({ data }: { data: DataType }) {
                                     <td>
                                         <Longtext
                                             text={viewedData.contract_id.bytes}
-                                            category="objects"
+                                            category="object"
                                             isLink
                                         />
                                     </td>

--- a/apps/explorer/src/pages/search-result/SearchResult.tsx
+++ b/apps/explorer/src/pages/search-result/SearchResult.tsx
@@ -35,7 +35,7 @@ const querySearchParams = async (input: string, network: Network | string) => {
                 .getTransactionWithEffects(input)
                 .then((data) => [
                     {
-                        category: 'transactions',
+                        category: 'transaction',
                         data: data,
                     },
                 ])
@@ -49,7 +49,7 @@ const querySearchParams = async (input: string, network: Network | string) => {
                         throw new Error('No objects for Address');
 
                     return {
-                        category: 'addresses',
+                        category: 'address',
                         data: data,
                     };
                 }),
@@ -60,7 +60,7 @@ const querySearchParams = async (input: string, network: Network | string) => {
                         throw new Error('no object found');
                     }
                     return {
-                        category: 'objects',
+                        category: 'object',
                         data: data,
                     };
                 }),

--- a/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
@@ -22,8 +22,4 @@ export type DataType = CertifiedTransaction & {
     timestamp_ms: number | null;
 };
 
-export type Category =
-    | 'object'
-    | 'transaction'
-    | 'address'
-    | 'unknown';
+export type Category = 'object' | 'transaction' | 'address' | 'unknown';

--- a/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionResultType.tsx
@@ -23,8 +23,7 @@ export type DataType = CertifiedTransaction & {
 };
 
 export type Category =
-    | 'objects'
-    | 'transactions'
-    | 'addresses'
-    | 'ethAddress'
+    | 'object'
+    | 'transaction'
+    | 'address'
     | 'unknown';

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -390,7 +390,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                           label: 'Module',
                           monotypeClass: true,
                           value: txKindData.module.value,
-                          href: `/objects/${txKindData.package.value}?module=${txKindData.module.value}`,
+                          href: `/object/${txKindData.package.value}?module=${txKindData.module.value}`,
                       },
                       {
                           label: 'Function',

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -95,16 +95,16 @@ function formatByTransactionKind(
                 sender: {
                     value: sender,
                     link: true,
-                    category: 'addresses',
+                    category: 'address',
                 },
                 objectId: {
                     value: transfer.objectRef.objectId,
                     link: true,
-                    category: 'objects',
+                    category: 'object',
                 },
                 recipient: {
                     value: transfer.recipient,
-                    category: 'addresses',
+                    category: 'address',
                     link: true,
                 },
             };
@@ -115,12 +115,12 @@ function formatByTransactionKind(
                 sender: {
                     value: sender,
                     link: true,
-                    category: 'addresses',
+                    category: 'address',
                 },
                 package: {
                     value: getObjectId(moveCall.package),
                     link: true,
-                    category: 'objects',
+                    category: 'object',
                 },
                 module: {
                     value: moveCall.module,
@@ -149,7 +149,7 @@ function formatByTransactionKind(
                           sender: {
                               value: sender,
                               link: true,
-                              category: 'addresses',
+                              category: 'address',
                           },
                       }
                     : {}),
@@ -383,7 +383,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                           label: 'Package ID',
                           monotypeClass: true,
                           link: true,
-                          category: 'objects',
+                          category: 'object',
                           value: txKindData.package.value,
                       },
                       {

--- a/apps/explorer/src/ui/InternalLink.tsx
+++ b/apps/explorer/src/ui/InternalLink.tsx
@@ -33,7 +33,7 @@ export function ObjectLink({ objectId, noTruncate }: ObjectLinkProps) {
         ? objectId
         : truncate(objectId, TRUNCATE_LENGTH);
     return (
-        <Link variant="mono" to={`/objects/${encodeURIComponent(objectId)}`}>
+        <Link variant="mono" to={`/object/${encodeURIComponent(objectId)}`}>
             {truncatedObjectId}
         </Link>
     );

--- a/apps/explorer/src/ui/SenderRecipientAddress.tsx
+++ b/apps/explorer/src/ui/SenderRecipientAddress.tsx
@@ -24,7 +24,7 @@ export function SenderRecipientAddress({
             <Link
                 variant="mono"
                 size="md"
-                to={`/addresses/${encodeURIComponent(address)}`}
+                to={`/address/${encodeURIComponent(address)}`}
             >
                 {address}
             </Link>

--- a/apps/explorer/src/ui/TableCard.tsx
+++ b/apps/explorer/src/ui/TableCard.tsx
@@ -11,11 +11,17 @@ import { useMemo } from 'react';
 
 import type { ExecutionStatusType, TransactionKindName } from '@mysten/sui.js';
 
+type Category =
+    | 'object'
+    | 'transaction'
+    | 'address'
+    | 'unknown';
+
 export type LinkObj = {
     url: string;
     name?: string;
     copy?: boolean;
-    category?: string;
+    category?: Category;
     isLink?: boolean;
 };
 

--- a/apps/explorer/src/ui/TableCard.tsx
+++ b/apps/explorer/src/ui/TableCard.tsx
@@ -11,11 +11,7 @@ import { useMemo } from 'react';
 
 import type { ExecutionStatusType, TransactionKindName } from '@mysten/sui.js';
 
-type Category =
-    | 'object'
-    | 'transaction'
-    | 'address'
-    | 'unknown';
+type Category = 'object' | 'transaction' | 'address' | 'unknown';
 
 export type LinkObj = {
     url: string;

--- a/apps/explorer/src/utils/api/searchUtil.ts
+++ b/apps/explorer/src/utils/api/searchUtil.ts
@@ -17,7 +17,7 @@ export const navigateWithUnknown = async (
             rpc(network)
                 .getTransactionWithEffects(input)
                 .then((data) => ({
-                    category: 'transactions',
+                    category: 'transaction',
                     data: data,
                 }))
         );
@@ -35,7 +35,7 @@ export const navigateWithUnknown = async (
                         throw new Error('No objects for Address');
 
                     return {
-                        category: 'addresses',
+                        category: 'address',
                         data: data,
                     };
                 }),
@@ -46,7 +46,7 @@ export const navigateWithUnknown = async (
                         throw new Error('no object found');
                     }
                     return {
-                        category: 'objects',
+                        category: 'object',
                         data: data,
                     };
                 }),

--- a/apps/explorer/src/utils/api/searchUtil.ts
+++ b/apps/explorer/src/utils/api/searchUtil.ts
@@ -77,9 +77,9 @@ export const navigateWithUnknown = async (
 
                 if (
                     pac?.data &&
-                    (pac?.category === 'objects' ||
-                        pac?.category === 'addresses' ||
-                        pac?.category === 'transactions')
+                    (pac?.category === 'object' ||
+                        pac?.category === 'address' ||
+                        pac?.category === 'transaction')
                 ) {
                     navigate(
                         `../${pac.category}/${encodeURIComponent(input)}`,

--- a/apps/explorer/src/utils/static/mock_data.json
+++ b/apps/explorer/src/utils/static/mock_data.json
@@ -846,6 +846,30 @@
             }
         },
         {
+            "id": "7bc832ec31709638cd8d9323e90edf332gff4389",
+            "category": "object",
+            "owner": {
+                "AddressOwner": "0xa5e6dbcf33730ace6ec8b400ff4788c1f150ff7e"
+            },
+            "version": "1",
+            "objType": "0x2::SuiDrop::NFT",
+            "name": "Bored Ape Yacht Club #8937",
+            "ethAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+            "ethTokenId": "8937",
+            "data": {
+                "tx_digest": "Da4vHc9IwbvOYblE8LnrVsqXwryt2Kmms+xnJ7Zx5E4=",
+                "contents": {
+                    "display": "https://lh3.googleusercontent.com/xcPvABPQX6sG4Wwg1FsD-ztMUZwp6NeZQLTWX1PfiWvti9cFfDXw5gxvBhg6S4B5Q4CFiZV4nWGRQnzfL0YJpL_yWVgHVZ_DOFSM=w600",
+                    "background": "Orange",
+                    "clothes": "Tanktop",
+                    "eyes": "Holographic",
+                    "fur": "Dark Brown",
+                    "hat": "Cowboy Hat",
+                    "mouth": "Bored Unshaven Bubblegum"
+                }
+            }
+        },
+        {
             "id": "37196de8502e6d80e6a31fba1a5d6986cc018805",
             "category": "object",
             "status": "Exists",

--- a/apps/explorer/src/utils/static/mock_data.json
+++ b/apps/explorer/src/utils/static/mock_data.json
@@ -846,30 +846,6 @@
             }
         },
         {
-            "id": "7bc832ec31709638cd8d9323e90edf332gff4389",
-            "category": "object",
-            "owner": {
-                "AddressOwner": "0xa5e6dbcf33730ace6ec8b400ff4788c1f150ff7e"
-            },
-            "version": "1",
-            "objType": "0x2::SuiDrop::NFT",
-            "name": "Bored Ape Yacht Club #8937",
-            "ethAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
-            "ethTokenId": "8937",
-            "data": {
-                "tx_digest": "Da4vHc9IwbvOYblE8LnrVsqXwryt2Kmms+xnJ7Zx5E4=",
-                "contents": {
-                    "display": "https://lh3.googleusercontent.com/xcPvABPQX6sG4Wwg1FsD-ztMUZwp6NeZQLTWX1PfiWvti9cFfDXw5gxvBhg6S4B5Q4CFiZV4nWGRQnzfL0YJpL_yWVgHVZ_DOFSM=w600",
-                    "background": "Orange",
-                    "clothes": "Tanktop",
-                    "eyes": "Holographic",
-                    "fur": "Dark Brown",
-                    "hat": "Cowboy Hat",
-                    "mouth": "Bored Unshaven Bubblegum"
-                }
-            }
-        },
-        {
             "id": "37196de8502e6d80e6a31fba1a5d6986cc018805",
             "category": "object",
             "status": "Exists",

--- a/apps/explorer/src/utils/static/searchUtil.ts
+++ b/apps/explorer/src/utils/static/searchUtil.ts
@@ -15,11 +15,11 @@ const navigateWithUnknown = async (
     const ownedObjects = findOwnedObjectsfromID(input);
 
     if (data?.category === 'transaction') {
-        navigate(`../transactions/${input}`, { state: data });
+        navigate(`../transaction/${input}`, { state: data });
     } else if (data?.category === 'object') {
-        navigate(`../objects/${input}`, { state: data });
+        navigate(`../object/${input}`, { state: data });
     } else if (ownedObjects && ownedObjects.length > 0) {
-        navigate(`../addresses/${input}`, { state: data });
+        navigate(`../address/${input}`, { state: data });
     } else {
         navigate(`../error/missing/${input}`);
     }

--- a/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
+++ b/apps/wallet/src/ui/app/components/explorer-link/Explorer.ts
@@ -24,7 +24,7 @@ function getExplorerUrl(path: string, apiEnv: API_ENV = DEFAULT_API_ENV) {
 }
 
 export function getObjectUrl(objectID: ObjectId, apiEnv: API_ENV) {
-    return getExplorerUrl(`/objects/${objectID}`, apiEnv);
+    return getExplorerUrl(`/object/${objectID}`, apiEnv);
 }
 
 export function getTransactionUrl(
@@ -32,11 +32,11 @@ export function getTransactionUrl(
     apiEnv: API_ENV
 ) {
     return getExplorerUrl(
-        `/transactions/${encodeURIComponent(txDigest)}`,
+        `/transaction/${encodeURIComponent(txDigest)}`,
         apiEnv
     );
 }
 
 export function getAddressUrl(address: SuiAddress, apiEnv: API_ENV) {
-    return getExplorerUrl(`/addresses/${address}`, apiEnv);
+    return getExplorerUrl(`/address/${address}`, apiEnv);
 }


### PR DESCRIPTION
This moves the explorer from plural routes for ID pages (`transactions`, `addresses`) to singular (`transaction`, `address`). I added a redirect for the old-style routes as well. My thinking here is that it's easier to type the singular form of these, making it less typo prone, and easier to read. 