### PR TITLE
[ExecDriver] Launch execution driver with AuthorityState

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -58,10 +58,6 @@ use gossip::GossipMetrics;
 
 use crate::authority_client::NetworkAuthorityClientMetrics;
 
-pub mod execution_driver;
-
-use self::execution_driver::ExecutionDriverMetrics;
-
 // TODO: Make these into a proper config
 const MAX_RETRIES_RECORDED: u32 = 10;
 const DELAY_FOR_1_RETRY_MS: u64 = 2_000;
@@ -132,8 +128,6 @@ pub struct ActiveAuthority<A> {
     // This is only meaningful if A is of type NetworkAuthorityClient,
     // and stored here for reconfiguration purposes.
     pub network_metrics: Arc<NetworkAuthorityClientMetrics>,
-
-    pub execution_driver_metrics: ExecutionDriverMetrics,
 }
 
 impl<A> ActiveAuthority<A> {
@@ -160,7 +154,6 @@ impl<A> ActiveAuthority<A> {
             net: ArcSwap::from(net),
             gossip_metrics: GossipMetrics::new(prometheus_registry),
             network_metrics,
-            execution_driver_metrics: ExecutionDriverMetrics::new(prometheus_registry),
         })
     }
 
@@ -238,7 +231,6 @@ impl<A> Clone for ActiveAuthority<A> {
             health: self.health.clone(),
             gossip_metrics: self.gossip_metrics.clone(),
             network_metrics: self.network_metrics.clone(),
-            execution_driver_metrics: self.execution_driver_metrics.clone(),
         }
     }
 }

--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -60,7 +60,7 @@ use crate::authority_client::NetworkAuthorityClientMetrics;
 
 pub mod execution_driver;
 
-use self::execution_driver::{execution_process, ExecutionDriverMetrics};
+use self::execution_driver::ExecutionDriverMetrics;
 
 // TODO: Make these into a proper config
 const MAX_RETRIES_RECORDED: u32 = 10;
@@ -328,10 +328,5 @@ where
     pub async fn cancel_node_sync_process_for_tests(&self) {
         let mut lock_guard = self.node_sync_process.lock().await;
         Self::cancel_node_sync_process_impl(&mut lock_guard).await;
-    }
-
-    /// Spawn pending certificate execution process
-    pub async fn spawn_execute_process(self: Arc<Self>) -> JoinHandle<()> {
-        spawn_monitored_task!(execution_process(self))
     }
 }

--- a/crates/sui-core/src/authority_active/execution_driver/tests.rs
+++ b/crates/sui-core/src/authority_active/execution_driver/tests.rs
@@ -168,7 +168,6 @@ async fn pending_exec_full() {
                     .run_batch_service(1, Duration::from_secs(1))
                     .await
             });
-            active_state.clone().spawn_execute_process().await;
             active_state
                 .spawn_checkpoint_process(CheckpointMetrics::new_for_tests())
                 .await;
