### PR TITLE
[ts-sdk] Lean harder into femver

### DIFF
--- a/.changeset/shiny-singers-rush.md
+++ b/.changeset/shiny-singers-rush.md
@@ -1,0 +1,5 @@
+---
+"@mysten/sui.js": minor
+---
+
+Change return of `getRpcApiVersion()` to be a string instead of an object.

--- a/apps/explorer/src/pages/search-result/SearchResult.tsx
+++ b/apps/explorer/src/pages/search-result/SearchResult.tsx
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidTransactionDigest, isValidSuiAddress } from '@mysten/sui.js';
+import {
+    isValidTransactionDigest,
+    isValidSuiAddress,
+    VersionUtils,
+} from '@mysten/sui.js';
 import { useEffect, useState, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -33,7 +37,7 @@ const querySearchParams = async (input: string, network: Network | string) => {
     if (
         isValidTransactionDigest(
             input,
-            version?.major === 0 && version?.minor < 18 ? 'base64' : 'base58'
+            version && VersionUtils.lt(version, '0.18.0') ? 'base64' : 'base58'
         )
     ) {
         searchPromises.push(

--- a/apps/explorer/src/utils/api/searchUtil.ts
+++ b/apps/explorer/src/utils/api/searchUtil.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidTransactionDigest, isValidSuiAddress } from '@mysten/sui.js';
+import {
+    isValidTransactionDigest,
+    isValidSuiAddress,
+    VersionUtils,
+} from '@mysten/sui.js';
 
 import { DefaultRpcClient as rpc, type Network } from './DefaultRpcClient';
 
@@ -15,7 +19,7 @@ export const navigateWithUnknown = async (
     if (
         isValidTransactionDigest(
             input,
-            version?.major === 0 && version?.minor < 18 ? 'base64' : 'base58'
+            version && VersionUtils.lt(version, '0.18.0') ? 'base64' : 'base58'
         )
     ) {
         searchPromises.push(

--- a/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
+++ b/apps/wallet/src/ui/app/redux/slices/transaction-requests/index.ts
@@ -6,6 +6,7 @@ import {
     getCertifiedTransaction,
     getTransactionEffects,
     LocalTxnDataSerializer,
+    VersionUtils,
     type SuiMoveNormalizedFunction,
 } from '@mysten/sui.js';
 import {
@@ -83,7 +84,7 @@ export const deserializeTxn = createAsyncThunk<
 
         //TODO: Error handling - either show the error or use the serialized txn
         const useIntentSigning =
-            version != null && version.major >= 0 && version.minor > 18;
+            !!version && VersionUtils.gt(version, '0.18.0');
         const deserializeTx =
             (await localSerializer.deserializeTransactionBytesToSignableTransaction(
                 useIntentSigning,

--- a/sdk/typescript/src/providers/json-rpc-provider.ts
+++ b/sdk/typescript/src/providers/json-rpc-provider.ts
@@ -46,7 +46,6 @@ import {
   TransactionQuery,
   SUI_TYPE_ARG,
   RpcApiVersion,
-  parseVersionFromString,
   EventQuery,
   EventId,
   PaginatedEvents,

--- a/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
+++ b/sdk/typescript/src/signers/txn-data-serializers/local-txn-data-serializer.ts
@@ -36,6 +36,7 @@ import {
 import { Provider } from '../../providers/provider';
 import { CallArgSerializer } from './call-arg-serializer';
 import { TypeTagSerializer } from './type-tag-serializer';
+import { gt } from '@suchipi/femver';
 
 export class LocalTxnDataSerializer implements TxnDataSerializer {
   /**
@@ -50,7 +51,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
   ): Promise<Base64DataBuffer> {
     try {
       const version = await this.provider.getRpcApiVersion();
-      const useIntentSigning = version != null && version.major >= 0 && version.minor > 18;
+      const useIntentSigning = !!version && gt(version, '0.18.0');
       return await this.serializeTransactionData(
         useIntentSigning,
         await this.constructTransactionData(signerAddress, txn)
@@ -334,7 +335,7 @@ export class LocalTxnDataSerializer implements TxnDataSerializer {
         TRANSACTION_DATA_TYPE_TAG.length + dataBytes.length
       );
       serialized.set(TRANSACTION_DATA_TYPE_TAG);
-      serialized.set(dataBytes, TRANSACTION_DATA_TYPE_TAG.length);  
+      serialized.set(dataBytes, TRANSACTION_DATA_TYPE_TAG.length);
       return new Base64DataBuffer(serialized);
     }
   }

--- a/sdk/typescript/src/types/index.guard.ts
+++ b/sdk/typescript/src/types/index.guard.ts
@@ -1659,12 +1659,7 @@ export function isTransactionData(obj: any, _argumentName?: string): obj is Tran
 
 export function isRpcApiVersion(obj: any, _argumentName?: string): obj is RpcApiVersion {
     return (
-        (obj !== null &&
-            typeof obj === "object" ||
-            typeof obj === "function") &&
-        isSuiMoveTypeParameterIndex(obj.major) as boolean &&
-        isSuiMoveTypeParameterIndex(obj.minor) as boolean &&
-        isSuiMoveTypeParameterIndex(obj.patch) as boolean
+        typeof obj === "string"
     )
 }
 

--- a/sdk/typescript/src/types/version.ts
+++ b/sdk/typescript/src/types/version.ts
@@ -1,21 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { parse } from '@suchipi/femver';
+import * as femver from '@suchipi/femver';
 
-export type RpcApiVersion = {
-  major: number;
-  minor: number;
-  patch: number;
-};
+export type RpcApiVersion = `${string}.${string}.${string}`;
 
-export function parseVersionFromString(
-  version: string
-): RpcApiVersion | undefined {
-  return parse(version);
+export function parseVersionFromString(version: string) {
+  return femver.parse(version);
 }
 
-export function versionToString(version: RpcApiVersion): string {
-  const { major, minor, patch } = version;
-  return `${major}.${minor}.${patch}`;
-}
+// TODO: Explore other ways to do this, maybe an object-oriented way where there's some `version` object
+// that contains functions like `gt` itself.
+
+// Export all of the version utilities in femver to make it easier for consumers to work with versioning.
+export const VersionUtils = femver;

--- a/sdk/typescript/src/types/version.ts
+++ b/sdk/typescript/src/types/version.ts
@@ -3,11 +3,7 @@
 
 import * as femver from '@suchipi/femver';
 
-export type RpcApiVersion = `${string}.${string}.${string}`;
-
-export function parseVersionFromString(version: string) {
-  return femver.parse(version);
-}
+export type RpcApiVersion = string;
 
 // TODO: Explore other ways to do this, maybe an object-oriented way where there's some `version` object
 // that contains functions like `gt` itself.

--- a/sdk/typescript/test/e2e/coin-metadata.test.ts
+++ b/sdk/typescript/test/e2e/coin-metadata.test.ts
@@ -1,15 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { lt } from '@suchipi/femver';
 import { describe, it, expect, beforeAll } from 'vitest';
-import {
-  getEvents,
-  getObjectExistsResponse,
-  getObjectFields,
-  LocalTxnDataSerializer,
-  ObjectId,
-  RawSigner,
-} from '../../src';
+import { LocalTxnDataSerializer, ObjectId, RawSigner } from '../../src';
 import { publishPackage, setup, TestToolbox } from './utils/setup';
 
 describe('Test Coin Metadata', () => {
@@ -28,7 +22,7 @@ describe('Test Coin Metadata', () => {
     // TODO: This API is only available under version 0.17.0. Clean
     // up this once 0.17. is released
     const version = await toolbox.provider.getRpcApiVersion();
-    if (version?.major === 0 && version?.minor < 17) {
+    if (version && lt(version, '0.17.0')) {
       shouldSkip = true;
       return;
     }

--- a/sdk/typescript/test/e2e/read-transactions.test.ts
+++ b/sdk/typescript/test/e2e/read-transactions.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { lt } from '@suchipi/femver';
 import { describe, it, expect, beforeAll } from 'vitest';
 import { setup, TestToolbox } from './utils/setup';
 
@@ -17,11 +18,7 @@ describe('Transaction Reading API', () => {
   });
 
   it('Get Transaction', async () => {
-    const resp = await toolbox.provider.getTransactions(
-      'All',
-      null,
-      1,
-    );
+    const resp = await toolbox.provider.getTransactions('All', null, 1);
     const digest = resp.data[0];
     const txn = await toolbox.provider.getTransactionWithEffects(digest);
     expect(txn.certificate.transactionDigest).toEqual(digest);
@@ -30,15 +27,11 @@ describe('Transaction Reading API', () => {
   it('Get Transaction Auth Signers', async () => {
     const version = await toolbox.provider.getRpcApiVersion();
     // This endpoint is only available in 0.18 and above
-    if (version?.major === 0 && version?.minor < 18) { 
+    if (version && lt(version, '0.18.0')) {
       return;
     }
-    
-    const resp = await toolbox.provider.getTransactions(
-      'All',
-      null,
-      1,
-    );
+
+    const resp = await toolbox.provider.getTransactions('All', null, 1);
     const digest = resp.data[0];
     const res = await toolbox.provider.getTransactionAuthSigners(digest);
     expect(res.signers.length).greaterThan(0);
@@ -54,19 +47,19 @@ describe('Transaction Reading API', () => {
     const allTransactions = await toolbox.provider.getTransactions(
       'All',
       null,
-      10,
+      10
     );
     expect(allTransactions.data.length).to.greaterThan(0);
 
     const resp2 = await toolbox.provider.getTransactions(
       { ToAddress: toolbox.address() },
       null,
-      null,
+      null
     );
     const resp3 = await toolbox.provider.getTransactions(
       { FromAddress: toolbox.address() },
       null,
-      null,
+      null
     );
     expect([...resp2.data, ...resp3.data]).toEqual(resp);
   });

--- a/sdk/typescript/test/e2e/txn-serializer.test.ts
+++ b/sdk/typescript/test/e2e/txn-serializer.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { gt } from '@suchipi/femver';
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   deserializeTransactionBytesToTransactionData,
@@ -51,7 +52,7 @@ describe('Transaction Serialization and deserialization', () => {
     expect(rpcTxnBytes).toEqual(localTxnBytes);
 
     const version = await toolbox.provider.getRpcApiVersion();
-    const useIntentSigning = version != null && version.major >= 0 && version.minor > 18;
+    const useIntentSigning = !!version && gt(version, '0.18.0');
     const deserialized =
       (await localSerializer.deserializeTransactionBytesToSignableTransaction(
         useIntentSigning,
@@ -59,9 +60,12 @@ describe('Transaction Serialization and deserialization', () => {
       )) as UnserializedSignableTransaction;
     expect(deserialized.kind).toEqual('moveCall');
 
-    const deserializedTxnData =
-      deserializeTransactionBytesToTransactionData(useIntentSigning, localTxnBytes);
-    const reserialized = await localSerializer.serializeTransactionData(useIntentSigning,
+    const deserializedTxnData = deserializeTransactionBytesToTransactionData(
+      useIntentSigning,
+      localTxnBytes
+    );
+    const reserialized = await localSerializer.serializeTransactionData(
+      useIntentSigning,
       deserializedTxnData
     );
     expect(reserialized).toEqual(localTxnBytes);


### PR DESCRIPTION
This leverages `femver` to do our version checking instead of writing it out manually. This should make the checking more correct, and easier to understand. I think there's opportunity to improve version checking in general, but we can follow-up later once we figure out ideal APIs here.