### PR TITLE
Ignore wallet typescript error

### DIFF
--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -125,9 +125,13 @@ const slice = createSlice({
     reducers: {},
     extraReducers: (builder) => {
         builder.addCase(sendTokens.fulfilled, (state, { payload }) => {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore: This causes a compiler error, but it will be removed when we migrate off of Redux.
             return txAdapter.setOne(state, payload);
         });
         builder.addCase(StakeTokens.fulfilled, (state, { payload }) => {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore: This causes a compiler error, but it will be removed when we migrate off of Redux.
             return txAdapter.setOne(state, payload);
         });
     },


### PR DESCRIPTION
The Wallet Extension builds have been very unstable lately, failing randomly due to the TypeScript compiler encountering deep recursion. This adds a `ts-ignore` to the problematic lines to get builds stable again. Once we migrate off of Redux, this will no longer be an issue.