### PR TITLE
[indexer] connection pool based on r2d2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "diesel_derives",
  "itoa",
  "pq-sys",
+ "r2d2",
  "serde_json",
 ]
 
@@ -6901,6 +6902,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot 0.12.1",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7514,6 +7526,15 @@ checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static 1.4.0",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
+dependencies = [
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -11470,6 +11491,7 @@ dependencies = [
  "quinn-udp",
  "quote 0.6.13",
  "quote 1.0.21",
+ "r2d2",
  "radium 0.5.3",
  "radium 0.6.2",
  "radix_trie",
@@ -11521,6 +11543,7 @@ dependencies = [
  "ryu",
  "same-file",
  "schannel",
+ "scheduled-thread-pool",
  "schemars",
  "schemars_derive",
  "scopeguard",

--- a/crates/sui-indexer/Cargo.toml
+++ b/crates/sui-indexer/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.23", features = [
   "serde",
 ] }
 clap = { version = "3.2.17", features = ["derive"] }
-diesel = { version = "2.0.0", features = ["chrono", "postgres", "serde_json"] }
+diesel = { version = "2.0.0", features = ["chrono", "postgres", "r2d2", "serde_json"] }
 futures = "0.3.23"
 jsonrpsee = { git="https://github.com/patrickkuo/jsonrpsee.git", rev= "adc19a124ed7045744442ca67f084ddfba4ba177", features = ["full"] }
 serde = { version = "1.0.144", features = ["derive"] }

--- a/crates/sui-indexer/src/errors.rs
+++ b/crates/sui-indexer/src/errors.rs
@@ -5,44 +5,56 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum IndexerError {
-    #[error("Indexer cannot read fullnode with error: `{0}`")]
-    FullNodeReadingError(String),
-
-    #[error("Indexer cannot read PostgresDB with error: `{0}`")]
-    PostgresReadError(String),
-
-    #[error("Indexer failed commiting changes to PostgresDB with error: `{0}`")]
-    PostgresWriteError(String),
-
-    #[error("Indexer failed converting to diesel Insertable with error: `{0}`")]
-    InsertableParsingError(String),
-
     #[error("Indexer failed to convert timestamp to NaiveDateTime with error: `{0}`")]
     DateTimeParsingError(String),
 
-    #[error("Indexer failed to parse transaction digest read from DB: `{0}`")]
-    TransactionDigestParsingError(String),
+    #[error("Indexer failed to deserialize event from events table with error: `{0}`")]
+    EventDeserializationError(String),
+
+    #[error("Indexer failed to read fullnode with error: `{0}`")]
+    FullNodeReadingError(String),
+
+    #[error("Indexer failed to convert structs to diesel Insertable with error: `{0}`")]
+    InsertableParsingError(String),
 
     #[error("Indexer failed to find object mutations, which should never happen.")]
     ObjectMutationNotAvailable,
 
-    #[error("Indexer failed to deserialize event from events table: `{0}`")]
-    EventDeserializationError(String),
+    #[error("Indexer failed to build PG connection pool with error: `{0}`")]
+    PgConnectionPoolInitError(String),
+
+    #[error("Indexer failed to get a pool connection from PG connection pool with error: `{0}`")]
+    PgPoolConnectionError(String),
+
+    #[error("Indexer failed to read PostgresDB with error: `{0}`")]
+    PostgresReadError(String),
+
+    #[error("Indexer failed to commit changes to PostgresDB with error: `{0}`")]
+    PostgresWriteError(String),
+
+    #[error("Indexer failed to initialize fullnode RPC client with error: `{0}`")]
+    RpcClientInitError(String),
+
+    #[error("Indexer failed to parse transaction digest read from DB with error: `{0}`")]
+    TransactionDigestParsingError(String),
 }
 
 impl IndexerError {
     pub fn name(&self) -> String {
         match self {
-            IndexerError::FullNodeReadingError(_) => "FullNodeReadingError".to_string(),
-            IndexerError::PostgresReadError(_) => "PostgresReadError".to_string(),
-            IndexerError::PostgresWriteError(_) => "PostgresWriteError".to_string(),
-            IndexerError::InsertableParsingError(_) => "InsertableParsingError".to_string(),
-            IndexerError::DateTimeParsingError(_) => "DateTimeParsingError".to_string(),
+            IndexerError::FullNodeReadingError(_) => "FullNodeReadingError".into(),
+            IndexerError::PostgresReadError(_) => "PostgresReadError".into(),
+            IndexerError::PostgresWriteError(_) => "PostgresWriteError".into(),
+            IndexerError::InsertableParsingError(_) => "InsertableParsingError".into(),
+            IndexerError::DateTimeParsingError(_) => "DateTimeParsingError".into(),
             IndexerError::TransactionDigestParsingError(_) => {
-                "TransactionDigestParsingError".to_string()
+                "TransactionDigestParsingError".into()
             }
-            IndexerError::ObjectMutationNotAvailable => "ObjectMutationNotAvailable".to_string(),
-            IndexerError::EventDeserializationError(_) => "EventDeserializationError".to_string(),
+            IndexerError::ObjectMutationNotAvailable => "ObjectMutationNotAvailable".into(),
+            IndexerError::EventDeserializationError(_) => "EventDeserializationError".into(),
+            IndexerError::PgConnectionPoolInitError(_) => "PgConnectionPoolInitError".into(),
+            IndexerError::RpcClientInitError(_) => "RpcClientInitError".into(),
+            IndexerError::PgPoolConnectionError(_) => "PgPoolConnectionError".into(),
         }
     }
 }

--- a/crates/sui-indexer/src/handlers/event_handler.rs
+++ b/crates/sui-indexer/src/handlers/event_handler.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use std::time::Duration;
 use sui_json_rpc_types::EventPage;
 use sui_sdk::SuiClient;
@@ -10,27 +11,31 @@ use tokio::time::sleep;
 use tracing::info;
 
 use sui_indexer::errors::IndexerError;
-use sui_indexer::establish_connection;
 use sui_indexer::models::event_logs::{commit_event_log, read_event_log};
 use sui_indexer::models::events::commit_events;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 
 const EVENT_PAGE_SIZE: usize = 100;
 
 pub struct EventHandler {
     rpc_client: SuiClient,
-    db_url: String,
+    pg_connection_pool: Arc<PgConnectionPool>,
 }
 
 impl EventHandler {
-    pub fn new(rpc_client: SuiClient, db_url: String) -> Self {
-        Self { rpc_client, db_url }
+    pub fn new(rpc_client: SuiClient, pg_connection_pool: Arc<PgConnectionPool>) -> Self {
+        Self {
+            rpc_client,
+            pg_connection_pool,
+        }
     }
 
     pub async fn start(&self) -> Result<(), IndexerError> {
         info!("Indexer event handler started...");
-        let mut pg_conn = establish_connection(self.db_url.clone());
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
         let mut next_cursor = None;
-        let event_log = read_event_log(&mut pg_conn)?;
+        let event_log = read_event_log(&mut pg_pool_conn)?;
         let (tx_seq_opt, event_seq_opt) = (
             event_log.next_cursor_tx_seq,
             event_log.next_cursor_event_seq,
@@ -42,9 +47,9 @@ impl EventHandler {
         loop {
             let event_page = fetch_event_page(self.rpc_client.clone(), next_cursor).await?;
             let event_count = event_page.data.len();
-            commit_events(&mut pg_conn, event_page.clone())?;
+            commit_events(&mut pg_pool_conn, event_page.clone())?;
             commit_event_log(
-                &mut pg_conn,
+                &mut pg_pool_conn,
                 event_page.next_cursor.clone().map(|c| c.tx_seq),
                 event_page.next_cursor.clone().map(|c| c.event_seq),
             )?;

--- a/crates/sui-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-indexer/src/handlers/transaction_handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::future::join_all;
+use std::sync::Arc;
 use std::time::Duration;
 use sui_json_rpc_types::{SuiTransactionResponse, TransactionsPage};
 use sui_sdk::SuiClient;
@@ -11,10 +12,10 @@ use tokio::time::sleep;
 use tracing::info;
 
 use sui_indexer::errors::IndexerError;
-use sui_indexer::establish_connection;
 use sui_indexer::models::transaction_logs::{commit_transction_log, read_transaction_log};
 use sui_indexer::models::transactions::commit_transactions;
 use sui_indexer::utils::log_errors_to_pg;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 
 use fastcrypto::encoding::{Base64, Encoding};
 
@@ -22,19 +23,23 @@ const TRANSACTION_PAGE_SIZE: usize = 100;
 
 pub struct TransactionHandler {
     rpc_client: SuiClient,
-    db_url: String,
+    pg_connection_pool: Arc<PgConnectionPool>,
 }
 
 impl TransactionHandler {
-    pub fn new(rpc_client: SuiClient, db_url: String) -> Self {
-        Self { rpc_client, db_url }
+    pub fn new(rpc_client: SuiClient, pg_connection_pool: Arc<PgConnectionPool>) -> Self {
+        Self {
+            rpc_client,
+            pg_connection_pool,
+        }
     }
 
     pub async fn start(&self) -> Result<(), IndexerError> {
         info!("Indexer transaction handler started...");
-        let mut pg_conn = establish_connection(self.db_url.clone());
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
         let mut next_cursor = None;
-        let txn_log = read_transaction_log(&mut pg_conn)?;
+        let txn_log = read_transaction_log(&mut pg_pool_conn)?;
         if let Some(txn_digest) = txn_log.next_cursor_tx_digest {
             let bytes = Base64::decode(txn_digest.as_str()).map_err(|e| {
                 IndexerError::TransactionDigestParsingError(format!(
@@ -68,10 +73,10 @@ impl TransactionHandler {
                 .filter_map(|f| f.map_err(|e| errors.push(e)).ok())
                 .collect();
 
-            log_errors_to_pg(&mut pg_conn, errors);
-            commit_transactions(&mut pg_conn, resp_vec)?;
+            log_errors_to_pg(&mut pg_pool_conn, errors);
+            commit_transactions(&mut pg_pool_conn, resp_vec)?;
             // canonical txn digest is Base64 encoded
-            commit_transction_log(&mut pg_conn, page.next_cursor.map(|d| d.encode()))?;
+            commit_transction_log(&mut pg_pool_conn, page.next_cursor.map(|d| d.encode()))?;
             next_cursor = page.next_cursor;
             if txn_count < TRANSACTION_PAGE_SIZE {
                 sleep(Duration::from_secs_f32(0.1)).await;

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -1,14 +1,65 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+use sui_sdk::SuiClient;
+
+use backoff::retry;
+use backoff::ExponentialBackoff;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
+use tracing::info;
 
 pub mod errors;
 pub mod models;
 pub mod schema;
 pub mod utils;
 
+pub type PgConnectionPool = Pool<ConnectionManager<PgConnection>>;
+pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
+
+use errors::IndexerError;
+
+pub async fn new_rpc_client(http_url: String) -> Result<SuiClient, IndexerError> {
+    info!("Getting new rpc client...");
+    SuiClient::new(http_url.as_str(), None, None)
+        .await
+        .map_err(|e| {
+            IndexerError::RpcClientInitError(format!(
+                "Failed to initialize fullnode RPC client with error: {:?}",
+                e
+            ))
+        })
+}
+
 pub fn establish_connection(db_url: String) -> PgConnection {
     PgConnection::establish(&db_url).unwrap_or_else(|_| panic!("Error connecting to {}", db_url))
+}
+
+pub async fn new_pg_connection_pool(db_url: String) -> Result<Arc<PgConnectionPool>, IndexerError> {
+    let manager = ConnectionManager::<PgConnection>::new(db_url);
+    // default connection pool max size is 10
+    let pool = Pool::builder().build(manager).map_err(|e| {
+        IndexerError::PgConnectionPoolInitError(format!(
+            "Failed to initialize connection pool with error: {:?}",
+            e
+        ))
+    })?;
+    Ok(Arc::new(pool))
+}
+
+pub fn get_pg_pool_connection(
+    pool: Arc<PgConnectionPool>,
+) -> Result<PgPoolConnection, IndexerError> {
+    retry(ExponentialBackoff::default(), || {
+        let pool_conn = pool.get()?;
+        Ok(pool_conn)
+    })
+    .map_err(|e| {
+        IndexerError::PgPoolConnectionError(format!(
+            "Failed to get pool connection from PG connection pool with error: {:?}",
+            e
+        ))
+    })
 }

--- a/crates/sui-indexer/src/models/address_logs.rs
+++ b/crates/sui-indexer/src/models/address_logs.rs
@@ -4,7 +4,9 @@
 use crate::errors::IndexerError;
 use crate::schema::address_logs;
 use crate::schema::address_logs::dsl::*;
+use crate::PgPoolConnection;
 use diesel::prelude::*;
+use diesel::result::Error;
 
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(last_processed_id))]
@@ -12,26 +14,34 @@ pub struct AddressLog {
     pub last_processed_id: i64,
 }
 
-pub fn read_address_log(conn: &mut PgConnection) -> Result<AddressLog, IndexerError> {
-    address_logs
-        .limit(1)
-        .first::<AddressLog>(conn)
-        .map_err(|e| {
-            IndexerError::PostgresReadError(format!(
-                "Failed reading address log with error: {:?}",
-                e
-            ))
-        })
+pub fn read_address_log(pg_pool_conn: &mut PgPoolConnection) -> Result<AddressLog, IndexerError> {
+    let addr_log_read_result: Result<AddressLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| address_logs.limit(1).first::<AddressLog>(conn));
+
+    addr_log_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!("Failed reading address log with error: {:?}", e))
+    })
 }
 
-pub fn commit_address_log(conn: &mut PgConnection, id: i64) -> Result<usize, IndexerError> {
-    diesel::update(address_logs::table)
-        .set(last_processed_id.eq(id))
-        .execute(conn)
-        .map_err(|e| {
-            IndexerError::PostgresWriteError(format!(
-                "Failed to commit address log with id: {:?} and error: {:?}",
-                id, e
-            ))
-        })
+pub fn commit_address_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    id: i64,
+) -> Result<usize, IndexerError> {
+    let addr_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(address_logs::table)
+                .set(last_processed_id.eq(id))
+                .execute(conn)
+        });
+
+    addr_log_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed to commit address log with id: {:?} and error: {:?}",
+            id, e
+        ))
+    })
 }

--- a/crates/sui-indexer/src/models/object_logs.rs
+++ b/crates/sui-indexer/src/models/object_logs.rs
@@ -4,7 +4,10 @@
 use crate::errors::IndexerError;
 use crate::schema::object_logs;
 use crate::schema::object_logs::dsl::*;
+use crate::PgPoolConnection;
+
 use diesel::prelude::*;
+use diesel::result::Error;
 
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(last_processed_id))]
@@ -12,20 +15,35 @@ pub struct ObjectLog {
     pub last_processed_id: i64,
 }
 
-pub fn read_object_log(conn: &mut PgConnection) -> Result<ObjectLog, IndexerError> {
-    object_logs.limit(1).first::<ObjectLog>(conn).map_err(|e| {
+pub fn read_object_log(pg_pool_conn: &mut PgPoolConnection) -> Result<ObjectLog, IndexerError> {
+    // NOTE: always read one row, as object logs only have one row
+    let obj_log_read_result: Result<ObjectLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| object_logs.limit(1).first::<ObjectLog>(conn));
+
+    obj_log_read_result.map_err(|e| {
         IndexerError::PostgresReadError(format!("Failed reading object log with error {:?}", e))
     })
 }
 
-pub fn commit_object_log(conn: &mut PgConnection, id: i64) -> Result<usize, IndexerError> {
-    diesel::update(object_logs::table)
-        .set(last_processed_id.eq(id))
-        .execute(conn)
-        .map_err(|e| {
-            IndexerError::PostgresWriteError(format!(
-                "Failed to commit object log with id: {:?} and error: {:?}",
-                id, e
-            ))
-        })
+pub fn commit_object_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    id: i64,
+) -> Result<usize, IndexerError> {
+    let event_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(object_logs::table)
+                .set(last_processed_id.eq(id))
+                .execute(conn)
+        });
+
+    event_log_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed to commit object log with id: {:?} and error: {:?}",
+            id, e
+        ))
+    })
 }

