### PR TITLE
[docs] Update pnpm usage docs

### DIFF
--- a/.github/workflows/changesets-ci-comment.yml
+++ b/.github/workflows/changesets-ci-comment.yml
@@ -52,7 +52,7 @@ jobs:
           pr_number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           comment_includes: "⚠️ 🦋 **Changesets Warning:**"
           message: |
-            ⚠️ 🦋 **Changesets Warning:** This PR has changes to public npm packages, but does not contain a changeset. You can create a changeset easily by running `pnpm changeset`, and following the prompts. If your change does not need a changeset (e.g. a documentation-only change), you can ignore this message. This warning will be removed when a changeset is added to this pull request.
+            ⚠️ 🦋 **Changesets Warning:** This PR has changes to public npm packages, but does not contain a changeset. You can create a changeset easily by running `pnpm changeset` in the root of the Sui repo, and following the prompts. If your change does not need a changeset (e.g. a documentation-only change), you can ignore this message. This warning will be removed when a changeset is added to this pull request.
 
             [Learn more about Changesets](https://github.com/changesets/changesets).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/explorer/README.md
+++ b/apps/explorer/README.md
@@ -12,6 +12,18 @@ Dependencies are managed using [`pnpm`](https://pnpm.io/). You can start by inst
 $ pnpm install
 ```
 
+> All `pnpm` commands are intended to be run in the root of the Sui repo. You can also run them within the `apps/explorer` directory, and remove change `pnpm explorer` to just `pnpm` when running commands.
+
+## Developing the Sui Explorer
+
+To start the explorer dev server, you can run the following command:
+
+```
+pnpm explorer dev
+```
+
+This will start the dev server on port 3000, which should be accessible on http://localhost:3000/
+
 # How to Switch Environment
 
 By default, the Sui Explorer attempts to connect to a local RPC server. For more information about using a local RPC server, see [Local RPC Server & JSON-RPC API Quick Start](../../doc/src/build/json-rpc.md).
@@ -25,7 +37,7 @@ The Sui Explorer can also connect to a local, static JSON dataset that can be fo
 For example, suppose we wish to locally run the website using the static JSON dataset and not the API, then we could run the following:
 
 ```bash
-pnpm dev:static
+pnpm explorer dev:static
 
 ```
 
@@ -51,21 +63,21 @@ pnpm explorer exec cypress open
 
 # Other pnpm commands
 
-### `pnpm test`
+### `pnpm explorer test`
 
 This runs a series of end-to-end browser tests using the website as connected to the static JSON dataset. This command is run by the GitHub checks. The tests must pass before merging a branch into main.
 
-### `pnpm build`
+### `pnpm explorer build`
 
 Builds the app for production to the `build` folder.
 
 It bundles React in production mode and optimizes the build for the best performance.
 
-### `pnpm lint`
+### `pnpm explorer lint`
 
 Run linting check (prettier/eslint/stylelint).
 
-### `pnpm lint:fix`
+### `pnpm explorer lint:fix`
 
 Run linting check but also try to fix any issues.
 

--- a/apps/wallet/README.md
+++ b/apps/wallet/README.md
@@ -18,12 +18,14 @@ Dependencies are managed using [`pnpm`](https://pnpm.io/). You can start by inst
 $ pnpm install
 ```
 
+> All `pnpm` commands are intended to be run in the root of the Sui repo. You can also run them within the `apps/wallet` directory, and remove change `pnpm wallet` to just `pnpm` when running commands.
+
 ## Build in watch mode (dev)
 
 To build the extension and watch for changes run:
 
 ```
-pnpm start
+pnpm wallet start
 ```
 
 This will build the app in the [dist/](./dist/) directory, watch for changes and rebuild it. (Also runs prettier to format the files that changed.)
@@ -33,7 +35,7 @@ This will build the app in the [dist/](./dist/) directory, watch for changes and
 To build the app once in development mode (no optimizations etc) run
 
 ```
-pnpm run build:dev
+pnpm wallet build:dev
 ```
 
 The output directory is the same [dist/](./dist/), all build artifacts will go there
@@ -43,7 +45,7 @@ The output directory is the same [dist/](./dist/), all build artifacts will go t
 To build the app once in production mode run
 
 ```
-pnpm run build:prod
+pnpm wallet build:prod
 ```
 
 Same as above the output is [dist/](./dist/).
@@ -55,5 +57,5 @@ After building the app, the extension needs to be installed to Chrome. Follow th
 ## Testing
 
 ```
-pnpm run test
+pnpm wallet test
 ```

--- a/sdk/bcs/README.md
+++ b/sdk/bcs/README.md
@@ -24,14 +24,15 @@ At the high level, BCS gives a set of handy abstractions to (de)serialize data.
 
 In BCS structs are merely sequences of fields, they contain no type information but the order in
 which fields are defined. It also means that you can use any field names - they won't affect serialization!
-```
+
+```ts
 bcs.registerStructType(<TYPE>, {
     [<FIELD>]: <FIELD_TYPE>,
     ...
 })
 ```
 
-```js
+```ts
 import { bcs } from "@mysten/bcs";
 
 // MyAddr is an address of 20 bytes; encoded and decoded as HEX
@@ -59,7 +60,7 @@ Vector generics are not supported by default. To use a vector type, add it first
 bcs.registerVectorType(<TYPE>, <ELEMENT_TYPE>);
 ```
 
-```js
+```ts
 import { bcs } from "@mysten/bcs";
 
 bcs.registerVectorType('vector<u8>', 'u8');
@@ -73,11 +74,12 @@ console.assert(again === '06010203040506', 'Whoopsie!');
 
 Even though the way of serializing Move addresses stays the same, the length of the address
 varies depending on the network. To register an address type use:
-```
+
+```ts
 bcs.registerAddressType(<TYPE>, <LENGTH>);
 ```
 
-```js
+```ts
 import { bcs } from "@mysten/bcs";
 
 bcs.registerAddressType('FiveByte', 5);
@@ -94,7 +96,7 @@ console.assert(ser === '9c88e852aa66b346860ada31aa75c6c27695ae4b', 'Long address
 
 To deserialize data, use a `BCS.de(type: string, data: Uint8Array)`. Type parameter is a name of the type; data is a BCS encoded as hex.
 
-```js
+```ts
 import { bcs } from '@mysten/bcs';
 
 // BCS has a set of built ins:
@@ -118,7 +120,7 @@ console.log(str);
 
 To serialize any type, use `bcs.ser(type: string, data: any)`. Type parameter is a name of the type to serialize, data is any data, depending on the type (can be object for structs or string for big integers - such as `u128`).
 
-```js
+```ts
 import { bcs } from '@mysten/bcs';
 
 let bcs_u8 = bcs.ser('u8', 255).toString('hex'); // uint Array
@@ -130,7 +132,7 @@ console.assert(bcs_ascii === '0a68656c6c6f5f6d6f7665');
 
 ### Working with Move structs
 
-```js
+```ts
 import { bcs } from '@mysten/bcs';
 
 // Move / Rust struct

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -35,6 +35,8 @@ $ pnpm install
 $ pnpm sdk build
 ```
 
+> All `pnpm` commands are intended to be run in the root of the Sui repo. You can also run them within the `sdk/typescript` directory, and remove change `pnpm sdk` to just `pnpm` when running commands.
+
 ## Type Doc
 
 You can view the generated [Type Doc](https://typedoc.org/) for the [current release of the SDK](https://www.npmjs.com/package/@mysten/sui.js) at http://typescript-sdk-docs.s3-website-us-east-1.amazonaws.com/.
@@ -46,23 +48,20 @@ For the latest docs for the `main` branch, run `pnpm doc` and open the [doc/inde
 To run unit tests
 
 ```
-cd sdk/typescript
-pnpm run test:unit
+pnpm sdk test:unit
 ```
 
 To run E2E tests against local network
 
 ```
-cd sdk/typescript
-pnpm run prepare:e2e
-pnpm run test:e2e
+pnpm sdk prepare:e2e
+pnpm sdk test:e2e
 ```
 
 To run E2E tests against DevNet
 
 ```
-cd sdk/typescript
-VITE_FAUCET_URL='https://faucet.devnet.sui.io:443/gas' VITE_FULLNODE_URL='https://fullnode.devnet.sui.io' vitest e2e
+VITE_FAUCET_URL='https://faucet.devnet.sui.io:443/gas' VITE_FULLNODE_URL='https://fullnode.devnet.sui.io' pnpm sdk exec vitest e2e
 ```
 
 ## Connecting to Sui Network


### PR DESCRIPTION
This updates the docs related to usage of `pnpm` so that all commands run from the root of the Sui repo (and document that they can also run within the package folder). This helps with consistency when using pnpm, as there are commands that can _only_ be run in the repo root, but all package-specific commands can also be run in the root with correct prefixing. I also updated the changeset comment to tell folks where to run the changeset command.