### PR TITLE
[2/x][dev-inspect] Add authority end-point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8420,6 +8420,7 @@ dependencies = [
  "move-core-types",
  "move-package",
  "move-vm-runtime",
+ "move-vm-types",
  "once_cell",
  "sui-cost-tables",
  "sui-framework",

--- a/crates/sui-adapter/Cargo.toml
+++ b/crates/sui-adapter/Cargo.toml
@@ -19,6 +19,7 @@ move-binary-format.workspace = true
 move-bytecode-verifier.workspace = true
 move-core-types.workspace = true
 move-vm-runtime.workspace = true
+move-vm-types.workspace = true
 
 sui-framework = { path = "../sui-framework" }
 sui-json = { path = "../sui-json" }

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -232,16 +232,6 @@ fn execute_internal<
     assert_invariant!(change_set.accounts().is_empty(), "Change set must be empty");
     // Sui Move no longer uses Move's internal event system
     assert_invariant!(events.is_empty(), "Events must be empty");
-    // Input ref parameters we put in should be the same number we get out, plus one for the &mut TxContext
-    let num_mut_objects = if has_ctx_arg {
-        mutable_ref_objects.len() + 1
-    } else {
-        mutable_ref_objects.len()
-    };
-    assert_invariant!(
-        num_mut_objects == mutable_reference_outputs.len(),
-        "Number of mutable references returned does not match input"
-    );
 
     // When this function is used during publishing, it
     // may be executed several times, with objects being
@@ -256,14 +246,24 @@ fn execute_internal<
         ctx.update_state(updated_ctx)?;
     }
 
-    let mutable_refs = mutable_reference_outputs
-        .into_iter()
-        .map(|(local_idx, bytes, _layout)| {
-            let object_id = mutable_ref_objects.remove(&local_idx).unwrap();
-            debug_assert!(!by_value_objects.contains(&object_id));
-            (object_id, bytes)
-        })
-        .collect();
+    let mut mutable_refs = vec![];
+    for (local_idx, bytes, _layout) in mutable_reference_outputs {
+        let object_id = match mutable_ref_objects.remove(&local_idx) {
+            Some(id) => id,
+            None => {
+                assert_invariant!(
+                    Mode::allow_arbitrary_function_calls(),
+                    "Mutable references should be populated only by objects in normal execution"
+                );
+                continue;
+            }
+        };
+        assert_invariant!(
+            !by_value_objects.contains(&object_id),
+            "object used by-ref and by-value"
+        );
+        mutable_refs.push((object_id, bytes));
+    }
     assert_invariant!(
         mutable_ref_objects.is_empty(),
         "All mutable references should have been marked as updated"

--- a/crates/sui-adapter/src/adapter.rs
+++ b/crates/sui-adapter/src/adapter.rs
@@ -211,10 +211,16 @@ fn execute_internal<
             .map_err(|e| convert_type_argument_error(idx, e))?;
     }
     // script visibility checked manually for entry points
