### PR TITLE
[sui framework] add `type_tag_bytes()` native function

### DIFF
--- a/crates/sui-framework/docs/types.md
+++ b/crates/sui-framework/docs/types.md
@@ -7,6 +7,7 @@ Sui types helpers and utilities
 
 
 -  [Function `is_one_time_witness`](#0x2_types_is_one_time_witness)
+-  [Function `type_tag_bytes`](#0x2_types_type_tag_bytes)
 
 
 <pre><code></code></pre>
@@ -31,6 +32,28 @@ across the entire code base.
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="types.md#0x2_types_is_one_time_witness">is_one_time_witness</a>&lt;T: drop&gt;(_: &T): bool;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x2_types_type_tag_bytes"></a>
+
+## Function `type_tag_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="types.md#0x2_types_type_tag_bytes">type_tag_bytes</a>&lt;T&gt;(): <a href="">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="types.md#0x2_types_type_tag_bytes">type_tag_bytes</a>&lt;T&gt;(): <a href="">vector</a>&lt;u8&gt;;
 </code></pre>
 
 

--- a/crates/sui-framework/sources/types.move
+++ b/crates/sui-framework/sources/types.move
@@ -8,4 +8,6 @@ module sui::types {
     /// Tests if the argument type is a one-time witness, that is a type with only one instantiation
     /// across the entire code base.
     public native fun is_one_time_witness<T: drop>(_: &T): bool;
+
+    public native fun type_tag_bytes<T>(): vector<u8>;
 }

--- a/crates/sui-framework/src/natives/mod.rs
+++ b/crates/sui-framework/src/natives/mod.rs
@@ -218,6 +218,11 @@ pub fn all_natives(
             make_native!(types::is_one_time_witness),
         ),
         (
+            "types",
+            "type_tag_bytes",
+            make_native!(types::type_tag_bytes),
+        ),
+        (
             "groth16",
             "verify_groth16_proof_internal",
             make_native!(crypto::verify_groth16_proof_internal),

--- a/crates/sui-framework/src/natives/types.rs
+++ b/crates/sui-framework/src/natives/types.rs
@@ -74,7 +74,7 @@ pub fn type_tag_bytes(
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.len() == 1);
-    assert!(args.len() == 0);
+    assert!(args.is_empty());
     let ty = ty_args.pop().unwrap();
     let tag = context.type_to_type_tag(&ty)?;
     // build bytes

--- a/crates/sui-framework/src/natives/types.rs
+++ b/crates/sui-framework/src/natives/types.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::legacy_length_cost;
+use crate::{legacy_emit_cost, legacy_length_cost};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
     language_storage::TypeTag,
@@ -13,6 +13,8 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
+
+const E_BCS_SERIALIZATION_FAILURE: u64 = 1;
 
 pub fn is_one_time_witness(
     context: &mut NativeContext,
@@ -62,5 +64,31 @@ pub fn is_one_time_witness(
         smallvec![Value::bool(
             matches!(type_tag, TypeTag::Struct(struct_tag) if has_one_bool_field && struct_tag.name.to_string() == struct_tag.module.to_string().to_ascii_uppercase())
         )],
+    ))
+}
+
+// native fun type_tag_bytes<T>(): address;
+pub fn type_tag_bytes(
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    assert!(ty_args.len() == 1);
+    assert!(args.len() == 0);
+    let ty = ty_args.pop().unwrap();
+    let tag = context.type_to_type_tag(&ty)?;
+    // build bytes
+    let tag_bytes = match bcs::to_bytes(&tag) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Ok(NativeResult::err(
+                legacy_emit_cost(),
+                E_BCS_SERIALIZATION_FAILURE,
+            ));
+        }
+    };
+    Ok(NativeResult::ok(
+        legacy_emit_cost(),
+        smallvec![Value::vector_u8(tag_bytes)],
     ))
 }

--- a/crates/sui-framework/tests/types_tests.move
+++ b/crates/sui-framework/tests/types_tests.move
@@ -1,0 +1,34 @@
+
+#[test_only]
+module sui::types_tests {
+    use sui::types::type_tag_bytes;
+    use sui::bag;
+    use sui::tx_context;
+
+    struct Foo<phantom T1, phantom T2> has store {}
+    struct Bar {}
+    struct Baz {}
+
+    const E_TEST_FAILED: u64 = 1;
+
+    #[test]
+    fun test_type_tag_bytes() {
+        // test hash properties
+        let k1 = type_tag_bytes<Foo<Bar, Baz>>();
+        let k2 = type_tag_bytes<Foo<Bar, Baz>>();
+        let k3 = type_tag_bytes<Foo<Baz, Bar>>();
+
+        assert!(k1 == k2, E_TEST_FAILED);
+        assert!(k1 != k3, E_TEST_FAILED);
+
+        // test using hash for bag key
+        let ctx = tx_context::dummy();
+        let b = bag::new(&mut ctx);
+        let v1 = Foo<Bar, Baz> {};
+        bag::add(&mut b, k1, v1);
+        assert!(bag::contains(&b, k1), E_TEST_FAILED);
+        let v1 = bag::remove(&mut b, k1);
+        Foo<Bar, Baz> {} = v1;
+        bag::destroy_empty(b);
+    }
+}

--- a/crates/sui-framework/tests/types_tests.move
+++ b/crates/sui-framework/tests/types_tests.move
@@ -1,3 +1,5 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
 module sui::types_tests {


### PR DESCRIPTION
Native function to provide bytes of type tags. Useful for maintaining a registry of objects based on type. For example, to maintain a registry of AMM pools with type `Pool<X, Y>` one could store pool objects in a bag keyed on the pool's type tag.