### PR TITLE
Pin GitHub Actions in workflows to commit SHA

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
     - name: Detect Changes
       uses: './.github/actions/diffs'
       id: diff
@@ -43,8 +43,8 @@ jobs:
     if: github.event.pull_request.draft == false && needs.diff.outputs.isRust == 'true'
     runs-on: [ubuntu-ghcloud]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
     # Turn off the caching on self-hosted jobs
     # Enable caching of the 'librocksdb-sys' crate by additionally caching the
     # 'librocksdb-sys' src directory which is managed by cargo
@@ -52,7 +52,7 @@ jobs:
     #   with:
     #     path: ~/.cargo/registry/src/**/librocksdb-sys-*
     - name: Install huniq
-      uses: actions-rs/install@v0.1
+      uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101 # pin@v0.1
       with:
         crate: huniq
     - name: Install python dependencies
@@ -62,7 +62,7 @@ jobs:
       run: |
         mkdir -p artifacts
     - name: Compile benchmark
-      uses: actions-rs/cargo@v1
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
       with:
         command: build
         args: --release
@@ -95,7 +95,7 @@ jobs:
         echo "$delimiter" >> $GITHUB_OUTPUT
 
     - name: Post commit comment
-      uses: peter-evans/commit-comment@v2.0.1
+      uses: peter-evans/commit-comment@76d2ae14b83cd171cd38507097b9616bb9ca7cb6 # pin@v2.0.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         body: |
@@ -103,13 +103,13 @@ jobs:
           ```
           ${{ steps.get-comment-body.outputs.owned }}
           ```
-          
-          
+
+
           **Shared Transactions Benchmark Results**
           ```
           ${{ steps.get-comment-body.outputs.shared }}
           ```
