### PR TITLE
[rocksdb] prorotype wrapper for transactional and regular db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,6 +7242,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "rustc_version 0.4.0",
+ "syn 1.0.105",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10170,6 +10196,7 @@ dependencies = [
  "prometheus",
  "quote 1.0.21",
  "rocksdb",
+ "rstest",
  "serde 1.0.150",
  "syn 1.0.105",
  "tap",
@@ -11369,12 +11396,15 @@ dependencies = [
  "ripemd",
  "roaring",
  "rocksdb",
+ "rstest",
+ "rstest_macros",
  "rust-ini",
  "rust_decimal",
  "rustc-demangle",
  "rustc-hash",
  "rustc-hex",
  "rustc_version 0.3.3",
+ "rustc_version 0.4.0",
  "rusticata-macros",
  "rustix",
  "rustls",

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -333,11 +333,6 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
     let secondary_db_map_struct_name: proc_macro2::TokenStream =
         secondary_db_map_struct_name_str.parse().unwrap();
 
-    let first_field_name = field_names
-        .get(0)
-        .expect("Expected at least one field")
-        .clone();
-
     TokenStream::from(quote! {
 
         // <----------- This section generates the configurator struct -------------->
@@ -401,6 +396,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
             pub fn open_tables_impl(
                 path: std::path::PathBuf,
                 as_secondary_with_path: Option<std::path::PathBuf>,
+                is_transaction: bool,
                 global_db_options_override: Option<rocksdb::Options>,
                 tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>
             ) -> Self {
@@ -420,9 +416,10 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                     };
                     // Safe to call unwrap because we will have atleast one field_name entry in the struct
                     let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), &q.1.options)).collect();
-                    let db = match as_secondary_with_path {
-                        Some(p) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, &opt_cfs),
-                        None    => typed_store::rocks::open_cf_opts(path, global_db_options_override, &opt_cfs)
+                    let db = match (as_secondary_with_path, is_transaction) {
+                        (Some(p), _) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, &opt_cfs),
+                        (_, true) => typed_store::rocks::open_cf_opts_transactional(path, global_db_options_override, &opt_cfs),
+                        _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, &opt_cfs)
                     };
                     db
                 }.expect("Cannot open DB.");
@@ -460,7 +457,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 global_db_options_override: Option<rocksdb::Options>,
                 tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>
             ) -> Self {
-                let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, global_db_options_override, tables_db_options_override);
+                let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, false, global_db_options_override, tables_db_options_override);
                 Self {
                     #(
                         #field_names: #post_process_fn(inner.#field_names),
@@ -468,11 +465,22 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 }
             }
 
