### PR TITLE
Fixed TS-SDK path manipulation (Issue #6376)

### DIFF
--- a/sdk/typescript/type_guards.mjs
+++ b/sdk/typescript/type_guards.mjs
@@ -3,20 +3,21 @@
 
 import { readFile, writeFile } from 'fs/promises';
 import { generate } from 'ts-auto-guard';
+import { fileURLToPath } from 'url';
 
 const GUARD_FILES = ['src/rpc/client.guard.ts', 'src/types/index.guard.ts'];
 const LICENSE =
   '// Copyright (c) Mysten Labs, Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n/* eslint-disable */\n\n';
 
 async function main() {
-  const tsconfig = new URL('./tsconfig.json', import.meta.url);
+  const tsconfig = fileURLToPath(new URL('./tsconfig.json', import.meta.url));
 
   // Change the directory to be the resolved directory of this file so that
   // the path resolution done in `generate` is guaranteed to work.
-  process.chdir(new URL('.', import.meta.url).pathname);
+  process.chdir(fileURLToPath(new URL('.', import.meta.url)));
 
   await generate({
-    project: tsconfig.pathname,
+    project: tsconfig,
     paths: ['src/rpc/client.ts', 'src/types/index.ts'],
     processOptions: {
       exportAll: true,


### PR DESCRIPTION
Issue #6376
The steps to build locally the typescript sdk fails on Windows.
All the dependencies are installed successfully with "pnpm install" but "pnpm sdk build" throws an error for path inconsistency.

With the use of fileURLToPath() instead of urlObject.pathname we ensure a cross-platform valid absolute path string.

