### PR TITLE
[Node] Add reconfig monitor

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -121,7 +121,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(store)
     }
 
-    #[allow(dead_code)]
     pub(crate) fn reopen_epoch_db(&self, new_epoch: EpochId) {
         info!(?new_epoch, "re-opening AuthorityEpochTables for new epoch");
         let epoch_tables = Arc::new(AuthorityPerEpochStore::new(

--- a/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
+++ b/crates/sui-core/src/authority_active/gossip/configurable_batch_action_client.rs
@@ -63,15 +63,7 @@ pub struct ConfigurableBatchActionClient {
 impl ConfigurableBatchActionClient {
     #[cfg(test)]
     pub async fn new(committee: Committee, secret: AuthorityKeyPair) -> Self {
-        let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = tokio::sync::mpsc::channel(10);
-        let state = AuthorityState::new_for_testing(
-            committee,
-            &secret,
-            None,
-            None,
-            tx_reconfigure_consensus,
-        )
-        .await;
+        let state = AuthorityState::new_for_testing(committee, &secret, None, None).await;
 
         ConfigurableBatchActionClient {
             state: Arc::new(state),

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -460,15 +460,7 @@ impl AuthorityAPI for LocalAuthorityClient {
 impl LocalAuthorityClient {
     #[cfg(test)]
     pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
-        let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = tokio::sync::mpsc::channel(10);
-        let state = AuthorityState::new_for_testing(
-            committee,
-            &secret,
-            None,
-            Some(genesis),
-            tx_reconfigure_consensus,
-        )
-        .await;
+        let state = AuthorityState::new_for_testing(committee, &secret, None, Some(genesis)).await;
         Self {
             state: Arc::new(state),
             fault_config: LocalAuthorityClientFaultConfig::default(),

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -893,16 +893,8 @@ mod tests {
         let store = Box::new(store);
 
         let (keypair, committee) = committee();
-        let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = mpsc::channel(10);
         let state = Arc::new(
-            AuthorityState::new_for_testing(
-                committee.clone(),
-                &keypair,
-                None,
-                None,
-                tx_reconfigure_consensus,
-            )
-            .await,
+            AuthorityState::new_for_testing(committee.clone(), &keypair, None, None).await,
         );
 
         let checkpoint_store = CheckpointStore::new(tempdir.path());

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2347,15 +2347,7 @@ pub async fn init_state_with_committee(
         }
     };
 
-    let (tx_reconfigure_consensus, _rx_reconfigure_consensus) = tokio::sync::mpsc::channel(10);
-    AuthorityState::new_for_testing(
-        committee,
-        &authority_key,
-        None,
-        None,
-        tx_reconfigure_consensus,
-    )
-    .await
+    AuthorityState::new_for_testing(committee, &authority_key, None, None).await
 }
 
 #[cfg(test)]

--- a/crates/sui-node/src/handle.rs
+++ b/crates/sui-node/src/handle.rs
@@ -65,7 +65,7 @@ impl SuiNodeHandle {
     }
 
     pub async fn wait(self) -> Result<()> {
-        self.0.wait().await
+        self.0.monitor_reconfiguration().await
     }
 }
 

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     sui_node::admin::start_admin_server(config.admin_interface_port, filter_handle);
 
     let node = sui_node::SuiNode::start(&config, prometheus_registry).await?;
-    node.wait().await?;
+    node.monitor_reconfiguration().await?;
 
     Ok(())
 }

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -64,7 +64,7 @@ impl<R> SwarmBuilder<R> {
         self
     }
 
-    /// Set the committe size (the number of validators in the validator set).
+    /// Set the committee size (the number of validators in the validator set).
     ///
     /// Defaults to 1.
     pub fn committee_size(mut self, committee_size: NonZeroUsize) -> Self {
@@ -328,11 +328,11 @@ mod test {
         swarm.launch().await.unwrap();
 
         for validator in swarm.validators() {
-            validator.health_check().await.unwrap();
+            validator.health_check(true).await.unwrap();
         }
 
         for fullnode in swarm.fullnodes() {
-            fullnode.health_check().await.unwrap();
+            fullnode.health_check(false).await.unwrap();
         }
     }
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -152,7 +152,7 @@ impl SuiCommand {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
                 loop {
                     for node in swarm.validators_mut() {
-                        node.health_check().await?;
+                        node.health_check(true).await?;
                     }
 
                     interval.tick().await;


### PR DESCRIPTION
Adds reconfiguration monitoring in the node main thread.
Upon receiving reconfig signal, it will attempt to reconfigure the system.
This includes starting the validator service if not active, or reconfigure Narwhal if it's already there.
Also reconfigure the authority state and epoch db.
