### PR TITLE
Remove `dhat` feature and imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,22 +2043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 
 [[package]]
-name = "dhat"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2aaf837aaf456f6706cb46386ba8dffd4013a757e36f4ea05c20dd46b209a3"
-dependencies = [
- "backtrace",
- "lazy_static 1.4.0",
- "mintex",
- "parking_lot 0.12.1",
- "rustc-hash",
- "serde 1.0.147",
- "serde_json",
- "thousands",
-]
-
-[[package]]
 name = "diesel"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4013,16 +3997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mintex"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7c5ba1c3b5a23418d7bbf98c71c3d4946a0125002129231da8d6b723d559cb"
-dependencies = [
- "once_cell",
- "sys-info",
-]
-
-[[package]]
 name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5195,7 +5169,6 @@ dependencies = [
  "bytes",
  "cfg-if",
  "clap 2.34.0",
- "dhat",
  "eyre",
  "fastcrypto",
  "futures",
@@ -5250,7 +5223,6 @@ dependencies = [
  "bytes",
  "dashmap",
  "derive_builder",
- "dhat",
  "fastcrypto",
  "futures",
  "indexmap",
@@ -9237,16 +9209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "tabular"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9500,12 +9462,6 @@ dependencies = [
  "quote 1.0.21",
  "syn 1.0.104",
 ]
-
-[[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
@@ -10983,7 +10939,6 @@ dependencies = [
  "derive_more",
  "determinator",
  "deunicode",
- "dhat",
  "diesel",
  "diesel_derives",
  "diff",
@@ -11165,7 +11120,6 @@ dependencies = [
  "mime_guess",
  "minimal-lexical",
  "miniz_oxide",
- "mintex",
  "mio 0.7.14",
  "mio 0.8.4",
  "mockall",
@@ -11468,7 +11422,6 @@ dependencies = [
  "syn 1.0.104",
  "sync_wrapper",
  "synstructure",
- "sys-info",
  "tabular",
  "tap",
  "target-lexicon",
@@ -11487,7 +11440,6 @@ dependencies = [
  "textwrap 0.16.0",
  "thiserror",
  "thiserror-impl",
- "thousands",
  "thread_local",
  "threadpool",
  "thrift",

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -158,7 +158,6 @@ der-parser = { version = "8", features = ["bigint", "num-bigint", "std"] }
 derive_builder = { version = "0.12", features = ["std"] }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
-dhat = { version = "0.3", default-features = false }
 diesel = { version = "2", features = ["32-column-tables", "bitflags", "byteorder", "chrono", "itoa", "postgres", "postgres_backend", "pq-sys", "serde_json", "with-deprecated"] }
 diff = { version = "0.1", default-features = false }
 difference = { version = "2" }
@@ -308,7 +307,6 @@ mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.5", default-features = false }
-mintex = { version = "0.1", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 move-abigen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
@@ -535,7 +533,6 @@ subtle = { version = "2", default-features = false, features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false, features = ["std"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
-sys-info = { version = "0.9", default-features = false }
 tabular = { version = "0.2", features = ["ansi-cell", "strip-ansi-escapes", "unicode-width"] }
 tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
@@ -552,7 +549,6 @@ textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-fe
 textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", default-features = false }
 textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", features = ["smawk", "unicode-linebreak", "unicode-width"] }
 thiserror = { version = "1", default-features = false }
-thousands = { version = "0.2", default-features = false }
 thread_local = { version = "1", default-features = false }
 threadpool = { version = "1", default-features = false }
 thrift = { version = "0.16", features = ["log", "server", "threadpool"] }
@@ -815,7 +811,6 @@ derive_builder_macro = { version = "0.12", default-features = false }
 derive_more = { version = "0.99", features = ["add", "add_assign", "as_mut", "as_ref", "constructor", "convert_case", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "iterator", "mul", "mul_assign", "not", "rustc_version", "sum", "try_into", "unwrap"] }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
-dhat = { version = "0.3", default-features = false }
 diesel = { version = "2", features = ["32-column-tables", "bitflags", "byteorder", "chrono", "itoa", "postgres", "postgres_backend", "pq-sys", "serde_json", "with-deprecated"] }
 diesel_derives = { version = "2", features = ["32-column-tables", "postgres", "with-deprecated"] }
 diff = { version = "0.1", default-features = false }
@@ -981,7 +976,6 @@ mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.5", default-features = false }
-mintex = { version = "0.1", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
@@ -1256,7 +1250,6 @@ syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-i
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
 synstructure = { version = "0.12", features = ["proc-macro"] }
-sys-info = { version = "0.9", default-features = false }
 tabular = { version = "0.2", features = ["ansi-cell", "strip-ansi-escapes", "unicode-width"] }
 tap = { version = "1", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
@@ -1275,7 +1268,6 @@ textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", default-fe
 textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", features = ["smawk", "unicode-linebreak", "unicode-width"] }
 thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
-thousands = { version = "0.2", default-features = false }
 thread_local = { version = "1", default-features = false }
 threadpool = { version = "1", default-features = false }
 thrift = { version = "0.16", features = ["log", "server", "threadpool"] }

--- a/narwhal/benchmark/README.md
+++ b/narwhal/benchmark/README.md
@@ -20,7 +20,6 @@ bench_params = {
     'tx_size': 512,
     'faults': 0,
     'duration': 300,
-    'mem_profiling': False
 }
 ```
 They specify the number of primaries (`nodes`) and workers per primary (`workers`) to deploy, the input rate (transactions per second, or tx/s) at which the clients submit transactions to the system (`rate`), the size of each transaction in bytes (`tx_size`), the number of faulty nodes (`faults`), and the duration of the benchmark in seconds (`duration`). The minimum transaction size is 9 bytes; this ensures the transactions of a client are all different.
@@ -115,19 +114,19 @@ Here is sample output:
 ```
 The 'Consensus TPS' and 'Consensus latency' report the average throughput and latency without considering the client, respectively. The consensus latency thus refers to the time elapsed between the block's creation and its commit. In contrast, `End-to-end TPS` and `End-to-end latency` report the performance of the whole system, starting from when the client submits the transaction. The end-to-end latency is often called 'client-perceived latency'. To accurately measure this value without degrading performance, the client periodically submits 'sample' transactions that are tracked across all the modules until they get committed into a block; the benchmark scripts use sample transactions to estimate the end-to-end latency.
 
-### Memory/Allocation Profiling
+### Memory / Allocation Profiling
 
-There is an option to run the benchmark in memory allocation profiling mode.  This slows down the benchmark,
-replacing the global allocator with one which profiles allocations.  It requires the `dhat-heap` compiler feature
-to be turned on.  To enable memory profiling mode, set the following benchmark options:
+Memory profiling for benchmarks are possible via `jemalloc` on Linux. It can be enabled in the following way:
 
-* `'mem_profiling': True`
-* `duration`: This should be set to 5 minutes or longer
+* Intall `jemalloc`, e.g. `sudo apt install libjemalloc-dev`
+* Enable `jemalloc` by setting `export MALLOC_CONF=prof:true,prof_prefix:jeprof.out,lg_prof_interval:33` before launching the benchmark script.
 
-`dhat-heap-*.json` files will be written to the benchmark dir, one for each primary.
-You might not get files for all primaries as some primaries might die with a panic (see https://github.com/nnethercote/dhat-rs/issues/19).
+Memory profiles with names `jeprof.out*` will be written to the currently directory.
 
-To view the profiling information, use the [hosted viewer](https://nnethercote.github.io/dh_view/dh_view.html) or see [the viewing instructions](https://docs.rs/dhat/latest/dhat/index.html#viewing) for details.
+To visualize the profile,
+
+* Intall `graphviz`, e.g. `sudo apt install graphviz`
+* `sudo jeprof --svg <path to Narwhal binary> <path to profile> > prof.svg`
 
 ## AWS Benchmarks
 This repo integrates various Python scripts to deploy and benchmark the codebase on [Amazon Web Services (AWS)](https://aws.amazon.com). They are particularly useful to run benchmarks in the WAN, across multiple data centers. This section provides a step-by-step tutorial explaining how to use them.

--- a/narwhal/benchmark/benchmark/commands.py
+++ b/narwhal/benchmark/benchmark/commands.py
@@ -17,13 +17,8 @@ class CommandMaker:
         return f'rm -r {PathMaker.logs_path()} ; mkdir -p {PathMaker.logs_path()}'
 
     @staticmethod
-    def compile(mem_profiling):
-        if mem_profiling:
-            params = ["--profile", "bench-profiling",
-                      "--features", "benchmark dhat-heap"]
-        else:
-            params = ["--release", "--features", "benchmark"]
-        return ["cargo", "build", "--quiet"] + params
+    def compile():
+        return ["cargo", "build", "--quiet", "--release", "--features", "benchmark"]
 
     @staticmethod
     def generate_key(filename):

--- a/narwhal/benchmark/benchmark/config.py
+++ b/narwhal/benchmark/benchmark/config.py
@@ -291,11 +291,6 @@ class BenchParameters:
 
             self.duration = int(json['duration'])
 
-            if 'mem_profiling' in json:
-                self.mem_profile = bool(json['mem_profiling'])
-            else:
-                self.mem_profile = False
-
             self.runs = int(json['runs']) if 'runs' in json else 1
         except KeyError as e:
             raise ConfigError(f'Malformed bench parameters: missing key {e}')

--- a/narwhal/benchmark/benchmark/full_demo.py
+++ b/narwhal/benchmark/benchmark/full_demo.py
@@ -59,10 +59,10 @@ class Demo:
             sleep(0.5)  # Removing the store may take time.
 
             # Recompile the latest code.
-            cmd = CommandMaker.compile(mem_profiling=self.mem_profile)
+            cmd = CommandMaker.compile()
             subprocess.run(cmd, check=True, cwd=PathMaker.node_crate_path())
             # Recompile the latest code.
-            cmd = CommandMaker.compile(mem_profiling=self.mem_profile)
+            cmd = CommandMaker.compile()
             subprocess.run(cmd, check=True,
                            cwd=PathMaker.examples_crate_path())
 

--- a/narwhal/benchmark/benchmark/local.py
+++ b/narwhal/benchmark/benchmark/local.py
@@ -52,7 +52,7 @@ class LocalBench:
             sleep(0.5)  # Removing the store may take time.
 
             # Recompile the latest code.
-            cmd = CommandMaker.compile(mem_profiling=self.mem_profile)
+            cmd = CommandMaker.compile()
             Print.info(f"About to run {cmd}...")
             subprocess.run(cmd, check=True, cwd=PathMaker.node_crate_path())
 

--- a/narwhal/benchmark/benchmark/remote.py
+++ b/narwhal/benchmark/benchmark/remote.py
@@ -147,8 +147,7 @@ class Bench:
         Print.info(
             f'Updating {len(ips)} machines (branch "{self.settings.branch}")...'
         )
-        compile_cmd = ' '.join(CommandMaker.compile(
-            mem_profiling=bench_parameters.mem_profile))
+        compile_cmd = ' '.join(CommandMaker.compile())
         cmd = [
             f'(cd {self.settings.repo_name} && git fetch -f)',
             f'(cd {self.settings.repo_name} && git checkout -f {self.settings.branch} --)',
@@ -171,8 +170,7 @@ class Bench:
         sleep(0.5)  # Removing the store may take time.
 
         # Recompile the latest code.
-        cmd = CommandMaker.compile(
-            mem_profiling=bench_parameters.mem_profile)
+        cmd = CommandMaker.compile()
         Print.info(f"About to run {cmd}...")
         subprocess.run(cmd, check=True, cwd=PathMaker.node_crate_path())
 

--- a/narwhal/benchmark/benchmark/seed.py
+++ b/narwhal/benchmark/benchmark/seed.py
@@ -55,7 +55,7 @@ class SeedData:
             sleep(0.5)  # Removing the store may take time.
 
             # Recompile the latest code.
-            cmd = CommandMaker.compile(mem_profiling=self.mem_profile)
+            cmd = CommandMaker.compile()
             subprocess.run(cmd, check=True, cwd=PathMaker.node_crate_path())
 
             # Create alias for the client and nodes binary.

--- a/narwhal/benchmark/fabfile.py
+++ b/narwhal/benchmark/fabfile.py
@@ -21,7 +21,6 @@ def local(ctx, debug=True):
         'rate': 50_000,
         'tx_size': 512,
         'duration': 20,
-        'mem_profiling': False
     }
     node_params = {
         'header_num_of_batches_threshold': 32,
@@ -71,7 +70,6 @@ def demo(ctx, debug=True):
         'rate': 50_000,
         'tx_size': 512,
         'duration': 10,
-        'mem_profiling': False
     }
     node_params = {
         "batch_size": 500000,
@@ -123,7 +121,6 @@ def seed(ctx, starting_data_port):
         'rate': 50_000,
         'tx_size': 512,
         'duration': 20,
-        'mem_profiling': False
     }
     try:
         SeedData(bench_params).run(int(starting_data_port))
@@ -197,7 +194,6 @@ def remote(ctx, debug=False):
         'tx_size': 512,
         'duration': 300,
         'runs': 2,
-        'mem_profiling': False
     }
     node_params = {
         'header_num_of_batches_threshold': 32,

--- a/narwhal/node/Cargo.toml
+++ b/narwhal/node/Cargo.toml
@@ -13,7 +13,6 @@ bincode = "1.3.3"
 bytes = "1.3.0"
 cfg-if = "1.0.0"
 clap = "2.34"
-dhat = { version = "0.3.2", optional = true }
 futures = "0.3.24"
 multiaddr = "0.16.0"
 rand = "0.8.5"
@@ -61,7 +60,6 @@ test-utils = { path = "../test-utils", package = "narwhal-test-utils" }
 
 [features]
 benchmark = ["worker/benchmark", "primary/benchmark", "consensus/benchmark"]
-dhat-heap = ["dhat"]    # if you are doing heap profiling
 trace_transaction = ["worker/trace_transaction"]
 
 [[bin]]

--- a/narwhal/node/src/main.rs
+++ b/narwhal/node/src/main.rs
@@ -34,10 +34,6 @@ use tracing::subscriber::set_global_default;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use worker::TrivialTransactionValidator;
 
-#[cfg(feature = "dhat-heap")]
-#[global_allocator]
-static ALLOC: dhat::Alloc = dhat::Alloc;
-
 #[tokio::main]
 async fn main() -> Result<(), eyre::Report> {
     let matches = App::new(crate_name!())

--- a/narwhal/primary/Cargo.toml
+++ b/narwhal/primary/Cargo.toml
@@ -18,7 +18,6 @@ bytes = "1.3.0"
 config = { path = "../config", package = "narwhal-config" }
 dashmap = "5.4.0"
 derive_builder = "0.12.0"
-dhat = { version = "0.3.2", optional = true }
 futures = "0.3.24"
 itertools = "0.10.5"
 multiaddr = "0.16.0"
@@ -73,4 +72,3 @@ reqwest = { version = "0.11.13", features = ["json"] }
 
 [features]
 benchmark = []
-dhat-heap = ["dhat"]    # if you are doing heap profiling


### PR DESCRIPTION
During the past few months, we don't seem to have used `dhat` for memory profiling, so cleaning up the feature for now.

`jemalloc` should be used for memory profiling instead. I will update the docs later.