### PR TITLE
Key `assigned_object_versions` by TransactionDigest

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -765,7 +765,7 @@ impl AuthorityState {
         let shared_locks: HashMap<_, _> = self
             .database
             .epoch_store()
-            .get_all_shared_locks(transaction_digest)?
+            .get_shared_locks(transaction_digest)?
             .into_iter()
             .collect();
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -65,12 +65,17 @@ pub struct AuthorityEpochTables<S> {
     #[default_options_override_fn = "transactions_table_default_config"]
     transactions: DBMap<TransactionDigest, TrustedEnvelope<SenderSignedData, S>>,
 
-    /// Hold the lock for shared objects. These locks are written by a single task: upon receiving a valid
-    /// certified transaction from consensus, the authority assigns a lock to each shared objects of the
-    /// transaction. Note that all authorities are guaranteed to assign the same lock to these objects.
-    /// TODO: These two maps should be merged into a single one (no reason to have two).
-    assigned_object_versions: DBMap<(TransactionDigest, ObjectID), SequenceNumber>,
-    next_object_versions: DBMap<ObjectID, SequenceNumber>,
+    /// The two tables below manage shared object locks / versions. There are two ways they can be
+    /// updated:
+    /// 1. Upon receiving a certified transaction from consensus, the authority assigns the next
+    /// version to each shared object of the transaction. The next versions of the shared objects
+    /// are updated as well.
+    /// 2. Upon receiving a certified effect, the authority assigns the shared object versions from
+    /// the effect to the transaction of the effect. Next object versions are not updated.
+    ///
+    /// REQUIRED: all authorities must assign the same shared object versions for each transaction.
+    assigned_shared_object_versions: DBMap<TransactionDigest, Vec<(ObjectID, SequenceNumber)>>,
+    next_shared_object_versions: DBMap<ObjectID, SequenceNumber>,
 
     /// Certificates that have been received from clients or received from consensus, but not yet
     /// executed. Entries are cleared after execution.
@@ -84,7 +89,7 @@ pub struct AuthorityEpochTables<S> {
     pending_certificates: DBMap<TransactionDigest, TrustedCertificate>,
 
     /// Track which transactions have been processed in handle_consensus_transaction. We must be
-    /// sure to advance next_object_versions exactly once for each transaction we receive from
+    /// sure to advance next_shared_object_versions exactly once for each transaction we receive from
     /// consensus. But, we may also be processing transactions from checkpoints, so we need to
     /// track this state separately.
     ///
@@ -236,11 +241,11 @@ where
         Ok(self.tables.transactions.get(tx_digest)?.map(|t| t.into()))
     }
 
-    pub fn multi_get_next_object_versions<'a>(
+    pub fn multi_get_next_shared_object_versions<'a>(
         &self,
         ids: impl Iterator<Item = &'a ObjectID>,
     ) -> SuiResult<Vec<Option<SequenceNumber>>> {
-        Ok(self.tables.next_object_versions.multi_get(ids)?)
+        Ok(self.tables.next_shared_object_versions.multi_get(ids)?)
     }
 
     pub fn get_last_checkpoint_boundary(&self) -> Option<(u64, u64)> {
@@ -311,63 +316,64 @@ where
             .collect()
     }
 
-    /// Read a lock for a specific (transaction, shared object) pair.
-    pub fn get_all_shared_locks(
+    /// Read shared object locks / versions for a specific transaction.
+    pub fn get_shared_locks(
         &self,
         transaction_digest: &TransactionDigest,
     ) -> Result<Vec<(ObjectID, SequenceNumber)>, SuiError> {
         Ok(self
             .tables
-            .assigned_object_versions
-            .iter()
-            .skip_to(&(*transaction_digest, ObjectID::ZERO))?
-            .take_while(|((tx, _objid), _ver)| tx == transaction_digest)
-            .map(|((_tx, objid), ver)| (objid, ver))
-            .collect())
+            .assigned_shared_object_versions
+            .get(transaction_digest)?
+            .unwrap_or_default())
     }
 
     #[cfg(test)]
     pub fn get_next_object_version(&self, obj: &ObjectID) -> Option<SequenceNumber> {
-        self.tables.next_object_versions.get(obj).unwrap()
+        self.tables.next_shared_object_versions.get(obj).unwrap()
     }
 
     /// Read a lock for a specific (transaction, shared object) pair.
     #[cfg(test)] // Nothing wrong with this function, but it is not currently used outside of tests
-    pub fn get_assigned_object_versions<'a>(
+    pub fn get_assigned_shared_object_versions<'a>(
         &self,
         transaction_digest: &TransactionDigest,
         object_ids: impl Iterator<Item = &'a ObjectID>,
     ) -> Result<Vec<Option<SequenceNumber>>, SuiError> {
-        let keys = object_ids.map(|objid| (*transaction_digest, *objid));
-
-        self.tables
-            .assigned_object_versions
-            .multi_get(keys)
-            .map_err(SuiError::from)
+        let object_keys: std::collections::BTreeMap<_, _> = self
+            .get_shared_locks(transaction_digest)?
+            .into_iter()
+            .collect();
+        Ok(object_ids.map(|id| object_keys.get(id).cloned()).collect())
     }
 
     pub fn remove_shared_objects_locks(
         &self,
-        sequenced_to_delete: &[(TransactionDigest, ObjectID)],
-        schedule_to_delete: &[ObjectID],
+        executed_transaction: &TransactionDigest,
+        deleted_objects: &[ObjectID],
     ) -> SuiResult {
-        let mut write_batch = self.tables.assigned_object_versions.batch();
+        let mut write_batch = self.tables.assigned_shared_object_versions.batch();
+        write_batch = write_batch.delete_batch(
+            &self.tables.assigned_shared_object_versions,
+            vec![executed_transaction],
+        )?;
         write_batch =
-            write_batch.delete_batch(&self.tables.assigned_object_versions, sequenced_to_delete)?;
-        write_batch =
-            write_batch.delete_batch(&self.tables.next_object_versions, schedule_to_delete)?;
+            write_batch.delete_batch(&self.tables.next_shared_object_versions, deleted_objects)?;
         write_batch.write()?;
         Ok(())
     }
 
