### PR TITLE
[move] Allow call to init functions in test code (Move version bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4082,7 +4082,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -4112,12 +4112,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4132,7 +4132,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "difference",
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4354,7 +4354,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4373,7 +4373,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "hex",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "hex",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4481,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4546,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "hex",
@@ -4640,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "once_cell",
  "serde 1.0.147",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4666,7 +4666,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "clap 3.2.22",
@@ -4698,7 +4698,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "better_any",
@@ -4729,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "better_any",
  "fail",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7#5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7"
+source = "git+https://github.com/awelc/move.git?rev=625b1e529b2c47cecb26ca133654db11cc504d10#625b1e529b2c47cecb26ca133654db11cc504d10"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,25 +98,25 @@ opt-level = 1
 tokio = "1.22.0"
 
 # Move dependencies
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-cli = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["address20"] }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-package = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-prover = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
+move-binary-format = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-bytecode-utils = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-bytecode-verifier = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-cli = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-compiler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-core-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["address20"] }
+move-disassembler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-package = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-stdlib = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-vm-runtime = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-unit-test = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-vm-test-utils = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-vm-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-command-line-common = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-transactional-test-runner = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-prover = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-prover-boogie-backend = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-symbol-pool = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
 
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3ac9fa490f2d7eecd133c87a7c616328a217b66a" }
 fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "3ac9fa490f2d7eecd133c87a7c616328a217b66a", package = "fastcrypto-zkp" }

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -486,7 +486,7 @@ pub fn verify_and_link<
     // run the Sui verifier
     for module in modules.iter() {
         // Run Sui bytecode verifier, which runs some additional checks that assume the Move bytecode verifier has passed.
-        verifier::verify_module(module)?;
+        verifier::verify_module(module, &BTreeMap::new())?;
     }
     Ok(vm)
 }

--- a/crates/sui-framework-build/src/compiled_package.rs
+++ b/crates/sui-framework-build/src/compiled_package.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
+    io::Write,
     path::PathBuf,
 };
 
@@ -13,18 +14,27 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_bytecode_utils::{layout::SerdeLayoutBuilder, module_cache::GetModule, Modules};
-use move_compiler::compiled_unit::CompiledUnitEnum;
+use move_compiler::{
+    compiled_unit::{AnnotatedCompiledModule, AnnotatedCompiledScript, CompiledUnitEnum},
+    diagnostics::{report_diagnostics_to_color_buffer, report_warnings},
+    expansion::ast::{AttributeName_, Attributes},
+    shared::known_attributes::KnownAttribute,
+};
 use move_core_types::{
     account_address::AccountAddress,
     language_storage::{ModuleId, StructTag, TypeTag},
 };
 use move_package::{
-    compilation::compiled_package::CompiledPackage as MoveCompiledPackage,
+    compilation::{
+        build_plan::BuildPlan, compiled_package::CompiledPackage as MoveCompiledPackage,
+    },
+    resolution::resolution_graph::ResolvedGraph,
     BuildConfig as MoveBuildConfig,
 };
 use serde_reflection::Registry;
 use sui_types::{
     error::{SuiError, SuiResult},
+    move_package::{FnInfo, FnInfoKey, FnInfoMap},
     MOVE_STDLIB_ADDRESS, SUI_FRAMEWORK_ADDRESS,
 };
 use sui_verifier::verifier as sui_bytecode_verifier;
