### PR TITLE
[TxManager] use TxManager to handle transactions with effects

### DIFF
--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -510,7 +510,7 @@ impl LocalAuthorityClient {
                     let epoch_store = state.epoch_store();
                     certificate.verify(epoch_store.committee())?
                 };
-                state.handle_certificate(&certificate).await?
+                state.execute_certificate_internal(&certificate).await?
             }
         };
         if fault_config.fail_after_handle_confirmation {

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -226,7 +226,7 @@ where
                 .process_transaction(advance_epoch_tx.clone().into_unsigned())
                 .await
             {
-                Ok(certificate) => match self.state.handle_certificate(&certificate).await {
+                Ok(certificate) => match self.state.execute_certificate_internal(&certificate).await {
                     Ok(_) => {
                         break;
                     }

--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -126,7 +126,7 @@ async fn test_start_epoch_change() {
             .verify(&genesis_committee)
             .unwrap();
     assert_eq!(
-        state.handle_certificate(&certificate).await.unwrap_err(),
+        state.execute_certificate_internal(&certificate).await.unwrap_err(),
         SuiError::ValidatorHaltedAtEpochEnd
     );
 

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -560,7 +560,7 @@ where
 
         match self
             .state()
-            .handle_certificate_with_effects(&cert, &effects)
+            .execute_certificate_with_effects(&cert, &effects)
             .await
         {
             Ok(_) => Ok(SyncStatus::CertExecuted),
@@ -580,7 +580,7 @@ where
 
         let cert = self.get_cert(epoch_id, digest).await?;
 
-        let result = self.state().handle_certificate(&cert).await;
+        let result = self.state().execute_certificate_internal(&cert).await;
         match result {
             Ok(_) => Ok(SyncStatus::CertExecuted),
             e @ Err(SuiError::TransactionInputObjectsErrors { .. }) => {
@@ -600,7 +600,7 @@ where
 
                 // Parents have been executed, so this should now succeed.
                 debug!(?digest, "parents executed, re-attempting cert");
-                self.state().handle_certificate(&cert).await?;
+                self.state().execute_certificate_internal(&cert).await?;
                 Ok(SyncStatus::CertExecuted)
             }
             Err(e) => Err(e),
@@ -712,7 +712,7 @@ where
             .await?;
 
         self.state()
-            .handle_certificate_with_effects(&cert, &effects)
+            .execute_certificate_with_effects(&cert, &effects)
             .await?;
 
         Ok(SyncStatus::CertExecuted)

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -67,7 +67,10 @@ async fn advance_epoch_tx_test() {
         handle
             .with_async(|node| async move {
                 // Check that every validator is able to execute such a cert.
-                node.state().handle_certificate(&cert).await.unwrap();
+                node.state()
+                    .execute_certificate_internal(&cert)
+                    .await
+                    .unwrap();
             })
             .await;
     }


### PR DESCRIPTION
Currently `AuthorityState::handle_certificate_with_effects()` does not enqueue transactions to `TransactionManager`. Instead, it directly calls `process_certificate()` to execute transactions, which will return errors if any input object is not yet available. So callers have to retry until a transaction can succeed, which is inefficient.

This PR refactors the the function to enqueue transactions to `TransactionManager` for execution. Now callers of `AuthorityState::handle_certificate_with_effects()` do not need to worry about checking errors or retries.