### PR TITLE
indexer: processor orchestrator and processors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8590,6 +8590,7 @@ dependencies = [
  "chrono",
  "diesel",
  "dotenvy",
+ "fastcrypto",
  "futures",
  "jsonrpsee",
  "narwhal-network",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -39,6 +39,8 @@ sui-sdk = { path = "../sui-sdk" }
 telemetry-subscribers.workspace = true
 workspace-hack = { path = "../workspace-hack"}
 
+fastcrypto = { workspace = true, features = ["copy_key"] }
+
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
 sui-framework-build = { path = "../sui-framework-build" }

--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/down.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/down.sql
@@ -1,2 +1,1 @@
 DROP TABLE transactions;
-DROP TABLE events;

--- a/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-195259_transactions/up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE transactions (
     id BIGSERIAL PRIMARY KEY,
-    transaction_digest VARCHAR(64) NOT NULL,
-    sender VARCHAR(64) NOT NULL,
+    transaction_digest VARCHAR(255) NOT NULL,
+    sender VARCHAR(255) NOT NULL,
     transaction_time TIMESTAMP,
     transaction_kinds TEXT[] NOT NULL,
     -- object related
@@ -11,13 +11,16 @@ CREATE TABLE transactions (
     unwrapped TEXT[] NOT NULL,
     wrapped TEXT[] NOT NULL,
     -- gas object related
-    gas_object_id VARCHAR(64) NOT NULL,
+    gas_object_id VARCHAR(255) NOT NULL,
     gas_object_sequence BIGINT NOT NULL,
-    gas_object_digest VARCHAR(64) NOT NULL,
+    gas_object_digest VARCHAR(255) NOT NULL,
     -- gas budget & cost related
     gas_budget BIGINT NOT NULL,
     total_gas_cost BIGINT NOT NULL,
     computation_cost BIGINT NOT NULL,
     storage_cost BIGINT NOT NULL,
-    storage_rebate BIGINT NOT NULL
+    storage_rebate BIGINT NOT NULL,
+    -- serialized transaction
+    transaction_content TEXT NOT NULL,
+    UNIQUE(transaction_digest) 
 );

--- a/crates/sui-indexer/migrations/2022-11-18-220045_events/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-18-220045_events/up.sql
@@ -1,12 +1,11 @@
 CREATE TABLE EVENTS (
     id BIGSERIAL PRIMARY KEY,
-    -- txn digest is bytes of 32, but if we do exactly 32,
-    -- DB write will fail with value too long for type character varying(32).
-    transaction_digest VARCHAR(64),
+    transaction_digest VARCHAR(255),
     -- below 2 are from Event ID, tx_seq and event_seq
     transaction_sequence BIGINT NOT NULL,
     event_sequence BIGINT NOT NULL,
     event_time TIMESTAMP,
     event_type VARCHAR NOT NULL,
-    event_content VARCHAR NOT NULL
+    event_content VARCHAR NOT NULL,
+    UNIQUE (transaction_sequence, event_sequence)
 );

--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/down.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS addresses;
+DROP TABLE IF EXISTS address_logs;

--- a/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
+++ b/crates/sui-indexer/migrations/2022-11-28-204251_addresses/up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE addresses (
+    account_address VARCHAR(255) PRIMARY KEY,
+    first_appearance_tx VARCHAR(255) NOT NULL, 
+    first_appearance_time TIMESTAMP
+);
+
+CREATE TABLE address_logs (
+    -- this is essentially BIGSERIAL starting from 1
+    -- see https://www.postgresql.org/docs/9.1/datatype-numeric.html
+    last_processed_id BIGINT PRIMARY KEY
+);
+
+-- last processed serial number, as the serial number starts from 1,
+-- initial value of last_processed_id should be 0.
+INSERT INTO address_logs VALUES (0);
+

--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/down.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE objects;
+DROP TABLE object_logs;

--- a/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-01-034426_objects/up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE objects (
+    object_id VARCHAR(255) PRIMARY KEY,
+    version BIGINT NOT NULL,
+
+    -- owner related
+    owner_type VARCHAR(255) NOT NULL,
+    -- only non-null for objects with an owner,
+    -- the owner can be an account or an object. 
+    owner_address VARCHAR(255),
+    -- only non-null for shared objects
+    initial_shared_version BIGINT,
+
+    package_id TEXT NOT NULL,
+    transaction_module TEXT NOT NULL,
+    object_type TEXT,
+
+    -- status can be CREATED, MUTATED or DELETED.
+    object_status VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE object_logs (
+    last_processed_id BIGINT PRIMARY KEY
+);
+
+INSERT INTO object_logs (last_processed_id) VALUES (0);

--- a/crates/sui-indexer/migrations/2022-12-02-202249_packages/down.sql
+++ b/crates/sui-indexer/migrations/2022-12-02-202249_packages/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE packages;
+DROP TABLE package_logs;

--- a/crates/sui-indexer/migrations/2022-12-02-202249_packages/up.sql
+++ b/crates/sui-indexer/migrations/2022-12-02-202249_packages/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE packages (
+    package_id TEXT PRIMARY KEY,
+    author TEXT NOT NULL,
+    -- means the column cannot be null,
+    -- the element in the array can stil be null
+    module_names TEXT[] NOT NULL,
+    package_content TEXT NOT NULL
+);
+
+CREATE TABLE package_logs (
+    last_processed_id BIGINT PRIMARY KEY
+);
+
+INSERT INTO package_logs (last_processed_id) VALUES (0);

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -22,6 +22,12 @@ pub enum IndexerError {
 
     #[error("Indexer failed to parse transaction digest read from DB: `{0}`")]
     TransactionDigestParsingError(String),
+
+    #[error("Indexer failed to find object mutations, which should never happen.")]
+    ObjectMutationNotAvailable,
+
+    #[error("Indexer failed to deserialize event from events table: `{0}`")]
+    EventDeserializationError(String),
 }
 
 impl IndexerError {
@@ -35,6 +41,8 @@ impl IndexerError {
             IndexerError::TransactionDigestParsingError(_) => {
                 "TransactionDigestParsingError".to_string()
             }
+            IndexerError::ObjectMutationNotAvailable => "ObjectMutationNotAvailable".to_string(),
+            IndexerError::EventDeserializationError(_) => "EventDeserializationError".to_string(),
         }
     }
 }

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -3,17 +3,12 @@
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use dotenvy::dotenv;
-use std::env;
 
 pub mod errors;
 pub mod models;
 pub mod schema;
 pub mod utils;
 
-pub fn establish_connection() -> PgConnection {
-    dotenv().ok();
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url)
-        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
+pub fn establish_connection(db_url: String) -> PgConnection {
+    PgConnection::establish(&db_url).unwrap_or_else(|_| panic!("Error connecting to {}", db_url))
 }

--- a/crates/sui-indexer/src/models/address_logs.rs
+++ b/crates/sui-indexer/src/models/address_logs.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::address_logs;
+use crate::schema::address_logs::dsl::*;
+use diesel::prelude::*;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(last_processed_id))]
+pub struct AddressLog {
+    pub last_processed_id: i64,
+}
+
+pub fn read_address_log(conn: &mut PgConnection) -> Result<AddressLog, IndexerError> {
+    address_logs
+        .limit(1)
+        .first::<AddressLog>(conn)
+        .map_err(|e| {
+            IndexerError::PostgresReadError(format!(
+                "Failed reading address log with error: {:?}",
+                e
+            ))
+        })
+}
+
+pub fn commit_address_log(conn: &mut PgConnection, id: i64) -> Result<usize, IndexerError> {
+    diesel::update(address_logs::table)
+        .set(last_processed_id.eq(id))
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed to commit address log with id: {:?} and error: {:?}",
+                id, e
+            ))
+        })
+}

