### PR TITLE
[core] Move AuthorityState.committee field to per epoch store

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use arc_swap::{ArcSwap, Guard};
+use arc_swap::Guard;
 use chrono::prelude::*;
 use fastcrypto::traits::KeyPair;
 use move_bytecode_utils::module_cache::SyncModuleCache;
@@ -19,7 +19,6 @@ use prometheus::{
 };
 use std::cmp::Ordering as CmpOrdering;
 use std::hash::Hash;
-use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
@@ -58,7 +57,7 @@ use sui_storage::{
     IndexStore,
 };
 use sui_types::committee::EpochId;
-use sui_types::crypto::{AuthorityKeyPair, NetworkKeyPair};
+use sui_types::crypto::{AuthorityKeyPair, AuthoritySignInfo, NetworkKeyPair};
 use sui_types::event::{Event, EventID};
 use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::object::{Owner, PastObjectRead};
@@ -81,6 +80,7 @@ use sui_types::{
 
 use crate::authority::authority_notifier::TransactionNotifierTicket;
 use crate::authority::authority_notify_read::NotifyRead;
+use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority_aggregator::AuthorityAggregator;
 use crate::checkpoints::CheckpointServiceNotify;
 use crate::consensus_handler::{
@@ -506,10 +506,6 @@ pub struct AuthorityState {
     /// The signature key of the authority.
     pub secret: StableSyncAuthoritySigner,
 
-    // Epoch related information.
-    /// Committee of this Sui instance.
-    committee: ArcSwap<Committee>,
-
     /// Move native functions that are available to invoke
     pub(crate) _native_functions: NativeFunctionTable,
     pub(crate) move_vm: Arc<MoveVM>,
@@ -558,7 +554,7 @@ pub struct AuthorityState {
 /// Repeating valid commands should produce no changes and return no error.
 impl AuthorityState {
     pub fn is_validator(&self) -> bool {
-        self.committee.load().authority_exists(&self.name)
+        self.epoch_store().committee().authority_exists(&self.name)
     }
 
     pub fn is_fullnode(&self) -> bool {
@@ -571,7 +567,7 @@ impl AuthorityState {
     }
 
     pub fn epoch(&self) -> EpochId {
-        self.committee().epoch
+        self.database.epoch_store().epoch()
     }
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {
@@ -681,7 +677,7 @@ impl AuthorityState {
             }
         );
 
-        let epoch_store = self.database.epoch_store();
+        let epoch_store = self.epoch_store();
         let tx_guard = epoch_store.acquire_tx_guard(certificate).await?;
 
         if certificate.contains_shared_object() {
@@ -747,7 +743,7 @@ impl AuthorityState {
             ?tx_digest,
             tx_kind = certificate.data().data.kind_as_str()
         );
-        let epoch_store = self.database.epoch_store();
+        let epoch_store = self.epoch_store();
         let tx_guard = epoch_store
             .acquire_tx_guard(certificate)
             .instrument(span)
@@ -779,7 +775,6 @@ impl AuthorityState {
         );
 
         let shared_locks: HashMap<_, _> = self
-            .database
             .epoch_store()
             .get_shared_locks(transaction_digest)?
             .into_iter()
@@ -840,7 +835,7 @@ impl AuthorityState {
 
         // first check to see if we have already executed and committed the tx
         // to the WAL
-        let epoch_store = self.database.epoch_store();
+        let epoch_store = self.epoch_store();
         if let Some((inner_temporary_storage, signed_effects)) = epoch_store
             .wal()
             .get_execution_output(certificate.digest())?
@@ -1440,7 +1435,6 @@ impl AuthorityState {
             adapter::new_move_vm(native_functions.clone())
                 .expect("We defined natives to not fail here"),
         );
-        let committee = committee_store.get_latest_committee();
         let module_cache = Arc::new(SyncModuleCache::new(ResolverWrapper(store.clone())));
         let event_handler = event_store.map(|es| {
             let handler = EventHandler::new(es, module_cache.clone());
@@ -1456,7 +1450,6 @@ impl AuthorityState {
         let mut state = AuthorityState {
             name,
             secret,
-            committee: ArcSwap::from(Arc::new(committee)),
             _native_functions: native_functions,
             move_vm,
             database: store.clone(),
@@ -1563,16 +1556,14 @@ impl AuthorityState {
     pub async fn add_pending_certificates(&self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
         self.node_sync_store
             .batch_store_certs(certs.iter().cloned())?;
-        self.database
-            .epoch_store()
-            .insert_pending_certificates(&certs)?;
+        self.epoch_store().insert_pending_certificates(&certs)?;
         self.transaction_manager.enqueue(certs).await
     }
 
     // Continually pop in-progress txes from the WAL and try to drive them to completion.
     pub async fn process_tx_recovery_log(&self, limit: Option<usize>) -> SuiResult {
         let mut limit = limit.unwrap_or(usize::MAX);
-        let epoch_store = self.database.epoch_store();
+        let epoch_store = self.epoch_store();
         while limit > 0 {
             limit -= 1;
             if let Some((cert, tx_guard)) = epoch_store.wal().read_one_recoverable_tx().await? {
@@ -1615,8 +1606,6 @@ impl AuthorityState {
         );
 
         self.committee_store.insert_new_committee(&new_committee)?;
-        let new_committee = Arc::new(new_committee);
-        self.committee.swap(new_committee.clone());
         self.db().reopen_epoch_db(new_committee);
         Ok(())
     }
@@ -1625,17 +1614,17 @@ impl AuthorityState {
         self.database.clone()
     }
 
-    pub fn committee(&self) -> Guard<Arc<Committee>> {
-        self.committee.load()
+    pub fn epoch_store(&self) -> Guard<Arc<AuthorityPerEpochStore<AuthoritySignInfo>>> {
+        self.database.epoch_store()
     }
 
     pub fn clone_committee(&self) -> Committee {
-        self.committee().clone().deref().clone()
+        self.epoch_store().committee().clone()
     }
 
     // This method can only be called from ConsensusAdapter::begin_reconfiguration
     pub fn close_user_certs(&self, lock_guard: parking_lot::RwLockWriteGuard<'_, ReconfigState>) {
-        self.database.epoch_store().close_user_certs(lock_guard)
+        self.epoch_store().close_user_certs(lock_guard)
     }
 
     pub(crate) async fn get_object(
@@ -2240,7 +2229,6 @@ impl AuthorityState {
                 );
 
                 if !self
-                    .database
                     .epoch_store()
                     .get_reconfig_state_read_lock_guard()
                     .should_accept_consensus_certs()

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -101,8 +101,6 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         perpetual_tables: AuthorityPerpetualTables<S>,
         committee: Committee,
     ) -> SuiResult<Self> {
-        let committee = Arc::new(committee);
-
         let epoch_tables = Arc::new(AuthorityPerEpochStore::new(
             committee,
             path,
@@ -138,7 +136,7 @@ impl<S: Eq + Debug + Serialize + for<'de> Deserialize<'de>> SuiDataStore<S> {
         Ok(store)
     }
 
-    pub(crate) fn reopen_epoch_db(&self, new_committee: Arc<Committee>) {
+    pub(crate) fn reopen_epoch_db(&self, new_committee: Committee) {
         info!(new_epoch = ?new_committee.epoch, "re-opening AuthorityEpochTables for new epoch");
         let epoch_tables = Arc::new(AuthorityPerEpochStore::new(
             new_committee,

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -506,7 +506,10 @@ impl LocalAuthorityClient {
         let response = match state.get_tx_info_already_executed(&tx_digest).await {
             Ok(Some(response)) => response,
             _ => {
-                let certificate = certificate.verify(&state.committee())?;
+                let certificate = {
+                    let epoch_store = state.epoch_store();
+                    certificate.verify(epoch_store.committee())?
+                };
                 state.handle_certificate(&certificate).await?
             }
         };

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -395,7 +395,10 @@ impl ValidatorService {
 
         // 2) Verify cert signatures
         let cert_verif_metrics_guard = metrics.cert_verification_latency.start_timer();
-        let certificate = certificate.verify(&state.committee())?;
+        let certificate = {
+            let epoch_store = state.epoch_store();
+            certificate.verify(epoch_store.committee())?
+        };
         cert_verif_metrics_guard.stop_and_record();
 
         // 3) All certificates are sent to consensus (at least by some authorities)

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -532,7 +532,7 @@ impl CheckpointAggregator {
                     next_index: 0,
                     digest: summary.digest(),
                     summary,
-                    signatures: StakeAggregator::new(self.state.committee().clone()),
+                    signatures: StakeAggregator::new(self.state.clone_committee()),
                 });
                 self.current.as_mut().unwrap()
             };

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -51,7 +51,7 @@ impl TransactionValidator for SuiTxValidator {
             .iter()
             .map(|tx| tx_from_bytes(tx))
             .collect::<Result<Vec<_>, _>>()?;
-        let committee = self.state.committee();
+        let epoch_store = self.state.epoch_store();
 
         let mut obligation = VerificationObligation::default();
         for tx in txs.into_iter() {
@@ -61,7 +61,7 @@ impl TransactionValidator for SuiTxValidator {
                     // todo - verify user signature when we pin signature in certificate
                     let idx = obligation.add_message(certificate.data(), certificate.epoch());
                     certificate.auth_sig().add_to_verification_obligation(
-                        &committee,
+                        epoch_store.committee(),
                         &mut obligation,
                         idx,
                     )?;
@@ -73,7 +73,11 @@ impl TransactionValidator for SuiTxValidator {
                     signature
                         .summary
                         .auth_signature
-                        .add_to_verification_obligation(&committee, &mut obligation, idx)?;
+                        .add_to_verification_obligation(
+                            epoch_store.committee(),
+                            &mut obligation,
+                            idx,
+                        )?;
                 }
                 ConsensusTransactionKind::EndOfPublish(_) => {}
             }

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -357,7 +357,8 @@ where
         epoch_id: EpochId,
     ) -> SuiResult<bool> {
         // Check if the tx is final.
-        let committee = self.state().committee();
+        let epoch_store = self.state().epoch_store();
+        let committee = epoch_store.committee();
         check_epoch!(committee.epoch, epoch_id);
         let stake = committee.weight(peer);
         let quorum_threshold = committee.quorum_threshold();

--- a/crates/sui-core/src/stake_aggregator.rs
+++ b/crates/sui-core/src/stake_aggregator.rs
@@ -3,18 +3,17 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::Arc;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::{Committee, StakeUnit};
 
 pub struct StakeAggregator<V, const STRENGTH: bool> {
     data: HashMap<AuthorityName, V>,
     stake: StakeUnit,
-    committee: Arc<Committee>,
+    committee: Committee,
 }
 
 impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
-    pub fn new(committee: Arc<Committee>) -> Self {
+    pub fn new(committee: Committee) -> Self {
         Self {
             data: Default::default(),
             stake: Default::default(),
@@ -23,7 +22,7 @@ impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
     }
 
     pub fn from_iter<I: Iterator<Item = (AuthorityName, V)>>(
-        committee: Arc<Committee>,
+        committee: Committee,
         data: I,
     ) -> Self {
         let mut this = Self::new(committee);
@@ -57,7 +56,7 @@ impl<V: Clone, const STRENGTH: bool> StakeAggregator<V, STRENGTH> {
         self.data.contains_key(authority)
     }
 
-    pub fn committee(&self) -> &Arc<Committee> {
+    pub fn committee(&self) -> &Committee {
         &self.committee
     }
 }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -92,7 +92,7 @@ pub async fn test_certificates(authority: &AuthorityState) -> Vec<CertifiedTrans
         let certificate = CertifiedTransaction::new(
             transaction.into_message(),
             vec![vote.auth_sig().clone()],
-            &authority.committee(),
+            &authority.clone_committee(),
         )
         .unwrap();
         certificates.push(certificate);

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -148,9 +148,10 @@ impl RpcReadApiServer for ReadApi {
             .tap_err(|err| debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err))?;
 
         let mut signers = Vec::new();
-        let committee = self.state.committee();
+        let epoch_store = self.state.epoch_store();
         for authority_index in cert.auth_sig().signers_map.iter() {
-            let authority = committee
+            let authority = epoch_store
+                .committee()
                 .authority_by_index(authority_index)
                 .ok_or_else(|| anyhow!("Failed to get authority"))?;
             signers.push(*authority);


### PR DESCRIPTION
Merge the committee field of the authority state into per epoch store. This reduces the chance of a data race / inconsistency when reading from them separately.