@@ -276,20 +275,12 @@ async fn test_transaction_manager() {
 
     // the 4th authority has never heard of either of these transactions. Tell it to execute the
     // cert, sends it the missing dependency and verify that it is able to fetch parents and apply.
-    let active_state = Arc::new(
-        ActiveAuthority::new_with_ephemeral_storage_for_test(
-            authorities[3].clone(),
-            aggregator.clone(),
-        )
-        .unwrap(),
-    );
     let batch_state = authorities[3].clone();
     tokio::task::spawn(async move {
         batch_state
             .run_batch_service(1, Duration::from_secs(1))
             .await
     });
-    active_state.clone().spawn_execute_process().await;
 
     // Basic test: add certs out of dependency order. They should still be executed.
     authorities[3]

--- a/crates/sui-core/src/authority_batch.rs
+++ b/crates/sui-core/src/authority_batch.rs
@@ -74,9 +74,8 @@ impl crate::authority::AuthorityState {
     /// crash by creating a last batch to include any trailing trasnactions not
     /// in a batch.
     ///
-    /// This needs exclusive access to the database at this point, so we take
-    /// the authority state as a &mut.
-    pub fn init_batches_from_database(&mut self) -> Result<AuthorityBatch, SuiError> {
+    /// Must have exclusive access to the database during the call.
+    pub fn init_batches_from_database(&self) -> Result<AuthorityBatch, SuiError> {
         // First read the last batch in the db
         let mut last_batch = match self
             .db()

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -462,7 +462,7 @@ impl LocalAuthorityClient {
     pub async fn new(committee: Committee, secret: AuthorityKeyPair, genesis: &Genesis) -> Self {
         let state = AuthorityState::new_for_testing(committee, &secret, None, Some(genesis)).await;
         Self {
-            state: Arc::new(state),
+            state,
             fault_config: LocalAuthorityClientFaultConfig::default(),
         }
     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -893,9 +893,7 @@ mod tests {
         let store = Box::new(store);
 
         let (keypair, committee) = committee();
-        let state = Arc::new(
-            AuthorityState::new_for_testing(committee.clone(), &keypair, None, None).await,
-        );
+        let state = AuthorityState::new_for_testing(committee.clone(), &keypair, None, None).await;
 
         let checkpoint_store = CheckpointStore::new(tempdir.path());
         let checkpoint_service = CheckpointService::spawn(

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -115,7 +115,7 @@ impl SuiTxValidatorMetrics {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, sync::Arc};
+    use std::collections::BTreeMap;
 
     use fastcrypto::traits::KeyPair;
     use narwhal_types::Batch;
@@ -165,7 +165,7 @@ mod tests {
         )
         .unwrap();
 
-        let validator = SuiTxValidator::new(Arc::new(state), &Default::default());
+        let validator = SuiTxValidator::new(state, &Default::default());
         let res = validator.validate(&first_transaction_bytes);
         assert!(res.is_ok(), "{res:?}");
 

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -7,7 +7,9 @@ pub mod authority_aggregator;
 pub mod authority_batch;
 pub mod authority_client;
 pub mod authority_server;
+pub mod checkpoints;
 pub mod consensus_adapter;
+pub mod consensus_validator;
 pub mod epoch;
 pub mod event_handler;
 pub mod execution_engine;
@@ -17,16 +19,14 @@ pub mod safe_client;
 pub mod storage;
 pub mod streamer;
 pub mod tbls;
+pub mod test_utils;
 pub mod transaction_input_checker;
 pub mod transaction_orchestrator;
 pub mod transaction_streamer;
 pub mod validator_info;
 
-pub mod test_utils;
-
-pub mod checkpoints;
 mod consensus_handler;
-pub mod consensus_validator;
+mod execution_driver;
 mod histogram;
 mod module_cache_gauge;
 mod node_sync;

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -172,6 +172,9 @@ impl TransactionManager {
             self.metrics
                 .transaction_manager_num_pending_certificates
                 .set(inner.pending_certificates.len() as i64);
+            self.metrics
+                .transaction_manager_num_executing_certificates
+                .set(inner.executing_certificates.len() as i64);
         }
 
         for digest in ready_digests.iter() {
@@ -206,6 +209,9 @@ impl TransactionManager {
         {
             let inner = &mut self.inner.write().await;
             inner.executing_certificates.remove(digest);
+            self.metrics
+                .transaction_manager_num_executing_certificates
+                .set(inner.executing_certificates.len() as i64);
         }
         let _ = self
             .authority_store

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -109,7 +109,6 @@ async fn submit_transaction_to_consensus_adapter() {
     let state = init_state_with_objects(objects).await;
     let certificate = test_certificates(&state).await.pop().unwrap();
 
-    let state = Arc::new(state);
     let metrics = ConsensusAdapterMetrics::new_test();
 
     #[derive(Clone)]

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority_active::ActiveAuthority;
 use crate::authority_aggregator::authority_aggregator_tests::{
     crate_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     init_local_authorities, transfer_object_move_transaction,
@@ -9,7 +8,6 @@ use crate::authority_aggregator::authority_aggregator_tests::{
 use crate::test_utils::wait_for_tx;
 
 use std::collections::BTreeSet;
-use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -515,7 +515,7 @@ async fn test_storage_gas_unit_price() -> SuiResult {
 }
 
 struct TransferResult {
-    pub authority_state: AuthorityState,
+    pub authority_state: Arc<AuthorityState>,
     pub object_id: ObjectID,
     pub gas_object_id: ObjectID,
     pub response: SuiResult<VerifiedTransactionInfoResponse>,

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -417,7 +417,7 @@ async fn test_pay_all_sui_success_multiple_input_coins() -> anyhow::Result<()> {
 }
 
 struct PaySuiTransactionExecutionResult {
-    pub authority_state: AuthorityState,
+    pub authority_state: Arc<AuthorityState>,
     pub txn_result: Result<TransactionInfoResponse, SuiError>,
 }
 

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -33,7 +33,7 @@ async fn test_simple_request() {
 
     let server = AuthorityServer::new_for_test(
         "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
-        Arc::new(authority_state),
+        authority_state,
         consensus_address,
     );
 
@@ -66,7 +66,7 @@ async fn test_subscription() {
     // Start the batch server
     let mut server = AuthorityServer::new_for_test(
         "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
-        Arc::new(authority_state),
+        authority_state,
         consensus_address,
     );
     server.min_batch_size = 10;
@@ -261,7 +261,7 @@ async fn test_subscription_safe_client() {
     let consensus_address = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
 
     // Start the batch server
-    let state = Arc::new(authority_state);
+    let state = authority_state;
     let server = Arc::new(AuthorityServer::new_for_test(
         "/ip4/127.0.0.1/tcp/998/http".parse().unwrap(),
         state.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -76,7 +76,6 @@ pub struct SuiNode {
     _batch_subsystem_handle: tokio::task::JoinHandle<()>,
     _post_processing_subsystem_handle: Option<tokio::task::JoinHandle<Result<()>>>,
     _gossip_handle: Option<tokio::task::JoinHandle<()>>,
-    _execute_driver_handle: tokio::task::JoinHandle<()>,
     state: Arc<AuthorityState>,
     active: Arc<ActiveAuthority<NetworkAuthorityClient>>,
     transaction_orchestrator: Option<Arc<TransactiondOrchestrator<NetworkAuthorityClient>>>,
@@ -170,20 +169,18 @@ impl SuiNode {
             None,
         ));
 
-        let state = Arc::new(
-            AuthorityState::new(
-                config.protocol_public_key(),
-                secret,
-                store,
-                node_sync_store,
-                committee_store.clone(),
-                index_store.clone(),
-                event_store,
-                transaction_streamer,
-                &prometheus_registry,
-            )
-            .await,
-        );
+        let state = AuthorityState::new(
+            config.protocol_public_key(),
+            secret,
+            store,
+            node_sync_store,
+            committee_store.clone(),
+            index_store.clone(),
+            event_store,
+            transaction_streamer,
+            &prometheus_registry,
+        )
+        .await;
 
         let active_authority = Arc::new(ActiveAuthority::new(
             state.clone(),
@@ -233,7 +230,6 @@ impl SuiNode {
         } else {
             None
         };
-        let execute_driver_handle = active_authority.clone().spawn_execute_process().await;
 
         let validator_server_info = Self::start_grpc_validator_service(
             config,
@@ -258,7 +254,6 @@ impl SuiNode {
             validator_server_info,
             _json_rpc_service: json_rpc_service,
             _gossip_handle: gossip_handle,
-            _execute_driver_handle: execute_driver_handle,
             _batch_subsystem_handle: batch_subsystem_handle,
             _post_processing_subsystem_handle: post_processing_subsystem_handle,
             state,


### PR DESCRIPTION
After Gateway deprecation, since we plan to execute certificates with effects in execution driver, there should not be a case where AuthorityState is launched but execution driver is not needed. Keeping execution driver in activate authority no longer brings in benefits. But merging execution driver into AuthorityState has additional values:
1. More straight forward to wire TransactionManager to execution driver.
2. Less boilerplate related to metrics.

Since execution driver requires an Arc<> reference to AuthorityState, AuthorityState::new() is refactored to return `Arc<AuthorityState>` instead. This removes the need for callers to wrap AuthorityState wit Arc themselves.

This change is a prerequisite for https://github.com/MystenLabs/sui/pull/6652, which uses TransactionManager for `handle_certificate_with_effects()` by default. Without running execution driver, a number of tests would fail.

An alternative approach is to launch ActiveAuthority when execution driver is needed, which is going to be almost all cases for tests and production code. The additional boilerplate seems unnecessary.