--- a/crates/sui-indexer/src/models/addresses.rs
+++ b/crates/sui-indexer/src/models/addresses.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::models::transactions::Transaction;
+use crate::schema::addresses;
+use crate::schema::addresses::dsl::*;
+
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+
+#[derive(Queryable, Debug)]
+#[diesel(primary_key(account_address))]
+pub struct Addresses {
+    pub account_address: String,
+    pub first_appearance_tx: String,
+    pub first_appearance_time: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = addresses)]
+pub struct NewAddress {
+    pub account_address: String,
+    pub first_appearance_tx: String,
+    pub first_appearance_time: Option<NaiveDateTime>,
+}
+
+pub fn commit_addresses(
+    conn: &mut PgConnection,
+    new_addr_vec: Vec<NewAddress>,
+) -> Result<usize, IndexerError> {
+    diesel::insert_into(addresses::table)
+        .values(&new_addr_vec)
+        .on_conflict(account_address)
+        .do_nothing()
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed writing addresses to Postgres DB with addresses {:?} and error: {:?}",
+                new_addr_vec, e
+            ))
+        })
+}
+
+pub fn transaction_to_address(txn: Transaction) -> NewAddress {
+    NewAddress {
+        account_address: txn.sender,
+        first_appearance_tx: txn.transaction_digest,
+        first_appearance_time: txn.transaction_time,
+    }
+}

--- a/crates/sui-indexer/src/models/event_logs.rs
+++ b/crates/sui-indexer/src/models/event_logs.rs
@@ -14,6 +14,16 @@ pub struct EventLog {
     pub next_cursor_event_seq: Option<i64>,
 }
 
+pub fn read_event_log(conn: &mut PgConnection) -> Result<EventLog, IndexerError> {
+    // NOTE: always read one row, as event logs only have one row
+    event_logs.limit(1).first::<EventLog>(conn).map_err(|e| {
+        IndexerError::PostgresReadError(format!(
+            "Failed reading event log in PostgresDB with error {:?}",
+            e
+        ))
+    })
+}
+
 pub fn commit_event_log(
     conn: &mut PgConnection,
     tx_seq: Option<i64>,
@@ -25,14 +35,4 @@ pub fn commit_event_log(
             tx_seq, event_seq, e
         ))
     )
-}
-
-pub fn read_event_log(conn: &mut PgConnection) -> Result<EventLog, IndexerError> {
-    // NOTE: always read one row, as event logs only have one row
-    event_logs.limit(1).first::<EventLog>(conn).map_err(|e| {
-        IndexerError::PostgresReadError(format!(
-            "Failed reading event log in PostgresDB with error {:?}",
-            e
-        ))
-    })
 }

--- a/crates/sui-indexer/src/models/events.rs
+++ b/crates/sui-indexer/src/models/events.rs
@@ -3,12 +3,13 @@
 
 use crate::errors::IndexerError;
 use crate::schema::events;
