### PR TITLE
typescript sdk: CommonJS to module

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -15,6 +15,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
Fixed bug when frontend used `@mysten/sui.js`
Error causing the application to crash
`Named export 'sha3_256' not found. The requested module 'js-sha3' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using`