### PR TITLE
[narwhal] add log statements to easily trace when tasks shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,6 +5260,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "serde 1.0.150",
+ "tap",
  "telemetry-subscribers",
  "tempfile",
  "thiserror",

--- a/narwhal/consensus/src/consensus.rs
+++ b/narwhal/consensus/src/consensus.rs
@@ -8,7 +8,7 @@ use crate::{metrics::ConsensusMetrics, SequenceNumber};
 use config::Committee;
 use crypto::PublicKey;
 use fastcrypto::hash::Hash;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use std::{
     cmp::{max, Ordering},
     collections::HashMap,
@@ -286,7 +286,7 @@ where
             state,
         };
 
-        spawn_monitored_task!(s.run())
+        spawn_logged_monitored_task!(s.run(), "Consensus", INFO)
     }
 
     fn change_epoch(&mut self, new_committee: Committee) -> StoreResult<ConsensusState> {

--- a/narwhal/consensus/src/dag.rs
+++ b/narwhal/consensus/src/dag.rs
@@ -5,7 +5,7 @@ use config::Committee;
 use crypto::PublicKey;
 use dag::node_dag::{NodeDag, NodeDagError};
 use fastcrypto::hash::Hash;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
@@ -352,7 +352,7 @@ impl Dag {
             metrics,
         );
 
-        let handle = spawn_monitored_task!(async move { idg.run().await });
+        let handle = spawn_logged_monitored_task!(async move { idg.run().await }, "DAGTask");
         let dag = Dag { tx_commands };
         (handle, dag)
     }

--- a/narwhal/executor/Cargo.toml
+++ b/narwhal/executor/Cargo.toml
@@ -26,6 +26,7 @@ prometheus = "0.13.3"
 backoff = { version = "0.4.0", features = ["tokio"] }
 storage = { path = "../storage", package = "narwhal-storage" }
 itertools = "0.10.5"
+tap = "1.0.1"
 
 types = { path = "../types", package = "narwhal-types" }
 network = { path = "../network", package = "narwhal-network" }

--- a/narwhal/executor/src/subscriber.rs
+++ b/narwhal/executor/src/subscriber.rs
@@ -17,7 +17,7 @@ use std::{sync::Arc, time::Duration, vec};
 
 use async_trait::async_trait;
 use fastcrypto::hash::Hash;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use rand::prelude::SliceRandom;
 use rand::rngs::ThreadRng;
 use tokio::time::Instant;
@@ -74,18 +74,24 @@ pub fn spawn_subscriber<State: ExecutionState + Send + Sync + 'static>(
     let rx_reconfigure_subscriber = tx_reconfigure.subscribe();
 
     vec![
-        spawn_monitored_task!(run_notify(state, rx_notifier, rx_reconfigure_notify)),
-        spawn_monitored_task!(create_and_run_subscriber(
-            name,
-            network,
-            worker_cache,
-            committee,
-            rx_reconfigure_subscriber,
-            rx_sequence,
-            metrics,
-            restored_consensus_output,
-            tx_notifier,
-        )),
+        spawn_logged_monitored_task!(
+            run_notify(state, rx_notifier, rx_reconfigure_notify),
+            "SubscriberNotifyTask"
+        ),
+        spawn_logged_monitored_task!(
+            create_and_run_subscriber(
+                name,
+                network,
+                worker_cache,
+                committee,
+                rx_reconfigure_subscriber,
+                rx_sequence,
+                metrics,
+                restored_consensus_output,
+                tx_notifier,
+            ),
+            "SubscriberTask"
+        ),
     ]
 }
 

--- a/narwhal/network/src/connectivity.rs
+++ b/narwhal/network/src/connectivity.rs
@@ -3,7 +3,7 @@
 
 use crate::metrics::NetworkConnectionMetrics;
 use anemo::PeerId;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