-use crate::schema::events::{event_sequence, transaction_digest, transaction_sequence};
+use crate::schema::events::dsl::{events as events_table, id};
+use crate::schema::events::{event_sequence, transaction_sequence};
 use crate::utils::log_errors_to_pg;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use sui_json_rpc_types::{EventPage, SuiEventEnvelope};
+use sui_json_rpc_types::{EventPage, SuiEvent, SuiEventEnvelope};
 
 #[derive(Queryable, Debug)]
 pub struct Event {
@@ -32,12 +33,29 @@ pub struct NewEvent {
     pub event_content: String,
 }
 
+pub fn read_events(
+    conn: &mut PgConnection,
+    last_processed_id: i64,
+    limit: usize,
+) -> Result<Vec<Event>, IndexerError> {
+    events_table
+        .filter(id.gt(last_processed_id))
+        .limit(limit as i64)
+        .load::<Event>(conn)
+        .map_err(|e| {
+            IndexerError::PostgresReadError(format!(
+                "Failed reading events with last_processed_id {} and error: {:?}",
+                last_processed_id, e
+            ))
+        })
+}
+
 // NOTE: no need to retry here b/c errors here are not transient,
 // instead we write them to PG tables for debugging purposes.
 pub fn event_to_new_event(e: SuiEventEnvelope) -> Result<NewEvent, IndexerError> {
     let event_json = serde_json::to_string(&e.event).map_err(|err| {
         IndexerError::InsertableParsingError(format!(
-            "Failed converting event to JSON with error : {}",
+            "Failed converting event to JSON with error: {:?}",
             err
         ))
     })?;
@@ -68,11 +86,11 @@ pub fn commit_events(
         .map(event_to_new_event)
         .filter_map(|r| r.map_err(|e| errors.push(e)).ok())
         .collect();
-    log_errors_to_pg(errors);
 
+    log_errors_to_pg(conn, errors);
     diesel::insert_into(events::table)
         .values(&new_events)
-        .on_conflict((transaction_digest, transaction_sequence, event_sequence))
+        .on_conflict((transaction_sequence, event_sequence))
         .do_nothing()
         .execute(conn)
         .map_err(|e| {
@@ -81,4 +99,29 @@ pub fn commit_events(
                 new_events, e
             ))
         })
+}
+
+pub fn events_to_sui_events(conn: &mut PgConnection, events: Vec<Event>) -> Vec<SuiEvent> {
+    let mut errors = vec![];
+    let sui_events_to_process: Vec<SuiEvent> = events
+        .into_iter()
+        .filter_map(|event| {
+            let sui_event_str = event.event_content.as_str();
+            let sui_event: Result<SuiEvent, IndexerError> = serde_json::from_str(sui_event_str)
+                .map_err(|e| {
+                    IndexerError::EventDeserializationError(format!(
+                        "Failed deserializing event {:?} with error: {:?}",
+                        event.event_content, e
+                    ))
+                });
+            sui_event
+                .map_err(|e| {
+                    errors.push(e.clone());
+                    e
+                })
+                .ok()
+        })
+        .collect();
+    log_errors_to_pg(conn, errors);
+    sui_events_to_process
 }

--- a/crates/sui-indexer/src/models/mod.rs
+++ b/crates/sui-indexer/src/models/mod.rs
@@ -1,8 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod address_logs;
+pub mod addresses;
 pub mod error_logs;
 pub mod event_logs;
 pub mod events;
+pub mod object_logs;
+pub mod objects;
+pub mod package_logs;
+pub mod packages;
 pub mod transaction_logs;
 pub mod transactions;

--- a/crates/sui-indexer/src/models/object_logs.rs
+++ b/crates/sui-indexer/src/models/object_logs.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::object_logs;
+use crate::schema::object_logs::dsl::*;
+use diesel::prelude::*;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(last_processed_id))]
+pub struct ObjectLog {
+    pub last_processed_id: i64,
+}
+
+pub fn read_object_log(conn: &mut PgConnection) -> Result<ObjectLog, IndexerError> {
+    object_logs.limit(1).first::<ObjectLog>(conn).map_err(|e| {
+        IndexerError::PostgresReadError(format!("Failed reading object log with error {:?}", e))
+    })
+}
+
+pub fn commit_object_log(conn: &mut PgConnection, id: i64) -> Result<usize, IndexerError> {
+    diesel::update(object_logs::table)
+        .set(last_processed_id.eq(id))
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed to commit object log with id: {:?} and error: {:?}",
+                id, e
+            ))
+        })
+}

