### PR TITLE
[8/x][lamport] Set test genesis versions to v1 initially

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/call/simple.exp
+++ b/crates/sui-adapter-transactional-tests/tests/call/simple.exp
@@ -10,5 +10,5 @@ written: object(104)
 
 task 3 'view-object'. lines 32-32:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(105)}}, value: 0u64}

--- a/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/count_decremented.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 56-56:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 4 'run'. lines 58-58:
@@ -26,7 +26,7 @@ deleted: object(109), object(110)
 
 task 6 'view-object'. lines 62-66:
 Owner: Account Address ( A )
-Version: 3
+Version: 4
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 7 'run'. lines 68-68:
@@ -35,7 +35,7 @@ written: object(112)
 
 task 8 'view-object'. lines 70-70:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(113)}}}
 
 task 9 'run'. lines 72-72:
@@ -47,7 +47,7 @@ written: object(113), object(115), object(116), object(117)
 
 task 11 'view-object'. lines 76-80:
 Owner: Account Address ( A )
-Version: 3
+Version: 4
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(113)}}}
 
 task 12 'run'. lines 82-82:
@@ -56,7 +56,7 @@ written: object(118)
 
 task 13 'view-object'. lines 84-84:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(119)}}}
 
 task 14 'run'. lines 86-86:
@@ -70,5 +70,5 @@ deleted: object(122)
 
 task 16 'view-object'. lines 90-90:
 Owner: Account Address ( A )
-Version: 3
+Version: 4
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(119)}}}

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_by_wrap.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 44-44:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 46-46:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_invalid.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 39-39:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 41-41:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 63-63:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 65-65:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/delete_parent_valid_one_txn.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 76-76:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 78-78:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_invalid.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 68-68:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 70-70:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 68-68:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 70-70:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/freeze_parent_valid_one_txn.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 71-71:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 73-73:

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 50-54:
 Owner: Shared
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}
 
 task 4 'run'. lines 56-56:
@@ -25,7 +25,7 @@ written: object(112), object(114)
 
 task 6 'view-object'. lines 60-64:
 Owner: Account Address ( B )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(112)}}}
 
 task 7 'run'. lines 66-66:
@@ -37,5 +37,5 @@ written: object(117), object(119)
 
 task 9 'view-object'. lines 70-70:
 Owner: Account Address ( B )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(117)}}}

--- a/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
+++ b/crates/sui-adapter-transactional-tests/tests/child_count/non_zero_child_count_valid_one_txn.exp
@@ -13,5 +13,5 @@ written: object(106)
 
 task 3 'view-object'. lines 40-40:
 Owner: Shared
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}}

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/unwrap_object.exp
@@ -18,7 +18,7 @@ deleted: object(107)
 
 task 4 'view-object'. lines 47-47:
 Owner: Object ID: ( fake(110) )
-Version: 2
+Version: 3
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}}
 
 task 5 'run'. lines 50-50:
@@ -39,5 +39,5 @@ deleted: object(117)
 
 task 9 'view-object'. lines 60-60:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(119)}}}

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/wrap_object.exp
@@ -13,7 +13,7 @@ written: object(105)
 
 task 3 'view-object'. lines 45-45:
 Owner: Object ID: ( fake(108) )
-Version: 1
+Version: 2
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 4 'run'. lines 47-47:
@@ -27,7 +27,7 @@ written: object(111)
 
 task 6 'view-object'. lines 52-52:
 Owner: Object ID: ( fake(114) )
-Version: 1
+Version: 2
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(112)}}}
 
 task 7 'run'. lines 54-54:
@@ -40,7 +40,7 @@ written: object(116)
 
 task 9 'view-object'. lines 59-59:
 Owner: Object ID: ( fake(119) )
-Version: 1
+Version: 2
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(118)}}}
 
 task 10 'run'. lines 61-61:
@@ -49,5 +49,5 @@ deleted: object(119)
 
 task 11 'view-object'. lines 63-63:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: a::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(118)}}}

--- a/crates/sui-adapter-transactional-tests/tests/publish/init.exp
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init.exp
@@ -6,7 +6,7 @@ written: object(102)
 
 task 2 'view-object'. lines 25-25:
 Owner: Account Address ( _ )
-Version: 1
+Version: 2
 Contents: Test::M1::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(104)}}, value: 42u64}
 
 task 3 'view-object'. lines 27-27:

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object.exp
@@ -14,7 +14,7 @@ written: object(106)
 
 task 4 'view-object'. lines 43-43:
 Owner: Shared
