### PR TITLE
[reconfiguration] Reject all certificates when collected quorum of EndOfPublish messages

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -784,7 +784,7 @@ impl AuthorityState {
 
         let shared_locks: HashMap<_, _> = self
             .database
-            .epoch_tables()
+            .epoch_store()
             .get_all_shared_locks(transaction_digest)?
             .into_iter()
             .collect();
@@ -1521,9 +1521,14 @@ impl AuthorityState {
 
         // unwrap ok - for testing only.
         let store = Arc::new(
-            AuthorityStore::open(&path.join("store"), None, genesis)
-                .await
-                .unwrap(),
+            AuthorityStore::open_with_committee(
+                &path.join("store"),
+                None,
+                &genesis_committee,
+                genesis,
+            )
+            .await
+            .unwrap(),
         );
 
         let epochs = Arc::new(CommitteeStore::new(
@@ -1559,7 +1564,7 @@ impl AuthorityState {
         self.node_sync_store
             .batch_store_certs(certs.iter().cloned())?;
         self.database
-            .epoch_tables()
+            .epoch_store()
             .insert_pending_certificates(&certs)?;
         let mut transaction_manager = self.transaction_manager.lock().await;
         transaction_manager.enqueue(certs).await
@@ -1610,8 +1615,9 @@ impl AuthorityState {
         );
 
         self.committee_store.insert_new_committee(&new_committee)?;
-        self.committee.swap(Arc::new(new_committee));
-        self.db().reopen_epoch_db(self.epoch());
+        let new_committee = Arc::new(new_committee);
+        self.committee.swap(new_committee.clone());
+        self.db().reopen_epoch_db(new_committee);
         Ok(())
     }
 
@@ -1629,14 +1635,7 @@ impl AuthorityState {
 
     // This method can only be called from ConsensusAdapter::begin_reconfiguration
     pub fn close_user_certs(&self, lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>) {
-        self.database.epoch_tables().close_user_certs(lock_guard)
-    }
-
-    pub async fn close_all_certs(
-        &self,
-        lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>,
-    ) {
-        self.database.epoch_tables().close_all_certs(lock_guard)
+        self.database.epoch_store().close_user_certs(lock_guard)
     }
 
     pub(crate) async fn get_object(
@@ -2234,9 +2233,6 @@ impl AuthorityState {
             .handle_consensus_duration_mcs
             .utilization_timer();
         let tracking_id = transaction.get_tracking_id();
-        // TODO: Somewhere here we check if we have seen 2f+1 EndOfPublish message, and if so,
-        // we call self.get_reconfig_state_write_lock_guard to get a guard, and then call
-        // self.close_all_certs() to close it.
         match &transaction.kind {
             ConsensusTransactionKind::UserTransaction(certificate) => {
                 let authority = (&consensus_output.certificate.header.author).into();
@@ -2261,7 +2257,7 @@ impl AuthorityState {
 
                 if !self
                     .database
-                    .epoch_tables()
+                    .epoch_store()
                     .get_reconfig_state_read_lock_guard()
                     .should_accept_consensus_certs()
                 {
@@ -2300,11 +2296,12 @@ impl AuthorityState {
                     .await
             }
             ConsensusTransactionKind::EndOfPublish(authority) => {
-                // todo - track authority stake and generate last checkpoint when 2f+1 EndOfPublish received
                 debug!("Received EndOfPublish from {:?}", authority.concise());
+                // todo use return value to signal last checkpoint
                 self.database
                     .record_end_of_publish(*authority, &transaction, consensus_index)
-                    .await
+                    .await?;
+                Ok(())
             }
         }
     }

--- a/crates/sui-core/src/authority/authority_notifier.rs
+++ b/crates/sui-core/src/authority/authority_notifier.rs
@@ -253,6 +253,8 @@ mod tests {
     use std::env;
     use std::fs;
 
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
     use std::time::Duration;
     use tokio::time::timeout;
 
@@ -262,10 +264,21 @@ mod tests {
         let path = dir.join(format!("DB_{:?}", ObjectID::random()));
         fs::create_dir(&path).unwrap();
 
+        let seed = [1u8; 32];
+        let (committee, _, _authority_key) =
+            crate::authority_batch::batch_tests::init_state_parameters_from_rng(
+                &mut StdRng::from_seed(seed),
+            );
+
         let store = Arc::new(
-            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-                .await
-                .unwrap(),
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+            )
+            .await
+            .unwrap(),
         );
 
         let notifier = Arc::new(

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -171,6 +171,13 @@ where
         Ok(self.get_sui_system_state_object()?.epoch)
     }
 
+    pub fn get_committee(&self) -> SuiResult<Committee> {
+        Ok(self
+            .get_sui_system_state_object()?
+            .get_current_epoch_committee()
+            .committee)
+    }
+
     pub fn database_is_empty(&self) -> SuiResult<bool> {
         Ok(self
             .objects

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -135,7 +135,7 @@ where
             let _ = authority
                 .state
                 .database
-                .epoch_tables()
+                .epoch_store()
                 .remove_pending_certificate(&digest);
 
             authority

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -52,10 +52,6 @@ impl ReconfigState {
         self.status = ReconfigCertStatus::RejectAllCerts;
     }
 
-    pub fn open_all_certs(&mut self) {
-        self.status = ReconfigCertStatus::AcceptAllCerts;
-    }
-
     pub fn should_accept_user_certs(&self) -> bool {
         matches!(self.status, ReconfigCertStatus::AcceptAllCerts)
     }

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -193,9 +193,10 @@ impl<A> GatewayState<A> {
         let auth_agg_metrics = AuthAggMetrics::new(prometheus_registry);
         let safe_client_metrics = Arc::new(SafeClientMetrics::new(prometheus_registry));
         let gateway_store = Arc::new(
-            GatewayStore::open(
+            GatewayStore::open_with_committee(
                 &base_path.join("store"),
                 None,
+                &committee,
                 &Genesis::get_default_genesis(),
             )
             .await?,

--- a/crates/sui-core/src/stake_aggregator.rs
+++ b/crates/sui-core/src/stake_aggregator.rs
@@ -22,6 +22,17 @@ impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
         }
     }
 
+    pub fn from_iter<I: Iterator<Item = (AuthorityName, V)>>(
+        committee: Arc<Committee>,
+        data: I,
+    ) -> Self {
+        let mut this = Self::new(committee);
+        for (authority, v) in data {
+            this.insert(authority, v);
+        }
+        this
+    }
+
     pub fn insert(&mut self, authority: AuthorityName, v: V) -> InsertResult<V> {
         match self.data.entry(authority) {
             Entry::Occupied(oc) => {
@@ -42,7 +53,6 @@ impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
         }
     }
 
-    #[allow(dead_code)]
     pub fn contains_key(&self, authority: &AuthorityName) -> bool {
         self.data.contains_key(authority)
     }
@@ -59,7 +69,6 @@ pub enum InsertResult<'a, V> {
 }
 
 impl<'a, V> InsertResult<'a, V> {
-    #[allow(dead_code)]
     pub fn is_success(&self) -> bool {
         matches!(self, InsertResult::Success(_))
     }

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -87,7 +87,7 @@ impl ReadStore for RocksDbStore {
     ) -> Result<Option<VerifiedCertificate>, Self::Error> {
         if let Some(transaction) = self
             .authority_store
-            .epoch_tables()
+            .epoch_store()
             .get_pending_certificate(digest)?
         {
             return Ok(Some(transaction));
@@ -146,7 +146,7 @@ impl WriteStore for RocksDbStore {
 
     fn insert_transaction(&self, transaction: VerifiedCertificate) -> Result<(), Self::Error> {
         self.authority_store
-            .epoch_tables()
+            .epoch_store()
             .insert_pending_certificates(&[transaction])
     }
 

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -45,7 +45,7 @@ impl TransactionManager {
             .enqueue(
                 transaction_manager
                     .authority_store
-                    .epoch_tables()
+                    .epoch_store()
                     .all_pending_certificates()
                     .unwrap(),
             )
@@ -133,7 +133,7 @@ impl TransactionManager {
                 // Otherwise, this has to crash.
                 let cert = match self
                     .authority_store
-                    .epoch_tables()
+                    .epoch_store()
                     .get_pending_certificate(&digest)
                 {
                     Ok(Some(cert)) => cert,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1712,9 +1712,14 @@ async fn test_authority_persist() {
 
     // Create an authority
     let store = Arc::new(
-        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-            .await
-            .unwrap(),
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+        )
+        .await
+        .unwrap(),
     );
     let authority =
         crate::authority_batch::batch_tests::init_state(committee, authority_key, store).await;
@@ -1741,9 +1746,14 @@ async fn test_authority_persist() {
             &mut StdRng::from_seed(seed),
         );
     let store = Arc::new(
-        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-            .await
-            .unwrap(),
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+        )
+        .await
+        .unwrap(),
     );
     let authority2 =
         crate::authority_batch::batch_tests::init_state(committee, authority_key, store).await;
@@ -2725,7 +2735,7 @@ async fn shared_object() {
 
     let shared_object_version = authority
         .db()
-        .epoch_tables()
+        .epoch_store()
         .get_assigned_object_versions(transaction_digest, [shared_object_id].iter())
         .unwrap()[0]
         .unwrap();
@@ -2867,11 +2877,11 @@ async fn test_consensus_message_processed() {
     assert_eq!(
         authority1
             .database
-            .epoch_tables()
+            .epoch_store()
             .get_next_object_version(&shared_object_id),
         authority2
             .database
-            .epoch_tables()
+            .epoch_store()
             .get_next_object_version(&shared_object_id),
     );
 }

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -104,9 +104,14 @@ async fn test_open_manager() {
     {
         // Create an authority
         let store = Arc::new(
-            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-                .await
-                .unwrap(),
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+            )
+            .await
+            .unwrap(),
         );
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
@@ -139,9 +144,14 @@ async fn test_open_manager() {
     {
         // Create an authority
         let store = Arc::new(
-            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-                .await
-                .unwrap(),
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+            )
+            .await
+            .unwrap(),
         );
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
@@ -170,9 +180,14 @@ async fn test_open_manager() {
     {
         // Create an authority
         let store = Arc::new(
-            AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-                .await
-                .unwrap(),
+            AuthorityStore::open_with_committee(
+                &path,
+                None,
+                &committee,
+                &Genesis::get_default_genesis(),
+            )
+            .await
+            .unwrap(),
         );
         let mut authority_state = init_state(committee, authority_key, store.clone()).await;
 
@@ -195,16 +210,21 @@ async fn test_batch_manager_happy_path() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(
-        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-            .await
-            .unwrap(),
-    );
-
-    // Make a test key pair
     let seed = [1u8; 32];
     let (committee, _, authority_key) =
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+        )
+        .await
+        .unwrap(),
+    );
+
+    // Make a test key pair
     let authority_state = Arc::new(init_state(committee, authority_key, store.clone()).await);
 
     let inner_state = authority_state.clone();
@@ -273,16 +293,19 @@ async fn test_batch_manager_out_of_order() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(
-        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-            .await
-            .unwrap(),
-    );
-
-    // Make a test key pair
     let seed = [1u8; 32];
     let (committee, _, authority_key) =
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+        )
+        .await
+        .unwrap(),
+    );
     let authority_state = Arc::new(init_state(committee, authority_key, store.clone()).await);
 
     let inner_state = authority_state.clone();
@@ -347,16 +370,19 @@ async fn test_batch_manager_drop_out_of_order() {
     fs::create_dir(&path).unwrap();
 
     // Create an authority
-    let store = Arc::new(
-        AuthorityStore::open(&path, None, &Genesis::get_default_genesis())
-            .await
-            .unwrap(),
-    );
-
-    // Make a test key pair
     let seed = [1u8; 32];
     let (committee, _, authority_key) =
         init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
+    let store = Arc::new(
+        AuthorityStore::open_with_committee(
+            &path,
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+        )
+        .await
+        .unwrap(),
+    );
     let authority_state = Arc::new(init_state(committee, authority_key, store.clone()).await);
 
     let inner_state = authority_state.clone();
@@ -725,11 +751,15 @@ async fn test_safe_batch_stream() {
 
     authorities.insert(public_key_bytes, 1);
     let committee = Committee::new(0, authorities).unwrap();
-    // Create an authority
     let store = Arc::new(
-        AuthorityStore::open(&path.join("store"), None, &Genesis::get_default_genesis())
-            .await
-            .unwrap(),
+        AuthorityStore::open_with_committee(
+            &path.join("store"),
+            None,
+            &committee,
+            &Genesis::get_default_genesis(),
+        )
+        .await
+        .unwrap(),
     );
     let state = init_state(committee.clone(), authority_key, store).await;
     let committee_store = state.committee_store().clone();


### PR DESCRIPTION
This PR also renames AuthorityStore::epoch_tables -> epoch_store as it was quite confusing that `epoch_tables` method was in fact returning instance of Store.

https://github.com/MystenLabs/sui/issues/5763