### PR TITLE
Fix latency metrics

### DIFF
--- a/narwhal/types/src/primary.rs
+++ b/narwhal/types/src/primary.rs
@@ -68,11 +68,17 @@ pub fn now() -> TimestampMs {
 // for NON CRITICAL purposes only. For example should not be used
 // for any processes that are part of our protocol that can affect
 // safety or liveness.
-#[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq, Eq, Arbitrary, MallocSizeOf)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Arbitrary, MallocSizeOf)]
 pub struct Metadata {
     // timestamp of when the entity created. This is generated
     // by the node which creates the entity.
     pub created_at: TimestampMs,
+}
+
+impl Default for Metadata {
+    fn default() -> Self {
+        Metadata { created_at: now() }
+    }
 }
 
 pub type Transaction = Vec<u8>;
@@ -86,7 +92,7 @@ impl Batch {
     pub fn new(transactions: Vec<Transaction>) -> Self {
         Batch {
             transactions,
-            metadata: Metadata { created_at: now() },
+            metadata: Metadata::default(),
         }
     }
 }


### PR DESCRIPTION
`Metadata` default impl was required to properly initialize metadata timestamps used in our [latency metrics](https://mysten.grafana.net/d/FaNbUhene/sui-validators-narwhal?orgId=1&var-network=private_testnet&var-validator=All&from=1670402344708&to=1670433723813&viewPanel=143) and after looking at [PR#6056](https://github.com/MystenLabs/sui/pull/6056) it looked okay to add it back. Also continuing to use the metadata field to track latency instead of the newly added header timestamps as it appears to be the more representative latency value.