### PR TITLE
Add table summary command to get accurate key/val sizes

### DIFF
--- a/crates/sui-tool/src/db_tool/db_dump.rs
+++ b/crates/sui-tool/src/db_tool/db_dump.rs
@@ -12,8 +12,11 @@ use sui_core::authority::authority_per_epoch_store::AuthorityEpochTables;
 use sui_core::authority::authority_store_tables::AuthorityPerpetualTables;
 use sui_core::epoch::committee_store::CommitteeStore;
 use sui_storage::default_db_options;
+use sui_storage::write_ahead_log::DBWriteAheadLogTables;
 use sui_storage::{lock_service::LockServiceImpl, node_sync_store::NodeSyncStore, IndexStore};
 use sui_types::base_types::EpochId;
+use sui_types::messages::{SignedTransactionEffects, TrustedCertificate};
+use sui_types::temporary_store::InnerTemporaryStore;
 
 #[derive(EnumString, Parser, Debug)]
 pub enum StoreName {
@@ -49,6 +52,43 @@ pub fn list_tables(path: PathBuf) -> anyhow::Result<Vec<String>> {
             })
             .collect()
     })
+}
+
+pub fn table_summary(
+    store_name: StoreName,
+    epoch: Option<EpochId>,
+    db_path: PathBuf,
+    table_name: &str,
+) -> anyhow::Result<(usize, usize, usize)> {
+    match store_name {
+        StoreName::Validator => {
+            let epoch_tables = AuthorityEpochTables::describe_tables();
+            if epoch_tables.contains_key(table_name) {
+                let epoch = epoch.ok_or_else(|| anyhow!("--epoch is required"))?;
+                AuthorityEpochTables::open_readonly(epoch, &db_path).table_summary(table_name)
+            } else {
+                AuthorityPerpetualTables::open_readonly(&db_path).table_summary(table_name)
+            }
+        }
+        StoreName::Index => {
+            IndexStore::get_read_only_handle(db_path, None, None).table_summary(table_name)
+        }
+        StoreName::LocksService => {
+            LockServiceImpl::get_read_only_handle(db_path, None, None).table_summary(table_name)
+        }
+        StoreName::NodeSync => {
+            NodeSyncStore::get_read_only_handle(db_path, None, None).table_summary(table_name)
+        }
+        StoreName::Wal => DBWriteAheadLogTables::<
+            TrustedCertificate,
+            (InnerTemporaryStore, SignedTransactionEffects),
+        >::get_read_only_handle(db_path, None, None)
+        .table_summary(table_name),
+        StoreName::Epoch => {
+            CommitteeStore::get_read_only_handle(db_path, None, None).table_summary(table_name)
+        }
+    }
+    .map_err(|err| anyhow!(err.to_string()))
 }
 
 // TODO: condense this using macro or trait dyn skills

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use self::db_dump::{dump_table, list_tables, StoreName};
+use self::db_dump::{dump_table, list_tables, table_summary, StoreName};
 use clap::Parser;
 use std::path::PathBuf;
 use sui_types::base_types::EpochId;
@@ -13,6 +13,7 @@ pub mod db_dump;
 pub enum DbToolCommand {
     ListTables,
     Dump(Dump),
+    TableSummary(Dump),
 }
 
 #[derive(Parser)]
@@ -50,11 +51,28 @@ pub fn execute_db_tool_command(db_path: PathBuf, cmd: DbToolCommand) -> anyhow::
             d.page_size,
             d.page_number,
         ),
+        DbToolCommand::TableSummary(d) => {
+            print_db_table_summary(d.store_name, d.epoch, db_path, &d.table_name)
+        }
     }
 }
 
 pub fn print_db_all_tables(db_path: PathBuf) -> anyhow::Result<()> {
     list_tables(db_path)?.iter().for_each(|t| println!("{}", t));
+    Ok(())
+}
+
+pub fn print_db_table_summary(
+    store: StoreName,
+    epoch: Option<EpochId>,
+    path: PathBuf,
+    table_name: &str,
+) -> anyhow::Result<()> {
+    let (count_keys, key_bytes, value_bytes) = table_summary(store, epoch, path, table_name)?;
+    println!(
+        "Total keys = {}, key bytes = {}, value bytes = {}",
+        count_keys, key_bytes, value_bytes
+    );
     Ok(())
 }
 

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -551,6 +551,30 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 })
             }
 
+            /// Get key value sizes from the db
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn table_summary(&self, table_name: &str) -> eyre::Result<(usize, usize, usize)> {
+                let mut count = 0;
+                let mut key_bytes = 0;
+                let mut value_bytes = 0;
+                Ok(match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
+                            let mut iter = self.#field_names.iterator_cf().map(Result::unwrap);
+                            for (key, value) in iter {
+                                count += 1;
+                                key_bytes += key.len();
+                                value_bytes += value.len();
+                            }
+                            (count, key_bytes, value_bytes)
+                        }
+                    )*
+
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                })
+            }
+
             /// Count the keys in this table
             /// Tables must be opened in read only mode using `open_tables_read_only`
             pub fn count_keys(&self, table_name: &str) -> eyre::Result<usize> {


### PR DESCRIPTION
Add a new command which can scan a column family and return table summary like count, raw byte size of all keys, values, etc