### PR TITLE
wallet-ext: improve nft transfer validation

### DIFF
--- a/apps/wallet/src/ui/app/hooks/index.ts
+++ b/apps/wallet/src/ui/app/hooks/index.ts
@@ -17,3 +17,4 @@ export { useObjectsState } from './useObjectsState';
 export { useWaitForElement } from './useWaitForElement';
 export { useFormatCoin, useCoinDecimals } from './useFormatCoin';
 export * from './useSigner';
+export * from './useIndividualCoinMaxBalance';

--- a/apps/wallet/src/ui/app/hooks/useIndividualCoinMaxBalance.ts
+++ b/apps/wallet/src/ui/app/hooks/useIndividualCoinMaxBalance.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import useAppSelector from './useAppSelector';
+import { accountItemizedBalancesSelector } from '_redux/slices/account';
+
+export function useIndividualCoinMaxBalance(coinTypeArg: string) {
+    const allCoins = useAppSelector(accountItemizedBalancesSelector);
+    const maxGasCoinBalance = useMemo(
+        () =>
+            allCoins[coinTypeArg]?.reduce(
+                (max, aBalance) => (max < aBalance ? aBalance : max),
+                BigInt(0)
+            ) || BigInt(0),
+        [allCoins, coinTypeArg]
+    );
+    return maxGasCoinBalance;
+}

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.module.scss
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/TransferNFTForm.module.scss
@@ -49,10 +49,6 @@
     }
 }
 
-.error {
-    @include utils.error-message-box;
-}
-
 .muted {
     font-size: 12px;
     font-weight: 400;

--- a/apps/wallet/src/ui/app/pages/home/nft-transfer/index.tsx
+++ b/apps/wallet/src/ui/app/pages/home/nft-transfer/index.tsx
@@ -15,6 +15,7 @@ import NFTDisplayCard from '_components/nft-display';
 import { useAppSelector, useAppDispatch, useObjectsState } from '_hooks';
 import { createAccountNftByIdSelector } from '_redux/slices/account';
 import { transferNFT } from '_redux/slices/sui-objects';
+import { DEFAULT_NFT_TRANSFER_GAS_FEE } from '_redux/slices/sui-objects/Coin';
 
 import type { SerializedError } from '@reduxjs/toolkit';
 import type { FormikHelpers } from 'formik';
@@ -55,8 +56,9 @@ function NftTransferPage() {
             try {
                 const resp = await dispatch(
                     transferNFT({
-                        recipientAddress: to,
-                        nftId: objectId,
+                        recipient: to,
+                        objectId,
+                        gasBudget: DEFAULT_NFT_TRANSFER_GAS_FEE,
                     })
                 ).unwrap();
                 resetForm();
@@ -105,8 +107,8 @@ function NftTransferPage() {
                                 onSubmit={onHandleSubmit}
                             >
                                 <TransferNFTForm
-                                    nftID={objectId}
                                     submitError={sendError}
+                                    gasBudget={DEFAULT_NFT_TRANSFER_GAS_FEE}
                                     onClearSubmitError={
                                         handleOnClearSubmitError
                                     }

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/index.ts
@@ -16,10 +16,7 @@ import {
     createSlice,
 } from '@reduxjs/toolkit';
 
-import {
-    DEFAULT_NFT_TRANSFER_GAS_FEE,
-    SUI_SYSTEM_STATE_OBJECT_ID,
-} from './Coin';
+import { SUI_SYSTEM_STATE_OBJECT_ID } from './Coin';
 import { ExampleNFT } from './NFT';
 
 import type { SuiObject, SuiAddress, ObjectId } from '@mysten/sui.js';
@@ -108,15 +105,11 @@ type NFTTxResponse = {
 
 export const transferNFT = createAsyncThunk<
     NFTTxResponse,
-    { nftId: ObjectId; recipientAddress: SuiAddress },
+    { objectId: ObjectId; recipient: SuiAddress; gasBudget: number },
     AppThunkConfig
 >('transferNFT', async (data, { extra: { api, keypairVault }, dispatch }) => {
     const signer = api.getSignerInstance(keypairVault.getKeypair());
-    const txn = await signer.transferObject({
-        objectId: data.nftId,
-        recipient: data.recipientAddress,
-        gasBudget: DEFAULT_NFT_TRANSFER_GAS_FEE,
-    });
+    const txn = await signer.transferObject(data);
     await dispatch(fetchAllOwnedAndRequiredObjects());
     const txnResp = {
         timestamp_ms: getTimestampFromTransactionResponse(txn),


### PR DESCRIPTION
* because only one coin is used for gas we check that gas budget is not more than the maximum balance of any of all the individual coin objects
* use Alert component for errors