--- a/crates/sui-indexer/src/models/objects.rs
+++ b/crates/sui-indexer/src/models/objects.rs
@@ -1,0 +1,252 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::objects;
+use crate::schema::objects::dsl::{
+    object_id as object_id_column, object_status as object_status_column, objects as objects_table,
+    version as version_column,
+};
+
+use diesel::pg::upsert::excluded;
+use diesel::prelude::*;
+use std::collections::BTreeMap;
+use sui_json_rpc_types::SuiEvent;
+use sui_types::object::Owner;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(object_id))]
+pub struct Object {
+    pub object_id: String,
+    pub version: i64,
+    pub owner_type: String,
+    pub owner_address: Option<String>,
+    pub initial_shared_version: Option<i64>,
+    pub package_id: String,
+    pub transaction_module: String,
+    pub object_type: Option<String>,
+    pub object_status: String,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = objects)]
+pub struct NewObject {
+    pub object_id: String,
+    pub version: i64,
+    pub owner_type: String,
+    pub owner_address: Option<String>,
+    pub initial_shared_version: Option<i64>,
+    pub package_id: String,
+    pub transaction_module: String,
+    pub object_type: Option<String>,
+    pub object_status: String,
+}
+
+pub fn commit_new_objects(
+    conn: &mut PgConnection,
+    new_objects: Vec<NewObject>,
+) -> Result<usize, IndexerError> {
+    if new_objects.is_empty() {
+        return Ok(0);
+    }
+    diesel::insert_into(objects::table)
+        .values(&new_objects)
+        .on_conflict(object_id_column)
+        .do_nothing()
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed inserting new objects into database with objects {:?} and error: {:?}",
+                new_objects, e
+            ))
+        })
+}
+
+pub fn commit_object_transfers(
+    conn: &mut PgConnection,
+    object_transfers: Vec<NewObject>,
+) -> Result<usize, IndexerError> {
+    if object_transfers.is_empty() {
+        return Ok(0);
+    }
+    diesel::insert_into(objects::table)
+        .values(&object_transfers)
+        .on_conflict(object_id_column)
+        .do_nothing()
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed inserting object transfers into database with objects {:?} and error: {:?}",
+                object_transfers, e
+            ))
+        })
+}
+
+// Multi-row update is not supported by Diesel, see https://github.com/diesel-rs/diesel/discussions/2879
+// even though Postgres can do it via UPDATE ... FROM.
+// As a work-around, this function will read all related rows into memory, update the columns and upsert back to DB.
+pub fn commit_object_mutations(
+    conn: &mut PgConnection,
+    object_mutations: Vec<(String, (i64, String))>,
+) -> Result<usize, IndexerError> {
+    if object_mutations.is_empty() {
+        return Ok(0);
+    }
+    let object_map = BTreeMap::from_iter(object_mutations.into_iter());
+    let object_ids: Vec<String> = object_map.keys().cloned().collect();
+    let objs = objects_table.filter(object_id_column.eq_any(object_ids)).load::<Object>(conn).map_err(
+        |e| IndexerError::PostgresReadError(
+            format!("Failed reading selected objects from database for object mutations with error: {:?}", e)
+        )
+    )?;
+    let updated_new_objs: Vec<NewObject> = objs
+        .into_iter()
+        .map(|obj| {
+            let updates = object_map.get(&obj.object_id);
+            let (mut version, mut status) = (obj.version, obj.object_status);
+            if let Some((new_version, new_status)) = updates {
+                version = *new_version;
+                status = new_status.clone();
+            }
+            NewObject {
+                object_id: obj.object_id,
+                version,
+                owner_type: obj.owner_type,
+                owner_address: obj.owner_address,
+                initial_shared_version: obj.initial_shared_version,
+                package_id: obj.package_id,
+                transaction_module: obj.transaction_module,
+                object_type: obj.object_type,
+                object_status: status,
+            }
+        })
+        .collect();
+
+    diesel::insert_into(objects::table)
+        .values(&updated_new_objs)
+        .on_conflict(object_id_column).do_update()
+        .set(
+        (version_column.eq(excluded(version_column)), object_status_column.eq(excluded(object_status_column)))
+    ).execute(conn).map_err(|e| IndexerError::PostgresWriteError(
+        format!("Failed writing object mutations to Postgres DB with mutations updated_new_objs {:?} and error: {:?} ", updated_new_objs, e) ))
+}
+
+pub fn commit_object_deletions(
+    conn: &mut PgConnection,
+    object_deletions: Vec<String>,
+) -> Result<usize, IndexerError> {
+    if object_deletions.is_empty() {
+        return Ok(0);
+    }
+    diesel::update(objects::table.filter(object_id_column.eq_any(object_deletions.clone())))
+        .set(object_status_column.eq(DELETED_STATUS.to_string()))
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed writing object deletions to Postgres DB with IDs {:?} and error: {:?} ",
+                object_deletions, e
+            ))
+        })
+}
+
+// return owner_type, owner_address and initial_shared_version
+fn owner_to_owner_info(owner: &Owner) -> (String, Option<String>, Option<i64>) {
+    match owner {
+        Owner::AddressOwner(address) => {
+            ("AddressOwner".to_string(), Some(address.to_string()), None)
+        }
+        Owner::ObjectOwner(address) => ("ObjectOwner".to_string(), Some(address.to_string()), None),
+        Owner::Shared {
+            initial_shared_version,
+        } => (
+            "Shared".to_string(),
+            None,
+            Some(initial_shared_version.value() as i64),
+        ),
+        Owner::Immutable => ("Immutable".to_string(), None, None),
+    }
+}
+
+const CREATED_STATUS: &str = "CREATED";
+const MUTATED_STATUS: &str = "MUTATED";
+const TRANSFERRED_STATUS: &str = "TRANSFERRED";
+const DELETED_STATUS: &str = "DELETED";
+
+pub fn commit_objects_from_events(
+    conn: &mut PgConnection,
+    events: Vec<SuiEvent>,
+) -> Result<(), IndexerError> {
+    let mut new_objects = vec![];
+    let mut object_transfers = vec![];
+    let mut object_mutations = vec![];
+    let mut object_deletions = vec![];
+
+    for e in events.into_iter() {
+        match e {
+            SuiEvent::NewObject {
+                package_id,
+                transaction_module,
+                sender: _,
+                recipient,
+                object_type,
+                object_id,
+                version,
+            } => {
+                let (owner_type, owner_address, initial_shared_version) =
+                    owner_to_owner_info(&recipient);
+                new_objects.push(NewObject {
+                    object_id: object_id.to_string(),
+                    version: version.value() as i64,
+                    owner_type,
+                    owner_address,
+                    initial_shared_version,
+                    package_id: package_id.to_string(),
+                    transaction_module,
+                    object_type: Some(object_type),
+                    object_status: CREATED_STATUS.to_string(),
+                });
+            }
+            SuiEvent::TransferObject {
+                package_id,
+                transaction_module,
+                sender: _,
+                recipient,
+                object_type,
+                object_id,
+                version,
+            } => {
+                let (owner_type, owner_address, initial_shared_version) =
+                    owner_to_owner_info(&recipient);
+                object_transfers.push(NewObject {
+                    object_id: object_id.to_string(),
+                    version: version.value() as i64,
+                    owner_type,
+                    owner_address,
+                    initial_shared_version,
+                    package_id: package_id.to_string(),
+                    transaction_module,
+                    object_type: Some(object_type),
+                    object_status: TRANSFERRED_STATUS.to_string(),
+                });
+            }
+            SuiEvent::MutateObject {
+                object_id, version, ..
+            } => {
+                object_mutations.push((
+                    object_id.to_string(),
+                    (version.value() as i64, MUTATED_STATUS.to_string()),
+                ));
+            }
+            SuiEvent::DeleteObject { object_id, .. } => {
+                object_deletions.push(object_id.to_string());
+            }
+            _ => {}
+        }
+    }
+    commit_new_objects(conn, new_objects)?;
+    commit_object_transfers(conn, object_transfers)?;
+    commit_object_mutations(conn, object_mutations)?;
+    commit_object_deletions(conn, object_deletions)?;
+
+    Ok(())
+}

