### PR TITLE
Add a scoped utility to monitor cumulative duration and iterations

### DIFF
--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Instant;
+
 use once_cell::sync::OnceCell;
 use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
 use tap::TapFallible;
-
-use tokio::time::Instant;
 use tracing::warn;
 
 pub use scopeguard;
@@ -129,7 +129,7 @@ pub fn monitored_scope(name: &'static str) -> Option<MonitoredScopeGuard> {
         Some(MonitoredScopeGuard {
             metrics: m,
             name,
-            timer: tokio::time::Instant::now(),
+            timer: Instant::now(),
         })
     } else {
         None

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -23,6 +23,7 @@ use move_core_types::identifier::Identifier;
 use move_core_types::parser::parse_struct_tag;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
+use mysten_metrics::monitored_scope;
 use prometheus::{
     exponential_buckets, register_histogram_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
@@ -87,7 +88,6 @@ use crate::consensus_handler::{
 };
 use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::reconfiguration::ReconfigState;
-use crate::metrics::TaskUtilizationExt;
 use crate::module_cache_gauge::ModuleCacheGauge;
 use crate::scoped_counter;
 use crate::{
@@ -166,10 +166,7 @@ pub struct AuthorityMetrics {
     pub(crate) transaction_manager_num_pending_certificates: IntGauge,
     pub(crate) transaction_manager_num_ready: IntGauge,
 
-    total_consensus_txns: IntCounter,
     skipped_consensus_txns: IntCounter,
-    handle_consensus_duration_mcs: IntCounter,
-    verify_narwhal_transaction_duration_mcs: IntCounter,
 
     pub follower_items_streamed: IntCounter,
     pub follower_items_loaded: IntCounter,
@@ -332,27 +329,9 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
-            total_consensus_txns: register_int_counter_with_registry!(
-                "total_consensus_txns",
-                "Total number of consensus transactions received from narwhal",
-                registry,
-            )
-            .unwrap(),
             skipped_consensus_txns: register_int_counter_with_registry!(
                 "skipped_consensus_txns",
                 "Total number of consensus transactions skipped",
-                registry,
-            )
-            .unwrap(),
-            handle_consensus_duration_mcs: register_int_counter_with_registry!(
-                "handle_consensus_duration_mcs",
-                "Total duration of handle_consensus_transaction",
-                registry,
-            )
-            .unwrap(),
-            verify_narwhal_transaction_duration_mcs: register_int_counter_with_registry!(
-                "verify_narwhal_transaction_duration_mcs",
-                "Total duration of verify_narwhal_transaction",
                 registry,
             )
             .unwrap(),
@@ -2159,10 +2138,7 @@ impl AuthorityState {
         consensus_output: &ConsensusOutput,
         transaction: SequencedConsensusTransaction,
     ) -> Result<VerifiedSequencedConsensusTransaction, ()> {
-        let _timer = self
-            .metrics
-            .verify_narwhal_transaction_duration_mcs
-            .utilization_timer();
+        let _scope = monitored_scope!("VerifyConsensusTransaction");
         if self
             .database
             .consensus_message_processed(&transaction.transaction.key())
@@ -2223,16 +2199,12 @@ impl AuthorityState {
         transaction: VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
     ) -> SuiResult {
+        let _scope = monitored_scope!("HandleConsensusTransaction");
         let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
             consensus_output: _consensus_output,
             consensus_index,
             transaction,
         }) = transaction;
-        self.metrics.total_consensus_txns.inc();
-        let _timer = self
-            .metrics
-            .handle_consensus_duration_mcs
-            .utilization_timer();
         let tracking_id = transaction.get_tracking_id();
         // TODO: Somewhere here we check if we have seen 2f+1 EndOfPublish message, and if so,
         // we call self.get_reconfig_state_write_lock_guard to get a guard, and then call

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2138,7 +2138,7 @@ impl AuthorityState {
         consensus_output: &ConsensusOutput,
         transaction: SequencedConsensusTransaction,
     ) -> Result<VerifiedSequencedConsensusTransaction, ()> {
-        let _scope = monitored_scope!("VerifyConsensusTransaction");
+        let _scope = monitored_scope("VerifyConsensusTransaction");
         if self
             .database
             .consensus_message_processed(&transaction.transaction.key())
@@ -2199,7 +2199,7 @@ impl AuthorityState {
         transaction: VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
     ) -> SuiResult {
-        let _scope = monitored_scope!("HandleConsensusTransaction");
+        let _scope = monitored_scope("HandleConsensusTransaction");
         let VerifiedSequencedConsensusTransaction(SequencedConsensusTransaction {
             consensus_output: _consensus_output,
             consensus_index,

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -3,7 +3,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use prometheus::{
     register_int_counter_with_registry, register_int_gauge_with_registry, IntCounter, IntGauge,
     Registry,
@@ -80,6 +80,8 @@ where
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
+        let _scope = monitored_scope!("ExecutionDriver");
+
         let certificate = if let Some(cert) = ready_certificates_stream.recv().await {
             cert
         } else {

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -80,7 +80,7 @@ where
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
-        let _scope = monitored_scope!("ExecutionDriver");
+        let _scope = monitored_scope("ExecutionDriver");
 
         let certificate = if let Some(cert) = ready_certificates_stream.recv().await {
             cert

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -283,7 +283,7 @@ impl CheckpointBuilder {
         roots: Vec<TransactionDigest>,
         last_checkpoint_of_epoch: bool,
     ) -> anyhow::Result<()> {
-        let _scope = monitored_scope!("MakeCheckpoint");
+        let _scope = monitored_scope("MakeCheckpoint");
         self.metrics
             .checkpoint_roots_count
             .inc_by(roots.len() as u64);
@@ -517,7 +517,7 @@ impl CheckpointAggregator {
     }
 
     async fn run_inner(&mut self) -> SuiResult {
-        let _scope = monitored_scope!("CheckpointAggregator");
+        let _scope = monitored_scope("CheckpointAggregator");
         'outer: loop {
             let current = if let Some(current) = &mut self.current {
                 current

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -12,12 +12,11 @@ pub use crate::checkpoints::checkpoint_output::{
     LogCheckpointOutput, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
 };
 pub use crate::checkpoints::metrics::CheckpointMetrics;
-use crate::metrics::TaskUtilizationExt;
 use crate::stake_aggregator::{InsertResult, StakeAggregator};
 use fastcrypto::encoding::{Encoding, Hex};
 use futures::future::{select, Either};
 use futures::FutureExt;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
@@ -284,7 +283,7 @@ impl CheckpointBuilder {
         roots: Vec<TransactionDigest>,
         last_checkpoint_of_epoch: bool,
     ) -> anyhow::Result<()> {
-        let _timer = self.metrics.builder_utilization.utilization_timer();
+        let _scope = monitored_scope!("MakeCheckpoint");
         self.metrics
             .checkpoint_roots_count
             .inc_by(roots.len() as u64);
@@ -518,7 +517,7 @@ impl CheckpointAggregator {
     }
 
     async fn run_inner(&mut self) -> SuiResult {
-        let _timer = self.metrics.aggregator_utilization.utilization_timer();
+        let _scope = monitored_scope!("CheckpointAggregator");
         'outer: loop {
             let current = if let Some(current) = &mut self.current {
                 current

--- a/crates/sui-core/src/metrics.rs
+++ b/crates/sui-core/src/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{Histogram, IntCounter};
+use prometheus::Histogram;
 use tokio::time::Instant;
 
 /// Increment an IntGauge metric, and decrement it when the scope ends.
@@ -22,32 +22,4 @@ pub fn start_timer(metrics: Histogram) -> impl Drop {
     scopeguard::guard((metrics, start_ts), |(metrics, start_ts)| {
         metrics.observe(start_ts.elapsed().as_secs_f64());
     })
-}
-
-pub struct TaskUtilizationGuard<'a> {
-    metric: &'a IntCounter,
-    start: Instant,
-}
-
-pub trait TaskUtilizationExt {
-    /// Measures amount of time spent until guard is dropped and increments the counter by duration in mcs
-    /// Primary usage for this counter is to measure 'utilization' of the single task
-    /// E.g. having rate(metric) / 1_000_000 can tell what portion of time this task is busy
-    /// For the tasks that are run in single thread this indicates how close is this task to a complete saturation
-    fn utilization_timer(&self) -> TaskUtilizationGuard;
-}
-
-impl TaskUtilizationExt for IntCounter {
-    fn utilization_timer(&self) -> TaskUtilizationGuard {
-        TaskUtilizationGuard {
-            start: Instant::now(),
-            metric: self,
-        }
-    }
-}
-
-impl<'a> Drop for TaskUtilizationGuard<'a> {
-    fn drop(&mut self) {
-        self.metric.inc_by(self.start.elapsed().as_micros() as u64);
-    }
 }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -6,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use mysten_metrics::monitored_scope;
 use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::VerifiedCertificate};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error};
@@ -65,7 +64,6 @@ impl TransactionManager {
     /// require shared object lock versions get passed in as input. But this function should not
     /// have many callsites. Investigate the alternatives here.
     pub(crate) async fn enqueue(&mut self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
-        let _scope = monitored_scope!("TransactionManager::enqueue");
         for cert in certs {
             let digest = *cert.digest();
             // hold the tx lock until we have finished checking if objects are missing, so that we

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+use mysten_metrics::monitored_scope;
 use sui_types::{base_types::TransactionDigest, error::SuiResult, messages::VerifiedCertificate};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error};
@@ -64,6 +65,7 @@ impl TransactionManager {
     /// require shared object lock versions get passed in as input. But this function should not
     /// have many callsites. Investigate the alternatives here.
     pub(crate) async fn enqueue(&mut self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
+        let _scope = monitored_scope!("TransactionManager::enqueue");
         for cert in certs {
             let digest = *cert.digest();
             // hold the tx lock until we have finished checking if objects are missing, so that we

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -501,7 +501,7 @@ impl LockServiceImpl {
         debug!("LockService command processing loop started");
         // NOTE: we use blocking_recv() as its faster than using regular async recv() with awaits in a loop
         while let Some(msg) = receiver.blocking_recv() {
-            let _scope = monitored_scope!("LockServiceCommandLoop");
+            let _scope = monitored_scope("LockServiceCommandLoop");
             match msg {
                 LockServiceCommands::Acquire {
                     epoch,
@@ -550,7 +550,7 @@ impl LockServiceImpl {
     fn run_queries_loop(&self, mut receiver: Receiver<LockServiceQueries>) {
         debug!("LockService queries processing loop started");
         while let Some(msg) = receiver.blocking_recv() {
-            let _scope = monitored_scope!("LockServiceQueryLoop");
+            let _scope = monitored_scope("LockServiceQueryLoop");
             match msg {
                 LockServiceQueries::GetLock {
                     object,

--- a/crates/sui-storage/src/lock_service.rs
+++ b/crates/sui-storage/src/lock_service.rs
@@ -16,6 +16,7 @@
 //! This allows reads to proceed without being blocked on writes.
 
 use futures::channel::oneshot;
+use mysten_metrics::monitored_scope;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -500,6 +501,7 @@ impl LockServiceImpl {
         debug!("LockService command processing loop started");
         // NOTE: we use blocking_recv() as its faster than using regular async recv() with awaits in a loop
         while let Some(msg) = receiver.blocking_recv() {
+            let _scope = monitored_scope!("LockServiceCommandLoop");
             match msg {
                 LockServiceCommands::Acquire {
                     epoch,
@@ -548,6 +550,7 @@ impl LockServiceImpl {
     fn run_queries_loop(&self, mut receiver: Receiver<LockServiceQueries>) {
         debug!("LockService queries processing loop started");
         while let Some(msg) = receiver.blocking_recv() {
+            let _scope = monitored_scope!("LockServiceQueryLoop");
             match msg {
                 LockServiceQueries::GetLock {
                     object,

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -8,7 +8,7 @@ use crate::{metrics::ConsensusMetrics, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use std::{
     cmp::{max, Ordering},
     collections::HashMap,
@@ -311,6 +311,8 @@ where
     async fn run_inner(mut self) -> StoreResult<()> {
         // Listen to incoming certificates.
         loop {
+            let _scope = monitored_scope!("NarwhalConsensus");
+
             tokio::select! {
                 Some(certificate) = self.rx_new_certificates.recv() => {
                     // If the core already moved to the next epoch we should pull the next

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -311,7 +311,7 @@ where
     async fn run_inner(mut self) -> StoreResult<()> {
         // Listen to incoming certificates.
         loop {
-            let _scope = monitored_scope!("NarwhalConsensus");
+            let _scope = monitored_scope("NarwhalConsensus");
 
             tokio::select! {
                 Some(certificate) = self.rx_new_certificates.recv() => {

--- a/narwhal/primary/src/certificate_waiter.rs
+++ b/narwhal/primary/src/certificate_waiter.rs
@@ -5,7 +5,7 @@ use crate::metrics::PrimaryMetrics;
 use config::Committee;
 use crypto::{NetworkPublicKey, PublicKey};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
-use mysten_metrics::{monitored_future, spawn_monitored_task};
+use mysten_metrics::{monitored_future, monitored_scope, spawn_monitored_task};
 use network::{P2pNetwork, PrimaryToPrimaryRpc};
 use rand::{rngs::ThreadRng, seq::SliceRandom};
 use std::{
@@ -272,14 +272,10 @@ impl CertificateWaiter {
         );
         self.fetch_certificates_task.push(
             spawn_monitored_task!(async move {
+                let _scope = monitored_scope!("CertificatesFetching");
                 state
                     .metrics
                     .certificate_waiter_inflight_fetch
-                    .with_label_values(&[&committee.epoch.to_string()])
-                    .inc();
-                state
-                    .metrics
-                    .certificate_waiter_fetch_attempts
                     .with_label_values(&[&committee.epoch.to_string()])
                     .inc();
 
@@ -298,11 +294,6 @@ impl CertificateWaiter {
                     }
                 };
 
-                state
-                    .metrics
-                    .certificate_waiter_op_latency
-                    .with_label_values(&[&committee.epoch.to_string()])
-                    .observe(now.elapsed().as_secs_f64());
                 state
                     .metrics
                     .certificate_waiter_inflight_fetch

--- a/narwhal/primary/src/certificate_waiter.rs
+++ b/narwhal/primary/src/certificate_waiter.rs
@@ -272,7 +272,7 @@ impl CertificateWaiter {
         );
         self.fetch_certificates_task.push(
             spawn_monitored_task!(async move {
-                let _scope = monitored_scope!("CertificatesFetching");
+                let _scope = monitored_scope("CertificatesFetching");
                 state
                     .metrics
                     .certificate_waiter_inflight_fetch

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -671,7 +671,7 @@ impl Core {
     pub async fn run(mut self) {
         info!("Core on node {} has started successfully.", self.name);
         loop {
-            let _scope = monitored_scope!("NarwhalCore");
+            let _scope = monitored_scope("NarwhalCore");
 
             let result = tokio::select! {
                 Some((certificate, notify)) = self.rx_certificates.recv() => {

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -15,7 +15,7 @@ use crypto::{NetworkPublicKey, PublicKey, Signature};
 use fastcrypto::{hash::Hash as _, SignatureService};
 use futures::StreamExt;
 use futures::{future::OptionFuture, stream::FuturesUnordered};
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use network::{anemo_ext::NetworkExt, CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc, time::Instant};
@@ -671,6 +671,8 @@ impl Core {
     pub async fn run(mut self) {
         info!("Core on node {} has started successfully.", self.name);
         loop {
+            let _scope = monitored_scope!("NarwhalCore");
+
             let result = tokio::select! {
                 Some((certificate, notify)) = self.rx_certificates.recv() => {
                     match self.sanitize_certificate(&certificate).await {

--- a/narwhal/primary/src/metrics.rs
+++ b/narwhal/primary/src/metrics.rs
@@ -337,12 +337,8 @@ pub struct PrimaryMetrics {
     pub highest_processed_round: IntGaugeVec,
     /// 0 if there is no inflight certificates fetching, 1 otherwise.
     pub certificate_waiter_inflight_fetch: IntGaugeVec,
-    /// Number of attempts to fetch certificates in certificate waiter.
-    pub certificate_waiter_fetch_attempts: IntGaugeVec,
     /// Number of fetched certificates successfully processed by core.
     pub certificate_waiter_num_certificates_processed: IntGaugeVec,
-    /// Latency per iteration of fetching and processing certificates.
-    pub certificate_waiter_op_latency: HistogramVec,
     /// Number of votes that were requested but not sent due to previously having voted differently
     pub votes_dropped_equivocation_protection: IntCounterVec,
     /// Number of pending batches in proposer
@@ -450,25 +446,10 @@ impl PrimaryMetrics {
                 registry
             )
             .unwrap(),
-            certificate_waiter_fetch_attempts: register_int_gauge_vec_with_registry!(
-                "certificate_waiter_fetch_attempts",
-                "Number of attempts to fetch certificates in certificate waiter.",
-                &["epoch"],
-                registry
-            )
-            .unwrap(),
             certificate_waiter_num_certificates_processed: register_int_gauge_vec_with_registry!(
                 "certificate_waiter_num_certificates_processed",
                 "Number of fetched certificates successfully processed by core.",
                 &["epoch"],
-                registry
-            )
-            .unwrap(),
-            certificate_waiter_op_latency: register_histogram_vec_with_registry!(
-                "certificate_waiter_op_latency",
-                "Latency per iteration of fetching and processing certificates",
-                &["epoch"],
-                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -110,7 +110,7 @@ impl BatchMaker {
         let mut batch_pipeline = FuturesOrdered::new();
 
         loop {
-            let _scope = monitored_scope!("NarwhalBatchMaker");
+            let _scope = monitored_scope("NarwhalBatchMaker");
 
             tokio::select! {
                 // Assemble client transactions into batches of preset size.

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 
 use futures::{Future, StreamExt};
 
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::{monitored_scope, spawn_monitored_task};
 use std::sync::Arc;
 use tokio::{
     sync::watch,
@@ -110,6 +110,8 @@ impl BatchMaker {
         let mut batch_pipeline = FuturesOrdered::new();
 
         loop {
+            let _scope = monitored_scope!("NarwhalBatchMaker");
+
             tokio::select! {
                 // Assemble client transactions into batches of preset size.
                 // Note that transactions are only consumed when the number of batches


### PR DESCRIPTION
This is a generalization of `TaskUtilizationExt` that we use in a few places. There are a few select loops and sections guarded by mutex that may become the bottleneck of the system. It is useful to monitor how "loaded" they are, and if increased load comes from increased number of calls. In future we can also record the number of times where a call is particularly long (> 1s or a user specified threshold).

@andll if you would like to, I can update the other callsites of `TaskUtilizationExt` and update the dashboards. Or I can revert the refactor in handle_consensus_transaction() etc.

As @mystenmark suggested this can also be implemented via trace spans. But the API is more involved, and I'm a bit worried about performance regression in tracing hurting hot loop performance. We can revisit if needed.