### PR TITLE
[dynamic fields] Add tests for dynamic_field

### DIFF
--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -276,3 +276,69 @@ fn get_tag_and_layout(
     };
     Ok(Some((layout, *tag)))
 }
+
+
+#[test]
+fn test_u64_dynamic_field_first_key() {
+    let u64_tag = TypeTag::U64;
+    let u64_tag_bytes = bcs::to_bytes(&u64_tag).unwrap();
+    assert_eq!(u64_tag_bytes, [2]);
+
+    let u64_value = Value::u64(0);
+    let u64_value_bytes = u64_value.simple_serialize(&MoveTypeLayout::U64).unwrap();
+    assert_eq!(u64_value_bytes, [0, 0, 0, 0, 0, 0, 0, 0]);
+
+    let account = AccountAddress::from_hex_literal("0x03c8e4462dfb7deecabb5af3dc6e95a02619ebae").unwrap();
+
+    let mut hasher = Sha3_256::default();
+    hasher.update(account);
+    hasher.update(u64_value_bytes);
+    hasher.update(u64_tag_bytes);
+    let hash = hasher.finalize();
+
+    let first_key = ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap();
+    assert_eq!("0xb55d2a87319747315615cb05a62d1b59307c832e", first_key.to_string());
+}
+
+#[test]
+fn test_u64_dynamic_object_field_first_key(){
+    use std::str::FromStr;
+    use move_core_types::{identifier::Identifier, value::MoveStructLayout};
+    use move_vm_types::values::Struct;
+
+    let struct_tag = StructTag {
+        address: AccountAddress::from_hex_literal("0x0000000000000000000000000000000000000002").unwrap(),
+        module: Identifier::from_str("dynamic_object_field").unwrap(),
+        name: Identifier::from_str("Wrapper").unwrap(),
+        type_params: vec![TypeTag::U64],
+    };
+
+    let wrapper_u64_tag = TypeTag::Struct(struct_tag.clone());
+    let wrapper_u64_tag_bytes = bcs::to_bytes(&wrapper_u64_tag).unwrap();
+    let expect = [
+        7u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 20,
+        100, 121, 110, 97, 109, 105, 99, 95, 111, 98, 106, 101, 99, 116, 95,
+        102, 105, 101, 108, 100, 7, 87, 114, 97, 112, 112, 101, 114, 1, 2].to_vec();
+    assert_eq!(expect, wrapper_u64_tag_bytes);
+
+    let wrapper_u64_layout = MoveTypeLayout::Struct(
+        MoveStructLayout::Runtime {
+            0: vec![MoveTypeLayout::U64]
+        }
+    );
+
+    let wrapper_u64_value = Value::struct_(Struct::pack([Value::u64(0)]));
+    let wrapper_u64_value_bytes = wrapper_u64_value.simple_serialize(&wrapper_u64_layout).unwrap();
+    assert_eq!(wrapper_u64_value_bytes, [0, 0, 0, 0, 0, 0, 0, 0]);
+
+    let table_id = AccountAddress::from_hex_literal("0xa236bdcab2880a9c7d5ef9974796bd4126c52eef").unwrap();
+
+    let mut hasher = Sha3_256::default();
+    hasher.update(table_id);
+    hasher.update(wrapper_u64_value_bytes);
+    hasher.update(wrapper_u64_tag_bytes);
+    let hash = hasher.finalize();
+
+    let first_key = ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap();
+    assert_eq!("0xdf50efa50e58c86d8417095299c0c7cbec92deb7", first_key.to_string());
+}

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -327,7 +327,8 @@ fn test_u64_dynamic_object_field_first_key() {
     .to_vec();
     assert_eq!(expect, wrapper_u64_tag_bytes);
 
-    let wrapper_u64_layout = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::U64]));
+    let wrapper_u64_layout =
+        MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::U64]));
 
     let wrapper_u64_value = Value::struct_(Struct::pack([Value::u64(0)]));
     let wrapper_u64_value_bytes = wrapper_u64_value

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -277,7 +277,6 @@ fn get_tag_and_layout(
     Ok(Some((layout, *tag)))
 }
 
