### PR TITLE
config: use 0.0.0.0 for listen address for dns multiaddrs

### DIFF
--- a/crates/sui-config/src/builder.rs
+++ b/crates/sui-config/src/builder.rs
@@ -267,7 +267,7 @@ impl<R: rand::RngCore + rand::CryptoRng> ConfigBuilder<R> {
                 };
 
                 let p2p_config = P2pConfig {
-                    listen_address: utils::udp_multiaddr_to_socket_address(&validator.p2p_address)
+                    listen_address: utils::udp_multiaddr_to_listen_address(&validator.p2p_address)
                         .unwrap(),
                     external_address: Some(validator.p2p_address),
                     ..Default::default()

--- a/crates/sui-config/src/utils.rs
+++ b/crates/sui-config/src/utils.rs
@@ -50,7 +50,7 @@ pub fn available_local_socket_address() -> std::net::SocketAddr {
         .unwrap()
 }
 
-pub fn udp_multiaddr_to_socket_address(
+pub fn udp_multiaddr_to_listen_address(
     multiaddr: &multiaddr::Multiaddr,
 ) -> Option<std::net::SocketAddr> {
     use multiaddr::Protocol;
@@ -59,6 +59,10 @@ pub fn udp_multiaddr_to_socket_address(
     match (iter.next(), iter.next()) {
         (Some(Protocol::Ip4(ipaddr)), Some(Protocol::Udp(port))) => Some((ipaddr, port).into()),
         (Some(Protocol::Ip6(ipaddr)), Some(Protocol::Udp(port))) => Some((ipaddr, port).into()),
+
+        (Some(Protocol::Dns(_)), Some(Protocol::Udp(port))) => {
+            Some((std::net::Ipv4Addr::UNSPECIFIED, port).into())
+        }
 
         _ => None,
     }


### PR DESCRIPTION
When constructing node configs for validators, if a dns address was provided use Ipv4Addr::UNSPECIFIED as the listen address instead of panicing.