@@ -22,12 +22,15 @@ impl ConnectionMonitor {
         connection_metrics: NetworkConnectionMetrics,
         peer_id_types: HashMap<PeerId, String>,
     ) -> JoinHandle<()> {
-        spawn_monitored_task!(Self {
-            network,
-            connection_metrics,
-            peer_id_types
-        }
-        .run())
+        spawn_logged_monitored_task!(
+            Self {
+                network,
+                connection_metrics,
+                peer_id_types
+            }
+            .run(),
+            "ConnectionMonitor"
+        )
     }
 
     async fn run(self) {

--- a/narwhal/node/src/metrics.rs
+++ b/narwhal/node/src/metrics.rs
@@ -4,7 +4,7 @@ use axum::{http::StatusCode, routing::get, Extension, Router};
 use config::WorkerId;
 use crypto::PublicKey;
 use multiaddr::Multiaddr;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use mysten_network::multiaddr::to_socket_addr;
 use prometheus::{Registry, TextEncoder};
 use std::collections::HashMap;
@@ -37,12 +37,15 @@ pub fn start_prometheus_server(addr: Multiaddr, registry: &Registry) -> JoinHand
 
     let socket_addr = to_socket_addr(&addr).expect("failed to convert Multiaddr to SocketAddr");
 
-    spawn_monitored_task!(async move {
-        axum::Server::bind(&socket_addr)
-            .serve(app.into_make_service())
-            .await
-            .unwrap();
-    })
+    spawn_logged_monitored_task!(
+        async move {
+            axum::Server::bind(&socket_addr)
+                .serve(app.into_make_service())
+                .await
+                .unwrap();
+        },
+        "MetricsServerTask"
+    )
 }
 
 async fn metrics(registry: Extension<Registry>) -> (StatusCode, String) {

--- a/narwhal/primary/src/proposer.rs
+++ b/narwhal/primary/src/proposer.rs
@@ -5,7 +5,7 @@ use crate::{metrics::PrimaryMetrics, NetworkModel};
 use config::{Committee, Epoch, WorkerId};
 use crypto::{PublicKey, Signature};
 use fastcrypto::{hash::Hash as _, SignatureService};
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use std::collections::BTreeMap;
 use std::{cmp::Ordering, sync::Arc};
 use storage::ProposerStore;
@@ -118,33 +118,36 @@ impl Proposer {
         metrics: Arc<PrimaryMetrics>,
     ) -> JoinHandle<()> {
         let genesis = Certificate::genesis(&committee);
-        spawn_monitored_task!(async move {
-            Self {
-                name,
-                committee,
-                signature_service,
-                header_num_of_batches_threshold,
-                max_header_num_of_batches,
-                max_header_delay,
-                header_resend_timeout,
-                network_model,
-                rx_reconfigure,
-                rx_parents,
-                rx_our_digests,
-                tx_headers,
-                tx_narwhal_round_updates,
-                proposer_store,
-                round: 0,
-                last_parents: genesis,
-                last_leader: None,
-                digests: Vec::with_capacity(2 * max_header_num_of_batches),
-                proposed_headers: BTreeMap::new(),
-                rx_commited_own_headers,
-                metrics,
-            }
-            .run()
-            .await;
-        })
+        spawn_logged_monitored_task!(
+            async move {
+                Self {
+                    name,
+                    committee,
+                    signature_service,
+                    header_num_of_batches_threshold,
+                    max_header_num_of_batches,
+                    max_header_delay,
+                    header_resend_timeout,
+                    network_model,
+                    rx_reconfigure,
+                    rx_parents,
+                    rx_our_digests,
+                    tx_headers,
+                    tx_narwhal_round_updates,
+                    proposer_store,
+                    round: 0,
+                    last_parents: genesis,
+                    last_leader: None,
+                    digests: Vec::with_capacity(2 * max_header_num_of_batches),
+                    proposed_headers: BTreeMap::new(),
+                    rx_commited_own_headers,
+                    metrics,
+                }
+                .run()
+                .await;
+            },
+            "ProposerTask"
+        )
     }
 
     /// make_header creates a new Header, persists it to database

--- a/narwhal/primary/src/state_handler.rs
+++ b/narwhal/primary/src/state_handler.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use config::{Committee, SharedCommittee, SharedWorkerCache, WorkerCache, WorkerIndex};
 use crypto::PublicKey;
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use network::{CancelOnDropHandler, ReliableNetwork};
 use std::{collections::BTreeMap, sync::Arc};
 use tap::{TapFallible, TapOptional};
@@ -46,20 +46,23 @@ impl StateHandler {
         tx_commited_own_headers: Option<Sender<(Round, Vec<Round>)>>,
         network: anemo::Network,
     ) -> JoinHandle<()> {
-        spawn_monitored_task!(async move {
-            Self {
-                name,
-                committee,
-                worker_cache,
-                rx_committed_certificates,
-                rx_state_handler,
-                tx_reconfigure,
-                tx_commited_own_headers,
-                network,
-            }
-            .run()
-            .await;
-        })
+        spawn_logged_monitored_task!(
+            async move {
+                Self {
+                    name,
+                    committee,
+                    worker_cache,
+                    rx_committed_certificates,
+                    rx_state_handler,
+                    tx_reconfigure,
+                    tx_commited_own_headers,
+                    network,
+                }
+                .run()
+                .await;
+            },
+            "StateHandlerTask"
+        )
     }
 
     async fn handle_sequenced(&mut self, commit_round: Round, certificates: Vec<Certificate>) {

--- a/narwhal/worker/src/batch_maker.rs
+++ b/narwhal/worker/src/batch_maker.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 
 use futures::{Future, StreamExt};
 
-use mysten_metrics::spawn_monitored_task;
+use mysten_metrics::spawn_logged_monitored_task;
 use std::sync::Arc;
 use tokio::{
     sync::watch,
@@ -79,23 +79,26 @@ impl BatchMaker {
         store: Store<BatchDigest, Batch>,
         tx_digest: Sender<(WorkerOurBatchMessage, PrimaryResponse)>,
     ) -> JoinHandle<()> {
-        spawn_monitored_task!(async move {
-            Self {
-                id,
-                committee,
-                batch_size,
-                max_batch_delay,
-                rx_reconfigure,
-                rx_batch_maker,
-                tx_message,
-                batch_start_timestamp: Instant::now(),
-                node_metrics,
-                store,
-                tx_digest,
-            }
-            .run()
-            .await;
-        })
+        spawn_logged_monitored_task!(
+            async move {
+                Self {
+                    id,
+                    committee,
+                    batch_size,
+                    max_batch_delay,
+                    rx_reconfigure,
+                    rx_batch_maker,
+                    tx_message,
+                    batch_start_timestamp: Instant::now(),
+                    node_metrics,
+                    store,
+                    tx_digest,
+                }
+                .run()
+                .await;
+            },
+            "BatchMakerTask"
+        )
     }
 
     /// Main loop receiving incoming transactions and creating batches.

--- a/narwhal/worker/src/primary_connector.rs
+++ b/narwhal/worker/src/primary_connector.rs
@@ -4,7 +4,7 @@
 
 use crypto::NetworkPublicKey;
 use futures::{stream::FuturesUnordered, StreamExt};
-use mysten_metrics::{monitored_future, spawn_monitored_task};
+use mysten_metrics::{monitored_future, spawn_logged_monitored_task};
 use network::{CancelOnDropHandler, ReliableNetwork};
 use tokio::{sync::watch, task::JoinHandle};
 use types::{
@@ -37,17 +37,20 @@ impl PrimaryConnector {
         rx_others_batch: Receiver<WorkerOthersBatchMessage>,
         primary_client: anemo::Network,
     ) -> JoinHandle<()> {
-        spawn_monitored_task!(async move {
-            Self {
-                primary_name,
-                rx_reconfigure,
-                rx_our_batch,
-                rx_others_batch,
-                primary_client,
-            }
-            .run()
-            .await;
-        })
+        spawn_logged_monitored_task!(
+            async move {
+                Self {
+                    primary_name,
+                    rx_reconfigure,
+                    rx_our_batch,
+                    rx_others_batch,
+                    primary_client,
+                }
+                .run()
+                .await;
+            },
+            "PrimaryConnectorTask"
+        )
     }
 
     async fn run(&mut self) {


### PR DESCRIPTION
This PR extends the `spawn_monitored_task` macro and introduces the `spawn_logged_monitored_task` in order to provide extra capabilities to print log statements when the passed in task future starts/ends. It also introduces the ability to add names for our tasks so we can easily identify them