### PR TITLE
Add a helper object for assigning tbls share ids

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -120,6 +120,10 @@ pub mod move_integration_tests;
 #[path = "unit_tests/gas_tests.rs"]
 mod gas_tests;
 
+#[cfg(test)]
+#[path = "unit_tests/tbls_tests.rs"]
+mod tbls_tests;
+
 pub mod authority_per_epoch_store;
 
 pub mod authority_store_tables;

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod quorum_driver;
 pub mod safe_client;
 pub mod storage;
 pub mod streamer;
+pub mod tbls;
 pub mod transaction_input_checker;
 pub mod transaction_orchestrator;
 pub mod transaction_streamer;

--- a/crates/sui-core/src/tbls/mod.rs
+++ b/crates/sui-core/src/tbls/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod tbls_ids;

--- a/crates/sui-core/src/tbls/mod.rs
+++ b/crates/sui-core/src/tbls/mod.rs
@@ -1,4 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// Modules for working with threshold BLS (tBLS), needed for the randomness beacon.
+
+/// Assignment of IDs to validators.
 pub mod tbls_ids;

--- a/crates/sui-core/src/tbls/tbls_ids.rs
+++ b/crates/sui-core/src/tbls/tbls_ids.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+use sui_types::base_types::AuthorityName;
+use sui_types::committee::StakeUnit;
+
+const MAX_NUM_OF_SHARES: u32 = 1000;
+
+type TBlsId = NonZeroU32;
+
+pub struct TBlsIds {
+    name_to_ids: HashMap<AuthorityName, Vec<TBlsId>>,
+    number_of_ids: u32,
+}
+
+impl TBlsIds {
+    pub fn new(stakes: &Vec<(AuthorityName, StakeUnit)>) -> Self {
+        let total_stake = stakes.into_iter().fold(0, |acc, x| acc + x.1);
+        // Indexes start from 1.
+        let mut curr_index: u32 = 1;
+        let mut result = HashMap::new();
+        stakes
+            .into_iter()
+            .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
+            .map(|(name, stake)| {
+                // Better to multiply before dividing, to improve precision.
+                let delta = ((*stake as f64) * (MAX_NUM_OF_SHARES as f64)) / (total_stake as f64);
+                (name, delta.floor())
+            })
+            .for_each(|(name, delta)| {
+                if delta == 0.0 {
+                    return;
+                }
+                // Next 2 lines are safe since:
+                // - delta >= 1.0 because of the above check.
+                // - delta < max(u32) because stake/total_stake < 1.0 and MAX_NUM_OF_SHARES is u32.
+                let range: Vec<u32> = (curr_index..(curr_index + (delta as u32))).collect();
+                curr_index += delta as u32;
+                // Next unwrap is safe since we start from curr_index = 1;
+                let range = range
+                    .into_iter()
+                    .map(|i| NonZeroU32::new(i).unwrap())
+                    .collect();
+                result.insert(name.clone(), range);
+            });
+        TBlsIds {
+            name_to_ids: result,
+            number_of_ids: curr_index - 1,
+        }
+    }
+
+    pub fn participants(&self) -> Vec<&AuthorityName> {
+        self.name_to_ids.keys().into_iter().collect()
+    }
+
+    pub fn get_ids(&self, name: &AuthorityName) -> Option<&Vec<TBlsId>> {
+        self.name_to_ids.get(name)
+    }
+
+    pub fn num_of_shares(&self) -> u32 {
+        self.number_of_ids
+    }
+}

