### PR TITLE
wallet-ext: fix crypto mock in test setup

### DIFF
--- a/apps/wallet/testSetup.ts
+++ b/apps/wallet/testSetup.ts
@@ -3,7 +3,7 @@
 
 import { webcrypto } from 'crypto';
 
-if (!globalThis.defined) {
+if (!globalThis.crypto) {
     globalThis.crypto = webcrypto as Crypto;
 }
 


### PR DESCRIPTION
* it breaks the tests since now crypto seems to be defined

| before | after |
| --- | --- |
| <img width="873" alt="Screenshot 2022-12-09 at 17 48 27" src="https://user-images.githubusercontent.com/10210143/206762470-d706f8c6-f702-4169-9978-f4624f3b23e3.png"> | <img width="873" alt="Screenshot 2022-12-09 at 17 48 51" src="https://user-images.githubusercontent.com/10210143/206762484-38806104-0608-493e-90f4-33ca2ce1c149.png"> |
