### PR TITLE
[object][BUGFIX] Omission of `cfg(debug_assertions)` Guard.

### DIFF
--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -169,6 +169,7 @@ impl MoveObject {
         self.contents = new_contents;
 
         // Update should not modify ID
+        #[cfg(debug_assertions)]
         debug_assert_eq!(self.id(), old_id);
 
         Ok(())


### PR DESCRIPTION
I recently removed this because I assumed `debug_assert_eq!` would only be enabled under the `debug_assertions` config, but that turned out not to be true.

Test Plan:

```
sui$ cargo build --release
```