### PR TITLE
Remove handle_certificate() shared transactions rate limit

### DIFF
--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -3,7 +3,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::spawn_monitored_task;
 use prometheus::{
     register_int_counter_with_registry, register_int_gauge_with_registry, IntCounter, IntGauge,
     Registry,
@@ -80,8 +80,6 @@ where
 
     // Loop whenever there is a signal that a new transactions is ready to process.
     loop {
-        let _scope = monitored_scope("ExecutionDriver");
-
         let certificate = if let Some(cert) = ready_certificates_stream.recv().await {
             cert
         } else {

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -8,7 +8,7 @@ use crate::{metrics::ConsensusMetrics, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::spawn_monitored_task;
 use std::{
     cmp::{max, Ordering},
     collections::HashMap,
@@ -311,8 +311,6 @@ where
     async fn run_inner(mut self) -> StoreResult<()> {
         // Listen to incoming certificates.
         loop {
-            let _scope = monitored_scope("NarwhalConsensus");
-
             tokio::select! {
                 Some(certificate) = self.rx_new_certificates.recv() => {
                     // If the core already moved to the next epoch we should pull the next

--- a/narwhal/primary/src/core.rs
+++ b/narwhal/primary/src/core.rs
@@ -15,7 +15,7 @@ use crypto::{NetworkPublicKey, PublicKey, Signature};
 use fastcrypto::{hash::Hash as _, SignatureService};
 use futures::StreamExt;
 use futures::{future::OptionFuture, stream::FuturesUnordered};
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::spawn_monitored_task;
 use network::{anemo_ext::NetworkExt, CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc, time::Instant};
@@ -671,8 +671,6 @@ impl Core {
     pub async fn run(mut self) {
         info!("Core on node {} has started successfully.", self.name);
         loop {
-            let _scope = monitored_scope("NarwhalCore");
-
             let result = tokio::select! {
                 Some((certificate, notify)) = self.rx_certificates.recv() => {
                     match self.sanitize_certificate(&certificate).await {

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 
 use futures::{Future, StreamExt};
 
-use mysten_metrics::{monitored_scope, spawn_monitored_task};
+use mysten_metrics::spawn_monitored_task;
 use std::sync::Arc;
 use tokio::{
     sync::watch,
@@ -110,8 +110,6 @@ impl BatchMaker {
         let mut batch_pipeline = FuturesOrdered::new();
 
         loop {
-            let _scope = monitored_scope("NarwhalBatchMaker");
-
             tokio::select! {
                 // Assemble client transactions into batches of preset size.
                 // Note that transactions are only consumed when the number of batches


### PR DESCRIPTION
Since all owned transactions go through Narwhal now, only rate limiting shared object transactions is insufficient to protect against Narwhal overload. Back pressure needs to be implemented inside Narwhal, and may need to propagate to signing / charging for owned object transactions. For now, just remove the shared transactions rate limit.

Also remove a few monitored scopes that were added incorrectly.