### PR TITLE
[doc] Rename Lamport Timestamps

### DIFF
--- a/DEVX_ROADMAP.md
+++ b/DEVX_ROADMAP.md
@@ -8,9 +8,9 @@ To keep Sui builders up-to-date with the latest happenings, we provide the follo
 ## Highlights
 
  * We plan to add the ability for developers to depend on packages from third-party package managers. More information in the following sections.
- * We are introducing Lamport Timestamps, a new mechanism to version Objects. More details below.
+ * We are introducing Lamport Object Versions, a new mechanism to version Objects. More details below.
  * We continue to make stability and performance improvements to our JSON RPC APIs.
- * We intend to introduce signing support soon. 
+ * We intend to introduce signing support soon.
 
 
 ## JSON RPC
@@ -37,7 +37,7 @@ To keep Sui builders up-to-date with the latest happenings, we provide the follo
     * Add the ability for developers to verify source code dependencies against their on-chain counterparts when publishing packages.
     * Enable third-party package managers like Movey to resolve dependencies in Sui Move packages. This enables library developers to distribute their packages under easy-to-identify names. This also removes the error-prone need for developers to remember the GitHub repository, revision, and subdirectories for all their dependencies.
  * Introduce a dev-inspect transaction type that can dry-run any Move function [[RFC](https://github.com/MystenLabs/sui/pull/6538)].
- * Introduce Lamport Timestamps for Object versioning. As opposed to the existing mechanism of incrementing an Object's version by one when it gets mutated, all the Objects mutated by a transaction get bumped to the same version, which is the smallest version that's greater than all input versions [[PR](https://github.com/MystenLabs/sui/pull/6163)]. As a result, it is no longer possible to discover previous version(s) of an Object by decrementing its `SequenceNumber` by one, because a transaction could increase an object's version by more than one. We are working on exposing an API to directly obtain an Object's previous version [[Issue](https://github.com/MystenLabs/sui/issues/6529)].
+ * Introduce Lamport Versions for Objects. As opposed to the existing mechanism of incrementing an Object's version by one when it gets mutated, all the Objects mutated by a transaction get bumped to the same version, which is the smallest version that's greater than all input versions [[PR](https://github.com/MystenLabs/sui/pull/6163)]. As a result, it is no longer possible to discover previous version(s) of an Object by decrementing its `SequenceNumber` by one, because a transaction could increase an object's version by more than one. We are working on exposing an API to directly obtain an Object's previous version [[Issue](https://github.com/MystenLabs/sui/issues/6529)].
  * Better debug printing for structs (including field names + nice formatting).
 
 


### PR DESCRIPTION
The word Timestmap is really confusing in this context, and makes people think we are adding some kind of timestamp.
It should really be Lamport Versions.