### PR TITLE
Execution mode for dev-inspect

### DIFF
--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -7,9 +7,16 @@ use sui_types::error::ExecutionError;
 pub type TransactionIndex = usize;
 
 pub trait ExecutionMode {
+    /// the type of a single Move call execution
     type ExecutionResult;
+
+    /// the gathered results from batched executions
     type ExecutionResults;
 
+    /// Controls two things:
+    /// - the calling of arbitrary Move functions
+    /// - the ability to instantiate any Move function parameter with a Pure call arg.
+    ///   In other words, you can instantiate any struct or object or other value with its BCS bytes.
     fn allow_arbitrary_function_calls() -> bool;
 
     fn make_result(
@@ -49,6 +56,9 @@ impl ExecutionMode for Normal {
     }
 }
 
+/// WARNING! Using this mode will bypass all normal checks around Move entry functions! This
+/// includes the various rules for function arguments, meaning any object can be created just from
+/// BCS bytes!
 pub struct DevInspect;
 
 impl ExecutionMode for DevInspect {

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -47,13 +47,9 @@ impl ExecutionMode for Normal {
         Ok(())
     }
 
-    fn empty_results() -> Self::ExecutionResults {
-        ()
-    }
+    fn empty_results() -> Self::ExecutionResults {}
 
-    fn add_result(_: &mut Self::ExecutionResults, _: TransactionIndex, _: Self::ExecutionResult) {
-        ()
-    }
+    fn add_result(_: &mut Self::ExecutionResults, _: TransactionIndex, _: Self::ExecutionResult) {}
 }
 
 /// WARNING! Using this mode will bypass all normal checks around Move entry functions! This

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_vm_runtime::session::SerializedReturnValues;
+use sui_types::error::ExecutionError;
+
+pub type TransactionIndex = usize;
+
+pub trait ExecutionMode {
+    type ExecutionResult;
+    type ExecutionResults;
+
+    fn allow_arbitrary_function_calls() -> bool;
+
+    fn make_result(
+        return_values: &SerializedReturnValues,
+    ) -> Result<Self::ExecutionResult, ExecutionError>;
+
+    fn empty_results() -> Self::ExecutionResults;
+
+    fn add_result(
+        results: &mut Self::ExecutionResults,
+        idx: TransactionIndex,
+        result: Self::ExecutionResult,
+    );
+}
+
+pub struct Normal;
+
+impl ExecutionMode for Normal {
+    type ExecutionResult = ();
+    type ExecutionResults = ();
+
+    fn allow_arbitrary_function_calls() -> bool {
+        false
+    }
+
+    fn make_result(srv: &SerializedReturnValues) -> Result<Self::ExecutionResult, ExecutionError> {
+        assert_invariant!(srv.return_values.is_empty(), "Return values must be empty");
+        Ok(())
+    }
+
+    fn empty_results() -> Self::ExecutionResults {
+        ()
+    }
+
+    fn add_result(_: &mut Self::ExecutionResults, _: TransactionIndex, _: Self::ExecutionResult) {
+        ()
+    }
+}
+
+pub struct DevInspect;
+
+impl ExecutionMode for DevInspect {
+    type ExecutionResult = SerializedReturnValues;
+    type ExecutionResults = Vec<(TransactionIndex, SerializedReturnValues)>;
+
+    fn allow_arbitrary_function_calls() -> bool {
+        true
+    }
+
+    fn make_result(srv: &SerializedReturnValues) -> Result<Self::ExecutionResult, ExecutionError> {
+        let SerializedReturnValues {
+            mutable_reference_outputs,
+            return_values,
+        } = srv;
+        Ok(SerializedReturnValues {
+            mutable_reference_outputs: mutable_reference_outputs.clone(),
+            return_values: return_values.clone(),
+        })
+    }
+
+    fn empty_results() -> Self::ExecutionResults {
+        todo!()
+    }
+
+    fn add_result(
+        results: &mut Self::ExecutionResults,
+        idx: TransactionIndex,
+        result: Self::ExecutionResult,
+    ) {
+        results.push((idx, result))
+    }
+}

--- a/crates/sui-adapter/src/lib.rs
+++ b/crates/sui-adapter/src/lib.rs
@@ -1,5 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+macro_rules! assert_invariant {
+    ($cond:expr, $msg:expr) => {
+        if !$cond {
+            return Err(sui_types::error::ExecutionError::new_with_source(
+                sui_types::error::ExecutionErrorKind::InvariantViolation,
+                $msg,
+            ));
+        }
+    };
+}
+
 pub mod adapter;
+pub mod execution_mode;
 pub mod genesis;

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -16,8 +16,8 @@ use serde_with::serde_as;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::{fs, path::Path};
-use sui_adapter::adapter;
 use sui_adapter::adapter::MoveVM;
+use sui_adapter::{adapter, execution_mode};
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::TransactionDigest;
 use sui_types::crypto::{AuthorityPublicKey, ToFromBytes};
@@ -565,7 +565,7 @@ pub fn generate_genesis_system_object(
         commission_rates.push(validator.commission_rate());
     }
 
-    adapter::execute(
+    adapter::execute::<execution_mode::Normal, _, _>(
         move_vm,
         &mut temporary_store,
         ModuleId::new(SUI_FRAMEWORK_ADDRESS, ident_str!("genesis").to_owned()),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -28,7 +28,6 @@ use prometheus::{
     exponential_buckets, register_histogram_with_registry, register_int_counter_with_registry,
     register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
 };
-use sui_adapter::execution_mode::DevInspect;
 use tap::TapFallible;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
@@ -1087,34 +1086,6 @@ impl AuthorityState {
                 self.epoch(),
             );
         SuiTransactionEffects::try_from(effects, self.module_cache.as_ref())
-    }
-
-    pub async fn dev_inspect_transaction(
-        &self,
-        transaction: TransactionData,
-        transaction_digest: TransactionDigest,
-    ) -> Result<DevInspectResults, anyhow::Error> {
-        let (gas_status, input_objects) =
-            transaction_input_checker::check_transaction_input(&self.database, &transaction)
-                .await?;
-        let shared_object_refs = input_objects.filter_shared_objects();
-
-        let transaction_dependencies = input_objects.transaction_dependencies();
-        let temporary_store =
-            TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
-        let (_inner_temp_store, effects, execution_error) =
-            execution_engine::execute_transaction_to_effects::<execution_mode::DevInspect, _>(
-                shared_object_refs,
-                temporary_store,
-                transaction,
-                transaction_digest,
-                transaction_dependencies,
-                &self.move_vm,
-                &self._native_functions,
-                gas_status,
-                self.epoch(),
-            );
-        DevInspectResults::try_from(effects, self.module_cache.as_ref())
     }
 
     pub fn is_tx_already_executed(&self, digest: &TransactionDigest) -> SuiResult<bool> {

--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
+use sui_adapter::execution_mode::{self, ExecutionMode};
 use sui_types::base_types::SequenceNumber;
 use tracing::{debug, instrument};
 
@@ -47,7 +48,10 @@ use crate::authority::TemporaryStore;
 mod pay_sui_tests;
 
 #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
-pub fn execute_transaction_to_effects<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
+pub fn execute_transaction_to_effects<
+    Mode: ExecutionMode,
+    S: BackingPackageStore + ParentSync + ChildObjectResolver,
+>(
     shared_object_refs: Vec<ObjectRef>,
     mut temporary_store: TemporaryStore<S>,
     transaction_data: TransactionData,
@@ -60,12 +64,12 @@ pub fn execute_transaction_to_effects<S: BackingPackageStore + ParentSync + Chil
 ) -> (
     InnerTemporaryStore,
     TransactionEffects,
-    Option<ExecutionError>,
+    Result<Mode::ExecutionResults, ExecutionError>,
 ) {
     let mut tx_ctx = TxContext::new(&transaction_data.signer(), &transaction_digest, epoch);
 
     let gas_object_ref = *transaction_data.gas_payment_object_ref();
-    let (gas_cost_summary, execution_result) = execute_transaction(
+    let (gas_cost_summary, execution_result) = execute_transaction::<Mode, _>(
         &mut temporary_store,
         transaction_data,
         gas_object_ref.0,
@@ -75,11 +79,11 @@ pub fn execute_transaction_to_effects<S: BackingPackageStore + ParentSync + Chil
         gas_status,
     );
 
-    let (status, execution_error) = match execution_result {
-        Ok(()) => (ExecutionStatus::Success, None),
+    let (status, execution_result) = match execution_result {
+        Ok(results) => (ExecutionStatus::Success, Ok(results)),
         Err(error) => (
             ExecutionStatus::new_failure(error.to_execution_status()),
-            Some(error),
+            Err(error),
         ),
     };
     debug!(
@@ -101,7 +105,7 @@ pub fn execute_transaction_to_effects<S: BackingPackageStore + ParentSync + Chil
         status,
         gas_object_ref,
     );
-    (inner, effects, execution_error)
+    (inner, effects, execution_result)
 }
 
 fn charge_gas_for_object_read<S>(
@@ -120,7 +124,10 @@ fn charge_gas_for_object_read<S>(
 }
 
 #[instrument(name = "tx_execute", level = "debug", skip_all)]
-fn execute_transaction<S: BackingPackageStore + ParentSync + ChildObjectResolver>(
+fn execute_transaction<
+    Mode: ExecutionMode,
+    S: BackingPackageStore + ParentSync + ChildObjectResolver,
+>(
     temporary_store: &mut TemporaryStore<S>,
     transaction_data: TransactionData,
     gas_object_id: ObjectID,
@@ -128,172 +135,29 @@ fn execute_transaction<S: BackingPackageStore + ParentSync + ChildObjectResolver
     move_vm: &Arc<MoveVM>,
     native_functions: &NativeFunctionTable,
     mut gas_status: SuiGasStatus,
-) -> (GasCostSummary, Result<(), ExecutionError>) {
+) -> (
+    GasCostSummary,
+    Result<Mode::ExecutionResults, ExecutionError>,
+) {
     // We must charge object read gas inside here during transaction execution, because if this fails
     // we must still ensure an effect is committed and all objects versions incremented.
-    let mut result = charge_gas_for_object_read(temporary_store, &mut gas_status);
-    if result.is_ok() {
-        // TODO: Since we require all mutable objects to not show up more than
-        // once across single tx, we should be able to run them in parallel.
-        for single_tx in transaction_data.kind.into_single_transactions() {
-            result = match single_tx {
-                SingleTransactionKind::TransferObject(TransferObject {
-                    recipient,
-                    object_ref,
-                }) => {
-                    // unwrap is safe because we built the object map from the transactions
-                    let object = temporary_store
-                        .objects()
-                        .get(&object_ref.0)
-                        .unwrap()
-                        .clone();
-                    transfer_object(temporary_store, object, tx_ctx.sender(), recipient)
-                }
-                SingleTransactionKind::TransferSui(TransferSui { recipient, amount }) => {
-                    let gas_object = temporary_store
-                        .objects()
-                        .get(&gas_object_id)
-                        .expect("We constructed the object map so it should always have the gas object id")
-                        .clone();
-                    transfer_sui(temporary_store, gas_object, recipient, amount, tx_ctx)
-                }
-                SingleTransactionKind::PaySui(PaySui {
-                    coins,
-                    recipients,
-                    amounts,
-                }) => {
-                    let mut coin_objects: Vec<Object> =  // unwrap is is safe because we built the object map from the transaction
-                    coins.iter().map(|c|
-                    temporary_store
-                        .objects()
-                        .get(&c.0)
-                        .unwrap()
-                        .clone()
-                    ).collect();
-                    pay_sui(
-                        temporary_store,
-                        &mut coin_objects,
-                        recipients,
-                        amounts,
-                        tx_ctx,
-                    )
-                }
-                SingleTransactionKind::PayAllSui(PayAllSui { coins, recipient }) => {
-                    let mut coin_objects: Vec<Object> =  // unwrap is is safe because we built the object map from the transaction
-                    coins.iter().map(|c|
-                    temporary_store
-                        .objects()
-                        .get(&c.0)
-                        .unwrap()
-                        .clone()
-                    ).collect();
-                    pay_all_sui(
-                        tx_ctx.sender(),
-                        temporary_store,
-                        &mut coin_objects,
-                        recipient,
-                    )
-                }
-                SingleTransactionKind::Call(MoveCall {
-                    package,
-                    module,
-                    function,
-                    type_arguments,
-                    arguments,
-                }) => {
-                    // Charge gas for this VM execution
-                    if let Err(e) = gas_status.charge_vm_gas() {
-                        result = Err(e);
-                        break;
-                    }
-
-                    let module_id = ModuleId::new(package.0.into(), module);
-                    adapter::execute(
-                        move_vm,
-                        temporary_store,
-                        module_id,
-                        &function,
-                        type_arguments,
-                        arguments,
-                        gas_status.create_move_gas_status(),
-                        tx_ctx,
-                    )
-                }
-                SingleTransactionKind::Publish(MoveModulePublish { modules }) => {
-                    // Charge gas for this VM execution
-                    if let Err(e) = gas_status.charge_vm_gas() {
-                        result = Err(e);
-                        break;
-                    }
-                    // Charge gas for this publish
-                    if let Err(e) =
-                        gas_status.charge_publish_package(modules.iter().map(|v| v.len()).sum())
-                    {
-                        result = Err(e);
-                        break;
-                    }
-                    adapter::publish(
-                        temporary_store,
-                        native_functions.clone(),
-                        modules,
-                        tx_ctx,
-                        gas_status.create_move_gas_status(),
-                    )
-                }
-                SingleTransactionKind::Pay(Pay {
-                    coins,
-                    recipients,
-                    amounts,
-                }) => {
-                    let coin_objects =  // unwrap is is safe because we built the object map from the transaction
-                    coins.iter().map(|c|
-                    temporary_store
-                        .objects()
-                        .get(&c.0)
-                        .unwrap()
-                        .clone()
-                    ).collect();
-                    pay(temporary_store, coin_objects, recipients, amounts, tx_ctx)
-                }
-                SingleTransactionKind::ChangeEpoch(ChangeEpoch {
-                    epoch,
-                    storage_charge,
-                    computation_charge,
-                    storage_rebate,
-                }) => {
-                    let module_id =
-                        ModuleId::new(SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_MODULE_NAME.to_owned());
-                    let function = ADVANCE_EPOCH_FUNCTION_NAME.to_owned();
-                    adapter::execute(
-                        move_vm,
-                        temporary_store,
-                        module_id,
-                        &function,
-                        vec![],
-                        vec![
-                            CallArg::Object(ObjectArg::SharedObject {
-                                id: SUI_SYSTEM_STATE_OBJECT_ID,
-                                initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
-                            }),
-                            CallArg::Pure(bcs::to_bytes(&epoch).unwrap()),
-                            CallArg::Pure(bcs::to_bytes(&storage_charge).unwrap()),
-                            CallArg::Pure(bcs::to_bytes(&computation_charge).unwrap()),
-                            CallArg::Pure(bcs::to_bytes(&storage_rebate).unwrap()),
-                        ],
-                        gas_status.create_move_gas_status(),
-                        tx_ctx,
-                    )
-                }
-            };
-            if result.is_err() {
-                break;
-            }
-        }
-        if result.is_err() {
+    let result = charge_gas_for_object_read(temporary_store, &mut gas_status);
+    let mut result = result.and_then(|()| {
+        let execution_result = execution_loop::<Mode, _>(
+            temporary_store,
+            transaction_data,
+            gas_object_id,
+            tx_ctx,
+            move_vm,
+            native_functions,
+            gas_status,
+        );
+        if execution_result.is_err() {
             // Roll back the temporary store if execution failed.
             temporary_store.reset();
         }
-    }
+        execution_result
+    });
 
     // Make sure every mutable object's version number is incremented.
     // This needs to happen before `charge_gas_for_storage_changes` so that it
@@ -306,6 +170,161 @@ fn execute_transaction<S: BackingPackageStore + ParentSync + ChildObjectResolver
 
     let cost_summary = gas_status.summary(result.is_ok());
     (cost_summary, result)
+}
+
+fn execution_loop<
+    Mode: ExecutionMode,
+    S: BackingPackageStore + ParentSync + ChildObjectResolver,
+>(
+    temporary_store: &mut TemporaryStore<S>,
+    transaction_data: TransactionData,
+    gas_object_id: ObjectID,
+    tx_ctx: &mut TxContext,
+    move_vm: &Arc<MoveVM>,
+    native_functions: &NativeFunctionTable,
+    mut gas_status: SuiGasStatus,
+) -> Result<Mode::ExecutionResults, ExecutionError> {
+    let mut results = Mode::empty_results();
+    // TODO: Since we require all mutable objects to not show up more than
+    // once across single tx, we should be able to run them in parallel.
+    for (idx, single_tx) in transaction_data.kind.into_single_transactions().enumerate() {
+        match single_tx {
+            SingleTransactionKind::TransferObject(TransferObject {
+                recipient,
+                object_ref,
+            }) => {
+                // unwrap is safe because we built the object map from the transactions
+                let object = temporary_store
+                    .objects()
+                    .get(&object_ref.0)
+                    .unwrap()
+                    .clone();
+                transfer_object(temporary_store, object, tx_ctx.sender(), recipient)?;
+            }
+            SingleTransactionKind::TransferSui(TransferSui { recipient, amount }) => {
+                let gas_object = temporary_store
+                    .objects()
+                    .get(&gas_object_id)
+                    .expect(
+                        "We constructed the object map so it should always have the gas object id",
+                    )
+                    .clone();
+                transfer_sui(temporary_store, gas_object, recipient, amount, tx_ctx)?;
+            }
+            SingleTransactionKind::PaySui(PaySui {
+                coins,
+                recipients,
+                amounts,
+            }) => {
+                let mut coin_objects: Vec<Object> =  // unwrap is is safe because we built the object map from the transaction
+                    coins.iter().map(|c|
+                    temporary_store
+                        .objects()
+                        .get(&c.0)
+                        .unwrap()
+                        .clone()
+                    ).collect();
+                pay_sui(
+                    temporary_store,
+                    &mut coin_objects,
+                    recipients,
+                    amounts,
+                    tx_ctx,
+                )?;
+            }
+            SingleTransactionKind::PayAllSui(PayAllSui { coins, recipient }) => {
+                // unwrap is is safe because we built the object map from the transaction
+                let mut coin_objects: Vec<Object> = coins
+                    .iter()
+                    .map(|c| temporary_store.objects().get(&c.0).unwrap().clone())
+                    .collect();
+                pay_all_sui(
+                    tx_ctx.sender(),
+                    temporary_store,
+                    &mut coin_objects,
+                    recipient,
+                )?;
+            }
+            SingleTransactionKind::Call(MoveCall {
+                package,
+                module,
+                function,
+                type_arguments,
+                arguments,
+            }) => {
+                // Charge gas for this VM execution
+                gas_status.charge_vm_gas()?;
+
+                let module_id = ModuleId::new(package.0.into(), module);
+                let result = adapter::execute::<Mode, _, _>(
+                    move_vm,
+                    temporary_store,
+                    module_id,
+                    &function,
+                    type_arguments,
+                    arguments,
+                    gas_status.create_move_gas_status(),
+                    tx_ctx,
+                )?;
+                Mode::add_result(&mut results, idx, result);
+            }
+            SingleTransactionKind::Publish(MoveModulePublish { modules }) => {
+                // Charge gas for this VM execution
+                gas_status.charge_vm_gas()?;
+                // Charge gas for this publish
+                gas_status.charge_publish_package(modules.iter().map(|v| v.len()).sum())?;
+                adapter::publish(
+                    temporary_store,
+                    native_functions.clone(),
+                    modules,
+                    tx_ctx,
+                    gas_status.create_move_gas_status(),
+                )?;
+            }
+            SingleTransactionKind::Pay(Pay {
+                coins,
+                recipients,
+                amounts,
+            }) => {
+                // unwrap is is safe because we built the object map from the transaction
+                let coin_objects = coins
+                    .iter()
+                    .map(|c| temporary_store.objects().get(&c.0).unwrap().clone())
+                    .collect();
+                pay(temporary_store, coin_objects, recipients, amounts, tx_ctx)?;
+            }
+            SingleTransactionKind::ChangeEpoch(ChangeEpoch {
+                epoch,
+                storage_charge,
+                computation_charge,
+                storage_rebate,
+            }) => {
+                let module_id =
+                    ModuleId::new(SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_MODULE_NAME.to_owned());
+                let function = ADVANCE_EPOCH_FUNCTION_NAME.to_owned();
+                adapter::execute::<execution_mode::Normal, _, _>(
+                    move_vm,
+                    temporary_store,
+                    module_id,
+                    &function,
+                    vec![],
+                    vec![
+                        CallArg::Object(ObjectArg::SharedObject {
+                            id: SUI_SYSTEM_STATE_OBJECT_ID,
+                            initial_shared_version: SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+                        }),
+                        CallArg::Pure(bcs::to_bytes(&epoch).unwrap()),
+                        CallArg::Pure(bcs::to_bytes(&storage_charge).unwrap()),
+                        CallArg::Pure(bcs::to_bytes(&computation_charge).unwrap()),
+                        CallArg::Pure(bcs::to_bytes(&storage_rebate).unwrap()),
+                    ],
+                    gas_status.create_move_gas_status(),
+                    tx_ctx,
+                )?;
+            }
+        };
+    }
+    Ok(results)
 }
 
 fn transfer_object<S>(

--- a/crates/sui-core/src/execution_engine.rs
+++ b/crates/sui-core/src/execution_engine.rs
@@ -150,7 +150,7 @@ fn execute_transaction<
             tx_ctx,
             move_vm,
             native_functions,
-            gas_status,
+            &mut gas_status,
         );
         if execution_result.is_err() {
             // Roll back the temporary store if execution failed.
@@ -182,7 +182,7 @@ fn execution_loop<
     tx_ctx: &mut TxContext,
     move_vm: &Arc<MoveVM>,
     native_functions: &NativeFunctionTable,
-    mut gas_status: SuiGasStatus,
+    gas_status: &mut SuiGasStatus,
 ) -> Result<Mode::ExecutionResults, ExecutionError> {
     let mut results = Mode::empty_results();
     // TODO: Since we require all mutable objects to not show up more than

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_adapter::execution_mode;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -1278,7 +1279,6 @@ where
 
         // Pass in the objects for a deeper check
         let is_genesis = false;
-        let allow_arbitrary_function_calls = false;
         let type_arguments = type_arguments
             .into_iter()
             .map(|arg| arg.try_into())
@@ -1288,14 +1288,13 @@ where
             .try_as_package()
             .ok_or_else(|| anyhow!("Cannot get package from object"))?
             .deserialize_module(&module)?;
-        resolve_and_type_check(
+        resolve_and_type_check::<execution_mode::Normal>(
             &objects,
             &compiled_module,
             &function,
             &type_arguments,
             args.clone(),
             is_genesis,
-            allow_arbitrary_function_calls,
         )?;
         used_object_ids.extend(objects.keys());
 

--- a/crates/sui-core/src/gateway_state.rs
+++ b/crates/sui-core/src/gateway_state.rs
@@ -1278,6 +1278,7 @@ where
 
         // Pass in the objects for a deeper check
         let is_genesis = false;
+        let allow_arbitrary_function_calls = false;
         let type_arguments = type_arguments
             .into_iter()
             .map(|arg| arg.try_into())
@@ -1294,6 +1295,7 @@ where
             &type_arguments,
             args.clone(),
             is_genesis,
+            allow_arbitrary_function_calls,
         )?;
         used_object_ids.extend(objects.keys());
 

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -38,7 +38,7 @@ use sui_types::base_types::{
 };
 use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthorityStrongQuorumSignInfo, SignableBytes, Signature};
-use sui_types::error::SuiError;
+use sui_types::error::{ExecutionError, SuiError};
 use sui_types::event::{BalanceChangeType, Event, EventID};
 use sui_types::event::{EventEnvelope, EventType};
 use sui_types::filter::{EventFilter, TransactionFilter};
@@ -1868,6 +1868,30 @@ pub struct SuiTransactionEffects {
     /// The set of transaction digests this transaction depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<TransactionDigest>,
+}
+
+/// The response from processing a dev inspect transaction
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "DevInspectResults", rename_all = "camelCase")]
+pub struct DevInspectResults {
+    /// Summary of effects that likely would be generated if the transaction is actually run.
+    /// Note however, that not all dev-inspect transactions are actually usable as transactions so
+    /// it might not be possible actually generate these effects from a normal transaction.
+    effects: SuiTransactionEffects,
+    /// Execution results (including return values) from executing the transactions
+    /// Currently contains only return values from Move calls
+    results: Result<Vec<(usize, ExecutionResult)>, String>,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ExecutionResult {
+    /// The value of any arguments that were mutably borrowed.
+    /// Non-mut borrowed values are not included
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mutable_reference_outputs: Vec<(u8, Vec<u8>, MoveTypeLayout)>,
+    /// The return values from the function
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub return_values: Vec<(Vec<u8>, MoveTypeLayout)>,
 }
 
 impl SuiTransactionEffects {

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -38,7 +38,7 @@ use sui_types::base_types::{
 };
 use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthorityStrongQuorumSignInfo, SignableBytes, Signature};
-use sui_types::error::{ExecutionError, SuiError};
+use sui_types::error::SuiError;
 use sui_types::event::{BalanceChangeType, Event, EventID};
 use sui_types::event::{EventEnvelope, EventType};
 use sui_types::filter::{EventFilter, TransactionFilter};
@@ -1868,30 +1868,6 @@ pub struct SuiTransactionEffects {
     /// The set of transaction digests this transaction depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dependencies: Vec<TransactionDigest>,
-}
-
-/// The response from processing a dev inspect transaction
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename = "DevInspectResults", rename_all = "camelCase")]
-pub struct DevInspectResults {
-    /// Summary of effects that likely would be generated if the transaction is actually run.
-    /// Note however, that not all dev-inspect transactions are actually usable as transactions so
-    /// it might not be possible actually generate these effects from a normal transaction.
-    effects: SuiTransactionEffects,
-    /// Execution results (including return values) from executing the transactions
-    /// Currently contains only return values from Move calls
-    results: Result<Vec<(usize, ExecutionResult)>, String>,
-}
-
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ExecutionResult {
-    /// The value of any arguments that were mutably borrowed.
-    /// Non-mut borrowed values are not included
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub mutable_reference_outputs: Vec<(u8, Vec<u8>, MoveTypeLayout)>,
-    /// The return values from the function
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub return_values: Vec<(Vec<u8>, MoveTypeLayout)>,
 }
 
 impl SuiTransactionEffects {

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -356,6 +356,8 @@ impl TransactionBuilder {
             type_args,
             args.clone(),
             false,
+            // TODO this needs to be set from outside?
+            false,
         )?;
 
         Ok(args)

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -13,6 +13,7 @@ use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::TypeTag;
 
 use sui_adapter::adapter::resolve_and_type_check;
+use sui_adapter::execution_mode;
 use sui_json::{resolve_move_function_args, SuiJsonCallArg, SuiJsonValue};
 use sui_json_rpc_types::GetRawObjectDataResponse;
 use sui_json_rpc_types::SuiObjectInfo;
@@ -349,14 +350,13 @@ impl TransactionBuilder {
         }
         let compiled_module = package.deserialize_module(module)?;
 
-        resolve_and_type_check(
+        // TODO set the Mode from outside?
+        resolve_and_type_check::<execution_mode::Normal>(
             &objects,
             &compiled_module,
             function,
             type_args,
             args.clone(),
-            false,
-            // TODO this needs to be set from outside?
             false,
         )?;
 

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -548,7 +548,7 @@ impl<'a> SuiTestAdapter<'a> {
                 Err(anyhow::anyhow!(self.stabilize_str(format!(
                     "Transaction Effects Status: {}\nExecution Error: {}",
                     error,
-                    execution_error.err().expect(
+                    execution_error.expect_err(
                         "to have an execution error if a transaction's status is a failure"
                     )
                 ))))

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -36,7 +36,7 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use sui_adapter::{adapter::new_move_vm, genesis};
+use sui_adapter::{adapter::new_move_vm, execution_mode, genesis};
 use sui_core::{execution_engine, test_utils::to_sender_signed_transaction};
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_types::temporary_store::TemporaryStore;
@@ -488,7 +488,7 @@ impl<'a> SuiTestAdapter<'a> {
                 ..
             },
             execution_error,
-        ) = execution_engine::execute_transaction_to_effects(
+        ) = execution_engine::execute_transaction_to_effects::<execution_mode::Normal, _>(
             shared_object_refs,
             temporary_store,
             transaction.into_inner().into_data().data,
@@ -548,7 +548,7 @@ impl<'a> SuiTestAdapter<'a> {
                 Err(anyhow::anyhow!(self.stabilize_str(format!(
                     "Transaction Effects Status: {}\nExecution Error: {}",
                     error,
-                    execution_error.expect(
+                    execution_error.err().expect(
                         "to have an execution error if a transaction's status is a failure"
                     )
                 ))))

--- a/crates/sui-types/src/temporary_store.rs
+++ b/crates/sui-types/src/temporary_store.rs
@@ -637,12 +637,12 @@ impl<S> TemporaryStore<S> {
             .insert(object.id(), (ctx.clone(), object, kind));
     }
 
-    pub fn charge_gas(
+    pub fn charge_gas<T>(
         &mut self,
         sender: SuiAddress,
         gas_object_id: ObjectID,
         gas_status: &mut SuiGasStatus<'_>,
-        result: &mut Result<(), ExecutionError>,
+        result: &mut Result<T, ExecutionError>,
     ) {
         // We must call `read_object` instead of getting it from `temporary_store.objects`
         // because a `TransferSui` transaction may have already mutated the gas object and put


### PR DESCRIPTION
- Introduces dev-inspect transaction type that can call any Move function
- Returns that Move function
- Also provides much more detailed error message information

Attempting to address issues raised in #5836 and #4967. 

I added a new `ExecutionMode` trait for the adapter and execution_engine that does a few things:
- Controls the calling of arbitrary Move functions
- Controls the ability to instantiate any Move function parameter with a `Pure` call arg
  - In other words, you can instantiate any struct or object or other value with its BCS bytes
- Handles the return values from the Move function 

(Note: The arbitrary function and arbitrary arg are both controlled by a single flag currently)
While I'm not the biggest fan of this trait based approach, it feels cleaner than passing in some flags and then having asserts everywhere for the normal mode.

There are two execution modes: `Normal` and `DevInspect` 
In the `Normal` execution mode, the flag is set to false and the handling of return values is skipped (just passes around unit `()`).
In the `DevInspect` execution mode, the flag is true (allowing arbitrary functions to be called with and arbitrary bytes) and the return values are passed back using `SerializedReturnValues` from the Move VM. 

I also hope we can provide the full `ExecutionError` when using the new endpoint, this will give folks the full error message (with stack traces and everything) from the Move VM! 


The PR does not currently work, and I will likely need the most help/feedback from @gegaowp and @Jordan-Mysten on actually creating an end point (lots of issues right now with what I'm doing and with the JsonSchema trait). 