### PR TITLE
wallet-ext: send keypair to UI instead of entropy

### DIFF
--- a/.changeset/friendly-impalas-talk.md
+++ b/.changeset/friendly-impalas-talk.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Allow keypairs to be exported

--- a/apps/wallet/src/background/connections/UiConnection.ts
+++ b/apps/wallet/src/background/connections/UiConnection.ts
@@ -17,7 +17,6 @@ import Permissions from '_src/background/Permissions';
 import Tabs from '_src/background/Tabs';
 import Transactions from '_src/background/Transactions';
 import Keyring from '_src/background/keyring';
-import { entropyToSerialized } from '_src/shared/utils/bip39';
 
 import type { Message } from '_messages';
 import type { PortChannelName } from '_messaging/PortChannelName';
@@ -60,9 +59,7 @@ export class UiConnection extends Connection {
                 method: 'walletStatusUpdate',
                 return: {
                     isLocked,
-                    entropy: Keyring.entropy
-                        ? entropyToSerialized(Keyring.entropy)
-                        : undefined,
+                    activeAccount: Keyring.keypair?.export(),
                     isInitialized: await Keyring.isWalletInitialized(),
                 },
             })

--- a/apps/wallet/src/background/keyring/index.ts
+++ b/apps/wallet/src/background/keyring/index.ts
@@ -82,22 +82,6 @@ class Keyring {
         return this.#keypair;
     }
 
-    public get entropy() {
-        return this.#vault?.entropy;
-    }
-
-    // sui address always prefixed with 0x
-    public get address() {
-        if (this.#keypair) {
-            let address = this.#keypair.getPublicKey().toSuiAddress();
-            if (!address.startsWith('0x')) {
-                address = `0x${address}`;
-            }
-            return address;
-        }
-        return null;
-    }
-
     public on = this.#events.on;
 
     public off = this.#events.off;