--- a/crates/sui-indexer/src/models/package_logs.rs
+++ b/crates/sui-indexer/src/models/package_logs.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::package_logs;
+use crate::schema::package_logs::dsl::*;
+use diesel::prelude::*;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(last_processed_id))]
+pub struct PackageLog {
+    pub last_processed_id: i64,
+}
+
+pub fn read_package_log(conn: &mut PgConnection) -> Result<PackageLog, IndexerError> {
+    package_logs
+        .limit(1)
+        .first::<PackageLog>(conn)
+        .map_err(|e| {
+            IndexerError::PostgresReadError(format!(
+                "Failed reading package log with error {:?}",
+                e
+            ))
+        })
+}
+
+pub fn commit_package_log(conn: &mut PgConnection, id: i64) -> Result<usize, IndexerError> {
+    diesel::update(package_logs::table)
+        .set(last_processed_id.eq(id))
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed to commit package log with id {:?} and error {:?}",
+                id, e
+            ))
+        })
+}

--- a/crates/sui-indexer/src/models/packages.rs
+++ b/crates/sui-indexer/src/models/packages.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::errors::IndexerError;
+use crate::schema::packages;
+use crate::schema::packages::dsl::{
+    author as author_column, module_names as module_names_column,
+    package_content as package_content_column, package_id as package_id_column,
+};
+use crate::utils::log_errors_to_pg;
+
+use diesel::pg::upsert::excluded;
+use diesel::prelude::*;
+use futures::future::join_all;
+use sui_json_rpc_types::SuiEvent;
+use sui_sdk::SuiClient;
+use sui_types::base_types::{ObjectID, SuiAddress};
+
+use tracing::info;
+
+#[derive(Queryable, Debug, Identifiable)]
+#[diesel(primary_key(package_id))]
+pub struct Package {
+    pub package_id: String,
+    pub author: String,
+    pub module_names: Vec<Option<String>>,
+    pub package_content: String,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = packages)]
+pub struct NewPackage {
+    pub package_id: String,
+    pub author: String,
+    pub module_names: Vec<Option<String>>,
+    pub package_content: String,
+}
+
+pub async fn commit_packages_from_events(
+    rpc_client: SuiClient,
+    conn: &mut PgConnection,
+    events: Vec<SuiEvent>,
+) -> Result<usize, IndexerError> {
+    let sender_pkg_pair_iter = events.into_iter().filter_map(|event| match event {
+        SuiEvent::Publish { sender, package_id } => Some((sender, package_id)),
+        _ => None,
+    });
+
+    let mut errors = vec![];
+    let new_pkg_res_vec = join_all(
+        sender_pkg_pair_iter
+            .map(|(sender, pkg)| generate_new_package(rpc_client.clone(), sender, pkg)),
+    )
+    .await;
+    let new_pkgs: Vec<NewPackage> = new_pkg_res_vec
+        .into_iter()
+        .filter_map(|f| f.map_err(|e| errors.push(e)).ok())
+        .collect();
+    info!("new packages are {:?}", new_pkgs);
+    info!("pkg errors are {:?}", errors);
+
+    log_errors_to_pg(conn, errors);
+    commit_new_packages(conn, new_pkgs)
+}
+
+fn commit_new_packages(
+    conn: &mut PgConnection,
+    new_pkgs: Vec<NewPackage>,
+) -> Result<usize, IndexerError> {
+    if new_pkgs.is_empty() {
+        return Ok(0);
+    }
+    diesel::insert_into(packages::table)
+        .values(&new_pkgs)
+        .on_conflict(package_id_column)
+        .do_update()
+        .set((
+            author_column.eq(excluded(author_column)),
+            module_names_column.eq(excluded(module_names_column)),
+            package_content_column.eq(excluded(package_content_column)),
+        ))
+        .execute(conn)
+        .map_err(|e| {
+            IndexerError::PostgresWriteError(format!(
+                "Failed writing or updating packages {:?} with error: {:?}",
+                new_pkgs, e
+            ))
+        })
+}
+
+async fn generate_new_package(
+    rpc_client: SuiClient,
+    sender: SuiAddress,
+    package: ObjectID,
+) -> Result<NewPackage, IndexerError> {
+    let pkg_module_map = rpc_client
+        .read_api()
+        .get_normalized_move_modules_by_package(package)
+        .await
+        .map_err(|e| {
+            IndexerError::FullNodeReadingError(format!(
+                "Failed reading normalized package from Fullnode with package {:?} and error: {:?}",
+                package, e
+            ))
+        })?;
+    let module_names: Vec<Option<String>> = pkg_module_map.keys().cloned().map(Some).collect();
+    let pkg_module_map_json = serde_json::to_string(&pkg_module_map).map_err(|err| {
+        IndexerError::InsertableParsingError(format!(
+            "Failed converting package module map to JSON with error: {:?}",
+            err
+        ))
+    })?;
+
+    Ok(NewPackage {
+        package_id: package.to_string(),
+        author: sender.to_string(),
+        module_names,
+        package_content: pkg_module_map_json,
+    })
+}

