### PR TITLE
NetworkAuthorityClient cleanup

### DIFF
--- a/crates/sui-core/src/authority_active.rs
+++ b/crates/sui-core/src/authority_active.rs
@@ -56,8 +56,6 @@ use tokio::time::Instant;
 pub mod gossip;
 use gossip::GossipMetrics;
 
-use crate::authority_client::NetworkAuthorityClientMetrics;
-
 // TODO: Make these into a proper config
 const MAX_RETRIES_RECORDED: u32 = 10;
 const DELAY_FOR_1_RETRY_MS: u64 = 2_000;
@@ -124,10 +122,6 @@ pub struct ActiveAuthority<A> {
     // Gossip Metrics including gossip between validators and
     // node sync process between fullnode and validators
     pub gossip_metrics: GossipMetrics,
-
-    // This is only meaningful if A is of type NetworkAuthorityClient,
-    // and stored here for reconfiguration purposes.
-    pub network_metrics: Arc<NetworkAuthorityClientMetrics>,
 }
 
 impl<A> ActiveAuthority<A> {
@@ -139,7 +133,6 @@ impl<A> ActiveAuthority<A> {
         let committee = authority.clone_committee();
 
         let net = Arc::new(net);
-        let network_metrics = net.network_client_metrics.clone();
 
         Ok(ActiveAuthority {
             health: Arc::new(Mutex::new(
@@ -153,7 +146,6 @@ impl<A> ActiveAuthority<A> {
             node_sync_process: Default::default(),
             net: ArcSwap::from(net),
             gossip_metrics: GossipMetrics::new(prometheus_registry),
-            network_metrics,
         })
     }
 
@@ -230,7 +222,6 @@ impl<A> Clone for ActiveAuthority<A> {
             net: ArcSwap::from(self.net.load().clone()),
             health: self.health.clone(),
             gossip_metrics: self.gossip_metrics.clone(),
-            network_metrics: self.network_metrics.clone(),
         }
     }
 }

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -27,7 +27,6 @@ use sui_types::{error::SuiError, messages::*};
 #[cfg(test)]
 use sui_types::{committee::Committee, crypto::AuthorityKeyPair, object::Object};
 
-use crate::epoch::reconfiguration::Reconfigurable;
 use sui_network::tonic::transport::Channel;
 
 #[async_trait]
@@ -115,17 +114,6 @@ impl NetworkAuthorityClient {
 
     fn client(&self) -> ValidatorClient<Channel> {
         self.client.clone()
-    }
-}
-
-#[async_trait]
-impl Reconfigurable for NetworkAuthorityClient {
-    fn needs_network_recreation() -> bool {
-        true
-    }
-
-    fn recreate(channel: Channel, metrics: Arc<NetworkAuthorityClientMetrics>) -> Self {
-        NetworkAuthorityClient::new(channel, metrics)
     }
 }
 
@@ -353,16 +341,6 @@ impl LocalAuthorityClientFaultConfig {
 pub struct LocalAuthorityClient {
     pub state: Arc<AuthorityState>,
     pub fault_config: LocalAuthorityClientFaultConfig,
-}
-
-impl Reconfigurable for LocalAuthorityClient {
-    fn needs_network_recreation() -> bool {
-        false
-    }
-
-    fn recreate(_channel: Channel, _metrics: Arc<NetworkAuthorityClientMetrics>) -> Self {
-        unreachable!(); // this function should not get called because the above function returns false
-    }
 }
 
 #[async_trait]

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -1,21 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::authority_client::NetworkAuthorityClientMetrics;
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use sui_network::tonic;
-
-#[async_trait]
-pub trait Reconfigurable {
-    fn needs_network_recreation() -> bool;
-
-    fn recreate(
-        channel: tonic::transport::Channel,
-        metrics: Arc<NetworkAuthorityClientMetrics>,
-    ) -> Self;
-}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReconfigCertStatus {

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -31,7 +31,7 @@ use crate::authority::AuthorityState;
 use crate::authority_client::make_authority_clients;
 use crate::authority_client::{
     AuthorityAPI, BatchInfoResponseItemStream, LocalAuthorityClient,
-    LocalAuthorityClientFaultConfig, NetworkAuthorityClient, NetworkAuthorityClientMetrics,
+    LocalAuthorityClientFaultConfig, NetworkAuthorityClient,
 };
 use crate::test_utils::to_sender_signed_transaction;
 use crate::validator_info::make_committee;
@@ -55,7 +55,6 @@ async fn init_network_authorities(
         configs.validator_set(),
         DEFAULT_CONNECT_TIMEOUT_SEC,
         DEFAULT_REQUEST_TIMEOUT_SEC,
-        Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
     );
 
     let registry = prometheus::Registry::new();
@@ -65,7 +64,6 @@ async fn init_network_authorities(
         auth_clients,
         AuthAggMetrics::new(&registry),
         Arc::new(SafeClientMetrics::new(&registry)),
-        Arc::new(NetworkAuthorityClientMetrics::new(&registry)),
     )
 }
 
@@ -162,7 +160,6 @@ pub async fn init_local_authorities_with_genesis(
             clients,
             AuthAggMetrics::new_for_tests(),
             Arc::new(SafeClientMetrics::new_for_tests()),
-            Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
             timeouts,
         ),
         states,
@@ -921,7 +918,6 @@ fn get_agg(
         clients,
         AuthAggMetrics::new_for_tests(),
         Arc::new(SafeClientMetrics::new_for_tests()),
-        Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
         TimeoutConfig {
             serial_authority_request_interval: Duration::from_millis(50),
             ..Default::default()

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    authority_client::{AuthorityAPI, NetworkAuthorityClient, NetworkAuthorityClientMetrics},
+    authority_client::{AuthorityAPI, NetworkAuthorityClient},
     authority_server::AuthorityServer,
     checkpoints::CheckpointServiceNoop,
     test_utils::to_sender_signed_transaction,
@@ -244,12 +244,9 @@ async fn test_handle_transfer_transaction_bad_signature() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(
-        server_handle.address(),
-        Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-    )
-    .await
-    .unwrap();
+    let client = NetworkAuthorityClient::connect(server_handle.address())
+        .await
+        .unwrap();
 
     let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
     let mut bad_signature_transfer_transaction = transfer_transaction.clone().into_inner();

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -5,8 +5,7 @@ use super::*;
 use crate::{
     authority::authority_tests::init_state_with_object_id,
     authority_client::{
-        AuthorityAPI, LocalAuthorityClient, LocalAuthorityClientFaultConfig,
-        NetworkAuthorityClient, NetworkAuthorityClientMetrics,
+        AuthorityAPI, LocalAuthorityClient, LocalAuthorityClientFaultConfig, NetworkAuthorityClient,
     },
     safe_client::SafeClientMetrics,
 };
@@ -39,12 +38,9 @@ async fn test_simple_request() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(
-        server_handle.address(),
-        Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-    )
-    .await
-    .unwrap();
+    let client = NetworkAuthorityClient::connect(server_handle.address())
+        .await
+        .unwrap();
 
     let req = ObjectInfoRequest::latest_object_info_request(
         object_id,
@@ -79,12 +75,9 @@ async fn test_subscription() {
 
     let server_handle = server.spawn_for_test().await.unwrap();
 
-    let client = NetworkAuthorityClient::connect(
-        server_handle.address(),
-        Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-    )
-    .await
-    .unwrap();
+    let client = NetworkAuthorityClient::connect(server_handle.address())
+        .await
+        .unwrap();
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -8,16 +8,13 @@ use multiaddr::Multiaddr;
 use std::cmp::min;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::Arc;
 use sui_config::{genesis::Genesis, ValidatorInfo};
 use sui_network::default_mysten_network_config;
 use sui_tool::db_tool::{execute_db_tool_command, print_db_all_tables, DbToolCommand};
 use sui_types::message_envelope::Message;
 use tokio::time::Instant;
 
-use sui_core::authority_client::{
-    AuthorityAPI, NetworkAuthorityClient, NetworkAuthorityClientMetrics,
-};
+use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use sui_types::{base_types::*, batch::*, messages::*, object::Owner};
 
 use anyhow::anyhow;
@@ -32,7 +29,7 @@ use sui_types::object::ObjectFormatOptions;
 
 #[derive(Parser, Clone, ArgEnum)]
 pub enum Verbosity {
-    Groupped,
+    Grouped,
     Concise,
     Verbose,
 }
@@ -78,7 +75,7 @@ pub enum ToolCommand {
         #[clap(
             arg_enum,
             long = "verbosity",
-            default_value = "groupped",
+            default_value = "grouped",
             ignore_case = true
         )]
         verbosity: Verbosity,
@@ -174,10 +171,7 @@ fn make_clients(
         let channel = net_config
             .connect_lazy(validator.network_address())
             .map_err(|err| anyhow!(err.to_string()))?;
-        let client = NetworkAuthorityClient::new(
-            channel,
-            Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-        );
+        let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes = validator.protocol_key();
         authority_clients.insert(public_key_bytes, (validator, client));
     }
@@ -244,10 +238,10 @@ impl std::fmt::Display for OwnerOutput {
     }
 }
 
-struct GrouppedObjectOutput(ObjectData);
+struct GroupedObjectOutput(ObjectData);
 
 #[allow(clippy::format_in_format_args)]
-impl std::fmt::Display for GrouppedObjectOutput {
+impl std::fmt::Display for GroupedObjectOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let responses = self
             .0
@@ -602,8 +596,8 @@ impl ToolCommand {
                     responses,
                 };
                 match verbosity {
-                    Verbosity::Groupped => {
-                        println!("{}", GrouppedObjectOutput(output));
+                    Verbosity::Grouped => {
+                        println!("{}", GroupedObjectOutput(output));
                     }
                     Verbosity::Verbose => {
                         println!("{}", VerboseObjectOutput(output));

--- a/crates/test-utils/src/authority.rs
+++ b/crates/test-utils/src/authority.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::TEST_COMMITTEE_SIZE;
 use prometheus::Registry;
 use rand::{prelude::StdRng, SeedableRng};
-use std::sync::Arc;
 use std::time::Duration;
 use sui_config::{NetworkConfig, NodeConfig, ValidatorInfo};
+use sui_core::authority_client::AuthorityAPI;
 use sui_core::authority_client::NetworkAuthorityClient;
-use sui_core::authority_client::{AuthorityAPI, NetworkAuthorityClientMetrics};
 use sui_types::object::Object;
 
 pub use sui_node::{SuiNode, SuiNodeHandle};
@@ -104,11 +104,7 @@ where
 
 /// Get a network client to communicate with the consensus.
 pub fn get_client(config: &ValidatorInfo) -> NetworkAuthorityClient {
-    NetworkAuthorityClient::connect_lazy(
-        config.network_address(),
-        Arc::new(NetworkAuthorityClientMetrics::new_for_tests()),
-    )
-    .unwrap()
+    NetworkAuthorityClient::connect_lazy(config.network_address()).unwrap()
 }
 
 pub async fn get_object(config: &ValidatorInfo, object_id: ObjectID) -> Object {


### PR DESCRIPTION
This PR cleans up two things:
1. We no longer need the Reconfigurable trait, deleting it
2. We do not need individual metrics inside NetworkAuthorityClient. All of them are already covered inside SafeClient.