@@ -112,7 +96,7 @@ class Keyring {
                 const { password, importedEntropy } = payload.args;
                 await this.createVault(password, importedEntropy);
                 await this.unlock(password);
-                if (!this.#vault?.entropy) {
+                if (!this.#keypair) {
                     throw new Error('Error created vault is empty');
                 }
                 uiConnection.send(
@@ -121,9 +105,7 @@ class Keyring {
                             type: 'keyring',
                             method: 'create',
                             return: {
-                                entropy: entropyToSerialized(
-                                    this.#vault.entropy
-                                ),
+                                keypair: this.#keypair.export(),
                             },
                         },
                         id
@@ -161,9 +143,7 @@ class Keyring {
                             return: {
                                 isLocked: this.isLocked,
                                 isInitialized: await this.isWalletInitialized(),
-                                entropy: this.#vault?.entropy
-                                    ? entropyToSerialized(this.#vault.entropy)
-                                    : undefined,
+                                activeAccount: this.#keypair?.export(),
                             },
                         },
                         id

--- a/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
+++ b/apps/wallet/src/shared/messaging/messages/payloads/keyring/index.ts
@@ -3,12 +3,13 @@
 
 import { isBasePayload } from '_payloads';
 
+import type { ExportedKeypair } from '@mysten/sui.js';
 import type { BasePayload, Payload } from '_payloads';
 
 type MethodToPayloads = {
     create: {
         args: { password: string; importedEntropy?: string };
-        return: { entropy: string };
+        return: { keypair: ExportedKeypair };
     };
     getEntropy: {
         args: string | undefined;
@@ -23,7 +24,8 @@ type MethodToPayloads = {
         return: Partial<{
             isLocked: boolean;
             isInitialized: boolean;
-            entropy: string;
+            // we can replace keypair (once we stop signing from the UI) with the account address
+            activeAccount: ExportedKeypair;
         }>;
     };
     lock: {

--- a/apps/wallet/src/ui/app/KeypairVault.ts
+++ b/apps/wallet/src/ui/app/KeypairVault.ts
@@ -1,19 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Ed25519Keypair } from '@mysten/sui.js';
+import { fromExportedKeypair } from '@mysten/sui.js';
 
-import { toEntropy, entropyToMnemonic } from '_shared/utils/bip39';
-
-import type { Keypair } from '@mysten/sui.js';
+import type { Keypair, ExportedKeypair } from '@mysten/sui.js';
 
 export default class KeypairVault {
     private _keypair: Keypair | null = null;
 
-    public set entropy(entropy: string) {
-        this._keypair = Ed25519Keypair.deriveKeypair(
-            entropyToMnemonic(toEntropy(entropy))
-        );
+    public set keypair(keypair: ExportedKeypair) {
+        this._keypair = fromExportedKeypair(keypair);
     }
 
     public getAccount(): string | null {
@@ -24,7 +20,7 @@ export default class KeypairVault {
         return address;
     }
 
-    public getKeyPair() {
+    public getKeypair() {
         if (!this._keypair) {
             throw new Error('Account keypair is not set');
         }

--- a/apps/wallet/src/ui/app/hooks/useSigner.ts
+++ b/apps/wallet/src/ui/app/hooks/useSigner.ts
@@ -5,5 +5,5 @@ import { thunkExtras } from '_redux/store/thunk-extras';
 
 export function useSigner() {
     const { api, keypairVault } = thunkExtras;
-    return api.getSignerInstance(keypairVault.getKeyPair());
+    return api.getSignerInstance(keypairVault.getKeypair());
 }

--- a/apps/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
+++ b/apps/wallet/src/ui/app/pages/dapp-tx-approval/index.tsx
@@ -326,7 +326,7 @@ export function DappTxApprovalPage() {
         queryFn: () => {
             if (txRequest) {
                 const signer = thunkExtras.api.getSignerInstance(
-                    thunkExtras.keypairVault.getKeyPair()
+                    thunkExtras.keypairVault.getKeypair()
                 );
                 let txToEstimate: Parameters<
                     typeof signer.dryRunTransaction

--- a/apps/wallet/src/ui/app/redux/slices/account/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/account/index.ts
@@ -13,14 +13,19 @@ import { isKeyringPayload } from '_payloads/keyring';
 import { suiObjectsAdapterSelectors } from '_redux/slices/sui-objects';
 import { Coin } from '_redux/slices/sui-objects/Coin';
 
-import type { ObjectId, SuiAddress, SuiMoveObject } from '@mysten/sui.js';
+import type {
+    ObjectId,
+    SuiAddress,
+    SuiMoveObject,
+    ExportedKeypair,
+} from '@mysten/sui.js';
 import type { PayloadAction, Reducer } from '@reduxjs/toolkit';
 import type { KeyringPayload } from '_payloads/keyring';
 import type { RootState } from '_redux/RootReducer';
 import type { AppThunkConfig } from '_store/thunk-extras';
 
 export const createVault = createAsyncThunk<
-    string,
+    ExportedKeypair,
     {
         importedEntropy?: string;
         password: string;
@@ -37,10 +42,10 @@ export const createVault = createAsyncThunk<
         if (!isKeyringPayload(payload, 'create')) {
             throw new Error('Unknown payload');
         }
-        if (!payload.return?.entropy) {
-            throw new Error('Empty entropy in payload');
+        if (!payload.return?.keypair) {
+            throw new Error('Empty keypair in payload');
         }
-        return payload.return.entropy;
+        return payload.return.keypair;
     }
 );
 

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -93,7 +93,7 @@ export const batchFetchObject = createAsyncThunk<
 export const mintDemoNFT = createAsyncThunk<void, void, AppThunkConfig>(
     'mintDemoNFT',
     async (_, { extra: { api, keypairVault }, dispatch }) => {
-        const signer = api.getSignerInstance(keypairVault.getKeyPair());
+        const signer = api.getSignerInstance(keypairVault.getKeypair());
         await ExampleNFT.mintExampleNFT(signer);
         await dispatch(fetchAllOwnedAndRequiredObjects());
     }
@@ -111,7 +111,7 @@ export const transferNFT = createAsyncThunk<
     { nftId: ObjectId; recipientAddress: SuiAddress },
     AppThunkConfig
 >('transferNFT', async (data, { extra: { api, keypairVault }, dispatch }) => {
-    const signer = api.getSignerInstance(keypairVault.getKeyPair());
+    const signer = api.getSignerInstance(keypairVault.getKeypair());
     const txn = await signer.transferObject({
         objectId: data.nftId,
         recipient: data.recipientAddress,

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -76,7 +76,7 @@ export const deserializeTxn = createAsyncThunk<
     'deserialize-transaction',
     async (data, { dispatch, extra: { api, keypairVault } }) => {
         const { id, serializedTxn } = data;
-        const signer = api.getSignerInstance(keypairVault.getKeyPair());
+        const signer = api.getSignerInstance(keypairVault.getKeypair());
         const localSerializer = new LocalTxnDataSerializer(signer.provider);
         const txnBytes = new Base64DataBuffer(serializedTxn);
 
@@ -138,7 +138,7 @@ export const respondToTransactionRequest = createAsyncThunk<
         let txResult: SuiTransactionResponse | undefined = undefined;
         let tsResultError: string | undefined;
         if (approved) {
-            const signer = api.getSignerInstance(keypairVault.getKeyPair());
+            const signer = api.getSignerInstance(keypairVault.getKeypair());
             try {
                 let response: SuiExecuteTransactionResponse;
                 if (

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -46,7 +46,7 @@ export const sendTokens = createAsyncThunk<
     ) => {
         const state = getState();
         const coins: SuiMoveObject[] = accountCoinsSelector(state);
-        const signer = api.getSignerInstance(keypairVault.getKeyPair());
+        const signer = api.getSignerInstance(keypairVault.getKeypair());
         const response = await CoinAPI.transfer(
             signer,
             coins,
@@ -101,7 +101,7 @@ export const StakeTokens = createAsyncThunk<
         const metadata = (first_validator as SuiMoveObject).fields.metadata;
         const validatorAddress = (metadata as SuiMoveObject).fields.sui_address;
         const response = await Coin.stakeCoin(
-            api.getSignerInstance(keypairVault.getKeyPair()),
+            api.getSignerInstance(keypairVault.getKeypair()),
             coins,
             amount,
             validatorAddress

--- a/sdk/typescript/src/cryptography/keypair.ts
+++ b/sdk/typescript/src/cryptography/keypair.ts
@@ -1,8 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fromB64 } from '@mysten/bcs';
 import { Base64DataBuffer } from '../serialization/base64';
+import { Ed25519Keypair } from './ed25519-keypair';
 import { PublicKey, SignatureScheme } from './publickey';
+import { Secp256k1Keypair } from './secp256k1-keypair';
+
+export type ExportedKeypair = {
+  schema: SignatureScheme;
+  privateKey: string;
+};
 
 /**
  * A keypair used for signing transactions.
@@ -22,4 +30,18 @@ export interface Keypair {
    * Get the key scheme of the keypair: Secp256k1 or ED25519
    */
   getKeyScheme(): SignatureScheme;
+
+  export(): ExportedKeypair;
+}
+
+export function fromExportedKeypair(keypair: ExportedKeypair): Keypair {
+  const secretKey = fromB64(keypair.privateKey);
+  switch (keypair.schema) {
+    case 'ED25519':
+      return Ed25519Keypair.fromSecretKey(secretKey);
+    case 'Secp256k1':
+      return Secp256k1Keypair.fromSecretKey(secretKey);
+    default:
+      throw new Error(`Invalid keypair schema ${keypair.schema}`);
+  }
 }

--- a/sdk/typescript/src/cryptography/secp256k1-keypair.ts
+++ b/sdk/typescript/src/cryptography/secp256k1-keypair.ts
@@ -3,7 +3,7 @@
 
 import * as secp from '@noble/secp256k1';
 import { Base64DataBuffer } from '../serialization/base64';
-import { Keypair } from './keypair';
+import type { ExportedKeypair, Keypair } from './keypair';
 import { PublicKey, SignatureScheme } from './publickey';
 import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha256';
@@ -11,6 +11,7 @@ import { Secp256k1PublicKey } from './secp256k1-publickey';
 import { Signature } from '@noble/secp256k1';
 import { isValidBIP32Path, mnemonicToSeed } from './mnemonics';
 import { HDKey } from '@scure/bip32';
+import { toB64 } from '@mysten/bcs';
 
 export const DEFAULT_SECP256K1_DERIVATION_PATH = "m/54'/784'/0'/0/0";
 
@@ -149,5 +150,12 @@ export class Secp256k1Keypair implements Keypair {
       publicKey: key.publicKey,
       secretKey: key.privateKey,
     });
+  }
+
+  export(): ExportedKeypair {
+    return {
+      schema: 'Secp256k1',
+      privateKey: toB64(this.keypair.secretKey),
+    };
   }
 }


### PR DESCRIPTION
* [ts-sdk: allow keypairs to be exported](https://github.com/MystenLabs/sui/commit/6adeda745ce29b40b812487e92063c07414c5434)
* this will allow us to use different keypairs without making the UI aware of how the keypair was created
* this will help us to support multiple accounts

closes: APPS-205