### PR TITLE
[Explorer] Fixes flickering between 1M and full number bug

### DIFF
--- a/apps/explorer/cypress/e2e/static/e2e.cy.ts
+++ b/apps/explorer/cypress/e2e/static/e2e.cy.ts
@@ -164,9 +164,7 @@ describe('End-to-end Tests', () => {
 
             cy.get(`${rowCSSSelector(1)} ${label}`).contains('USD');
             cy.get(`${rowCSSSelector(1)} ${count}`).contains('2');
-            cy.get(`${rowCSSSelector(1)} ${balance}`).contains(
-                '9,007,199,254,740,993'
-            );
+            cy.get(`${rowCSSSelector(1)} ${balance}`).contains('9,007,199.254');
 
             cy.get(`${rowCSSSelector(2)} ${label}`).contains('SUI');
             cy.get(`${rowCSSSelector(2)} ${count}`).contains('2');

--- a/apps/explorer/src/hooks/useFormatCoin.ts
+++ b/apps/explorer/src/hooks/useFormatCoin.ts
@@ -105,19 +105,19 @@ export function useFormatCoin(
     );
 
     const [decimals, queryResult] = useCoinDecimals(coinType);
-    const { isFetched, isError } = queryResult;
+    const { isFetched } = queryResult;
 
     const formatted = useMemo(() => {
         if (typeof balance === 'undefined' || balance === null) return '';
 
-        if (isError) {
+        if (!coinType) {
             return numberFormatter.format(BigInt(balance));
         }
 
         if (!isFetched) return '...';
 
         return formatBalance(balance, decimals, format);
-    }, [decimals, isError, isFetched, balance, format]);
+    }, [decimals, isFetched, balance, format, coinType]);
 
     return [formatted, symbol, queryResult];
 }

--- a/apps/explorer/src/hooks/useFormatCoin.ts
+++ b/apps/explorer/src/hooks/useFormatCoin.ts
@@ -83,10 +83,6 @@ export function useCoinDecimals(coinType?: string | null) {
     return [queryResult.data?.decimals || 0, queryResult] as const;
 }
 
-const numberFormatter = new Intl.NumberFormat('en', {
-    maximumFractionDigits: 0,
-});
-
 // TODO: Unify this into.
 // Candidate holding packages:
 // - @mysten/sui.js
@@ -110,14 +106,10 @@ export function useFormatCoin(
     const formatted = useMemo(() => {
         if (typeof balance === 'undefined' || balance === null) return '';
 
-        if (!coinType) {
-            return numberFormatter.format(BigInt(balance));
-        }
-
         if (!isFetched) return '...';
 
         return formatBalance(balance, decimals, format);
-    }, [decimals, isFetched, balance, format, coinType]);
+    }, [decimals, isFetched, balance, format]);
 
     return [formatted, symbol, queryResult];
 }


### PR DESCRIPTION
Currently when an owned coin row is opened, the numbers flick between showing '1M' and '1,000,000'. This PR fixes this issue.

https://user-images.githubusercontent.com/11377188/205658552-0ed5aca3-9d49-41fd-8089-2dd64b89e945.mp4

