### PR TITLE
Cleanup SafeClientMetrics

### DIFF
--- a/crates/sui-core/src/node_sync/node_follower.rs
+++ b/crates/sui-core/src/node_sync/node_follower.rs
@@ -252,9 +252,6 @@ where
         ?max_stream_items,
         "requesting new batch stream items"
     );
-    client
-        .metrics_seq_number_to_handle_batch_stream
-        .set(start_seq as i64);
 
     let req = BatchInfoRequest {
         start: Some(start_seq),

--- a/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_aggregator_tests.rs
@@ -57,14 +57,7 @@ async fn init_network_authorities(
         DEFAULT_REQUEST_TIMEOUT_SEC,
     );
 
-    let registry = prometheus::Registry::new();
-    AuthorityAggregator::new(
-        committee,
-        committee_store,
-        auth_clients,
-        AuthAggMetrics::new(&registry),
-        Arc::new(SafeClientMetrics::new(&registry)),
-    )
+    AuthorityAggregator::new(committee, committee_store, auth_clients, &Registry::new())
 }
 
 pub async fn init_local_authorities(
@@ -158,8 +151,7 @@ pub async fn init_local_authorities_with_genesis(
             committee,
             committee_store,
             clients,
-            AuthAggMetrics::new_for_tests(),
-            Arc::new(SafeClientMetrics::new_for_tests()),
+            &Registry::new(),
             timeouts,
         ),
         states,
@@ -916,8 +908,7 @@ fn get_agg(
         committee,
         committee_store,
         clients,
-        AuthAggMetrics::new_for_tests(),
-        Arc::new(SafeClientMetrics::new_for_tests()),
+        &Registry::new(),
         TimeoutConfig {
             serial_authority_request_interval: Duration::from_millis(50),
             ..Default::default()

--- a/crates/sui-core/src/unit_tests/batch_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_tests.rs
@@ -769,7 +769,7 @@ async fn test_safe_batch_stream() {
         auth_client,
         committee_store,
         public_key_bytes,
-        Arc::new(SafeClientMetrics::new_for_tests()),
+        SafeClientMetrics::new_for_tests(public_key_bytes),
     );
 
     let request = BatchInfoRequest {
@@ -810,7 +810,7 @@ async fn test_safe_batch_stream() {
         auth_client_from_byzantine,
         committee_store,
         public_key_bytes_b,
-        Arc::new(SafeClientMetrics::new_for_tests()),
+        SafeClientMetrics::new_for_tests(public_key_bytes_b),
     );
 
     let mut batch_stream = safe_client_from_byzantine

--- a/crates/sui-core/src/unit_tests/server_tests.rs
+++ b/crates/sui-core/src/unit_tests/server_tests.rs
@@ -272,7 +272,7 @@ async fn test_subscription_safe_client() {
         },
         state.committee_store().clone(),
         state.name,
-        Arc::new(SafeClientMetrics::new_for_tests()),
+        SafeClientMetrics::new_for_tests(state.name),
     );
 
     let _join = server


### PR DESCRIPTION
This PR moves all the safe client metrics into a dedicated struct, which is constructed from SafeClientMetricsBase that's shared among all safe client metrics. Added proper latency buckets for the base.
Also removed all the metrics_ prefix as they are unnecessary. This may affect our dashboard for our latency metrics.