### PR TITLE
[narwhal] shutdown network when reconfigure

### DIFF
--- a/narwhal/network/src/admin.rs
+++ b/narwhal/network/src/admin.rs
@@ -47,6 +47,7 @@ pub fn start_admin_server(
             let message = rx_reconfigure.borrow().clone();
             if let ReconfigureNotification::Shutdown = message {
                 handle.clone().shutdown();
+
                 return;
             }
         }
@@ -58,6 +59,8 @@ pub fn start_admin_server(
             .serve(router.into_make_service())
             .await
             .unwrap();
+
+        info!("Shutting down admin server");
     }));
 
     handles

--- a/narwhal/node/src/restarter.rs
+++ b/narwhal/node/src/restarter.rs
@@ -35,7 +35,7 @@ impl NodeRestarter {
             Vec<(WorkerId, NetworkKeyPair)>,
             WorkerCache,
         )>,
-        _registry: &Registry,
+        registry: &Registry,
     ) where
         State: ExecutionState + Send + Sync + 'static,
     {
@@ -49,8 +49,6 @@ impl NodeRestarter {
 
         // Listen for new committees.
         loop {
-            let registry = Registry::new();
-
             tracing::info!("Starting epoch E{}", committee.epoch());
 
             // Get a fresh store for the new epoch.
@@ -68,7 +66,7 @@ impl NodeRestarter {
                 parameters.clone(),
                 /* consensus */ true,
                 execution_state.clone(),
-                &registry,
+                registry,
             )
             .await
             .unwrap();
@@ -81,7 +79,7 @@ impl NodeRestarter {
                 &store,
                 parameters.clone(),
                 tx_validator.clone(),
-                &registry,
+                registry,
             );
 
             handles.extend(primary_handles);

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -5,7 +5,7 @@
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use config::{Committee, Parameters, SharedWorkerCache, WorkerCache, WorkerId};
+use config::{Committee, Epoch, Parameters, SharedWorkerCache, WorkerCache, WorkerId};
 use crypto::{KeyPair, NetworkKeyPair, PublicKey};
 use executor::ExecutionState;
 use fastcrypto::traits::KeyPair as _;
@@ -13,6 +13,8 @@ use futures::future::{join_all, try_join_all};
 use narwhal_node as node;
 use node::{restarter::NodeRestarter, Node};
 use prometheus::Registry;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
@@ -23,6 +25,7 @@ use tokio::{
     sync::mpsc::{channel, Receiver, Sender},
     time::{interval, sleep, Duration, MissedTickBehavior},
 };
+use tracing::info;
 use types::{ConsensusOutput, Transaction};
 use types::{ReconfigureNotification, TransactionProto, TransactionsClient};
 use worker::TrivialTransactionValidator;
@@ -75,16 +78,12 @@ impl SimpleExecutionState {
 #[async_trait::async_trait]
 impl ExecutionState for SimpleExecutionState {
     async fn handle_consensus_output(&self, consensus_output: ConsensusOutput) {
-        let mut i = 0;
-        for (_, batches) in consensus_output.batches {
-            for batch in batches {
-                for transaction in batch.transactions.into_iter() {
-                    i += 1;
-                    let mut change_epoch = false;
-                    if i % 3 == 0 {
-                        change_epoch = true
+        if consensus_output.sub_dag.sub_dag_index % 3 == 0 {
+            for (_, batches) in consensus_output.batches {
+                for batch in batches {
+                    for transaction in batch.transactions.into_iter() {
+                        self.process_transaction(transaction, true).await;
                     }
-                    self.process_transaction(transaction, change_epoch).await;
                 }
             }
         }
@@ -97,36 +96,41 @@ impl ExecutionState for SimpleExecutionState {
 
 impl SimpleExecutionState {
     async fn process_transaction(&self, transaction: Transaction, change_epoch: bool) {
-        let _transaction: u64 = bincode::deserialize(&transaction).unwrap();
+        let transaction: u64 = bincode::deserialize(&transaction).unwrap();
         // Change epoch every few certificates. Note that empty certificates are not provided to
         // this function (they are immediately skipped).
         let mut epoch = self.committee.lock().unwrap().epoch();
-        if change_epoch {
+        if transaction >= epoch && change_epoch {
             epoch += 1;
-            {
-                let mut guard = self.committee.lock().unwrap();
-                guard.epoch = epoch;
-            };
 
-            let worker_keypairs = self.worker_keypairs.iter().map(|kp| kp.copy());
-            let worker_ids = 0..self.worker_keypairs.len() as u32;
-            let worker_ids_and_keypairs = worker_ids.zip(worker_keypairs).collect();
-
-            let new_committee = self.committee.lock().unwrap().clone();
-
-            self.tx_reconfigure
-                .send((
-                    self.keypair.copy(),
-                    self.network_keypair.copy(),
-                    new_committee,
-                    worker_ids_and_keypairs,
-                    self.worker_cache.clone(),
-                ))
-                .await
-                .unwrap();
+            self.send_new_epoch_reconfigure(epoch).await;
         }
 
         let _ = self.tx_output.send(epoch).await;
+    }
+
+    async fn send_new_epoch_reconfigure(&self, epoch: Epoch) {
+        {
+            let mut guard = self.committee.lock().unwrap();
+            guard.epoch = epoch;
+        }
+
+        let worker_keypairs = self.worker_keypairs.iter().map(|kp| kp.copy());
+        let worker_ids = 0..self.worker_keypairs.len() as u32;
+        let worker_ids_and_keypairs = worker_ids.zip(worker_keypairs).collect();
+
+        let new_committee = self.committee.lock().unwrap().clone();
+
+        self.tx_reconfigure
+            .send((
+                self.keypair.copy(),
+                self.network_keypair.copy(),
+                new_committee,
+                worker_ids_and_keypairs,
+                self.worker_cache.clone(),
+            ))
+            .await
+            .unwrap();
     }
 }
 
@@ -150,7 +154,7 @@ async fn run_client(
     };
 
     // Repeatedly send transactions.
-    let mut interval = interval(Duration::from_millis(50));
+    let mut interval = interval(Duration::from_millis(100));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     tokio::pin!(interval);
 
@@ -175,16 +179,23 @@ async fn run_client(
     }
 }
 
-#[ignore]
 #[tokio::test]
 async fn restart() {
     telemetry_subscribers::init_for_testing();
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+
+    let fixture = CommitteeFixture::builder()
+        .number_of_workers(NonZeroUsize::new(1).unwrap())
+        .randomize_ports(true)
+        .build();
     let committee = fixture.committee();
     let worker_cache = fixture.shared_worker_cache();
 
     // Spawn the nodes.
     let mut rx_nodes = Vec::new();
+    let latest_observed_epoch = Arc::new(AtomicU64::new(0));
+
+    let mut validators_execution_states = Vec::new();
+
     for a in fixture.authorities() {
         let (tx_output, rx_output) = channel(10);
         let (tx_node_reconfigure, rx_node_reconfigure) = channel(10);
@@ -199,6 +210,8 @@ async fn restart() {
             tx_node_reconfigure,
         ));
 
+        validators_execution_states.push(execution_state.clone());
+
         let worker_keypairs = a.worker_keypairs();
         let worker_ids = 0..worker_keypairs.len() as u32;
         let worker_ids_and_keypairs = worker_ids.zip(worker_keypairs.into_iter()).collect();
@@ -208,6 +221,7 @@ async fn restart() {
 
         let parameters = Parameters {
             batch_size: 200,
+            max_header_delay: Duration::from_secs(1),
             max_header_num_of_batches: 1,
             ..Parameters::default()
         };
@@ -253,22 +267,62 @@ async fn restart() {
     // Listen to the outputs.
     let mut handles = Vec::new();
     for (tx, mut rx) in tx_clients.into_iter().zip(rx_nodes.into_iter()) {
+        let global_epoch = latest_observed_epoch.clone();
+        let execution_state = validators_execution_states.remove(0);
+
         handles.push(tokio::spawn(async move {
             let mut current_epoch = 0u64;
+            static MAX_EPOCH: u64 = 10;
 
-            while let Some(epoch) = rx.recv().await {
-                println!("Received epoch {}", epoch);
-                if epoch == 5 {
-                    return;
-                }
-                if epoch > current_epoch {
-                    current_epoch = epoch;
-                    tx.send(current_epoch).await.unwrap();
+            // Repeatedly send transactions.
+            let mut interval = interval(Duration::from_secs(3));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            tokio::pin!(interval);
+
+            loop {
+                tokio::select! {
+                    result = rx.recv() => {
+                        // channel broke - we need to exit the loop
+                        if result.is_none() {
+                            break;
+                        }
+
+                        let epoch = result.unwrap();
+
+                        info!("Received epoch {}", epoch);
+
+                        // update the latest observed global epoch - but only swap
+                        // if it's greater than the previous value
+                        let _ = global_epoch.compare_exchange(epoch-1, epoch, Ordering::SeqCst, Ordering::SeqCst);
+
+                        if epoch == MAX_EPOCH {
+                            return;
+                        }
+                        if epoch > current_epoch {
+                            current_epoch = epoch;
+                            tx.send(current_epoch).await.unwrap();
+                        }
+                    },
+                    _ = interval.tick() => {
+                        // detect whether all the other nodes managed to advance in epochs
+                        // and our node did fall behind - in this case we want to advance
+                        // our node
+                        let global_epoch = global_epoch.load(Ordering::SeqCst);
+
+                        if global_epoch > current_epoch {
+                            info!("Detected greater epoch compared to our current {global_epoch} > {current_epoch} : will update epoch");
+
+                            current_epoch = global_epoch;
+
+                            // reconfigure - send details
+                            execution_state.send_new_epoch_reconfigure(current_epoch).await;
+                        }
+                    }
                 }
             }
 
-            if current_epoch < 5 {
-                panic!("Node never reached epoch 5, something broke our connection");
+            if current_epoch < MAX_EPOCH {
+                panic!("Node never reached epoch {MAX_EPOCH}, something broke our connection");
             }
         }));
     }
@@ -300,6 +354,7 @@ async fn epoch_change() {
 
     // Spawn the nodes.
     let mut rx_nodes = Vec::new();
+
     for a in fixture.authorities() {
         let (tx_output, rx_output) = channel(10);
         let (tx_node_reconfigure, mut rx_node_reconfigure) = channel(10);

--- a/narwhal/node/tests/reconfigure.rs
+++ b/narwhal/node/tests/reconfigure.rs
@@ -179,6 +179,7 @@ async fn run_client(
     }
 }
 
+#[ignore]
 #[tokio::test]
 async fn restart() {
     telemetry_subscribers::init_for_testing();

--- a/narwhal/primary/src/primary.rs
+++ b/narwhal/primary/src/primary.rs
@@ -673,7 +673,9 @@ impl PrimaryReceiverHandler {
                     break
                 },
                 result = rx_narwhal_round_updates.changed() => {
-                    result.unwrap();
+                    if result.is_err() {
+                        return Err(DagError::NetworkError("Node shutting down".to_owned()));
+                    }
                     let narwhal_round = *rx_narwhal_round_updates.borrow();
                     ensure!(
                         narwhal_round.saturating_sub(HEADER_AGE_LIMIT) <= header.round,

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -4,10 +4,9 @@
 use config::{Committee, SharedCommittee, SharedWorkerCache, WorkerCache, WorkerIndex};
 use crypto::PublicKey;
 use mysten_metrics::spawn_monitored_task;
-use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
+use network::{CancelOnDropHandler, ReliableNetwork};
 use std::{collections::BTreeMap, sync::Arc};
-use tap::TapFallible;
-use tap::TapOptional;
+use tap::{TapFallible, TapOptional};
 use tokio::{sync::watch, task::JoinHandle};
 use tracing::{debug, error, info, warn};
 use types::{
@@ -183,7 +182,7 @@ impl StateHandler {
                     // the shutdown message.
                     if shutdown {
                         // shutdown network as well
-                        let _ = self.network.network().shutdown().await.tap_err(|err|{
+                        let _ = self.network.shutdown().await.tap_err(|err|{
                             error!("Error while shutting down network: {err}")
                         });
 

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -4,11 +4,12 @@
 use config::{Committee, SharedCommittee, SharedWorkerCache, WorkerCache, WorkerIndex};
 use crypto::PublicKey;
 use mysten_metrics::spawn_monitored_task;
-use network::UnreliableNetwork;
+use network::{CancelOnDropHandler, P2pNetwork, ReliableNetwork};
 use std::{collections::BTreeMap, sync::Arc};
+use tap::TapFallible;
 use tap::TapOptional;
 use tokio::{sync::watch, task::JoinHandle};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use types::{
     metered_channel::{Receiver, Sender},
     Certificate, ReconfigureNotification, Round, WorkerReconfigureMessage,
@@ -118,7 +119,10 @@ impl StateHandler {
         tracing::debug!("Committee updated to {}", self.committee);
     }
 
-    fn notify_our_workers(&mut self, message: ReconfigureNotification) {
+    fn notify_our_workers(
+        &mut self,
+        message: ReconfigureNotification,
+    ) -> Vec<CancelOnDropHandler<anyhow::Result<anemo::Response<()>>>> {
         let message = WorkerReconfigureMessage { message };
         let our_workers = self
             .worker_cache
@@ -129,7 +133,7 @@ impl StateHandler {
             .map(|info| info.name)
             .collect();
 
-        self.network.unreliable_broadcast(our_workers, &message);
+        self.network.broadcast(our_workers, &message)
     }
 
     async fn run(mut self) {
@@ -145,7 +149,7 @@ impl StateHandler {
 
                 Some(message) = self.rx_state_handler.recv() => {
                     // Notify our workers
-                    self.notify_our_workers(message.to_owned());
+                    let notify_handlers = self.notify_our_workers(message.to_owned());
 
                     let shutdown = match &message {
                         ReconfigureNotification::NewEpoch(committee) => {
@@ -166,10 +170,25 @@ impl StateHandler {
                         .send(message)
                         .expect("Reconfigure channel dropped");
 
+                    // wait for all the workers to eventually receive the message
+                    // TODO: this request will be removed https://mysten.atlassian.net/browse/SUI-984
+                    let join_all = futures::future::try_join_all(notify_handlers);
+                    join_all.await.expect("Error while sending reconfiguration message to the workers");
+
                     // Exit only when we are sure that all the other tasks received
                     // the shutdown message.
                     if shutdown {
+                        // shutdown network as well
+                        let _ = self.network.network().shutdown().await.tap_err(|err|{
+                            error!("Error while shutting down network: {err}")
+                        });
+
+                        warn!("Network has shutdown");
+
                         self.tx_reconfigure.closed().await;
+
+                        warn!("All reconfiguration receivers dropped");
+
                         return;
                     }
                 }

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -170,10 +170,14 @@ impl StateHandler {
                         .send(message)
                         .expect("Reconfigure channel dropped");
 
+                    warn!("Waiting to broadcast reconfigure message to workers");
+
                     // wait for all the workers to eventually receive the message
                     // TODO: this request will be removed https://mysten.atlassian.net/browse/SUI-984
                     let join_all = futures::future::try_join_all(notify_handlers);
                     join_all.await.expect("Error while sending reconfiguration message to the workers");
+
+                    warn!("Successfully broadcasted reconfigure message to workers");
 
                     // Exit only when we are sure that all the other tasks received
                     // the shutdown message.

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -148,7 +148,7 @@ async fn test_simple_epoch_change() {
             futs.push(fut);
         }
 
-        info!("Sent to all the reconfigure message {:?}", message);
+        info!("Sent to all the reconfigure message {message:?}");
 
         try_join_all(futs).await.unwrap();
 

--- a/narwhal/primary/tests/epoch_change.rs
+++ b/narwhal/primary/tests/epoch_change.rs
@@ -8,21 +8,29 @@ use config::{Committee, Parameters};
 use fastcrypto::traits::KeyPair;
 use futures::future::{join_all, try_join_all};
 use narwhal_primary as primary;
+use node::Node;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
+use std::num::NonZeroUsize;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use storage::NodeStorage;
 use test_utils::{ensure_test_environment, temp_dir, CommitteeFixture};
 use tokio::sync::watch;
+use tracing::info;
 use types::ReconfigureNotification;
+use worker::TrivialTransactionValidator;
 
 /// The epoch changes but the stake distribution and network addresses stay the same.
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_simple_epoch_change() {
     ensure_test_environment();
+    telemetry_subscribers::init_for_testing();
 
     // The configuration of epoch 0.
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let fixture = CommitteeFixture::builder()
+        .number_of_workers(NonZeroUsize::new(1).unwrap())
+        .randomize_ports(true)
+        .build();
     let committee_0 = fixture.committee();
     let worker_cache_0 = fixture.shared_worker_cache();
     let parameters = fixture
@@ -57,15 +65,16 @@ async fn test_simple_epoch_change() {
         let (tx_reconfigure, _rx_reconfigure) = watch::channel(initial_committee);
 
         let store = NodeStorage::reopen(temp_dir());
+        let registry = Registry::new();
 
         let p = parameters.get(&name).unwrap().clone();
         Primary::spawn(
-            name,
+            name.clone(),
             signer.copy(),
             authority.network_keypair().copy(),
             Arc::new(ArcSwap::from_pointee(committee_0.clone())),
             worker_cache_0.clone(),
-            p,
+            p.clone(),
             store.header_store.clone(),
             store.certificate_store.clone(),
             store.proposer_store.clone(),
@@ -78,8 +87,23 @@ async fn test_simple_epoch_change() {
             NetworkModel::Asynchronous,
             tx_reconfigure,
             /* tx_committed_certificates */ tx_feedback,
-            &Registry::new(),
+            &registry,
             None,
+        );
+
+        let worker_keypairs = authority.worker_keypairs();
+        let worker_ids = 0..worker_keypairs.len() as u32;
+        let worker_ids_and_keypairs = worker_ids.zip(worker_keypairs.into_iter()).collect();
+
+        Node::spawn_workers(
+            name,
+            worker_ids_and_keypairs,
+            Arc::new(ArcSwap::from_pointee(committee_0.clone())),
+            worker_cache_0.clone(),
+            &store,
+            p.clone(),
+            TrivialTransactionValidator::default(),
+            &registry,
         );
     }
 
@@ -87,6 +111,7 @@ async fn test_simple_epoch_change() {
     for rx in rx_channels.iter_mut() {
         loop {
             let certificate = rx.recv().await.unwrap();
+
             assert_eq!(certificate.epoch(), 0);
             if certificate.round() == 10 {
                 break;
@@ -122,6 +147,9 @@ async fn test_simple_epoch_change() {
                 .send();
             futs.push(fut);
         }
+
+        info!("Sent to all the reconfigure message {:?}", message);
+
         try_join_all(futs).await.unwrap();
 
         // Run for a while.
@@ -129,6 +157,7 @@ async fn test_simple_epoch_change() {
             loop {
                 let certificate = rx.recv().await.unwrap();
                 if certificate.epoch() == epoch && certificate.round() == 10 {
+                    info!("Received certificate of epoch {}", certificate.epoch());
                     break;
                 }
             }

--- a/narwhal/worker/src/worker.rs
+++ b/narwhal/worker/src/worker.rs
@@ -27,10 +27,12 @@ use network::metrics::MetricsMakeCallbackHandler;
 use std::collections::HashMap;
 use std::{net::Ipv4Addr, sync::Arc};
 use store::Store;
+use tap::TapFallible;
+use tokio::sync::watch::Receiver;
 use tokio::{sync::watch, task::JoinHandle};
 use tonic::{Request, Response, Status};
 use tower::ServiceBuilder;
-use tracing::info;
+use tracing::{error, info};
 use types::{
     error::DagError,
     metered_channel::{channel_with_total, Sender},
@@ -289,14 +291,16 @@ impl Worker {
             network.clone(),
         );
         let client_flow_handles = worker.handle_clients_transactions(
-            rx_reconfigure,
+            rx_reconfigure.clone(),
             tx_our_batch,
             node_metrics,
             channel_metrics,
             endpoint_metrics,
             validator,
-            network,
+            network.clone(),
         );
+
+        let network_shutdown_handle = Self::shutdown_network_listener(rx_reconfigure, network);
 
         // NOTE: This log entry is used to compute performance.
         info!(
@@ -310,10 +314,35 @@ impl Worker {
                 .transactions
         );
 
-        let mut handles = vec![primary_connector_handle, connection_monitor_handle];
+        let mut handles = vec![
+            primary_connector_handle,
+            connection_monitor_handle,
+            network_shutdown_handle,
+        ];
         handles.extend(admin_handles);
         handles.extend(client_flow_handles);
         handles
+    }
+
+    // Spawns a task responsible for explicitly shutting down the network
+    // when a shutdown signal has been sent to the node.
+    fn shutdown_network_listener(
+        mut rx_reconfigure: Receiver<ReconfigureNotification>,
+        network: Network,
+    ) -> JoinHandle<()> {
+        spawn_monitored_task!(async move {
+            while let Ok(_result) = rx_reconfigure.changed().await {
+                let message = rx_reconfigure.borrow().clone();
+                if let ReconfigureNotification::Shutdown = message {
+                    let _ = network
+                        .shutdown()
+                        .await
+                        .tap_err(|err| error!("Error while shutting down network: {err}"));
+                    info!("Worker network server shutdown");
+                    return;
+                }
+            }
+        })
     }
 
     fn add_peer_in_network(


### PR DESCRIPTION
This PR is taking care of a few things:

* explicitly shutting down primary/worker's network when reconfiguration (Shutdown) happens
* convert the signal propagation from primary -> worker to a reliable broadcast (although that part will effectively be removed in later iterations)
* refactor the `restart` test in order to ensure that a node left behind in epoch changes can catch up with others and can be reconfigured to the latest epoch that other nodes did.

The `restart` test as is won't work correctly , as the `restarter` handler will need to be refactor to allow us pass a new `registry` every time we reconfigure. Once this work is done https://mysten.atlassian.net/browse/SUI-1028 then the `restarter` can be refactored to make it work