-
 #[test]
 fn test_u64_dynamic_field_first_key() {
     let u64_tag = TypeTag::U64;
@@ -288,7 +287,8 @@ fn test_u64_dynamic_field_first_key() {
     let u64_value_bytes = u64_value.simple_serialize(&MoveTypeLayout::U64).unwrap();
     assert_eq!(u64_value_bytes, [0, 0, 0, 0, 0, 0, 0, 0]);
 
-    let account = AccountAddress::from_hex_literal("0x03c8e4462dfb7deecabb5af3dc6e95a02619ebae").unwrap();
+    let account =
+        AccountAddress::from_hex_literal("0x03c8e4462dfb7deecabb5af3dc6e95a02619ebae").unwrap();
 
     let mut hasher = Sha3_256::default();
     hasher.update(account);
@@ -297,17 +297,21 @@ fn test_u64_dynamic_field_first_key() {
     let hash = hasher.finalize();
 
     let first_key = ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap();
-    assert_eq!("0xb55d2a87319747315615cb05a62d1b59307c832e", first_key.to_string());
+    assert_eq!(
+        "0xb55d2a87319747315615cb05a62d1b59307c832e",
+        first_key.to_string()
+    );
 }
 
 #[test]
-fn test_u64_dynamic_object_field_first_key(){
-    use std::str::FromStr;
+fn test_u64_dynamic_object_field_first_key() {
     use move_core_types::{identifier::Identifier, value::MoveStructLayout};
     use move_vm_types::values::Struct;
+    use std::str::FromStr;
 
     let struct_tag = StructTag {
-        address: AccountAddress::from_hex_literal("0x0000000000000000000000000000000000000002").unwrap(),
+        address: AccountAddress::from_hex_literal("0x0000000000000000000000000000000000000002")
+            .unwrap(),
         module: Identifier::from_str("dynamic_object_field").unwrap(),
         name: Identifier::from_str("Wrapper").unwrap(),
         type_params: vec![TypeTag::U64],
@@ -316,22 +320,25 @@ fn test_u64_dynamic_object_field_first_key(){
     let wrapper_u64_tag = TypeTag::Struct(struct_tag.clone());
     let wrapper_u64_tag_bytes = bcs::to_bytes(&wrapper_u64_tag).unwrap();
     let expect = [
-        7u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 20,
-        100, 121, 110, 97, 109, 105, 99, 95, 111, 98, 106, 101, 99, 116, 95,
-        102, 105, 101, 108, 100, 7, 87, 114, 97, 112, 112, 101, 114, 1, 2].to_vec();
+        7u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 20, 100, 121, 110, 97,
+        109, 105, 99, 95, 111, 98, 106, 101, 99, 116, 95, 102, 105, 101, 108, 100, 7, 87, 114, 97,
+        112, 112, 101, 114, 1, 2,
+    ]
+    .to_vec();
     assert_eq!(expect, wrapper_u64_tag_bytes);
 
-    let wrapper_u64_layout = MoveTypeLayout::Struct(
-        MoveStructLayout::Runtime {
-            0: vec![MoveTypeLayout::U64]
-        }
-    );
+    let wrapper_u64_layout = MoveTypeLayout::Struct(MoveStructLayout::Runtime {
+        0: vec![MoveTypeLayout::U64],
+    });
 
     let wrapper_u64_value = Value::struct_(Struct::pack([Value::u64(0)]));
-    let wrapper_u64_value_bytes = wrapper_u64_value.simple_serialize(&wrapper_u64_layout).unwrap();
+    let wrapper_u64_value_bytes = wrapper_u64_value
+        .simple_serialize(&wrapper_u64_layout)
+        .unwrap();
     assert_eq!(wrapper_u64_value_bytes, [0, 0, 0, 0, 0, 0, 0, 0]);
 
-    let table_id = AccountAddress::from_hex_literal("0xa236bdcab2880a9c7d5ef9974796bd4126c52eef").unwrap();
+    let table_id =
+        AccountAddress::from_hex_literal("0xa236bdcab2880a9c7d5ef9974796bd4126c52eef").unwrap();
 
     let mut hasher = Sha3_256::default();
     hasher.update(table_id);
@@ -340,5 +347,8 @@ fn test_u64_dynamic_object_field_first_key(){
     let hash = hasher.finalize();
 
     let first_key = ObjectID::try_from(&hash.as_ref()[0..ObjectID::LENGTH]).unwrap();
-    assert_eq!("0xdf50efa50e58c86d8417095299c0c7cbec92deb7", first_key.to_string());
+    assert_eq!(
+        "0xdf50efa50e58c86d8417095299c0c7cbec92deb7",
+        first_key.to_string()
+    );
 }

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -287,11 +287,11 @@ fn test_u64_dynamic_field_first_key() {
     let u64_value_bytes = u64_value.simple_serialize(&MoveTypeLayout::U64).unwrap();
     assert_eq!(u64_value_bytes, [0, 0, 0, 0, 0, 0, 0, 0]);
 
-    let account =
+    let table_id =
         AccountAddress::from_hex_literal("0x03c8e4462dfb7deecabb5af3dc6e95a02619ebae").unwrap();
 
     let mut hasher = Sha3_256::default();
-    hasher.update(account);
+    hasher.update(table_id);
     hasher.update(u64_value_bytes);
     hasher.update(u64_tag_bytes);
     let hash = hasher.finalize();

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -317,7 +317,7 @@ fn test_u64_dynamic_object_field_first_key() {
         type_params: vec![TypeTag::U64],
     };
 
-    let wrapper_u64_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
+    let wrapper_u64_tag = TypeTag::Struct(Box::new(struct_tag));
     let wrapper_u64_tag_bytes = bcs::to_bytes(&wrapper_u64_tag).unwrap();
     let expect = [
         7u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 20, 100, 121, 110, 97,
@@ -327,9 +327,7 @@ fn test_u64_dynamic_object_field_first_key() {
     .to_vec();
     assert_eq!(expect, wrapper_u64_tag_bytes);
 
-    let wrapper_u64_layout = MoveTypeLayout::Struct(MoveStructLayout::Runtime {
-        0: vec![MoveTypeLayout::U64],
-    });
+    let wrapper_u64_layout = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::U64]));
 
     let wrapper_u64_value = Value::struct_(Struct::pack([Value::u64(0)]));
     let wrapper_u64_value_bytes = wrapper_u64_value

--- a/crates/sui-framework/src/natives/dynamic_field.rs
+++ b/crates/sui-framework/src/natives/dynamic_field.rs
@@ -317,7 +317,7 @@ fn test_u64_dynamic_object_field_first_key() {
         type_params: vec![TypeTag::U64],
     };
 
-    let wrapper_u64_tag = TypeTag::Struct(struct_tag.clone());
+    let wrapper_u64_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
     let wrapper_u64_tag_bytes = bcs::to_bytes(&wrapper_u64_tag).unwrap();
     let expect = [
         7u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 20, 100, 121, 110, 97,


### PR DESCRIPTION
These two tests show how to compute `table` and `object_table` keys off-chain.
This can guide contract developers to design more appropriate keys, and use `calculation keys` instead of `query keys`