### PR TITLE
Fix faulty test

### DIFF
--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -1214,17 +1214,13 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
 
     // Create the object
     let (sender, object_id, _) = create_devnet_nft(context).await?;
-    sleep(Duration::from_secs(15)).await;
+    sleep(Duration::from_secs(1)).await;
 
     let recipient = context.config.keystore.addresses().get(1).cloned().unwrap();
     assert_ne!(sender, recipient);
 
     let (object_ref_v1, object_v1, _) = get_obj_read_from_node(&node, object_id, None).await?;
 
-    // Transfer some SUI to recipient
-    transfer_coin(context)
-        .await
-        .expect("Failed to transfer coins to recipient");
     // Transfer the object from sender to recipient
     let gas_ref = get_gas_object_with_wallet_context(context, &sender)
         .await
@@ -1237,17 +1233,22 @@ async fn test_get_objects_read() -> Result<(), anyhow::Error> {
         recipient,
     );
     context.execute_transaction(nft_transfer_tx).await.unwrap();
-    sleep(Duration::from_secs(15)).await;
+    sleep(Duration::from_secs(1)).await;
 
     let (object_ref_v2, object_v2, _) = get_obj_read_from_node(&node, object_id, None).await?;
     assert_ne!(object_ref_v2, object_ref_v1);
+
+    // Transfer some SUI to recipient
+    transfer_coin(context)
+        .await
+        .expect("Failed to transfer coins to recipient");
 
     // Delete the object
     let package_ref = node.state().get_framework_object_ref().await.unwrap();
     let (_tx_cert, effects) =
         delete_devnet_nft(context, &recipient, object_ref_v2, package_ref).await;
     assert_eq!(effects.status, SuiExecutionStatus::Success);
-    sleep(Duration::from_secs(15)).await;
+    sleep(Duration::from_secs(1)).await;
 
     // Now test get_object_read
     let object_ref_v3 = match node.state().get_object_read(&object_id).await? {


### PR DESCRIPTION
The problem was that the transfer_coin call transfers away a random object without checking if it is a gas object. It was transfering away object_ref_v1 instead of a random coin, which was making the later make_transfer_object_transaction_with_wallet_context call fail.

(The right fix would be to improve the testing code to make it less error prone but this is blocking CI right now).