--- a/crates/sui-indexer/src/processors/address_processor.rs
+++ b/crates/sui-indexer/src/processors/address_processor.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::establish_connection;
+use tracing::info;
+
+use sui_indexer::models::address_logs::{commit_address_log, read_address_log};
+use sui_indexer::models::addresses::{commit_addresses, transaction_to_address, NewAddress};
+use sui_indexer::models::transactions::read_transactions;
+
+const TRANSACTION_BATCH_SIZE: usize = 100;
+
+pub struct AddressProcessor {
+    db_url: String,
+}
+
+impl AddressProcessor {
+    pub fn new(db_url: String) -> AddressProcessor {
+        Self { db_url }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer address processor started...");
+        let mut pg_conn = establish_connection(self.db_url.clone());
+
+        let address_log = read_address_log(&mut pg_conn)?;
+        let last_processed_id = address_log.last_processed_id;
+
+        // fetch transaction rows from DB, with filter id > last_processed_id and limit of batch size.
+        let txn_vec = read_transactions(&mut pg_conn, last_processed_id, TRANSACTION_BATCH_SIZE)?;
+        let addr_vec: Vec<NewAddress> = txn_vec.into_iter().map(transaction_to_address).collect();
+        let next_processed_id = last_processed_id + addr_vec.len() as i64;
+
+        commit_addresses(&mut pg_conn, addr_vec)?;
+        commit_address_log(&mut pg_conn, next_processed_id)?;
+        Ok(())
+    }
+}

--- a/crates/sui-indexer/src/processors/mod.rs
+++ b/crates/sui-indexer/src/processors/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod address_processor;
+pub mod object_processor;
+pub mod package_processor;
+pub mod processor_orchestrator;

--- a/crates/sui-indexer/src/processors/object_processor.rs
+++ b/crates/sui-indexer/src/processors/object_processor.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::establish_connection;
+use sui_indexer::models::events::{events_to_sui_events, read_events};
+use sui_indexer::models::object_logs::{commit_object_log, read_object_log};
+use sui_indexer::models::objects::commit_objects_from_events;
+
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::info;
+
+const OBJECT_EVENT_BATCH_SIZE: usize = 100;
+
+pub struct ObjectProcessor {
+    db_url: String,
+}
+
+impl ObjectProcessor {
+    pub fn new(db_url: String) -> ObjectProcessor {
+        Self { db_url }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer object processor started...");
+        let mut pg_conn = establish_connection(self.db_url.clone());
+        let object_log = read_object_log(&mut pg_conn)?;
+        let mut last_processed_id = object_log.last_processed_id;
+
+        loop {
+            let events_to_process =
+                read_events(&mut pg_conn, last_processed_id, OBJECT_EVENT_BATCH_SIZE)?;
+            let event_count = events_to_process.len();
+            let sui_events_to_process = events_to_sui_events(&mut pg_conn, events_to_process);
+            commit_objects_from_events(&mut pg_conn, sui_events_to_process)?;
+
+            last_processed_id += event_count as i64;
+            commit_object_log(&mut pg_conn, last_processed_id)?;
+            if event_count < OBJECT_EVENT_BATCH_SIZE {
+                sleep(Duration::from_secs_f32(0.1)).await;
+            }
+        }
+    }
+}

