### PR TITLE
[explorer] Add merged search params helper

### DIFF
--- a/apps/explorer/.eslintrc.js
+++ b/apps/explorer/.eslintrc.js
@@ -138,9 +138,9 @@ module.exports = {
                 paths: [
                     {
                         name: 'react-router-dom',
-                        importNames: ['Link', 'useNavigate'],
+                        importNames: ['Link', 'useNavigate', 'useSearchParams'],
                         message:
-                            'Please use `LinkWithQuery` and `useNavigateWithQuery` from "~/ui/utils/LinkWithQuery" instead.',
+                            'Please use `LinkWithQuery`, `useSearchParamsMerged`, and `useNavigateWithQuery` from "~/ui/utils/LinkWithQuery" instead.',
                     },
                 ],
             },

--- a/apps/explorer/src/components/module/ModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/ModulesWrapper.tsx
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useState, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 import Pagination from '../../components/pagination/Pagination';
 import ModuleView from './ModuleView';
 
 import styles from './ModuleView.module.css';
+
+import { useSearchParamsMerged } from '~/ui/utils/LinkWithQuery';
 
 type Modules = {
     title: string;
@@ -22,7 +23,7 @@ interface Props {
 const MODULES_PER_PAGE = 3;
 // TODO: Include Pagination for now use viewMore and viewLess
 function ModuleViewWrapper({ id, data }: Props) {
-    const [searchParams] = useSearchParams();
+    const [searchParams] = useSearchParamsMerged();
     const [modulesPageNumber, setModulesPageNumber] = useState(1);
     const totalModulesCount = data.content.length;
     const numOfMudulesToShow = MODULES_PER_PAGE;

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -61,10 +61,10 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
     // If module in URL exists but is not in module list, then delete module from URL
     useEffect(() => {
         if (
-            searchParams.get('module') &&
+            searchParams.has('module') &&
             !modulenames.includes(searchParams.get('module')!)
         ) {
-            setSearchParams({ module: undefined }, { replace: true });
+            setSearchParams({}, { replace: true });
         }
     }, [searchParams, setSearchParams, modulenames]);
 

--- a/apps/explorer/src/components/module/PkgModulesWrapper.tsx
+++ b/apps/explorer/src/components/module/PkgModulesWrapper.tsx
@@ -5,7 +5,6 @@ import { useFeature } from '@growthbook/growthbook-react';
 import { Combobox } from '@headlessui/react';
 import clsx from 'clsx';
 import { useState, useCallback, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 import ModuleView from './ModuleView';
 import { ModuleFunctionsInteraction } from './module-functions-interaction';
@@ -13,6 +12,7 @@ import { ModuleFunctionsInteraction } from './module-functions-interaction';
 import { ReactComponent as SearchIcon } from '~/assets/SVGIcons/24px/Search.svg';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
 import { ListItem, VerticalList } from '~/ui/VerticalList';
+import { useSearchParamsMerged } from '~/ui/utils/LinkWithQuery';
 import { GROWTHBOOK_FEATURES } from '~/utils/growthbook';
 
 type ModuleType = [moduleName: string, code: string];
@@ -48,7 +48,7 @@ function ModuleViewWrapper({
 
 function PkgModuleViewWrapper({ id, modules }: Props) {
     const modulenames = modules.map(([name]) => name);
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParamsMerged();
     const [query, setQuery] = useState('');
 
     // Extract module in URL or default to first module in list
@@ -64,9 +64,7 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
             searchParams.get('module') &&
             !modulenames.includes(searchParams.get('module')!)
         ) {
-            const newSearchParams = new URLSearchParams(searchParams);
-            newSearchParams.delete('module');
-            setSearchParams(newSearchParams, { replace: true });
+            setSearchParams({ module: undefined }, { replace: true });
         }
     }, [searchParams, setSearchParams, modulenames]);
 
@@ -81,16 +79,16 @@ function PkgModuleViewWrapper({ id, modules }: Props) {
 
     const submitSearch = useCallback(() => {
         if (filteredModules.length === 1) {
-            const convertedSearchParams = new URLSearchParams(searchParams);
-            convertedSearchParams.set('module', filteredModules[0]);
-            setSearchParams(convertedSearchParams);
+            setSearchParams({
+                module: filteredModules[0],
+            });
         }
-    }, [filteredModules, setSearchParams, searchParams]);
+    }, [filteredModules, setSearchParams]);
 
     const onChangeModule = (newModule: string) => {
-        const convertedSearchParams = new URLSearchParams(searchParams);
-        convertedSearchParams.set('module', newModule);
-        setSearchParams(convertedSearchParams);
+        setSearchParams({
+            module: newModule,
+        });
     };
 
     const isModuleFnExecEnabled = useFeature(

--- a/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
+++ b/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
@@ -10,7 +10,6 @@ import { type QueryStatus, useQuery } from '@tanstack/react-query';
 import cl from 'clsx';
 import { useState, useCallback, useMemo } from 'react';
 import toast from 'react-hot-toast';
-import { useSearchParams } from 'react-router-dom';
 
 import { ReactComponent as ArrowRight } from '../../assets/SVGIcons/12px/ArrowRight.svg';
 import TabFooter from '../../components/tabs/TabFooter';
@@ -32,6 +31,7 @@ import { PlaceholderTable } from '~/ui/PlaceholderTable';
 import { PlayPause } from '~/ui/PlayPause';
 import { TableCard } from '~/ui/TableCard';
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '~/ui/Tabs';
+import { useSearchParamsMerged } from '~/ui/utils/LinkWithQuery';
 
 const TRUNCATE_LENGTH = 10;
 const NUMBER_OF_TX_PER_PAGE = 20;
@@ -136,7 +136,7 @@ export function LatestTxCard({
     );
 
     const rpc = useRpc();
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParamsMerged();
 
     const [pageIndex, setPageIndex] = useState(
         parseInt(searchParams.get('p') || '1', 10) || 1
@@ -145,9 +145,9 @@ export function LatestTxCard({
     const handlePageChange = useCallback(
         (newPage: number) => {
             setPageIndex(newPage);
-            const newSearchParams = new URLSearchParams(searchParams);
-            newSearchParams.set('p', newPage.toString());
-            setSearchParams(newSearchParams);
+            setSearchParams({
+                p: newPage.toString(),
+            });
         },
         [searchParams, setSearchParams]
     );

--- a/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
+++ b/apps/explorer/src/components/transaction-card/RecentTxCard.tsx
@@ -149,7 +149,7 @@ export function LatestTxCard({
                 p: newPage.toString(),
             });
         },
-        [searchParams, setSearchParams]
+        [setSearchParams]
     );
 
     const countQuery = useQuery(

--- a/apps/explorer/src/context.ts
+++ b/apps/explorer/src/context.ts
@@ -3,6 +3,7 @@
 
 import * as Sentry from '@sentry/react';
 import { createContext, useLayoutEffect, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSearchParams } from 'react-router-dom';
 
 import { Network } from './utils/api/DefaultRpcClient';

--- a/apps/explorer/src/ui/utils/LinkWithQuery.tsx
+++ b/apps/explorer/src/ui/utils/LinkWithQuery.tsx
@@ -17,6 +17,9 @@ import {
 
 export { LinkProps };
 
+/** Query params that we want to be preserved between all pages. */
+export const PRESERVE_QUERY = ['network'];
+
 // TODO: Once we have a new router configuration based on the new react router configuration,
 // we should just move these components there so that we import the link from the router.
 // This also will align closer to how TanStack Router works.
@@ -40,15 +43,13 @@ export function useSearchParamsMerged() {
 
     const setSearchParamsMerged = useCallback(
         (
-            params: Record<string, any>,
+            params: Record<string, string>,
             navigateOptions?: Parameters<typeof setSearchParams>[1]
         ) => {
-            const nextParams = new URLSearchParams(searchParams);
-            Object.entries(params).forEach(([key, value]) => {
-                if (typeof value === 'undefined' || value === null) {
-                    nextParams.delete(key);
-                } else {
-                    nextParams.set(key, value);
+            const nextParams = new URLSearchParams(params);
+            PRESERVE_QUERY.forEach((param) => {
+                if (searchParams.has(param)) {
+                    nextParams.set(param, searchParams.get(param)!);
                 }
             });
             setSearchParams(nextParams, navigateOptions);
@@ -66,10 +67,13 @@ export const LinkWithQuery = forwardRef<HTMLAnchorElement, LinkProps>(
         const [toBaseURL, toSearchParamString] = href.split('?');
 
         const mergedSearchParams = useMemo(() => {
-            return new URLSearchParams({
-                ...Object.fromEntries(searchParams),
-                ...Object.fromEntries(new URLSearchParams(toSearchParamString)),
-            }).toString();
+            const nextParams = new URLSearchParams(toSearchParamString);
+            PRESERVE_QUERY.forEach((param) => {
+                if (searchParams.has(param)) {
+                    nextParams.set(param, searchParams.get(param)!);
+                }
+            });
+            return nextParams.toString();
         }, [toSearchParamString, searchParams]);
 
         return (

--- a/apps/explorer/src/ui/utils/LinkWithQuery.tsx
+++ b/apps/explorer/src/ui/utils/LinkWithQuery.tsx
@@ -17,6 +17,10 @@ import {
 
 export { LinkProps };
 
+// TODO: Once we have a new router configuration based on the new react router configuration,
+// we should just move these components there so that we import the link from the router.
+// This also will align closer to how TanStack Router works.
+
 export function useNavigateWithQuery() {
     const navigate = useNavigate();
     const { search } = useLocation();


### PR DESCRIPTION
This adds a search params helper to make it easier to use `setSearchParams` without needing to worry about the merging that's required for tracking the `network`. I also cleaned up some patterns in the Link to be a little more correct.