### PR TITLE
[wallet-ext] Add viewport to wallet storybook

### DIFF
--- a/apps/wallet/.storybook/preview.js
+++ b/apps/wallet/.storybook/preview.js
@@ -15,4 +15,17 @@ export const parameters = {
             date: /Date$/,
         },
     },
+    viewport: {
+        viewports: {
+            extension: {
+                name: 'Chrome Extension',
+                styles: {
+                    height: '595px',
+                    width: '360px',
+                },
+                type: 'mobile',
+            },
+        },
+        defaultViewport: 'extension',
+    },
 };


### PR DESCRIPTION
This should just make it easy to test components within the compact wallet UI by default.