### PR TITLE
Fix usage of named export for CommonJS module

### DIFF
--- a/.changeset/dirty-boats-turn.md
+++ b/.changeset/dirty-boats-turn.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Fixed usage of named export for CommonJS module

--- a/sdk/typescript/src/cryptography/hash.ts
+++ b/sdk/typescript/src/cryptography/hash.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fromHEX } from '@mysten/bcs';
-import { sha3_256 } from 'js-sha3';
+import sha3 from 'js-sha3';
 
 /**
  * Generates a SHA 256 hash of typed data as a base64 string.
@@ -11,7 +11,7 @@ import { sha3_256 } from 'js-sha3';
  * @param data data to hash
  */
 export function sha256Hash(typeTag: string, data: Uint8Array): Uint8Array {
-  const hash = sha3_256.create();
+  const hash = sha3.sha3_256.create();
 
   const typeTagBytes = Array.from(`${typeTag}::`).map((e) => e.charCodeAt(0));
 


### PR DESCRIPTION
Fixed an error mentioned in [#6377](https://github.com/MystenLabs/sui/issues/6377):

```
SyntaxError: Named export 'sha3_256' not found. The requested module 'js-sha3' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'js-sha3';
const { sha3_256 } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:127:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:193:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:437:15) {
  page: '/'
}
```