### PR TITLE
simplify move example

### DIFF
--- a/sui_programmability/examples/games/sources/shared_tic_tac_toe.move
+++ b/sui_programmability/examples/games/sources/shared_tic_tac_toe.move
@@ -100,9 +100,9 @@ module games::shared_tic_tac_toe {
             // Notify the server that the game ended so that it can delete the game.
             event::emit(GameEndEvent { game_id: object::id(game) });
             if (game.game_status == X_WIN) {
-                transfer::transfer( Trophy { id: object::new(ctx) }, *&game.x_address);
+                transfer::transfer( Trophy { id: object::new(ctx) }, game.x_address);
             } else if (game.game_status == O_WIN) {
-                transfer::transfer( Trophy { id: object::new(ctx) }, *&game.o_address);
+                transfer::transfer( Trophy { id: object::new(ctx) }, game.o_address);
             }
         }
     }
@@ -123,9 +123,9 @@ module games::shared_tic_tac_toe {
 
     fun get_cur_turn_address(game: &TicTacToe): address {
         if (game.cur_turn % 2 == 0) {
-            *&game.x_address
+            game.x_address
         } else {
-            *&game.o_address
+            game.o_address
         }
     }
 


### PR DESCRIPTION
This PR more for my own understanding than anything else--

Played around removing the `*&` syntax in this example and noticed it didn't seem to change anything (disassembly is identical before and after with `sui move disassemble --name shared_tic_tac_toe`)

Am I missing something or can this be simplified?