--- a/crates/sui-indexer/src/models/package_logs.rs
+++ b/crates/sui-indexer/src/models/package_logs.rs
@@ -4,7 +4,9 @@
 use crate::errors::IndexerError;
 use crate::schema::package_logs;
 use crate::schema::package_logs::dsl::*;
+use crate::PgPoolConnection;
 use diesel::prelude::*;
+use diesel::result::Error;
 
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(last_processed_id))]
@@ -12,26 +14,34 @@ pub struct PackageLog {
     pub last_processed_id: i64,
 }
 
-pub fn read_package_log(conn: &mut PgConnection) -> Result<PackageLog, IndexerError> {
-    package_logs
-        .limit(1)
-        .first::<PackageLog>(conn)
-        .map_err(|e| {
-            IndexerError::PostgresReadError(format!(
-                "Failed reading package log with error {:?}",
-                e
-            ))
-        })
+pub fn read_package_log(pg_pool_conn: &mut PgPoolConnection) -> Result<PackageLog, IndexerError> {
+    let pkg_log_read_result: Result<PackageLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| package_logs.limit(1).first::<PackageLog>(conn));
+
+    pkg_log_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!("Failed reading package log with error {:?}", e))
+    })
 }
 
-pub fn commit_package_log(conn: &mut PgConnection, id: i64) -> Result<usize, IndexerError> {
-    diesel::update(package_logs::table)
-        .set(last_processed_id.eq(id))
-        .execute(conn)
-        .map_err(|e| {
-            IndexerError::PostgresWriteError(format!(
-                "Failed to commit package log with id {:?} and error {:?}",
-                id, e
-            ))
-        })
+pub fn commit_package_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    id: i64,
+) -> Result<usize, IndexerError> {
+    let pkg_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(package_logs::table)
+                .set(last_processed_id.eq(id))
+                .execute(conn)
+        });
+
+    pkg_log_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed to commit package log with id {:?} and error {:?}",
+            id, e
+        ))
+    })
 }

