### PR TITLE
[TxManager] hold lock while checking for missing input objects

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -671,7 +671,7 @@ impl AuthorityState {
     ) -> SuiResult {
         let _metrics_guard = start_timer(self.metrics.handle_node_sync_certificate_latency.clone());
         let digest = *certificate.digest();
-        debug!(?digest, "handle_certificate_with_effects");
+        debug!(tx_digest = ?digest, "handle_certificate_with_effects");
         fp_ensure!(
             effects.data().transaction_digest == digest,
             SuiError::ErrorWhileProcessingCertificate {
@@ -976,7 +976,9 @@ impl AuthorityState {
         //
         // REQUIRED: this must be called before tx_guard.commit_tx() (below), to ensure
         // TransactionManager can get the notifications after the node crashes and restarts.
-        self.transaction_manager.objects_committed(output_keys);
+        self.transaction_manager
+            .objects_committed(output_keys)
+            .await;
 
         // commit_certificate finished, the tx is fully committed to the store.
         tx_guard.commit_tx();

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1076,6 +1076,11 @@ impl AuthorityState {
         Ok((inner_temp_store, signed_effects))
     }
 
+    /// Notifies TransactionManager about an executed certificate.
+    pub async fn certificate_executed(&self, digest: &TransactionDigest) {
+        self.transaction_manager.certificate_executed(digest).await
+    }
+
     pub async fn dry_exec_transaction(
         &self,
         transaction: TransactionData,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -304,11 +304,6 @@ where
             .collect())
     }
 
-    /// Checks if a certificate is in the pending queue.
-    pub fn pending_certificate_exists(&self, tx: &TransactionDigest) -> Result<bool, SuiError> {
-        Ok(self.tables.pending_certificates.contains_key(tx)?)
-    }
-
     /// Deletes one pending certificate.
     pub fn remove_pending_certificate(&self, digest: &TransactionDigest) -> SuiResult<()> {
         self.tables.pending_certificates.remove(digest)?;

--- a/crates/sui-core/src/authority_active/execution_driver/mod.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/mod.rs
@@ -131,12 +131,8 @@ where
                 }
             }
 
-            // Remove the certificate that finished execution.
-            let _ = authority
-                .state
-                .database
-                .epoch_store()
-                .remove_pending_certificate(&digest);
+            // Remove the certificate that finished execution from the pending_certificates table.
+            authority.state.certificate_executed(&digest).await;
 
             authority
                 .execution_driver_metrics


### PR DESCRIPTION
Background at https://github.com/MystenLabs/sui/pull/6504#issuecomment-1338139608. An alternative is to first add all input objects to the missing_input map with write lock, get available input objects without lock, then remove available input objects from the missing_input map with write lock. But we don't need to complexity yet.

Also, keep track of executing transaction digests in TransactionManager, to avoid duplicated executions.