-Version: 1
+Version: 2
 Contents: t2::o2::Obj2 {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 5 'run'. lines 45-45:

--- a/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
+++ b/crates/sui-adapter-transactional-tests/tests/shared/upgrade.exp
@@ -13,7 +13,7 @@ written: object(105)
 
 task 3 'view-object'. lines 44-44:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: t::m::Obj {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}}
 
 task 4 'run'. lines 46-46:

--- a/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/coin_transfer.exp
@@ -5,7 +5,7 @@ A: object(100), B: object(101), C: object(102)
 
 task 1 'view-object'. lines 8-8:
 Owner: Account Address ( A )
-Version: 0
+Version: 1
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1000000u64}}
 
 task 2 'run'. lines 10-10:
@@ -14,12 +14,12 @@ written: object(100), object(105)
 
 task 3 'view-object'. lines 12-12:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 999990u64}}
 
 task 4 'view-object'. lines 14-14:
 Owner: Account Address ( B )
-Version: 1
+Version: 2
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 10u64}}
 
 task 5 'run'. lines 16-16:
@@ -28,5 +28,5 @@ written: object(100), object(107)
 
 task 6 'view-object'. lines 18-18:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 999990u64}}

--- a/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/object_basics.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 74-74:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::object_basics::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}, value: 10u64}
 
 task 4 'run'. lines 76-76:
@@ -21,7 +21,7 @@ written: object(107), object(108)
 
 task 5 'view-object'. lines 78-78:
 Owner: Account Address ( B )
-Version: 2
+Version: 3
 Contents: test::object_basics::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}, value: 10u64}
 
 task 6 'run'. lines 80-80:
@@ -29,7 +29,7 @@ created: object(110)
 written: object(109)
 
 task 7 'run'. lines 82-82:
-events: CoinBalanceChange { package_id: sui, transaction_module: Identifier("gas"), sender: B, change_type: Gas, owner: AddressOwner(B), coin_type: "sui::sui::SUI", coin_object_id: fake(111), version: SequenceNumber(0), amount: -82 }, MutateObject { package_id: test, transaction_module: Identifier("object_basics"), sender: B, object_type: "test::object_basics::Object", object_id: fake(107), version: SequenceNumber(3) }, MutateObject { package_id: sui, transaction_module: Identifier("unused_input_object"), sender: B, object_type: "test::object_basics::Object", object_id: fake(110), version: SequenceNumber(3) }, MoveEvent { package_id: test, transaction_module: Identifier("object_basics"), sender: B, type_: StructTag { address: test, module: Identifier("object_basics"), name: Identifier("NewValueEvent"), type_params: [] }, contents: [20, 0, 0, 0, 0, 0, 0, 0] }
+events: CoinBalanceChange { package_id: sui, transaction_module: Identifier("gas"), sender: B, change_type: Gas, owner: AddressOwner(B), coin_type: "sui::sui::SUI", coin_object_id: fake(111), version: SequenceNumber(1), amount: -82 }, MutateObject { package_id: test, transaction_module: Identifier("object_basics"), sender: B, object_type: "test::object_basics::Object", object_id: fake(107), version: SequenceNumber(4) }, MutateObject { package_id: sui, transaction_module: Identifier("unused_input_object"), sender: B, object_type: "test::object_basics::Object", object_id: fake(110), version: SequenceNumber(4) }, MoveEvent { package_id: test, transaction_module: Identifier("object_basics"), sender: B, type_: StructTag { address: test, module: Identifier("object_basics"), name: Identifier("NewValueEvent"), type_params: [] }, contents: [20, 0, 0, 0, 0, 0, 0, 0] }
 written: object(107), object(110), object(111)
 
 task 8 'run'. lines 84-84:

--- a/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/sui/unwrap.exp
@@ -13,7 +13,7 @@ written: object(105)
 
 task 3 'view-object'. lines 75-75:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::object_basics::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}, value: 10u64}
 
 task 4 'run'. lines 77-77:
@@ -27,5 +27,5 @@ deleted: object(108)
 
 task 6 'view-object'. lines 81-81:
 Owner: Account Address ( A )
-Version: 3
+Version: 4
 Contents: test::object_basics::Object {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}, value: 10u64}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/does_not_have_store.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 33-33:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 4 'transfer-object'. lines 35-35:
@@ -22,7 +22,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5 'view-object'. lines 37-40:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 6 'run'. lines 42-42:
@@ -31,7 +31,7 @@ written: object(109)
 
 task 7 'view-object'. lines 44-44:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::Cup<test::m::S> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}}
 
 task 8 'transfer-object'. lines 46-46:
@@ -40,5 +40,5 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 9 'view-object'. lines 48-48:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: test::m::Cup<test::m::S> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/has_store.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 33-33:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 4 'transfer-object'. lines 35-35:
@@ -21,7 +21,7 @@ written: object(107), object(108)
 
 task 5 'view-object'. lines 37-40:
 Owner: Account Address ( B )
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 6 'run'. lines 42-42:
@@ -30,7 +30,7 @@ written: object(109)
 
 task 7 'view-object'. lines 44-44:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: test::m::Cup<test::m::S> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}}
 
 task 8 'transfer-object'. lines 46-46:
