### PR TITLE
wallet-ext: explorer: reduce sentry noise

### DIFF
--- a/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
+++ b/apps/explorer/src/components/ownedobjects/OwnedObjects.tsx
@@ -112,7 +112,7 @@ function OwnedObjectAPI({ id, byAddress }: { id: string; byAddress: boolean }) {
 
         req.then((objects) => {
             const ids = objects.map(({ objectId }) => objectId);
-            rpc.getObjectBatch(ids).then((results) => {
+            return rpc.getObjectBatch(ids).then((results) => {
                 setResults(
                     results
                         .filter(({ status }) => status === 'Exists')

--- a/apps/explorer/src/components/transaction-card/TxForID.tsx
+++ b/apps/explorer/src/components/transaction-card/TxForID.tsx
@@ -79,26 +79,29 @@ function TxForIDAPI({ id, category }: { id: string; category: categoryType }) {
     const [network] = useContext(NetworkContext);
     const rpc = useRpc();
     useEffect(() => {
-        getTx(id, network, category).then((transactions) => {
-            //If the API method does not exist, the transactions will be undefined
-            if (!transactions?.[0]) {
-                setData({
-                    loadState: 'loaded',
-                });
-            } else {
-                getDataOnTxDigests(rpc, transactions)
-                    .then((data) => {
-                        setData({
-                            data: data as TxnData[],
-                            loadState: 'loaded',
-                        });
-                    })
-                    .catch((error) => {
-                        console.log(error);
-                        setData({ ...DATATYPE_DEFAULT, loadState: 'fail' });
+        getTx(id, network, category).then(
+            (transactions) => {
+                //If the API method does not exist, the transactions will be undefined
+                if (!transactions?.[0]) {
+                    setData({
+                        loadState: 'loaded',
                     });
-            }
-        });
+                } else {
+                    getDataOnTxDigests(rpc, transactions)
+                        .then((data) => {
+                            setData({
+                                data: data as TxnData[],
+                                loadState: 'loaded',
+                            });
+                        })
+                        .catch((error) => {
+                            console.log(error);
+                            setData({ ...DATATYPE_DEFAULT, loadState: 'fail' });
+                        });
+                }
+            },
+            () => {}
+        );
     }, [id, network, rpc, category]);
 
     if (showData.loadState === 'pending') {

--- a/apps/explorer/src/index.tsx
+++ b/apps/explorer/src/index.tsx
@@ -34,6 +34,11 @@ if (import.meta.env.PROD) {
         tracesSampler: () => {
             return growthbook.getFeatureValue('explorer-sentry-tracing', 0);
         },
+        allowUrls: [
+            /.*\.sui\.io/i,
+            /.*-mysten-labs\.vercel\.app/i,
+            'explorer-topaz.vercel.app',
+        ],
     });
 }
 

--- a/apps/wallet/configs/webpack/webpack.config.common.ts
+++ b/apps/wallet/configs/webpack/webpack.config.common.ts
@@ -223,6 +223,7 @@ const commonConfig: () => Promise<Configuration> = async () => {
                 dryRun: !IS_PROD || !sentryAuthToken,
                 authToken: sentryAuthToken,
                 release: walletVersionDetails.version,
+                silent: true,
             }),
         ],
     };

--- a/apps/wallet/src/shared/sentry.ts
+++ b/apps/wallet/src/shared/sentry.ts
@@ -23,6 +23,10 @@ export default function initSentry() {
         tracesSampler: () => {
             return growthbook.getFeatureValue('wallet-sentry-tracing', 0);
         },
+        allowUrls: [
+            'ehndjpedolgphielnhnpnkomdhgpaaei', // chrome beta
+            'opcgpfmipidbgpenhmajoajpbobppdil', // chrome prod
+        ],
     });
 }
 

--- a/apps/wallet/src/ui/app/components/menu/content/menu-list/index.tsx
+++ b/apps/wallet/src/ui/app/components/menu/content/menu-list/index.tsx
@@ -71,8 +71,12 @@ function MenuList() {
                     mode="secondary"
                     size="large"
                     onClick={async () => {
-                        await dispatch(lockWallet()).unwrap();
-                        navigate('/locked', { replace: true });
+                        try {
+                            await dispatch(lockWallet()).unwrap();
+                            navigate('/locked', { replace: true });
+                        } catch (e) {
+                            // Do nothing
+                        }
                     }}
                 >
                     <Icon icon={SuiIcons.Lock} />

--- a/apps/wallet/src/ui/app/components/sui-apps/index.tsx
+++ b/apps/wallet/src/ui/app/components/sui-apps/index.tsx
@@ -26,7 +26,7 @@ function AppsPlayGround() {
     const dispatch = useAppDispatch();
 
     useEffect(() => {
-        dispatch(getCuratedApps()).unwrap();
+        dispatch(getCuratedApps());
     }, [dispatch, mintStatus]);
 
     // Get connected apps

--- a/apps/wallet/src/ui/app/components/transactions-card/RecentTransactions.tsx
+++ b/apps/wallet/src/ui/app/components/transactions-card/RecentTransactions.tsx
@@ -30,7 +30,7 @@ function RecentTransactions({ coinType }: Props) {
     );
 
     useEffect(() => {
-        dispatch(getTransactionsByAddress()).unwrap();
+        dispatch(getTransactionsByAddress());
     }, [dispatch]);
 
     return (

--- a/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/receipt/index.tsx
@@ -34,7 +34,7 @@ function ReceiptPage() {
     );
 
     useEffect(() => {
-        dispatch(getTransactionsByAddress()).unwrap();
+        dispatch(getTransactionsByAddress());
     }, [dispatch]);
 
     const txnItem = useMemo(() => {

--- a/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
+++ b/apps/wallet/src/ui/app/shared/dapp-status/index.tsx
@@ -80,9 +80,16 @@ function DappStatus() {
                 props: { source: 'Header' },
             });
             setDisconnecting(true);
-            await dispatch(appDisconnect({ origin: activeOriginUrl })).unwrap();
-            setVisible(false);
-            setDisconnecting(false);
+            try {
+                await dispatch(
+                    appDisconnect({ origin: activeOriginUrl })
+                ).unwrap();
+                setVisible(false);
+            } catch (e) {
+                // Do nothing
+            } finally {
+                setDisconnecting(false);
+            }
         }
     }, [disconnecting, isConnected, activeOriginUrl, dispatch]);
     if (!isConnected) {


### PR DESCRIPTION
* client report errors for known domains / filter out errors from extensions etc
* ignore api/rpc errors
* wallet sentry webpack plugin stop logging

closes: APPS-227