### PR TITLE
[wal] Move wal to per-epoch store

### DIFF
--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -68,7 +68,8 @@ impl TransactionManager {
             let digest = *cert.digest();
             // hold the tx lock until we have finished checking if objects are missing, so that we
             // don't race with a concurrent execution of this tx.
-            let _tx_lock = self.authority_store.acquire_tx_lock(&digest);
+            let epoch_store = self.authority_store.epoch_store();
+            let _tx_lock = epoch_store.acquire_tx_lock(&digest);
 
             // Skip processing if the certificate is already enqueued.
             if self.pending_certificates.contains_key(&digest) {

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1239,8 +1239,8 @@ async fn test_handle_certificate_interrupted_retry() {
         }
         interrupted_count += 1;
 
-        let g = authority_state
-            .database
+        let epoch_store = authority_state.database.epoch_store();
+        let g = epoch_store
             .acquire_tx_guard(&shared_object_cert)
             .await
             .unwrap();


### PR DESCRIPTION
wal should be per-epoch, and should not be mixed across epochs.
This PR moves it there.
Note that we are now starting to expose things that need to be further improved down the road: instead of obtaining the epoch tables each time we need to access the wal, ideally we should make sure we always use the same epoch table in an entire call path.