### PR TITLE
chore: adding sui-indexer to sui-tools container

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -42,6 +42,7 @@ RUN cargo build --release \
     --bin sui \
     --bin sui-faucet \
     --bin stress \
+    --bin sui-indexer \
     --bin sui-cluster-test
 
 # Production Image
@@ -51,6 +52,7 @@ COPY --from=builder /sui/target/release/sui-node /usr/local/bin
 COPY --from=builder /sui/target/release/sui /usr/local/bin
 COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin
 COPY --from=builder /sui/target/release/stress /usr/local/bin
+COPY --from=builder /sui/target/release/sui-indexer /usr/local/bin
 COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin
 
 ARG BUILD_DATE


### PR DESCRIPTION
Adding sui-indexer binary to the sui-tools container.
This will be used for running sui-indexer during development for now.
