### PR TITLE
[7/x][lamport] Less brittle tests w.r.t. SequenceNumber changes

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -823,7 +823,7 @@ async fn test_handle_move_transaction() {
     assert_eq!(effects.mutated.len(), 1);
 
     let created_object_id = effects.created[0].0 .0;
-    // check that transaction actually created an object with the expected ID, owner, sequence number
+    // check that transaction actually created an object with the expected ID, owner
     let created_obj = authority_state
         .get_object(&created_object_id)
         .await
@@ -831,7 +831,6 @@ async fn test_handle_move_transaction() {
         .unwrap();
     assert_eq!(created_obj.owner, sender);
     assert_eq!(created_obj.id(), created_object_id);
-    assert_eq!(created_obj.version(), OBJECT_START_VERSION);
 }
 
 #[tokio::test]
@@ -1040,7 +1039,6 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(OBJECT_START_VERSION, account.version());
 
     assert!(authority_state
         .parent(&(object_id, account.version(), account.digest()))

--- a/crates/sui/tests/shared_objects_version_tests.rs
+++ b/crates/sui/tests/shared_objects_version_tests.rs
@@ -20,10 +20,10 @@ use test_utils::transaction::{
 };
 
 #[sim_test]
-async fn fresh_shared_objects_get_start_version() {
+async fn fresh_shared_object_initial_version_matches_current() {
     let mut env = TestEnvironment::new().await;
-    let (_, owner) = env.create_shared_counter().await;
-    assert!(is_shared_at(&owner, OBJECT_START_VERSION));
+    let ((_, curr, _), owner) = env.create_shared_counter().await;
+    assert!(is_shared_at(&owner, curr));
 }
 
 #[sim_test]


### PR DESCRIPTION
Rather than testing against an absolute version number, test against a
known good version number from previously in the test, or just don't 
test for a precise SequenceNumber, because one may no long exist.

## Test Plan

```
sui$ cargo simtest
```

## Stack

- #6667 