@@ -38,5 +38,5 @@ written: object(110), object(111)
 
 task 9 'view-object'. lines 48-48:
 Owner: Account Address ( B )
-Version: 2
+Version: 3
 Contents: test::m::Cup<test::m::S> {id: sui::object::UID {id: sui::object::ID {bytes: fake(110)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/immutable.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 26-26:
 Owner: Immutable
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 4 'transfer-object'. lines 28-28:
@@ -22,5 +22,5 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5 'view-object'. lines 30-30:
 Owner: Immutable
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/quasi_shared.exp
@@ -17,7 +17,7 @@ written: object(107), object(108)
 
 task 4 'view-object'. lines 33-33:
 Owner: Object ID: ( fake(107) )
-Version: 2
+Version: 3
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(110)}}
 
 task 5 'transfer-object'. lines 35-35:
@@ -26,5 +26,5 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 6 'view-object'. lines 37-37:
 Owner: Object ID: ( fake(107) )
-Version: 3
+Version: 4
 Contents: sui::dynamic_field::Field<sui::dynamic_object_field::Wrapper<u64>, sui::object::ID> {id: sui::object::UID {id: sui::object::ID {bytes: fake(109)}}, name: sui::dynamic_object_field::Wrapper<u64> {name: 0u64}, value: sui::object::ID {bytes: fake(110)}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.exp
@@ -13,7 +13,7 @@ written: object(106)
 
 task 3 'view-object'. lines 25-25:
 Owner: Shared
-Version: 1
+Version: 2
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}
 
 task 4 'transfer-object'. lines 27-27:
@@ -22,5 +22,5 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5 'view-object'. lines 29-29:
 Owner: Shared
-Version: 2
+Version: 3
 Contents: test::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(107)}}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/transfer_coin.exp
@@ -5,7 +5,7 @@ A: object(100), B: object(101)
 
 task 1 'view-object'. lines 8-8:
 Owner: Account Address ( A )
-Version: 0
+Version: 1
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1000000u64}}
 
 task 2 'transfer-object'. lines 10-10:
@@ -13,5 +13,5 @@ written: object(100), object(104)
 
 task 3 'view-object'. lines 12-12:
 Owner: Account Address ( B )
-Version: 1
+Version: 2
 Contents: sui::coin::Coin<sui::sui::SUI> {id: sui::object::UID {id: sui::object::ID {bytes: fake(100)}}, balance: sui::balance::Balance<sui::sui::SUI> {value: 1000000u64}}

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/wrap_unwrap.exp
@@ -13,7 +13,7 @@ written: object(105)
 
 task 3 'view-object'. lines 45-45:
 Owner: Account Address ( A )
-Version: 1
+Version: 2
 Contents: a::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}}
 
 task 4 'run'. lines 47-47:
@@ -23,7 +23,7 @@ deleted: object(106)
 
 task 5 'view-object'. lines 49-49:
 Owner: Account Address ( A )
-Version: 2
+Version: 3
 Contents: a::m::T {id: sui::object::UID {id: sui::object::ID {bytes: fake(108)}}, s: a::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}}}
 
 task 6 'run'. lines 51-51:
@@ -32,5 +32,5 @@ deleted: object(108)
 
 task 7 'view-object'. lines 53-53:
 Owner: Account Address ( A )
