### PR TITLE
Laura/check for reconfiguration messages first narwhal

### DIFF
--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -320,14 +320,19 @@ where
                     let message = self.rx_reconfigure.borrow().clone();
                     match message {
                         ReconfigureNotification::NewEpoch(new_committee) => {
+                            tracing::debug!("received new epoch reconfiguration message in consensus");
                             self.state = self.change_epoch(new_committee)?;
                         },
                         ReconfigureNotification::UpdateCommittee(new_committee) => {
+                            tracing::debug!("received new committee reconfiguration message in consensus");
                             self.committee = new_committee;
+                            tracing::debug!("Committee updated to {}", self.committee);
                         }
-                        ReconfigureNotification::Shutdown => return Ok(())
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in consensus");
+                            return Ok(())}
                     }
-                    tracing::debug!("Committee updated to {}", self.committee);
+
                 }
 
                 Some(certificate) = self.rx_new_certificates.recv() => {

--- a/narwhal/primary/src/block_synchronizer/mod.rs
+++ b/narwhal/primary/src/block_synchronizer/mod.rs
@@ -251,14 +251,19 @@ impl BlockSynchronizer {
                     let message = self.rx_reconfigure.borrow().clone();
                     match message {
                         ReconfigureNotification::NewEpoch(new_committee)=> {
+                            tracing::debug!("received new epoch reconfiguration message in block synchronizer");
                             self.committee = new_committee;
                         }
                         ReconfigureNotification::UpdateCommittee(new_committee)=> {
+                            tracing::debug!("received new committee reconfiguration message in block synchronizer");
                             self.committee = new_committee;
+                            tracing::debug!("Committee updated to {}", self.committee);
                         }
-                        ReconfigureNotification::Shutdown => return
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in block synchronizer");
+                            return
+                        }
                     }
-                    tracing::debug!("Committee updated to {}", self.committee);
                 }
 
 

--- a/narwhal/primary/src/certificate_fetcher.rs
+++ b/narwhal/primary/src/certificate_fetcher.rs
@@ -141,18 +141,24 @@ impl CertificateFetcher {
                     let message = self.rx_reconfigure.borrow_and_update().clone();
                     match message {
                         ReconfigureNotification::NewEpoch(committee) => {
+                            tracing::debug!("received new epoch reconfiguration message in certificate fetcher");
                             self.committee = committee;
                             self.targets.clear();
                             self.fetch_certificates_task = FuturesUnordered::new();
+
                         },
                         ReconfigureNotification::UpdateCommittee(committee) => {
+                            tracing::debug!("received new committee reconfiguration message in certificate fetcher");
                             self.committee = committee;
-                            // There should be no committee membership change so self.targets does
-                            // not need to be updated.
+                            debug!("Committee updated to {}", self.committee);
+
                         },
-                        ReconfigureNotification::Shutdown => return
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in certificate fetcher");
+                            return
+                        }
                     }
-                    debug!("Committee updated to {}", self.committee);
+
                 }
 
 

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -412,14 +412,20 @@ impl Proposer {
                     let message = self.rx_reconfigure.borrow().clone();
                     match message {
                         ReconfigureNotification::NewEpoch(new_committee) => {
+                            tracing::debug!("received new epoch reconfiguration message in proposer");
                             self.change_epoch(new_committee);
                         },
                         ReconfigureNotification::UpdateCommittee(new_committee) => {
+                            tracing::debug!("received new committee reconfiguration message in proposer");
                             self.committee = new_committee;
+                            tracing::debug!("Committee updated to {}", self.committee);
                         },
-                        ReconfigureNotification::Shutdown => return,
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in proposer");
+                            return
+                        },
                     }