@@ -48,25 +58,90 @@ pub struct BuildConfig {
 }
 
 impl BuildConfig {
+    fn is_test(attributes: &Attributes) -> bool {
+        attributes
+            .iter()
+            .any(|(_, name, _)| matches!(name, AttributeName_::Known(KnownAttribute::Testing(_))))
+    }
+
+    fn fn_info(
+        units: &[CompiledUnitEnum<AnnotatedCompiledModule, AnnotatedCompiledScript>],
+    ) -> FnInfoMap {
+        let mut fn_info_map = BTreeMap::new();
+        for u in units {
+            match u {
+                CompiledUnitEnum::Module(m) => {
+                    let mod_addr = m.named_module.address.into_inner();
+                    for (_, s, info) in &m.function_infos {
+                        let fn_name = s.as_str().to_string();
+                        let is_test = Self::is_test(&info.attributes);
+                        fn_info_map.insert(FnInfoKey { fn_name, mod_addr }, FnInfo { is_test });
+                    }
+                }
+                CompiledUnitEnum::Script(_) => continue,
+            }
+        }
+
+        fn_info_map
+    }
+
+    fn compile_package<W: Write>(
+        resolution_graph: ResolvedGraph,
+        writer: &mut W,
+    ) -> anyhow::Result<(MoveCompiledPackage, FnInfoMap)> {
+        let build_plan = BuildPlan::create(resolution_graph)?;
+        let mut fn_info = None;
+        let compiled_pkg = build_plan.compile_with_driver(writer, |compiler| {
+            let (files, units_res) = compiler.build()?;
+            match units_res {
+                Ok((units, warning_diags)) => {
+                    report_warnings(&files, warning_diags);
+                    fn_info = Some(Self::fn_info(&units));
+                    Ok((files, units))
+                }
+                Err(error_diags) => {
+                    assert!(!error_diags.is_empty());
+                    let diags_buf = report_diagnostics_to_color_buffer(&files, error_diags);
+                    if let Err(err) = std::io::stdout().write_all(&diags_buf) {
+                        anyhow::bail!("Cannot output compiler diagnostics: {}", err);
+                    }
+                    anyhow::bail!("Compilation error");
+                }
+            }
+        })?;
+        Ok((compiled_pkg, fn_info.unwrap()))
+    }
+
     /// Given a `path` and a `build_config`, build the package in that path, including its dependencies.
     /// If we are building the Sui framework, we skip the check that the addresses should be 0
     pub fn build(self, path: PathBuf) -> SuiResult<CompiledPackage> {
         let res = if self.print_diags_to_stderr {
-            self.config
-                .compile_package_no_exit(&path, &mut std::io::stderr())
+            let resolution_graph = self
+                .config
+                .resolution_graph_for_package(&path, &mut std::io::stderr())
+                .map_err(|err| SuiError::ModuleBuildFailure {
+                    error: format!("{:?}", err),
+                })?;
+            Self::compile_package(resolution_graph, &mut std::io::stderr())
         } else {
-            self.config.compile_package_no_exit(&path, &mut Vec::new())
+            let resolution_graph = self
+                .config
+                .resolution_graph_for_package(&path, &mut Vec::new())
+                .map_err(|err| SuiError::ModuleBuildFailure {
+                    error: format!("{:?}", err),
+                })?;
+            Self::compile_package(resolution_graph, &mut Vec::new())
         };
 
         // write build failure diagnostics to stderr, convert `error` to `String` using `Debug`
         // format to include anyhow's error context chain.
-        let package = match res {
+        let (package, fn_info) = match res {
             Err(error) => {
                 return Err(SuiError::ModuleBuildFailure {
                     error: format!("{:?}", error),
                 })
             }
-            Ok(package) => package,
+            Ok((package, fn_info)) => (package, fn_info),
         };
         let compiled_modules = package.root_modules_map();
         let package_name = package.compiled_package_info.package_name.as_str();
@@ -94,7 +169,7 @@ impl BuildConfig {
                         error: err.to_string(),
                     }
                 })?;
-                sui_bytecode_verifier::verify_module(m)?;
+                sui_bytecode_verifier::verify_module(m, &fn_info)?;
             }
             // TODO(https://github.com/MystenLabs/sui/issues/69): Run Move linker
         }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -10,7 +10,7 @@ use move_binary_format::access::ModuleAccess;
 use move_binary_format::binary_views::BinaryIndexedView;
 use move_binary_format::file_format::CompiledModule;
 use move_binary_format::normalized;
-use move_core_types::identifier::Identifier;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,23 @@ use std::collections::BTreeMap;
 // #[cfg(test)]
 // #[path = "unit_tests/move_package.rs"]
 // mod base_types_tests;
