### PR TITLE
[explorer] Add cache headers for assets

### DIFF
--- a/apps/explorer/vercel.json
+++ b/apps/explorer/vercel.json
@@ -1,6 +1,18 @@
 {
+    "$schema": "https://openapi.vercel.sh/vercel.json",
     "rewrites": [{ "source": "/(.*)", "destination": "/" }],
     "github": {
         "silent": true
-    }
+    },
+    "headers": [
+        {
+            "source": "/assets/(.*)",
+            "headers": [
+                {
+                    "key": "cache-control",
+                    "value": "public,max-age=31536000,immutable"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This adds cache headers for the built explorer assets. These assets are hashed, so they should be unique per-build. As such we set it to be cached for up to 365 days, and mark them as immutable.