### PR TITLE
[TxManager] use TransactionManager to order user submitted transactions for execution

### DIFF
--- a/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
+++ b/crates/sui-cluster-test/src/test_case/fullnode_build_publish_transaction_test.rs
@@ -5,8 +5,8 @@ use crate::{TestCaseImpl, TestContext};
 use async_trait::async_trait;
 use fastcrypto::encoding::Base64;
 use jsonrpsee::rpc_params;
+use sui_core::test_utils::compile_basics_package;
 use sui_types::{base_types::ObjectID, object::Owner};
-use test_utils::transaction::compile_basics_package;
 
 pub struct FullNodeBuildPublishTransactionTest;
 
@@ -22,6 +22,7 @@ impl TestCaseImpl for FullNodeBuildPublishTransactionTest {
 
     async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
         let all_module_bytes = compile_basics_package()
+            .get_package_bytes()
             .iter()
             .map(|bytes| Base64::from_bytes(bytes))
             .collect::<Vec<_>>();

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -160,11 +160,12 @@ pub struct AuthorityMetrics {
     num_shared_objects: Histogram,
     batch_size: Histogram,
 
+    handle_transaction_latency: Histogram,
+    execute_certificate_latency: Histogram,
+    execute_certificate_with_effects_latency: Histogram,
+    internal_execution_latency: Histogram,
     prepare_certificate_latency: Histogram,
     commit_certificate_latency: Histogram,
-    handle_transaction_latency: Histogram,
-    handle_certificate_latency: Histogram,
-    handle_node_sync_certificate_latency: Histogram,
 
     pub(crate) transaction_manager_num_missing_objects: IntGauge,
     pub(crate) transaction_manager_num_pending_certificates: IntGauge,
@@ -288,37 +289,44 @@ impl AuthorityMetrics {
                 registry,
             )
             .unwrap(),
+            handle_transaction_latency: register_histogram_with_registry!(
+                "authority_state_handle_transaction_latency",
+                "Latency of handling transactions",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            execute_certificate_latency: register_histogram_with_registry!(
+                "authority_state_execute_certificate_latency",
+                "Latency of executing certificates, including waiting for inputs",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            execute_certificate_with_effects_latency: register_histogram_with_registry!(
+                "authority_state_execute_certificate_with_effects_latency",
+                "Latency of executing certificates with effects, including waiting for inputs",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            internal_execution_latency: register_histogram_with_registry!(
+                "authority_state_internal_execution_latency",
+                "Latency of actual certificate executions",
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
             prepare_certificate_latency: register_histogram_with_registry!(
-                "validator_prepare_certificate_latency",
-                "Latency of preparing certificate",
+                "authority_state_prepare_certificate_latency",
+                "Latency of executing certificates, before committing the results",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
             commit_certificate_latency: register_histogram_with_registry!(
-                "validator_commit_certificate_latency",
-                "Latency of committing certificate",
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_transaction_latency: register_histogram_with_registry!(
-                "validator_handle_transaction_latency",
-                "Latency of committing certificate",
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_certificate_latency: register_histogram_with_registry!(
-                "validator_handle_certificate_latency",
-                "Latency of handling certificate",
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            handle_node_sync_certificate_latency: register_histogram_with_registry!(
-                "fullnode_handle_node_sync_certificate_latency",
-                "Latency of fullnode handling certificate from node sync",
+                "authority_state_commit_certificate_latency",
+                "Latency of committing certificate execution results",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -697,7 +705,7 @@ impl AuthorityState {
     ) -> SuiResult {
         let _metrics_guard = self
             .metrics
-            .handle_node_sync_certificate_latency
+            .execute_certificate_with_effects_latency
             .start_timer();
         let digest = *certificate.digest();
         debug!(tx_digest = ?digest, "execute_certificate_with_effects");
@@ -716,11 +724,8 @@ impl AuthorityState {
 
         let expected_effects_digest = effects.digest();
 
-        let certs = vec![certificate.clone()];
-        self.database
-            .epoch_store()
-            .insert_pending_certificates(&certs)?;
-        self.transaction_manager.enqueue(certs).await?;
+        self.enqueue_certificates_for_execution(vec![certificate.clone()])
+            .await?;
 
         let observed_effects = self
             .database
@@ -751,6 +756,7 @@ impl AuthorityState {
         &self,
         certificate: &VerifiedCertificate,
     ) -> SuiResult<VerifiedTransactionInfoResponse> {
+        let _metrics_guard = self.metrics.execute_certificate_latency.start_timer();
         let tx_digest = *certificate.digest();
         debug!(?tx_digest, "execute_certificate");
 
@@ -767,11 +773,8 @@ impl AuthorityState {
             return Err(SuiError::SharedObjectLockNotSetError);
         }
 
-        let certs = vec![certificate.clone()];
-        self.database
-            .epoch_store()
-            .insert_pending_certificates(&certs)?;
-        self.transaction_manager.enqueue(certs).await?;
+        self.enqueue_certificates_for_execution(vec![certificate.clone()])
+            .await?;
 
         self.notify_read_transaction_info(certificate).await
     }
@@ -792,10 +795,9 @@ impl AuthorityState {
         &self,
         certificate: &VerifiedCertificate,
     ) -> SuiResult<VerifiedTransactionInfoResponse> {
+        let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
         let tx_digest = *certificate.digest();
         debug!(?tx_digest, "execute_certificate_internal");
-
-        let _metrics_guard = self.metrics.handle_certificate_latency.start_timer();
 
         // This acquires a lock on the tx digest to prevent multiple concurrent executions of the
         // same tx. While we don't need this for safety (tx sequencing is ultimately atomic), it is
@@ -808,7 +810,7 @@ impl AuthorityState {
         // epsilon of txes) while solutions without false contention have slightly higher cost
         // for every tx.
         let span = tracing::debug_span!(
-            "handle_certificate_tx_guard",
+            "execute_certificate_internal_guard",
             ?tx_digest,
             tx_kind = certificate.data().intent_message.value.kind_as_str()
         );
@@ -1850,10 +1852,10 @@ impl AuthorityState {
     }
 
     /// Adds certificates to the pending certificate store and transaction manager for ordered execution.
-    /// Currently, only used in tests and deprecated callsites.
-    pub async fn add_pending_certificates(&self, certs: Vec<VerifiedCertificate>) -> SuiResult<()> {
-        self.node_sync_store
-            .batch_store_certs(certs.iter().cloned())?;
+    pub async fn enqueue_certificates_for_execution(
+        &self,
+        certs: Vec<VerifiedCertificate>,
+    ) -> SuiResult<()> {
         self.epoch_store().insert_pending_certificates(&certs)?;
         self.transaction_manager.enqueue(certs).await
     }

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -439,7 +439,7 @@ impl LocalAuthorityClient {
                     let epoch_store = state.epoch_store();
                     certificate.verify(epoch_store.committee())?
                 };
-                state.execute_certificate_internal(&certificate).await?
+                state.try_execute_immediately(&certificate).await?
             }
         };
         if fault_config.fail_after_handle_confirmation {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -17,8 +17,7 @@ use sui_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
-use sui_types::messages_checkpoint::CheckpointRequest;
-use sui_types::messages_checkpoint::CheckpointResponse;
+use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
 use sui_types::{error::*, messages::*};
 use tap::TapFallible;
 use tokio::task::JoinHandle;
@@ -366,7 +365,7 @@ impl ValidatorService {
                 }
             })?;
             // Do not wait for the result, because the transaction might have already executed.
-            // Instead, read or wait for effects which is done below.
+            // Instead, check or wait for the existence of certificate effects below.
         }
 
         // 4) Execute the certificate if it contains only owned object transactions, or wait for

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -2,10 +2,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    authority::AuthorityState,
-    consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics},
-};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{stream::BoxStream, TryStreamExt};
@@ -21,12 +17,17 @@ use sui_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
-use sui_types::error::{SuiError, SuiResult};
-use sui_types::messages::*;
-use sui_types::messages_checkpoint::{CheckpointRequest, CheckpointResponse};
+use sui_types::messages_checkpoint::CheckpointRequest;
+use sui_types::messages_checkpoint::CheckpointResponse;
+use sui_types::{error::*, messages::*};
 use tap::TapFallible;
-use tokio::{task::JoinHandle, time::sleep};
-use tracing::{debug, info, Instrument};
+use tokio::task::JoinHandle;
+use tracing::{info, Instrument};
+
+use crate::{
+    authority::AuthorityState,
+    consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics},
+};
 
 #[cfg(test)]
 #[path = "unit_tests/server_tests.rs"]
@@ -359,59 +360,27 @@ impl ValidatorService {
                 &state.name,
                 certificate.clone().into(),
             );
-            let waiter = consensus_adapter.submit(transaction).tap_err(|e| {
+            let _waiter = consensus_adapter.submit(transaction).tap_err(|e| {
                 if let SuiError::ValidatorHaltedAtEpochEnd = e {
                     metrics.num_rejected_cert_in_epoch_boundary.inc();
                 }
             })?;
-            if certificate.contains_shared_object() {
-                // This is expect on tokio JoinHandle result, not SuiResult
-                waiter
-                    .await
-                    .expect("Tokio runtime failure when waiting for consensus result");
-            }
+            // Do not wait for the result, because the transaction might have already executed.
+            // Instead, read or wait for effects which is done below.
         }
 
-        // 4) Execute the certificate.
-        // Often we cannot execute a cert due to dependenties haven't been executed, and we will
-        // observe TransactionInputObjectsErrors. In such case, we can wait and retry. It should eventually
-        // succeed.
-        // TODO: call execute_certificate_internal() instead and remove retries.
-        let mut retry_delay_ms = 200;
-        loop {
-            let span = tracing::debug_span!(
-                "handle_certificate_execution",
-                ?tx_digest,
-                tx_kind = certificate.data().intent_message.value.kind_as_str()
-            );
-            match state
-                .execute_certificate_internal(&certificate)
-                .instrument(span)
-                .await
-            {
-                // For owned object certificates, we could also be getting this error
-                // if this validator hasn't executed some of the causal dependencies.
-                // And that's ok because there must exist 2f+1 that has. So we can
-                // afford this validator returning error.
-                err @ Err(SuiError::TransactionInputObjectsErrors { .. }) if shared_object_tx => {
-                    if retry_delay_ms >= 12800 {
-                        return Err(tonic::Status::from(err.unwrap_err()));
-                    }
-                    debug!(
-                        ?tx_digest,
-                        ?retry_delay_ms,
-                        "Certificate failed due to missing dependencies, wait and retry",
-                    );
-                    sleep(Duration::from_millis(retry_delay_ms)).await;
-                    retry_delay_ms *= 2;
-                }
-                Err(e) => {
-                    return Err(tonic::Status::from(e));
-                }
-                Ok(response) => {
-                    return Ok(tonic::Response::new(response.into()));
-                }
-            }
+        // 4) Execute the certificate if it contains only owned object transactions, or wait for
+        // the execution results if it contains shared objects.
+        let res = if certificate.contains_shared_object() {
+            // The transaction needs sequencing by Narwhal before it can be sent for execution.
+            // So rely on the submission to consensus above to execute the certificate.
+            state.notify_read_transaction_info(&certificate).await
+        } else {
+            state.execute_certificate(&certificate).await
+        };
+        match res {
+            Ok(response) => Ok(tonic::Response::new(response.into())),
+            Err(e) => Err(tonic::Status::from(e)),
         }
     }
 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -496,7 +496,7 @@ impl CheckpointBuilder {
             .await?;
         let signed_effect = self
             .state
-            .execute_certificate_internal(&cert)
+            .try_execute_immediately(&cert)
             .await?
             .signed_effects
             .unwrap();

--- a/crates/sui-core/src/epoch/reconfiguration.rs
+++ b/crates/sui-core/src/epoch/reconfiguration.rs
@@ -212,7 +212,7 @@ where
                 .process_transaction(advance_epoch_tx.clone().into_unsigned())
                 .await
             {
-                Ok(certificate) => match self.state.execute_certificate_internal(&certificate).await {
+                Ok(certificate) => match self.state.try_execute_immediately(&certificate).await {
                     Ok(_) => {
                         break;
                     }

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -77,7 +77,7 @@ pub async fn execution_process(
             let mut attempts = 0;
             loop {
                 attempts += 1;
-                let res = authority.execute_certificate_internal(&certificate).await;
+                let res = authority.try_execute_immediately(&certificate).await;
                 if let Err(e) = res {
                     if attempts == EXECUTION_MAX_ATTEMPTS {
                         error!("Failed to execute certified transaction after {attempts} attempts! error={e} certificate={:?}", certificate);

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -580,7 +580,7 @@ where
 
         let cert = self.get_cert(epoch_id, digest).await?;
 
-        let result = self.state().execute_certificate_internal(&cert).await;
+        let result = self.state().try_execute_immediately(&cert).await;
         match result {
             Ok(_) => Ok(SyncStatus::CertExecuted),
             e @ Err(SuiError::TransactionInputObjectsErrors { .. }) => {
@@ -600,7 +600,7 @@ where
 
                 // Parents have been executed, so this should now succeed.
                 debug!(?digest, "parents executed, re-attempting cert");
-                self.state().execute_certificate_internal(&cert).await?;
+                self.state().try_execute_immediately(&cert).await?;
                 Ok(SyncStatus::CertExecuted)
             }
             Err(e) => Err(e),

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_config::genesis::Genesis;
 use sui_config::ValidatorInfo;
-use sui_framework_build::compiled_package::BuildConfig;
+use sui_framework_build::compiled_package::{BuildConfig, CompiledPackage};
 use sui_types::base_types::ObjectRef;
 use sui_types::crypto::AuthorityKeyPair;
 use sui_types::crypto::{
@@ -118,6 +118,14 @@ pub fn dummy_transaction_effects(tx: &Transaction) -> TransactionEffects {
     }
 }
 
+pub fn compile_basics_package() -> CompiledPackage {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("../../sui_programmability/examples/basics");
+
+    let build_config = BuildConfig::default();
+    sui_framework::build_move_package(&path, build_config).unwrap()
+}
+
 async fn init_genesis(
     committee_size: usize,
     mut genesis_objects: Vec<Object>,
@@ -127,11 +135,7 @@ async fn init_genesis(
     ObjectRef,
 ) {
     // add object_basics package object to genesis
-    let build_config = BuildConfig::default();
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("src/unit_tests/data/object_basics");
-    let modules = sui_framework::build_move_package(&path, build_config)
-        .unwrap()
+    let modules = compile_basics_package()
         .get_modules()
         .into_iter()
         .cloned()

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -93,7 +93,7 @@ pub fn transfer_object_move_transaction(
     )
 }
 
-pub fn crate_object_move_transaction(
+pub fn create_object_move_transaction(
     src: SuiAddress,
     secret: &dyn signature::Signer<Signature>,
     dest: SuiAddress,
@@ -318,7 +318,7 @@ async fn test_quorum_map_and_reduce_timeout() {
     let gas_ref_1 = gas_object1.compute_object_reference();
     let genesis_objects = vec![pkg, gas_object1];
     let (mut authorities, _, _) = init_local_authorities(4, genesis_objects).await;
-    let tx = crate_object_move_transaction(addr1, &key1, addr1, 100, pkg_ref, gas_ref_1);
+    let tx = create_object_move_transaction(addr1, &key1, addr1, 100, pkg_ref, gas_ref_1);
     let certified_tx = authorities.process_transaction(tx.clone()).await;
     assert!(certified_tx.is_ok());
     let certificate = certified_tx.unwrap();
@@ -492,7 +492,7 @@ async fn test_execute_cert_to_true_effects() {
 
     // Make a schedule of transactions
     let gas_ref_1 = get_latest_ref(authority_clients[0], gas_object1.id()).await;
-    let create1 = crate_object_move_transaction(addr1, &key1, addr1, 100, pkg_ref, gas_ref_1);
+    let create1 = create_object_move_transaction(addr1, &key1, addr1, 100, pkg_ref, gas_ref_1);
 
     do_transaction(authority_clients[0], &create1).await;
     do_transaction(authority_clients[1], &create1).await;

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1493,7 +1493,7 @@ async fn test_handle_confirmation_transaction_bad_sequence_number() {
         authority_state.insert_genesis_object(sender_object).await;
     }
 
-    // Explanation: providing an old cert that has already need applied
+    // Explanation: providing an old cert that has already been applied
     //              returns a Ok(_) with info about the new object states.
     let response = authority_state
         .execute_certificate_internal(&certified_transfer_transaction)
@@ -1540,7 +1540,7 @@ async fn test_handle_confirmation_transaction_receiver_equal_sender() {
         &authority_state,
     );
     let response = authority_state
-        .execute_certificate_internal(&certified_transfer_transaction)
+        .execute_certificate(&certified_transfer_transaction)
         .await
         .unwrap();
     response.signed_effects.unwrap().into_data().status.unwrap();
@@ -1594,7 +1594,7 @@ async fn test_handle_confirmation_transaction_ok() {
         .unwrap();
 
     let info = authority_state
-        .execute_certificate_internal(&certified_transfer_transaction.clone())
+        .execute_certificate(&certified_transfer_transaction.clone())
         .await
         .unwrap();
     info.signed_effects.unwrap().into_data().status.unwrap();
@@ -1803,13 +1803,13 @@ async fn test_handle_confirmation_transaction_idempotent() {
     );
 
     let info = authority_state
-        .execute_certificate_internal(&certified_transfer_transaction)
+        .execute_certificate(&certified_transfer_transaction)
         .await
         .unwrap();
     assert!(info.signed_effects.as_ref().unwrap().data().status.is_ok());
 
     let info2 = authority_state
-        .execute_certificate_internal(&certified_transfer_transaction)
+        .execute_certificate(&certified_transfer_transaction)
         .await
         .unwrap();
     assert!(info2.signed_effects.as_ref().unwrap().data().status.is_ok());
@@ -1948,7 +1948,7 @@ async fn test_move_call_insufficient_gas() {
         &authority_state,
     );
     let effects = authority_state
-        .execute_certificate_internal(&certified_transfer_transaction)
+        .execute_certificate(&certified_transfer_transaction)
         .await
         .unwrap()
         .signed_effects
@@ -2299,7 +2299,7 @@ async fn test_idempotent_reversed_confirmation() {
         &authority_state,
     );
     let result1 = authority_state
-        .execute_certificate_internal(&certified_transfer_transaction)
+        .execute_certificate(&certified_transfer_transaction)
         .await;
     assert!(result1.is_ok());
     let result2 = authority_state
@@ -2349,7 +2349,7 @@ async fn test_transfer_sui_no_amount() {
 
     let certificate = init_certified_transaction(transaction, &authority_state);
     let response = authority_state
-        .execute_certificate_internal(&certificate)
+        .execute_certificate(&certificate)
         .await
         .unwrap();
     let effects = response.signed_effects.unwrap().into_data();
@@ -2387,7 +2387,7 @@ async fn test_transfer_sui_with_amount() {
     let transaction = to_sender_signed_transaction(tx_data, &sender_key);
     let certificate = init_certified_transaction(transaction, &authority_state);
     let response = authority_state
-        .execute_certificate_internal(&certificate)
+        .execute_certificate(&certificate)
         .await
         .unwrap();
     let effects = response.signed_effects.unwrap().into_data();
@@ -2441,7 +2441,7 @@ async fn test_store_revert_transfer_sui() {
     let certificate = init_certified_transaction(transaction, &authority_state);
     let tx_digest = *certificate.digest();
     authority_state
-        .execute_certificate_internal(&certificate)
+        .execute_certificate(&certificate)
         .await
         .unwrap();
 
@@ -2510,7 +2510,7 @@ async fn test_store_revert_wrap_move_call() {
     let wrap_digest = *wrap_cert.digest();
 
     let wrap_effects = authority_state
-        .execute_certificate_internal(&wrap_cert)
+        .execute_certificate(&wrap_cert)
         .await
         .unwrap()
         .signed_effects
@@ -2597,7 +2597,7 @@ async fn test_store_revert_unwrap_move_call() {
     let unwrap_digest = *unwrap_cert.digest();
 
     let unwrap_effects = authority_state
-        .execute_certificate_internal(&unwrap_cert)
+        .execute_certificate(&unwrap_cert)
         .await
         .unwrap()
         .signed_effects
@@ -2830,7 +2830,7 @@ async fn test_store_revert_add_ofield() {
     let add_digest = *add_cert.digest();
 
     let add_effects = authority_state
-        .execute_certificate_internal(&add_cert)
+        .execute_certificate(&add_cert)
         .await
         .unwrap()
         .signed_effects
@@ -2942,7 +2942,7 @@ async fn test_store_revert_remove_ofield() {
     let remove_ofield_digest = *remove_ofield_cert.digest();
 
     let remove_effects = authority_state
-        .execute_certificate_internal(&remove_ofield_cert)
+        .execute_certificate(&remove_ofield_cert)
         .await
         .unwrap()
         .signed_effects

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -1,23 +1,28 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::authority::authority_tests::{send_consensus, send_consensus_no_execution};
+use crate::authority::{AuthorityState, EffectsNotifyRead};
 use crate::authority_aggregator::authority_aggregator_tests::{
-    crate_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
+    create_object_move_transaction, do_cert, do_transaction, extract_cert, get_latest_ref,
     transfer_object_move_transaction,
 };
-use crate::test_utils::{init_local_authorities, wait_for_tx};
+use crate::authority_client::LocalAuthorityClient;
+use crate::safe_client::SafeClient;
+use crate::test_utils::init_local_authorities;
 
 use std::collections::BTreeSet;
 use std::time::Duration;
 
 use itertools::Itertools;
 use sui_types::base_types::TransactionDigest;
+use sui_types::committee::Committee;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
-use sui_types::messages::VerifiedCertificate;
-use sui_types::object::Object;
+use sui_types::messages::{TransactionEffects, VerifiedCertificate, VerifiedTransaction};
+use sui_types::object::{Object, Owner};
+use test_utils::messages::{make_counter_create_transaction, make_counter_increment_transaction};
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::timeout;
-use tracing::info;
 
 #[allow(dead_code)]
 async fn wait_for_certs(
@@ -120,7 +125,7 @@ async fn pending_exec_notify_ready_certificates() {
 
     // Insert the certificates
     authority_state
-        .add_pending_certificates(certs.clone())
+        .enqueue_certificates_for_execution(certs.clone())
         .await
         .expect("Storage is ok");
 
@@ -202,7 +207,7 @@ async fn pending_exec_full() {
 
     // Insert the certificates
     authority_state
-        .add_pending_certificates(certs.clone())
+        .enqueue_certificates_for_execution(certs.clone())
         .await
         .expect("Storage is ok");
 
@@ -214,90 +219,208 @@ async fn pending_exec_full() {
 
  */
 
+async fn execute_owned_on_first_three_authorities(
+    authority_clients: &[&SafeClient<LocalAuthorityClient>],
+    committee: &Committee,
+    txn: &VerifiedTransaction,
+) -> (VerifiedCertificate, TransactionEffects) {
+    do_transaction(authority_clients[0], txn).await;
+    do_transaction(authority_clients[1], txn).await;
+    do_transaction(authority_clients[2], txn).await;
+    let cert = extract_cert(authority_clients, committee, txn.digest())
+        .await
+        .verify(committee)
+        .unwrap();
+    do_cert(authority_clients[0], &cert).await;
+    do_cert(authority_clients[1], &cert).await;
+    let effects = do_cert(authority_clients[2], &cert).await;
+    (cert, effects)
+}
+
+pub async fn do_cert_with_shared_objects(
+    authority: &AuthorityState,
+    cert: &VerifiedCertificate,
+) -> TransactionEffects {
+    send_consensus(authority, cert).await;
+    authority
+        .database
+        .notify_read_effects(vec![*cert.digest()])
+        .await
+        .unwrap()
+        .pop()
+        .unwrap()
+        .into_data()
+}
+
+async fn execute_shared_on_first_three_authorities(
+    authority_clients: &[&SafeClient<LocalAuthorityClient>],
+    committee: &Committee,
+    txn: &VerifiedTransaction,
+) -> (VerifiedCertificate, TransactionEffects) {
+    do_transaction(authority_clients[0], txn).await;
+    do_transaction(authority_clients[1], txn).await;
+    do_transaction(authority_clients[2], txn).await;
+    let cert = extract_cert(authority_clients, committee, txn.digest())
+        .await
+        .verify(committee)
+        .unwrap();
+    do_cert_with_shared_objects(&authority_clients[0].authority_client().state, &cert).await;
+    do_cert_with_shared_objects(&authority_clients[1].authority_client().state, &cert).await;
+    let effects =
+        do_cert_with_shared_objects(&authority_clients[2].authority_client().state, &cert).await;
+    (cert, effects)
+}
+
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_transaction_manager() {
     telemetry_subscribers::init_for_testing();
 
-    let (addr1, key1): (_, AccountKeyPair) = get_key_pair();
-    let gas_objects = vec![0..100]
-        .iter()
-        .map(|_| Object::with_owner_for_testing(addr1))
+    // ---- Initialize a network with three accounts, each with 10 gas objects.
+
+    const NUM_ACCOUNTS: usize = 3;
+    let accounts: Vec<(_, AccountKeyPair)> = (0..NUM_ACCOUNTS)
+        .into_iter()
+        .map(|_| get_key_pair())
         .collect_vec();
+
+    const NUM_GAS_OBJECTS_PER_ACCOUNT: usize = 10;
+    let gas_objects = (0..NUM_ACCOUNTS)
+        .into_iter()
+        .map(|i| {
+            (0..NUM_GAS_OBJECTS_PER_ACCOUNT)
+                .into_iter()
+                .map(|_| Object::with_owner_for_testing(accounts[i].0))
+                .collect_vec()
+        })
+        .collect_vec();
+    let all_gas_objects = gas_objects.clone().into_iter().flatten().collect_vec();
+
     let (aggregator, authorities, framework_obj_ref) =
-        init_local_authorities(4, gas_objects.clone()).await;
+        init_local_authorities(4, all_gas_objects.clone()).await;
     let authority_clients: Vec<_> = authorities
         .iter()
         .map(|a| &aggregator.authority_clients[&a.name])
         .collect();
 
-    // Make a schedule of transactions
-    let gas_ref_0 = get_latest_ref(authority_clients[0], gas_objects[0].id()).await;
-    let tx1 = crate_object_move_transaction(addr1, &key1, addr1, 100, framework_obj_ref, gas_ref_0);
+    // ---- Create an owned object and a shared counter.
 
-    // create an object and execute the cert on 3 authorities
-    do_transaction(authority_clients[0], &tx1).await;
-    do_transaction(authority_clients[1], &tx1).await;
-    do_transaction(authority_clients[2], &tx1).await;
-    let cert1 = extract_cert(&authority_clients, &aggregator.committee, tx1.digest())
-        .await
-        .verify(&aggregator.committee)
-        .unwrap();
+    let mut executed_owned_certs = Vec::new();
+    let mut executed_shared_certs = Vec::new();
 
-    do_cert(authority_clients[0], &cert1).await;
-    do_cert(authority_clients[1], &cert1).await;
-    let effects1 = do_cert(authority_clients[2], &cert1).await;
-    info!(digest = ?tx1.digest(), "cert1 finished");
+    // Initialize an object owned by 1st account.
+    let (addr1, key1): &(_, AccountKeyPair) = &accounts[0];
+    let gas_ref = get_latest_ref(authority_clients[0], gas_objects[0][0].id()).await;
+    let tx1 = create_object_move_transaction(*addr1, key1, *addr1, 100, framework_obj_ref, gas_ref);
+    let (cert, effects1) =
+        execute_owned_on_first_three_authorities(&authority_clients, &aggregator.committee, &tx1)
+            .await;
+    executed_owned_certs.push(cert);
+    let mut owned_object_ref = effects1.created[0].0;
 
-    // now create a tx to transfer that object (only on 3 authorities), and then execute it on one
-    // authority only.
-    let (addr2, _): (_, AccountKeyPair) = get_key_pair();
+    // Initialize a shared counter, re-using gas_ref_0 so it has to execute after tx1.
+    let gas_ref = get_latest_ref(authority_clients[0], gas_objects[0][0].id()).await;
+    let tx2 = make_counter_create_transaction(gas_ref, framework_obj_ref, *addr1, key1);
+    let (cert, effects2) =
+        execute_owned_on_first_three_authorities(&authority_clients, &aggregator.committee, &tx2)
+            .await;
+    executed_owned_certs.push(cert);
+    let (mut shared_counter_ref, owner) = effects2.created[0];
+    let shared_counter_initial_version = if let Owner::Shared {
+        initial_shared_version,
+    } = owner
+    {
+        // Because the gas object used has version 2, the initial lamport timestamp of the shared
+        // counter is 3.
+        assert_eq!(initial_shared_version.value(), 3);
+        initial_shared_version
+    } else {
+        panic!("Not a shared object! {:?} {:?}", shared_counter_ref, owner);
+    };
 
-    let tx2 = transfer_object_move_transaction(
-        addr1,
-        &key1,
-        addr2,
-        effects1.created[0].0,
-        framework_obj_ref,
-        effects1.gas_object.0,
-    );
+    // ---- Execute transactions with dependencies on first 3 nodes in the dependency order.
 
-    do_transaction(authority_clients[0], &tx2).await;
-    do_transaction(authority_clients[1], &tx2).await;
-    do_transaction(authority_clients[2], &tx2).await;
-    let cert2 = extract_cert(&authority_clients, &aggregator.committee, tx2.digest())
-        .await
-        .verify(&aggregator.committee)
-        .unwrap();
-    do_cert(authority_clients[0], &cert2).await;
-    info!(digest = ?tx2.digest(), "cert2 finished");
+    // In each iteration, creates an owned and a shared transaction that depends on previous input
+    // and gas objects.
+    for i in 0..100 {
+        let source_index = i % NUM_ACCOUNTS;
+        let (source_addr, source_key) = &accounts[source_index];
 
-    // the 4th authority has never heard of either of these transactions. Tell it to execute the
-    // cert, sends it the missing dependency and verify that it is able to fetch parents and apply.
-    let batch_state = authorities[3].clone();
-    tokio::task::spawn(async move {
-        batch_state
-            .run_batch_service(1, Duration::from_secs(1))
+        let gas_ref = get_latest_ref(
+            authority_clients[source_index],
+            gas_objects[source_index][i * 3 % NUM_GAS_OBJECTS_PER_ACCOUNT].id(),
+        )
+        .await;
+        let (dest_addr, _) = &accounts[(i + 1) % NUM_ACCOUNTS];
+        let owned_tx = transfer_object_move_transaction(
+            *source_addr,
+            source_key,
+            *dest_addr,
+            owned_object_ref,
+            framework_obj_ref,
+            gas_ref,
+        );
+        let (cert, effects) = execute_owned_on_first_three_authorities(
+            &authority_clients,
+            &aggregator.committee,
+            &owned_tx,
+        )
+        .await;
+        executed_owned_certs.push(cert);
+        owned_object_ref = effects.mutated_excluding_gas().next().unwrap().0;
+
+        let gas_ref = get_latest_ref(
+            authority_clients[source_index],
+            gas_objects[source_index][i * 7 % NUM_GAS_OBJECTS_PER_ACCOUNT].id(),
+        )
+        .await;
+        let shared_tx = make_counter_increment_transaction(
+            gas_ref,
+            framework_obj_ref,
+            shared_counter_ref.0,
+            shared_counter_initial_version,
+            *source_addr,
+            source_key,
+        );
+        let (cert, effects) = execute_shared_on_first_three_authorities(
+            &authority_clients,
+            &aggregator.committee,
+            &shared_tx,
+        )
+        .await;
+        executed_shared_certs.push(cert);
+        shared_counter_ref = effects.mutated_excluding_gas().next().unwrap().0;
+    }
+
+    // ---- Execute transactions in reverse dependency order on the last authority.
+
+    // Sets shared object locks in the executed order.
+    for cert in executed_shared_certs.iter() {
+        send_consensus_no_execution(&authorities[3], cert).await;
+    }
+
+    // Enqueue certs out of dependency order for executions.
+    for cert in executed_shared_certs.iter().rev() {
+        authorities[3]
+            .enqueue_certificates_for_execution(vec![cert.clone()])
             .await
-    });
+            .unwrap();
+    }
+    for cert in executed_owned_certs.iter().rev() {
+        authorities[3]
+            .enqueue_certificates_for_execution(vec![cert.clone()])
+            .await
+            .unwrap();
+    }
 
-    // Basic test: add certs out of dependency order. They should still be executed.
+    // All certs should get executed eventually.
+    let digests = executed_shared_certs
+        .iter()
+        .chain(executed_owned_certs.iter())
+        .map(|cert| *cert.digest())
+        .collect();
     authorities[3]
-        .add_pending_certificates(vec![cert2.clone()])
+        .database
+        .notify_read_effects(digests)
         .await
         .unwrap();
-    authorities[3]
-        .add_pending_certificates(vec![cert1.clone()])
-        .await
-        .unwrap();
-
-    wait_for_tx(*tx2.digest(), authorities[3].clone()).await;
-    // verify it has the effect.
-    authority_clients[3]
-        .handle_transaction_info_request((*tx2.digest()).into())
-        .await
-        .unwrap()
-        .signed_effects
-        .unwrap();
-
-    // TODO: more test cases.
 }

--- a/crates/sui-types/src/unit_tests/utils.rs
+++ b/crates/sui-types/src/unit_tests/utils.rs
@@ -11,11 +11,11 @@ use crate::{
         get_key_pair, get_key_pair_from_rng, AccountKeyPair, AuthorityKeyPair,
         AuthorityPublicKeyBytes, Signature,
     },
-    intent::{Intent, IntentMessage},
+    intent::Intent,
     messages::{Transaction, TransactionData, VerifiedTransaction},
     object::Object,
 };
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 pub fn make_committee_key<R>(rand: &mut R) -> (Vec<AuthorityKeyPair>, Committee)
 where
@@ -71,17 +71,4 @@ pub fn to_sender_signed_transaction(
         Intent::default(),
         signer,
     ))
-}
-
-// Workaround for benchmark setup.
-pub fn to_sender_signed_transaction_arc(
-    data: TransactionData,
-    signer: &Arc<fastcrypto::ed25519::Ed25519KeyPair>,
-) -> VerifiedTransaction {
-    let data1 = data.clone();
-    let intent_message = IntentMessage::new(Intent::default(), data);
-    // OK to unwrap because this is used for benchmark only.
-    let bytes = bcs::to_bytes(&intent_message).unwrap();
-    let signature: Signature = signer.sign(&bytes);
-    VerifiedTransaction::new_unchecked(Transaction::from_data(data1, Intent::default(), signature))
 }

--- a/crates/sui/tests/reconfiguration_tests.rs
+++ b/crates/sui/tests/reconfiguration_tests.rs
@@ -89,7 +89,7 @@ async fn advance_epoch_tx_test_impl(
         .collect::<anyhow::Result<Vec<_>>>()
         .unwrap();
     for (state, cert) in states.iter().zip(results) {
-        let results = state.execute_certificate_internal(&cert).await.unwrap();
+        let results = state.try_execute_for_test(&cert).await.unwrap();
         assert!(results.signed_effects.unwrap().status.is_ok());
     }
 }

--- a/crates/test-utils/src/messages.rs
+++ b/crates/test-utils/src/messages.rs
@@ -5,7 +5,6 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::ident_str;
 use move_core_types::language_storage::TypeTag;
 use std::path::PathBuf;
-use std::sync::Arc;
 use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_adapter::genesis;
@@ -32,7 +31,7 @@ use sui_types::messages::{
 use sui_types::object::{
     generate_test_gas_objects, generate_test_gas_objects_with_owner_list, Object,
 };
-use sui_types::utils::{to_sender_signed_transaction, to_sender_signed_transaction_arc};
+use sui_types::utils::to_sender_signed_transaction;
 
 /// The maximum gas per transaction.
 pub const MAX_GAS: u64 = 2_000;
@@ -357,7 +356,7 @@ pub fn make_counter_increment_transaction(
     counter_id: ObjectID,
     counter_initial_shared_version: SequenceNumber,
     sender: SuiAddress,
-    keypair: &Arc<AccountKeyPair>,
+    keypair: &AccountKeyPair,
 ) -> VerifiedTransaction {
     let data = TransactionData::new_move_call(
         sender,
@@ -372,7 +371,7 @@ pub fn make_counter_increment_transaction(
         })],
         MAX_GAS,
     );
-    to_sender_signed_transaction_arc(data, keypair)
+    to_sender_signed_transaction(data, keypair)
 }
 
 /// Make a transaction calling a specific move module & function.

--- a/crates/test-utils/src/transaction.rs
+++ b/crates/test-utils/src/transaction.rs
@@ -10,8 +10,7 @@ use sui::client_commands::WalletContext;
 use sui::client_commands::{SuiClientCommandResult, SuiClientCommands};
 use sui_config::ValidatorInfo;
 use sui_core::authority_client::AuthorityAPI;
-pub use sui_core::test_utils::{wait_for_all_txes, wait_for_tx};
-use sui_framework_build::compiled_package::BuildConfig;
+pub use sui_core::test_utils::{compile_basics_package, wait_for_all_txes, wait_for_tx};
 use sui_json_rpc_types::SuiCertifiedTransaction;
 use sui_json_rpc_types::SuiObjectRead;
 use sui_json_rpc_types::SuiTransactionEffects;
@@ -75,19 +74,14 @@ pub async fn publish_counter_package(gas_object: Object, configs: &[ValidatorInf
     publish_package(gas_object, path, configs).await
 }
 
-pub fn compile_basics_package() -> Vec<Vec<u8>> {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("../../sui_programmability/examples/basics");
-
-    let build_config = BuildConfig::default();
-    sui_framework::build_move_package(&path, build_config)
-        .unwrap()
-        .get_package_bytes()
-}
-
 /// Helper function to publish basic package.
 pub async fn publish_basics_package(context: &WalletContext, sender: SuiAddress) -> ObjectRef {
-    publish_package_with_wallet(context, sender, compile_basics_package()).await
+    publish_package_with_wallet(
+        context,
+        sender,
+        compile_basics_package().get_package_bytes(),
+    )
+    .await
 }
 
 /// Returns the published package's ObjectRef.


### PR DESCRIPTION
Change the Authority server `handle_certificate()` handler to call `execute_certificate()`, which uses `TransactionManager` to delay transactions until their input objects are ready. This should remove some unnecessary retries.

Also, convert some remaining call sites of `execute_certificate_internal()` to call `execute_certificate()` instead.

Disable a test for the error case of submitting a transaction with `initial_shared_version` set to a non-existent value, which is returning errors immediately before this change. After this change, this internal error will no longer get exposed, and instead the certificate will wait on the missing object to become available.

Enchance the transaction manager execution test to cover more cases of dependencies not found, including missing a shared input object created by an owned object transaction.