--- a/crates/sui-core/src/tbls/tbls_ids.rs
+++ b/crates/sui-core/src/tbls/tbls_ids.rs
@@ -17,13 +17,13 @@ pub struct TBlsIds {
 }
 
 impl TBlsIds {
-    pub fn new(stakes: &Vec<(AuthorityName, StakeUnit)>) -> Self {
-        let total_stake = stakes.into_iter().fold(0, |acc, x| acc + x.1);
+    pub fn new(stakes: &[(AuthorityName, StakeUnit)]) -> Self {
+        let total_stake = stakes.iter().fold(0, |acc, x| acc + x.1);
         // Indexes start from 1.
         let mut curr_index: u32 = 1;
         let mut result = HashMap::new();
         stakes
-            .into_iter()
+            .iter()
             .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
             .map(|(name, stake)| {
                 // Better to multiply before dividing, to improve precision.
@@ -34,17 +34,16 @@ impl TBlsIds {
                 if delta == 0.0 {
                     return;
                 }
-                // Next 2 lines are safe since:
+                // Next lines are safe since:
                 // - delta >= 1.0 because of the above check.
                 // - delta < max(u32) because stake/total_stake < 1.0 and MAX_NUM_OF_SHARES is u32.
-                let range: Vec<u32> = (curr_index..(curr_index + (delta as u32))).collect();
-                curr_index += delta as u32;
-                // Next unwrap is safe since we start from curr_index = 1;
-                let range = range
+                // - We start from curr_index = 1;
+                let range = (curr_index..(curr_index + (delta as u32)))
                     .into_iter()
                     .map(|i| NonZeroU32::new(i).unwrap())
                     .collect();
-                result.insert(name.clone(), range);
+                result.insert(*name, range);
+                curr_index += delta as u32;
             });
         TBlsIds {
             name_to_ids: result,

--- a/crates/sui-core/src/tbls/tbls_ids.rs
+++ b/crates/sui-core/src/tbls/tbls_ids.rs
@@ -4,50 +4,65 @@
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::num::NonZeroU32;
+use std::ops::Range;
+use std::unreachable;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::StakeUnit;
 
-const MAX_NUM_OF_SHARES: u32 = 1000;
-
-type TBlsId = NonZeroU32;
-
+/// Threshold BLS requires unique integer "share IDs".
+///
+/// TBlsIds allocates IDs to validators, proportionally to their stake. E.g., if validator A has
+/// stake x and validator B has stake 2x, validator B will receive ~twice than number of IDs A
+/// received.
+///
+/// The maximal number of IDs is fixed. Since we are working with integers, some rounding is used
+/// and thus the ratios between the number of IDs allocated to different validators is only a close
+/// approximation to the ratios between the stakes of those validators. Also, some validators may
+/// not receive any ID (e.g., if they stake is very small compared to the total stake).
+///
 pub struct TBlsIds {
-    name_to_ids: HashMap<AuthorityName, Vec<TBlsId>>,
+    name_to_ids: HashMap<AuthorityName, Range<TBlsId>>,
     number_of_ids: u32,
 }
 
+type TBlsId = NonZeroU32;
+const MAX_NUM_OF_SHARES: u16 = 1000;
+
 impl TBlsIds {
     pub fn new(stakes: &[(AuthorityName, StakeUnit)]) -> Self {
-        let total_stake = stakes.iter().fold(0, |acc, x| acc + x.1);
-        // Indexes start from 1.
-        let mut curr_index: u32 = 1;
-        let mut result = HashMap::new();
-        stakes
+        let total_stake: u64 = stakes.iter().map(|(_name, stake)| stake).sum();
+        let deltas = stakes
             .iter()
-            .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))
-            .map(|(name, stake)| {
+            .sorted_by_key(|(name, _stake)| name)
+            .filter_map(|(name, stake)| {
                 // Better to multiply before dividing, to improve precision.
-                let delta = ((*stake as f64) * (MAX_NUM_OF_SHARES as f64)) / (total_stake as f64);
-                (name, delta.floor())
-            })
-            .for_each(|(name, delta)| {
+                let delta =
+                    (((*stake as f64) * (MAX_NUM_OF_SHARES as f64)) / (total_stake as f64)).floor();
                 if delta == 0.0 {
-                    return;
+                    return None;
                 }
-                // Next lines are safe since:
-                // - delta >= 1.0 because of the above check.
-                // - delta < max(u32) because stake/total_stake < 1.0 and MAX_NUM_OF_SHARES is u32.
-                // - We start from curr_index = 1;
-                let range = (curr_index..(curr_index + (delta as u32)))
-                    .into_iter()
-                    .map(|i| NonZeroU32::new(i).unwrap())
-                    .collect();
-                result.insert(*name, range);
-                curr_index += delta as u32;
-            });
+                // delta < max(u32) because stake/total_stake <= 1.0 and MAX_NUM_OF_SHARES is u16.
+                Some((*name, delta as u32))
+            })
+            .collect::<Vec<_>>();
+
+        let number_of_ids = deltas.iter().map(|(_name, delta)| delta).sum();
+
+        let name_to_ids = deltas
+            .into_iter()
+            .scan(NonZeroU32::new(1).unwrap(), |curr_index, (name, delta)| {
+                let final_index = curr_index.checked_add(delta).unwrap_or_else(|| {
+                    unreachable!("We should have no overflow because MAX_NUM_OF_SHARES is u16")
+                });
+                let ids = *curr_index..final_index;
+                *curr_index = final_index;
+                Some((name, ids))
+            })
+            .collect();
+
         TBlsIds {
-            name_to_ids: result,
-            number_of_ids: curr_index - 1,
+            name_to_ids,
+            number_of_ids,
         }
     }
 
@@ -55,7 +70,7 @@ impl TBlsIds {
         self.name_to_ids.keys().into_iter().collect()
     }
 
-    pub fn get_ids(&self, name: &AuthorityName) -> Option<&Vec<TBlsId>> {
+    pub fn get_ids(&self, name: &AuthorityName) -> Option<&Range<TBlsId>> {
         self.name_to_ids.get(name)
     }
 

--- a/crates/sui-core/src/tbls/tbls_ids.rs
+++ b/crates/sui-core/src/tbls/tbls_ids.rs
@@ -9,7 +9,8 @@ use std::unreachable;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::StakeUnit;
 
-/// Threshold BLS requires unique integer "share IDs".
+/// Threshold BLS (tBLS) requires unique integer "share IDs". (tBLS will be used soon by the
+/// randomness beacon.)
 ///
 /// TBlsIds allocates IDs to validators, proportionally to their stake. E.g., if validator A has
 /// stake x and validator B has stake 2x, validator B will receive ~twice than number of IDs A
@@ -18,7 +19,7 @@ use sui_types::committee::StakeUnit;
 /// The maximal number of IDs is fixed. Since we are working with integers, some rounding is used
 /// and thus the ratios between the number of IDs allocated to different validators is only a close
 /// approximation to the ratios between the stakes of those validators. Also, some validators may
-/// not receive any ID (e.g., if they stake is very small compared to the total stake).
+/// not receive any ID (e.g., if their stake is very small compared to the total stake).
 ///
 pub struct TBlsIds {
     name_to_ids: HashMap<AuthorityName, Range<TBlsId>>,

--- a/crates/sui-core/src/unit_tests/tbls_tests.rs
+++ b/crates/sui-core/src/unit_tests/tbls_tests.rs
@@ -82,5 +82,5 @@ fn test_validator_without_shares() {
     // Validators with stake of 100 should get floor(100*1000/1001) = 99.
     let tbls_ids = TBlsIds::new(&stakes);
     assert_eq!(tbls_ids.get_ids(&get_key(1)).unwrap().len(), 99);
-    assert_eq!(tbls_ids.get_ids(&get_key(11)).is_some(), false);
+    assert!(tbls_ids.get_ids(&get_key(11)).is_none());
 }

--- a/crates/sui-core/src/unit_tests/tbls_tests.rs
+++ b/crates/sui-core/src/unit_tests/tbls_tests.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tbls::tbls_ids::TBlsIds;
+use fastcrypto::traits::{ToFromBytes, VerifyingKey};
+use std::num::NonZeroU32;
+use sui_types::base_types::AuthorityName;
+use sui_types::committee::StakeUnit;
+use sui_types::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes};
+
+fn get_key(id: u16) -> AuthorityName {
+    let mut buffer = [0u8; AuthorityPublicKey::LENGTH];
+    buffer[0] = (id >> 8) as u8;
+    buffer[1] = (id % 0x100) as u8;
+    AuthorityPublicKeyBytes::from_bytes(&buffer).unwrap()
+}
+
+#[test]
+fn test_1000_validators_with_1000_stake() {
+    let stakes: Vec<(AuthorityName, StakeUnit)> =
+        (1..=1000).into_iter().map(|i| (get_key(i), 1)).collect();
+
+    let tbls_ids = TBlsIds::new(&stakes);
+    for i in 1..=1000 {
+        assert_eq!(
+            tbls_ids.get_ids(&get_key(i)),
+            Some(&vec![NonZeroU32::new(i as u32).unwrap()])
+        );
+    }
+    assert_eq!(tbls_ids.participants().len(), 1000);
+    assert_eq!(tbls_ids.num_of_shares(), 1000);
+}
+
+#[test]
+fn test_1000_validators_with_100000_stake() {
+    let stakes: Vec<(AuthorityName, StakeUnit)> =
+        (1..=1000).into_iter().map(|i| (get_key(i), 100)).collect();
+
+    let tbls_ids = TBlsIds::new(&stakes);
+    for i in 1..=1000 {
+        assert_eq!(tbls_ids.get_ids(&get_key(i)).unwrap().len(), 1);
+    }
+}
+
+#[test]
+fn test_100_validators_one_with_large_stake() {
+    let mut stakes: Vec<(AuthorityName, StakeUnit)> =
+        (1..=100).into_iter().map(|i| (get_key(i), 1)).collect();
+    stakes.get_mut(0).unwrap().1 = 900;
+
+    let tbls_ids = TBlsIds::new(&stakes);
+    assert_eq!(tbls_ids.get_ids(&get_key(1)).unwrap().len(), 900);
+    assert_eq!(
+        tbls_ids.get_ids(&get_key(2)),
+        Some(&vec![NonZeroU32::new(901).unwrap()])
+    );
+}
+
+#[test]
+fn test_unsorted_100_validators_with_1000_stake() {
+    let mut stakes: Vec<(AuthorityName, StakeUnit)> = (1..=100)
+        .into_iter()
+        .map(|i| (get_key(101 - i), 1))
+        .collect();
+    stakes.get_mut(0).unwrap().1 = 900;
+
+    let tbls_ids = TBlsIds::new(&stakes);
+    assert_eq!(tbls_ids.get_ids(&get_key(100)).unwrap().len(), 900);
+    assert_eq!(
+        tbls_ids.get_ids(&get_key(1)),
+        Some(&vec![NonZeroU32::new(1).unwrap()])
+    );
+}
+
+#[test]
+fn test_validator_without_shares() {
+    let mut stakes: Vec<(AuthorityName, StakeUnit)> =
+        (1..=10).into_iter().map(|i| (get_key(i), 100)).collect();
+    // The next validator should not receive any id.
+    stakes.push((get_key(11), 1));
+
+    // Validators with stake of 100 should get floor(100*1000/1001) = 99.
+    let tbls_ids = TBlsIds::new(&stakes);
+    assert_eq!(tbls_ids.get_ids(&get_key(1)).unwrap().len(), 99);
+    assert_eq!(tbls_ids.get_ids(&get_key(11)).is_some(), false);
+}

--- a/crates/sui-core/src/unit_tests/tbls_tests.rs
+++ b/crates/sui-core/src/unit_tests/tbls_tests.rs
@@ -84,4 +84,7 @@ fn test_validator_without_shares() {
     let tbls_ids = TBlsIds::new(&stakes);
     assert_eq!(*tbls_ids.get_ids(&get_key(1)).unwrap(), get_range(1, 100));
     assert!(tbls_ids.get_ids(&get_key(11)).is_none());
+
+    assert_eq!(tbls_ids.participants().len(), 10);
+    assert_eq!(tbls_ids.num_of_shares(), 990);
 }

--- a/crates/sui-core/src/unit_tests/tbls_tests.rs
+++ b/crates/sui-core/src/unit_tests/tbls_tests.rs
@@ -4,6 +4,7 @@
 use crate::tbls::tbls_ids::TBlsIds;
 use fastcrypto::traits::{ToFromBytes, VerifyingKey};
 use std::num::NonZeroU32;
+use std::ops::Range;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::StakeUnit;
 use sui_types::crypto::{AuthorityPublicKey, AuthorityPublicKeyBytes};
@@ -15,6 +16,12 @@ fn get_key(id: u16) -> AuthorityName {
     AuthorityPublicKeyBytes::from_bytes(&buffer).unwrap()
 }
 
+fn get_range(begin: u16, end: u16) -> Range<NonZeroU32> {
+    let first = NonZeroU32::new(begin as u32).unwrap();
+    let last = NonZeroU32::new(end as u32).unwrap();
+    first..last
+}
+
 #[test]
 fn test_1000_validators_with_1000_stake() {
     let stakes: Vec<(AuthorityName, StakeUnit)> =
@@ -22,10 +29,7 @@ fn test_1000_validators_with_1000_stake() {
 
     let tbls_ids = TBlsIds::new(&stakes);
     for i in 1..=1000 {
-        assert_eq!(
-            tbls_ids.get_ids(&get_key(i)),
-            Some(&vec![NonZeroU32::new(i as u32).unwrap()])
-        );
+        assert_eq!(*tbls_ids.get_ids(&get_key(i)).unwrap(), get_range(i, i + 1));
     }
     assert_eq!(tbls_ids.participants().len(), 1000);
     assert_eq!(tbls_ids.num_of_shares(), 1000);
@@ -38,7 +42,7 @@ fn test_1000_validators_with_100000_stake() {
 
     let tbls_ids = TBlsIds::new(&stakes);
     for i in 1..=1000 {
-        assert_eq!(tbls_ids.get_ids(&get_key(i)).unwrap().len(), 1);
+        assert_eq!(*tbls_ids.get_ids(&get_key(i)).unwrap(), get_range(i, i + 1));
     }
 }
 
@@ -49,11 +53,8 @@ fn test_100_validators_one_with_large_stake() {
     stakes.get_mut(0).unwrap().1 = 900;
 
     let tbls_ids = TBlsIds::new(&stakes);
-    assert_eq!(tbls_ids.get_ids(&get_key(1)).unwrap().len(), 900);
-    assert_eq!(
-        tbls_ids.get_ids(&get_key(2)),
-        Some(&vec![NonZeroU32::new(901).unwrap()])
-    );
+    assert_eq!(*tbls_ids.get_ids(&get_key(1)).unwrap(), get_range(1, 901));
+    assert_eq!(*tbls_ids.get_ids(&get_key(2)).unwrap(), get_range(901, 902));
 }
 
 #[test]
@@ -65,11 +66,11 @@ fn test_unsorted_100_validators_with_1000_stake() {
     stakes.get_mut(0).unwrap().1 = 900;
 
     let tbls_ids = TBlsIds::new(&stakes);
-    assert_eq!(tbls_ids.get_ids(&get_key(100)).unwrap().len(), 900);
     assert_eq!(
-        tbls_ids.get_ids(&get_key(1)),
-        Some(&vec![NonZeroU32::new(1).unwrap()])
+        *tbls_ids.get_ids(&get_key(100)).unwrap(),
+        get_range(100, 1000)
     );
+    assert_eq!(*tbls_ids.get_ids(&get_key(1)).unwrap(), get_range(1, 2));
 }
 
 #[test]
@@ -81,6 +82,6 @@ fn test_validator_without_shares() {
 
     // Validators with stake of 100 should get floor(100*1000/1001) = 99.
     let tbls_ids = TBlsIds::new(&stakes);
-    assert_eq!(tbls_ids.get_ids(&get_key(1)).unwrap().len(), 99);
+    assert_eq!(*tbls_ids.get_ids(&get_key(1)).unwrap(), get_range(1, 100));
     assert!(tbls_ids.get_ids(&get_key(11)).is_none());
 }


### PR DESCRIPTION
Add an object that assigns globally consistent share ids to validators, with at most 1000 ids.
Each validator receives a number of ids that is proportional to its stake.