-            /// This gives info about memory usage and returns a tuple of total table memory usage and cache memory usage
-            pub fn get_memory_usage(&self) -> Result<(u64, u64), typed_store::rocks::TypedStoreError> {
-                let stats = rocksdb::perf::get_memory_usage_stats(Some(&[&self.#first_field_name.rocksdb]), None)
-                    .map_err(|e| typed_store::rocks::TypedStoreError::RocksDBError(e.to_string()))?;
-                Ok((stats.mem_table_total, stats.cache_total))
+            /// Opens a set of tables in transactional read-write mode
+            /// Only one process is allowed to do this at a time
+            /// `global_db_options_override` apply to the whole DB
+            /// `tables_db_options_override` apply to each table. If `None`, the attributes from `default_options_override_fn` are used if any
+            #[allow(unused_parens)]
+            pub fn open_tables_transactional(
+                path: std::path::PathBuf,
+                global_db_options_override: Option<rocksdb::Options>,
+                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>
+            ) -> Self {
+                let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, true, global_db_options_override, tables_db_options_override);
+                Self {
+                    #(
+                        #field_names: #post_process_fn(inner.#field_names),
+                    )*
+                }
             }
 
             /// Returns a list of the tables name and type pairs
@@ -514,12 +522,12 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 global_db_options_override: Option<rocksdb::Options>,
             ) -> Self {
                 let inner = match with_secondary_path {
-                    Some(q) => #intermediate_db_map_struct_name::open_tables_impl(primary_path, Some(q), global_db_options_override, None),
+                    Some(q) => #intermediate_db_map_struct_name::open_tables_impl(primary_path, Some(q), false, global_db_options_override, None),
                     None => {
                         let p: std::path::PathBuf = tempfile::tempdir()
                         .expect("Failed to open temporary directory")
                         .into_path();
-                        #intermediate_db_map_struct_name::open_tables_impl(primary_path, Some(p), global_db_options_override, None)
+                        #intermediate_db_map_struct_name::open_tables_impl(primary_path, Some(p), false, global_db_options_override, None)
                     }
                 };
                 Self {

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -30,5 +30,6 @@ tempfile = "3.3.0"
 once_cell = "1.13.0"
 proc-macro2 = "1.0.47"
 quote = "1.0.9"
+rstest = "0.16.0"
 syn = { version = "1.0.104", features = ["derive"] }
 typed-store-derive = {path = "../typed-store-derive"}

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -9,7 +9,6 @@
 )]
 
 use eyre::Result;
-use rocksdb::MultiThreaded;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     cmp::Eq,
@@ -26,6 +25,7 @@ pub mod traits;
 pub use traits::Map;
 pub mod metrics;
 pub mod rocks;
+use crate::rocks::RocksDB;
 pub use metrics::DBMetrics;
 
 #[cfg(test)]
@@ -55,7 +55,7 @@ pub enum StoreCommand<Key, Value> {
 #[derive(Clone)]
 pub struct Store<K, V> {
     channel: Sender<StoreCommand<K, V>>,
-    pub rocksdb: Arc<rocksdb::DBWithThreadMode<MultiThreaded>>,
+    pub rocksdb: Arc<RocksDB>,
 }
 
 impl<Key, Value> Store<Key, Value>

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -471,6 +471,7 @@ ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_ce
 ripemd = { version = "0.1", default-features = false }
 roaring = { version = "0.10", default-features = false }
 rocksdb = { version = "0.19", features = ["bzip2", "lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
+rstest = { version = "0.16", features = ["async-timeout"] }
 rust-ini = { version = "0.13", default-features = false }
 rust_decimal = { version = "1", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
@@ -1173,12 +1174,15 @@ ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_ce
 ripemd = { version = "0.1", default-features = false }
 roaring = { version = "0.10", default-features = false }
 rocksdb = { version = "0.19", features = ["bzip2", "lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
+rstest = { version = "0.16", features = ["async-timeout"] }
+rstest_macros = { version = "0.16", default-features = false, features = ["async-timeout"] }
 rust-ini = { version = "0.13", default-features = false }
 rust_decimal = { version = "1", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", features = ["std"] }
 rustc-hex = { version = "2", default-features = false, features = ["std"] }
-rustc_version = { version = "0.3", default-features = false }
+rustc_version-468e82937335b1c9 = { package = "rustc_version", version = "0.3", default-features = false }
+rustc_version-9fbad63c4bcf4a8f = { package = "rustc_version", version = "0.4", default-features = false }
 rusticata-macros = { version = "4", default-features = false }
 rustls = { version = "0.20", features = ["dangerous_configuration", "log", "logging", "quic", "tls12"] }
 rustls-native-certs = { version = "0.6", default-features = false }


### PR DESCRIPTION
**context**: in rust rocksdb binding each database is represented by a separate struct. 
And although majority of methods share the same semantic, DBWithThreadMode, OptimisticTransactionDB and TransactionDB are different structs. 
Majority of db structs in the codebase, such as DBMap, have embedded reference to DBWithThreadMode instance.

In order to enable optimistic transactions for some use cases, while reusing existing data structures(e.g. DBMap), PR introduces thin wrapper around various rocksdb structs that unifies the interface.

To recap, for now PR only introduces new unified interface for DBWithThreadMode/OptimisticTransactionDB, switches existing call sites to use new enum and adds a unit test as a reference example of transaction usage
