### PR TITLE
[Bugfix] - Do not emit CoinBalanceChange for object owned object mutation

### DIFF
--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -223,17 +223,21 @@ impl<S> TemporaryStore<S> {
             (WriteKind::Mutate, Ok(Some(_)), Some(old_obj)) => {
                 Self::create_coin_mutate_events(&ctx, gas_id, obj, old_obj, gas_charged)
             }
-            // For all other coin change (unwrap/create), we emit full balance transfer event to the new owner.
+            // For all other coin change (unwrap/create), we emit full balance transfer event to the new address owner.
             (_, Ok(Some(balance)), _) => {
-                vec![Event::balance_change(
-                    &ctx,
-                    BalanceChangeType::Receive,
-                    obj.owner,
-                    obj.id(),
-                    obj.version(),
-                    obj.type_().unwrap(),
-                    balance as i128,
-                )]
+                if let Owner::AddressOwner(_) = obj.owner {
+                    vec![Event::balance_change(
+                        &ctx,
+                        BalanceChangeType::Receive,
+                        obj.owner,
+                        obj.id(),
+                        obj.version(),
+                        obj.type_().unwrap(),
+                        balance as i128,
+                    )]
+                } else {
+                    vec![]
+                }
             }
             // For non-coin mutation
             (WriteKind::Mutate, Ok(None), old_obj) | (WriteKind::Unwrap, Ok(None), old_obj) => {


### PR DESCRIPTION
We are emitting CoinBalanceChange event incorrectly for object owned object mutation, where the input object is not present similar to create and unwrap.

Example:
<img width="2056" alt="image" src="https://user-images.githubusercontent.com/1888654/204932233-bd4fe512-c4ae-4d31-ac8d-9dc9aeedea40.png">


