### PR TITLE
[wallet-ext] Update to use comment tag

### DIFF
--- a/.github/workflows/changesets-ci-comment.yml
+++ b/.github/workflows/changesets-ci-comment.yml
@@ -50,7 +50,7 @@ jobs:
         if: steps.get-artifact.outputs.result == 'true' && steps.source-run-info.outputs.pullRequestNumber
         with:
           pr_number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
-          comment_includes: "⚠️ 🦋 **Changesets Warning:**"
+          comment_tag: "changesets-warning"
           message: |
             ⚠️ 🦋 **Changesets Warning:** This PR has changes to public npm packages, but does not contain a changeset. You can create a changeset easily by running `pnpm changeset`, and following the prompts. If your change does not need a changeset (e.g. a documentation-only change), you can ignore this message. This warning will be removed when a changeset is added to this pull request.
 

--- a/.github/workflows/wallet-ext-comment.yml
+++ b/.github/workflows/wallet-ext-comment.yml
@@ -49,7 +49,7 @@ jobs:
         if: steps.get-artifact.outputs.result != ''
         with:
           pr_number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
-          comment_includes: "💳 Wallet Extension"
+          comment_tag: "wallet-extension"
           message: |
             💳 Wallet Extension has been built, you can download the packaged extension here: ${{steps.get-artifact.outputs.result}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The github action had a breaking change, so this updates to use the new comment tag mechanism.