-          
+
           
           **Narwhal Benchmark Results**
           ```

--- a/.github/workflows/changesets-ci-comment.yml
+++ b/.github/workflows/changesets-ci-comment.yml
@@ -16,14 +16,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Get workflow run information
-        uses: potiuk/get-workflow-origin@v1_1
+        uses: potiuk/get-workflow-origin@e3ba776faee1134e17551924b852bfb374e1703d # pin@v1_1
         id: source-run-info
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
 
       - name: "Download artifact"
-        uses: actions/github-script@v6
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6
         id: get-artifact
         if: steps.source-run-info.outputs.pullRequestNumber
         with:
@@ -46,7 +46,7 @@ jobs:
             return 'true';
 
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@c22fb302208b7b170d252a61a505d2ea27245eff # pin@v2
         if: steps.get-artifact.outputs.result == 'true' && steps.source-run-info.outputs.pullRequestNumber
         with:
           pr_number: ${{ steps.source-run-info.outputs.pullRequestNumber }}
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove outdated comments
-        uses: actions/github-script@v6
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # pin@v6
         if: steps.get-artifact.outputs.result == 'false' && steps.source-run-info.outputs.pullRequestNumber
         env:
           ISSUE_NUMBER: ${{ steps.source-run-info.outputs.pullRequestNumber }}

--- a/.github/workflows/changesets-ci.yml
+++ b/.github/workflows/changesets-ci.yml
@@ -5,14 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
           node-version: "16"
           cache: "pnpm"
@@ -23,7 +23,7 @@ jobs:
         run: echo "hasChanges=$(pnpm list --filter "...[$(git rev-parse HEAD^1)]" --depth -1 --json | jq "any(.[] | select(.private != true) ; length > 0)")" >> $GITHUB_OUTPUT
       - name: Get changed files in the changesets folder
         id: has-changesets
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@3f1e44af6ca48144748dfc62a7a6fb22e4ca67f3 # pin@v34
         with:
           files: |
             .changeset/**
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "true" > missing-changeset.txt
       - name: Upload missing changeset artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # pin@v3
         if: steps.has-changesets.outputs.any_changed != 'true' && steps.diff.outputs.hasChanges == 'true'
         with:
           name: missing-changeset

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch Changesets To Operations
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@26b39ed245ab8f31526069329e112ab2fb224588 # pin@v2
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.CHANGESETS_DEPLOY_DISPATCH }}
@@ -25,27 +25,27 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # pin@v1
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: checkout code repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
           node-version: "16"
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create Release Pull Request
-        uses: changesets/action@v1
+        uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a # pin@v1
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # pin@v2
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
 
       - name: Generate documentation
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
         with:
@@ -34,7 +34,7 @@ jobs:
           args: --workspace --no-deps
 
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # pin@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,10 +14,10 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Detect Changes
-      uses: './.github/actions/diffs'
-      id: diff
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - name: Detect Changes
+        uses: './.github/actions/diffs'
+        id: diff
 
   codecov-grcov:
     name: Generate code coverage
@@ -27,19 +27,19 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
         with:
           components: llvm-tools-preview
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
       # 'librocksdb-sys' src directory which is managed by cargo
       - name: Install grcov, and cache the binary
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # pin@v1
         with:
           crate: grcov
           locked: true
       - name: Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         with:
           command: build
         env:
@@ -54,4 +54,4 @@ jobs:
       - name: Run grcov
         run: grcov . --binary-path target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.5
+        uses: dependabot/fetch-metadata@5ef00187930bafb52d529e0b9c3dff045dfa9851 # pin@v1.3.5
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.AUTOMERGE_TOKEN }}
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
       - name: Install cargo-hakari, and cache the binary
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # pin@v1
         with:
           crate: cargo-hakari
           locked: true
@@ -44,7 +44,7 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.AUTOMERGE_TOKEN }}@github.com/${{ github.repository }}
           git commit -am "chore(deps): cargo hakari"
           git push
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
+      - uses: ahmadnassri/action-dependabot-auto-merge@7dbc44641f77fb62b23158c1294b5b757d6091a5 # pin@v2.6
         with:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
           command: 'squash and merge'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
     outputs:
       isDoc: ${{ steps.diff.outputs.isDoc }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Detect Changes
-      uses: './.github/actions/diffs'
-      id: diff
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - name: Detect Changes
+        uses: './.github/actions/diffs'
+        id: diff
 
   spelling:
     name: Lint documentation
@@ -24,8 +24,8 @@ jobs:
     if: needs.diff.outputs.isDoc == 'true'
     runs-on: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
-    - name: Spell Check Docs
-      uses: crate-ci/typos@master
-      with:
-        files: ./doc ./*.md
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - name: Spell Check Docs
+        uses: crate-ci/typos@1d8996e20538a68f390ac049102ff99b33273525 # pin@master
+        with:
+          files: ./doc ./*.md

--- a/.github/workflows/explorer-client-prs.yml
+++ b/.github/workflows/explorer-client-prs.yml
@@ -6,7 +6,7 @@ jobs:
     outputs:
       isClient: ${{ (steps.pnpm.outputs.packages && contains(fromJson(steps.pnpm.outputs.packages), 'sui-explorer')) || steps.diff.outputs.isRust }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
       - name: Detect Changes (pnpm)
         uses: "./.github/actions/pnpm-diffs"
         id: pnpm
@@ -20,12 +20,12 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.4
+        uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
           node-version: "16"
           cache: "pnpm"
@@ -44,12 +44,12 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2.2.4
+        uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
           node-version: "16"
           cache: "pnpm"
@@ -58,7 +58,7 @@ jobs:
       - name: Install Cypress
         run: pnpm explorer exec cypress install
       - name: Run e2e tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@c5724eda82337bcff977ce14509f47052c12e04c # pin@v5
         with:
           install: false
           start: pnpm dev:static
@@ -70,14 +70,14 @@ jobs:
     if: needs.diff.outputs.isClient == 'true'
     runs-on: [ubuntu-ghcloud]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: actions/checkout@7dd9e2a3dc350cf687eb1b2a4fadfee8c8e49675 # pin@v3
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # pin@v2.2.4
         with:
           version: 7
       - run: cargo build --bin sui-test-validator --profile dev
       - name: Install Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # pin@v3
         with:
           node-version: "16"
           cache: "pnpm"
@@ -86,7 +86,7 @@ jobs:
       - name: Install Cypress
         run: pnpm explorer exec cypress install
       - name: Run e2e tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@c5724eda82337bcff977ce14509f47052c12e04c # pin@v5
         with:
           install: false
           start: pnpm dlx concurrently --kill-others 'cargo run --bin sui-test-validator' 'pnpm dev'


### PR DESCRIPTION
Used
[mheap/pin-github-action](https://github.com/mheap/pin-github-action) to update the workfows in `.github/workflows/*.yml`

The utility updates the actions in the workflow to the specific SHA commit referenced at that particular version. It leaves the specific version pinned as a comment alongside the action.

This change follows best practices documented by:
* [GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) 
* [OpenSSF](https://github.com/ossf/scorecard/blob/7206a2bdeb7020ab45744a1a6234c9ddf2f3713c/docs/checks.md#pinned-dependencies)