### PR TITLE
[TypeScript SDK] Remove the usage of cross-fetch

### DIFF
--- a/.changeset/pretty-trees-rhyme.md
+++ b/.changeset/pretty-trees-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": patch
+---
+
+Remove the usage of cross-fetch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7770,7 +7770,7 @@ packages:
   /axios/0.21.4_debug@4.3.2:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -7778,7 +7778,7 @@ packages:
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -7786,7 +7786,7 @@ packages:
   /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.2
+      follow-redirects: 1.15.1
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -11505,7 +11505,7 @@ packages:
     engines: {node: '>=8.9.0'}
     dev: true
 
-  /follow-redirects/1.15.1_debug@4.3.2:
+  /follow-redirects/1.15.1:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -11513,8 +11513,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dependencies:
-      debug: 4.3.2
     dev: true
 
   /for-each/0.3.3:

--- a/sdk/typescript/src/rpc/client.ts
+++ b/sdk/typescript/src/rpc/client.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import RpcClient from 'jayson/lib/client/browser/index.js';
-import fetch from 'cross-fetch';
 import { isErrorResponse, isValidResponse } from './client.guard';
 import * as LosslessJSON from 'lossless-json';
 

--- a/sdk/typescript/src/rpc/faucet-client.ts
+++ b/sdk/typescript/src/rpc/faucet-client.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import fetch from 'cross-fetch';
-
 import { FaucetResponse, SuiAddress } from '../types';
 import { HttpHeaders } from './client';
 


### PR DESCRIPTION
The usage of `cross-fetch` is causing some [errors](https://github.com/MystenLabs/sui/issues/6377) in NextJS@13. Since node 18 has `fetch` built-in, we would recommend polyfilling fetch for clients that is running on < node 18.

Closes https://github.com/MystenLabs/sui/issues/6377

## Testing

Verified that the error in https://github.com/MystenLabs/sui/issues/6377 no longer repro after removing the usage of `cross-fetch`. 