--- a/crates/sui-indexer/src/processors/package_processor.rs
+++ b/crates/sui-indexer/src/processors/package_processor.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_indexer::errors::IndexerError;
+use sui_indexer::establish_connection;
+use sui_indexer::models::events::{events_to_sui_events, read_events};
+use sui_indexer::models::package_logs::{commit_package_log, read_package_log};
+use sui_indexer::models::packages::commit_packages_from_events;
+use sui_sdk::SuiClient;
+
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::info;
+
+const PACKAGE_EVENT_BATCH_SIZE: usize = 100;
+
+pub struct PackageProcessor {
+    rpc_client: SuiClient,
+    db_url: String,
+}
+
+impl PackageProcessor {
+    pub fn new(rpc_client: SuiClient, db_url: String) -> PackageProcessor {
+        Self { rpc_client, db_url }
+    }
+
+    pub async fn start(&self) -> Result<(), IndexerError> {
+        info!("Indexer package processor started...");
+        let mut pg_conn = establish_connection(self.db_url.clone());
+
+        let pkg_log = read_package_log(&mut pg_conn)?;
+        let mut last_processed_id = pkg_log.last_processed_id;
+        loop {
+            let events_to_process =
+                read_events(&mut pg_conn, last_processed_id, PACKAGE_EVENT_BATCH_SIZE)?;
+            let sui_events_to_process = events_to_sui_events(&mut pg_conn, events_to_process);
+
+            let event_count = sui_events_to_process.len();
+
+            commit_packages_from_events(
+                self.rpc_client.clone(),
+                &mut pg_conn,
+                sui_events_to_process,
+            )
+            .await?;
+
+            last_processed_id += event_count as i64;
+            commit_package_log(&mut pg_conn, last_processed_id)?;
+            if event_count < PACKAGE_EVENT_BATCH_SIZE {
+                sleep(Duration::from_secs_f32(0.1)).await;
+            }
+        }
+    }
+}

--- a/crates/sui-indexer/src/processors/processor_orchestrator.rs
+++ b/crates/sui-indexer/src/processors/processor_orchestrator.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use backoff::future::retry;
+use backoff::ExponentialBackoff;
+use sui_sdk::SuiClient;
+use tracing::{error, info, warn};
+
+use crate::processors::address_processor::AddressProcessor;
+use crate::processors::object_processor::ObjectProcessor;
+use crate::processors::package_processor::PackageProcessor;
+
+pub struct ProcessorOrchestrator {
+    pub rpc_client: SuiClient,
+    pub db_url: String,
+}
+
+impl ProcessorOrchestrator {
+    pub fn new(rpc_client: SuiClient, db_url: String) -> Self {
+        Self { rpc_client, db_url }
+    }
+
+    pub async fn run_forever(&mut self) {
+        info!("Processor orchestrator started...");
+        let address_processor = AddressProcessor::new(self.db_url.clone());
+        let object_processor = ObjectProcessor::new(self.db_url.clone());
+        let package_processor = PackageProcessor::new(self.rpc_client.clone(), self.db_url.clone());
+
+        tokio::task::spawn(async move {
+            let addr_result = retry(ExponentialBackoff::default(), || async {
+                let addr_processor_exec_res = address_processor.start().await;
+                if let Err(e) = addr_processor_exec_res.clone() {
+                    warn!(
+                        "Indexer address processor failed with error: {:?}, retrying...",
+                        e
+                    );
+                }
+                Ok(addr_processor_exec_res?)
+            })
+            .await;
+            if let Err(e) = addr_result {
+                error!(
+                    "Indexer address processor failed after retrials with error {:?}",
+                    e
+                );
+            }
+        });
+        tokio::task::spawn(async move {
+            let obj_result = retry(ExponentialBackoff::default(), || async {
+                let obj_processor_exec_res = object_processor.start().await;
+                if let Err(e) = obj_processor_exec_res.clone() {
+                    warn!(
+                        "Indexer object processor failed with error: {:?}, retrying...",
+                        e
+                    );
+                }
+                Ok(obj_processor_exec_res?)
+            })
+            .await;
+            if let Err(e) = obj_result {
+                error!(
+                    "Indexer object processor failed after retrials with error {:?}",
+                    e
+                );
+            }
+        });
+        tokio::task::spawn(async move {
+            let pkg_result = retry(ExponentialBackoff::default(), || async {
+                let pkg_processor_exec_res = package_processor.start().await;
+                if let Err(e) = pkg_processor_exec_res.clone() {
+                    warn!(
+                        "Indexer package processor failed with error: {:?}, retrying...",
+                        e
+                    );
+                }
+                Ok(pkg_processor_exec_res?)
+            })
+            .await;
+            if let Err(e) = pkg_result {
+                error!(
+                    "Indexer package processor failed after retrials with error {:?}",
+                    e
+                );
+            }
+        });
+    }
+}