-                    tracing::debug!("Committee updated to {}", self.committee);
+
 
                 }
                 else => {

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -139,9 +139,7 @@ impl StateHandler {
         );
         loop {
             tokio::select! {
-                Some((commit_round, certificates)) = self.rx_committed_certificates.recv() => {
-                    self.handle_sequenced(commit_round, certificates).await;
-                },
+                biased;
 
                 Some(message) = self.rx_state_handler.recv() => {
                     // Notify our workers
@@ -173,6 +171,12 @@ impl StateHandler {
                         return;
                     }
                 }
+
+                Some((commit_round, certificates)) = self.rx_committed_certificates.recv() => {
+                    self.handle_sequenced(commit_round, certificates).await;
+                },
+
+
             }
         }
     }

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -147,16 +147,20 @@ impl StateHandler {
 
                     let shutdown = match &message {
                         ReconfigureNotification::NewEpoch(committee) => {
+                            tracing::debug!("received new epoch reconfiguration message in state handler");
                             self.update_committee(committee.to_owned());
-
                             false
                         },
                         ReconfigureNotification::UpdateCommittee(committee) => {
+                            tracing::debug!("received new committee reconfiguration message in state handler");
                             self.update_committee(committee.to_owned());
-
+                            tracing::debug!("Committee updated to {}", self.committee);
                             false
                         }
-                        ReconfigureNotification::Shutdown => true,
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in state handler");
+                            true
+                        },
                     };
 
                     // Notify all other tasks.

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -113,21 +113,25 @@ impl BatchMaker {
             tokio::select! {
                 biased;
 
-                // check for reconfiguration.
+                // check for reconfiguration
                 result = self.rx_reconfigure.changed() => {
                     result.expect("Committee channel dropped");
                     let message = self.rx_reconfigure.borrow().clone();
                     match message {
                         ReconfigureNotification::NewEpoch(new_committee) => {
+                            tracing::debug!("received new epoch reconfiguration message in batch maker");
                             self.committee = new_committee;
                         },
                         ReconfigureNotification::UpdateCommittee(new_committee) => {
+                            tracing::debug!("received new committee reconfiguration message in batch maker");
                             self.committee = new_committee;
-
+                            tracing::debug!("Committee updated to {}", self.committee);
                         },
-                        ReconfigureNotification::Shutdown => return
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in batch maker");
+                            return
+                        }
                     }
-                    tracing::debug!("Committee updated to {}", self.committee);
                 },
 
                 else => {

--- a/narwhal/worker/src/primary_connector.rs
+++ b/narwhal/worker/src/primary_connector.rs
@@ -63,9 +63,11 @@ impl PrimaryConnector {
                 // check for reconfiguration
                 result = self.rx_reconfigure.changed() => {
                     result.expect("Committee channel dropped");
+
                     // TODO: Move logic to handle epoch & committee changes to wherever anemo
                     // network is managed after worker-to-worker interface is migrated.
                     if self.rx_reconfigure.borrow().clone() == ReconfigureNotification::Shutdown {
+                        tracing::debug!("received shutdown message in primary connector");
                         return
                     }
                 }

--- a/narwhal/worker/src/quorum_waiter.rs
+++ b/narwhal/worker/src/quorum_waiter.rs
@@ -88,9 +88,12 @@ impl QuorumWaiter {
                     let message = self.rx_reconfigure.borrow().clone();
                     match message {
                         ReconfigureNotification::NewEpoch(new_committee) => {
+                            tracing::debug!("received new epoch reconfiguration message in quorum waiter");
                             self.committee = new_committee;
+                            tracing::debug!("Committee updated to {}", self.committee);
                         },
                         ReconfigureNotification::UpdateCommittee(new_committee) => {
+                            tracing::debug!("received new committee reconfiguration message in quorum waiter");
                             self.committee = new_committee;
 
                             // Upon reconfiguration we drop all current batches.
@@ -101,9 +104,12 @@ impl QuorumWaiter {
                             best_effort_with_timeout = FuturesUnordered::new()
 
                         },
-                        ReconfigureNotification::Shutdown => return
+                        ReconfigureNotification::Shutdown => {
+                            tracing::debug!("received shutdown message in quorum waiter");
+                            return
+                        }
                     }
-                    tracing::debug!("Committee updated to {}", self.committee);
+
                 }
 
                 else => {


### PR DESCRIPTION
This is a spike to refactor our NW component main loops and adds the `biased` macro while reordering the check for reconfiguration messages first, and moving all other select branch statements into a nested tokio select in an else branch of the outer loop. Doing so has the effect that upon selection of branches in the loop, if a reconfiguration message is present, that branch will always be evaluated first, and we will proceed to shutdown / change the committee at that time. If there is no reconfiguration message, we evaluate the else branch, which now contains a nested select that randomly selects the next branch of the remaining futures. This will reduce the latency of reconfiguration in any reconfiguration strategy. The way the loops were arranged before, after sending reconfiguration messages, for 8 different loops, we were waiting until the reconfiguration branch was randomly polled out of several others. Now the max latency will be the max time for any of the other branches in the main loop to complete the pending processing. 

Edit: In order for this to work, I think we need a conditional clause as a part of the macro that evaluates to false if there is no new message on the watch channel