### PR TITLE
crypto: Add r1 sui  user signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6462,9 +6462,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.16"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac662b3a6490de378b0ee15cf2dfff7127aebfe0b19acc65e7fbca3d299c3788"
+checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "pprof"

--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -16,7 +16,7 @@ pub fn get_ed25519_keypair_from_keystore(
 ) -> Result<AccountKeyPair> {
     let keystore = FileBasedKeystore::new(&keystore_path)?;
     match keystore.get_key(requested_address) {
-        Ok(SuiKeyPair::Ed25519SuiKeyPair(kp)) => Ok(kp.copy()),
+        Ok(SuiKeyPair::Ed25519(kp)) => Ok(kp.copy()),
         other => Err(anyhow::anyhow!("Invalid key type: {:?}", other)),
     }
 }

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -233,9 +233,7 @@ pub async fn new_wallet_context_from_cluster(
     let keystore_path = temp_dir.path().join(SUI_KEYSTORE_FILENAME);
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let address: SuiAddress = key_pair.public().into();
-    keystore
-        .add_key(SuiKeyPair::Ed25519SuiKeyPair(key_pair))
-        .unwrap();
+    keystore.add_key(SuiKeyPair::Ed25519(key_pair)).unwrap();
     SuiClientConfig {
         keystore,
         envs: vec![SuiEnv {

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -17,7 +17,7 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let (address, phrase, scheme) = keystore
-        .generate_new_key(SignatureScheme::ED25519, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None)
         .unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -4411,6 +4411,9 @@
       "Secp256k1SuiSignature": {
         "$ref": "#/components/schemas/Base64"
       },
+      "Secp256r1SuiSignature": {
+        "$ref": "#/components/schemas/Base64"
+      },
       "SequenceNumber": {
         "type": "integer",
         "format": "uint64",
@@ -4441,6 +4444,18 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "Secp256r1SuiSignature"
+            ],
+            "properties": {
+              "Secp256r1SuiSignature": {
+                "$ref": "#/components/schemas/Secp256r1SuiSignature"
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -4449,6 +4464,7 @@
         "enum": [
           "ED25519",
           "Secp256k1",
+          "Secp256r1",
           "BLS12381"
         ]
       },

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -163,11 +163,14 @@ fn read_prefunded_account(path: &Path) -> Result<Vec<PrefundedAccount>, anyhow::
         .into_iter()
         .map(|(address, key)| {
             let (privkey, curve_type) = match key {
-                SuiKeyPair::Ed25519SuiKeyPair(k) => {
+                SuiKeyPair::Ed25519(k) => {
                     (Hex::encode(k.private().as_bytes()), CurveType::Edwards25519)
                 }
-                SuiKeyPair::Secp256k1SuiKeyPair(k) => {
+                SuiKeyPair::Secp256k1(k) => {
                     (Hex::encode(k.private().as_bytes()), CurveType::Secp256k1)
+                }
+                SuiKeyPair::Secp256r1(k) => {
+                    (Hex::encode(k.private().as_bytes()), CurveType::Secp256r1)
                 }
             };
             PrefundedAccount {
@@ -188,9 +191,11 @@ fn test_read_keystore() {
     let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().join("sui.keystore");
     let mut ks = Keystore::from(FileBasedKeystore::new(&path).unwrap());
-    let key1 = ks.generate_new_key(SignatureScheme::ED25519, None).unwrap();
+    let key1 = ks
+        .generate_and_add_new_key(SignatureScheme::ED25519, None)
+        .unwrap();
     let key2 = ks
-        .generate_new_key(SignatureScheme::Secp256k1, None)
+        .generate_and_add_new_key(SignatureScheme::Secp256k1, None)
         .unwrap();
 
     let accounts = read_prefunded_account(&path).unwrap();

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -371,6 +371,7 @@ impl TryInto<SuiAddress> for PublicKey {
 pub enum CurveType {
     Secp256k1,
     Edwards25519,
+    Secp256r1,
 }
 
 impl From<CurveType> for SignatureScheme {
@@ -378,6 +379,7 @@ impl From<CurveType> for SignatureScheme {
         match type_ {
             CurveType::Secp256k1 => SignatureScheme::Secp256k1,
             CurveType::Edwards25519 => SignatureScheme::ED25519,
+            CurveType::Secp256r1 => SignatureScheme::Secp256r1,
         }
     }
 }

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -17,7 +17,7 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let (address, phrase, scheme) = keystore
-        .generate_new_key(SignatureScheme::ED25519, None)
+        .generate_and_add_new_key(SignatureScheme::ED25519, None)
         .unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");

--- a/crates/sui-types/src/unit_tests/crypto_tests.rs
+++ b/crates/sui-types/src/unit_tests/crypto_tests.rs
@@ -7,10 +7,10 @@ use proptest::prelude::*;
 
 #[test]
 fn public_key_equality() {
-    let (_, ed_kp1) = random_key_pair_by_type(SignatureScheme::ED25519).unwrap();
-    let (_, ed_kp2) = random_key_pair_by_type(SignatureScheme::ED25519).unwrap();
-    let (_, k1_kp1) = random_key_pair_by_type(SignatureScheme::Secp256k1).unwrap();
-    let (_, k1_kp2) = random_key_pair_by_type(SignatureScheme::Secp256k1).unwrap();
+    let ed_kp1: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair().1);
+    let ed_kp2: SuiKeyPair = SuiKeyPair::Ed25519(get_key_pair().1);
+    let k1_kp1: SuiKeyPair = SuiKeyPair::Secp256k1(get_key_pair().1);
+    let k1_kp2: SuiKeyPair = SuiKeyPair::Secp256k1(get_key_pair().1);
 
     let ed_pk1 = ed_kp1.public();
     let ed_pk2 = ed_kp2.public();

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -276,8 +276,8 @@ pub enum SuiClientCommands {
     #[clap(name = "addresses")]
     Addresses,
 
-    /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1}
-    /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1.
+    /// Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1 | secp256r1}
+    /// with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1.
     #[clap(name = "new-address")]
     NewAddress {
         key_scheme: SignatureScheme,
@@ -696,7 +696,7 @@ impl SuiClientCommands {
                 let (address, phrase, scheme) = context
                     .config
                     .keystore
-                    .generate_new_key(key_scheme, derivation_path)?;
+                    .generate_and_add_new_key(key_scheme, derivation_path)?;
                 SuiClientCommandResult::NewAddress((address, phrase, scheme))
             }
             SuiClientCommands::Gas { address } => {
@@ -1274,7 +1274,6 @@ pub async fn call_move(
             gas_budget,
         )
         .await?;
-
     let signature = context
         .config
         .keystore

--- a/crates/sui/src/genesis_ceremony.rs
+++ b/crates/sui/src/genesis_ceremony.rs
@@ -306,25 +306,16 @@ mod test {
                 write_authority_keypair_to_file(&keypair, &key_file).unwrap();
 
                 let worker_key_file = dir.path().join(format!("{}.key", info.name));
-                write_keypair_to_file(
-                    &SuiKeyPair::Ed25519SuiKeyPair(worker_keypair),
-                    &worker_key_file,
-                )
-                .unwrap();
+                write_keypair_to_file(&SuiKeyPair::Ed25519(worker_keypair), &worker_key_file)
+                    .unwrap();
 
                 let network_key_file = dir.path().join(format!("{}-1.key", info.name));
-                write_keypair_to_file(
-                    &SuiKeyPair::Ed25519SuiKeyPair(network_keypair),
-                    &network_key_file,
-                )
-                .unwrap();
+                write_keypair_to_file(&SuiKeyPair::Ed25519(network_keypair), &network_key_file)
+                    .unwrap();
 
                 let account_key_file = dir.path().join(format!("{}-2.key", info.name));
-                write_keypair_to_file(
-                    &SuiKeyPair::Ed25519SuiKeyPair(account_keypair),
-                    &account_key_file,
-                )
-                .unwrap();
+                write_keypair_to_file(&SuiKeyPair::Ed25519(account_keypair), &account_key_file)
+                    .unwrap();
 
                 (
                     key_file,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -325,7 +325,7 @@ async fn genesis(
 
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     for key in &network_config.account_keys {
-        keystore.add_key(SuiKeyPair::Ed25519SuiKeyPair(key.copy()))?;
+        keystore.add_key(SuiKeyPair::Ed25519(key.copy()))?;
     }
     let active_address = keystore.addresses().pop();
 
@@ -429,12 +429,13 @@ async fn prompt_if_no_config(wallet_conf_path: &Path) -> Result<(), anyhow::Erro
                 .unwrap_or(&sui_config_dir()?)
                 .join(SUI_KEYSTORE_FILENAME);
             let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
-            println!("Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1):");
+            println!("Select key scheme to generate keypair (0 for ed25519, 1 for secp256k1, 2: for secp256r1:");
             let key_scheme = match SignatureScheme::from_flag(read_line()?.trim()) {
                 Ok(s) => s,
                 Err(e) => return Err(anyhow!("{e}")),
             };
-            let (new_address, phrase, scheme) = keystore.generate_new_key(key_scheme, None)?;
+            let (new_address, phrase, scheme) =
+                keystore.generate_and_add_new_key(key_scheme, None)?;
             println!(
                 "Generated new keypair for address with scheme {:?} [{new_address}]",
                 scheme.to_string()

--- a/crates/sui/src/unit_tests/cli_tests.rs
+++ b/crates/sui/src/unit_tests/cli_tests.rs
@@ -112,7 +112,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
         context
             .config
             .keystore
-            .add_key(SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1))?;
+            .add_key(SuiKeyPair::Ed25519(get_key_pair().1))?;
     }
 
     // Print all addresses
@@ -1128,7 +1128,8 @@ async fn test_signature_flag() -> Result<(), anyhow::Error> {
     assert_eq!(res.unwrap().flag(), SignatureScheme::Secp256k1.flag());
 
     let res = SignatureScheme::from_flag("2");
-    assert!(res.is_err());
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap().flag(), SignatureScheme::Secp256r1.flag());
 
     let res = SignatureScheme::from_flag("something");
     assert!(res.is_err());

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -18,6 +18,7 @@ use sui_types::crypto::AuthorityKeyPair;
 use sui_types::crypto::Ed25519SuiSignature;
 use sui_types::crypto::EncodeDecodeBase64;
 use sui_types::crypto::Secp256k1SuiSignature;
+use sui_types::crypto::Secp256r1SuiSignature;
 use sui_types::crypto::Signature;
 use sui_types::crypto::SignatureScheme;
 use sui_types::crypto::SuiKeyPair;
@@ -34,7 +35,7 @@ fn test_addresses_command() -> Result<(), anyhow::Error> {
 
     // Add another 3 Secp256k1 KeyPairs
     for _ in 0..3 {
-        keystore.add_key(SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1))?;
+        keystore.add_key(SuiKeyPair::Secp256k1(get_key_pair().1))?;
     }
 
     // List all addresses with flag
@@ -46,8 +47,8 @@ fn test_addresses_command() -> Result<(), anyhow::Error> {
 fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new(0));
 
-    keystore.add_key(SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1))?;
-    keystore.add_key(SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1))?;
+    keystore.add_key(SuiKeyPair::Secp256k1(get_key_pair().1))?;
+    keystore.add_key(SuiKeyPair::Ed25519(get_key_pair().1))?;
 
     for pk in keystore.keys() {
         let pk1 = pk.clone();
@@ -69,6 +70,13 @@ fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
                 );
                 assert!(pk1.flag() == Secp256k1SuiSignature::SCHEME.flag())
             }
+            Signature::Secp256r1SuiSignature(_) => {
+                assert_eq!(
+                    *sig.as_ref().first().unwrap(),
+                    Secp256r1SuiSignature::SCHEME.flag()
+                );
+                assert!(pk1.flag() == Secp256r1SuiSignature::SCHEME.flag())
+            }
         }
     }
     Ok(())
@@ -79,7 +87,7 @@ fn test_read_write_keystore_with_flag() {
     let dir = tempfile::TempDir::new().unwrap();
 
     // create Secp256k1 keypair
-    let kp_secp = SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1);
+    let kp_secp = SuiKeyPair::Secp256k1(get_key_pair().1);
     let addr_secp: SuiAddress = (&kp_secp.public()).into();
     let fp_secp = dir.path().join(format!("{}.key", addr_secp));
     let fp_secp_2 = fp_secp.clone();
@@ -103,7 +111,7 @@ fn test_read_write_keystore_with_flag() {
     assert!(kp_secp_read.is_err());
 
     // create Ed25519 keypair
-    let kp_ed = SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1);
+    let kp_ed = SuiKeyPair::Ed25519(get_key_pair().1);
     let addr_ed: SuiAddress = (&kp_ed.public()).into();
     let fp_ed = dir.path().join(format!("{}.key", addr_ed));
     let fp_ed_2 = fp_ed.clone();

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -1087,11 +1087,11 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
     context
         .config
         .keystore
-        .add_key(SuiKeyPair::Secp256k1SuiKeyPair(get_key_pair().1))?;
+        .add_key(SuiKeyPair::Secp256k1(get_key_pair().1))?;
     context
         .config
         .keystore
-        .add_key(SuiKeyPair::Ed25519SuiKeyPair(get_key_pair().1))?;
+        .add_key(SuiKeyPair::Ed25519(get_key_pair().1))?;
 
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -20,7 +20,7 @@ use sui_sdk::SuiClient;
 use sui_swarm::memory::{Swarm, SwarmBuilder};
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::KeypairTraits;
-use sui_types::crypto::SuiKeyPair::Ed25519SuiKeyPair;
+use sui_types::crypto::SuiKeyPair;
 
 const NUM_VALIDAOTR: usize = 4;
 
@@ -209,7 +209,7 @@ impl TestClusterBuilder {
         swarm.config().save(&network_path)?;
         let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
         for key in &swarm.config().account_keys {
-            keystore.add_key(Ed25519SuiKeyPair(key.copy()))?;
+            keystore.add_key(SuiKeyPair::Ed25519(key.copy()))?;
         }
 
         let active_address = keystore.addresses().first().cloned();


### PR DESCRIPTION
closes https://github.com/MystenLabs/sui/issues/6536

tested e2e: 

```
target/debug/sui keytool list 
                Sui Address                 |              Public Key (Base64)              | Scheme
----------------------------------------------------------------------------------------------------
 0xf2153e8ca4954d98d59d15b3e1828f170119fc4b | A8hM5NjMr1fEKzdkTdn8pIlEEHR3Hl+npqoxvr9jlHek  | secp256r1

target/debug/sui client active-address  
0xf2153e8ca4954d98d59d15b3e1828f170119fc4b

Successfully created an ExampleNFT:

----- Move Object (0x959710f2cbd38966a7baa0359b2223478a0e45aa[3]) -----
Owner: Account Address ( 0xf2153e8ca4954d98d59d15b3e1828f170119fc4b )
Version: 3
Storage Rebate: 25
Previous Transaction: 8G56qwt4j1WZjDAbyha48XhoWBwbaqqnkX1gFQUg7Qeo
----- Data -----
type: 0x2::devnet_nft::DevNetNFT
description: An NFT created by the Sui Command Line Tool
id: 0x959710f2cbd38966a7baa0359b2223478a0e45aa
name: Example NFT
url: ipfs://bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty
```

will follow up a PR on supporting this in Typescript. 