### PR TITLE
[ts-sdk, wallet-ext]: fix pay tx edge cases

### DIFF
--- a/.changeset/brown-bears-count.md
+++ b/.changeset/brown-bears-count.md
@@ -1,0 +1,7 @@
+---
+"@mysten/sui.js": minor
+---
+
+- removes `transfer` function from framework Coin
+- renames `newTransferTx` function from framework Coin to `newPayTransaction`. Also it's now a public method and without the need of signer so a dapp can use it
+- fixes edge cases with pay txs

--- a/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
+++ b/apps/wallet/src/ui/app/redux/slices/sui-objects/Coin.ts
@@ -117,13 +117,14 @@ export class Coin {
             return coinWithExactAmount;
         }
         // use transferSui API to get a coin with the exact amount
-        await CoinAPI.transfer(
-            signer,
-            coins,
-            SUI_TYPE_ARG,
-            amount,
-            await signer.getAddress(),
-            Coin.computeGasBudgetForPay(coins, amount)
+        await signer.signAndExecuteTransaction(
+            await CoinAPI.newPayTransaction(
+                coins,
+                SUI_TYPE_ARG,
+                amount,
+                await signer.getAddress(),
+                Coin.computeGasBudgetForPay(coins, amount)
+            )
         );
 
         const coinWithExactAmount2 = await Coin.selectSuiCoinWithExactAmount(

--- a/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transactions/index.ts
@@ -47,17 +47,18 @@ export const sendTokens = createAsyncThunk<
         const state = getState();
         const coins: SuiMoveObject[] = accountCoinsSelector(state);
         const signer = api.getSignerInstance(keypairVault.getKeypair());
-        const response = await CoinAPI.transfer(
-            signer,
-            coins,
-            tokenTypeArg,
-            amount,
-            recipientAddress,
-            Coin.computeGasBudgetForPay(
-                coins.filter(
-                    (aCoin) => Coin.getCoinTypeArg(aCoin) === tokenTypeArg
-                ),
-                amount
+        const response = await signer.signAndExecuteTransaction(
+            await CoinAPI.newPayTransaction(
+                coins,
+                tokenTypeArg,
+                amount,
+                recipientAddress,
+                Coin.computeGasBudgetForPay(
+                    coins.filter(
+                        (aCoin) => Coin.getCoinTypeArg(aCoin) === tokenTypeArg
+                    ),
+                    amount
+                )
             )
         );
         // TODO: better way to sync latest objects

--- a/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/txn-data-serializer.ts
@@ -45,7 +45,7 @@ export interface PayTransaction {
 /// 2. accumulate all residual SUI from input coins left and deposit all SUI to the first
 /// input coin, then use the first input coin as the gas coin object.
 /// 3. the balance of the first input coin after tx is sum(input_coins) - sum(amounts) - actual_gas_cost
-/// 4. all other input coints other than the first one are deleted.
+/// 4. all other input coins other than the first one are deleted.
 export interface PaySuiTransaction {
   /**
    * use `provider.selectCoinSetWithCombinedBalanceGreaterThanOrEqual` to

--- a/sdk/typescript/src/types/framework.ts
+++ b/sdk/typescript/src/types/framework.ts
@@ -17,7 +17,7 @@ import { normalizeSuiObjectId, SuiAddress } from './common';
 import { getOption, Option } from './option';
 import { StructTag } from './sui-bcs';
 import { isSuiMoveObject } from './index.guard';
-import { SignerWithProvider } from '../signers/signer-with-provider';
+import { UnserializedSignableTransaction } from '../signers/txn-data-serializers/txn-data-serializer';
 
 export const SUI_FRAMEWORK_ADDRESS = '0x2';
 export const MOVE_STDLIB_ADDRESS = '0x1';
@@ -212,64 +212,55 @@ export class Coin {
   }
 
   /**
-   * Creates and executes a transaction to transfer coins to a recipient address.
-   * @param signer User's signer
-   * @param allCoins All the coins that are owned by the user. Can be only the relevant type of coins for the transfer, Sui for gas and the coins with the same type as the type to send.
-   * @param coinTypeArg The coin type argument (Coin<T> the T) of the coin to send
-   * @param amountToSend Total amount to send to recipient
-   * @param recipient Recipient's address
-   * @param gasBudget Gas budget for the tx
-   * @throws in case of insufficient funds, network errors etc
-   */
-  public static async transfer(
-    signer: SignerWithProvider,
-    allCoins: SuiMoveObject[],
-    coinTypeArg: string,
-    amountToSend: bigint,
-    recipient: SuiAddress,
-    gasBudget: number
-  ) {
-    const tx = await Coin.newTransferTx(
-      signer,
-      allCoins,
-      coinTypeArg,
-      amountToSend,
-      recipient,
-      gasBudget
-    );
-    return signer.signAndExecuteTransaction(tx);
-  }
-
-  /**
    * Create a new transaction for sending coins ready to be signed and executed.
-   * @param signer User's signer
-   * @param allCoins All the coins that are owned by the user. Can be only the relevant type of coins for the transfer, Sui for gas and the coins with the same type as the type to send.
+   * @param allCoins All the coins that are owned by the sender. Can be only the relevant type of coins for the transfer, Sui for gas and the coins with the same type as the type to send.
    * @param coinTypeArg The coin type argument (Coin<T> the T) of the coin to send
    * @param amountToSend Total amount to send to recipient
    * @param recipient Recipient's address
    * @param gasBudget Gas budget for the tx
-   * @throws in case of insufficient funds, network errors etc
+   * @throws in case of insufficient funds
    */
-  private static async newTransferTx(
-    signer: SignerWithProvider,
+  public static async newPayTransaction(
     allCoins: SuiMoveObject[],
     coinTypeArg: string,
     amountToSend: bigint,
     recipient: SuiAddress,
     gasBudget: number
-  ) {
+  ): Promise<UnserializedSignableTransaction> {
     const isSuiTransfer = coinTypeArg === SUI_TYPE_ARG;
     const coinsOfTransferType = allCoins.filter(
       (aCoin) => Coin.getCoinTypeArg(aCoin) === coinTypeArg
     );
-    const totalAmountIncludingGas =
-      amountToSend + BigInt(isSuiTransfer ? gasBudget : 0);
-    const inputCoinObjs =
-      await Coin.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
-        coinsOfTransferType,
-        totalAmountIncludingGas
+    const coinsOfGas = isSuiTransfer
+      ? coinsOfTransferType
+      : allCoins.filter((aCoin) => Coin.isSUI(aCoin));
+    const gasCoin = Coin.selectCoinWithBalanceGreaterThanOrEqual(
+      coinsOfGas,
+      BigInt(gasBudget)
+    );
+    if (!gasCoin) {
+      // TODO: denomination for gasBudget?
+      throw new Error(
+        `Unable to find a coin to cover the gas budget ${gasBudget}`
       );
-    if (!inputCoinObjs.length) {
+    }
+    const totalAmountIncludingGas =
+      amountToSend +
+      BigInt(
+        isSuiTransfer
+          ? // subtract from the total the balance of the gasCoin as it's going be the first element of the inputCoins
+            BigInt(gasBudget) - BigInt(Coin.getBalance(gasCoin) || 0)
+          : 0
+      );
+    const inputCoinObjs =
+      totalAmountIncludingGas > 0
+        ? await Coin.selectCoinSetWithCombinedBalanceGreaterThanOrEqual(
+            coinsOfTransferType,
+            totalAmountIncludingGas,
+            isSuiTransfer ? [Coin.getID(gasCoin)] : []
+          )
+        : [];
+    if (totalAmountIncludingGas > 0 && !inputCoinObjs.length) {
       const totalBalanceOfTransferType = Coin.totalBalance(coinsOfTransferType);
       const suggestedAmountToSend =
         totalBalanceOfTransferType - BigInt(isSuiTransfer ? gasBudget : 0);
@@ -279,40 +270,19 @@ export class Coin {
           `${amountToSend}. Try reducing the transfer amount to ${suggestedAmountToSend}.`
       );
     }
-    if (!isSuiTransfer) {
-      const allGasCoins = allCoins.filter((aCoin) => Coin.isSUI(aCoin));
-      const gasCoin = Coin.selectCoinWithBalanceGreaterThanOrEqual(
-        allGasCoins,
-        BigInt(gasBudget)
-      );
-      if (!gasCoin) {
-        // TODO: denomination for gasBudget?
-        throw new Error(
-          `Unable to find a coin to cover the gas budget ${gasBudget}`
-        );
-      }
-    }
-    const signerAddress = await signer.getAddress();
-    const inputCoins = inputCoinObjs.map(Coin.getID);
-    const txCommon = {
-      inputCoins,
-      recipients: [recipient],
-      // TODO: change this to string to avoid losing precision
-      amounts: [Number(amountToSend)],
-      gasBudget: Number(gasBudget),
-    };
     if (isSuiTransfer) {
-      return signer.serializer.serializeToBytes(signerAddress, {
-        kind: 'paySui',
-        data: { ...txCommon },
-      });
+      inputCoinObjs.unshift(gasCoin);
     }
-    return signer.serializer.serializeToBytes(signerAddress, {
-      kind: 'pay',
-      data: { ...txCommon },
-      // we know there is a gas coin with enough balance to cover
-      // the gas budget let rpc select one for us
-    });
+    return {
+      kind: isSuiTransfer ? 'paySui' : 'pay',
+      data: {
+        inputCoins: inputCoinObjs.map(Coin.getID),
+        recipients: [recipient],
+        // TODO: change this to string to avoid losing precision
+        amounts: [Number(amountToSend)],
+        gasBudget: Number(gasBudget),
+      },
+    };
   }
 }
 


### PR DESCRIPTION
* take into account when creating a pay transaction that only one single coin (and for the case of paySui only the first of the inputCoins) is used for gas
* make transfer tx creation from framework coin public so it can be used from dapps