--- a/crates/sui-indexer/src/models/transaction_logs.rs
+++ b/crates/sui-indexer/src/models/transaction_logs.rs
@@ -4,7 +4,10 @@
 use crate::errors::IndexerError;
 use crate::schema::transaction_logs;
 use crate::schema::transaction_logs::dsl::*;
+use crate::PgPoolConnection;
+
 use diesel::prelude::*;
+use diesel::result::Error;
 
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(primary_key(id))]
@@ -13,29 +16,40 @@ pub struct TransactionLog {
     pub next_cursor_tx_digest: Option<String>,
 }
 
-pub fn commit_transction_log(
-    conn: &mut PgConnection,
-    txn_digest: Option<String>,
-) -> Result<usize, IndexerError> {
-    diesel::update(transaction_logs::table)
-        .set(next_cursor_tx_digest.eq(txn_digest.clone()))
-        .execute(conn)
-        .map_err(|e| {
-            IndexerError::PostgresWriteError(format!(
-                "Failed updating transaction log in PostgresDB with tx digest {:?} and error {:?}",
-                txn_digest, e
-            ))
-        })
+pub fn read_transaction_log(
+    pg_pool_conn: &mut PgPoolConnection,
+) -> Result<TransactionLog, IndexerError> {
+    // NOTE: always read one row, as txn logs only have one row
+    let txn_log_read_result: Result<TransactionLog, Error> = pg_pool_conn
+        .build_transaction()
+        .read_only()
+        .run::<_, Error, _>(|conn| transaction_logs.limit(1).first::<TransactionLog>(conn));
+
+    txn_log_read_result.map_err(|e| {
+        IndexerError::PostgresReadError(format!(
+            "Failed reading transaction log in PostgresDB with tx with error {:?}",
+            e
+        ))
+    })
 }
 
-pub fn read_transaction_log(conn: &mut PgConnection) -> Result<TransactionLog, IndexerError> {
-    transaction_logs
-        .limit(1)
-        .first::<TransactionLog>(conn)
-        .map_err(|e| {
-            IndexerError::PostgresReadError(format!(
-                "Failed reading transaction log in PostgresDB with tx with error {:?}",
-                e
-            ))
-        })
+pub fn commit_transction_log(
+    pg_pool_conn: &mut PgPoolConnection,
+    txn_digest: Option<String>,
+) -> Result<usize, IndexerError> {
+    let txn_log_commit_result: Result<usize, Error> = pg_pool_conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|conn| {
+            diesel::update(transaction_logs::table)
+                .set(next_cursor_tx_digest.eq(txn_digest.clone()))
+                .execute(conn)
+        });
+
+    txn_log_commit_result.map_err(|e| {
+        IndexerError::PostgresWriteError(format!(
+            "Failed updating transaction log in PostgresDB with tx digest {:?} and error {:?}",
+            txn_digest, e
+        ))
+    })
 }

--- a/crates/sui-indexer/src/processors/address_processor.rs
+++ b/crates/sui-indexer/src/processors/address_processor.rs
@@ -1,39 +1,41 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use sui_indexer::errors::IndexerError;
-use sui_indexer::establish_connection;
 use tracing::info;
 
 use sui_indexer::models::address_logs::{commit_address_log, read_address_log};
 use sui_indexer::models::addresses::{commit_addresses, transaction_to_address, NewAddress};
 use sui_indexer::models::transactions::read_transactions;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 
 const TRANSACTION_BATCH_SIZE: usize = 100;
 
 pub struct AddressProcessor {
-    db_url: String,
+    pg_connection_pool: Arc<PgConnectionPool>,
 }
 
 impl AddressProcessor {
-    pub fn new(db_url: String) -> AddressProcessor {
-        Self { db_url }
+    pub fn new(pg_connection_pool: Arc<PgConnectionPool>) -> AddressProcessor {
+        Self { pg_connection_pool }
     }
 
     pub async fn start(&self) -> Result<(), IndexerError> {
         info!("Indexer address processor started...");
-        let mut pg_conn = establish_connection(self.db_url.clone());
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
 
-        let address_log = read_address_log(&mut pg_conn)?;
+        let address_log = read_address_log(&mut pg_pool_conn)?;
         let last_processed_id = address_log.last_processed_id;
 
         // fetch transaction rows from DB, with filter id > last_processed_id and limit of batch size.
-        let txn_vec = read_transactions(&mut pg_conn, last_processed_id, TRANSACTION_BATCH_SIZE)?;
+        let txn_vec =
+            read_transactions(&mut pg_pool_conn, last_processed_id, TRANSACTION_BATCH_SIZE)?;
         let addr_vec: Vec<NewAddress> = txn_vec.into_iter().map(transaction_to_address).collect();
         let next_processed_id = last_processed_id + addr_vec.len() as i64;
 
-        commit_addresses(&mut pg_conn, addr_vec)?;
-        commit_address_log(&mut pg_conn, next_processed_id)?;
+        commit_addresses(&mut pg_pool_conn, addr_vec)?;
+        commit_address_log(&mut pg_pool_conn, next_processed_id)?;
         Ok(())
     }
 }

--- a/crates/sui-indexer/src/processors/object_processor.rs
+++ b/crates/sui-indexer/src/processors/object_processor.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_indexer::errors::IndexerError;
-use sui_indexer::establish_connection;
 use sui_indexer::models::events::{events_to_sui_events, read_events};
 use sui_indexer::models::object_logs::{commit_object_log, read_object_log};
 use sui_indexer::models::objects::commit_objects_from_events;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::info;
@@ -14,29 +15,33 @@ use tracing::info;
 const OBJECT_EVENT_BATCH_SIZE: usize = 100;
 
 pub struct ObjectProcessor {
-    db_url: String,
+    pg_connection_pool: Arc<PgConnectionPool>,
 }
 
 impl ObjectProcessor {
-    pub fn new(db_url: String) -> ObjectProcessor {
-        Self { db_url }
+    pub fn new(pg_connection_pool: Arc<PgConnectionPool>) -> ObjectProcessor {
+        Self { pg_connection_pool }
     }
 
     pub async fn start(&self) -> Result<(), IndexerError> {
         info!("Indexer object processor started...");
-        let mut pg_conn = establish_connection(self.db_url.clone());
-        let object_log = read_object_log(&mut pg_conn)?;
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
+
+        let object_log = read_object_log(&mut pg_pool_conn)?;
         let mut last_processed_id = object_log.last_processed_id;
 
         loop {
-            let events_to_process =
-                read_events(&mut pg_conn, last_processed_id, OBJECT_EVENT_BATCH_SIZE)?;
+            let events_to_process = read_events(
+                &mut pg_pool_conn,
+                last_processed_id,
+                OBJECT_EVENT_BATCH_SIZE,
+            )?;
             let event_count = events_to_process.len();
-            let sui_events_to_process = events_to_sui_events(&mut pg_conn, events_to_process);
-            commit_objects_from_events(&mut pg_conn, sui_events_to_process)?;
+            let sui_events_to_process = events_to_sui_events(&mut pg_pool_conn, events_to_process);
+            commit_objects_from_events(&mut pg_pool_conn, sui_events_to_process)?;
 
             last_processed_id += event_count as i64;
-            commit_object_log(&mut pg_conn, last_processed_id)?;
+            commit_object_log(&mut pg_pool_conn, last_processed_id)?;
             if event_count < OBJECT_EVENT_BATCH_SIZE {
                 sleep(Duration::from_secs_f32(0.1)).await;
             }

--- a/crates/sui-indexer/src/processors/package_processor.rs
+++ b/crates/sui-indexer/src/processors/package_processor.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_indexer::errors::IndexerError;
-use sui_indexer::establish_connection;
 use sui_indexer::models::events::{events_to_sui_events, read_events};
 use sui_indexer::models::package_logs::{commit_package_log, read_package_log};
 use sui_indexer::models::packages::commit_packages_from_events;
+use sui_indexer::{get_pg_pool_connection, PgConnectionPool};
 use sui_sdk::SuiClient;
 
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::info;
@@ -16,36 +17,45 @@ const PACKAGE_EVENT_BATCH_SIZE: usize = 100;
 
 pub struct PackageProcessor {
     rpc_client: SuiClient,
-    db_url: String,
+    pg_connection_pool: Arc<PgConnectionPool>,
 }
 
 impl PackageProcessor {
-    pub fn new(rpc_client: SuiClient, db_url: String) -> PackageProcessor {
-        Self { rpc_client, db_url }
+    pub fn new(
+        rpc_client: SuiClient,
+        pg_connection_pool: Arc<PgConnectionPool>,
+    ) -> PackageProcessor {
+        Self {
+            rpc_client,
+            pg_connection_pool,
+        }
     }
 
     pub async fn start(&self) -> Result<(), IndexerError> {
         info!("Indexer package processor started...");
-        let mut pg_conn = establish_connection(self.db_url.clone());
+        let mut pg_pool_conn = get_pg_pool_connection(self.pg_connection_pool.clone())?;
 
-        let pkg_log = read_package_log(&mut pg_conn)?;
+        let pkg_log = read_package_log(&mut pg_pool_conn)?;
         let mut last_processed_id = pkg_log.last_processed_id;
         loop {
-            let events_to_process =
-                read_events(&mut pg_conn, last_processed_id, PACKAGE_EVENT_BATCH_SIZE)?;
-            let sui_events_to_process = events_to_sui_events(&mut pg_conn, events_to_process);
+            let events_to_process = read_events(
+                &mut pg_pool_conn,
+                last_processed_id,
+                PACKAGE_EVENT_BATCH_SIZE,
+            )?;
+            let sui_events_to_process = events_to_sui_events(&mut pg_pool_conn, events_to_process);
 
             let event_count = sui_events_to_process.len();
 
             commit_packages_from_events(
                 self.rpc_client.clone(),
-                &mut pg_conn,
+                &mut pg_pool_conn,
                 sui_events_to_process,
             )
             .await?;
 
             last_processed_id += event_count as i64;
-            commit_package_log(&mut pg_conn, last_processed_id)?;
+            commit_package_log(&mut pg_pool_conn, last_processed_id)?;
             if event_count < PACKAGE_EVENT_BATCH_SIZE {
                 sleep(Duration::from_secs_f32(0.1)).await;
             }

--- a/crates/sui-indexer/src/utils.rs
+++ b/crates/sui-indexer/src/utils.rs
@@ -3,16 +3,16 @@
 
 use crate::errors::IndexerError;
 use crate::models::error_logs::{commit_error_logs, err_to_error_log, NewErrorLog};
+use crate::PgPoolConnection;
 
-use diesel::pg::PgConnection;
 use tracing::error;
 
-pub fn log_errors_to_pg(pg_conn: &mut PgConnection, errors: Vec<IndexerError>) {
+pub fn log_errors_to_pg(pg_pool_conn: &mut PgPoolConnection, errors: Vec<IndexerError>) {
     if errors.is_empty() {
         return;
     }
     let new_error_logs: Vec<NewErrorLog> = errors.into_iter().map(err_to_error_log).collect();
-    if let Err(e) = commit_error_logs(pg_conn, new_error_logs) {
+    if let Err(e) = commit_error_logs(pg_pool_conn, new_error_logs) {
         error!("Failed writing error logs with error {:?}", e);
     }
 }

--- a/crates/workspace-hack/Cargo.toml
+++ b/crates/workspace-hack/Cargo.toml
@@ -162,7 +162,7 @@ der-parser = { version = "8", features = ["bigint", "num-bigint", "std"] }
 derive_builder = { version = "0.12", features = ["std"] }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
-diesel = { version = "2", features = ["32-column-tables", "bitflags", "byteorder", "chrono", "itoa", "postgres", "postgres_backend", "pq-sys", "serde_json", "with-deprecated"] }
+diesel = { version = "2", features = ["32-column-tables", "bitflags", "byteorder", "chrono", "itoa", "postgres", "postgres_backend", "pq-sys", "r2d2", "serde_json", "with-deprecated"] }
 diff = { version = "0.1", default-features = false }
 difference = { version = "2" }
 difflib = { version = "0.4", default-features = false }
@@ -444,6 +444,7 @@ quinn = { version = "0.9", default-features = false, features = ["futures-io", "
 quinn-proto = { version = "0.9", default-features = false, features = ["ring", "rustls", "tls-rustls", "webpki"] }
 quinn-udp = { version = "0.3", default-features = false }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+r2d2 = { version = "0.8", default-features = false }
 radium-d8f496e17d97b5cb = { package = "radium", version = "0.5", default-features = false }
 radium-3b31131e45eafb45 = { package = "radium", version = "0.6", default-features = false }
 radix_trie = { version = "0.2", default-features = false }
@@ -486,6 +487,7 @@ rusty-fork = { version = "0.3", default-features = false, features = ["timeout",
 rustyline = { version = "9", features = ["dirs-next", "with-dirs"] }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
+scheduled-thread-pool = { version = "0.2", default-features = false }
 schemars = { version = "0.8", features = ["derive", "either", "schemars_derive"] }
 scopeguard = { version = "1", features = ["use_std"] }
 sct = { version = "0.7", default-features = false }
@@ -824,7 +826,7 @@ derive_builder_macro = { version = "0.12", default-features = false }
 derive_more = { version = "0.99", features = ["add", "add_assign", "as_mut", "as_ref", "constructor", "convert_case", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "iterator", "mul", "mul_assign", "not", "rustc_version", "sum", "try_into", "unwrap"] }
 determinator = { version = "0.10", default-features = false }
 deunicode = { version = "0.4", default-features = false }
-diesel = { version = "2", features = ["32-column-tables", "bitflags", "byteorder", "chrono", "itoa", "postgres", "postgres_backend", "pq-sys", "serde_json", "with-deprecated"] }
+diesel = { version = "2", features = ["32-column-tables", "bitflags", "byteorder", "chrono", "itoa", "postgres", "postgres_backend", "pq-sys", "r2d2", "serde_json", "with-deprecated"] }
 diesel_derives = { version = "2", features = ["32-column-tables", "postgres", "with-deprecated"] }
 diff = { version = "0.1", default-features = false }
 difference = { version = "2" }
@@ -1151,6 +1153,7 @@ quinn-proto = { version = "0.9", default-features = false, features = ["ring", "
 quinn-udp = { version = "0.3", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+r2d2 = { version = "0.8", default-features = false }
 radium-d8f496e17d97b5cb = { package = "radium", version = "0.5", default-features = false }
 radium-3b31131e45eafb45 = { package = "radium", version = "0.6", default-features = false }
 radix_trie = { version = "0.2", default-features = false }
@@ -1198,6 +1201,7 @@ rustyline = { version = "9", features = ["dirs-next", "with-dirs"] }
 rustyline-derive = { version = "0.7", default-features = false }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
+scheduled-thread-pool = { version = "0.2", default-features = false }
 schemars = { version = "0.8", features = ["derive", "either", "schemars_derive"] }
 schemars_derive = { version = "0.8", default-features = false }
 scopeguard = { version = "1", features = ["use_std"] }


### PR DESCRIPTION
before this PR, each time a processor / handler tries to establish a new PG database connection, this PR instead uses PG connection pool based on r2d2 feature of diesel crate.

Test below and make sure that tables can still be populated.
```
cargo run --bin sui-indexer -- --db-url "postgres://postgres:postgres@localhost/gegao" --rpc-client-url "https://fullnode.devnet.sui.io:443"
```
