### PR TITLE
[wallet-kit] Move from peer dep to direct dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,13 +608,13 @@ importers:
       tsup: ^6.2.2
       typescript: ^4.8.3
     dependencies:
+      '@mysten/sui.js': link:../../../typescript
       '@mysten/wallet-adapter-base': link:../adapters/base-adapter
       '@mysten/wallet-adapter-react': link:../react-providers
       '@mysten/wallet-adapter-wallet-standard': link:../adapters/wallet-standard-adapter
       '@radix-ui/react-dialog': 1.0.2
       '@stitches/react': 1.2.8
     devDependencies:
-      '@mysten/sui.js': link:../../../typescript
       tsup: 6.2.2_typescript@4.8.3
       typescript: 4.8.3
 

--- a/sdk/wallet-adapter/packages/wallet-kit/README.md
+++ b/sdk/wallet-adapter/packages/wallet-kit/README.md
@@ -9,7 +9,7 @@ Sui Wallet Kit is a library that makes it easy to connect your dApp to Sui walle
 To get started in a React application, you can install the following packages:
 
 ```bash
-npm install @mysten/wallet-kit @mysten/sui.js
+npm install @mysten/wallet-kit
 ```
 
 At the root of your application, you can then set up the wallet kit provider:

--- a/sdk/wallet-adapter/packages/wallet-kit/package.json
+++ b/sdk/wallet-adapter/packages/wallet-kit/package.json
@@ -26,11 +26,11 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "@mysten/sui.js": "workspace:*",
     "react": "*",
     "react-dom": "*"
   },
   "dependencies": {
+    "@mysten/sui.js": "workspace:*",
     "@mysten/wallet-adapter-base": "workspace:*",
     "@mysten/wallet-adapter-react": "workspace:*",
     "@mysten/wallet-adapter-wallet-standard": "workspace:*",
@@ -38,7 +38,6 @@
     "@stitches/react": "^1.2.8"
   },
   "devDependencies": {
-    "@mysten/sui.js": "workspace:*",
     "tsup": "^6.2.2",
     "typescript": "^4.8.3"
   }


### PR DESCRIPTION
This moves from a peer sui dep to a direct one. Peer deps on premajor versions with changesets works weird, so we'll just avoid it for now. This is mostly for types anyway, so it shouldn't be a big issue.