--- a/crates/sui-indexer/src/schema.rs
+++ b/crates/sui-indexer/src/schema.rs
@@ -2,6 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 diesel::table! {
+    address_logs (last_processed_id) {
+        last_processed_id -> Int8,
+    }
+}
+
+diesel::table! {
+    addresses (account_address) {
+        account_address -> Varchar,
+        first_appearance_tx -> Varchar,
+        first_appearance_time -> Nullable<Timestamp>,
+    }
+}
+
+diesel::table! {
     error_logs (id) {
         id -> Int8,
         error_type -> Varchar,
@@ -27,6 +41,41 @@ diesel::table! {
         event_time -> Nullable<Timestamp>,
         event_type -> Varchar,
         event_content -> Varchar,
+    }
+}
+
+diesel::table! {
+    object_logs (last_processed_id) {
+        last_processed_id -> Int8,
+    }
+}
+
+diesel::table! {
+    objects (object_id) {
+        object_id -> Varchar,
+        version -> Int8,
+        owner_type -> Varchar,
+        owner_address -> Nullable<Varchar>,
+        initial_shared_version -> Nullable<Int8>,
+        package_id -> Text,
+        transaction_module -> Text,
+        object_type -> Nullable<Text>,
+        object_status -> Varchar,
+    }
+}
+
+diesel::table! {
+    package_logs (last_processed_id) {
+        last_processed_id -> Int8,
+    }
+}
+
+diesel::table! {
+    packages (package_id) {
+        package_id -> Text,
+        author -> Text,
+        module_names -> Array<Nullable<Text>>,
+        package_content -> Text,
     }
 }
 
@@ -57,13 +106,20 @@ diesel::table! {
         computation_cost -> Int8,
         storage_cost -> Int8,
         storage_rebate -> Int8,
+        transaction_content -> Text,
     }
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    address_logs,
+    addresses,
     error_logs,
     event_logs,
     events,
+    object_logs,
+    objects,
+    package_logs,
+    packages,
     transaction_logs,
     transactions,
 );

--- a/crates/sui-indexer/src/utils.rs
+++ b/crates/sui-indexer/src/utils.rs
@@ -2,15 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::IndexerError;
-use crate::establish_connection;
 use crate::models::error_logs::{commit_error_logs, err_to_error_log, NewErrorLog};
 
+use diesel::pg::PgConnection;
 use tracing::error;
 
-pub fn log_errors_to_pg(errors: Vec<IndexerError>) {
-    let mut pg_conn = establish_connection();
+pub fn log_errors_to_pg(pg_conn: &mut PgConnection, errors: Vec<IndexerError>) {
+    if errors.is_empty() {
+        return;
+    }
     let new_error_logs: Vec<NewErrorLog> = errors.into_iter().map(err_to_error_log).collect();
-    if let Err(e) = commit_error_logs(&mut pg_conn, new_error_logs) {
+    if let Err(e) = commit_error_logs(pg_conn, new_error_logs) {
         error!("Failed writing error logs with error {:?}", e);
     }
 }

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate core;
 
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -34,7 +35,7 @@ use sui_json_rpc::api::TransactionExecutionApiClient;
 pub use sui_json_rpc_types as rpc_types;
 use sui_json_rpc_types::{
     EventPage, GetObjectDataResponse, GetRawObjectDataResponse, SuiEventEnvelope, SuiEventFilter,
-    SuiObjectInfo, SuiTransactionResponse, TransactionsPage,
+    SuiMoveNormalizedModule, SuiObjectInfo, SuiTransactionResponse, TransactionsPage,
 };
 use sui_transaction_builder::{DataReader, TransactionBuilder};
 pub use sui_types as types;
@@ -292,6 +293,17 @@ impl ReadApi {
             .api
             .http
             .get_transactions(query, cursor, limit, descending_order)
+            .await?)
+    }
+
+    pub async fn get_normalized_move_modules_by_package(
+        &self,
+        package: ObjectID,
+    ) -> anyhow::Result<BTreeMap<String, SuiMoveNormalizedModule>> {
+        Ok(self
+            .api
+            .http
+            .get_normalized_move_modules_by_package(package)
             .await?)
     }
 }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -488,6 +488,10 @@ impl TransactionDigest {
     pub fn into_bytes(self) -> [u8; TRANSACTION_DIGEST_LENGTH] {
         self.0
     }
+
+    pub fn encode(&self) -> String {
+        Base64::encode(self.0)
+    }
 }
 
 impl AsRef<[u8]> for TransactionDigest {
@@ -562,6 +566,10 @@ impl ObjectDigest {
     pub fn random() -> Self {
         let random_bytes = rand::thread_rng().gen::<[u8; OBJECT_DIGEST_LENGTH]>();
         Self::new(random_bytes)
+    }
+
+    pub fn encode(&self) -> String {
+        Base64::encode(self.0)
     }
 }
 


### PR DESCRIPTION
This PR implements processors part
- processor orchestrator dispatches each processor and manage their failures via retrial
- each processor reads from events / txns, and populate corresponding data table and log table
  - addresses table contains all active addresses from txns
  - objects table contains all updated object info based on object related events including NewObject, TransferObject, MutateObject and DeleteObject
  - modules table contains all published modules

Tested locally 
addresses
![Screen Shot 2022-12-04 at 1 40 17 PM](https://user-images.githubusercontent.com/106119108/205510513-85d38a2d-1f4a-4e66-b445-50f4814c514c.png)

objects
![Screen Shot 2022-12-04 at 1 40 04 PM](https://user-images.githubusercontent.com/106119108/205510517-b40fcb4e-ba4b-4192-a275-17ebf6ff60f0.png)

modules
![Screen Shot 2022-12-04 at 1 51 44 PM](https://user-images.githubusercontent.com/106119108/205510526-30fc80bb-1fb2-4925-9339-38871aadd00b.png)

