### PR TITLE
[move] Temporarily disable verification of test code

### DIFF
--- a/crates/sui/src/sui_move/unit_test.rs
+++ b/crates/sui/src/sui_move/unit_test.rs
@@ -31,7 +31,9 @@ impl Test {
         build::Build::execute_internal(
             &rerooted_path,
             BuildConfig {
-                test_mode: true, // make sure to verify tests
+                // TODO: test_mode should be true - flip it when calling init function from test
+                // code issue is resolved
+                test_mode: false, // make sure to verify tests
                 ..build_config.clone()
             },
             dump_bytecode_as_base64,


### PR DESCRIPTION
This is a temporary fix to enable developers to run tests that explicitly call module `init` functions. A proper fix is in the works.