-    let (result, (change_set, events, mut native_context_extensions)) = session
-        .execute_function_bypass_visibility(module_id, function, type_args, args, gas_status)
-        .and_then(|ret| Ok((ret, session.finish_with_extensions()?)))?;
-    let mode_result = Mode::make_result(&result)?;
+    let result = session.execute_function_bypass_visibility(
+        module_id,
+        function,
+        type_args.clone(),
+        args,
+        gas_status,
+    )?;
+    let mode_result = Mode::make_result(&session, module_id, function, &type_args, &result)?;
+
+    let (change_set, events, mut native_context_extensions) = session.finish_with_extensions()?;
     let SerializedReturnValues {
         mut mutable_reference_outputs,
         ..

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -135,7 +135,7 @@ impl ExecutionMode for DevInspect {
             .iter()
             .enumerate()
             .map(|(i, (bytes, _))| {
-                let ty = remove_ref_and_subst_ty(&loaded_function.parameters[i], ty_args)?;
+                let ty = remove_ref_and_subst_ty(&loaded_function.return_[i], ty_args)?;
                 let tag = type_to_type_tag(session, &ty)?;
                 Ok((bytes.clone(), tag))
             })

--- a/crates/sui-adapter/src/execution_mode.rs
+++ b/crates/sui-adapter/src/execution_mode.rs
@@ -1,7 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_vm_runtime::session::SerializedReturnValues;
+use move_binary_format::file_format::LocalIndex;
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+    resolver::MoveResolver,
+};
+use move_vm_runtime::session::{SerializedReturnValues, Session};
+use move_vm_types::loaded_data::runtime_types::Type;
 use sui_types::error::ExecutionError;
 
 pub type TransactionIndex = usize;
@@ -19,7 +26,11 @@ pub trait ExecutionMode {
     ///   In other words, you can instantiate any struct or object or other value with its BCS bytes.
     fn allow_arbitrary_function_calls() -> bool;
 
-    fn make_result(
+    fn make_result<S: MoveResolver>(
+        session: &Session<S>,
+        module_id: &ModuleId,
+        function: &Identifier,
+        type_arguments: &[TypeTag],
         return_values: &SerializedReturnValues,
     ) -> Result<Self::ExecutionResult, ExecutionError>;
 
@@ -42,7 +53,13 @@ impl ExecutionMode for Normal {
         false
     }
 
-    fn make_result(srv: &SerializedReturnValues) -> Result<Self::ExecutionResult, ExecutionError> {
+    fn make_result<S: MoveResolver>(
+        _session: &Session<S>,
+        _module_id: &ModuleId,
+        _function: &Identifier,
+        _type_arguments: &[TypeTag],
+        srv: &SerializedReturnValues,
+    ) -> Result<Self::ExecutionResult, ExecutionError> {
         assert_invariant!(srv.return_values.is_empty(), "Return values must be empty");
         Ok(())
     }
@@ -57,23 +74,57 @@ impl ExecutionMode for Normal {
 /// BCS bytes!
 pub struct DevInspect;
 
+pub type ExecutionResult = (
+    /*  mutable_reference_outputs */ Vec<(LocalIndex, Vec<u8>, TypeTag)>,
+    /*  return_values */ Vec<(Vec<u8>, TypeTag)>,
+);
+
 impl ExecutionMode for DevInspect {
-    type ExecutionResult = SerializedReturnValues;
-    type ExecutionResults = Vec<(TransactionIndex, SerializedReturnValues)>;
+    type ExecutionResult = ExecutionResult;
+    type ExecutionResults = Vec<(TransactionIndex, ExecutionResult)>;
 
     fn allow_arbitrary_function_calls() -> bool {
         true
     }
 
-    fn make_result(srv: &SerializedReturnValues) -> Result<Self::ExecutionResult, ExecutionError> {
+    fn make_result<S: MoveResolver>(
+        session: &Session<S>,
+        module_id: &ModuleId,
+        function: &Identifier,
+        type_arguments: &[TypeTag],
+        srv: &SerializedReturnValues,
+    ) -> Result<Self::ExecutionResult, ExecutionError> {
         let SerializedReturnValues {
             mutable_reference_outputs,
             return_values,
         } = srv;
-        Ok(SerializedReturnValues {
-            mutable_reference_outputs: mutable_reference_outputs.clone(),
-            return_values: return_values.clone(),
-        })
+        let loaded_function = match session.load_function(module_id, function, type_arguments) {
+            Ok(loaded) => loaded,
+            Err(_) => {
+                return Err(ExecutionError::new_with_source(
+                    sui_types::error::ExecutionErrorKind::InvariantViolation,
+                    "The function should have been able to load, as it was already executed",
+                ));
+            }
+        };
+        let ty_args = &loaded_function.type_arguments;
+        let mutable_reference_outputs = mutable_reference_outputs
+            .iter()
+            .map(|(i, bytes, _)| {
+                let ty = subst_ty(&loaded_function.parameters[(*i as usize)], ty_args)?;
+                let tag = type_to_type_tag(&ty);
+                Ok((*i, bytes.clone(), tag))
+            })
+            .collect::<Result<Vec<_>, ExecutionError>>()?;
+        let return_values = return_values
+            .iter()
+            .enumerate()
+            .map(|(i, (bytes, _))| {
+                let ty = subst_ty(&loaded_function.parameters[i], ty_args)?;
+                Ok((bytes.clone(), type_to_type_tag(&ty)))
+            })
+            .collect::<Result<Vec<_>, ExecutionError>>()?;
+        Ok((mutable_reference_outputs, return_values))
     }
 
     fn empty_results() -> Self::ExecutionResults {
@@ -87,4 +138,17 @@ impl ExecutionMode for DevInspect {
     ) {
         results.push((idx, result))
     }
+}
+
+fn subst_ty(ty: &Type, ty_args: &[Type]) -> Result<Type, ExecutionError> {
+    ty.subst(ty_args).map_err(|_| {
+        ExecutionError::new_with_source(
+            sui_types::error::ExecutionErrorKind::InvariantViolation,
+            "The type should subst, as the function was already executed",
+        )
+    })
+}
+
+fn type_to_type_tag(_ty: &Type) -> TypeTag {
+    todo!()
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1195,7 +1195,7 @@ impl AuthorityState {
         transaction_digest: TransactionDigest,
     ) -> Result<DevInspectResults, anyhow::Error> {
         let (gas_status, input_objects) =
-            transaction_input_checker::check_transaction_input(&self.database, &transaction)
+            transaction_input_checker::check_dev_inspect_input(&self.database, &transaction)
                 .await?;
         let shared_object_refs = input_objects.filter_shared_objects();
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -43,7 +43,8 @@ use narwhal_types::CommittedSubDag;
 use sui_adapter::{adapter, execution_mode};
 use sui_config::genesis::Genesis;
 use sui_json_rpc_types::{
-    type_and_fields_from_move_struct, SuiEvent, SuiEventEnvelope, SuiTransactionEffects,
+    type_and_fields_from_move_struct, DevInspectResults, SuiEvent, SuiEventEnvelope,
+    SuiTransactionEffects,
 };
 use sui_simulator::nondeterministic;
 use sui_storage::write_ahead_log::WriteAheadLog;
@@ -1186,6 +1187,34 @@ impl AuthorityState {
                 self.epoch(),
             );
         SuiTransactionEffects::try_from(effects, self.module_cache.as_ref())
+    }
+
+    pub async fn dev_inspect_transaction(
+        &self,
+        transaction: TransactionData,
+        transaction_digest: TransactionDigest,
+    ) -> Result<DevInspectResults, anyhow::Error> {
+        let (gas_status, input_objects) =
+            transaction_input_checker::check_transaction_input(&self.database, &transaction)
+                .await?;
+        let shared_object_refs = input_objects.filter_shared_objects();
+
+        let transaction_dependencies = input_objects.transaction_dependencies();
+        let temporary_store =
+            TemporaryStore::new(self.database.clone(), input_objects, transaction_digest);
+        let (_inner_temp_store, effects, execution_result) =
+            execution_engine::execute_transaction_to_effects::<execution_mode::DevInspect, _>(
+                shared_object_refs,
+                temporary_store,
+                transaction,
+                transaction_digest,
+                transaction_dependencies,
+                &self.move_vm,
+                &self._native_functions,
+                gas_status,
+                self.epoch(),
+            );
+        DevInspectResults::new(effects, execution_result, self.module_cache.as_ref())
     }
 
     pub fn is_tx_already_executed(&self, digest: &TransactionDigest) -> SuiResult<bool> {

--- a/crates/sui-core/src/transaction_input_checker.rs
+++ b/crates/sui-core/src/transaction_input_checker.rs
@@ -63,6 +63,22 @@ pub async fn check_transaction_input(
     Ok((gas_status, input_objects))
 }
 
+#[instrument(level = "trace", skip_all)]
+/// WARNING! This should only be used for the dev-inspect transaction. This transaction type
+/// bypasses many of the normal object checks
+pub(crate) async fn check_dev_inspect_input(
+    store: &AuthorityStore,
+    transaction: &TransactionData,
+) -> SuiResult<(SuiGasStatus<'static>, InputObjects)> {
+    transaction.validity_check()?;
+    transaction.kind.validity_check()?;
+    let gas_status = get_gas_status(store, transaction).await?;
+    let input_objects = transaction.input_objects()?;
+    let objects = store.check_input_objects(&input_objects)?;
+    let input_objects = InputObjects::new(input_objects.into_iter().zip(objects).collect());
+    Ok((gas_status, input_objects))
+}
+
 pub async fn check_certificate_input(
     store: &AuthorityStore,
     cert: &VerifiedCertificate,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -216,7 +216,7 @@ async fn test_dev_inspect_object_by_bytes() {
 
     // test normal call
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -248,7 +248,7 @@ async fn test_dev_inspect_object_by_bytes() {
 
     // actually make the call to make an object
     let effects = call_move(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -278,7 +278,7 @@ async fn test_dev_inspect_object_by_bytes() {
 
     // use the created object directly, via its bytes
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -313,7 +313,7 @@ async fn test_dev_inspect_object_by_bytes() {
 
     // make the same call with the object id
     let effects = call_move(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -352,7 +352,7 @@ async fn test_dev_inspect_unowned_gas() {
 
     // bob uses dev inspect with alice's gas
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &alice_gas_id,
         &bob,
         &bob_key,
@@ -393,7 +393,7 @@ async fn test_dev_inspect_unowned_object() {
 
     // make an object, send it to bob
     let effects = call_move(
-        &*authority_state,
+        &authority_state,
         &alice_gas_id,
         &alice,
         &alice_key,
@@ -419,7 +419,7 @@ async fn test_dev_inspect_unowned_object() {
 
     // alice uses the object with dev inspect, despite not being the owner
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &alice_gas_id,
         &alice,
         &alice_key,
@@ -464,7 +464,7 @@ async fn test_dev_inspect_dynamic_field() {
         macro_rules! mk_obj {
             () => {{
                 let effects = call_move(
-                    &*authority_state,
+                    &authority_state,
                     &gas_object_id,
                     &sender,
                     &sender_key,
@@ -503,7 +503,7 @@ async fn test_dev_inspect_dynamic_field() {
 
     // add a dynamic field to itself
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -523,7 +523,7 @@ async fn test_dev_inspect_dynamic_field() {
 
     // add a dynamic field to an object
     let DevInspectResults { effects, results } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -564,7 +564,7 @@ async fn test_dev_inspect_return_values() {
     // make an object
     let init_value = 16_u64;
     let effects = call_move(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -594,7 +594,7 @@ async fn test_dev_inspect_return_values() {
 
     // mutably borrow a value from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -624,7 +624,7 @@ async fn test_dev_inspect_return_values() {
 
     // borrow a value from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -654,7 +654,7 @@ async fn test_dev_inspect_return_values() {
 
     // read one value from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,
@@ -684,7 +684,7 @@ async fn test_dev_inspect_return_values() {
 
     // read two values from it's bytes
     let DevInspectResults { results, .. } = call_dev_inspect(
-        &*authority_state,
+        &authority_state,
         &gas_object_id,
         &sender,
         &sender_key,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -26,6 +26,7 @@ use std::fs;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use sui_json_rpc_types::SuiExecutionResult;
 use sui_types::utils::to_sender_signed_transaction;
 
 use std::{convert::TryInto, env};
@@ -204,6 +205,353 @@ async fn test_dry_run_transaction() {
         .unwrap()
         .version();
     assert_eq!(shared_object_version, SequenceNumber::MIN);
+}
+
+#[tokio::test]
+async fn test_dev_inspect_object_by_bytes() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let (authority_state, object_basics) =
+        init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+
+    // test normal call
+    let DevInspectResults { effects, results } = call_dev_inspect(
+        &*authority_state,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics,
+        "object_basics",
+        "create",
+        vec![],
+        vec![
+            TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
+            TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(effects.created.len(), 1);
+    assert_eq!(effects.mutated.len(), 1);
+    assert!(effects.deleted.is_empty());
+    assert_eq!(effects.mutated[0].reference.object_id, gas_object_id);
+    let mut results = results.unwrap();
+    assert_eq!(results.len(), 1);
+    let (idx, exec_results) = results.pop().unwrap();
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = exec_results;
+    assert_eq!(idx, 0);
+    assert!(mutable_reference_outputs.is_empty());
+    assert!(return_values.is_empty());
+
+    // actually make the call to make an object
+    let effects = call_move(
+        &*authority_state,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics,
+        "object_basics",
+        "create",
+        vec![],
+        vec![
+            TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
+            TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    let created_object_id = effects.created[0].0 .0;
+    let created_object = authority_state
+        .get_object(&created_object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let created_object_bytes = created_object
+        .data
+        .try_as_move()
+        .unwrap()
+        .contents()
+        .to_vec();
+
+    // use the created object directly, via its bytes
+    let DevInspectResults { effects, results } = call_dev_inspect(
+        &*authority_state,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics,
+        "object_basics",
+        "set_value",
+        vec![],
+        vec![
+            TestCallArg::Pure(created_object_bytes),
+            TestCallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert!(effects.created.is_empty());
+    // the object is not marked as mutated, since it was passed in via bytes
+    assert_eq!(effects.mutated.len(), 1);
+    assert!(effects.deleted.is_empty());
+    assert_eq!(effects.mutated[0].reference.object_id, gas_object_id);
+
+    let mut results = results.unwrap();
+    assert_eq!(results.len(), 1);
+    let (idx, exec_results) = results.pop().unwrap();
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = exec_results;
+    assert_eq!(idx, 0);
+    assert_eq!(mutable_reference_outputs.len(), 1);
+    assert!(return_values.is_empty());
+    let updated_reference_bytes = &mutable_reference_outputs[0].1;
+
+    // make the same call with the object id
+    let effects = call_move(
+        &*authority_state,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics,
+        "object_basics",
+        "set_value",
+        vec![],
+        vec![
+            TestCallArg::Object(created_object_id),
+            TestCallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert!(effects.created.is_empty());
+    assert_eq!(effects.mutated.len(), 2);
+    assert!(effects.deleted.is_empty());
+
+    // compare the bytes
+    let updated_object = authority_state
+        .get_object(&created_object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    let updated_object_bytes = updated_object.data.try_as_move().unwrap().contents();
+    assert_eq!(updated_object_bytes, updated_reference_bytes)
+}
+
+#[tokio::test]
+async fn test_dev_inspect_unowned_gas() {
+    let (alice, _alice_key): (_, AccountKeyPair) = get_key_pair();
+    let alice_gas_id = ObjectID::random();
+    let (authority_state, object_basics) =
+        init_state_with_ids_and_object_basics(vec![(alice, alice_gas_id)]).await;
+    let (bob, bob_key): (_, AccountKeyPair) = get_key_pair();
+
+    // bob uses dev inspect with alice's gas
+    let DevInspectResults { effects, results } = call_dev_inspect(
+        &*authority_state,
+        &alice_gas_id,
+        &bob,
+        &bob_key,
+        &object_basics,
+        "object_basics",
+        "create",
+        vec![],
+        vec![
+            TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
+            TestCallArg::Pure(bcs::to_bytes(&bob).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(effects.created.len(), 1);
+    assert_eq!(effects.mutated.len(), 1);
+    assert!(effects.deleted.is_empty());
+    assert_eq!(effects.mutated[0].reference.object_id, alice_gas_id);
+    let mut results = results.unwrap();
+    assert_eq!(results.len(), 1);
+    let (idx, exec_results) = results.pop().unwrap();
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = exec_results;
+    assert_eq!(idx, 0);
+    assert!(mutable_reference_outputs.is_empty());
+    assert!(return_values.is_empty());
+}
+
+#[tokio::test]
+async fn test_dev_inspect_unowned_object() {
+    let (alice, alice_key): (_, AccountKeyPair) = get_key_pair();
+    let alice_gas_id = ObjectID::random();
+    let (authority_state, object_basics) =
+        init_state_with_ids_and_object_basics(vec![(alice, alice_gas_id)]).await;
+    let (bob, _bob_key): (_, AccountKeyPair) = get_key_pair();
+
+    // make an object, send it to bob
+    let effects = call_move(
+        &*authority_state,
+        &alice_gas_id,
+        &alice,
+        &alice_key,
+        &object_basics,
+        "object_basics",
+        "create",
+        vec![],
+        vec![
+            TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
+            TestCallArg::Pure(bcs::to_bytes(&bob).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    let created_object_id = effects.created[0].0 .0;
+    let created_object = authority_state
+        .get_object(&created_object_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(alice != bob);
+    assert_eq!(created_object.owner, Owner::AddressOwner(bob));
+
+    // alice uses the object with dev inspect, despite not being the owner
+    let DevInspectResults { effects, results } = call_dev_inspect(
+        &*authority_state,
+        &alice_gas_id,
+        &alice,
+        &alice_key,
+        &object_basics,
+        "object_basics",
+        "set_value",
+        vec![],
+        vec![
+            TestCallArg::Object(created_object_id),
+            TestCallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert!(effects.created.is_empty());
+    assert_eq!(effects.mutated.len(), 2);
+    assert!(effects.deleted.is_empty());
+    assert!(effects
+        .mutated
+        .iter()
+        .any(|mutated| mutated.reference.object_id == alice_gas_id));
+
+    let mut results = results.unwrap();
+    assert_eq!(results.len(), 1);
+    let (idx, exec_results) = results.pop().unwrap();
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = exec_results;
+    assert_eq!(idx, 0);
+    assert_eq!(mutable_reference_outputs.len(), 1);
+    assert!(return_values.is_empty());
+}
+
+#[tokio::test]
+async fn test_dev_inspect_dynamic_field() {
+    let (test_object1_bytes, test_object2_bytes) = {
+        let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+        let gas_object_id = ObjectID::random();
+        let (authority_state, object_basics) =
+            init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+        macro_rules! mk_obj {
+            () => {{
+                let effects = call_move(
+                    &*authority_state,
+                    &gas_object_id,
+                    &sender,
+                    &sender_key,
+                    &object_basics,
+                    "object_basics",
+                    "create",
+                    vec![],
+                    vec![
+                        TestCallArg::Pure(bcs::to_bytes(&(16_u64)).unwrap()),
+                        TestCallArg::Pure(bcs::to_bytes(&sender).unwrap()),
+                    ],
+                )
+                .await
+                .unwrap();
+                let created_object_id = effects.created[0].0 .0;
+                let created_object = authority_state
+                    .get_object(&created_object_id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                created_object
+                    .data
+                    .try_as_move()
+                    .unwrap()
+                    .contents()
+                    .to_vec()
+            }};
+        }
+        (mk_obj!(), mk_obj!())
+    };
+
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let (authority_state, object_basics) =
+        init_state_with_ids_and_object_basics(vec![(sender, gas_object_id)]).await;
+
+    // add a dynamic field to itself
+    let DevInspectResults { results, .. } = call_dev_inspect(
+        &*authority_state,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics,
+        "object_basics",
+        "add_ofield",
+        vec![],
+        vec![
+            TestCallArg::Pure(test_object1_bytes.clone()),
+            TestCallArg::Pure(test_object1_bytes.clone()),
+        ],
+    )
+    .await
+    .unwrap();
+    // produces an error
+    assert!(matches!(results, Err(e) if e.contains("kind: CircularObjectOwnership")));
+
+    // add a dynamic field to an object
+    let DevInspectResults { effects, results } = call_dev_inspect(
+        &*authority_state,
+        &gas_object_id,
+        &sender,
+        &sender_key,
+        &object_basics,
+        "object_basics",
+        "add_ofield",
+        vec![],
+        vec![
+            TestCallArg::Pure(test_object1_bytes.clone()),
+            TestCallArg::Pure(test_object2_bytes.clone()),
+        ],
+    )
+    .await
+    .unwrap();
+    let mut results = results.unwrap();
+    assert_eq!(effects.created.len(), 1);
+    assert_eq!(effects.mutated.len(), 1);
+    assert!(effects.deleted.is_empty());
+    assert_eq!(effects.mutated[0].reference.object_id, gas_object_id);
+    assert_eq!(results.len(), 1);
+    let (idx, exec_results) = results.pop().unwrap();
+    let SuiExecutionResult {
+        mutable_reference_outputs,
+        return_values,
+    } = exec_results;
+    assert_eq!(idx, 0);
+    assert_eq!(mutable_reference_outputs.len(), 1);
+    assert!(return_values.is_empty());
 }
 
 #[tokio::test]
@@ -2642,6 +2990,44 @@ pub async fn add_ofield(
         ],
     )
     .await
+}
+
+pub async fn call_dev_inspect(
+    authority: &AuthorityState,
+    gas_object_id: &ObjectID,
+    sender: &SuiAddress,
+    sender_key: &AccountKeyPair,
+    package: &ObjectRef,
+    module: &str,
+    function: &str,
+    type_args: Vec<TypeTag>,
+    test_args: Vec<TestCallArg>,
+) -> Result<DevInspectResults, anyhow::Error> {
+    let gas_object = authority.get_object(gas_object_id).await.unwrap();
+    let gas_object_ref = gas_object.unwrap().compute_object_reference();
+    let mut args = Vec::with_capacity(test_args.len());
+    for a in test_args {
+        args.push(a.to_call_arg(authority).await)
+    }
+    let data = TransactionData::new_move_call(
+        *sender,
+        *package,
+        Identifier::new(module).unwrap(),
+        Identifier::new(function).unwrap(),
+        type_args,
+        gas_object_ref,
+        args,
+        MAX_GAS,
+    );
+
+    let transaction = to_sender_signed_transaction(data, sender_key);
+    let transaction_digest = *transaction.digest();
+    authority
+        .dev_inspect_transaction(
+            transaction.data().intent_message.value.clone(),
+            transaction_digest,
+        )
+        .await
 }
 
 #[cfg(test)]

--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -75,6 +75,14 @@ module examples::object_basics {
         );
     }
 
+    fun borrow_value_mut(o: &mut Object): &mut u64 {
+        &mut o.value
+    }
+
+    fun borrow_value(o: &Object): &u64 {
+        &o.value
+    }
+
     fun get_value(o: &Object): u64 {
         o.value
     }

--- a/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
+++ b/crates/sui-core/src/unit_tests/data/object_basics/sources/object_basics.move
@@ -5,7 +5,7 @@
 module examples::object_basics {
     use sui::dynamic_object_field as ofield;
     use sui::event;
-    use sui::object::{Self, UID};
+    use sui::object::{Self, UID, ID};
     use sui::tx_context::{Self, TxContext};
     use sui::transfer;
 
@@ -73,5 +73,13 @@ module examples::object_basics {
             ofield::remove<bool, Object>(&mut o.id, true),
             tx_context::sender(ctx),
         );
+    }
+
+    fun get_value(o: &Object): u64 {
+        o.value
+    }
+
+    fun get_contents(o: &Object): (ID, u64) {
+        (object::id(o), o.value)
     }
 }

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -1974,10 +1974,10 @@ pub struct DevInspectResults {
     /// Summary of effects that likely would be generated if the transaction is actually run.
     /// Note however, that not all dev-inspect transactions are actually usable as transactions so
     /// it might not be possible actually generate these effects from a normal transaction.
-    effects: SuiTransactionEffects,
+    pub effects: SuiTransactionEffects,
     /// Execution results (including return values) from executing the transactions
     /// Currently contains only return values from Move calls
-    results: Result<Vec<(usize, SuiExecutionResult)>, String>,
+    pub results: Result<Vec<(usize, SuiExecutionResult)>, String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -36,7 +36,7 @@ use sui_types::base_types::{
 use sui_types::coin::CoinMetadata;
 use sui_types::committee::EpochId;
 use sui_types::crypto::{AuthorityStrongQuorumSignInfo, Signature};
-use sui_types::error::SuiError;
+use sui_types::error::{ExecutionError, SuiError};
 use sui_types::event::{BalanceChangeType, Event, EventID};
 use sui_types::event::{EventEnvelope, EventType};
 use sui_types::filter::{EventFilter, TransactionFilter};
@@ -1964,6 +1964,68 @@ impl Display for SuiTransactionEffects {
             }
         }
         write!(f, "{}", writer)
+    }
+}
+
+/// The response from processing a dev inspect transaction
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename = "DevInspectResults", rename_all = "camelCase")]
+pub struct DevInspectResults {
+    /// Summary of effects that likely would be generated if the transaction is actually run.
+    /// Note however, that not all dev-inspect transactions are actually usable as transactions so
+    /// it might not be possible actually generate these effects from a normal transaction.
+    effects: SuiTransactionEffects,
+    /// Execution results (including return values) from executing the transactions
+    /// Currently contains only return values from Move calls
+    results: Result<Vec<(usize, SuiExecutionResult)>, String>,
+}
+
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SuiExecutionResult {
+    /// The value of any arguments that were mutably borrowed.
+    /// Non-mut borrowed values are not included
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mutable_reference_outputs: Vec<(/* local index */ u8, Vec<u8>, SuiTypeTag)>,
+    /// The return values from the function
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub return_values: Vec<(Vec<u8>, SuiTypeTag)>,
+}
+
+type ExecutionResult = (
+    /*  mutable_reference_outputs */ Vec<(u8, Vec<u8>, TypeTag)>,
+    /*  return_values */ Vec<(Vec<u8>, TypeTag)>,
+);
+
+impl DevInspectResults {
+    pub fn new(
+        effects: TransactionEffects,
+        return_values: Result<Vec<(usize, ExecutionResult)>, ExecutionError>,
+        resolver: &impl GetModule,
+    ) -> Result<Self, anyhow::Error> {
+        let effects = SuiTransactionEffects::try_from(effects, resolver)?;
+        let results = match return_values {
+            Err(e) => Err(format!("{}", e)),
+            Ok(srvs) => Ok(srvs
+                .into_iter()
+                .map(|(idx, srv)| {
+                    let (mutable_reference_outputs, return_values) = srv;
+                    let mutable_reference_outputs = mutable_reference_outputs
+                        .into_iter()
+                        .map(|(i, bytes, tag)| (i, bytes, SuiTypeTag::from(tag)))
+                        .collect();
+                    let return_values = return_values
+                        .into_iter()
+                        .map(|(bytes, tag)| (bytes, SuiTypeTag::from(tag)))
+                        .collect();
+                    let res = SuiExecutionResult {
+                        mutable_reference_outputs,
+                        return_values,
+                    };
+                    (idx, res)
+                })
+                .collect()),
+        };
+        Ok(Self { effects, results })
     }
 }
 


### PR DESCRIPTION
- Add dev_inspect_transction entry point on the authority
- Added new result type for dev inspect

Follow-up to #6538 that is blocked by https://github.com/move-language/move/pull/728.

Putting this up initially to get feedback on the result type. 