### PR TITLE
add fullnode wal log and plug into transaction orchestrator

### DIFF
--- a/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
+++ b/crates/sui-core/src/epoch/tests/reconfiguration_tests.rs
@@ -31,8 +31,8 @@ use crate::{
     authority_active::ActiveAuthority,
     authority_aggregator::authority_aggregator_tests::init_local_authorities,
     checkpoints::{CheckpointLocals, CHECKPOINT_COUNT_PER_EPOCH},
-    test_utils::to_sender_signed_transaction,
 };
+use sui_types::utils::to_sender_signed_transaction;
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_start_epoch_change() {

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -5,7 +5,7 @@ use crate::authority::{AuthorityState, EffectsNotifyRead};
 use signature::Signer;
 use std::sync::Arc;
 use std::time::Duration;
-
+use sui_types::utils::create_fake_transaction;
 use sui_types::{
     base_types::{
         dbg_addr, random_object_ref, AuthorityName, ExecutionDigests, ObjectID, TransactionDigest,
@@ -56,23 +56,6 @@ pub async fn wait_for_all_txes(digests: Vec<TransactionDigest>, state: Arc<Autho
     }
 }
 
-// Creates a fake sender-signed transaction for testing. This transaction will
-// not actually work.
-pub fn create_fake_transaction() -> VerifiedTransaction {
-    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
-    let recipient = dbg_addr(2);
-    let object_id = ObjectID::random();
-    let object = Object::immutable_with_id_for_testing(object_id);
-    let data = TransactionData::new_transfer_sui(
-        recipient,
-        sender,
-        None,
-        object.compute_object_reference(),
-        10000,
-    );
-    to_sender_signed_transaction(data, &sender_key)
-}
-
 pub fn create_fake_cert_and_effect_digest<'a>(
     signers: impl Iterator<
         Item = (
@@ -98,31 +81,6 @@ pub fn create_fake_cert_and_effect_digest<'a>(
         ExecutionDigests::new(*transaction.digest(), effects.digest()),
         cert,
     )
-}
-
-// This is used to sign transaction with signer using default Intent.
-pub fn to_sender_signed_transaction(
-    data: TransactionData,
-    signer: &dyn Signer<Signature>,
-) -> VerifiedTransaction {
-    VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
-        data,
-        Intent::default(),
-        signer,
-    ))
-}
-
-// Workaround for benchmark setup.
-pub fn to_sender_signed_transaction_arc(
-    data: TransactionData,
-    signer: &Arc<fastcrypto::ed25519::Ed25519KeyPair>,
-) -> VerifiedTransaction {
-    let data1 = data.clone();
-    let intent_message = IntentMessage::new(Intent::default(), data);
-    // OK to unwrap because this is used for benchmark only.
-    let bytes = bcs::to_bytes(&intent_message).unwrap();
-    let signature: Signature = signer.sign(&bytes);
-    VerifiedTransaction::new_unchecked(Transaction::from_data(data1, Intent::default(), signature))
 }
 
 pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -7,19 +7,13 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_types::utils::create_fake_transaction;
 use sui_types::{
-    base_types::{
-        dbg_addr, random_object_ref, AuthorityName, ExecutionDigests, ObjectID, TransactionDigest,
-    },
+    base_types::{random_object_ref, AuthorityName, ExecutionDigests, TransactionDigest},
     committee::Committee,
-    crypto::{get_key_pair, AccountKeyPair, AuthoritySignInfo, AuthoritySignature, Signature},
+    crypto::{AuthoritySignInfo, AuthoritySignature},
     gas::GasCostSummary,
-    intent::{Intent, IntentMessage},
     message_envelope::Message,
-    messages::{
-        CertifiedTransaction, ExecutionStatus, Transaction, TransactionData, TransactionEffects,
-        VerifiedTransaction,
-    },
-    object::{Object, Owner},
+    messages::{CertifiedTransaction, ExecutionStatus, Transaction, TransactionEffects},
+    object::Owner,
 };
 use tokio::time::timeout;
 use tracing::{info, warn};

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -19,6 +19,8 @@ use prometheus::{
     register_int_counter_vec_with_registry, register_int_counter_with_registry,
     register_int_gauge_vec_with_registry, register_int_gauge_with_registry, Registry,
 };
