### PR TITLE
[explorer, wallet] Dynamic tracing sampling

### DIFF
--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -16,6 +16,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from './app/App';
+import { growthbook } from './utils/growthbook';
 import { plausible } from './utils/plausible';
 import { reportWebVitals } from './utils/vitals';
 
@@ -29,7 +30,9 @@ if (import.meta.env.PROD) {
     Sentry.init({
         dsn: 'https://e4251274d1b141d7ba272103fa0f8d83@o1314142.ingest.sentry.io/6564988',
         integrations: [new BrowserTracing()],
-        tracesSampleRate: 0.2,
+        tracesSampler: () => {
+            return growthbook.getFeatureValue('explorer-sentry-tracing', 0);
+        },
     });
 }
 

--- a/apps/wallet/src/shared/sentry.ts
+++ b/apps/wallet/src/shared/sentry.ts
@@ -5,6 +5,8 @@ import * as Sentry from '@sentry/react';
 import { BrowserTracing } from '@sentry/tracing';
 import Browser from 'webextension-polyfill';
 
+import { growthbook } from '_src/ui/app/experimentation/feature-gating';
+
 const WALLET_VERSION = Browser.runtime.getManifest().version;
 const SENTRY_DSN =
     'https://e52a4e5c90224fe0800cc96aa2570581@o1314142.ingest.sentry.io/6761112';
@@ -18,7 +20,9 @@ export default function initSentry() {
         dsn: SENTRY_DSN,
         integrations: [new BrowserTracing()],
         release: WALLET_VERSION,
-        tracesSampleRate: 0.2,
+        tracesSampler: () => {
+            return growthbook.getFeatureValue('wallet-sentry-tracing', 0);
+        },
     });
 }
 


### PR DESCRIPTION
This updates the sampling logic to pull the value from growthbook, allowing sample rates to be determined dynamically. This should help us dial this up and down (we'll probably update the ingestion to ignore every november release of the wallet after this lands because we don't want to deal with non-dynamic sample rates). Right now they're set to 1% because we're not 100% sure of the value of traces right now (mostly because we don't have usable traces). 