### PR TITLE
[authority] Move reconfiguration state into PerEpochStore

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -26,7 +26,6 @@ use move_core_types::identifier::Identifier;
 use move_core_types::parser::parse_struct_tag;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
-use parking_lot::RwLock;
 use prometheus::{
     exponential_buckets, register_histogram_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
@@ -563,9 +562,6 @@ pub struct AuthorityState {
     pub consensus_guardrail: AtomicUsize,
 
     pub metrics: Arc<AuthorityMetrics>,
-
-    /// In-memory cache of the content from the reconfig_state db table.
-    reconfig_state_mem: RwLock<ReconfigState>,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -1487,11 +1483,6 @@ impl AuthorityState {
             ),
             consensus_guardrail: AtomicUsize::new(0),
             metrics,
-            reconfig_state_mem: RwLock::new(
-                store
-                    .load_reconfig_state()
-                    .expect("Load reconfig state at initialization cannot fail"),
-            ),
         };
 
         prometheus_registry
@@ -1643,47 +1634,16 @@ impl AuthorityState {
         self.committee().clone().deref().clone()
     }
 
-    pub fn get_reconfig_state_read_lock_guard(
-        &self,
-    ) -> parking_lot::RwLockReadGuard<ReconfigState> {
-        self.reconfig_state_mem.read()
-    }
-
-    pub fn get_reconfig_state_write_lock_guard(
-        &self,
-    ) -> parking_lot::RwLockWriteGuard<ReconfigState> {
-        self.reconfig_state_mem.write()
-    }
-
     // This method can only be called from ConsensusAdapter::begin_reconfiguration
-    pub fn close_user_certs(
-        &self,
-        mut lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>,
-    ) {
-        lock_guard.close_user_certs();
-        self.database
-            .store_reconfig_state(&lock_guard)
-            .expect("Updating reconfig state cannot fail");
+    pub fn close_user_certs(&self, lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>) {
+        self.database.epoch_tables().close_user_certs(lock_guard)
     }
 
     pub async fn close_all_certs(
         &self,
-        mut lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>,
+        lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>,
     ) {
-        lock_guard.close_all_certs();
-        self.database
-            .store_reconfig_state(&lock_guard)
-            .expect("Updating reconfig state cannot fail");
-    }
-
-    pub async fn open_all_certs(
-        &self,
-        mut lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>,
-    ) {
-        lock_guard.open_all_certs();
-        self.database
-            .store_reconfig_state(&lock_guard)
-            .expect("Updating reconfig state cannot fail");
+        self.database.epoch_tables().close_all_certs(lock_guard)
     }
 
     pub(crate) async fn get_object(
@@ -2307,6 +2267,8 @@ impl AuthorityState {
                 );
 
                 if !self
+                    .database
+                    .epoch_tables()
                     .get_reconfig_state_read_lock_guard()
                     .should_accept_consensus_certs()
                 {

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -40,8 +40,6 @@ pub struct CertLockGuard(LockGuard);
 const NUM_SHARDS: usize = 4096;
 const SHARD_SIZE: usize = 128;
 
-const RECONFIG_STATE_INDEX: u64 = 0;
-
 /// ALL_OBJ_VER determines whether we want to store all past
 /// versions of every object in the store. Authority doesn't store
 /// them, but other entities such as replicas will.
@@ -989,29 +987,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         };
 
         Ok(assigned_seq)
-    }
-
-    pub fn load_reconfig_state(&self) -> SuiResult<ReconfigState> {
-        let state = match self
-            .perpetual_tables
-            .reconfig_state
-            .get(&RECONFIG_STATE_INDEX)?
-        {
-            Some(state) => state,
-            None => {
-                let init_state = ReconfigState::default();
-                self.store_reconfig_state(&init_state)?;
-                init_state
-            }
-        };
-        Ok(state)
-    }
-
-    pub fn store_reconfig_state(&self, new_state: &ReconfigState) -> SuiResult {
-        self.perpetual_tables
-            .reconfig_state
-            .insert(&RECONFIG_STATE_INDEX, new_state)?;
-        Ok(())
     }
 
     /// This function is called at the end of epoch for each transaction that's

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -79,8 +79,6 @@ pub struct AuthorityPerpetualTables<S> {
 
     /// A sequence of batches indexing into the sequence of executed transactions.
     pub batches: DBMap<TxSequenceNumber, SignedBatch>,
-
-    pub reconfig_state: DBMap<u64, ReconfigState>,
 }
 
 impl<S> AuthorityPerpetualTables<S>


### PR DESCRIPTION
The reconfiguration state information is tightly coupled to other epoch tables. For example, we do state transaction from CloseUserCerts => CloseAllCerts based on `epoch_tables.end_of_publish`.

If external event happens, for example due to state sync where we need to change an epoch any state regarding reconfiguration of previous epoch becomes irrelevant.

I did not think super well yet what to do with the RwLock holding the ReconfigurationState in regards with bigger picture. I think most likely the `epoch_tables` itself needs to be stored in the RwLock. (will do that in separate PR when I have more clarity on that)

Note that `open_all_certs` method is also deleted in this case - there is no way to transition back to open reconfiguration state, other than by switching to a new epoch(that will create empty reconfiguration state table).