### PR TITLE
[checkpoints] Use consensus adapter to send checkpoint signatures

### DIFF
--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -439,6 +439,13 @@ impl<'a> Drop for InflightDropGuard<'a> {
 // TODO: replace by a ConsensusTxValidator in order to make Narwhal-side validation effective
 pub use narwhal_worker::TrivialTransactionValidator as SuiTxValidator;
 
+#[async_trait::async_trait]
+impl SubmitToConsensus for Arc<ConsensusAdapter> {
+    async fn submit_to_consensus(&self, transaction: &ConsensusTransaction) -> SuiResult {
+        self.submit(transaction.clone()).map(|_| ())
+    }
+}
+
 #[cfg(test)]
 mod adapter_tests {
     use super::ConsensusAdapter;


### PR DESCRIPTION
This PR uses persistent `ConsensusAdapter` to send checkpoint signatures, instead of directly using stateless `ConsensusClient`.

This is needed for liveness, to ensure that if node restarts the checkpoint signatures produced by this validators will be eventually submitted to consensus.

https://github.com/MystenLabs/sui/issues/5763