### PR TITLE
[consensus] Drop pending consensus adapter tasks when epoch ends

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2098,16 +2098,6 @@ impl AuthorityState {
             ))
     }
 
-    /// Check whether certificate was processed by consensus.
-    /// Returned future is immediately ready if consensus message was already processed.
-    /// Otherwise returns future that waits for message to be processed by consensus.
-    pub async fn consensus_message_processed_notify(
-        &self,
-        key: ConsensusTransactionKey,
-    ) -> Result<(), SuiError> {
-        self.database.consensus_message_processed_notify(key).await
-    }
-
     /// Get a read reference to an object/seq lock
     pub async fn get_transaction_lock(
         &self,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -145,7 +145,8 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
             &self.path,
             self.db_options.clone(),
         ));
-        self.epoch_store.store(epoch_tables);
+        let previous_store = self.epoch_store.swap(epoch_tables);
+        previous_store.epoch_terminated();
     }
 
     pub fn epoch_store(&self) -> Guard<Arc<AuthorityPerEpochStore<S>>> {
@@ -1176,19 +1177,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         key: &ConsensusTransactionKey,
     ) -> Result<bool, SuiError> {
         self.epoch_store().is_consensus_message_processed(key)
-    }
-
-    pub async fn consensus_message_processed_notify(
-        &self,
-        key: ConsensusTransactionKey,
-    ) -> Result<(), SuiError> {
-        let epoch_tables = self.epoch_store();
-        let registration = epoch_tables.register_consensus_message_notify(&key);
-        if self.consensus_message_processed(&key)? {
-            return Ok(());
-        }
-        registration.await;
-        Ok(())
     }
 
     pub fn sent_end_of_publish(&self, authority: &AuthorityName) -> SuiResult<bool> {

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod consensus_validator;
 mod histogram;
 mod module_cache_gauge;
 mod node_sync;
+mod notify_once;
 mod query_helpers;
 mod stake_aggregator;
 mod transaction_manager;

--- a/crates/sui-core/src/notify_once.rs
+++ b/crates/sui-core/src/notify_once.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tokio::sync::futures::Notified;
+use tokio::sync::Notify;
+
+/// Notify once allows waiter to register for certain conditions and unblocks waiter
+/// when condition is signalled with `notify` method.
+///
+/// The functionality is somewhat similar to a tokio watch channel with subscribe method,
+/// however it is much less error prone to use NotifyOnce rather then tokio watch.
+///
+/// Specifically with tokio watch you may miss notification,
+/// if you subscribe to it after the value was changed
+/// (Note that this is not a bug in tokio watch, but rather a mis-use of it).
+///
+/// NotifyOnce guarantees that wait() will return once notify() is called,
+/// regardless of whether wait() was called before or after notify().
+pub struct NotifyOnce {
+    notify: Mutex<Option<Arc<Notify>>>,
+}
+
+impl NotifyOnce {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Notify all waiters, present and future about event
+    ///
+    /// After this method all pending and future calls to .wait() will return
+    ///
+    /// This method returns errors if called more then once
+    #[allow(clippy::result_unit_err)]
+    pub fn notify(&self) -> Result<(), ()> {
+        let Some(notify) = self.notify.lock().take()else { return Err(()) };
+        // At this point all `register` either registered with current notify,
+        // or will be returning immediately
+        notify.notify_waiters();
+        Ok(())
+    }
+
+    /// Awaits for `notify` method to be called.
+    ///
+    /// This future is cancellation safe.
+    pub async fn wait(&self) {
+        // Note that we only hold lock briefly when registering for notification
+        // There is a bit of a trickery here with lock - we take a lock and if it is not empty,
+        // we register .notified() first and then release lock
+        //
+        // This is to make sure no notification is lost because Notify::notify_waiters do not
+        // notify waiters that register **after** notify_waiters was called
+        let mut notify = None;
+        let notified = self.make_notified(&mut notify);
+
+        if let Some(notified) = notified {
+            notified.await;
+        }
+    }
+
+    // This made into separate function as it is only way to make compiler
+    // not to hold `lock` in a generated async future.
+    fn make_notified<'a>(&self, notify: &'a mut Option<Arc<Notify>>) -> Option<Notified<'a>> {
+        let lock = self.notify.lock();
+        *notify = lock.as_ref().cloned();
+        notify.as_ref().map(|n| n.notified())
+    }
+}
+
+impl Default for NotifyOnce {
+    fn default() -> Self {
+        let notify = Arc::new(Notify::new());
+        let notify = Mutex::new(Some(notify));
+        Self { notify }
+    }
+}
+
+#[tokio::test]
+async fn notify_once_test() {
+    let notify_once = NotifyOnce::new();
+    // Before notify() is called .wait() is not ready
+    assert!(futures::future::poll_immediate(notify_once.wait())
+        .await
+        .is_none());
+    let wait = notify_once.wait();
+    notify_once.notify().unwrap();
+    // Pending wait() call is ready now
+    assert!(futures::future::poll_immediate(wait).await.is_some());
+    // Take wait future and don't resolve it.
+    // This makes sure lock is dropped properly and wait futures resolve independently of each other
+    let _dangle_wait = notify_once.wait();
+    // Any new wait() is immediately ready
+    assert!(futures::future::poll_immediate(notify_once.wait())
+        .await
+        .is_some());
+}


### PR DESCRIPTION
Consensus adapter has a bunch of pending tasks that submits to consensus and wait for transaction to be sequenced.

Some of those tasks might never complete after epoch change, because at some point we stop consensus and some submitted transactions will never get committed.

In order to release those tasks, we introduce separate mechanism - `AuthorityPerEpochStore` has a new method `wait_epoch_terminated` which returns future that resolves when epoch ends. We make use of this future to terminate all ConsensusAdapter tasks on epoch change.

In terms of implementation details, we introduce new `NotifyOnce` struct in order to propagate such notification.

https://github.com/MystenLabs/sui/issues/5763