### PR TITLE
[consensus] Move signature verification from consensus handler to narwhal batch verification

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -4,7 +4,8 @@
 
 use crate::{
     authority::{AuthorityState, ReconfigConsensusMessage},
-    consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics, SuiTxValidator},
+    consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics},
+    consensus_validator::SuiTxValidator,
 };
 use anyhow::anyhow;
 use anyhow::Result;
@@ -307,6 +308,7 @@ impl ValidatorService {
         let network_keypair = config.network_key_pair.copy();
 
         let registry = prometheus_registry.clone();
+        let tx_validator = SuiTxValidator::new(state.clone());
         spawn_monitored_task!(narwhal_node::restarter::NodeRestarter::watch(
             consensus_keypair,
             network_keypair,
@@ -316,8 +318,7 @@ impl ValidatorService {
             consensus_storage_base_path,
             consensus_execution_state,
             consensus_parameters,
-            // TODO: provide something more clever here to specify TX validity
-            SuiTxValidator::default(),
+            tx_validator,
             rx_reconfigure_consensus,
             &registry,
         ));

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -452,10 +452,6 @@ impl<'a> Drop for InflightDropGuard<'a> {
     }
 }
 
-/// An implementation of the Narwhal TxValidator trait that validates transactions coming from Sui, and those coming from the network.
-// TODO: replace by a ConsensusTxValidator in order to make Narwhal-side validation effective
-pub use narwhal_worker::TrivialTransactionValidator as SuiTxValidator;
-
 #[async_trait::async_trait]
 impl SubmitToConsensus for Arc<ConsensusAdapter> {
     async fn submit_to_consensus(&self, transaction: &ConsensusTransaction) -> SuiResult {


### PR DESCRIPTION
This moves signature verification for consensus messages to narwhal payload verification step, effectively removing signature verification from the consensus handler critical path.

To elaborate, it is safe to skip signature verification in consensus handler, because in order to create certificate in narwhal, header needs to be signed by 2f+1 authorities, which only sign header if they have all batches stored locally. Additionally, authorities only store batches locally if all signatures in the batch are correct according to configured `TxVerifier`.

Additional benefit of this approach is that because batches are processed in parallel, this gives parallel verification of signatures for free.

Note: one hesitation for using `SuiTxValidator` initially was that it does not have any mechanism for signature verification deduplication. However, after #6588 is merged we have nearly no amplification for consensus messages, and it is ok to just use `SuiTxValidator` as is.