+
+#[derive(Clone, Debug)]
+/// Additional information about a function
+pub struct FnInfo {
+    /// If true, it's a function involved in testing (`[test]`, `[test_only]`, `[expected_failure]`)
+    pub is_test: bool,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+/// Uniquely identifies a function in a module
+pub struct FnInfoKey {
+    pub fn_name: String,
+    pub mod_addr: AccountAddress,
+}
+
+/// A map from function info keys to function info
+pub type FnInfoMap = BTreeMap<FnInfoKey, FnInfo>;
 
 // serde_bytes::ByteBuf is an analog of Vec<u8> with built-in fast serialization.
 #[serde_as]

--- a/crates/sui-verifier/src/verifier.rs
+++ b/crates/sui-verifier/src/verifier.rs
@@ -4,7 +4,7 @@
 //! This module contains the public APIs supported by the bytecode verifier.
 
 use move_binary_format::file_format::CompiledModule;
-use sui_types::error::ExecutionError;
+use sui_types::{error::ExecutionError, move_package::FnInfoMap};
 
 use crate::{
     entry_points_verifier, global_storage_access_verifier, id_leak_verifier,
@@ -12,11 +12,14 @@ use crate::{
 };
 
 /// Helper for a "canonical" verification of a module.
-pub fn verify_module(module: &CompiledModule) -> Result<(), ExecutionError> {
+pub fn verify_module(
+    module: &CompiledModule,
+    fn_info_map: &FnInfoMap,
+) -> Result<(), ExecutionError> {
     struct_with_key_verifier::verify_module(module)?;
     global_storage_access_verifier::verify_module(module)?;
     id_leak_verifier::verify_module(module)?;
     private_generics::verify_module(module)?;
-    entry_points_verifier::verify_module(module)?;
+    entry_points_verifier::verify_module(module, fn_info_map)?;
     one_time_witness_verifier::verify_module(module)
 }

--- a/crates/sui/src/sui_move/unit_test.rs
+++ b/crates/sui/src/sui_move/unit_test.rs
@@ -33,7 +33,7 @@ impl Test {
             BuildConfig {
                 // TODO: test_mode should be true - flip it when calling init function from test
                 // code issue is resolved
-                test_mode: false, // make sure to verify tests
+                test_mode: true, // make sure to verify tests
                 ..build_config.clone()
             },
             dump_bytecode_as_base64,

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -88,7 +88,7 @@ bs58 = { version = "0.4", features = ["alloc", "check", "sha2", "std"] }
 bstr = { version = "0.2", default-features = false, features = ["std"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 byte-slice-cast = { version = "1", features = ["std"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -311,41 +311,41 @@ miniz_oxide = { version = "0.5", default-features = false }
 mintex = { version = "0.1", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-cli = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
+move-abigen = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-binary-format = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-borrow-graph = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-bytecode-utils = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-bytecode-viewer = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-cli = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-command-line-common = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-compiler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-core-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["address20"] }
+move-coverage = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-disassembler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-docgen = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-errmapgen = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-ir-compiler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-to-bytecode = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-model = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-package = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-prover = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-read-write-set-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-resource-viewer = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-stdlib = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-table-extension = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-unit-test = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-vm-runtime = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-vm-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
 multiaddr-582f2526e08bb6a0 = { package = "multiaddr", version = "0.14", features = ["url"] }
 multiaddr-986da7b5efc2b80e = { package = "multiaddr", version = "0.16", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
@@ -450,8 +450,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["pem", "x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
+read-write-set = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
@@ -729,7 +729,7 @@ bstr = { version = "0.2", default-features = false, features = ["std"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 bumpalo = { version = "3" }
 byte-slice-cast = { version = "1", features = ["std"] }
-bytecode-interpreter-crypto = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["fiat"] }
+bytecode-interpreter-crypto = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["fiat"] }
 bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["serde", "std"] }
@@ -985,41 +985,41 @@ mintex = { version = "0.1", default-features = false }
 mio-c38e5c1d305a1b54 = { package = "mio", version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 mockall_derive = { version = "0.11", default-features = false }
-move-abigen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-borrow-graph = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-bytecode-source-map = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-bytecode-viewer = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-cli = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-compiler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-core-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["address20"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-to-bytecode = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-to-bytecode-syntax = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-ir-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-model = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-package = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-prover = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false, features = ["testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", features = ["debugging", "testing"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7" }
+move-abigen = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-binary-format = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-borrow-graph = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-bytecode-source-map = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-bytecode-utils = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-bytecode-verifier = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-bytecode-viewer = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-cli = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-command-line-common = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-compiler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-core-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["address20"] }
+move-coverage = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-disassembler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-docgen = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-errmapgen = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-ir-compiler = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-to-bytecode = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-to-bytecode-syntax = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-ir-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-model = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-package = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-prover = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-prover-boogie-backend = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-read-write-set-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-resource-viewer = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-stackless-bytecode = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-stackless-bytecode-interpreter = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-stdlib = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false, features = ["testing"] }
+move-symbol-pool = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-table-extension = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-transactional-test-runner = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-unit-test = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+move-vm-runtime = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", features = ["debugging", "testing"] }
+move-vm-test-utils = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
+move-vm-types = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10" }
 multiaddr-582f2526e08bb6a0 = { package = "multiaddr", version = "0.14", features = ["url"] }
 multiaddr-986da7b5efc2b80e = { package = "multiaddr", version = "0.16", features = ["url"] }
 multibase = { version = "0.9", features = ["std"] }
@@ -1152,8 +1152,8 @@ rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 rcgen-93f6ce9d446188ac = { package = "rcgen", version = "0.10", features = ["pem", "x509-parser"] }
 rcgen-274715c4dabd11b0 = { package = "rcgen", version = "0.9", features = ["pem"] }
-read-write-set = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "5bb2ac5a4a69e6f2df06183aec9b69c6d940f9f7", default-features = false }
+read-write-set = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
+read-write-set-dynamic = { git = "https://github.com/awelc/move.git", rev = "625b1e529b2c47cecb26ca133654db11cc504d10", default-features = false }
 readonly = { version = "0.2", default-features = false }
 ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }


### PR DESCRIPTION
This PR brings back bytecode verification of test code with the exception of calling `init` functions from the test code which is now allowed.