### PR TITLE
[explorer] Show gas breakdown on transaction page

### DIFF
--- a/apps/core/tailwind.config.js
+++ b/apps/core/tailwind.config.js
@@ -126,6 +126,7 @@ module.exports = {
       spacing: {
         3.75: "0.9375rem",
         4.5: "1.125rem",
+        50: '12.5rem',
         verticalListShort: "13.0625rem",
         verticalListLong: "35.6875rem",
       },

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -272,7 +272,7 @@ function GasAmount({
             </div>
 
             <Text variant="bodySmall">
-                <div className="flex items-center text-gray-65">
+                <div className="flex items-center text-steel">
                     (
                     <div className="flex items-baseline gap-0.5">
                         <div>{amount?.toLocaleString()}</div>

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -271,14 +271,6 @@ function GasAmount({
                 <Text variant="subtitleSmall">{symbol}</Text>
             </div>
 
-            {expandable && (
-                <ChevronDownIcon
-                    height={12}
-                    width={12}
-                    className={clsx('text-steel', expanded && 'rotate-180')}
-                />
-            )}
-
             <Text variant="bodySmall">
                 <div className="flex items-center text-gray-65">
                     (
@@ -289,6 +281,14 @@ function GasAmount({
                     )
                 </div>
             </Text>
+
+            {expandable && (
+                <ChevronDownIcon
+                    height={12}
+                    width={12}
+                    className={clsx('text-steel', expanded && 'rotate-180')}
+                />
+            )}
         </div>
     );
 }

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -591,7 +591,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                                         }
                                     >
                                         <button
-                                            className="cursor-pointer bg-inherit p-0 border-none"
+                                            className="cursor-pointer border-none bg-inherit p-0"
                                             type="button"
                                             onClick={() =>
                                                 setGasFeesExpanded(

--- a/apps/explorer/src/pages/transaction-result/TransactionView.tsx
+++ b/apps/explorer/src/pages/transaction-result/TransactionView.tsx
@@ -12,7 +12,8 @@ import {
     getObjectId,
     SUI_TYPE_ARG,
 } from '@mysten/sui.js';
-import cl from 'clsx';
+import clsx from 'clsx';
+import { useState } from 'react';
 
 import { ErrorBoundary } from '../../components/error-boundary/ErrorBoundary';
 import {
@@ -44,11 +45,16 @@ import styles from './TransactionResult.module.css';
 import { CoinFormat, useFormatCoin } from '~/hooks/useFormatCoin';
 import { Banner } from '~/ui/Banner';
 import { DateCard } from '~/ui/DateCard';
+import { DescriptionList, DescriptionItem } from '~/ui/DescriptionList';
+import { ObjectLink } from '~/ui/InternalLink';
 import { PageHeader } from '~/ui/PageHeader';
 import { SenderRecipient } from '~/ui/SenderRecipient';
 import { StatAmount } from '~/ui/StatAmount';
+import { TableHeader } from '~/ui/TableHeader';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 import { Text } from '~/ui/Text';
+import { Tooltip } from '~/ui/Tooltip';
+import { ReactComponent as ChevronDownIcon } from '~/ui/icons/chevron_down.svg';
 import { LinkWithQuery } from '~/ui/utils/LinkWithQuery';
 
 type TxDataProps = CertifiedTransaction & {
@@ -198,7 +204,7 @@ function ItemView({ data }: { data: TxItemView }) {
                     return (
                         <div
                             key={index}
-                            className={cl(
+                            className={clsx(
                                 styles.itemviewcontentitem,
                                 label && styles.singleitem
                             )}
@@ -209,7 +215,7 @@ function ItemView({ data }: { data: TxItemView }) {
                                 </div>
                             )}
                             <div
-                                className={cl(
+                                className={clsx(
                                     styles.itemviewcontentvalue,
                                     item.monotypeClass && styles.mono
                                 )}
@@ -243,7 +249,15 @@ function ItemView({ data }: { data: TxItemView }) {
     );
 }
 
-function GasAmount({ amount }: { amount: bigint | number }) {
+function GasAmount({
+    amount,
+    expandable,
+    expanded,
+}: {
+    amount?: bigint | number;
+    expandable?: boolean;
+    expanded?: boolean;
+}) {
     const [formattedAmount, symbol] = useFormatCoin(
         amount,
         SUI_TYPE_ARG,
@@ -256,11 +270,20 @@ function GasAmount({ amount }: { amount: bigint | number }) {
                 <Text variant="body">{formattedAmount}</Text>
                 <Text variant="subtitleSmall">{symbol}</Text>
             </div>
+
+            {expandable && (
+                <ChevronDownIcon
+                    height={12}
+                    width={12}
+                    className={clsx('text-steel', expanded && 'rotate-180')}
+                />
+            )}
+
             <Text variant="bodySmall">
                 <div className="flex items-center text-gray-65">
                     (
                     <div className="flex items-baseline gap-0.5">
-                        <div>{amount.toLocaleString()}</div>
+                        <div>{amount?.toLocaleString()}</div>
                         <Text variant="subtitleSmall">MIST</Text>
                     </div>
                     )
@@ -274,6 +297,9 @@ function TransactionView({ txdata }: { txdata: DataType }) {
     const txdetails = getTransactions(txdata)[0];
     const txKindName = getTransactionKindName(txdetails);
     const sender = getTransactionSender(txdata);
+    const gasUsed = txdata.transaction?.effects.gasUsed;
+
+    const [gasFeesExpanded, setGasFeesExpanded] = useState(false);
 
     const txnTransfer = getAmount(txdetails, txdata.transaction?.effects);
     const sendReceiveRecipients = txnTransfer?.map((item) => ({
@@ -355,25 +381,6 @@ function TransactionView({ txdata }: { txdata: DataType }) {
 
     const createdMutateData = generateMutatedCreated(txdata);
 
-    const GasStorageFees = {
-        title: 'Gas & Storage Fees',
-        content: [
-            {
-                label: 'Gas Payment',
-                value: txdata.data.gasPayment.objectId,
-                link: true,
-            },
-            {
-                label: 'Gas Budget',
-                value: <GasAmount amount={txdata.data.gasBudget} />,
-            },
-            {
-                label: 'Total Gas Fee',
-                value: <GasAmount amount={txdata.gasFee} />,
-            },
-            //TODO: Add Storage Fees
-        ],
-    };
     const typearguments =
         txKindData.title === 'Call' && txKindData.package
             ? {
@@ -425,7 +432,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
     const hasEvents = txEventData && txEventData.length > 0;
 
     return (
-        <div className={cl(styles.txdetailsbg)}>
+        <div className={clsx(styles.txdetailsbg)}>
             <div className="mt-5 mb-10">
                 <PageHeader
                     type={txKindName}
@@ -452,7 +459,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                         >
                             {typearguments && (
                                 <section
-                                    className={cl([
+                                    className={clsx([
                                         styles.txcomponent,
                                         styles.txgridcolspan2,
                                         styles.packagedetails,
@@ -462,7 +469,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                                 </section>
                             )}
                             <section
-                                className={cl([
+                                className={clsx([
                                     styles.txcomponent,
                                     styles.txsender,
                                     'md:ml-4',
@@ -494,7 +501,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                             </section>
 
                             <section
-                                className={cl([
+                                className={clsx([
                                     styles.txcomponent,
                                     styles.txgridcolspan2,
                                 ])}
@@ -508,7 +515,7 @@ function TransactionView({ txdata }: { txdata: DataType }) {
 
                             {modules && (
                                 <section
-                                    className={cl([
+                                    className={clsx([
                                         styles.txcomponent,
                                         styles.txgridcolspan3,
                                     ])}
@@ -522,8 +529,85 @@ function TransactionView({ txdata }: { txdata: DataType }) {
                                 </section>
                             )}
                         </div>
-                        <div className={styles.txgridcomponent}>
-                            <ItemView data={GasStorageFees} />
+                        <div className="mt-8">
+                            <TableHeader>Gas & Storage Fees</TableHeader>
+
+                            <DescriptionList>
+                                <DescriptionItem title="Gas Payment">
+                                    <ObjectLink
+                                        noTruncate
+                                        objectId={
+                                            txdata.data.gasPayment.objectId
+                                        }
+                                    />
+                                </DescriptionItem>
+
+                                <DescriptionItem title="Gas Budget">
+                                    <GasAmount amount={txdata.data.gasBudget} />
+                                </DescriptionItem>
+
+                                {gasFeesExpanded && (
+                                    <>
+                                        <DescriptionItem title="Computation Fee">
+                                            <GasAmount
+                                                amount={
+                                                    gasUsed?.computationCost
+                                                }
+                                            />
+                                        </DescriptionItem>
+
+                                        <DescriptionItem title="Storage Fee">
+                                            <GasAmount
+                                                amount={gasUsed?.storageCost}
+                                            />
+                                        </DescriptionItem>
+
+                                        <DescriptionItem title="Storage Rebate">
+                                            <GasAmount
+                                                amount={gasUsed?.storageRebate}
+                                            />
+                                        </DescriptionItem>
+
+                                        <div className="h-px bg-gray-45" />
+                                    </>
+                                )}
+
+                                <DescriptionItem
+                                    title={
+                                        <Text
+                                            variant="body"
+                                            weight="semibold"
+                                            color="steel-darker"
+                                        >
+                                            Total Gas Fee
+                                        </Text>
+                                    }
+                                >
+                                    <Tooltip
+                                        tip={
+                                            gasFeesExpanded
+                                                ? 'Hide Gas Fee breakdown'
+                                                : 'Show Gas Fee breakdown'
+                                        }
+                                    >
+                                        <button
+                                            className="cursor-pointer bg-inherit p-0 border-none"
+                                            type="button"
+                                            onClick={() =>
+                                                setGasFeesExpanded(
+                                                    (expanded) => !expanded
+                                                )
+                                            }
+                                        >
+                                            <GasAmount
+                                                amount={txdata.gasFee}
+                                                expanded={gasFeesExpanded}
+                                                expandable
+                                            />
+                                        </button>
+                                    </Tooltip>
+                                </DescriptionItem>
+                            </DescriptionList>
                         </div>
                     </TabPanel>
                     {hasEvents && (

--- a/apps/explorer/src/ui/DescriptionList.tsx
+++ b/apps/explorer/src/ui/DescriptionList.tsx
@@ -12,8 +12,8 @@ export interface DescriptionItemProps {
 
 export function DescriptionItem({ title, children }: DescriptionItemProps) {
     return (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
-            <dt>
+        <div className="flex flex-col md:flex-row items-start gap-2 md:gap-10">
+            <dt className="w-full md:w-48">
                 {typeof title === 'string' ? (
                     <Text variant="body" weight="medium" color="steel-darker">
                         {title}
@@ -22,7 +22,7 @@ export function DescriptionItem({ title, children }: DescriptionItemProps) {
                     title
                 )}
             </dt>
-            <dd className="ml-0 col-span-2 flex">{children}</dd>
+            <dd className="ml-0 flex flex-1">{children}</dd>
         </div>
     );
 }

--- a/apps/explorer/src/ui/DescriptionList.tsx
+++ b/apps/explorer/src/ui/DescriptionList.tsx
@@ -10,8 +10,8 @@ export interface DescriptionItemProps {
 
 export function DescriptionItem({ title, children }: DescriptionItemProps) {
     return (
-        <div className="flex flex-col md:flex-row items-start gap-2 md:gap-10">
-            <dt className="w-full md:w-50 text-steel-darker font-medium text-p1">
+        <div className="flex flex-col md:items-center gap-2 md:flex-row md:gap-10">
+            <dt className="w-full text-p1 font-medium text-steel-darker md:w-50">
                 {title}
             </dt>
             <dd className="ml-0 flex-1 leading-none">{children}</dd>

--- a/apps/explorer/src/ui/DescriptionList.tsx
+++ b/apps/explorer/src/ui/DescriptionList.tsx
@@ -3,23 +3,28 @@
 
 import type { ReactNode } from 'react';
 
-import { Text, type TextProps } from '~/ui/Text';
+import { Text } from '~/ui/Text';
 
-export interface LabelProps extends TextProps {}
-export type ValueProps = {
+export interface DescriptionItemProps {
+    title: string | ReactNode;
     children: ReactNode;
-};
-
-export function Label(props: LabelProps) {
-    return (
-        <dt className="col-span-1">
-            <Text variant="body" {...props} />
-        </dt>
-    );
 }
 
-export function Value({ children }: ValueProps) {
-    return <dd className="col-span-2 ml-0">{children}</dd>;
+export function DescriptionItem({ title, children }: DescriptionItemProps) {
+    return (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+            <dt>
+                {typeof title === 'string' ? (
+                    <Text variant="body" weight="medium" color="steel-darker">
+                        {title}
+                    </Text>
+                ) : (
+                    title
+                )}
+            </dt>
+            <dd className="ml-0 col-span-2 flex">{children}</dd>
+        </div>
+    );
 }
 
 export type DescriptionListProps = {
@@ -27,7 +32,5 @@ export type DescriptionListProps = {
 };
 
 export function DescriptionList({ children }: DescriptionListProps) {
-    return (
-        <dl className="grid grid-cols-1 gap-2 md:grid-cols-3">{children}</dl>
-    );
+    return <dl className="flex flex-col gap-4">{children}</dl>;
 }

--- a/apps/explorer/src/ui/DescriptionList.tsx
+++ b/apps/explorer/src/ui/DescriptionList.tsx
@@ -3,8 +3,6 @@
 
 import type { ReactNode } from 'react';
 
-import { Text } from '~/ui/Text';
-
 export interface DescriptionItemProps {
     title: string | ReactNode;
     children: ReactNode;
@@ -13,16 +11,10 @@ export interface DescriptionItemProps {
 export function DescriptionItem({ title, children }: DescriptionItemProps) {
     return (
         <div className="flex flex-col md:flex-row items-start gap-2 md:gap-10">
-            <dt className="w-full md:w-48">
-                {typeof title === 'string' ? (
-                    <Text variant="body" weight="medium" color="steel-darker">
-                        {title}
-                    </Text>
-                ) : (
-                    title
-                )}
+            <dt className="w-full md:w-50 text-steel-darker font-medium text-p1">
+                {title}
             </dt>
-            <dd className="ml-0 flex flex-1">{children}</dd>
+            <dd className="ml-0 flex-1 leading-none">{children}</dd>
         </div>
     );
 }

--- a/apps/explorer/src/ui/DescriptionList.tsx
+++ b/apps/explorer/src/ui/DescriptionList.tsx
@@ -10,7 +10,7 @@ export interface DescriptionItemProps {
 
 export function DescriptionItem({ title, children }: DescriptionItemProps) {
     return (
-        <div className="flex flex-col md:items-center gap-2 md:flex-row md:gap-10">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-10">
             <dt className="w-full text-p1 font-medium text-steel-darker md:w-50">
                 {title}
             </dt>

--- a/apps/explorer/src/ui/InternalLink.tsx
+++ b/apps/explorer/src/ui/InternalLink.tsx
@@ -1,11 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { truncate } from '../utils/stringUtils';
+import { formatAddress } from '../utils/stringUtils';
 
 import { Link } from '~/ui/Link';
-
-const TRUNCATE_LENGTH = 16;
 
 export type AddressLinkProps = {
     address: string;
@@ -18,9 +16,7 @@ export type ObjectLinkProps = {
 };
 
 export function AddressLink({ address, noTruncate }: AddressLinkProps) {
-    const truncatedAddress = noTruncate
-        ? address
-        : truncate(address, TRUNCATE_LENGTH);
+    const truncatedAddress = noTruncate ? address : formatAddress(address);
     return (
         <Link variant="mono" to={`/address/${encodeURIComponent(address)}`}>
             {truncatedAddress}
@@ -29,9 +25,7 @@ export function AddressLink({ address, noTruncate }: AddressLinkProps) {
 }
 
 export function ObjectLink({ objectId, noTruncate }: ObjectLinkProps) {
-    const truncatedObjectId = noTruncate
-        ? objectId
-        : truncate(objectId, TRUNCATE_LENGTH);
+    const truncatedObjectId = noTruncate ? objectId : formatAddress(objectId);
     return (
         <Link variant="mono" to={`/object/${encodeURIComponent(objectId)}`}>
             {truncatedObjectId}

--- a/apps/explorer/src/ui/TableHeader.tsx
+++ b/apps/explorer/src/ui/TableHeader.tsx
@@ -12,7 +12,7 @@ export interface TableHeaderProps extends Pick<HeadingProps, 'as'> {
 
 export function TableHeader({ as = 'h3', children, after }: TableHeaderProps) {
     return (
-        <div className="flex items-center pb-5 border-0 border-b border-solid border-gray-45">
+        <div className="flex items-center border-0 border-b border-solid border-gray-45 pb-5">
             <div className="flex-1">
                 <Heading
                     as={as}

--- a/apps/explorer/src/ui/TableHeader.tsx
+++ b/apps/explorer/src/ui/TableHeader.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react';
+
+import { Heading, type HeadingProps } from './Heading';
+
+export interface TableHeaderProps extends Pick<HeadingProps, 'as'> {
+    children: ReactNode;
+    after?: ReactNode;
+}
+
+export function TableHeader({ as = 'h3', children, after }: TableHeaderProps) {
+    return (
+        <div className="flex items-center pb-5 border-0 border-b border-solid border-gray-45">
+            <div className="flex-1">
+                <Heading
+                    as={as}
+                    variant="heading4"
+                    weight="semibold"
+                    color="gray-90"
+                >
+                    {children}
+                </Heading>
+            </div>
+            {after && <div className="flex items-center">{after}</div>}
+        </div>
+    );
+}

--- a/apps/explorer/src/ui/Tooltip.tsx
+++ b/apps/explorer/src/ui/Tooltip.tsx
@@ -97,7 +97,6 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
         <>
             <div
                 tabIndex={0}
-                // TODO: Remove this:
                 className="w-fit"
                 {...getReferenceProps({ ref: reference })}
             >

--- a/apps/explorer/src/ui/Tooltip.tsx
+++ b/apps/explorer/src/ui/Tooltip.tsx
@@ -97,6 +97,7 @@ export function Tooltip({ tip, children, placement = 'top' }: TooltipProps) {
         <>
             <div
                 tabIndex={0}
+                // TODO: Remove this:
                 className="w-fit"
                 {...getReferenceProps({ ref: reference })}
             >

--- a/apps/explorer/src/ui/stories/DescriptionList.stories.tsx
+++ b/apps/explorer/src/ui/stories/DescriptionList.stories.tsx
@@ -5,13 +5,13 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import {
-    Label,
-    Value,
     DescriptionList,
+    DescriptionItem,
     type DescriptionListProps,
 } from '../DescriptionList';
 
 import { Link } from '~/ui/Link';
+import { Text } from '~/ui/Text';
 
 export default {
     component: DescriptionList,
@@ -27,14 +27,14 @@ export default {
 export const Default: StoryObj<DescriptionListProps> = {
     render: () => (
         <DescriptionList>
-            <Label>Object ID</Label>
-            <Value>
+            <DescriptionItem title="Object ID">
                 <Link variant="mono" to="/">
                     0xb758af2061e7c0e55df23de52c51968f6efbc959
                 </Link>
-            </Value>
-            <Label variant="bodySmall">Owner</Label>
-            <Value>Value 1</Value>
+            </DescriptionItem>
+            <DescriptionItem title={<Text variant="bodySmall">Owner</Text>}>
+                Value 1
+            </DescriptionItem>
         </DescriptionList>
     ),
 };

--- a/apps/explorer/src/ui/stories/TableHeader.stories.tsx
+++ b/apps/explorer/src/ui/stories/TableHeader.stories.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { TableHeader, type TableHeaderProps } from '../TableHeader';
+
+export default {
+    component: TableHeader,
+} as Meta;
+
+export const Default: StoryObj<TableHeaderProps> = {
+    args: {
+        children: 'Table Header',
+        after: 'After Content',
+    },
+};

--- a/apps/explorer/src/utils/stringUtils.ts
+++ b/apps/explorer/src/utils/stringUtils.ts
@@ -48,6 +48,15 @@ export function truncate(fullStr: string, strLen: number, separator?: string) {
     );
 }
 
+const ELLIPSIS = '\u{2026}';
+export function formatAddress(address: string) {
+    const offset = address.startsWith('0x') ? 2 : 0;
+
+    return `0x${address.slice(offset, offset + 4)}${ELLIPSIS}${address.slice(
+        -4
+    )}`;
+}
+
 export async function extractFileType(
     displayString: string,
     signal: AbortSignal


### PR DESCRIPTION
This updates the gas on the transaction page to show a breakdown. This is aligned with the current figma designs for this. I used the new `DescriptionList` components here, and found an improvement to the API that cleaned things up. I also updated the styles for this component to more closely match the designs.

I also added a `formatAddress()` function that I think we should eventually move to the SDK itself, once we have a little more clarity around things like zero-padding. This will basically replace `truncate` as we now have a consistent way we want to display these instead of the inconsistent formatting we have in place today.