-    pub fn insert_assigned_shared_object_versions(
+    pub fn set_assigned_shared_object_versions(
         &self,
-        sequenced: Vec<((TransactionDigest, ObjectID), SequenceNumber)>,
+        transaction_digest: &TransactionDigest,
+        assigned_versions: Vec<(ObjectID, SequenceNumber)>,
     ) -> SuiResult {
-        let mut write_batch = self.tables.assigned_object_versions.batch();
-        write_batch = write_batch.insert_batch(&self.tables.assigned_object_versions, sequenced)?;
+        let mut write_batch = self.tables.assigned_shared_object_versions.batch();
+        write_batch = write_batch.insert_batch(
+            &self.tables.assigned_shared_object_versions,
+            vec![(transaction_digest, assigned_versions)],
+        )?;
         write_batch.write()?;
-
         Ok(())
     }
 
@@ -499,18 +505,20 @@ where
         key: ConsensusTransactionKey,
         certificate: &VerifiedCertificate,
         consensus_index: ExecutionIndicesWithHash,
-        sequenced_to_write: Vec<((TransactionDigest, ObjectID), SequenceNumber)>,
-        schedule_to_write: Vec<(ObjectID, SequenceNumber)>,
+        assigned_versions: Vec<(ObjectID, SequenceNumber)>,
+        next_versions: Vec<(ObjectID, SequenceNumber)>,
     ) -> SuiResult {
         // Atomically store all elements.
         // TODO: clear the shared object locks per transaction after ensuring consistency.
-        let mut write_batch = self.tables.assigned_object_versions.batch();
+        let mut write_batch = self.tables.assigned_shared_object_versions.batch();
+
+        write_batch = write_batch.insert_batch(
+            &self.tables.assigned_shared_object_versions,
+            vec![(certificate.digest(), assigned_versions)],
+        )?;
 
         write_batch =
-            write_batch.insert_batch(&self.tables.assigned_object_versions, sequenced_to_write)?;
-
-        write_batch =
-            write_batch.insert_batch(&self.tables.next_object_versions, schedule_to_write)?;
+            write_batch.insert_batch(&self.tables.next_shared_object_versions, next_versions)?;
 
         self.finish_consensus_certificate_process_with_batch(
             write_batch,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -347,7 +347,7 @@ where
         Ok(object_ids.map(|id| object_keys.get(id).cloned()).collect())
     }
 
-    pub fn remove_shared_objects_locks(
+    pub fn delete_shared_object_versions(
         &self,
         executed_transaction: &TransactionDigest,
         deleted_objects: &[ObjectID],

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -299,7 +299,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                     let shared_locks = shared_locks_cell.get_or_try_init(|| {
                         Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
                             self.epoch_store()
-                                .get_all_shared_locks(digest)?
+                                .get_shared_locks(digest)?
                                 .into_iter()
                                 .collect(),
                         )
@@ -370,7 +370,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                     let shared_locks = shared_locks_cell.get_or_try_init(|| {
                         Ok::<HashMap<ObjectID, SequenceNumber>, SuiError>(
                             self.epoch_store()
-                                .get_all_shared_locks(digest)?
+                                .get_shared_locks(digest)?
                                 .into_iter()
                                 .collect(),
                         )
@@ -695,7 +695,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // Cleanup the lock of the shared objects. This must be done after we write effects, as
         // effects_exists is used as the guard to avoid re-locking objects for a previously
         // executed tx. remove_shared_objects_locks.
-        self.remove_shared_objects_locks(transaction_digest, certificate)?;
+        self.remove_shared_objects_locks(certificate)?;
 
         Ok(seq)
     }
@@ -1139,22 +1139,15 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
     }
 
     /// Remove the shared objects locks.
-    pub fn remove_shared_objects_locks(
-        &self,
-        transaction_digest: &TransactionDigest,
-        transaction: &VerifiedCertificate,
-    ) -> SuiResult {
-        let mut sequenced_to_delete = Vec::new();
-        let mut schedule_to_delete = Vec::new();
+    pub fn remove_shared_objects_locks(&self, transaction: &VerifiedCertificate) -> SuiResult {
+        let mut deleted_objects = Vec::new();
         for (object_id, _) in transaction.shared_input_objects() {
-            sequenced_to_delete.push((*transaction_digest, *object_id));
-
             if !self.object_exists(*object_id)? {
-                schedule_to_delete.push(*object_id);
+                deleted_objects.push(*object_id);
             }
         }
         self.epoch_store()
-            .remove_shared_objects_locks(&sequenced_to_delete, &schedule_to_delete)
+            .remove_shared_objects_locks(transaction.digest(), &deleted_objects)
     }
 
     /// Lock a sequence number for the shared objects of the input transaction based on the effects
@@ -1167,17 +1160,14 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // lock.
         _tx_guard: &CertTxGuard<'_>,
     ) -> SuiResult {
-        let digest = *certificate.digest();
-
-        let sequenced: Vec<_> = effects
-            .shared_objects
-            .iter()
-            .map(|(id, version, _)| ((digest, *id), *version))
-            .collect();
-        debug!(?sequenced, "Shared object locks sequenced from effects");
-
-        self.epoch_store()
-            .insert_assigned_shared_object_versions(sequenced)
+        self.epoch_store().set_assigned_shared_object_versions(
+            certificate.digest(),
+            effects
+                .shared_objects
+                .iter()
+                .map(|(id, version, _)| (*id, *version))
+                .collect(),
+        )
     }
 
     pub fn consensus_message_processed(
@@ -1255,14 +1245,14 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // Make an iterator to update the locks of the transaction's shared objects.
         let ids = certificate.shared_input_objects().map(|(id, _)| id);
         let epoch_store = self.epoch_store();
-        let versions = epoch_store.multi_get_next_object_versions(ids)?;
+        let versions = epoch_store.multi_get_next_shared_object_versions(ids)?;
 
         let mut input_object_keys = certificate_input_object_keys(certificate)?;
-        let mut sequenced_to_write = Vec::new();
+        let mut assigned_versions = Vec::new();
         for ((id, initial_shared_version), v) in
             certificate.shared_input_objects().zip(versions.iter())
         {
-            // On epoch changes, the `next_object_versions` table will be empty, and we rely on
+            // On epoch changes, the `next_shared_object_versions` table will be empty, and we rely on
             // parent sync to recover the current version of the object.  However, if an object was
             // previously aware of the object as owned, and it was upgraded to shared, the version
             // in parent sync may be out of date, causing a fork.  In that case, we know that the
@@ -1282,20 +1272,19 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
                 ),
             };
 
-            sequenced_to_write.push(((transaction_digest, *id), version));
+            assigned_versions.push((*id, version));
             input_object_keys.push(ObjectKey(*id, version));
         }
 
         let next_version =
             SequenceNumber::lamport_increment(input_object_keys.iter().map(|obj| obj.1));
-
-        let schedule_to_write: Vec<_> = sequenced_to_write
+        let next_versions: Vec<_> = assigned_versions
             .iter()
-            .map(|((_, id), _)| (*id, next_version))
+            .map(|(id, _)| (*id, next_version))
             .collect();
 
         trace!(tx_digest = ?transaction_digest,
-               ?sequenced_to_write, ?schedule_to_write,
+               ?assigned_versions, ?next_version,
                "locking shared objects");
 
         // Make an iterator to update the last consensus index.
@@ -1303,7 +1292,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         // Holding _tx_lock avoids the following race:
         // - we check effects_exist, returns false
         // - another task (starting from handle_node_sync_certificate) writes effects,
-        //    and then deletes locks from assigned_object_versions
+        //    and then deletes locks from assigned_shared_object_versions
         // - we write to assigned_object versions, re-creating the locks that were just deleted
         // - now it's possible to run a new tx against old versions of the shared objects.
         let _tx_lock = epoch_store.acquire_tx_lock(&transaction_digest).await;
@@ -1315,8 +1304,8 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             transaction.key(),
             certificate,
             consensus_index,
-            sequenced_to_write,
-            schedule_to_write,
+            assigned_versions,
+            next_versions,
         )
     }
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2736,7 +2736,7 @@ async fn shared_object() {
     let shared_object_version = authority
         .db()
         .epoch_store()
-        .get_assigned_object_versions(transaction_digest, [shared_object_id].iter())
+        .get_assigned_shared_object_versions(transaction_digest, [shared_object_id].iter())
         .unwrap()[0]
         .unwrap();
     assert_eq!(shared_object_version, OBJECT_START_VERSION);

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2736,9 +2736,17 @@ async fn shared_object() {
     let shared_object_version = authority
         .db()
         .epoch_store()
-        .get_assigned_shared_object_versions(transaction_digest, [shared_object_id].iter())
-        .unwrap()[0]
-        .unwrap();
+        .get_shared_locks(transaction_digest)
+        .expect("Reading shared locks should not fail")
+        .into_iter()
+        .find_map(|(object_id, version)| {
+            if object_id == shared_object_id {
+                Some(version)
+            } else {
+                None
+            }
+        })
+        .expect("Shared object must be locked");
     assert_eq!(shared_object_version, OBJECT_START_VERSION);
 
     // Finally process the certificate and execute the contract. Ensure that the


### PR DESCRIPTION
Currently the `assigned_object_versions` table is keyed by `(TransactionDigest, ObjectID)`. Shared object versions for a given transaction are inserted when the transaction is received from consensus, and deleted after the transaction finished execution. It is expected that the column family for `assigned_object_versions` contains mostly deletion tombstones.

However this does not work well with how the table is queried. The current query logic is:
```
pub fn get_all_shared_locks(
    &self,
    transaction_digest: &TransactionDigest,
) -> Result<Vec<(ObjectID, SequenceNumber)>, SuiError> {
    Ok(self
        .tables
        .assigned_object_versions
        .iter()
        .skip_to(&(*transaction_digest, ObjectID::ZERO))?
        .take_while(|((tx, _objid), _ver)| tx == transaction_digest)
        .map(|((_tx, objid), ver)| (objid, ver))
        .collect())
}
```
which has two problems:
1. `iter()` seeks to the start of the table, so it needs to go through many tombstones (majority of the column family data).
2. By limiting the scan with `take_while()`, the scan makes one additional seek for non-deleted row after finishing reading all rows prefixed with `transaction_digest`. This additional seek can scan over many tombstones, or until the end of the table.

This issue is observed in tests, where `handle_consensus_transaction()` is taking much longer than before we start to delete from the `assigned_object_versions` table.

The PR avoids this issue by keying `assigned_object_versions` by TransactionDigest, and convert the scan to a single lookup. In a future follow up I plan to refactor the `iter()` and `take_while()` methods to be less error prone.