+use std::path::Path;
+use sui_storage::fullnode_pending_tx_log::FullNodePendingTransactionLog;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages::{
     CertifiedTransactionEffects, ExecuteTransactionRequest, ExecuteTransactionRequestType,
@@ -32,6 +34,8 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::{debug, error, instrument, warn};
 
+use sui_types::messages::VerifiedTransaction;
+
 // How long to wait for local execution (including parents) before a timeout
 // is returned to client.
 const LOCAL_EXECUTION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -41,6 +45,7 @@ pub struct TransactiondOrchestrator<A> {
     quorum_driver: Arc<QuorumDriver<A>>,
     validator_state: Arc<AuthorityState>,
     _local_executor_handle: JoinHandle<()>,
+    pending_tx_log: Arc<FullNodePendingTransactionLog>,
     metrics: Arc<TransactionOrchestratorMetrics>,
 }
 
@@ -51,6 +56,7 @@ where
     pub fn new(
         validators: Arc<AuthorityAggregator<A>>,
         validator_state: Arc<AuthorityState>,
+        parent_path: &Path,
         prometheus_registry: &Registry,
     ) -> Self {
         let quorum_driver_handler =
@@ -60,11 +66,16 @@ where
         let state_clone = validator_state.clone();
         let metrics = Arc::new(TransactionOrchestratorMetrics::new(prometheus_registry));
         let metrics_clone = metrics.clone();
+        let pending_tx_log = Arc::new(FullNodePendingTransactionLog::new(
+            parent_path.join("fullnode_pending_transactions"),
+        ));
+        let pending_tx_log_clone = pending_tx_log.clone();
         let _local_executor_handle = {
             spawn_monitored_task!(async move {
                 Self::loop_execute_finalized_tx_locally(
                     state_clone,
                     effects_receiver,
+                    pending_tx_log_clone,
                     metrics_clone,
                 )
                 .await;
@@ -75,6 +86,7 @@ where
             quorum_driver,
             validator_state,
             _local_executor_handle,
+            pending_tx_log,
             metrics,
         }
     }
@@ -86,15 +98,24 @@ where
     ) -> SuiResult<ExecuteTransactionResponse> {
         let (_in_flight_metrics_guard, good_response_metrics) =
             self.update_metrics(&request.request_type);
+
         // TODO check if tx is already executed on this node.
         // Note: since EffectsCert is not stored today, we need to gather that from validators
         // (and maybe store it for caching purposes)
+
+        let transaction = request.transaction.verify()?;
+
+        // We will shortly refactor the TransactionOrchestrator with a queue-based implementation.
+        // TDOO: `should_enqueue` will be used to determine if the transaction should be enqueued.
+        let _should_enqueue = self
+            .pending_tx_log
+            .write_pending_transaction(&transaction)
+            .await?;
+
         let wait_for_local_execution = matches!(
             request.request_type,
             ExecuteTransactionRequestType::WaitForLocalExecution
         );
-        let transaction = request.transaction.verify()?;
-        let tx_digest = *transaction.digest();
         let request_type = match request.request_type {
             ExecuteTransactionRequestType::ImmediateReturn => {
                 QuorumDriverRequestType::ImmediateReturn
@@ -105,6 +126,7 @@ where
                 QuorumDriverRequestType::WaitForEffectsCert
             }
         };
+        let tx_digest = *transaction.digest();
         let execution_result = self
             .quorum_driver
             .execute_transaction(QuorumDriverRequest {
@@ -218,6 +240,7 @@ where
     async fn loop_execute_finalized_tx_locally(
         validator_state: Arc<AuthorityState>,
         mut effects_receiver: Receiver<(VerifiedCertificate, VerifiedCertifiedTransactionEffects)>,
+        pending_transaction_log: Arc<FullNodePendingTransactionLog>,
         metrics: Arc<TransactionOrchestratorMetrics>,
     ) {
         loop {
@@ -295,6 +318,10 @@ where
             }),
             good_response,
         )
+    }
+
+    pub fn load_all_pending_transactions(&self) -> Vec<VerifiedTransaction> {
+        self.pending_tx_log.load_all_pending_transactions()
     }
 }
 

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -33,8 +33,8 @@ use crate::authority_client::{
     AuthorityAPI, BatchInfoResponseItemStream, LocalAuthorityClient,
     LocalAuthorityClientFaultConfig, NetworkAuthorityClient,
 };
-use crate::test_utils::to_sender_signed_transaction;
 use crate::validator_info::make_committee;
+use sui_types::utils::to_sender_signed_transaction;
 
 use tokio::time::Instant;
 

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2,14 +2,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::*;
 use crate::{
     authority_client::{AuthorityAPI, NetworkAuthorityClient},
     authority_server::AuthorityServer,
     checkpoints::CheckpointServiceNoop,
-    test_utils::to_sender_signed_transaction,
 };
-
-use super::*;
 use bcs;
 use move_binary_format::{
     file_format::{self, AddressIdentifierIndex, IdentifierIndex, ModuleHandle},
@@ -28,6 +26,7 @@ use std::fs;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use sui_types::utils::to_sender_signed_transaction;
 
 use std::{convert::TryInto, env};
 use sui_adapter::genesis;

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -1,13 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    authority::authority_tests::init_state_with_ids_and_object_basics,
-    test_utils::to_sender_signed_transaction,
-};
-
 use super::*;
+use crate::authority::authority_tests::init_state_with_ids_and_object_basics;
 use bcs;
+use sui_types::utils::to_sender_signed_transaction;
 
 use authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use move_binary_format::file_format;

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -5,13 +5,13 @@ use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_handler::VerifiedSequencedConsensusTransaction;
-use crate::test_utils::to_sender_signed_transaction;
 use move_core_types::{account_address::AccountAddress, ident_str};
 use multiaddr::Multiaddr;
 use narwhal_types::Transactions;
 use narwhal_types::TransactionsServer;
 use narwhal_types::{Empty, TransactionProto};
 use sui_network::tonic;
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     base_types::{ObjectID, TransactionDigest},
     messages::{CallArg, CertifiedTransaction, ObjectArg, TransactionData},

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -6,13 +6,13 @@ use super::*;
 use super::authority_tests::{init_state_with_ids, send_and_confirm_transaction};
 use super::move_integration_tests::build_and_try_publish_test_package;
 use crate::authority::authority_tests::{init_state, init_state_with_ids_and_object_basics};
-use crate::test_utils::to_sender_signed_transaction;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use sui_adapter::genesis;
 use sui_types::crypto::AccountKeyPair;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::GAS_VALUE_FOR_TESTING;
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     base_types::dbg_addr,
     crypto::get_key_pair,

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::{
-    authority::authority_tests::{
-        call_move, call_move_with_shared, init_state_with_ids, send_and_confirm_transaction,
-        TestCallArg,
-    },
-    test_utils::to_sender_signed_transaction,
+use crate::authority::authority_tests::{
+    call_move, call_move_with_shared, init_state_with_ids, send_and_confirm_transaction,
+    TestCallArg,
 };
+use sui_types::utils::to_sender_signed_transaction;
 
 use move_core_types::{
     language_storage::TypeTag,

--- a/crates/sui-core/src/unit_tests/pay_sui_tests.rs
+++ b/crates/sui-core/src/unit_tests/pay_sui_tests.rs
@@ -5,10 +5,10 @@ use super::*;
 
 use crate::authority::authority_tests::{init_state, send_and_confirm_transaction};
 use crate::authority::AuthorityState;
-use crate::test_utils::to_sender_signed_transaction;
 use futures::future::join_all;
 use std::collections::HashMap;
 use sui_types::crypto::AccountKeyPair;
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     base_types::dbg_addr,
     crypto::get_key_pair,

--- a/crates/sui-cost/src/estimator.rs
+++ b/crates/sui-cost/src/estimator.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use strum_macros::Display;
 use strum_macros::EnumString;
 use sui_core::authority::AuthorityState;
-use sui_core::test_utils::to_sender_signed_transaction;
 use sui_core::transaction_input_checker;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
@@ -24,6 +23,7 @@ use sui_types::messages::SingleTransactionKind;
 use sui_types::messages::TransactionData;
 use sui_types::messages::TransactionKind;
 use sui_types::temporary_store::TemporaryStore;
+use sui_types::utils::to_sender_signed_transaction;
 
 const DEFAULT_COMPUTATION_GAS_UNIT_PRICE: u64 = 1;
 const DEFAULT_STORAGE_GAS_UNIT_PRICE: u64 = 1;

--- a/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc/src/unit_tests/rpc_server_tests.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 
 use sui_config::utils::get_available_port;
 use sui_config::SUI_KEYSTORE_FILENAME;
-use sui_core::test_utils::to_sender_signed_transaction;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
@@ -23,6 +22,7 @@ use sui_types::gas_coin::GAS;
 use sui_types::messages::ExecuteTransactionRequestType;
 use sui_types::object::Owner;
 use sui_types::query::{EventQuery, TransactionQuery};
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{parse_sui_struct_tag, parse_sui_type_tag, SUI_FRAMEWORK_ADDRESS};
 use test_utils::network::TestClusterBuilder;
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -210,6 +210,7 @@ impl SuiNode {
             Some(Arc::new(TransactiondOrchestrator::new(
                 arc_net,
                 state.clone(),
+                config.db_path(),
                 &prometheus_registry,
             )))
         } else {

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -14,7 +14,6 @@ use serde_json::json;
 use sui::client_commands::EXAMPLE_NFT_DESCRIPTION;
 use sui::client_commands::EXAMPLE_NFT_NAME;
 use sui::client_commands::EXAMPLE_NFT_URL;
-use sui_core::test_utils::to_sender_signed_transaction;
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
     EventPage, MoveCallParams, OwnedObjectRef, RPCTransactionRequestParams,
@@ -41,6 +40,7 @@ use sui_types::messages::{
 use sui_types::object::{Owner, PACKAGE_VERSION};
 use sui_types::query::EventQuery;
 use sui_types::query::TransactionQuery;
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::SUI_FRAMEWORK_OBJECT_ID;
 
 struct Examples {

--- a/crates/sui-storage/src/fullnode_pending_tx_log.rs
+++ b/crates/sui-storage/src/fullnode_pending_tx_log.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! FullNodePendingTransactionLog is Write Ahead Log uesd in Transaction Orchestrator
+//! for transaction submission processing. It plays two roles:
+//! 1. At one time, a transaction is only processed once.
+//! 2. When Fullnode crashes and restarts, the pending transaction will be loaded and retried.
+
+use crate::mutex_table::MutexTable;
+use crate::write_ahead_log::{MUTEX_TABLE_SHARD_SIZE, MUTEX_TABLE_SIZE};
+use std::path::PathBuf;
+use sui_types::base_types::TransactionDigest;
+use sui_types::error::{SuiError, SuiResult};
+use sui_types::messages::{TrustedTransction, VerifiedTransaction};
+use typed_store::traits::TypedStoreDebug;
+use typed_store::{rocks::DBMap, traits::Map};
+use typed_store_derive::DBMapUtils;
+
+pub type IsFirstRecord = bool;
+
+#[derive(DBMapUtils)]
+struct FullNodePendingTransactionTable {
+    logs: DBMap<TransactionDigest, TrustedTransction>,
+}
+
+pub struct FullNodePendingTransactionLog {
+    pending_transactions: FullNodePendingTransactionTable,
+    mutex_table: MutexTable<TransactionDigest>,
+}
+
+impl FullNodePendingTransactionLog {
+    pub fn new(path: PathBuf) -> Self {
+        let pending_transactions =
+            FullNodePendingTransactionTable::open_tables_read_write(path, None, None);
+        Self {
+            pending_transactions,
+            mutex_table: MutexTable::new(MUTEX_TABLE_SIZE, MUTEX_TABLE_SHARD_SIZE),
+        }
+    }
+
+    pub async fn write_pending_transaction(
+        &self,
+        tx: &VerifiedTransaction,
+    ) -> SuiResult<IsFirstRecord> {
+        let tx_digest = tx.digest();
+        let _guard = self.mutex_table.acquire_lock(*tx_digest).await;
+        if self.pending_transactions.logs.contains_key(tx_digest)? {
+            Ok(false)
+        } else {
+            self.pending_transactions
+                .logs
+                .insert(tx_digest, tx.serializable_ref())?;
+            Ok(true)
+        }
+    }
+
+    pub fn finish_transaction(&self, tx: &TransactionDigest) -> SuiResult {
+        let write_batch = self.pending_transactions.logs.batch();
+        let write_batch =
+            write_batch.delete_batch(&self.pending_transactions.logs, std::iter::once(tx))?;
+        write_batch.write().map_err(SuiError::from)
+    }
+
+    pub fn load_all_pending_transactions(&self) -> Vec<VerifiedTransaction> {
+        self.pending_transactions
+            .logs
+            .iter()
+            .map(|(_tx_digest, tx)| VerifiedTransaction::from(tx))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow;
+    use std::collections::HashSet;
+    use sui_types::utils::create_fake_transaction;
+
+    #[tokio::test]
+    async fn test_pending_tx_log_basic() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let pending_txes = FullNodePendingTransactionLog::new(temp_dir.path().to_path_buf());
+        let tx = create_fake_transaction();
+        let tx_digest = *tx.digest();
+        assert!(pending_txes.write_pending_transaction(&tx).await.unwrap());
+        // The second write will return false
+        assert!(!pending_txes.write_pending_transaction(&tx).await.unwrap());
+
+        let loaded_txes = pending_txes.load_all_pending_transactions();
+        assert_eq!(vec![tx], loaded_txes);
+
+        pending_txes.finish_transaction(&tx_digest).unwrap();
+        let loaded_txes = pending_txes.load_all_pending_transactions();
+        assert!(loaded_txes.is_empty());
+
+        // It's ok to finish an already finished transaction
+        pending_txes.finish_transaction(&tx_digest).unwrap();
+
+        // Test writing and finishing more transactions
+        let txes: Vec<_> = (0..10).map(|_| create_fake_transaction()).collect();
+        for tx in txes.iter().take(10) {
+            assert!(pending_txes.write_pending_transaction(tx).await.unwrap());
+        }
+        let loaded_tx_digests: HashSet<_> = pending_txes
+            .load_all_pending_transactions()
+            .iter()
+            .map(|t| *t.digest())
+            .collect();
+        assert_eq!(
+            txes.iter().map(|t| *t.digest()).collect::<HashSet<_>>(),
+            loaded_tx_digests
+        );
+
+        for tx in txes.iter().take(5) {
+            pending_txes.finish_transaction(tx.digest()).unwrap();
+        }
+        let loaded_tx_digests: HashSet<_> = pending_txes
+            .load_all_pending_transactions()
+            .iter()
+            .map(|t| *t.digest())
+            .collect();
+        assert_eq!(
+            txes.iter()
+                .skip(5)
+                .map(|t| *t.digest())
+                .collect::<HashSet<_>>(),
+            loaded_tx_digests
+        );
+
+        Ok(())
+    }
+}

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -8,10 +8,10 @@ pub mod indexes;
 pub use indexes::IndexStore;
 
 pub mod event_store;
-pub mod fullnode_pending_tx_log;
 pub mod mutex_table;
 pub mod node_sync_store;
 pub mod write_ahead_log;
+pub mod write_path_pending_tx_log;
 
 use rocksdb::Options;
 use std::future::Future;

--- a/crates/sui-storage/src/lib.rs
+++ b/crates/sui-storage/src/lib.rs
@@ -8,6 +8,7 @@ pub mod indexes;
 pub use indexes::IndexStore;
 
 pub mod event_store;
+pub mod fullnode_pending_tx_log;
 pub mod mutex_table;
 pub mod node_sync_store;
 pub mod write_ahead_log;

--- a/crates/sui-storage/src/write_ahead_log.rs
+++ b/crates/sui-storage/src/write_ahead_log.rs
@@ -212,8 +212,8 @@ where
     mutex_table: MutexTable<TransactionDigest>,
 }
 
-const MUTEX_TABLE_SIZE: usize = 1024;
-const MUTEX_TABLE_SHARD_SIZE: usize = 128;
+pub(crate) const MUTEX_TABLE_SIZE: usize = 1024;
+pub(crate) const MUTEX_TABLE_SHARD_SIZE: usize = 128;
 
 impl<C, ExecutionOutput> DBWriteAheadLog<C, ExecutionOutput>
 where

--- a/crates/sui-storage/src/write_path_pending_tx_log.rs
+++ b/crates/sui-storage/src/write_path_pending_tx_log.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! FullNodePendingTransactionLog is Write Ahead Log uesd in Transaction Orchestrator
-//! for transaction submission processing. It plays two roles:
+//! WritePathPendingTransactionLog is used in the transaction write path (e.g. in
+//! TranasctionOrchestrator) for transaction submission processing. It helps to achieve:
 //! 1. At one time, a transaction is only processed once.
 //! 2. When Fullnode crashes and restarts, the pending transaction will be loaded and retried.
 
@@ -19,26 +19,31 @@ use typed_store_derive::DBMapUtils;
 pub type IsFirstRecord = bool;
 
 #[derive(DBMapUtils)]
-struct FullNodePendingTransactionTable {
+struct WritePathPendingTransactionTable {
     logs: DBMap<TransactionDigest, TrustedTransction>,
 }
 
-pub struct FullNodePendingTransactionLog {
-    pending_transactions: FullNodePendingTransactionTable,
+pub struct WritePathPendingTransactionLog {
+    pending_transactions: WritePathPendingTransactionTable,
     mutex_table: MutexTable<TransactionDigest>,
 }
 
-impl FullNodePendingTransactionLog {
+impl WritePathPendingTransactionLog {
     pub fn new(path: PathBuf) -> Self {
         let pending_transactions =
-            FullNodePendingTransactionTable::open_tables_read_write(path, None, None);
+            WritePathPendingTransactionTable::open_tables_read_write(path, None, None);
         Self {
             pending_transactions,
             mutex_table: MutexTable::new(MUTEX_TABLE_SIZE, MUTEX_TABLE_SHARD_SIZE),
         }
     }
 
-    pub async fn write_pending_transaction(
+    // Returns whether the table currently has this transaction in record.
+    // If not, write the transaction and return true; otherwise return false.
+    // Because the record will be cleanded up when the transaction finishes,
+    // even when it returns true, the callsite of this function should check
+    // the transaction status before doing anything, to avoid duplicates.
+    pub async fn write_pending_transaction_maybe(
         &self,
         tx: &VerifiedTransaction,
     ) -> SuiResult<IsFirstRecord> {
@@ -54,6 +59,17 @@ impl FullNodePendingTransactionLog {
         }
     }
 
+    // This function does not need to be behind a lock because:
+    // 1. there is supposed to be only one callsite; Even when there are
+    //    several, the deletion is idempotent.
+    // 2. it does not race with the insert (`write_pending_transaction_maybe`)
+    //    in a way that we care.
+    //    2.a. for one transaction, `finish_transaction` shouldn't predate
+    //        `write_pending_transaction_maybe`.
+    //    2.b  for concurrent requests of one transaction, a call to this
+    //        function may happen in bewteen hence making the second request
+    //        thinks it is the first record. It's preventable by checking this
+    //        transaction again after the call of `write_pending_transaction_maybe`.
     pub fn finish_transaction(&self, tx: &TransactionDigest) -> SuiResult {
         let write_batch = self.pending_transactions.logs.batch();
         let write_batch =
@@ -80,12 +96,18 @@ mod tests {
     #[tokio::test]
     async fn test_pending_tx_log_basic() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
-        let pending_txes = FullNodePendingTransactionLog::new(temp_dir.path().to_path_buf());
+        let pending_txes = WritePathPendingTransactionLog::new(temp_dir.path().to_path_buf());
         let tx = create_fake_transaction();
         let tx_digest = *tx.digest();
-        assert!(pending_txes.write_pending_transaction(&tx).await.unwrap());
+        assert!(pending_txes
+            .write_pending_transaction_maybe(&tx)
+            .await
+            .unwrap());
         // The second write will return false
-        assert!(!pending_txes.write_pending_transaction(&tx).await.unwrap());
+        assert!(!pending_txes
+            .write_pending_transaction_maybe(&tx)
+            .await
+            .unwrap());
 
         let loaded_txes = pending_txes.load_all_pending_transactions();
         assert_eq!(vec![tx], loaded_txes);
@@ -100,7 +122,10 @@ mod tests {
         // Test writing and finishing more transactions
         let txes: Vec<_> = (0..10).map(|_| create_fake_transaction()).collect();
         for tx in txes.iter().take(10) {
-            assert!(pending_txes.write_pending_transaction(tx).await.unwrap());
+            assert!(pending_txes
+                .write_pending_transaction_maybe(tx)
+                .await
+                .unwrap());
         }
         let loaded_tx_digests: HashSet<_> = pending_txes
             .load_all_pending_transactions()

--- a/crates/sui-swarm/src/memory/node.rs
+++ b/crates/sui-swarm/src/memory/node.rs
@@ -70,6 +70,11 @@ impl Node {
         self.thread = None;
     }
 
+    /// If this Node is currently running
+    pub fn is_running(&self) -> bool {
+        self.thread.is_some()
+    }
+
     /// Perform a health check on this Node by:
     /// * Checking that the node is running
     /// * Calling the Node's gRPC Health service if it's a validator.

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -37,9 +37,10 @@ use std::{
     sync::Arc,
 };
 use sui_adapter::{adapter::new_move_vm, execution_mode, genesis};
-use sui_core::{execution_engine, test_utils::to_sender_signed_transaction};
+use sui_core::execution_engine;
 use sui_framework::DEFAULT_FRAMEWORK_PATH;
 use sui_types::temporary_store::TemporaryStore;
+use sui_types::utils::to_sender_signed_transaction;
 use sui_types::{
     base_types::{
         ObjectDigest, ObjectID, ObjectRef, SuiAddress, TransactionDigest, SUI_ADDRESS_LENGTH,

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -48,6 +48,7 @@ pub mod sui_system_state;
 pub mod temporary_store;
 
 pub mod filter;
+
 #[path = "./unit_tests/utils.rs"]
 pub mod utils;
 

--- a/crates/sui-types/src/messages.rs
+++ b/crates/sui-types/src/messages.rs
@@ -879,6 +879,7 @@ impl<S> Envelope<SenderSignedData, S> {
 /// A transaction that is signed by a sender but not yet by an authority.
 pub type Transaction = Envelope<SenderSignedData, EmptySignInfo>;
 pub type VerifiedTransaction = VerifiedEnvelope<SenderSignedData, EmptySignInfo>;
+pub type TrustedTransction = TrustedEnvelope<SenderSignedData, EmptySignInfo>;
 
 impl Transaction {
     pub fn from_data_and_signer(

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -2,12 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fastcrypto::traits::KeyPair as KeypairTraits;
+use signature::Signer;
 
 use crate::{
+    base_types::{dbg_addr, ObjectID},
     committee::Committee,
-    crypto::{get_key_pair_from_rng, AuthorityKeyPair, AuthorityPublicKeyBytes},
+    crypto::{
+        get_key_pair, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
+        AuthorityPublicKeyBytes, Signature,
+    },
+    intent::{Intent, IntentMessage},
+    messages::{Transaction, TransactionData, VerifiedTransaction},
+    object::Object,
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 pub fn make_committee_key<R>(rand: &mut R) -> (Vec<AuthorityKeyPair>, Committee)
 where
@@ -34,4 +42,46 @@ where
 
     let committee = Committee::new(0, authorities).unwrap();
     (keys, committee)
+}
+
+// Creates a fake sender-signed transaction for testing. This transaction will
+// not actually work.
+pub fn create_fake_transaction() -> VerifiedTransaction {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let recipient = dbg_addr(2);
+    let object_id = ObjectID::random();
+    let object = Object::immutable_with_id_for_testing(object_id);
+    let data = TransactionData::new_transfer_sui(
+        recipient,
+        sender,
+        None,
+        object.compute_object_reference(),
+        10000,
+    );
+    to_sender_signed_transaction(data, &sender_key)
+}
+
+// This is used to sign transaction with signer using default Intent.
+pub fn to_sender_signed_transaction(
+    data: TransactionData,
+    signer: &dyn Signer<Signature>,
+) -> VerifiedTransaction {
+    VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
+        data,
+        Intent::default(),
+        signer,
+    ))
+}
+
+// Workaround for benchmark setup.
+pub fn to_sender_signed_transaction_arc(
+    data: TransactionData,
+    signer: &Arc<fastcrypto::ed25519::Ed25519KeyPair>,
+) -> VerifiedTransaction {
+    let data1 = data.clone();
+    let intent_message = IntentMessage::new(Intent::default(), data);
+    // OK to unwrap because this is used for benchmark only.
+    let bytes = bcs::to_bytes(&intent_message).unwrap();
+    let signature: Signature = signer.sign(&bytes);
+    VerifiedTransaction::new_unchecked(Transaction::from_data(data1, Intent::default(), signature))
 }

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -6,7 +6,6 @@ use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_node::SuiNode;
 use sui_types::base_types::TransactionDigest;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::error::SuiResult;
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
@@ -29,12 +28,8 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
 
     let net = active.agg_aggregator();
     let temp_dir = tempfile::tempdir().unwrap();
-    let orchestrator = TransactiondOrchestrator::new(
-        net,
-        node.state(),
-        temp_dir.path(),
-        &Registry::new(),
-    );
+    let orchestrator =
+        TransactiondOrchestrator::new(net, node.state(), temp_dir.path(), &Registry::new());
 
     let txn_count = 4;
     let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
@@ -94,12 +89,8 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
 
     let net = active.agg_aggregator();
     let temp_dir = tempfile::tempdir().unwrap();
-    let orchestrator = TransactiondOrchestrator::new(
-        net,
-        node.state(),
-        temp_dir.path(),
-        &Registry::new(),
-    );
+    let orchestrator =
+        TransactiondOrchestrator::new(net, node.state(), temp_dir.path(), &Registry::new());
 
     let txn_count = 4;
     let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
@@ -148,137 +139,6 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[ignore]
-#[tokio::test]
-async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error> {
-    telemetry_subscribers::init_for_testing();
-    let mut test_cluster = TestClusterBuilder::new().build().await?;
-
-    let fullnode_handle = test_cluster.start_fullnode().await.unwrap();
-    // Note this node is different from the one connected with WalletContext
-    let node = &fullnode_handle.sui_node;
-
-    let context = &mut test_cluster.wallet;
-    let wallet_context_node = &test_cluster.fullnode_handle.sui_node;
-
-    let active = node.active();
-
-    // Disable node sync process
-    active.cancel_node_sync_process_for_tests().await;
-
-    let net = active.agg_aggregator();
-    let temp_dir = tempfile::tempdir().unwrap();
-    let orchestrator = TransactiondOrchestrator::new(
-        net,
-        node.state(),
-        temp_dir.path(),
-        &Registry::new(),
-    );
-
-    let signer = context.config.keystore.addresses().get(0).cloned().unwrap();
-    let (pkg_ref, counter_id) = publish_basics_package_and_make_counter(context, signer).await;
-    let counter_shared_at = counter_id.1;
-
-    // 0. Execute transaction through Quorum Driver
-    info!("Execute with a Quorum Driver");
-    let digests0 = increment(context, &signer, counter_id.0, 20, pkg_ref).await;
-    // Since the node sync process is disabled, the node does not know about these txns
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-    node_does_not_know_txes(node, &digests0).await;
-
-    let tx0 = make_counter_increment_transaction_with_wallet_context(
-        context,
-        signer,
-        counter_id.0,
-        counter_shared_at,
-        None,
-    )
-    .await;
-    let digest0 = *tx0.digest();
-    // Then we use this node's Quorum Driver to submit transaction.
-    orchestrator
-        .quorum_driver()
-        .execute_transaction(QuorumDriverRequest {
-            transaction: tx0,
-            request_type: QuorumDriverRequestType::WaitForTxCert,
-        })
-        .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest0, e));
-
-    // Even though tx0 is **not** executed from the Orchestrator,
-    // it subscribes to the Quorum Driver's effects queue,
-    // receives the finalized transactions and executes them.
-    // Wait for the async execution to finish
-    wait_for_tx(digest0, node.state().clone()).await;
-    node_knows_txes(node, &digests0).await;
-    node_knows_txes(node, &vec![digest0]).await;
-
-    // 1. Execute with Orchestrator, WaitForLocalExecution
-    info!("Execute with Orchestrator, WaitForLocalExecution");
-
-    // We wait until the wallet context node knows about digest0 so it can pick the right gas
-    wait_for_tx(digest0, wallet_context_node.state().clone()).await;
-    let digests1 = increment(context, &signer, counter_id.0, 20, pkg_ref).await;
-
-    let tx1 = make_counter_increment_transaction_with_wallet_context(
-        context,
-        signer,
-        counter_id.0,
-        counter_shared_at,
-        None,
-    )
-    .await;
-    let digest1 = *tx1.digest();
-    // WaitForLocalExecution synchronuously executes all previous txns
-    let res = execute_with_orchestrator(
-        &orchestrator,
-        tx1,
-        ExecuteTransactionRequestType::WaitForLocalExecution,
-    )
-    .await
-    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest1, e));
-
-    if let ExecuteTransactionResponse::EffectsCert(result) = res {
-        let (_, _, executed_locally) = *result;
-        assert!(executed_locally);
-    };
-    node_knows_txes(node, &digests1).await;
-    node_knows_txes(node, &vec![digest1]).await;
-
-    // 2. Execute with Orchestrator, ImmediateReturn
-    info!("Execute with Orchestrator, ImmediateReturn");
-
-    // We wait until the wallet context node knows about digest1 so it can pick the right gas
-    wait_for_tx(digest1, wallet_context_node.state().clone()).await;
-    let digests2 = increment(context, &signer, counter_id.0, 20, pkg_ref).await;
-    node_does_not_know_txes(node, &digests2).await;
-
-    let tx2 = make_counter_increment_transaction_with_wallet_context(
-        context,
-        signer,
-        counter_id.0,
-        counter_shared_at,
-        None,
-    )
-    .await;
-    // ImmediateReturn does not wait for execution results. But the execution asynchronuously triggers
-    // all dependencies to be executed as well.
-    let digest2 = *tx2.digest();
-    execute_with_orchestrator(
-        &orchestrator,
-        tx2,
-        ExecuteTransactionRequestType::ImmediateReturn,
-    )
-    .await
-    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest2, e));
-
-    // Wait for the async execution to finish
-    wait_for_tx(digest2, node.state().clone()).await;
-    node_knows_txes(node, &digests2).await;
-
-    Ok(())
-}
-
 #[tokio::test]
 async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
@@ -288,15 +148,9 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
 
     let active = node.active();
     let net = active.agg_aggregator();
-    let node_sync_handle = active.clone().node_sync_handle();
     let temp_dir = tempfile::tempdir().unwrap();
-    let orchestrator = TransactiondOrchestrator::new(
-        net,
-        node.state(),
-        node_sync_handle,
-        temp_dir.path(),
-        &Registry::new(),
-    );
+    let orchestrator =
+        TransactiondOrchestrator::new(net, node.state(), temp_dir.path(), &Registry::new());
 
     let txn_count = 2;
     let context = &mut test_cluster.wallet;
@@ -357,24 +211,6 @@ async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
     assert!(pending_txes.is_empty());
 
     Ok(())
-}
-
-async fn increment(
-    context: &WalletContext,
-    signer: &SuiAddress,
-    counter_id: ObjectID,
-    delta: usize,
-    pkg_ref: ObjectRef,
-) -> Vec<TransactionDigest> {
-    let mut digests = Vec::with_capacity(delta);
-    for _ in 0..delta {
-        let digest = increment_counter(context, *signer, None, pkg_ref, counter_id)
-            .await
-            .0
-            .transaction_digest;
-        digests.push(digest);
-    }
-    digests
 }
 
 async fn node_knows_txes(node: &SuiNode, digests: &Vec<TransactionDigest>) {

--- a/crates/sui/tests/transaction_orchestrator_tests.rs
+++ b/crates/sui/tests/transaction_orchestrator_tests.rs
@@ -6,6 +6,8 @@ use sui_core::authority_client::NetworkAuthorityClient;
 use sui_core::transaction_orchestrator::TransactiondOrchestrator;
 use sui_node::SuiNode;
 use sui_types::base_types::TransactionDigest;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, TransactionDigest};
+use sui_types::error::SuiResult;
 use sui_types::messages::{
     ExecuteTransactionRequest, ExecuteTransactionRequestType, ExecuteTransactionResponse,
     QuorumDriverRequest, QuorumDriverRequestType, VerifiedTransaction,
@@ -26,7 +28,13 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
     active.cancel_node_sync_process_for_tests().await;
 
     let net = active.agg_aggregator();
-    let orchestrator = TransactiondOrchestrator::new(net, node.state(), &Registry::new());
+    let temp_dir = tempfile::tempdir().unwrap();
+    let orchestrator = TransactiondOrchestrator::new(
+        net,
+        node.state(),
+        temp_dir.path(),
+        &Registry::new(),
+    );
 
     let txn_count = 4;
     let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
@@ -60,7 +68,8 @@ async fn test_blocking_execution() -> Result<(), anyhow::Error> {
         txn,
         ExecuteTransactionRequestType::WaitForLocalExecution,
     )
-    .await;
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
 
     if let ExecuteTransactionResponse::EffectsCert(result) = res {
         let (_, _, executed_locally) = *result;
@@ -84,7 +93,13 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
     active.cancel_node_sync_process_for_tests().await;
 
     let net = active.agg_aggregator();
-    let orchestrator = TransactiondOrchestrator::new(net, node.state(), &Registry::new());
+    let temp_dir = tempfile::tempdir().unwrap();
+    let orchestrator = TransactiondOrchestrator::new(
+        net,
+        node.state(),
+        temp_dir.path(),
+        &Registry::new(),
+    );
 
     let txn_count = 4;
     let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
@@ -103,7 +118,8 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
         txn,
         ExecuteTransactionRequestType::ImmediateReturn,
     )
-    .await;
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest1, e));
 
     let txn = txns.swap_remove(0);
     let digest2 = *txn.digest();
@@ -112,7 +128,8 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
         txn,
         ExecuteTransactionRequestType::WaitForTxCert,
     )
-    .await;
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest2, e));
 
     let txn = txns.swap_remove(0);
     let digest3 = *txn.digest();
@@ -121,13 +138,243 @@ async fn test_non_blocking_execution() -> Result<(), anyhow::Error> {
         txn,
         ExecuteTransactionRequestType::WaitForEffectsCert,
     )
-    .await;
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest3, e));
 
     let digests = vec![digest1, digest2, digest3];
     wait_for_all_txes(digests.clone(), node.state().clone()).await;
     node_knows_txes(node, &digests).await;
 
     Ok(())
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_local_execution_with_missing_parents() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let mut test_cluster = TestClusterBuilder::new().build().await?;
+
+    let fullnode_handle = test_cluster.start_fullnode().await.unwrap();
+    // Note this node is different from the one connected with WalletContext
+    let node = &fullnode_handle.sui_node;
+
+    let context = &mut test_cluster.wallet;
+    let wallet_context_node = &test_cluster.fullnode_handle.sui_node;
+
+    let active = node.active();
+
+    // Disable node sync process
+    active.cancel_node_sync_process_for_tests().await;
+
+    let net = active.agg_aggregator();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let orchestrator = TransactiondOrchestrator::new(
+        net,
+        node.state(),
+        temp_dir.path(),
+        &Registry::new(),
+    );
+
+    let signer = context.config.keystore.addresses().get(0).cloned().unwrap();
+    let (pkg_ref, counter_id) = publish_basics_package_and_make_counter(context, signer).await;
+    let counter_shared_at = counter_id.1;
+
+    // 0. Execute transaction through Quorum Driver
+    info!("Execute with a Quorum Driver");
+    let digests0 = increment(context, &signer, counter_id.0, 20, pkg_ref).await;
+    // Since the node sync process is disabled, the node does not know about these txns
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    node_does_not_know_txes(node, &digests0).await;
+
+    let tx0 = make_counter_increment_transaction_with_wallet_context(
+        context,
+        signer,
+        counter_id.0,
+        counter_shared_at,
+        None,
+    )
+    .await;
+    let digest0 = *tx0.digest();
+    // Then we use this node's Quorum Driver to submit transaction.
+    orchestrator
+        .quorum_driver()
+        .execute_transaction(QuorumDriverRequest {
+            transaction: tx0,
+            request_type: QuorumDriverRequestType::WaitForTxCert,
+        })
+        .await
+        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest0, e));
+
+    // Even though tx0 is **not** executed from the Orchestrator,
+    // it subscribes to the Quorum Driver's effects queue,
+    // receives the finalized transactions and executes them.
+    // Wait for the async execution to finish
+    wait_for_tx(digest0, node.state().clone()).await;
+    node_knows_txes(node, &digests0).await;
+    node_knows_txes(node, &vec![digest0]).await;
+
+    // 1. Execute with Orchestrator, WaitForLocalExecution
+    info!("Execute with Orchestrator, WaitForLocalExecution");
+
+    // We wait until the wallet context node knows about digest0 so it can pick the right gas
+    wait_for_tx(digest0, wallet_context_node.state().clone()).await;
+    let digests1 = increment(context, &signer, counter_id.0, 20, pkg_ref).await;
+
+    let tx1 = make_counter_increment_transaction_with_wallet_context(
+        context,
+        signer,
+        counter_id.0,
+        counter_shared_at,
+        None,
+    )
+    .await;
+    let digest1 = *tx1.digest();
+    // WaitForLocalExecution synchronuously executes all previous txns
+    let res = execute_with_orchestrator(
+        &orchestrator,
+        tx1,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest1, e));
+
+    if let ExecuteTransactionResponse::EffectsCert(result) = res {
+        let (_, _, executed_locally) = *result;
+        assert!(executed_locally);
+    };
+    node_knows_txes(node, &digests1).await;
+    node_knows_txes(node, &vec![digest1]).await;
+
+    // 2. Execute with Orchestrator, ImmediateReturn
+    info!("Execute with Orchestrator, ImmediateReturn");
+
+    // We wait until the wallet context node knows about digest1 so it can pick the right gas
+    wait_for_tx(digest1, wallet_context_node.state().clone()).await;
+    let digests2 = increment(context, &signer, counter_id.0, 20, pkg_ref).await;
+    node_does_not_know_txes(node, &digests2).await;
+
+    let tx2 = make_counter_increment_transaction_with_wallet_context(
+        context,
+        signer,
+        counter_id.0,
+        counter_shared_at,
+        None,
+    )
+    .await;
+    // ImmediateReturn does not wait for execution results. But the execution asynchronuously triggers
+    // all dependencies to be executed as well.
+    let digest2 = *tx2.digest();
+    execute_with_orchestrator(
+        &orchestrator,
+        tx2,
+        ExecuteTransactionRequestType::ImmediateReturn,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest2, e));
+
+    // Wait for the async execution to finish
+    wait_for_tx(digest2, node.state().clone()).await;
+    node_knows_txes(node, &digests2).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_fullnode_wal_log() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let mut test_cluster = TestClusterBuilder::new().build().await?;
+
+    let node = &test_cluster.fullnode_handle.sui_node;
+
+    let active = node.active();
+    let net = active.agg_aggregator();
+    let node_sync_handle = active.clone().node_sync_handle();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let orchestrator = TransactiondOrchestrator::new(
+        net,
+        node.state(),
+        node_sync_handle,
+        temp_dir.path(),
+        &Registry::new(),
+    );
+
+    let txn_count = 2;
+    let context = &mut test_cluster.wallet;
+    let mut txns = make_transactions_with_wallet_context(context, txn_count).await;
+    assert!(
+        txns.len() >= txn_count,
+        "Expect at least {} txns. Do we generate enough gas objects during genesis?",
+        txn_count,
+    );
+    // As a comparison, we first verify a tx can go through
+    let txn = txns.swap_remove(0);
+    let digest = *txn.digest();
+    execute_with_orchestrator(
+        &orchestrator,
+        txn,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e));
+
+    let validator_addresses = test_cluster.get_validator_addresses();
+    assert_eq!(validator_addresses.len(), 4);
+
+    // Stop 2 validators and we lose quorum
+    test_cluster.stop_validator(validator_addresses[0]);
+    test_cluster.stop_validator(validator_addresses[1]);
+
+    let txn = txns.swap_remove(0);
+    // Expect tx to fail
+    execute_with_orchestrator(
+        &orchestrator,
+        txn.clone(),
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .unwrap_err();
+
+    // Because the tx did not go through, we expect to see it in the WAL log
+    let pending_txes = orchestrator.load_all_pending_transactions();
+    assert_eq!(pending_txes, vec![txn.clone()]);
+
+    // Bring up 1 validator, we obtain quorum again and tx should succeed
+    test_cluster.start_validator(validator_addresses[0]).await;
+    execute_with_orchestrator(
+        &orchestrator,
+        txn,
+        ExecuteTransactionRequestType::WaitForLocalExecution,
+    )
+    .await
+    .unwrap();
+
+    // TODO: wal erasing is done in the loop handling effects, so may have some delay.
+    // However, once the refactoring is completed the wal removal will be done before
+    // response is returned and we will not need the sleep.
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    // The tx should be erased in wal log.
+    let pending_txes = orchestrator.load_all_pending_transactions();
+    assert!(pending_txes.is_empty());
+
+    Ok(())
+}
+
+async fn increment(
+    context: &WalletContext,
+    signer: &SuiAddress,
+    counter_id: ObjectID,
+    delta: usize,
+    pkg_ref: ObjectRef,
+) -> Vec<TransactionDigest> {
+    let mut digests = Vec::with_capacity(delta);
+    for _ in 0..delta {
+        let digest = increment_counter(context, *signer, None, pkg_ref, counter_id)
+            .await
+            .0
+            .transaction_digest;
+        digests.push(digest);
+    }
+    digests
 }
 
 async fn node_knows_txes(node: &SuiNode, digests: &Vec<TransactionDigest>) {
@@ -140,13 +387,11 @@ async fn execute_with_orchestrator(
     orchestrator: &TransactiondOrchestrator<NetworkAuthorityClient>,
     txn: VerifiedTransaction,
     request_type: ExecuteTransactionRequestType,
-) -> ExecuteTransactionResponse {
-    let digest = *txn.digest();
+) -> SuiResult<ExecuteTransactionResponse> {
     orchestrator
         .execute_transaction(ExecuteTransactionRequest {
             transaction: txn.into(),
             request_type,
         })
         .await
-        .unwrap_or_else(|e| panic!("Failed to execute transaction {:?}: {:?}", digest, e))
 }

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -11,9 +11,7 @@ use std::sync::Arc;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_adapter::genesis;
-use sui_core::test_utils::{
-    dummy_transaction_effects, to_sender_signed_transaction, to_sender_signed_transaction_arc,
-};
+use sui_core::test_utils::dummy_transaction_effects;
 use sui_framework_build::compiled_package::BuildConfig;
 use sui_json_rpc_types::SuiObjectInfo;
 use sui_keys::keystore::AccountKeystore;
@@ -34,6 +32,7 @@ use sui_types::messages::{
     VerifiedSignedTransaction, VerifiedTransaction,
 };
 use sui_types::object::Object;
+use sui_types::utils::{to_sender_signed_transaction, to_sender_signed_transaction_arc};
 
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 2_000;

--- a/crates/test-utils/src/network.rs
+++ b/crates/test-utils/src/network.rs
@@ -84,6 +84,22 @@ impl TestCluster {
         let config = self.fullnode_config_builder().build().unwrap();
         start_fullnode_from_config(config).await
     }
+
+    pub fn get_validator_addresses(&self) -> Vec<SuiAddress> {
+        self.swarm.validators().map(|v| v.name()).collect()
+    }
+
+    pub fn stop_validator(&mut self, name: SuiAddress) {
+        self.swarm.validator_mut(name).unwrap().stop();
+    }
+
+    pub async fn start_validator(&mut self, name: SuiAddress) {
+        let node = self.swarm.validator_mut(name).unwrap();
+        if node.is_running() {
+            return;
+        }
+        node.start().await.unwrap();
+    }
 }
 
 pub struct TestClusterBuilder {


### PR DESCRIPTION
This PR implements `FullNodePendingTransactionLog`, a write-ahead-log for transaction orchestrator. It plays two rules in fullnode write path:
1. a transaction, even submitted to the fullnode multiple times (which we are observed a lot due to client not handling it correctly), is only processed once. Note we will shortly refactor TO/QD into a queue based implementation. Then we will use the log to determine if the transaction should be enqueued or not.
2. we see objects being locked/equivocated happen the most frequently when fullnode crashes, and clients do not retry. This log lets fullnode retry transactions that it was handling when it stopped, reducing the chances of object losing of liveness.