-Version: 3
+Version: 4
 Contents: a::m::S {id: sui::object::UID {id: sui::object::ID {bytes: fake(106)}}}

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -194,7 +194,7 @@ async fn test_dry_run_transaction() {
         .unwrap()
         .unwrap()
         .version();
-    assert_eq!(gas_object_version, SequenceNumber::new());
+    assert_eq!(gas_object_version, OBJECT_START_VERSION);
     let shared_object_version = authority
         .get_object(&shared_object_id)
         .await
@@ -1114,11 +1114,11 @@ async fn test_handle_confirmation_transaction_ok() {
 
     // Check locks are set and archived correctly
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 0.into(), old_account.digest()), 0)
+        .get_transaction_lock(&(object_id, 1.into(), old_account.digest()), 0)
         .await
         .is_err());
     assert!(authority_state
-        .get_transaction_lock(&(object_id, 1.into(), new_account.digest()), 0)
+        .get_transaction_lock(&(object_id, 2.into(), new_account.digest()), 0)
         .await
         .expect("Exists")
         .is_none());

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -823,7 +823,7 @@ async fn test_handle_move_transaction() {
     assert_eq!(effects.mutated.len(), 1);
 
     let created_object_id = effects.created[0].0 .0;
-    // check that transaction actually created an object with the expected ID, owner, sequence number
+    // check that transaction actually created an object with the expected ID, owner
     let created_obj = authority_state
         .get_object(&created_object_id)
         .await
@@ -831,7 +831,6 @@ async fn test_handle_move_transaction() {
         .unwrap();
     assert_eq!(created_obj.owner, sender);
     assert_eq!(created_obj.id(), created_object_id);
-    assert_eq!(created_obj.version(), OBJECT_START_VERSION);
 }
 
 #[tokio::test]
@@ -1040,7 +1039,6 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(OBJECT_START_VERSION, account.version());
 
     assert!(authority_state
         .parent(&(object_id, account.version(), account.digest()))

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -516,7 +516,7 @@ impl Object {
         let data = Data::Move(MoveObject {
             type_: GasCoin::type_(),
             has_public_transfer: true,
-            version: SequenceNumber::new(),
+            version: OBJECT_START_VERSION,
             contents: GasCoin::new(id, GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
         });
         Self {
@@ -531,7 +531,7 @@ impl Object {
         let data = Data::Move(MoveObject {
             type_: GasCoin::type_(),
             has_public_transfer: true,
-            version: SequenceNumber::new(),
+            version: OBJECT_START_VERSION,
             contents: GasCoin::new(id, gas).to_bcs_bytes(),
         });
         Self {
@@ -546,7 +546,7 @@ impl Object {
         let data = Data::Move(MoveObject {
             type_: GasCoin::type_(),
             has_public_transfer: true,
-            version: SequenceNumber::new(),
+            version: OBJECT_START_VERSION,
             contents: GasCoin::new(id, GAS_VALUE_FOR_TESTING).to_bcs_bytes(),
         });
         Self {

--- a/crates/sui/tests/full_node_tests.rs
+++ b/crates/sui/tests/full_node_tests.rs
@@ -243,7 +243,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
         change_type: BalanceChangeType::Pay,
         owner: Owner::AddressOwner(sender),
         coin_type: "0x2::sui::SUI".to_string(),
-        version: SequenceNumber::from_u64(0),
+        version: SequenceNumber::from_u64(1),
         coin_object_id: transferred_object,
         amount: -100000000000000,
     };
@@ -254,7 +254,7 @@ async fn test_full_node_indexes() -> Result<(), anyhow::Error> {
         change_type: BalanceChangeType::Receive,
         owner: Owner::AddressOwner(receiver),
         coin_type: "0x2::sui::SUI".to_string(),
-        version: SequenceNumber::from_u64(1),
+        version: SequenceNumber::from_u64(2),
         coin_object_id: transferred_object,
         amount: 100000000000000,
     };
@@ -729,7 +729,7 @@ async fn test_full_node_event_read_api_ok() {
         change_type: BalanceChangeType::Pay,
         owner: Owner::AddressOwner(sender),
         coin_type: "0x2::sui::SUI".to_string(),
-        version: SequenceNumber::from_u64(0),
+        version: SequenceNumber::from_u64(1),
         coin_object_id: transferred_object,
         amount: -100000000000000,
     };
@@ -740,7 +740,7 @@ async fn test_full_node_event_read_api_ok() {
         change_type: BalanceChangeType::Receive,
         owner: Owner::AddressOwner(receiver),
         coin_type: "0x2::sui::SUI".to_string(),
-        version: SequenceNumber::from_u64(1),
+        version: SequenceNumber::from_u64(2),
         coin_object_id: transferred_object,
         amount: 100000000000000,
     };

--- a/crates/sui/tests/shared_objects_version_tests.rs
+++ b/crates/sui/tests/shared_objects_version_tests.rs
@@ -20,10 +20,10 @@ use test_utils::transaction::{
 };
 
 #[sim_test]
-async fn fresh_shared_objects_get_start_version() {
+async fn fresh_shared_object_initial_version_matches_current() {
     let mut env = TestEnvironment::new().await;
-    let (_, owner) = env.create_shared_counter().await;
-    assert!(is_shared_at(&owner, OBJECT_START_VERSION));
+    let ((_, curr, _), owner) = env.create_shared_counter().await;
+    assert!(is_shared_at(&owner, curr));
 }
 
 #[sim_test]


### PR DESCRIPTION
Make sure that objects created for genesis (in this case, genesis gas
objects for testing) start at `OBJECT_START_VERSION` rather than `0`
to avoid angering code that assumed that all object versions are >=
OBJECT_START_VERSION.

## Test Plan

```
sui$ cargo simtest
sui$ cargo nextest run
```

## Stack

- #6668 
- #6667