### PR TITLE
crypto: use executeTransaction legacy if version < 0.18

### DIFF
--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -553,7 +553,7 @@ export class JsonRpcProvider extends Provider {
     try {
       let resp;
       let version = await this.getRpcApiVersion();
-      if (version?.major === 0 && version?.minor < 19) {
+      if (version?.major === 0 && version?.minor < 18) {
         resp = await this.client.requestWithType(
           'sui_executeTransaction',
           [txnBytes.toString(), signatureScheme, signature.toString(), pubkey.toString(), requestType],


### PR DESCRIPTION
since 18 is not released this should really be 18. otherwise if this gets deployed in 18, the client would call the new endpoint by mistake